### PR TITLE
Add a chart for Mercure.rocks

### DIFF
--- a/stable/mercure/.helmignore
+++ b/stable/mercure/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/mercure/.helmignore
+++ b/stable/mercure/.helmignore
@@ -20,3 +20,4 @@
 .idea/
 *.tmproj
 .vscode/
+OWNERS

--- a/stable/mercure/Chart.yaml
+++ b/stable/mercure/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.3.2"
+appVersion: "0.3.3"
 description: The Mercure hub allows to push data updates using the Mercure protocol to web browsers and other HTTP clients in a convenient, fast, reliable and battery-efficient way
 name: mercure
 version: 0.1.0

--- a/stable/mercure/Chart.yaml
+++ b/stable/mercure/Chart.yaml
@@ -12,5 +12,5 @@ icon: https://cdn.jsdelivr.net/gh/dunglas/mercure/public/mercure.svg
 sources:
 - https://github.com/dunglas/mercure
 maintainers:
-- name: Kévin Dunglas
+- name: dunglas
   email: dunglas+mercure@gmail.com

--- a/stable/mercure/Chart.yaml
+++ b/stable/mercure/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.3.3"
 description: The Mercure hub allows to push data updates using the Mercure protocol to web browsers and other HTTP clients in a convenient, fast, reliable and battery-efficient way
 name: mercure
-version: 0.1.0
+version: 1.0.0
 keywords:
 - mercure
 - hub

--- a/stable/mercure/Chart.yaml
+++ b/stable/mercure/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+appVersion: "0.3.2"
+description: The Mercure hub allows to push data updates using the Mercure protocol to web browsers and other HTTP clients in a convenient, fast, reliable and battery-efficient way
+name: mercure
+version: 0.1.0
+keywords:
+- mercure
+- hub
+- push
+home: https://mercure.rocks
+icon: https://cdn.jsdelivr.net/gh/dunglas/mercure/public/mercure.svg
+sources:
+- https://github.com/dunglas/mercure
+maintainers:
+- name: Kévin Dunglas
+  email: dunglas+mercure@gmail.com

--- a/stable/mercure/OWNERS
+++ b/stable/mercure/OWNERS
@@ -1,2 +1,4 @@
 approvers:
 - dunglas
+reviewers:
+- dunglas

--- a/stable/mercure/OWNERS
+++ b/stable/mercure/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- dunglas

--- a/stable/mercure/README.md
+++ b/stable/mercure/README.md
@@ -1,0 +1,90 @@
+# Mercure
+
+[Mercure](https://mercure.rocks) is a protocol allowing to push data updates to web browsers and other HTTP clients in a convenient, fast, reliable and battery-efficient way.
+
+## TL;DR;
+
+```console
+$ helm install stable/mercure
+```
+
+## Introduction
+
+This chart bootstraps a [Mercure Hub](https://mercure.rocks) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.4+ with Beta APIs enabled
+- PV provisioner support in the underlying infrastructure
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release stable/mercure
+```
+
+The command deploys the Mercure Hub on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Moodle chart and their default values.
+
+| Parameter               | Description                                                                                         | Default             |   |   |
+|-------------------------|-----------------------------------------------------------------------------------------------------|---------------------|---|---|
+| `acmeHosts`             | a comma separated list of hosts for which Let's Encrypt certificates must be issued                 | empty               |   |   |
+| `allowAnonymous`        | set to `1` to allow subscribers with no valid JWT to connect                                        | `0`                 |   |   |
+| `corsAllowedOrigins`    | a comma separated list of allowed CORS origins, can be `*` for all                                  | empty               |   |   |
+| `debug`                 | set to `1` to enable the debug mode (prints recovery stack traces)                                  | `0`                 |   |   |
+| `demo`                  | set to `1` to enable the demo mode (automatically enabled when `debug` is `1`)                      | `0`                 |   |   |
+| `jwtKey`                | the JWT key to use for both publishers and subscribers                                              | random string       |   |   |
+| `logFormat`             | the log format                                                                                      | `FLUENTD`           |   |   |
+| `publishAllowedOrigins` | a comma separated list of origins allowed to publish (only applicable when using cookie-based auth) | empty               |   |   |
+| `publisherJwtKey`       | must contain the secret key to valid publishers' JWT, can be omited in favor of `jwtKey`            | empty               |   |   |
+| `subscriberJwtKey`      | must contain the secret key to valid subscribers' JWT, can be omited in favor of `jwtKey`           | empty               |   |   |
+| `image.repository`      | controller container image repository                                                               | `dunglas/mercure`   |   |   |
+| `image.tag`             | controller container image tag                                                                      | `v0.3.2`            |   |   |
+| `image.pullPolicy`      | controller container image pull policy                                                              | `IfNotPresent`      |   |   |
+| `nameOverride`          | Name override                                                                                       | empty               |   |   |
+| `fullnameOverride`      | fullname override                                                                                   | `empty              |   |   |
+| `service.type`          | Service type                                                                                        | `NodePort`          |   |   |
+| `service.port`          | Service port                                                                                        | `80`                |   |   |
+| `ingress.enabled`       | Enables Ingress                                                                                     | `false`             |   |   |
+| `ingress.annotations`   | Ingress annotations                                                                                 | `{}`                |   |   |
+| `ingress.path`          | Ingress path                                                                                        | `/`                 |   |   |
+| `ingress.hosts`         | Ingress accepted hostnames                                                                          | `["mercure.local"]` |   |   |
+| `ingress.tls`           | Ingress TLS configuration                                                                           | `[]`                |   |   |
+| `resources`             | controller pod resource requests & limits                                                           | `{}`                |   |   |
+| `nodeSelector`          | node labels for controller pod assignment                                                           | `{}`                |   |   |
+| `tolerations`           | controller pod toleration for taints                                                                | `{}`                |   |   |
+|                         |                                                                                                     |                     |   |   |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install --name my-release --set jwtKey=FooBar,corsAllowedOrigins=example.com stable/mercure
+```
+
+The above command sets the JWT key to `FooBar`.
+Additionally it allows pages served from `example.com` to connect to the hub.
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name my-release -f values.yaml stable/mercure
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/mercure/README.md
+++ b/stable/mercure/README.md
@@ -45,7 +45,6 @@ The following table lists the configurable parameters of the Moodle chart and th
 
 | Parameter               | Description                                                                                         | Default             |   |   |
 |-------------------------|-----------------------------------------------------------------------------------------------------|---------------------|---|---|
-| `acmeHosts`             | a comma separated list of hosts for which Let's Encrypt certificates must be issued                 | empty               |   |   |
 | `allowAnonymous`        | set to `1` to allow subscribers with no valid JWT to connect                                        | `0`                 |   |   |
 | `corsAllowedOrigins`    | a comma separated list of allowed CORS origins, can be `*` for all                                  | empty               |   |   |
 | `debug`                 | set to `1` to enable the debug mode (prints recovery stack traces)                                  | `0`                 |   |   |

--- a/stable/mercure/templates/NOTES.txt
+++ b/stable/mercure/templates/NOTES.txt
@@ -1,0 +1,23 @@
+The Mercure Hub is now running in the cluster.
+
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range $.Values.ingress.paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "chart.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "chart.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "chart.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "chart.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/stable/mercure/templates/NOTES.txt
+++ b/stable/mercure/templates/NOTES.txt
@@ -8,16 +8,16 @@ The Mercure Hub is now running in the cluster.
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "chart.fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "mercure.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "chart.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "chart.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "mercure.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "mercure.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "chart.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "mercure.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:80
 {{- end }}

--- a/stable/mercure/templates/_helpers.tpl
+++ b/stable/mercure/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chart.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/mercure/templates/_helpers.tpl
+++ b/stable/mercure/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "chart.name" -}}
+{{- define "mercure.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -11,7 +11,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "chart.fullname" -}}
+{{- define "mercure.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -27,6 +27,6 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "chart.chart" -}}
+{{- define "mercure.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/stable/mercure/templates/configmap.yaml
+++ b/stable/mercure/templates/configmap.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "chart.fullname" . }}
+  name: {{ include "mercure.fullname" . }}
   annotations:
     helm.sh/hook: "pre-install"
   labels:
-    app.kubernetes.io/name: {{ include "chart.name" . }}
-    helm.sh/chart: {{ include "chart.chart" . }}
+    app.kubernetes.io/name: {{ include "mercure.name" . }}
+    helm.sh/chart: {{ include "mercure.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:

--- a/stable/mercure/templates/configmap.yaml
+++ b/stable/mercure/templates/configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "chart.fullname" . }}
+  annotations:
+    helm.sh/hook: "pre-install"
+  labels:
+    app.kubernetes.io/name: {{ include "chart.name" . }}
+    helm.sh/chart: {{ include "chart.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  acmeHosts: {{ .Values.acmeHosts | quote }}
+  allowAnonymous: {{ .Values.allowAnonymous | quote }}
+  corsAllowedOrigins: {{ .Values.corsAllowedOrigins | quote }}
+  debug: {{ .Values.debug | quote }}
+  demo: {{ .Values.demo | quote }}
+  logFormat: {{ .Values.logFormat | quote }}
+  publishAllowedOrigins: {{ .Values.publishAllowedOrigins | quote }}

--- a/stable/mercure/templates/deployment.yaml
+++ b/stable/mercure/templates/deployment.yaml
@@ -17,7 +17,9 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: {{ include "mercure.name" . }}
+        helm.sh/chart: {{ include "mercure.chart" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/stable/mercure/templates/deployment.yaml
+++ b/stable/mercure/templates/deployment.yaml
@@ -1,22 +1,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "chart.fullname" . }}
+  name: {{ include "mercure.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "chart.name" . }}
-    helm.sh/chart: {{ include "chart.chart" . }}
+    app.kubernetes.io/name: {{ include "mercure.name" . }}
+    helm.sh/chart: {{ include "mercure.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "chart.name" . }}
+      app.kubernetes.io/name: {{ include "mercure.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "chart.name" . }}
+        app.kubernetes.io/name: {{ include "mercure.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       containers:
@@ -31,47 +31,47 @@ spec:
             - name: ALLOW_ANONYMOUS
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "chart.fullname" . }}
+                  name: {{ include "mercure.fullname" . }}
                   key: allowAnonymous
             - name: CORS_ALLOWED_ORIGINS
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "chart.fullname" . }}
+                  name: {{ include "mercure.fullname" . }}
                   key: corsAllowedOrigins
             - name: DEBUG
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "chart.fullname" . }}
+                  name: {{ include "mercure.fullname" . }}
                   key: debug
             - name: DEMO
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "chart.fullname" . }}
+                  name: {{ include "mercure.fullname" . }}
                   key: demo
             - name: JWT_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "chart.fullname" . }}
+                  name: {{ include "mercure.fullname" . }}
                   key: jwtKey
             - name: LOG_FORMAT
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "chart.fullname" . }}
+                  name: {{ include "mercure.fullname" . }}
                   key: logFormat
             - name: PUBLISH_ALLOWED_ORIGINS
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "chart.fullname" . }}
+                  name: {{ include "mercure.fullname" . }}
                   key: publishAllowedOrigins
             - name: PUBLISHER_JWT_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "chart.fullname" . }}
+                  name: {{ include "mercure.fullname" . }}
                   key: publisherJwtKey
             - name: SUBSCRIBER_JWT_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "chart.fullname" . }}
+                  name: {{ include "mercure.fullname" . }}
                   key: subscriberJwtKey
           livenessProbe:
             httpGet:

--- a/stable/mercure/templates/deployment.yaml
+++ b/stable/mercure/templates/deployment.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "chart.name" . }}
+    helm.sh/chart: {{ include "chart.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "chart.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "chart.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          env:
+            - name: ACME_HOSTS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "chart.fullname" . }}
+                  key: acmeHosts
+            - name: ALLOW_ANONYMOUS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "chart.fullname" . }}
+                  key: allowAnonymous
+            - name: CORS_ALLOWED_ORIGINS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "chart.fullname" . }}
+                  key: corsAllowedOrigins
+            - name: DEBUG
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "chart.fullname" . }}
+                  key: debug
+            - name: DEMO
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "chart.fullname" . }}
+                  key: demo
+            - name: JWT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "chart.fullname" . }}
+                  key: jwtKey
+            - name: LOG_FORMAT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "chart.fullname" . }}
+                  key: logFormat
+            - name: PUBLISH_ALLOWED_ORIGINS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "chart.fullname" . }}
+                  key: publishAllowedOrigins
+            - name: PUBLISHER_JWT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "chart.fullname" . }}
+                  key: publisherJwtKey
+            - name: SUBSCRIBER_JWT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "chart.fullname" . }}
+                  key: subscriberJwtKey
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/stable/mercure/templates/deployment.yaml
+++ b/stable/mercure/templates/deployment.yaml
@@ -28,11 +28,6 @@ spec:
               containerPort: 80
               protocol: TCP
           env:
-            - name: ACME_HOSTS
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "chart.fullname" . }}
-                  key: acmeHosts
             - name: ALLOW_ANONYMOUS
               valueFrom:
                 configMapKeyRef:

--- a/stable/mercure/templates/ingress.yaml
+++ b/stable/mercure/templates/ingress.yaml
@@ -1,13 +1,13 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "chart.fullname" . -}}
+{{- $fullName := include "mercure.fullname" . -}}
 {{- $ingressPaths := .Values.ingress.paths -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    app.kubernetes.io/name: {{ include "chart.name" . }}
-    helm.sh/chart: {{ include "chart.chart" . }}
+    app.kubernetes.io/name: {{ include "mercure.name" . }}
+    helm.sh/chart: {{ include "mercure.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   {{- with .Values.ingress.annotations }}

--- a/stable/mercure/templates/ingress.yaml
+++ b/stable/mercure/templates/ingress.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "chart.fullname" . -}}
+{{- $ingressPaths := .Values.ingress.paths -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "chart.name" . }}
+    helm.sh/chart: {{ include "chart.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+        {{- range $ingressPaths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/stable/mercure/templates/secret.yaml
+++ b/stable/mercure/templates/secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "chart.fullname" . }}
+  annotations:
+    helm.sh/hook: "pre-install"
+  labels:
+    app.kubernetes.io/name: {{ include "chart.name" . }}
+    helm.sh/chart: {{ include "chart.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+data:
+  jwtKey: {{ if .Values.jwtKey }}{{ .Values.jwtKey | b64enc | quote }}{{ else }}{{ randAlphaNum 12 | b64enc | quote }}{{ end }}
+  publisherJwtKey: {{ .Values.jwtKey | b64enc | quote }}
+  subscriberJwtKey: {{ .Values.jwtKey | b64enc | quote }}

--- a/stable/mercure/templates/secret.yaml
+++ b/stable/mercure/templates/secret.yaml
@@ -11,6 +11,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
-  jwtKey: {{ if .Values.jwtKey }}{{ .Values.jwtKey | b64enc | quote }}{{ else }}{{ randAlphaNum 12 | b64enc | quote }}{{ end }}
+  jwtKey: {{ .Values.jwtKey | default (randAlphaNum 12) | b64enc | quote }}
   publisherJwtKey: {{ .Values.jwtKey | b64enc | quote }}
   subscriberJwtKey: {{ .Values.jwtKey | b64enc | quote }}

--- a/stable/mercure/templates/secret.yaml
+++ b/stable/mercure/templates/secret.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "chart.fullname" . }}
+  name: {{ include "mercure.fullname" . }}
   annotations:
     helm.sh/hook: "pre-install"
   labels:
-    app.kubernetes.io/name: {{ include "chart.name" . }}
-    helm.sh/chart: {{ include "chart.chart" . }}
+    app.kubernetes.io/name: {{ include "mercure.name" . }}
+    helm.sh/chart: {{ include "mercure.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque

--- a/stable/mercure/templates/service.yaml
+++ b/stable/mercure/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "chart.name" . }}
+    helm.sh/chart: {{ include "chart.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "chart.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/mercure/templates/service.yaml
+++ b/stable/mercure/templates/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "chart.fullname" . }}
+  name: {{ include "mercure.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "chart.name" . }}
-    helm.sh/chart: {{ include "chart.chart" . }}
+    app.kubernetes.io/name: {{ include "mercure.name" . }}
+    helm.sh/chart: {{ include "mercure.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
@@ -15,5 +15,5 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: {{ include "chart.name" . }}
+    app.kubernetes.io/name: {{ include "mercure.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/mercure/values.yaml
+++ b/stable/mercure/values.yaml
@@ -1,0 +1,57 @@
+# Default values for chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+acmeHosts: ""
+allowAnonymous: "0"
+corsAllowedOrigins: ""
+debug: "0"
+demo: "0"
+jwtKey: ""
+logFormat: "FLUENTD"
+publishAllowedOrigins: ""
+publisherJwtKey: ""
+subscriberJwtKey: ""
+
+image:
+  repository: dunglas/mercure
+  tag: latest
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: NodePort
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  paths: []
+  hosts:
+    - mercure.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - mercure.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/stable/mercure/values.yaml
+++ b/stable/mercure/values.yaml
@@ -2,7 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-acmeHosts: ""
 allowAnonymous: "0"
 corsAllowedOrigins: ""
 debug: "0"

--- a/stable/mercure/values.yaml
+++ b/stable/mercure/values.yaml
@@ -14,7 +14,7 @@ subscriberJwtKey: ""
 
 image:
   repository: dunglas/mercure
-  tag: latest
+  tag: v0
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds a chart for [the Mercure hub](https://mercure.rocks).

Mercure is a protocol allowing to push data updates to web browsers and other HTTP clients in a convenient, fast, reliable and battery-efficient way. It is especially useful to publish real-time updates of resources served through web APIs, to reactive web and mobile apps.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
