### PR TITLE
[stable/node-red] use a default values for the `flows` setting

### DIFF
--- a/stable/node-red/Chart.yaml
+++ b/stable/node-red/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.19.4
 description: Node-RED is flow-based programming for the Internet of Things
 name: node-red
-version: 1.0.1
+version: 1.0.2
 keywords:
   - nodered
   - node-red

--- a/stable/node-red/README.md
+++ b/stable/node-red/README.md
@@ -41,7 +41,7 @@ The following tables lists the configurable parameters of the Sentry chart and t
 | `image.repository`                   | node-red image                             | `nodered/node-red-docker` |
 | `image.tag`                          | node-red image tag                         | `0.19.4-v8` |
 | `image.pullPolicy`                   | node-red image pull policy                 | `IfNotPresent` |
-| `flows`                              | Default flows configuration                | `` |
+| `flows`                              | Default flows configuration                | `flows.json` |
 | `nodeOptions`                        | Node.js runtime arguments                  | `` |
 | `timezone`                           | Default timezone                           | `UTC` |
 | `service.type`                       | Kubernetes service type for the GUI        | `ClusterIP` |

--- a/stable/node-red/values.yaml
+++ b/stable/node-red/values.yaml
@@ -12,7 +12,7 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
-# flows: ""
+flows: "flows.json"
 # nodeOptions: ""
 timezone: "UTC"
 


### PR DESCRIPTION
#### What this PR does / why we need it: use a default values for the `flows` setting

#### Which issue this PR fixes

If the `flows` setting is left unset, node-red will default the files it creates for new flows to match the hostname of the container it's running under. This hostname is dynamic and changes with a pod restart. As a result changes made and persisted will be lost.

By defaulting the `flows` value to some static value, we ensure that the changes will persist between pod restarts (assuming using persistent storage)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
