### PR TITLE
[stable/concourse] Add warning about test user; Update README

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 3.6.2
+version: 3.6.3
 appVersion: 4.2.2
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -37,7 +37,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 
 ### Cleanup orphaned Persistent Volumes
 
-This chart uses `StatefulSets` for Concourse Workers. Deleting a `StatefulSet` will not delete associated Persistent Volumes.
+This chart uses `StatefulSets` for Concourse Workers. Deleting a `StatefulSet` does not delete associated Persistent Volumes.
 
 Do the following after deleting the chart release to clean up orphaned Persistent Volumes.
 
@@ -55,7 +55,7 @@ $ kubectl scale statefulset my-release-worker --replicas=3
 
 ### Restarting workers
 
-If a worker isn't taking on work, you can restart the worker with `kubectl delete pod`. This will initiate a graceful shutdown by "retiring" the worker, to ensure Concourse doesn't try looking for old volumes on the new worker. The value`worker.terminationGracePeriodSeconds` can be used to provide an upper limit on graceful shutdown time before forcefully terminating the container. Check the output of `fly workers`, and if a worker is `stalled`, you'll also need to run `fly prune-worker` to allow the new incarnation of the worker to start.
+If a worker isn't taking on work, you can restart the worker with `kubectl delete pod`. This initiates a graceful shutdown by "retiring" the worker, to ensure Concourse doesn't try looking for old volumes on the new worker. The value`worker.terminationGracePeriodSeconds` can be used to provide an upper limit on graceful shutdown time before forcefully terminating the container. Check the output of `fly workers`, and if a worker is `stalled`, you'll also need to run `fly prune-worker` to allow the new incarnation of the worker to start.
 
 ### Worker Liveness Probe
 
@@ -128,48 +128,48 @@ The following table lists the configurable parameters of the Concourse chart and
 | `rbac.apiVersion` | RBAC version | `v1beta1` |
 | `rbac.webServiceAccountName` | Name of the service account to use for web pods if `rbac.create` is `false` | `default` |
 | `rbac.workerServiceAccountName` | Name of the service account to use for workers if `rbac.create` is `false` | `default` |
-| `secrets.localUsers` | Create concourse local users. Default username and password are test:test *See [values.yaml](values.yaml)* |
 | `secrets.create` | Create the secret resource from the following values. *See [Secrets](#secrets)* | `true` |
-| `secrets.hostKey` | Concourse Host Private Key | *See [values.yaml](values.yaml)* |
-| `secrets.hostKeyPub` | Concourse Host Public Key | *See [values.yaml](values.yaml)* |
-| `secrets.sessionSigningKey` | Concourse Session Signing Private Key | *See [values.yaml](values.yaml)* |
-| `secrets.workerKey` | Concourse Worker Private Key | *See [values.yaml](values.yaml)* |
-| `secrets.workerKeyPub` | Concourse Worker Public Key | *See [values.yaml](values.yaml)* |
-| `secrets.postgresqlUser` | PostgreSQL User Name | `nil` |
-| `secrets.postgresqlPassword` | PostgreSQL User Password | `nil` |
-| `secrets.postgresqlCaCert` | PostgreSQL CA certificate | `nil` |
-| `secrets.postgresqlClientCert` | PostgreSQL Client certificate | `nil` |
-| `secrets.postgresqlClientKey` | PostgreSQL Client key | `nil` |
-| `secrets.encryptionKey` | current encryption key | `nil` |
-| `secrets.oldEncryptionKey` | old encryption key, used for key rotation | `nil` |
 | `secrets.awsSsmAccessKey` | AWS Access Key ID for SSM access | `nil` |
 | `secrets.awsSsmSecretKey` | AWS Secret Access Key ID for SSM access | `nil` |
 | `secrets.awsSsmSessionToken` | AWS Session Token for SSM access | `nil` |
+| `secrets.cfCaCert` | CA certificate for cf auth provider | `nil` |
 | `secrets.cfClientId` | Client ID for cf auth provider | `nil` |
 | `secrets.cfClientSecret` | Client secret for cf auth provider | `nil` |
-| `secrets.cfCaCert` | CA certificate for cf auth provider | `nil` |
+| `secrets.encryptionKey` | current encryption key | `nil` |
+| `secrets.githubCaCert` | CA certificate for Enterprise Github OAuth | `nil` |
 | `secrets.githubClientId` | Application client ID for GitHub OAuth | `nil` |
 | `secrets.githubClientSecret` | Application client secret for GitHub OAuth | `nil` |
-| `secrets.githubCaCert` | CA certificate for Enterprise Github OAuth | `nil` |
 | `secrets.gitlabClientId` | Application client ID for GitLab OAuth | `nil` |
 | `secrets.gitlabClientSecret` | Application client secret for GitLab OAuth | `nil` |
+| `secrets.hostKeyPub` | Concourse Host Public Key | *See [values.yaml](values.yaml)* |
+| `secrets.hostKey` | Concourse Host Private Key | *See [values.yaml](values.yaml)* |
+| `secrets.influxdbPassword` | Password used to authenticate with influxdb | `nil` |
+| `secrets.localUsers` | Create concourse local users. Default username and password are `test:test` *See [values.yaml](values.yaml)* |
+| `secrets.oauthCaCert` | CA certificate for Generic OAuth | `nil` |
 | `secrets.oauthClientId` | Application client ID for Generic OAuth | `nil` |
 | `secrets.oauthClientSecret` | Application client secret for Generic OAuth | `nil` |
-| `secrets.oauthCaCert` | CA certificate for Generic OAuth | `nil` |
+| `secrets.oidcCaCert` | CA certificate for OIDC Oauth | `nil` |
 | `secrets.oidcClientId` | Application client ID for OIDI OAuth | `nil` |
 | `secrets.oidcClientSecret` | Application client secret for OIDC OAuth | `nil` |
-| `secrets.oidcCaCert` | CA certificate for OIDC Oauth | `nil` |
+| `secrets.oldEncryptionKey` | old encryption key, used for key rotation | `nil` |
+| `secrets.postgresqlCaCert` | PostgreSQL CA certificate | `nil` |
+| `secrets.postgresqlClientCert` | PostgreSQL Client certificate | `nil` |
+| `secrets.postgresqlClientKey` | PostgreSQL Client key | `nil` |
+| `secrets.postgresqlPassword` | PostgreSQL User Password | `nil` |
+| `secrets.postgresqlUser` | PostgreSQL User Name | `nil` |
+| `secrets.sessionSigningKey` | Concourse Session Signing Private Key | *See [values.yaml](values.yaml)* |
+| `secrets.syslogCaCert` | SSL certificate to verify Syslog server | `nil` |
+| `secrets.vaultAuthParam` | Paramter to pass when logging in via the backend | `nil` |
 | `secrets.vaultCaCert` | CA certificate use to verify the vault server SSL cert | `nil` |
 | `secrets.vaultClientCert` | Vault Client Certificate | `nil` |
 | `secrets.vaultClientKey` | Vault Client Key | `nil` |
 | `secrets.vaultClientToken` | Vault periodic client token | `nil` |
-| `secrets.vaultAuthParam` | Paramter to pass when logging in via the backend | `nil` |
 | `secrets.webTlsCert` | TLS certificate for the web component to terminate TLS connections | `nil` |
 | `secrets.webTlsKey` | An RSA private key, used to encrypt HTTPS traffic  | `nil` |
-| `secrets.influxdbPassword` | Password used to authenticate with influxdb | `nil` |
-| `secrets.syslogCaCert` | SSL certificate to verify Syslog server | `nil` |
+| `secrets.workerKeyPub` | Concourse Worker Public Key | *See [values.yaml](values.yaml)* |
+| `secrets.workerKey` | Concourse Worker Private Key | *See [values.yaml](values.yaml)* |
 
-For configurable concourse parameters, refer to [values.yaml](values.yaml) `concourse` section. All parameters under this section are strictly mapped from concourse binary commands. For example if one needs to configure the concourse external URL, the param `concourse` -> `web` -> `externalUrl` should be set, which is equivalent to running concourse binary as `concourse web --external-url`. For those sub-sections have `enabled`, one will need to set `enabled` to be `true` to use the following params within the section.
+For configurable concourse parameters, refer to [values.yaml](values.yaml) `concourse` section. All parameters under this section are strictly mapped from concourse binary commands. For example if one needs to configure the concourse external URL, the param `concourse` -> `web` -> `externalUrl` should be set, which is equivalent to running concourse binary as `concourse web --external-url`. For those sub-sections that have `enabled`, one needs to set `enabled` to be `true` to use the following params within the section.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
@@ -183,7 +183,7 @@ $ helm install --name my-release -f values.yaml stable/concourse
 
 ### Secrets
 
-For your convenience, this chart provides some default values for secrets, but it is recommended that you generate and manage these secrets outside the Helm chart. To do this, set `secrets.create` to `false`, create files for each secret value, and turn it all into a k8s secret. Be careful with introducing trailing newline characters; following the steps below ensures none will end up in your secrets. First, perform the following to create the manditory secret values:
+For your convenience, this chart provides some default values for secrets, but it is recommended that you generate and manage these secrets outside the Helm chart. To do this, set `secrets.create` to `false`, create files for each secret value, and turn it all into a k8s secret. Be careful with introducing trailing newline characters; following the steps below ensures none end up in your secrets. First, perform the following to create the mandatory secret values:
 
 ```console
 mkdir concourse-secrets
@@ -194,23 +194,26 @@ ssh-keygen -t rsa -f worker-key  -N ''
 mv worker-key.pub worker-key-pub
 ssh-keygen -t rsa -f session-signing-key  -N ''
 rm session-signing-key.pub
-printf "%s" "concourse" > basic-auth-username
-printf "%s" "$(openssl rand -base64 24)" > basic-auth-password
+printf "%s:%s" "concourse" "$(openssl rand -base64 24)" > local-users
 ```
 
-You'll also need to create/copy secret values for optional features. See [templates/secrets.yaml](templates/secrets.yaml) for possible values. In the example below, we are not using the [PostgreSQL](#postgresql) chart dependency, and so we must set a `postgresql-uri` secret.
+You'll also need to create/copy secret values for optional features. See [templates/secrets.yaml](templates/secrets.yaml) for possible values. In the example below, we are not using the [PostgreSQL](#postgresql) chart dependency, and so we must set `postgresql-user` and `postgresql-password` secrets.
 
 ```console
-# copy a posgres URI to clipboard and paste it to file
-printf "%s" "$(pbpaste)" > postgresql-uri
+# copy a posgres user to clipboard and paste it to file
+printf "%s" "$(pbpaste)" > postgresql-user
+# copy a posgres password to clipboard and paste it to file
+printf "%s" "$(pbpaste)" > postgresql-password
+
 # copy Github client id and secrets to clipboard and paste to files
-printf "%s" "$(pbpaste)" > github-auth-client-id
-printf "%s" "$(pbpaste)" > github-auth-client-secret
+printf "%s" "$(pbpaste)" > github-client-id
+printf "%s" "$(pbpaste)" > github-client-secret
+
 # set an encryption key for DB encryption at rest
 printf "%s" "$(openssl rand -base64 24)" > encryption-key
 ```
 
-Then create a secret called [release-name]-concourse from all the secret value files in the current folder:
+Then create a secret called `[release-name]-concourse` from all the secret value files in the current folder:
 
 ```console
 kubectl create secret generic my-release-concourse --from-file=.
@@ -247,7 +250,7 @@ persistence:
     size: "20Gi"
 ```
 
-It is highly recommended to use Persistent Volumes for Concourse Workers; otherwise the container images managed by the Worker are stored in an `emptyDir` volume on the node's disk. This will interfere with k8s ImageGC and the node's disk will fill up as a result. This will be fixed in a future release of k8s: https://github.com/kubernetes/kubernetes/pull/57020
+It is highly recommended to use Persistent Volumes for Concourse Workers; otherwise, the container images managed by the Worker are stored in an `emptyDir` volume on the node's disk. This will interfere with k8s ImageGC and the node's disk will fill up as a result. This will be fixed in a future release of k8s: https://github.com/kubernetes/kubernetes/pull/57020
 
 ### Ingress TLS
 
@@ -290,15 +293,12 @@ web:
 
 ### PostgreSQL
 
-By default, this chart will use a PostgreSQL database deployed as a chart dependency, with default values for username, password, and database name. These can be modified by setting the `postgresql.*` values.
+By default, this chart uses a PostgreSQL database deployed as a chart dependency, with default values for username, password, and database name. These can be modified by setting the `postgresql.*` values.
 
-You can also bring your own PostgreSQL. To do so, set `postgresql.enabled` to false. You'll then need to specify the full uri to the database, including the username and password, e.g. `postgres://concourse:changeme@my-postgres.com:5432/concourse?sslmode=require`. You can do this one of two ways:
+You can also bring your own PostgreSQL. To do so, set `postgresql.enabled` to false, and then configure Concourse's `postgres` values (`concourse.web.postgres.*`).
 
-1. Set `secrets.postgresqlUri` in your values
+Note that some values get set in the form of secrets, like `postgresql-user`, `postgresql-password`, and others (see [templates/secrets.yaml](templates/secrets.yaml) for possible values and the [secrets section](#secrets) on this README for guidance on how to set those secrets).
 
-2. Set `postgresql-uri` in your release's secrets as described in [Secrets](#secrets).
-
-The only way to completely avoid putting secrets in Helm is to bring your own PostgreSQL, and use option 2 above.
 
 ### Credential Management
 
@@ -306,9 +306,11 @@ Pipelines usually need credentials to do things. Concourse supports the use of a
 
 #### Kubernetes Secrets
 
-By default, this chart will use Kubernetes Secrets as a credential manager. For a given Concourse *team*, a pipeline will look for secrets in a namespace named `[namespacePrefix][teamName]`. The namespace prefix is the release name hyphen by default, and can be overridden with the value `credentialManager.kubernetes.namespacePrefix`. Each team listed under `credentialManager.kubernetes.teams` will have a namespace created for it, and the namespace will remain after deletion of the release unless you set `credentialManager.kubernetes.keepNamespace` to `false`. By default, a namespace will be created for the `main` team.
+By default, this chart uses Kubernetes Secrets as a credential manager. 
 
-The service account used by Concourse must have `get` access to secrets in that namespace. When `rbac.create` is true, this access is granted for each team listed under `credentialManager.kubernetes.teams`.
+For a given Concourse *team*, a pipeline looks for secrets in a namespace named `[namespacePrefix][teamName]`. The namespace prefix is the release name followed by a hyphen by default, and can be overridden with the value `concourse.web.kubernetes.namespacePrefix`. Each team listed under `concourse.web.kubernetes.teams` will have a namespace created for it, and the namespace remains after deletion of the release unless you set `concourse.web.kubernetes.keepNamespace` to `false`. By default, a namespace will be created for the `main` team.
+
+The service account used by Concourse must have `get` access to secrets in that namespace. When `rbac.create` is true, this access is granted for each team listed under `concourse.web.kubernetes.teams`.
 
 Here are some examples of the lookup heuristics, given release name `concourse`:
 
@@ -351,37 +353,36 @@ jobs:
 
 #### Hashicorp Vault
 
-To use Vault, set `credentialManager.kubernetes.enabled` to false, and set the following values:
+To use Vault, set `concourse.web.kubernetes.enabled` to false, and set the following values:
 
 
 ```yaml
 ## Configuration values for the Credential Manager.
 ## ref: https://concourse-ci.org/creds.html
 ##
-credentialManager:
+concourse:
+  web:
+    vault:
+      ## Use Hashicorp Vault for the Credential Manager.
+      ##
+      enabled: false
 
-  vault:
-    ## Use Hashicorp Vault for the Credential Manager.
-    ##
-    enabled: false
+      ## URL pointing to vault addr (i.e. http://vault:8200).
+      ##
+      # url:
 
-    ## URL pointing to vault addr (i.e. http://vault:8200).
-    ##
-    # url:
-
-    ## vault path under which to namespace credential lookup, defaults to /concourse.
-    ##
-    # pathPrefix:
-
+      ## vault path under which to namespace credential lookup, defaults to /concourse.
+      ##
+      # pathPrefix:
 ```
 
 #### AWS Systems Manager Parameter Store (SSM)
 
-To use SSM, set `credentialManager.kubernetes.enabled` to false, and set `credentialManager.ssm.enabled` to true.
+To use SSM, set `concourse.web.kubernetes.enabled` to false, and set `concourse.web.awsSsm.enabled` to true.
 
-For a given Concourse *team*, a pipeline will look for secrets in SSM using either `/concourse/{team}/{secret}` or `/concourse/{team}/{pipeline}/{secret}`; the patterns can be overridden using the `credentialManager.ssm.teamSecretTemplate` and `credentialManager.ssm.pipelineSecretTemplate` settings.
+For a given Concourse *team*, a pipeline looks for secrets in SSM using either `/concourse/{team}/{secret}` or `/concourse/{team}/{pipeline}/{secret}`; the patterns can be overridden using the `concourse.web.awsSsm.teamSecretTemplate` and `concourse.web.awsSsm.pipelineSecretTemplate` settings.
 
-Concourse requires AWS credentials which are able to read from SSM for this feature to function. Credentials can be set in the `secrets.awsSsm*` settings; if your cluster is running in a different AWS region, you may also need to set `credentialManager.ssm.region`.
+Concourse requires AWS credentials which are able to read from SSM for this feature to function. Credentials can be set in the `secrets.awsSsm*` settings; if your cluster is running in a different AWS region, you may also need to set `concourse.web.awsSsm.region`.
 
 The minimum IAM policy you need to use SSM with Concourse is:
 
@@ -403,15 +404,15 @@ The minimum IAM policy you need to use SSM with Concourse is:
 }
 ```
 
-Where `<kms-key-arn>` is the ARN of the KMS key used to encrypt the secrets in Paraemter Store, and the `<...arn...>` should be replaced with a correct ARN for your account and region's Parameter Store.
+Where `<kms-key-arn>` is the ARN of the KMS key used to encrypt the secrets in Parameter Store, and the `<...arn...>` should be replaced with a correct ARN for your account and region's Parameter Store.
 
 #### AWS Secrets Manager
 
-To use Secrets Manager, set `credentialManager.kubernetes.enabled` to false, and set `credentialManager.awsSecretsManager.enabled` to true.
+To use Secrets Manager, set `concourse.web.kubernetes.enabled` to false, and set `concourse.web.awsSecretsManager.enabled` to true.
 
-For a given Concourse *team*, a pipeline will look for secrets in Secrets Manager using either `/concourse/{team}/{secret}` or `/concourse/{team}/{pipeline}/{secret}`; the patterns can be overridden using the `credentialManager.awsSecretsManager.teamSecretTemplate` and `credentialManager.awsSecretsManager.pipelineSecretTemplate` settings.
+For a given Concourse *team*, a pipeline looks for secrets in Secrets Manager using either `/concourse/{team}/{secret}` or `/concourse/{team}/{pipeline}/{secret}`; the patterns can be overridden using the `concourse.web.awsSecretsManager.teamSecretTemplate` and `concourse.web.awsSecretsManager.pipelineSecretTemplate` settings.
 
-Concourse requires AWS credentials which are able to read from Secrets Manager for this feature to function. Credentials can be set in the `secrets.awsSecretsmanager*` settings; if your cluster is running in a different AWS region, you may also need to set `credentialManager.awsSecretsManager.region`.
+Concourse requires AWS credentials which are able to read from Secrets Manager for this feature to function. Credentials can be set in the `secrets.awsSecretsmanager*` settings; if your cluster is running in a different AWS region, you may also need to set `concourse.web.awsSecretsManager.region`.
 
 The minimum IAM policy you need to use Secrets Manager with Concourse is:
 

--- a/stable/concourse/templates/NOTES.txt
+++ b/stable/concourse/templates/NOTES.txt
@@ -34,11 +34,35 @@
     {{- end }}
   {{- end }}
 * If this is your first time using Concourse, follow the tutorials at https://concourse-ci.org/tutorials.html
+
 {{- if contains "naive" .Values.concourse.worker.baggageclaim.driver }}
 
 *******************
 ******WARNING******
 *******************
 
-You are using the "naive" baggage claim driver, which is also the default value for this chart. This is the default for compatibility reasons, but is very space inefficient, and should be changed to either "btrfs" (recommended) or "overlay" depending on that filesystem's support in the Linux kernel your cluster is using. Please see https://github.com/concourse/concourse/issues/1230 and https://github.com/concourse/concourse/issues/1966 for background.
+You are using the "naive" baggage claim driver, which is also the default value for this chart. 
+
+This is the default for compatibility reasons, but is very space inefficient, and should be changed to either "btrfs" (recommended) or "overlay" depending on that filesystem's support in the Linux kernel your cluster is using. 
+
+Please see https://github.com/concourse/concourse/issues/1230 and https://github.com/concourse/concourse/issues/1966 for background.
+
+{{- end }}
+
+
+
+{{- if .Values.concourse.web.localAuth.enabled }}
+{{- if contains "test:test" .Values.secrets.localUsers }}
+
+*******************
+******WARNING******
+*******************
+
+You're using the default "test" user with the default "test" password.
+
+Make sure you either disable local auth or change the combination to something more secure, preferably specifying a password in the bcrypted form.
+
+Please see `README.md` for examples.
+
+{{- end }}
 {{- end }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1031,8 +1031,8 @@ rbac:
 ##
 secrets:
 
-  ## List of username:bcrypted_password combinations for all your local concourse users.
-  localUsers: "test:$2a$10$sDB6AsH2HheOWHILrnHVJOCZq/GYtUYE02ypJJTQBmWJNivYNhP3y"
+  ## List of username:password or username:bcrypted_password combinations for all your local concourse users.
+  localUsers: "test:test"
   ## Create the secret resource from the following values. Set this to
   ## false to manage these secrets outside Helm.
   ##


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR improves:

- notes regarding the use of the default `test:test` default user; and
- README instructions
  - so that we don't use the future tense too much; and
  - so that the instructions regarding credential management match the actual `values.yml` structure.

It also incorporates the corrections made by #9949. 

#### Special notes for your reviewer:

The `notes` generation can be tested by running `helm template`:

```sh
# Running with the default values, outputs the warning
helm template ./ --notes -x templates/NOTES.txt | grep "WARNING" | wc -l
2

# With something that is not the default user, outputs just one warning (the one about naive):
helm template --set secrets.localUsers=this:that . --notes -x templates/NOTES.txt  | grep "WARNING" | wc -l
1
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

cc @william-tran 