### PR TITLE
[stable/spinnaker] make spinnaker work behind GCE ingress

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.2.1
+version: 1.3.0
 appVersion: 1.11.6
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/hooks/cleanup.yaml
+++ b/stable/spinnaker/templates/hooks/cleanup.yaml
@@ -23,6 +23,7 @@ spec:
       containers:
       - name: halyard-install
         image: {{ .Values.halyard.image.repository }}:{{ .Values.halyard.image.tag }}
+        imagePullPolicy: {{ .Values.halyard.image.pullPolicy }}
         volumeMounts:
         - name: halyard-config
           mountPath: /opt/halyard/scripts

--- a/stable/spinnaker/templates/hooks/expose-nodeports.yaml
+++ b/stable/spinnaker/templates/hooks/expose-nodeports.yaml
@@ -26,6 +26,7 @@ spec:
       containers:
       - name: patch-services
         image: {{ .Values.halyard.image.repository }}:{{ .Values.halyard.image.tag }}
+        imagePullPolicy: {{ .Values.halyard.image.pullPolicy }}
         command:
         - bash
         - -c

--- a/stable/spinnaker/templates/hooks/install-using-hal.yaml
+++ b/stable/spinnaker/templates/hooks/install-using-hal.yaml
@@ -61,6 +61,7 @@ spec:
       containers:
       - name: halyard-install
         image: {{ .Values.halyard.image.repository }}:{{ .Values.halyard.image.tag }}
+        imagePullPolicy: {{ .Values.halyard.image.pullPolicy }}
         volumeMounts:
         - name: halyard-config
           mountPath: /opt/halyard/scripts

--- a/stable/spinnaker/templates/ingress/deck.yaml
+++ b/stable/spinnaker/templates/ingress/deck.yaml
@@ -14,9 +14,18 @@ spec:
   - host: {{ .Values.ingress.host | quote }}
     http:
       paths:
-      - backend:
-          serviceName: spin-deck
-          servicePort: 9000
+      {{- if index $.Values.ingress "annotations" }}
+        {{- if eq (index $.Values.ingress.annotations "kubernetes.io/ingress.class" | default "") "gce" "alb" }}
+        - path: /*
+        {{- else }}{{/* Has annotations but ingress class is not "gce" nor "alb" */}}
+        - path: /
+        {{- end }}
+      {{- else}}{{/* Has no annotations */}}
+        - path: /
+      {{- end }}
+          backend:
+            serviceName: spin-deck
+            servicePort: 9000
 {{- if .Values.ingress.tls }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}

--- a/stable/spinnaker/templates/ingress/deck.yaml
+++ b/stable/spinnaker/templates/ingress/deck.yaml
@@ -14,8 +14,7 @@ spec:
   - host: {{ .Values.ingress.host | quote }}
     http:
       paths:
-      - path: /
-        backend:
+      - backend:
           serviceName: spin-deck
           servicePort: 9000
 {{- if .Values.ingress.tls }}

--- a/stable/spinnaker/templates/ingress/gate.yaml
+++ b/stable/spinnaker/templates/ingress/gate.yaml
@@ -14,9 +14,19 @@ spec:
   - host: {{ .Values.ingressGate.host | quote }}
     http:
       paths:
-      - backend:
-          serviceName: spin-gate
-          servicePort: 8084
+      {{- if index $.Values.ingress "annotations" }}
+        {{- if eq (index $.Values.ingress.annotations "kubernetes.io/ingress.class" | default "") "gce" "alb" }}
+        - path: /*
+        {{- else }}{{/* Has annotations but ingress class is not "gce" nor "alb" */}}
+        - path: /
+        {{- end }}
+      {{- else}}{{/* Has no annotations */}}
+        - path: /
+      {{- end }}
+      backend:
+        serviceName: spin-gate
+        servicePort: 8084
+
 {{- if .Values.ingressGate.tls }}
   tls:
 {{ toYaml .Values.ingressGate.tls | indent 4 }}

--- a/stable/spinnaker/templates/ingress/gate.yaml
+++ b/stable/spinnaker/templates/ingress/gate.yaml
@@ -23,9 +23,9 @@ spec:
       {{- else}}{{/* Has no annotations */}}
         - path: /
       {{- end }}
-      backend:
-        serviceName: spin-gate
-        servicePort: 8084
+          backend:
+            serviceName: spin-gate
+            servicePort: 8084
 
 {{- if .Values.ingressGate.tls }}
   tls:

--- a/stable/spinnaker/templates/ingress/gate.yaml
+++ b/stable/spinnaker/templates/ingress/gate.yaml
@@ -14,8 +14,7 @@ spec:
   - host: {{ .Values.ingressGate.host | quote }}
     http:
       paths:
-      - path: /
-        backend:
+      - backend:
           serviceName: spin-gate
           servicePort: 8084
 {{- if .Values.ingressGate.tls }}

--- a/stable/spinnaker/templates/statefulsets/halyard.yaml
+++ b/stable/spinnaker/templates/statefulsets/halyard.yaml
@@ -28,6 +28,7 @@ spec:
       initContainers:
       - name: "create-halyard-local"
         image: {{ .Values.halyard.image.repository }}:{{ .Values.halyard.image.tag }}
+        imagePullPolicy: {{ .Values.halyard.image.pullPolicy }}
         command:
         - bash
         - -c
@@ -37,9 +38,12 @@ spec:
           printf 'server.address: 0.0.0.0\n' > /tmp/config/halyard-local.yml && \
           # Use Redis deployed via the dependent Helm chart
           mkdir -p /tmp/spinnaker/.hal/default/service-settings && \
-          printf 'overrideBaseUrl: redis://:{{ .Values.redis.password }}@{{ .Release.Name }}-redis-master:6379\nskipLifeCycleManagement: true\n' > /tmp/spinnaker/.hal/default/service-settings/redis.yml && \
+          printf 'overrideBaseUrl: redis://:{{ .Values.redis.password }}@{{ .Release.Name }}-redis-master:6379\nskipLifeCycleManagement: true\n' > /tmp/spinnaker/.hal/default/service-settings/redis.yml
           # Route the /gate path of Deck to Gate
           printf 'env:\n  API_HOST: http://spin-gate.{{ .Release.Namespace }}:8084/\n' > /tmp/spinnaker/.hal/default/service-settings/deck.yml
+          # set gate profile to work behind a TLS LB/Proxy
+          # see https://github.com/spinnaker/spinnaker/issues/1630
+          printf '\nserver:\n  tomcat:\n    protocolHeader: X-Forwarded-Proto\n    remoteIpHeader: X-Forwarded-For\n    internalProxies: .*\n    httpsServerPort: X-Forwarded-Port\n' > /tmp/spinnaker/.hal/default/profiles/gate-local.yml
         volumeMounts:
         - name: halyard-config
           mountPath: /tmp/config
@@ -87,6 +91,7 @@ spec:
       containers:
       - name: halyard
         image: {{ .Values.halyard.image.repository }}:{{ .Values.halyard.image.tag }}
+        imagePullPolicy: {{ .Values.halyard.image.pullPolicy }}
         ports:
         - containerPort: 8064
           name: daemon

--- a/stable/spinnaker/templates/statefulsets/halyard.yaml
+++ b/stable/spinnaker/templates/statefulsets/halyard.yaml
@@ -43,6 +43,7 @@ spec:
           printf 'env:\n  API_HOST: http://spin-gate.{{ .Release.Namespace }}:8084/\n' > /tmp/spinnaker/.hal/default/service-settings/deck.yml
           # set gate profile to work behind a TLS LB/Proxy
           # see https://github.com/spinnaker/spinnaker/issues/1630
+          mkdir -p /tmp/spinnaker/.hal/default/profiles
           printf '\nserver:\n  tomcat:\n    protocolHeader: X-Forwarded-Proto\n    remoteIpHeader: X-Forwarded-For\n    internalProxies: .*\n    httpsServerPort: X-Forwarded-Port\n' > /tmp/spinnaker/.hal/default/profiles/gate-local.yml
         volumeMounts:
         - name: halyard-config

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -3,6 +3,7 @@ halyard:
   image:
     repository: gcr.io/spinnaker-marketplace/halyard
     tag: 1.13.1
+    pullPolicy: IfNotPresent
   # Provide a config map with Hal commands that will be run the core config (storage)
   # The config map should contain a script in the config.sh key
   additionalScripts:


### PR DESCRIPTION
I've been installing spinnaker into a GCE based kubernetes environment and had to make a few changes for it to function correctly behind a ingress controller there.

* Allow setting a imagePullPolicy
* removed / path rule as we only have the one service behind each ingress anyways, was causing some confusing for my gce LBs
* update tomcat server profile to get scheme from LB ( see https://github.com/spinnaker/spinnaker/issues/1630 )



#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
