### PR TITLE
[stable/nginx-ingress] Modifies PSP to allow for hostNetwork if enabled for controller

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 1.1.4
+version: 1.1.5
 appVersion: 0.21.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/podsecuritypolicy.yaml
+++ b/stable/nginx-ingress/templates/podsecuritypolicy.yaml
@@ -20,7 +20,7 @@ spec:
     #- 'projected'
     - 'secret'
     #- 'downwardAPI'
-  hostNetwork: false
+  hostNetwork: {{ .Values.controller.hostNetwork }}
   hostIPC: false
   hostPID: false
   runAsUser:


### PR DESCRIPTION
Signed-off-by: Belmin Fernandez <belminf@gmail.com>

#### What this PR does / why we need it:
Current PSP disallows `hostNetwork` despite the fact that we could enable `hostNetwork` for the controller resource via `.Values.controller.hostNetwork`.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
