### PR TITLE
add collabora-code chart

### DIFF
--- a/stable/collabora-code/.helmignore
+++ b/stable/collabora-code/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/collabora-code/Chart.yaml
+++ b/stable/collabora-code/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+appVersion: "4.0.0.2"
+description: A Helm chart for Collabora Office - CODE-Edition
+name: collabora-code
+version: 1.0.0
+icon: https://avatars0.githubusercontent.com/u/22418908?s=200&v=4
+sources:
+- https://github.com/CollaboraOnline/Docker-CODE
+maintainers:
+- name: Christian
+  email: christian.ingenhaag@googlemail.com

--- a/stable/collabora-code/Chart.yaml
+++ b/stable/collabora-code/Chart.yaml
@@ -9,3 +9,4 @@ sources:
 maintainers:
 - name: Christian
   email: christian.ingenhaag@googlemail.com
+home: https://www.collaboraoffice.com/code/

--- a/stable/collabora-code/OWNERS
+++ b/stable/collabora-code/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- chrisingenhaag
+reviewers:
+- chrisingenhaag

--- a/stable/collabora-code/README.md
+++ b/stable/collabora-code/README.md
@@ -1,0 +1,87 @@
+# Collabora CODE
+
+[Collabora](https://www.collaboraoffice.com/code/) is a online office suite.
+
+## Introduction
+
+This chart creates a single Collabora CODE Pod to run Collabora CODE suite, for example as integration together with nextcloud. Installation is based on the docker documentation [CollaboraDocker](https://www.collaboraoffice.com/code/docker/).
+
+For most easy integration it´s recommended to use cert-manager together with your favorite ingress controller to get a fully working, ssl-terminated Collabora CODE server.
+
+## Prerequisites
+
+- Kubernetes 1.4+ with Beta APIs enabled
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`, run:
+
+```bash
+$ helm install --name my-release stable/collabora
+```
+
+This command deploys a Collabora Online Development Edition server.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+Refer to [values.yaml](values.yaml) for the full run-down on defaults. These are a mixture of Kubernetes and Collabora-related directives that map to environment variables in the [CollaboraCODEDocker](https://github.com/CollaboraOnline/Docker-CODE) Docker image.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name my-release \
+    --set varname=true stable/collabora
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/collabora
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+The following tables lists the configurable parameters of this chart and their default values.
+
+| Parameter                                         | Description                                                   | Default                                                     |
+| ------------------------------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------- |
+| `replicaCount`                                    | Number of provisioner instances to deployed                   | `1`                                                         |
+| `strategy`                                        | Specifies the strategy used to replace old Pods by new ones   | `Recreate`                                                  |
+| `image.repository`                                | Provisioner image                                             | `collabora/code`                                            |
+| `image.tag`                                       | Version of provisioner image                                  | `4.0.0.2`                                                   |
+| `image.pullPolicy`                                | Image pull policy                                             | `IfNotPresent`                                              |
+| `collabora.DONT_GEN_SSL_CERT`                     |                                                               | `true`                                                      |
+| `collabora.domain`                                | Double escaped WOPI host                                      | `wopihost\\.domain`                                         |
+| `collabora.extra_params`                          | List of params to use as env var                              | `--o:ssl.termination=true --o:ssl.enable=false`             |
+| `collabora.server_name`                           | Collabora server name (single escaped)                        | `collabora\.domain`                                         |
+| `collabora.password`                              | Collabora admin panel pass                                    | `examplepass`                                               |
+| `collabora.username`                              | Collabora admin panel user                                    | `admin`                                                     |
+| `collabora.dictionaries`                          | Collabora enabled dictionaries                                | `de_DE en_GB en_US es_ES fr_FR it nl pt_BR pt_PT ru`        |
+| `ingress.enabled`                                 |                                                               | `false`                                                     |
+| `ingress.annotations`                             |                                                               | `{}`                                                        |
+| `ingress.paths`                                   |                                                               | `[]`                                                        |
+| `ingress.hosts`                                   |                                                               | `[]`                                                        |
+| `ingress.tls`                                     |                                                               | `[]`                                                        |
+| `securityContext.allowPrivilegeEscalation`	    | Create & use Pod Security Policy resources                    | `true`						                              |
+| `securitycontext.capabilities.add`                | Collabora needs to run with MKNOD as capabibility             | `[MKNOD]`                                                   |
+| `resources`                                       | Resources required (e.g. CPU, memory)                         | `{}`                                                        |
+| `nodeSelector`                                    | Node labels for pod assignment                                | `{}`                                                        |
+| `affinity`                                        | Affinity settings                                             | `{}`                                                        |
+| `tolerations`                                     | List of node taints to tolerate                               | `[]`                                                        |
+
+
+## Persistence
+
+There is no need for a persistent storage to run collabora code edition. All parameters in `/etc/loolwsd/loolwsd.xml` can be adjusted with using extra_params environment variable.

--- a/stable/collabora-code/README.md
+++ b/stable/collabora-code/README.md
@@ -10,7 +10,7 @@ For most easy integration it´s recommended to use cert-manager together with yo
 
 ## Prerequisites
 
-- Kubernetes 1.4+ with Beta APIs enabled
+- Kubernetes 1.9+ with Beta APIs enabled
 
 ## Installing the Chart
 

--- a/stable/collabora-code/templates/NOTES.txt
+++ b/stable/collabora-code/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range $.Values.ingress.paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "collabora-code.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ include "collabora-code.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "collabora-code.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "collabora-code.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:9980 to use your application"
+  kubectl port-forward $POD_NAME 9980:9980
+{{- end }}

--- a/stable/collabora-code/templates/_helpers.tpl
+++ b/stable/collabora-code/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "collabora-code.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "collabora-code.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "collabora-code.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/collabora-code/templates/configmap.yaml
+++ b/stable/collabora-code/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "collabora-code.fullname" . }}
+data:
+  DONT_GEN_SSL_CERT: "{{ .Values.collabora.DONT_GEN_SSL_CERT }}"
+  dictionaries: {{ .Values.collabora.dictionaries }}
+  domain: {{ .Values.collabora.domain }}
+  extra_params: {{ .Values.collabora.extra_params }}
+  server_name: {{ .Values.collabora.server_name }}

--- a/stable/collabora-code/templates/deployment.yaml
+++ b/stable/collabora-code/templates/deployment.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "collabora-code.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "collabora-code.name" . }}
+    helm.sh/chart: {{ include "collabora-code.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.strategy }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "collabora-code.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "collabora-code.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: DONT_GEN_SSL_CERT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "collabora-code.fullname" . }}
+                  key: DONT_GEN_SSL_CERT
+            - name: dictionaries
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "collabora-code.fullname" . }}
+                  key: dictionaries
+            - name: domain
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "collabora-code.fullname" . }}
+                  key: domain
+            - name: extra_params
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "collabora-code.fullname" . }}
+                  key: extra_params
+            - name: server_name
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "collabora-code.fullname" . }}
+                  key: server_name
+            - name: username
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "collabora-code.fullname" . }}
+                  key: username
+            - name: password
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "collabora-code.fullname" . }}
+                  key: password
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securitycontext | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/stable/collabora-code/templates/deployment.yaml
+++ b/stable/collabora-code/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
             failureThreshold: 3
             httpGet:
               path: /
-              port: {{ .Values.service.port }}
+              port: http
               scheme: HTTP
             initialDelaySeconds: 30
             periodSeconds: 10
@@ -75,14 +75,15 @@ spec:
             failureThreshold: 3
             httpGet:
               path: /
-              port: {{ .Values.service.port }}
+              port: http
               scheme: HTTP
             initialDelaySeconds: 30
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 2
           ports:
-            - containerPort: {{ .Values.service.port }}
+            - name: http
+              containerPort: {{ .Values.service.port }}
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/stable/collabora-code/templates/deployment.yaml
+++ b/stable/collabora-code/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
             failureThreshold: 3
             httpGet:
               path: /
-              port: http
+              port: {{ .Values.service.port }}
               scheme: HTTP
             initialDelaySeconds: 30
             periodSeconds: 10
@@ -75,15 +75,14 @@ spec:
             failureThreshold: 3
             httpGet:
               path: /
-              port: http
+              port: {{ .Values.service.port }}
               scheme: HTTP
             initialDelaySeconds: 30
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 2
           ports:
-            - name: http
-              containerPort: {{ .Values.service.port }}
+            - containerPort: {{ .Values.service.port }}
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/stable/collabora-code/templates/ingress.yaml
+++ b/stable/collabora-code/templates/ingress.yaml
@@ -30,11 +30,11 @@ spec:
     - host: {{ . | quote }}
       http:
         paths:
-	{{- range $ingressPaths }}
+  {{- range $ingressPaths }}
           - path: {{ . }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: http
-	{{- end }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/stable/collabora-code/templates/ingress.yaml
+++ b/stable/collabora-code/templates/ingress.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "collabora-code.fullname" . -}}
+{{- $ingressPaths := .Values.ingress.paths -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "collabora-code.name" . }}
+    helm.sh/chart: {{ include "collabora-code.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+	{{- range $ingressPaths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+	{{- end }}
+  {{- end }}
+{{- end }}

--- a/stable/collabora-code/templates/ingress.yaml
+++ b/stable/collabora-code/templates/ingress.yaml
@@ -34,7 +34,7 @@ spec:
           - path: {{ . }}
             backend:
               serviceName: {{ $fullName }}
-              servicePort: http
+              servicePort: {{ .Values.service.port }}
 	{{- end }}
   {{- end }}
 {{- end }}

--- a/stable/collabora-code/templates/ingress.yaml
+++ b/stable/collabora-code/templates/ingress.yaml
@@ -34,7 +34,7 @@ spec:
           - path: {{ . }}
             backend:
               serviceName: {{ $fullName }}
-              servicePort: {{ .Values.service.port }}
+              servicePort: http
 	{{- end }}
   {{- end }}
 {{- end }}

--- a/stable/collabora-code/templates/secret.yaml
+++ b/stable/collabora-code/templates/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "collabora-code.fullname" . }}
+data:
+  username: {{ .Values.collabora.username | b64enc }}
+  password: {{ .Values.collabora.password | b64enc }}

--- a/stable/collabora-code/templates/service.yaml
+++ b/stable/collabora-code/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "collabora-code.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "collabora-code.name" . }}
+    helm.sh/chart: {{ include "collabora-code.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "collabora-code.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/collabora-code/templates/service.yaml
+++ b/stable/collabora-code/templates/service.yaml
@@ -11,9 +11,8 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: {{ .Values.service.port }}
       protocol: TCP
-      name: http
   selector:
     app.kubernetes.io/name: {{ include "collabora-code.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/collabora-code/templates/service.yaml
+++ b/stable/collabora-code/templates/service.yaml
@@ -11,8 +11,9 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.port }}
+      targetPort: http
       protocol: TCP
+      name: http
   selector:
     app.kubernetes.io/name: {{ include "collabora-code.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/collabora-code/templates/tests/test-connection.yaml
+++ b/stable/collabora-code/templates/tests/test-connection.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "collabora-code.fullname" . }}-test-connection"
+  labels:
+    app.kubernetes.io/name: {{ include "collabora-code.name" . }}
+    helm.sh/chart: {{ include "collabora-code.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ include "collabora-code.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/stable/collabora-code/values.yaml
+++ b/stable/collabora-code/values.yaml
@@ -1,0 +1,55 @@
+# Default values for collabora-code.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: collabora/code
+  tag: 4.0.0.2
+  pullPolicy: IfNotPresent
+
+strategy: Recreate
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 9980
+
+ingress:
+  enabled: false
+  annotations: {}
+  paths: []
+  hosts: []
+  tls: []
+
+collabora:
+  DONT_GEN_SSL_CERT: true
+  domain: nextcloud\\.domain
+  extra_params: --o:ssl.termination=true --o:ssl.enable=false
+  server_name: collabora\.domain
+  password: examplepass
+  username: admin
+  dictionaries: de_DE en_GB en_US es_ES fr_FR it nl pt_BR pt_PT ru
+
+securitycontext:
+  allowPrivilegeEscalation: true
+  capabilities:
+    add:
+    - MKNOD
+
+resources: {}
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Signed-off-by: Christian Ingenhaag <christian.ingenhaag@googlemail.com>

#### What this PR does / why we need it:

Adds easy deployment for collabora online office suite developer edition in order to run is in kubernetes.

#### Special notes for your reviewer:

* Additionally to the OK message given at port 9980 you should be able to log in at http://localhost:9980/loleaflet/dist/admin/admin.html with the default credentials from values.yaml
* Valid SSL Termination is kind of mandatory for a fully working integation of collabora with a wopi compatible solution like nextcloud for example. But it´s user dependent which ingress system one wants to use or if an kubernetes-external ssl-termination is provided

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
