### PR TITLE
[stable/concourse] Allow namespace creation independently of rbac

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 3.7.1
+version: 3.7.2
 appVersion: 4.2.2
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/namespace.yaml
+++ b/stable/concourse/templates/namespace.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.concourse.web.kubernetes.enabled -}}
+{{- if and .Values.concourse.web.kubernetes.enabled .Values.concourse.web.kubernetes.createTeamNamespaces -}}
 {{- range .Values.concourse.web.kubernetes.teams }}
 ---
 apiVersion: v1

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -121,8 +121,11 @@ concourse:
       teams:
         - main
 
-      ## When true, namespaces are not deleted when the release is deleted.
+      ## Create the Kubernetes namespace for each team listed above.
+      createTeamNamespaces: true
 
+      ## When true, namespaces are not deleted when the release is deleted.
+      ## Irrelevant if the namespaces are not created by this chart.
       keepNamespaces: true
 
       ## Path to Kubernetes config when running ATC outside Kubernetes.


### PR DESCRIPTION
#### What this PR does / why we need it:

At the moment, when defining `concourse.web.kubernetes.teams`, the helm
chart will take care of namespace generation. Although this is very
useful in most cases, we believe some people may find it problematic.

Our use case, is to create the namespaces ahead of time and fill them
with `Pipeline` type resources defining Concourse pipelines. These are
then picked by our `pipeline-operator` and continuously applied to
Concourse for specific teams.

A hacky way around it, would be to set the
`concourse.web.kubernetes.teams` value to an empty array, and create the
role bindings manually. It feels a little like cheating, and a cleaner
way to accomplish that would be to have a separate flag responsible for
namespace creation in the Concourse helm chart.

#### Special notes for your reviewer:

- Code review should be sufficient
- Optionally, run:
  ```
  mkdir out
  helm template . --output-dir out --set concourse.web.kubernetes.createTeamNamespaces=false
  # expect no `namespace.yaml` file
  helm template . --output-dir out ### --set concourse.web.kubernetes.createTeamNamespaces=true
  # expect `namespace.yaml` file
  ```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [ ] ~~Variables are documented in the README.md~~
  - Do I need it? I cannot find the `concourse.web.kubernetes.teams` there...
