### PR TITLE
[stable/keycloak] Update postgresql chart version for podsecuritypolicy support

### DIFF
--- a/stable/keycloak/Chart.yaml
+++ b/stable/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 4.3.0
+version: 4.4.0
 appVersion: 4.8.3.Final
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/stable/keycloak/README.md
+++ b/stable/keycloak/README.md
@@ -95,9 +95,9 @@ Parameter | Description | Default
 `keycloak.persistence.dbPort` | The database host port (if `deployPostgres=false`) | `5432`
 `keycloak.persistence.dbUser` |The database user (if `deployPostgres=false`) | `keycloak`
 `keycloak.persistence.dbPassword` |The database password (if `deployPostgres=false`) | `""`
-`postgresql.postgresUser` | The PostgreSQL user (if `keycloak.persistence.deployPostgres=true`) | `keycloak`
-`postgresql.postgresPassword` | The PostgreSQL password (if `keycloak.persistence.deployPostgres=true`) | `""`
-`postgresql.postgresDatabase` | The PostgreSQL database (if `keycloak.persistence.deployPostgres=true`) | `keycloak`
+`postgresql.postgresqlUsername` | The PostgreSQL user (if `keycloak.persistence.deployPostgres=true`) | `keycloak`
+`postgresql.postgresqlPassword` | The PostgreSQL password (if `keycloak.persistence.deployPostgres=true`) | `nil`
+`postgresql.postgresqlDatabase` | The PostgreSQL database (if `keycloak.persistence.deployPostgres=true`) | `keycloak`
 `test.image.repository` | Test image repository | `unguiculus/docker-python3-phantomjs-selenium`
 `test.image.tag` | Test image tag | `v1`
 `test.image.pullPolicy` | Test image pull policy | `IfNotPresent`

--- a/stable/keycloak/requirements.lock
+++ b/stable/keycloak/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.15.0
-digest: sha256:428d8302be9a566a3e77538af30c56b63e0bfc97dd01dd434f303f4434cb8100
-generated: 2018-07-06T08:41:15.715456938+02:00
+  version: 3.9.2
+digest: sha256:48768e91548bd470d9cc713ca4016498860b16ecedca0f820c34b98d3c6b266c
+generated: 2019-01-22T13:41:59.077536376Z

--- a/stable/keycloak/requirements.yaml
+++ b/stable/keycloak/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: postgresql
-    version: 0.15.0
+    version: 3.9.x
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: keycloak.persistence.deployPostgres

--- a/stable/keycloak/templates/_helpers.tpl
+++ b/stable/keycloak/templates/_helpers.tpl
@@ -76,14 +76,14 @@ Create environment variables for database configuration.
 - name: DB_PORT
   value: "5432"
 - name: DB_DATABASE
-  value: {{ .Values.postgresql.postgresDatabase | quote }}
+  value: {{ .Values.postgresql.postgresqlDatabase | quote }}
 - name: DB_USER
-  value: {{ .Values.postgresql.postgresUser | quote }}
+  value: {{ .Values.postgresql.postgresqlUsername | quote }}
 - name: DB_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ template "keycloak.postgresql.fullname" . }}
-      key: postgres-password
+      key: postgresql-password
 {{- else }}
 - name: DB_VENDOR
   value: {{ .Values.keycloak.persistence.dbVendor | quote }}

--- a/stable/keycloak/values.yaml
+++ b/stable/keycloak/values.yaml
@@ -217,7 +217,7 @@ postgresql:
   ## PostgreSQL Password for the new user.
   ## If not set, a random 10 characters password will be used.
   ##
-  #postgresqlPassword: ""
+  # postgresqlPassword: ""
 
   ## PostgreSQL Database to create.
   ##

--- a/stable/keycloak/values.yaml
+++ b/stable/keycloak/values.yaml
@@ -212,16 +212,16 @@ keycloak:
 postgresql:
   ### PostgreSQL User to create.
   ##
-  postgresUser: keycloak
+  postgresqlUsername: keycloak
 
   ## PostgreSQL Password for the new user.
   ## If not set, a random 10 characters password will be used.
   ##
-  postgresPassword: ""
+  #postgresqlPassword: ""
 
   ## PostgreSQL Database to create.
   ##
-  postgresDatabase: keycloak
+  postgresqlDatabase: keycloak
 
   ## Persistent Volume Storage configuration.
   ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes


### PR DESCRIPTION
Signed-off-by: Bart Verwilst <bart@verwilst.be>

#### What this PR does / why we need it:

When using current required postgresql chart, when deploying on a cluster with podsecuritypolicies enabled:
```
  Normal   Pulling    2m                kubelet, k8s-acc-node01  pulling image "postgres:9.6.2"
  Normal   Pulled     1m                kubelet, k8s-acc-node01  Successfully pulled image "postgres:9.6.2"
  Warning  Failed     2s (x10 over 1m)  kubelet, k8s-acc-node01  Error: container has runAsNonRoot and image will run as root
  Normal   Pulled     2s (x9 over 1m)   kubelet, k8s-acc-node01  Container image "postgres:9.6.2" already present on machine
```
Updating to the latest postgresql chart which runs under a non-privileged user allows us to get a fully working keycloak setup.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
