### PR TITLE
chaoskube: update appVersion to v0.12.1, add logo and keywords

### DIFF
--- a/stable/chaoskube/Chart.yaml
+++ b/stable/chaoskube/Chart.yaml
@@ -1,11 +1,15 @@
 apiVersion: v1
 name: chaoskube
-version: 0.13.0
-appVersion: 0.11.0
+version: 0.14.0
+appVersion: 0.12.1
 description: Chaoskube periodically kills random pods in your Kubernetes cluster.
+icon: https://raw.githubusercontent.com/linki/chaoskube/master/chaoskube.png
 home: https://github.com/linki/chaoskube
 sources:
   - https://github.com/linki/chaoskube
+keywords:
+  - chaos-monkey
+  - chaos-engineering
 maintainers:
 - name: linki
   email: linki+kubernetes.io@posteo.de

--- a/stable/chaoskube/values.yaml
+++ b/stable/chaoskube/values.yaml
@@ -5,7 +5,7 @@ name: chaoskube
 image: quay.io/linki/chaoskube
 
 # docker image tag
-imageTag: v0.11.0
+imageTag: v0.12.1
 
 # number of replicas to run
 replicas: 1


### PR DESCRIPTION
This updates chaoskube to the latest version and also adds a logo for https://kubeapps.com.