### PR TITLE
Datadog helm update

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.16.0
+version: 1.17.0
 appVersion: 6.6.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -160,6 +160,10 @@ spec:
           - name: DD_CRI_SOCKET_PATH
             value: {{ .Values.datadog.criSocketPath | quote }}
           {{- end }}
+          {{- if not .Values.datadog.livenessProbe }}
+          - name: DD_HEALTH_PORT
+            value: "5555"
+          {{- end }}
 {{- if .Values.datadog.env }}
 {{ toYaml .Values.datadog.env | indent 10 }}
 {{- end }}
@@ -204,11 +208,13 @@ spec:
 {{ toYaml .Values.datadog.livenessProbe | indent 10 }}
 {{- else }}
         livenessProbe:
-          exec:
-            command:
-            - ./probe.sh
+          httpGet:
+            path: /health
+            port: 5555
           initialDelaySeconds: 15
-          periodSeconds: 5
+          periodSeconds: 15
+          timeoutSeconds: 5
+          successThreshold: 1
           failureThreshold: 6
 {{- end }}
       volumes:

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -25,9 +25,9 @@ daemonset:
   ## metrics and traces will be accepted from any host able to connect to this host.
   # useHostNetwork: true
 
-  ## Sets the hostPort to the same value of the container port. Can be used as
-  ## for sending custom metrics. The ports will need to be available on all
-  ## hosts.
+  ## Sets the hostPort to the same value of the container port. Needs to be used
+  ## to receive traces in a standard APM set up. Can be used as for sending custom metrics.
+  ## The ports will need to be available on all hosts.
   ## WARNING: Make sure that hosts using this are properly firewalled otherwise
   ## metrics and traces will be accepted from any host able to connect to this host.
   # useHostPort: true


### PR DESCRIPTION
#### What this PR does / why we need it:
It gives more info about the useHostPort parameter and why you need to use it for APM.
It also changes the liveness probe to use httpGet instead of a sh script.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
