### PR TITLE
docs(OWNERS): add emeritus section

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,3 +10,7 @@ approvers:
   - davidkarlsen
   - paulczar
   - cpanato
+emeritus:
+  - linki
+  - mgoodness
+  - seanknox


### PR DESCRIPTION
Signed-off-by: Lachlan Evenson <lachlan.evenson@microsoft.com>

Adds emeritus section to OWNERS based on emeritus membership.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
