### PR TITLE
sumologic: add "extraEnv" for specifying custom env vars

### DIFF
--- a/stable/sumologic-fluentd/Chart.yaml
+++ b/stable/sumologic-fluentd/Chart.yaml
@@ -1,5 +1,5 @@
 name: sumologic-fluentd
-version: 0.10.1
+version: 0.11.0
 appVersion: 2.1.0
 description: Sumologic Log Collector
 keywords:

--- a/stable/sumologic-fluentd/README.md
+++ b/stable/sumologic-fluentd/README.md
@@ -61,6 +61,7 @@ The following table lists the configurable parameters of the sumologic-fluentd c
 |-----------|-------------|---------|
 | `podAnnotations` | Annotations to add to the DaemonSet's Pods | `{}` |
 | `tolerations` | List of node taints to tolerate (requires Kubernetes >= 1.6) | `[]` |
+| `extraEnv` | List of additional env vars to append to pods | `[]` |
 | `updateStrategy` | `OnDelete` or `RollingUpdate` (requires Kubernetes >= 1.6) | `OnDelete` |
 | `sumologic.collectorUrl` | An HTTP collector in SumoLogic that the container can send logs to via HTTP | `Nil` You must provide your own value |
 | `sumologic.collectorUrlExistingSecret` | If set, use the secret with the name provided instead of creating a new one | `Nil` You must reference an existing secret |

--- a/stable/sumologic-fluentd/templates/daemonset.yaml
+++ b/stable/sumologic-fluentd/templates/daemonset.yaml
@@ -198,6 +198,9 @@ spec:
             - name: ENABLE_STAT_WATCHER
               value: {{ quote .Values.sumologic.enableStatWatcher }}
             {{- end }}
+{{- if .Values.extraEnv }}
+{{ toYaml .Values.extraEnv | indent 12 }}
+{{- end }}
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "sumologic-fluentd.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       volumes:
         - name: pos-files

--- a/stable/sumologic-fluentd/values.yaml
+++ b/stable/sumologic-fluentd/values.yaml
@@ -14,6 +14,9 @@ tolerations: []
 #     effect: NoSchedule
 #     operator: "Exists"
 
+# Extra environment variables to set for fluentd
+extraEnv: []
+
 ## Allow the DaemonSet to perform a rolling update on helm update
 ## ref: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
 updateStrategy: OnDelete


### PR DESCRIPTION
Adds `extraEnv` value, enabling the user to set custom environment variables without us having to explicitly support each configuration option in the chart. This is a common pattern across many charts:

https://github.com/helm/charts/search?q=extraEnv&unscoped_q=extraEnv

We might consider removing some of the many explicitly referenced vars in the future (https://github.com/helm/charts/blob/master/stable/sumologic-fluentd/templates/daemonset.yaml#L75-L200) but for now this should eliminate the need to create new ones for obscure configurations that most users won't need and those who do will consult the [upstream](https://github.com/SumoLogic/fluentd-kubernetes-sumologic) app repo for full configuration docs.

FYI @frankreno 