### PR TITLE
Fix fatal error caused by Postgresql probes (#10838)

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 3.9.2
+version: 3.9.3
 appVersion: 10.6.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/statefulset-slaves.yaml
+++ b/stable/postgresql/templates/statefulset-slaves.yaml
@@ -115,7 +115,7 @@ spec:
             command:
             - sh
             - -c
-            - exec pg_isready -U {{ .Values.postgresqlUsername | quote }} -h localhost
+            - exec pg_isready -U {{ .Values.postgresqlUsername | quote }} -d {{ .Values.postgresqlDatabase | quote }} -h localhost
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -128,7 +128,7 @@ spec:
             command:
             - sh
             - -c
-            - exec pg_isready -U {{ .Values.postgresqlUsername | quote }} -h localhost
+            - exec pg_isready -U {{ .Values.postgresqlUsername | quote }} -d {{ .Values.postgresqlDatabase | quote }} -h localhost
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -142,7 +142,7 @@ spec:
             command:
             - sh
             - -c
-            - exec pg_isready -U {{ .Values.postgresqlUsername | quote }} -h localhost
+            - exec pg_isready -U {{ .Values.postgresqlUsername | quote }} -d {{ .Values.postgresqlDatabase | quote }} -h localhost
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -155,7 +155,7 @@ spec:
             command:
             - sh
             - -c
-            - exec pg_isready -U {{ .Values.postgresqlUsername | quote }} -h localhost
+            - exec pg_isready -U {{ .Values.postgresqlUsername | quote }} -d {{ .Values.postgresqlDatabase | quote }} -h localhost
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}


### PR DESCRIPTION
Signed-off-by: Timothy Guenthner <aerotog@gmail.com>

#### What this PR does / why we need it:
This fixes the readiness and liveness probes for the Postgresql chart. The current probes cause continuous FATAL errors when using a custom names for user and database.

#### Which issue this PR fixes
  - fixes #10838

#### Special notes for your reviewer:
N/A

#### Checklist
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
