### PR TITLE
allowing option to deploy namespaced grafana rbac rules

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 1.25.3
+version: 1.25.4
 appVersion: 5.4.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -88,6 +88,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `admin.userKey`                           | The key in the existing admin secret containing the username. | `"admin-user"`                          |
 | `admin.passwordKey`                       | The key in the existing admin secret containing the password. | `"admin-password"`                      |
 | `rbac.create`                             | Create and use RBAC resources | `true` |
+| `rbac.namespaced`                         | Creates Role and Rolebinding instead of the default ClusterRole and ClusteRoleBindings for the grafana instance  | `false` |
 | `rbac.pspEnabled`                         | Create PodSecurityPolicy (with `rbac.create`, grant roles permissions as well) | `true` |
 | `rbac.pspUseAppArmor`                     | Enforce AppArmor in created PodSecurityPolicy (requires `rbac.pspEnabled`)  | `true` |
 

--- a/stable/grafana/templates/clusterrole.yaml
+++ b/stable/grafana/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and .Values.rbac.create (not .Values.rbac.namespaced) }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/stable/grafana/templates/clusterrolebinding.yaml
+++ b/stable/grafana/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and .Values.rbac.create (not .Values.rbac.namespaced) }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -20,4 +20,4 @@ roleRef:
   kind: ClusterRole
   name: {{ template "grafana.fullname" . }}-clusterrole
   apiGroup: rbac.authorization.k8s.io
-{{- end}}
+{{- end -}}

--- a/stable/grafana/templates/role.yaml
+++ b/stable/grafana/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
@@ -8,11 +8,24 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if .Values.rbac.pspEnabled }}
+{{- with .Values.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if or .Values.rbac.pspEnabled (and .Values.rbac.namespaced (or .Values.sidecar.dashboards.enabled .Values.sidecar.datasources.enabled)) }}
 rules:
+{{- if .Values.rbac.pspEnabled }}
 - apiGroups:      ['extensions']
   resources:      ['podsecuritypolicies']
   verbs:          ['use']
   resourceNames:  [{{ template "grafana.fullname" . }}]
+{{- end }}
+{{- if and .Values.rbac.namespaced (or .Values.sidecar.dashboards.enabled .Values.sidecar.datasources.enabled) }}
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["configmaps"]
+  verbs: ["get", "watch", "list"]
+{{- end }}
+{{- else }}
+rules: []
 {{- end }}
 {{- end }}

--- a/stable/grafana/templates/rolebinding.yaml
+++ b/stable/grafana/templates/rolebinding.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- with .Values.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -15,4 +19,11 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "grafana.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- if .Values.rbac.namespaced }}
+roleRef:
+  kind: Role
+  name: {{ template "grafana.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end -}}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -2,6 +2,7 @@ rbac:
   create: true
   pspEnabled: true
   pspUseAppArmor: true
+  namespaced: false
 serviceAccount:
   create: true
   name:


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR aims to extend the functionality of the grafana helm chart by adding an option to deploy namespace restricted rbac rules as there is no need to have clusterroles/clusterrolebindings in all use cases.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
