### PR TITLE
[incubator/jaeger] Add support for using a custom ES index prefix.

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.8.2
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.8.2
+version: 0.8.3
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -207,6 +207,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `storage.cassandra.password`             | Provisioned cassandra password      |  password                              |
 | `storage.cassandra.port`                 | Provisioned cassandra port          |  9042                                  |
 | `storage.cassandra.user`                 | Provisioned cassandra username      |  user                                  |
+| `storage.elasticsearch.indexPrefix`      | Provisioned elasticsearch index prefix | jaeger                              |
 | `storage.elasticsearch.host`             | Provisioned elasticsearch host      |  elasticsearch                         |
 | `storage.elasticsearch.password`         | Provisioned elasticsearch password  |  changeme                              |
 | `storage.elasticsearch.port`             | Provisioned elasticsearch port      |  9200                                  |

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -67,6 +67,11 @@ spec:
                 key: cassandra.keyspace
           {{- end }}
           {{- if eq .Values.storage.type "elasticsearch" }}
+          - name: ES_INDEX_PREFIX
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: es.index-prefix
           - name: ES_PASSWORD
             valueFrom:
               configMapKeyRef:

--- a/incubator/jaeger/templates/common-cm.yaml
+++ b/incubator/jaeger/templates/common-cm.yaml
@@ -19,6 +19,7 @@ data:
   collector.http-port: {{ .Values.collector.service.httpPort | quote }}
   collector.port: {{ .Values.collector.service.tchannelPort | quote }}
   collector.zipkin.http-port: {{ .Values.collector.service.zipkinPort | quote }}
+  es.index-prefix: {{ .Values.storage.elasticsearch.indexPrefix | quote }}
   es.password: {{ .Values.storage.elasticsearch.password }}
   es.server-urls: {{ template "elasticsearch.client.url" . }}
   es.username: {{ .Values.storage.elasticsearch.user }}

--- a/incubator/jaeger/templates/query-deploy.yaml
+++ b/incubator/jaeger/templates/query-deploy.yaml
@@ -67,6 +67,11 @@ spec:
                 key: cassandra.keyspace
           {{- end }}
           {{- if eq .Values.storage.type "elasticsearch" }}
+          - name: ES_INDEX_PREFIX
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: es.index-prefix
           - name: ES_PASSWORD
             valueFrom:
               configMapKeyRef:

--- a/incubator/jaeger/templates/spark-cronjob.yaml
+++ b/incubator/jaeger/templates/spark-cronjob.yaml
@@ -61,6 +61,11 @@ spec:
                   key: cassandra.keyspace
               {{- end }}
             {{- if eq .Values.storage.type "elasticsearch" }}
+            - name: ES_INDEX_PREFIX
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "jaeger.fullname" . }}
+                  key: es.index-prefix
             - name: ES_NODES
               valueFrom:
                 configMapKeyRef:

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -21,6 +21,7 @@ storage:
     host: elasticsearch
     port: 9200
     user: elastic
+    indexPrefix: jaeger
     password: changeme
     nodesWanOnly: false
 


### PR DESCRIPTION
Signed-off-by: Alan Matuszczak <alan.matuszczak@fastmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Allows to use a single Elasticsearch instance as a backend for multiple Jaeger Helm releases without having to worry about span data being intermingled in the search results.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
