### PR TITLE
Improve notes shown when installing ark

### DIFF
--- a/stable/ark/Chart.yaml
+++ b/stable/ark/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.10.1
 description: A Helm chart for ark
 name: ark
-version: 3.0.0
+version: 3.0.1
 home: https://github.com/heptio/ark
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/stable/ark/templates/NOTES.txt
+++ b/stable/ark/templates/NOTES.txt
@@ -1,9 +1,13 @@
 Check that the ark is up and running:
 
+  kubectl logs deployment/heptio-ark -n {{ .Release.Namespace }}
+
 Check that the secret has been created:
+
+  kubectl get secrets -n {{ .Release.Namespace }}
 
 Once ark server is up and running you need the client before you can use it
 1. wget https://github.com/heptio/ark/releases/download/{{ .Values.image.tag }}/ark-{{ .Values.image.tag }}-darwin-amd64.tar.gz
-2. tar -xvf ark-{{ .Values.image.tag }}-darwin-amd64.tar.gz -C ark-client
+2. tar -xvf ark-{{ .Values.image.tag }}-darwin-amd64.tar.gz ark
 
 More info on the official site: https://github.com/heptio/ark#install-client


### PR DESCRIPTION
* Display kubectl command for showing logs and listing secrets
* Change tar command to extract ark client binary only

Signed-off-by: Steffen Pingel <steffen.pingel@tasktop.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
