### PR TITLE
remove missing LF in cert-manager templates

### DIFF
--- a/stable/cert-manager/Chart.yaml
+++ b/stable/cert-manager/Chart.yaml
@@ -1,6 +1,6 @@
 name: cert-manager
-version: v0.6.0
-appVersion: v0.6.0
+version: v0.6.1
+appVersion: v0.6.1
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager
 keywords:

--- a/stable/cert-manager/templates/certificate-crd.yaml
+++ b/stable/cert-manager/templates/certificate-crd.yaml
@@ -23,4 +23,4 @@ spec:
     shortNames:
 {{ toYaml .Values.certificateResourceShortNames | indent 6 }}
     {{- end -}}
-{{- end -}}
+{{- end }}

--- a/stable/cert-manager/templates/issuer-crd.yaml
+++ b/stable/cert-manager/templates/issuer-crd.yaml
@@ -19,4 +19,4 @@ spec:
     kind: Issuer
     plural: issuers
   scope: Namespaced
-{{- end -}}
+{{- end }}

--- a/stable/cert-manager/templates/rbac.yaml
+++ b/stable/cert-manager/templates/rbac.yaml
@@ -36,7 +36,7 @@ subjects:
   - name: {{ template "cert-manager.serviceAccountName" . }}
     namespace: {{ .Release.Namespace | quote }}
     kind: ServiceAccount
----
+----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -69,4 +69,4 @@ rules:
   - apiGroups: ["certmanager.k8s.io"]
     resources: ["certificates", "issuers"]
     verbs: ["create", "delete", "deletecollection", "patch", "update"]
-{{- end -}}
+{{- end }}


### PR DESCRIPTION
When parsing templates (e.g. with `helm template`) it is important to have the right file-ends - otherwise LineFeeds are missing and yaml files parsed with get broken.

This PR prevents problems like:

```
 1	---
     2	# Source: cert-manager/templates/certificate-crd.yaml
     3	apiVersion: apiextensions.k8s.io/v1beta1
     4	kind: CustomResourceDefinition
     5	metadata:
     6	  name: certificates.certmanager.k8s.io
     7	  annotations:
     8	    "helm.sh/hook": crd-install
     9	  labels:
    10	    app: cert-manager
    11	    chart: cert-manager-v0.5.2
    12	    release: cert-manager
    13	    heritage: Tiller
    14	spec:
    15	  group: certmanager.k8s.io
    16	  version: v1alpha1
    17	  scope: Namespaced
    18	  names:
    19	    kind: Certificate
    20	    plural: certificates
    21	    shortNames:
    22	      - cert
    23	      - certs
    24	      ---
    25	# Source: cert-manager/templates/clusterissuer-crd.yaml
    26	apiVersion: apiextensions.k8s.io/v1beta1
    27	kind: CustomResourceDefinition
    28	metadata:
    29	  name: clusterissuers.certmanager.k8s.io
    30	  annotations:
    31	    "helm.sh/hook": crd-install
    32	  labels:
    33	    app: cert-manager
    34	    chart: cert-manager-v0.5.2
    35	    release: cert-manager
    36	    heritage: Tiller
    37	spec:
    38	  group: certmanager.k8s.io
    39	  version: v1alpha1
    40	  names:
    41	    kind: ClusterIssuer
    42	    plural: clusterissuers
    43	  scope: Cluster---
    44	# Source: cert-manager/templates/deployment.yaml
    45	apiVersion: apps/v1beta1
    46	kind: Deployment
    47	metadata:
    48	  name: cert-manager
    49	  namespace: "default"
    50	  labels:
    51	    app: cert-manager
    52	    chart: cert-manager-v0.5.2
    53	    release: cert-manager
    54	    heritage: Tiller
    55	spec:
    56	  replicas: 1
    57	  selector:
    58	    matchLabels:
    59	      app: cert-manager
    60	      release: cert-manager
    61	  template:
    62	    metadata:
    63	      labels:
    64	        app: cert-manager
    65	        release: cert-manager
    66	      annotations:
    67	    spec:
    68	      serviceAccountName: cert-manager
    69	      containers:
    70	        - name: cert-manager
    71	          image: "quay.io/jetstack/cert-manager-controller:v0.5.2"
    72	          imagePullPolicy: IfNotPresent
    73	          args:
    74	          - --cluster-resource-namespace=$(POD_NAMESPACE)
    75	          - --leader-election-namespace=$(POD_NAMESPACE)
    76	          env:
    77	          - name: POD_NAMESPACE
    78	            valueFrom:
    79	              fieldRef:
    80	                fieldPath: metadata.namespace
    81	          resources:
    82	            {}
    83	            
    84	---
    85	# Source: cert-manager/templates/issuer-crd.yaml
    86	apiVersion: apiextensions.k8s.io/v1beta1
    87	kind: CustomResourceDefinition
    88	metadata:
    89	  name: issuers.certmanager.k8s.io
    90	  annotations:
    91	    "helm.sh/hook": crd-install
    92	  labels:
    93	    app: cert-manager
    94	    chart: cert-manager-v0.5.2
    95	    release: cert-manager
    96	    heritage: Tiller
    97	spec:
    98	  group: certmanager.k8s.io
    99	  version: v1alpha1
   100	  names:
   101	    kind: Issuer
   102	    plural: issuers
   103	  scope: Namespaced---
   104	# Source: cert-manager/templates/rbac.yaml
   105	apiVersion: rbac.authorization.k8s.io/v1beta1
   106	kind: ClusterRole
   107	metadata:
   108	  name: cert-manager
   109	  labels:
   110	    app: cert-manager
   111	    chart: cert-manager-v0.5.2
   112	    release: cert-manager
   113	    heritage: Tiller
   114	rules:
   115	  - apiGroups: ["certmanager.k8s.io"]
   116	    resources: ["certificates", "issuers", "clusterissuers"]
   117	    verbs: ["*"]
   118	  - apiGroups: [""]
   119	    resources: ["configmaps", "secrets", "events", "services", "pods"]
   120	    verbs: ["*"]
   121	  - apiGroups: ["extensions"]
   122	    resources: ["ingresses"]
   123	    verbs: ["*"]
   124	---
   125	apiVersion: rbac.authorization.k8s.io/v1beta1
   126	kind: ClusterRoleBinding
   127	metadata:
   128	  name: cert-manager
   129	  labels:
   130	    app: cert-manager
   131	    chart: cert-manager-v0.5.2
   132	    release: cert-manager
   133	    heritage: Tiller
   134	roleRef:
   135	  apiGroup: rbac.authorization.k8s.io
   136	  kind: ClusterRole
   137	  name: cert-manager
   138	subjects:
   139	  - name: cert-manager
   140	    namespace: "default"
   141	    kind: ServiceAccount---
   142	# Source: cert-manager/templates/serviceaccount.yaml
   143	apiVersion: v1
   144	kind: ServiceAccount
   145	metadata:
   146	  name: cert-manager
   147	  namespace: "default"
   148	  labels:
   149	    app: cert-manager
   150	    chart: cert-manager-v0.5.2
   151	    release: cert-manager
   152	    heritage: Tiller$ cat build/cert-manager/templates/* | ssh root@${MASTER} kubectl --namespace ${NAMESPACE} apply -f - --dry-run
Warning: Permanently added '10.139.0.121' (ECDSA) to the list of known hosts.
error: error parsing STDIN: error converting YAML to JSON: yaml: line 25: could not find expected ':'
```

Especially look at the lines 24, 43, 102, 141
`
Client: &version.Version{SemVer:"v2.12.3", GitCommit:"eecf22f77df5f65c823aacd2dbd30ae6c65f186e", GitTreeState:"clean"}`