### PR TITLE
[stable/spinnaker] Add support for additional commands during init

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.3.0
+version: 1.4.0
 appVersion: 1.11.6
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/configmap/halyard-init-script.yaml
+++ b/stable/spinnaker/templates/configmap/halyard-init-script.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "spinnaker.fullname" . }}-halyard-init-script
+  labels:
+{{ include "spinnaker.standard-labels" . | indent 4 }}
+data:
+  init.sh: |
+    #!/bin/bash
+
+    # Override Halyard daemon's listen address
+    cp /opt/halyard/config/* /tmp/config
+    printf 'server.address: 0.0.0.0\n' > /tmp/config/halyard-local.yml
+    # Use Redis deployed via the dependent Helm chart
+    mkdir -p /tmp/spinnaker/.hal/default/service-settings
+    printf 'overrideBaseUrl: redis://:{{ .Values.redis.password }}@{{ .Release.Name }}-redis-master:6379\nskipLifeCycleManagement: true\n' > /tmp/spinnaker/.hal/default/service-settings/redis.yml
+    # Route the /gate path of Deck to Gate
+    printf 'env:\n  API_HOST: http://spin-gate.{{ .Release.Namespace }}:8084/\n' > /tmp/spinnaker/.hal/default/service-settings/deck.yml
+
+    {{- if .Values.halyard.additionalProfileConfigMaps.create }}
+    rm -rf /tmp/spinnaker/.hal/default/profiles && \
+    mkdir -p /tmp/spinnaker/.hal/default/profiles && \
+    cp /tmp/additionalProfileConfigMaps/* /tmp/spinnaker/.hal/default/profiles/
+    {{- end }}
+
+    {{- if hasKey .Values.halyard "additionalInitScript" }}
+    # additionalInitScript
+    {{ .Values.halyard.additionalInitScript | indent 4 }}
+    {{- end }}

--- a/stable/spinnaker/templates/hooks/install-using-hal.yaml
+++ b/stable/spinnaker/templates/hooks/install-using-hal.yaml
@@ -33,10 +33,14 @@ spec:
         configMap:
           name: {{ .Values.halyard.additionalScripts.configMapName }}
       {{- end }}
-      {{- if .Values.halyard.additionalSecrets.create }}
+      {{- if or .Values.halyard.additionalSecrets.create (hasKey .Values.halyard.additionalSecrets "name") }}
       - name: additional-secrets
         secret:
+        {{- if .Values.halyard.additionalSecrets.create }}
           secretName: {{ template "spinnaker.fullname" . }}-additional-secrets
+        {{- else if .Values.halyard.additionalSecrets.name }}
+          secretName: {{ .Values.halyard.additionalSecrets.name }}
+        {{- end }}
       {{- end }}
       {{- if .Values.halyard.additionalConfigMaps.create }}
       - name: additional-config-maps
@@ -68,7 +72,7 @@ spec:
         - name: additional-config
           mountPath: /opt/halyard/additional
         {{- end }}
-        {{- if .Values.halyard.additionalSecrets.create }}
+        {{- if or .Values.halyard.additionalSecrets.create (hasKey .Values.halyard.additionalSecrets "name") }}
         - name: additional-secrets
           mountPath: /opt/halyard/additionalSecrets
         {{- end }}

--- a/stable/spinnaker/templates/statefulsets/halyard.yaml
+++ b/stable/spinnaker/templates/statefulsets/halyard.yaml
@@ -30,21 +30,7 @@ spec:
         image: {{ .Values.halyard.image.repository }}:{{ .Values.halyard.image.tag }}
         command:
         - bash
-        - -c
-        - |
-          # Override Halyard daemon's listen address
-          cp /opt/halyard/config/* /tmp/config && \
-          printf 'server.address: 0.0.0.0\n' > /tmp/config/halyard-local.yml && \
-          # Use Redis deployed via the dependent Helm chart
-          mkdir -p /tmp/spinnaker/.hal/default/service-settings && \
-          printf 'overrideBaseUrl: redis://:{{ .Values.redis.password }}@{{ .Release.Name }}-redis-master:6379\nskipLifeCycleManagement: true\n' > /tmp/spinnaker/.hal/default/service-settings/redis.yml && \
-          # Route the /gate path of Deck to Gate
-          printf 'env:\n  API_HOST: http://spin-gate.{{ .Release.Namespace }}:8084/\n' > /tmp/spinnaker/.hal/default/service-settings/deck.yml {{ if .Values.halyard.additionalProfileConfigMaps.create }}&& \{{ end }}
-          {{- if .Values.halyard.additionalProfileConfigMaps.create }}
-          rm -rf /tmp/spinnaker/.hal/default/profiles && \
-          mkdir -p /tmp/spinnaker/.hal/default/profiles && \
-          cp /tmp/additionalProfileConfigMaps/* /tmp/spinnaker/.hal/default/profiles/
-          {{- end }}
+        - /tmp/initscript/init.sh
         volumeMounts:
         - name: halyard-config
           mountPath: /tmp/config
@@ -54,6 +40,8 @@ spec:
         - name: additional-profile-config-maps
           mountPath: /tmp/additionalProfileConfigMaps
         {{- end }}
+        - name: halyard-initscript
+          mountPath: /tmp/initscript
       volumes:
       {{- if .Values.kubeConfig.enabled }}
       - name: kube-config
@@ -64,7 +52,7 @@ spec:
       - name: gcs-key
         secret:
         {{- if .Values.gcs.secretName }}
-          secretName: {{ .Values.gce.secretName }}
+          secretName: {{ .Values.gcs.secretName }}
         {{- else }}
           secretName: {{ template "spinnaker.fullname" . }}-gcs
         {{- end }}
@@ -81,10 +69,14 @@ spec:
         secret:
           secretName: {{ template "spinnaker.fullname" . }}-s3
       {{- end }}
-      {{- if .Values.halyard.additionalSecrets.create }}
+      {{- if or .Values.halyard.additionalSecrets.create (hasKey .Values.halyard.additionalSecrets "name") }}
       - name: additional-secrets
         secret:
+        {{- if .Values.halyard.additionalSecrets.create }}
           secretName: {{ template "spinnaker.fullname" . }}-additional-secrets
+        {{- else if .Values.halyard.additionalSecrets.name }}
+          secretName: {{ .Values.halyard.additionalSecrets.name }}
+        {{- end }}
       {{- end }}
       {{- if .Values.halyard.additionalConfigMaps.create }}
       - name: additional-config-maps
@@ -98,6 +90,9 @@ spec:
       {{- end }}
       - name: halyard-config
         emptyDir: {}
+      - name: halyard-initscript
+        configMap:
+          name: {{ template "spinnaker.fullname" . }}-halyard-init-script
       containers:
       - name: halyard
         image: {{ .Values.halyard.image.repository }}:{{ .Values.halyard.image.tag }}
@@ -117,7 +112,7 @@ spec:
         - name: kube-config
           mountPath: /opt/kube
         {{- end }}
-        {{- if .Values.halyard.additionalSecrets.create }}
+        {{- if or .Values.halyard.additionalSecrets.create (hasKey .Values.halyard.additionalSecrets "name") }}
         - name: additional-secrets
           mountPath: /opt/halyard/additionalSecrets
         {{- end }}

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -15,12 +15,18 @@ halyard:
   additionalSecrets:
     create: false
     data: {}
+    ## Uncomment if you want to use a pre-created secret rather than feeding data in via helm.
+    # name:
   additionalConfigMaps:
     create: false
     data: {}
   additionalProfileConfigMaps:
     create: false
     data: {}
+
+  ## Uncomment if you want to add extra commands to the init script
+  ## run by the init container before halyard is started.
+  # additionalInitScript: |-
 
 # Define which registries and repositories you want available in your
 # Spinnaker pipeline definitions


### PR DESCRIPTION
Sometimes you need to modify config or service-settings files before
starting halyard.  This gives you that ability by moving the chain of
commands run by the init container into a script inside a configmap
which can be added to via a modified value.

Signed-off-by: Paul Czarkowski <username.taken@gmail.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
