### PR TITLE
[stable/traefik] Add DNS Provider 'gandiv5' to avoid confusion with '…

### DIFF
--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -210,6 +210,12 @@ acme:
       EXOSCALE_ENDPOINT: ""
     gandi:
       GANDI_API_KEY: ""
+    gandiv5:
+      GANDIV5_API_KEY: ""
+      # GANDIV5_POLLING_INTERVAL: "" # default 20 seconds
+      # GANDIV5_TTL: "" # default 300 seconds
+      # GANDIV5_PROPAGATION_TIMEOUT: "" # default 20 minutes
+      # GANDIV5_HTTP_TIMEOUT: "" # default 10 seconds
     godaddy:
       GODADDY_API_KEY: ""
       GODADDY_API_SECRET: ""


### PR DESCRIPTION
…gandi'

Signed-off-by: Michele Azzolari <michele@azzolari.it>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
I found myself losing some time activating ACME because of DNS provider "gandi".
In the values.yaml there's a "gandi" example but actually it works only with old gandi accounts.
So I think it's better to add also the "gandiv5" provider to avoid confusion.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md

CC: @dtomcej  