### PR TITLE
Use entrypoint from Docker image and fix probe paths

### DIFF
--- a/stable/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/stable/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.2.1
+version: 0.3.0
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -51,7 +51,6 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | `service.type`              | Service type                                           | `ClusterIP`                |
 | `service.port`              | The service port                                       | `80`                       |
 | `service.portName`          | The name of the service port                           | `http`                     |
-| `service.targetPort`        | The target port of the container                       | `9100`                     |
 | `service.annotations`       | Custom annotations for service                         | `{}`                       |
 | `service.labels`            | Additional custom labels for the service               | `{}`                       |
 | `resources`                 |                                                        | `{}`                       |

--- a/stable/prometheus-cloudwatch-exporter/templates/configmap.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/configmap.yaml
@@ -8,5 +8,5 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  config.yaml: |
+  config.yml: |
 {{ printf .Values.config | indent 4 }}

--- a/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /healthy/
+              path: /-/healthy
               port: {{ .Values.service.portName }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds}}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -56,7 +56,7 @@ spec:
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           readinessProbe:
             httpGet:
-              path: /ready/
+              path: /-/ready
               port: {{ .Values.service.portName }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds}}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -24,12 +24,6 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          command:
-            - java
-            - -jar
-            - /cloudwatch_exporter.jar
-            - "{{ .Values.service.targetPort }}"
-            - /config/config.yaml
         {{- if not .Values.aws.role }}
         {{- if and .Values.aws.aws_secret_access_key .Values.aws.aws_access_key_id }}
           env:
@@ -49,7 +43,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: {{ .Values.service.portName }}
-              containerPort: {{ .Values.service.targetPort }}
+              containerPort: 9106
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -12,7 +12,6 @@ image:
 service:
   type: ClusterIP
   port: 80
-  targetPort: 9100
   portName: http
   annotations: {}
   labels: {}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Updates the Helm chart to use the entrypoint and command from the specified Docker image. This allows consumers with a custom Docker image to have the entrypoint from that image picked up automatically

Fixes the paths used by the readiness and liveness probes to match those defined in the Java application. Previously, the probes were targeting `/ready/` and `/healthy`. These paths actually direct to the HomePageServlet defined [here](https://github.com/prometheus/cloudwatch_exporter/blob/master/src/main/java/io/prometheus/cloudwatch/WebServer.java#L38). The correct endpoints for readiness and healthiness are `/-/ready` and `/-/healthy` as defined [here](https://github.com/prometheus/cloudwatch_exporter/blob/master/src/main/java/io/prometheus/cloudwatch/WebServer.java#L36-L37)

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
