### PR TITLE
[stable/rocketchat] Allow disabling MongoDB dependency

### DIFF
--- a/stable/rocketchat/Chart.yaml
+++ b/stable/rocketchat/Chart.yaml
@@ -1,5 +1,5 @@
 name: rocketchat
-version: 0.2.2
+version: 0.3.0
 appVersion: 0.73.2
 description: Prepare to take off with the ultimate chat platform, experience the next
   level of team communications

--- a/stable/rocketchat/requirements.lock
+++ b/stable/rocketchat/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mongodb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.1.1
-digest: sha256:c37d293a678a1f3a6f6f1bd567dab13f0d02aff050ee0ec6d6bcdd9fd5c8a7d5
-generated: 2019-01-14T16:56:18.315012357+01:00
+  version: 5.1.4
+digest: sha256:420bf2b07e91d09139e98906a20c1e179485d7225d47c1b5cc0b352a491850ce
+generated: 2019-01-24T15:33:57.393572713+01:00

--- a/stable/rocketchat/requirements.yaml
+++ b/stable/rocketchat/requirements.yaml
@@ -2,3 +2,4 @@ dependencies:
 - name: mongodb
   version: 5.1.x
   repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: mongodb.enabled

--- a/stable/rocketchat/templates/deployment.yaml
+++ b/stable/rocketchat/templates/deployment.yaml
@@ -37,6 +37,8 @@ spec:
             secretKeyRef:
               name: {{ template "rocketchat.fullname" . }}
               key: mongo-uri
+        {{ else if .Values.mongodbURL }}
+          value: {{ .Values.mongodbURL }}
         {{ else }}
           value: mongodb://{{ template "rocketchat.mongodb.fullname" . }}:27017/rocketchat
         {{ end }}

--- a/stable/rocketchat/values.yaml
+++ b/stable/rocketchat/values.yaml
@@ -27,10 +27,16 @@ config:
   WebRTC_Enable_Private: false
   WebRTC_Enable_Direct: false
 
+## MongoDB URL if using an externally provisioned MongoDB
+mongodbURL: ~
+
 ##
 ## MongoDB chart configuration
 ##
 mongodb:
+  ## Enable or disable MongoDB dependency completely.
+  enabled: true
+
   ## MongoDB admin password
   ### ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#setting-the-root-password-on-first-run
   ###


### PR DESCRIPTION
#### What this PR does / why we need it:

Allow disabling MongoDB depdency. Allows users of the chart to completely skip deploying MongoDB while still allowing the MONGO_URL env var to be configured through helm.

This makes it possible to "bring your own MongoDB" (ie. by using MongoDB Atlas or any othre MongoDB-as-a-service provider).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped

