### PR TITLE
[stable/datadog] Update default value of datadog.livenessProbe in README

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.18.0
+version: 1.18.1
 appVersion: 6.9.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -92,7 +92,7 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `datadog.resources.requests.memory` | Memory resource requests   | `256Mi`                                   |
 | `datadog.resources.limits.memory` | Memory resource limits       | `256Mi`                                   |
 | `datadog.securityContext`   | Allows you to overwrite the default securityContext applied to the container  | `nil`  |
-| `datadog.livenessProbe`     | Overrides the default liveness probe | exec /probe.sh                          |
+| `datadog.livenessProbe`     | Overrides the default liveness probe | http port 5555                          |
 | `datadog.hostname`          | Set the hostname (write it in datadog.conf) | `nil`                            |
 | `datadog.acInclude`         | Include containers based on image name | `nil`                                 |
 | `datadog.acExclude`         | Exclude containers based on image name | `nil`                                 |


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

- The default value for `datadog.livenessProbe` has been updated by this PR: https://github.com/helm/charts/pull/10827
- This keeps the documentation updated and could save other people's time when debugging the problem which the new default value might cause. (In my case, we are still respecting the former default `probe.sh`)

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md