### PR TITLE
Add support for pre-created secrets and AWS STS session tokens

### DIFF
--- a/stable/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/stable/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.3.0
+version: 0.4.0
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -14,17 +14,22 @@ This chart bootstraps a [cloudwatch exporter](http://github.com/prometheus/cloud
 
 ## Prerequisites
 
-- [kube2iam](../../stable/kube2iam) installed to used the **aws.role** config option otherwise configure **aws.aws_access_key_id** and **aws.aws_secret_access_key**
+- [kube2iam](../../stable/kube2iam) installed to used the **aws.role** config option otherwise configure **aws.aws_access_key_id** and **aws.aws_secret_access_key** or **aws.secret.name**
 
 ## Installing the Chart
 
 To install the chart with the release name `my-release`:
 
 ```console
-$ # edit aws.aws_access_key_id and aws.aws_access_key_id with the key/password of a AWS user with a policy to access  Cloudwatch
-$ helm install --name my-release stable/prometheus-cloudwatch-exporter
-$ # or add a role to aws with the [correct policy](https://github.com/prometheus/cloudwatch_exporter#credentials-and-permissions) to add to cloud watch
-$ helm install --name my-release stable/prometheus-cloudwatch-exporter --set awsRole=roll_name_here
+$ # pass AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY as values
+$ helm install --name my-release stable/prometheus-cloudwatch-exporter --set aws.aws_access_key_id=$AWS_ACCESS_KEY_ID,aws.aws_secret_access_key=$AWS_SECRET_ACCESS_KEY
+
+$ # or store them in a secret and pass its name as a value
+$ kubectl create secret generic <SECRET_NAME> --from-literal=access_key=$AWS_ACCESS_KEY_ID --from-literal=secret_key=$AWS_SECRET_ACCESS_KEY
+$ helm install --name my-release stable/prometheus-cloudwatch-exporter --set aws.secret.name=<SECRET_NAME>
+
+$ # or add a role to aws with the [correct policy](https://github.com/prometheus/cloudwatch_exporter#credentials-and-permissions) to add to cloud watch and pass its name as a value
+$ helm install --name my-release stable/prometheus-cloudwatch-exporter --set awsRole=<ROLL_NAME>
 ```
 
 The command deploys Cloudwatch exporter on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -58,6 +63,8 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | `aws.role`                  | AWS IAM Role To Use                                    |                            |
 | `aws.aws_access_key_id`     | AWS access key id                                      |                            |
 | `aws.aws_secret_access_key` | AWS secret access key                                  |                            |
+| `aws.secret.name` | The name of a pre-created secret in which AWS credentials are stored                                 |                            |
+| `aws.secret.includesSessionToken` |  Whether or not the pre-created secret contains an AWS STS session token                                  |                            |
 | `config`                    | Cloudwatch exporter configuration                      | `example configuration`    |
 | `rbac.create`               | If true, create & use RBAC resources                   | `false`                    |
 | `serviceAccount.create`     | Specifies whether a service account should be created. | `true`                     |

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -59,7 +59,6 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | `service.annotations`       | Custom annotations for service                         | `{}`                       |
 | `service.labels`            | Additional custom labels for the service               | `{}`                       |
 | `resources`                 |                                                        | `{}`                       |
-| `aws.region`                | AWS Cloudwatch region                                  | `eu-west-1`                |
 | `aws.role`                  | AWS IAM Role To Use                                    |                            |
 | `aws.aws_access_key_id`     | AWS access key id                                      |                            |
 | `aws.aws_secret_access_key` | AWS secret access key                                  |                            |
@@ -79,7 +78,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```console
 $ helm install --name my-release \
-  --set aws.region=us-east-1 --set aws.role=my-aws-role \
+    --set aws.role=my-aws-role \
     stable/prometheus-cloudwatch-exporter
 ```
 

--- a/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -25,7 +25,26 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
         {{- if not .Values.aws.role }}
-        {{- if and .Values.aws.aws_secret_access_key .Values.aws.aws_access_key_id }}
+        {{- if .Values.aws.secret.name }}
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: access_key
+                  name: {{ .Values.aws.secret.name }}
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: secret_key
+                  name: {{ .Values.aws.secret.name }}
+          {{- if .Values.aws.secret.includesSessionToken }}
+            - name: AWS_SESSION_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: security_token
+                  name: {{ .Values.aws.secret.name }}
+          {{- end }}
+        {{- else if and .Values.aws.aws_secret_access_key .Values.aws.aws_access_key_id }}
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:

--- a/stable/prometheus-cloudwatch-exporter/templates/secrets.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/secrets.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.aws.role }}
+{{- if and (not .Values.aws.role) (not .Values.aws.secret.name) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -31,7 +31,17 @@ resources: {}
 aws:
   region: eu-west-1
   role:
-  # Note: Do not specify the aws_access_key_id abd aws_secret_access_key if you specified role before
+
+  # The name of a pre-created secret in which AWS credentials are stored. When
+  # set, aws_access_key_id is assumed to be in a field called access_key,
+  # aws_secret_access_key is assumed to be in a field called secret_key, and the
+  # session token, if it exists, is assumed to be in a field called
+  # security_token
+  secret:
+    name:
+    includesSessionToken: false
+
+  # Note: Do not specify the aws_access_key_id and aws_secret_access_key if you specified role or secret.name before
   aws_access_key_id:
   aws_secret_access_key:
 

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -29,7 +29,6 @@ resources: {}
   #   memory: 128Mi
 
 aws:
-  region: eu-west-1
   role:
 
   # The name of a pre-created secret in which AWS credentials are stored. When


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Not all consumers want to provide AWS secrets such as `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` via values. For consumers, it may be preferable to create the Kubernetes secret containing the credentials out-of-band and pass the name of the secret to the chart instead.

The AWS Java SDK supports AWS STS session tokens via the `AWS_SESSION_TOKEN` environment variables. This PR also updates the chart to optionally retrieve session tokens from the pre-created Kubernetes secret described above. Since session tokens are short lived, it doesn't make sense to provide them via values to `helm install` or `helm upgrade`

This PR also removes the unused `aws.region` value. The region is instead meant to be specified as part of the `config` value

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
