### PR TITLE
[stable/concourse] Adds additional volumes and volumeMounts to web

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 3.6.3
+version: 3.7.0
 appVersion: 4.2.2
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -71,33 +71,35 @@ The following table lists the configurable parameters of the Concourse chart and
 | `imageTag` | Concourse image version | `4.2.2` |
 | `imagePullPolicy` | Concourse image pull policy | `IfNotPresent` |
 | `imagePullSecrets` | Array of imagePullSecrets in the namespace for pulling images | `[]` |
+| `web.additionalAffinities` | Additional affinities to apply to web pods. E.g: node affinity | `{}` |
+| `web.additionalVolumeMounts` | VolumeMounts to be added to the web pods | `nil` |
+| `web.additionalVolumes` | Volumes to be added to the web pods | `nil` |
+| `web.annotations`| Concourse Web deployment annotations | `nil` |
+| `web.authSecretsPath` | Specify the mount directory of the web auth secrets | `/concourse-auth` |
+| `web.env` | Configure additional environment variables for the web containers | `[]` |
+| `web.ingress.annotations` | Concourse Web Ingress annotations | `{}` |
+| `web.ingress.enabled` | Enable Concourse Web Ingress | `false` |
+| `web.ingress.hosts` | Concourse Web Ingress Hostnames | `[]` |
+| `web.ingress.tls` | Concourse Web Ingress TLS configuration | `[]` |
+| `web.keysSecretsPath` | Specify the mount directory of the web keys secrets | `/concourse-keys` |
+| `web.livenessProbe` | Liveness Probe settings | `{"failureThreshold":5,"httpGet":{"path":"/api/v1/info","port":"atc"},"initialDelaySeconds":10,"periodSeconds":15,"timeoutSeconds":3}` |
 | `web.nameOverride` | Override the Concourse Web components name | `nil` |
+| `web.nodeSelector` | Node selector for web nodes | `{}` |
+| `web.postgresqlSecrtsPath` | Specify the mount directory of the web postgresql secrets | `/concourse-postgresql` |
+| `web.readinessProbe` | Readiness Probe settings | `{"httpGet":{"path":"/api/v1/info","port":"atc"}}` |
 | `web.replicas` | Number of Concourse Web replicas | `1` |
 | `web.resources` | Concourse Web resource requests and limits | `{requests: {cpu: "100m", memory: "128Mi"}}` |
-| `web.readinessProbe` | Readiness Probe settings | `{"httpGet":{"path":"/api/v1/info","port":"atc"}}` |
-| `web.livenessProbe` | Liveness Probe settings | `{"failureThreshold":5,"httpGet":{"path":"/api/v1/info","port":"atc"},"initialDelaySeconds":10,"periodSeconds":15,"timeoutSeconds":3}` |
-| `web.additionalAffinities` | Additional affinities to apply to web pods. E.g: node affinity | `{}` |
-| `web.env` | Configure additional environment variables for the web containers | `[]` |
-| `web.annotations`| Concourse Web deployment annotations | `nil` |
-| `web.keysSecretsPath` | Specify the mount directory of the web keys secrets | `/concourse-keys` |
-| `web.postgresqlSecrtsPath` | Specify the mount directory of the web postgresql secrets | `/concourse-postgresql` |
-| `web.vaultSecretsPath` | Specify the mount directory of the web vault secrets | `/concourse-vault` |
-| `web.syslogSecretsPath` | Specify the mount directory of the web syslog secrets | `/concourse-syslog` |
-| `web.authSecretsPath` | Specify the mount directory of the web auth secrets | `/concourse-auth` |
-| `web.tolerations` | Tolerations for the web nodes | `[]` |
-| `web.nodeSelector` | Node selector for web nodes | `{}` |
-| `web.service.type` | Concourse Web service type | `ClusterIP` |
 | `web.service.annotations` | Concourse Web Service annotations | `nil` |
+| `web.service.atcNodePort` | Sets the nodePort for atc when using `NodePort` | `nil` |
+| `web.service.atcTlsNodePort` | Sets the nodePort for atc tls when using `NodePort` | `nil` |
 | `web.service.labels` | Additional concourse web service labels | `nil` |
 | `web.service.loadBalancerIP` | The IP to use when web.service.type is LoadBalancer | `nil` |
 | `web.service.loadBalancerSourceRanges` | Concourse Web Service Load Balancer Source IP ranges | `nil` |
-| `web.service.atcNodePort` | Sets the nodePort for atc when using `NodePort` | `nil` |
-| `web.service.atcTlsNodePort` | Sets the nodePort for atc tls when using `NodePort` | `nil` |
 | `web.service.tsaNodePort` | Sets the nodePort for tsa when using `NodePort` | `nil` |
-| `web.ingress.enabled` | Enable Concourse Web Ingress | `false` |
-| `web.ingress.annotations` | Concourse Web Ingress annotations | `{}` |
-| `web.ingress.hosts` | Concourse Web Ingress Hostnames | `[]` |
-| `web.ingress.tls` | Concourse Web Ingress TLS configuration | `[]` |
+| `web.service.type` | Concourse Web service type | `ClusterIP` |
+| `web.syslogSecretsPath` | Specify the mount directory of the web syslog secrets | `/concourse-syslog` |
+| `web.tolerations` | Tolerations for the web nodes | `[]` |
+| `web.vaultSecretsPath` | Specify the mount directory of the web vault secrets | `/concourse-vault` |
 | `worker.nameOverride` | Override the Concourse Worker components name | `nil` |
 | `worker.replicas` | Number of Concourse Worker replicas | `2` |
 | `worker.minAvailable` | Minimum number of workers available after an eviction | `1` |

--- a/stable/concourse/more-config.yaml
+++ b/stable/concourse/more-config.yaml
@@ -1,0 +1,8 @@
+web:
+  additionalVolumes:
+  - name: team-authorized-keys
+    configMap:
+      name: hush-house-team-authorized-keys
+  additionalVolumeMounts:
+  - name: team-authorized-keys
+    mountPath: /team-authorized-keys/

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -930,11 +930,17 @@ spec:
             - name: auth-keys
               mountPath: {{ .Values.web.authSecretsPath | quote }}
               readOnly: true
+{{- if .Values.web.additionalVolumeMounts }}
+{{ toYaml .Values.web.additionalVolumeMounts | indent 12 }}
+{{- end }}
       affinity:
 {{- if .Values.web.additionalAffinities }}
 {{ toYaml .Values.web.additionalAffinities | indent 8 }}
 {{- end }}
       volumes:
+{{- if .Values.web.additionalVolumes }}
+{{ toYaml .Values.web.additionalVolumes | indent 8 }}
+{{- end }}
         - name: concourse-keys
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -702,6 +702,21 @@ web:
   syslogSecretsPath: "/concourse-syslog"
   tlsSecretsPath: "/concourse-web-tls"
 
+  ## Configure additional volumes for the
+  ## web container(s)
+  ##
+  # additionalVolumes:
+  #   - name: my-team-authorized-keys
+  #     configMap:
+  #       name: my-team-authorized-keys-config
+
+  ## Configure additional volumeMounts for the
+  ## web container(s)
+  ##
+  # additionalVolumeMounts:
+  #   - name: my-team-authorized-keys
+  #     mountPath: /my-team-authorized-keys
+
   ## Additional affinities to add to the web pods.
   ##
   # additionalAffinities:


### PR DESCRIPTION
#### What this PR does / why we need it:

Previously, it was not possible to include neither additional volumes nor volume mounts to the web instance.

This ends up prohibiting and operator of specifying configuration for team authorized keys or any other future configuration that might depend on files on disk.

#### Special notes for your reviewer:

Having the following values file:

```yaml
web:
  additionalVolumes:
  - name: team-authorized-keys
    configMap:
      name: hush-house-team-authorized-keys
  additionalVolumeMounts:
  - name: team-authorized-keys
    mountPath: /team-authorized-keys/
```

We can see the final result of the templating, the difference:

```diff
diff --git a/tmp/before b/tmp/after
index 7417e365..ec2f9175 100644
--- a/tmp/before
+++ b/tmp/after
@@ -452,8 +452,15 @@ spec:
             - name: auth-keys
               mountPath: "/concourse-auth"
               readOnly: true
+            - mountPath: /team-authorized-keys/
+              name: team-authorized-keys

       affinity:
       volumes:
+        - configMap:
+            name: hush-house-team-authorized-keys
+          name: team-authorized-keys

         - name: concourse-keys
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

cc @william-tran 