### PR TITLE
[stable/spinnaker] Add support for adding env vars to Halyard

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.4.0
+version: 1.4.1
 appVersion: 1.11.6
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/statefulsets/halyard.yaml
+++ b/stable/spinnaker/templates/statefulsets/halyard.yaml
@@ -126,6 +126,13 @@ spec:
           mountPath: /opt/halyard/config
         - name: reg-secrets
           mountPath: /opt/registry/passwords
+        {{- if .Values.halyard.additionalEnvVars }}
+        env:
+        {{- range $key, $value := .Values.halyard.additionalEnvVars }}
+        - name: {{ default "none" $key }}
+          value: {{ default "none" $value }}
+        {{- end }}
+        {{- end }}
   volumeClaimTemplates:
   - metadata:
       name: halyard-home

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -23,6 +23,8 @@ halyard:
   additionalProfileConfigMaps:
     create: false
     data: {}
+  # Sets environment variables on the Halyard pod, e.g. DEFAULT_JVM_OPTS
+  additionalEnvVars: {}
 
   ## Uncomment if you want to add extra commands to the init script
   ## run by the init container before halyard is started.


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Environment variables such as DEFAULT_JVM_OPTS need to be set in order
for Halyard to use a proxy. This adds an option to let you pass through
any env vars to the Halyard pod.

#### Which issue this PR fixes
No known issue

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
