### PR TITLE
[stable/jasperreports] Avoid setting STMP env. variables when not defined

### DIFF
--- a/stable/jasperreports/Chart.yaml
+++ b/stable/jasperreports/Chart.yaml
@@ -1,5 +1,5 @@
 name: jasperreports
-version: 4.0.0
+version: 4.0.1
 appVersion: 7.1.0
 description: The JasperReports server can be used as a stand-alone or embedded reporting
   and BI server that offers web-based reporting, analytic tools and visualization,

--- a/stable/jasperreports/templates/_helpers.tpl
+++ b/stable/jasperreports/templates/_helpers.tpl
@@ -16,6 +16,13 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "jasperreports.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/stable/jasperreports/templates/deployment.yaml
+++ b/stable/jasperreports/templates/deployment.yaml
@@ -3,21 +3,21 @@ kind: Deployment
 metadata:
   name: {{ template "jasperreports.fullname" . }}
   labels:
-    app: {{ template "jasperreports.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: "{{ template "jasperreports.fullname" . }}"
+    chart: "{{ template "jasperreports.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "jasperreports.fullname" . }}
-      release: "{{ .Release.Name }}"
+      app: "{{ template "jasperreports.fullname" . }}"
+      release: {{ .Release.Name | quote }}
   template:
     metadata:
       labels:
-        app: {{ template "jasperreports.fullname" . }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-        release: "{{ .Release.Name }}"
+        app: "{{ template "jasperreports.fullname" . }}"
+        chart: "{{ template "jasperreports.chart" . }}"
+        release: {{ .Release.Name | quote }}
     spec:
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
@@ -70,21 +70,33 @@ spec:
               key: jasperreports-password
         - name: JASPERREPORTS_EMAIL
           value: {{ .Values.jasperreportsEmail | quote }}
+        {{- if .Values.smtpHost }}
         - name: SMTP_HOST
           value: {{ .Values.smtpHost | quote }}
+        {{- end }}
+        {{- if .Values.smtpPort }}
         - name: SMTP_PORT
           value: {{ .Values.smtpPort | quote }}
+        {{- end }}
+        {{- if .Values.smtpEmail }}
         - name: SMTP_EMAIL
           value: {{ .Values.smtpEmail| quote }}
+        {{- end }}
+        {{- if .Values.smtpUser }}
         - name: SMTP_USER
           value: {{ .Values.smtpUser | quote }}
+        {{- end }}
+        {{- if .Values.smtpPassword }}
         - name: SMTP_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "jasperreports.fullname" . }}
               key: smtp-password
+        {{- end }}
+        {{- if .Values.smtpProtocol }}
         - name: SMTP_PROTOCOL
           value: {{ .Values.smtpProtocol | quote }}
+        {{- end }}
         ports:
         - name: http
           containerPort: 8080

--- a/stable/jasperreports/templates/externaldb-secrets.yaml
+++ b/stable/jasperreports/templates/externaldb-secrets.yaml
@@ -4,10 +4,10 @@ kind: Secret
 metadata:
   name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
   labels:
-    app: {{ printf "%s-%s" .Release.Name "externaldb"  }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: "{{ template "jasperreports.fullname" . }}"
+    chart: "{{ template "jasperreports.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 type: Opaque
 data:
   db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}

--- a/stable/jasperreports/templates/pvc.yaml
+++ b/stable/jasperreports/templates/pvc.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 metadata:
   name: {{ template "jasperreports.fullname" . }}
   labels:
-    app: {{ template "jasperreports.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: "{{ template "jasperreports.fullname" . }}"
+    chart: "{{ template "jasperreports.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/stable/jasperreports/templates/secrets.yaml
+++ b/stable/jasperreports/templates/secrets.yaml
@@ -3,15 +3,17 @@ kind: Secret
 metadata:
   name: {{ template "jasperreports.fullname" . }}
   labels:
-    app: {{ template "jasperreports.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: "{{ template "jasperreports.fullname" . }}"
+    chart: "{{ template "jasperreports.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 type: Opaque
 data:
-  {{ if .Values.jasperreportsPassword }}
+  {{- if .Values.jasperreportsPassword }}
   jasperreports-password: {{ default "" .Values.jasperreportsPassword | b64enc | quote }}
-  {{ else }}
+  {{- else }}
   jasperreports-password: {{ randAlphaNum 10 | b64enc | quote }}
-  {{ end }}
+  {{- end }}
+  {{- if .Values.smtpPassword }}
   smtp-password: {{ default "" .Values.smtpPassword | b64enc | quote }}
+  {{- end }}

--- a/stable/jasperreports/templates/svc.yaml
+++ b/stable/jasperreports/templates/svc.yaml
@@ -3,10 +3,10 @@ kind: Service
 metadata:
   name: {{ template "jasperreports.fullname" . }}
   labels:
-    app: {{ template "jasperreports.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: "{{ template "jasperreports.fullname" . }}"
+    chart: "{{ template "jasperreports.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   type: {{ .Values.service.type }}
   {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
@@ -20,4 +20,4 @@ spec:
       nodePort: {{ .Values.service.nodePorts.http }}
       {{- end }}
   selector:
-    app: {{ template "jasperreports.fullname" . }}
+    app: "{{ template "jasperreports.fullname" . }}"


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR avoids setting SMTP env. variables when the parameters are not set. It also refactors the labels.

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
