### PR TITLE
[mysqldump] Only use the bucketname for the permission and not the fo…

### DIFF
--- a/stable/mysqldump/Chart.yaml
+++ b/stable/mysqldump/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.0.0
 description: A Helm chart to help backup MySQL databases using mysqldump
 name: mysqldump
-version: 2.1.2
+version: 2.1.3
 keywords:
 - mysql
 - mysqldump

--- a/stable/mysqldump/templates/gcpserviceaccount.yaml
+++ b/stable/mysqldump/templates/gcpserviceaccount.yaml
@@ -14,7 +14,7 @@ spec:
   serviceAccountDescription: Service account for accessing a storage bucket for mysql backups
   secretName: {{ template "mysqldump.gcpsecretName" . }}
   bindings:
-  - resource: buckets/{{ .Values.upload.googlestoragebucket.bucketname | replace "gs://" "" }}
+  - resource: buckets/{{ index (splitList "/" (.Values.upload.googlestoragebucket.bucketname | replace "gs://" "")) 0  }}
     roles:
     - roles/storage.objectAdmin
 {{ end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
When using the gcp service account controller together with a folder in a storagebucket, the foldername will be included in the resource definition of the service account permissions. The controller will fail to set the permissions in that case.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
