### PR TITLE
[keycloak] Add option to disable test pod

### DIFF
--- a/incubator/keycloak/Chart.yaml
+++ b/incubator/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 0.6.0
+version: 0.6.1
 appVersion: 3.4.3.Final
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/incubator/keycloak/README.md
+++ b/incubator/keycloak/README.md
@@ -97,6 +97,7 @@ Parameter | Description | Default
 `postgresql.postgresUser` | The PostgreSQL user (if `keycloak.persistence.deployPostgres=true`) | `keycloak`
 `postgresql.postgresPassword` | The PostgreSQL password (if `keycloak.persistence.deployPostgres=true`) | `""`
 `postgresql.postgresDatabase` | The PostgreSQL database (if `keycloak.persistence.deployPostgres=true`) | `keycloak`
+`test.enabled` | If `true`, test pods get scheduled | `true`
 `test.image.repository` | Test image repository | `unguiculus/docker-python3-phantomjs-selenium`
 `test.image.tag` | Test image tag | `v1`
 `test.image.pullPolicy` | Test image pull policy | `IfNotPresent`

--- a/incubator/keycloak/templates/test/test-configmap.yaml
+++ b/incubator/keycloak/templates/test/test-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.test.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -53,3 +54,4 @@ data:
     print('URLs match. Login successful.')
 
     driver.quit()
+{{- end }}

--- a/incubator/keycloak/templates/test/test-pod.yaml
+++ b/incubator/keycloak/templates/test/test-pod.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.test.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -33,3 +34,4 @@ spec:
       configMap:
         name: {{ template "keycloak.fullname" . }}-test
   restartPolicy: Never
+{{- end }}

--- a/incubator/keycloak/values.yaml
+++ b/incubator/keycloak/values.yaml
@@ -212,6 +212,7 @@ postgresql:
     enabled: false
 
 test:
+  enabled: true
   image:
     repository: unguiculus/docker-python3-phantomjs-selenium
     tag: v1

--- a/stable/keycloak/Chart.yaml
+++ b/stable/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 4.3.0
+version: 4.3.1
 appVersion: 4.8.3.Final
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/stable/keycloak/README.md
+++ b/stable/keycloak/README.md
@@ -98,6 +98,7 @@ Parameter | Description | Default
 `postgresql.postgresUser` | The PostgreSQL user (if `keycloak.persistence.deployPostgres=true`) | `keycloak`
 `postgresql.postgresPassword` | The PostgreSQL password (if `keycloak.persistence.deployPostgres=true`) | `""`
 `postgresql.postgresDatabase` | The PostgreSQL database (if `keycloak.persistence.deployPostgres=true`) | `keycloak`
+`test.enabled` | If `true`, test pods get scheduled | `true`
 `test.image.repository` | Test image repository | `unguiculus/docker-python3-phantomjs-selenium`
 `test.image.tag` | Test image tag | `v1`
 `test.image.pullPolicy` | Test image pull policy | `IfNotPresent`

--- a/stable/keycloak/templates/test/test-configmap.yaml
+++ b/stable/keycloak/templates/test/test-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.test.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -53,3 +54,4 @@ data:
     print('URLs match. Login successful.')
 
     driver.quit()
+{{- end }}

--- a/stable/keycloak/templates/test/test-pod.yaml
+++ b/stable/keycloak/templates/test/test-pod.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.test.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -34,3 +35,4 @@ spec:
       configMap:
         name: {{ template "keycloak.fullname" . }}-test
   restartPolicy: Never
+{{- end }}

--- a/stable/keycloak/values.yaml
+++ b/stable/keycloak/values.yaml
@@ -232,6 +232,7 @@ postgresql:
     enabled: false
 
 test:
+  enabled: true
   image:
     repository: unguiculus/docker-python3-phantomjs-selenium
     tag: v1


### PR DESCRIPTION

#### What this PR does / why we need it:
This patch adds the flag `test.enabled` to disable creation of test resources to the keycloak stable and incubator chart.
On my cluster, the test pod failed to launch.
I guess the general consensus is that the test resources should not run in production anyways.


#### Special notes for your reviewer:
Maybe we could let `test.enabled` default to `false`. Not sure if this would break a lot of stuff.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
