### PR TITLE
add nextcloud chart

### DIFF
--- a/stable/nextcloud/.helmignore
+++ b/stable/nextcloud/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/nextcloud/Chart.yaml
+++ b/stable/nextcloud/Chart.yaml
@@ -1,0 +1,17 @@
+name: nextcloud
+version: 1.0.0
+appVersion: 15.0.2
+description: A file sharing server that puts the control and security of your own data back into your hands.
+keywords:
+- nextcloud
+- storage
+- http
+- web
+- php
+home: https://nextcloud.com/
+icon: https://cdn.rawgit.com/docker-library/docs/defa5ffc7123177acd60ddef6e16bddf694cc35f/nextcloud/logo.svg
+sources:
+- https://github.com/nextcloud/docker
+maintainers:
+- name: chrisingenhaag
+  email: christian.ingenhaag@googlemail.com

--- a/stable/nextcloud/README.md
+++ b/stable/nextcloud/README.md
@@ -1,0 +1,119 @@
+# nextcloud
+
+[nextcloud](https://nextcloud.com/) is a file sharing server that puts the control and security of your own data back into your hands.
+
+## TL;DR;
+
+```console
+$ helm install stable/nextcloud
+```
+
+## Introduction
+
+This chart bootstraps an [nextcloud](https://hub.docker.com/_/nextcloud/) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+It also packages the [Bitnami MariaDB chart](https://github.com/kubernetes/charts/tree/master/stable/mariadb) which is required for bootstrapping a MariaDB deployment for the database requirements of the nextcloud application.
+
+## Prerequisites
+
+- Kubernetes 1.9+ with Beta APIs enabled
+- PV provisioner support in the underlying infrastructure
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release stable/nextcloud
+```
+
+The command deploys nextcloud on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the nextcloud chart and their default values.
+
+|              Parameter              |                Description                |                   Default                               |
+|-------------------------------------|-------------------------------------------|-------------------------------------------------------- |
+| `image.repository`                  | nextcloud Image name                       | `nextcloud`                                      |
+| `image.tag`                         | nextcloud Image tag                        | `{VERSION}`                                             |
+| `image.pullPolicy`                  | Image pull policy                         | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
+| `image.pullSecrets`                 | Specify image pull secrets                | `nil`                                                   |
+| `ingress.enabled`                   | Enable use of ingress controllers         | `false`                                                 |
+| `ingress.servicePort`               | Ingress' backend servicePort              | `http`                                                  |
+| `ingress.annotations`               | An array of service annotations           | `nil`                                                   |
+| `ingress.tls`                       | Ingress TLS configuration                 | `[]`                                                    |
+| `nextcloud.host`                     | nextcloud host to create application URLs  | `nextcloud.kube.home`                                                   |
+| `nextcloud.username`                 | User of the application                   | `admin`                                                  |
+| `nextcloud.password`                 | Application password                      | `changeme`                                    |
+| `internalDatabase.enabled`         | Whether to use internal sqlite database    | `true`                                      |
+| `internalDatabase.database`         | Name of the existing database             | `nextcloud`                                      |
+| `externalDatabase.enabled`          | Whether to use external database          | `false`                                                   |
+| `externalDatabase.host`             | Host of the external database             | `nil`                                                   |
+| `externalDatabase.database`         | Name of the existing database             | `nextcloud`                                      |
+| `externalDatabase.user`             | Existing username in the external db      | `nextcloud`                                           |
+| `externalDatabase.password`         | Password for the above username           | `nil`                                                   |
+| `mariadb.enabled`                   | Whether to use the MariaDB chart          | `false`                                                  |
+| `mariadb.db.name`           | Database name to create                   | `nextcloud`                                      |
+| `mariadb.db.password`           | Password for the database                 | `changeme`                                                   |
+| `mariadb.db.user`               | Database user to create                   | `nextcloud`                                           |
+| `mariadb.rootUser.password`       | MariaDB admin password                    | `nil`                                                   |
+| `service.type`                      | Kubernetes Service type                   | `ClusterIp`                                          |
+| `service.loadBalancerIP`            | LoadBalancerIp for service type LoadBalancer                   | `nil`                                          |
+| `persistence.enabled`     | Enable persistence using PVC              | `true`                                                  |
+| `persistence.storageClass` | PVC Storage Class for nextcloud volume     | `nil` (uses alpha storage class annotation)             |
+| `persistence.existingClaim`| An Existing PVC name for nextcloud volume  | `nil` (uses alpha storage class annotation)             |
+| `persistence.accessMode`   | PVC Access Mode for nextcloud volume       | `ReadWriteOnce`                                         |
+| `persistence.size`         | PVC Storage Request for nextcloud volume   | `8Gi`                                                   |
+| `resources`                         | CPU/Memory resource requests/limits       | `{}`                 |
+
+> **Note**:
+>
+> For nextcloud to function correctly, you should specify the `nextcloud.host` parameter to specify the FQDN (recommended) or the public IP address of the nextcloud service.
+>
+> Optionally, you can specify the `service.loadBalancerIP` parameter to assign a reserved IP address to the nextcloud service of the chart. However please note that this feature is only available on a few cloud providers (f.e. GKE).
+>
+> To reserve a public IP address on GKE:
+>
+> ```bash
+> $ gcloud compute addresses create nextcloud-public-ip
+> ```
+>
+> The reserved IP address can be associated to the nextcloud service by specifying it as the value of the `service.loadBalancerIP` parameter while installing the chart.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install --name my-release \
+  --set nextcloud.username=admin,nextcloud.password=password,mariadb.rootUser.password=secretpassword \
+    stable/nextcloud
+```
+
+The above command sets the nextcloud administrator account username and password to `admin` and `password` respectively. Additionally, it sets the MariaDB `root` user password to `secretpassword`.
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name my-release -f values.yaml stable/nextcloud
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Persistence
+
+The [Nextcloud](https://hub.docker.com/_/nextcloud/) image stores the nextcloud data and configurations at the `/var/www/html` paths of the container.
+
+Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
+See the [Configuration](#configuration) section to configure the PVC or to disable persistence.

--- a/stable/nextcloud/requirements.lock
+++ b/stable/nextcloud/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: mariadb
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 5.5.0
+digest: sha256:66e8bec50806f6576f4954c145d45b44a55975cad4f10b3bdd6cc4e208055bca
+generated: 2019-01-26T18:57:18.847326+01:00

--- a/stable/nextcloud/requirements.yaml
+++ b/stable/nextcloud/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+- name: mariadb
+  version: ~5.5.0
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: mariadb.enabled

--- a/stable/nextcloud/templates/NOTES.txt
+++ b/stable/nextcloud/templates/NOTES.txt
@@ -1,0 +1,93 @@
+{{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
+
+{{- if empty (include "nextcloud.host" .) -}}
+###############################################################################
+### ERROR: You did not provide an external host in your 'helm install' call ###
+###############################################################################
+
+This deployment will be incomplete until you configure nextcloud with a resolvable
+host. To configure nextcloud with the URL of your service:
+
+1. Get the nextcloud URL by running:
+
+  {{- if contains "NodePort" .Values.service.type }}
+
+  export APP_PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "nextcloud.fullname" . }} -o jsonpath="{.spec.ports[0].nodePort}")
+  export APP_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+
+  {{- else if contains "LoadBalancer" .Values.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "nextcloud.fullname" . }}'
+
+  export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "nextcloud.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+  export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "nextcloud.fullname" . }} -o jsonpath="{.data.nextcloud-password}" | base64 --decode)
+  {{- if .Values.mariadb.db.password }}
+  export APP_DATABASE_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "nextcloud.mariadb.fullname" . }} -o jsonpath="{.data.mariadb-password}" | base64 --decode)
+  {{- end }}
+  {{- end }}
+
+2. Complete your nextcloud deployment by running:
+
+{{- if .Values.mariadb.enabled }}
+
+  helm upgrade {{ .Release.Name }} stable/nextcloud \
+    --set nextcloud.host=$APP_HOST,nextcloud.password=$APP_PASSWORD{{ if .Values.mariadb.db.password }},mariadb.db.password=$APP_DATABASE_PASSWORD{{ end }}
+{{- else }}
+
+  ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
+
+  helm upgrade {{ .Release.Name }} stable/nextcloud \
+    --set nextcloud.password=$APP_PASSWORD,nextcloud.host=$APP_HOST,service.type={{ .Values.service.type }},mariadb.enabled=false{{- if not (empty .Values.externalDatabase.host) }},externalDatabase.host={{ .Values.externalDatabase.host }}{{- end }}{{- if not (empty .Values.externalDatabase.user) }},externalDatabase.user={{ .Values.externalDatabase.user }}{{- end }}{{- if not (empty .Values.externalDatabase.password) }},externalDatabase.password={{ .Values.externalDatabase.password }}{{- end }}{{- if not (empty .Values.externalDatabase.database) }},externalDatabase.database={{ .Values.externalDatabase.database }}{{- end }}
+{{- end }}
+
+{{- else -}}
+1. Get the nextcloud URL by running:
+
+{{- if eq .Values.service.type "ClusterIP" }}
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "nextcloud.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+  echo http://127.0.0.1:8080/
+  kubectl port-forward $POD_NAME 8080:8080
+{{- else }}
+
+  echo http://{{ include "nextcloud.host" . }}{{ if .Values.nextcloudPort }}:{{ .Values.nextcloudPort  }}{{ end }}/
+{{- end }}
+
+2. Get your nextcloud login credentials by running:
+
+  echo User:     {{ .Values.nextcloud.username }}
+  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "nextcloud.fullname" . }} -o jsonpath="{.data.nextcloud-password}" | base64 --decode)
+{{- end }}
+
+{{- else -}}
+
+########################################################################################
+### ERROR: You did not provide an external database host in your 'helm install' call ###
+########################################################################################
+
+This deployment will be incomplete until you configure nextcloud with a resolvable database
+host. To configure nextcloud to use and external database host:
+
+
+1. Complete your nextcloud deployment by running:
+
+{{- if contains "NodePort" .Values.service.type }}
+  export APP_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "nextcloud.fullname" . }}'
+
+  export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "nextcloud.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+{{- else }}
+
+  export APP_HOST=127.0.0.1
+{{- end }}
+  export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "nextcloud.fullname" . }} -o jsonpath="{.data.nextcloud-password}" | base64 --decode)
+
+  ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
+
+  helm upgrade {{ .Release.Name }} stable/nextcloud \
+    --set nextcloud.password=$APP_PASSWORD,nextcloud.host=$APP_HOST,service.type={{ .Values.service.type }},mariadb.enabled=false{{- if not (empty .Values.externalDatabase.user) }},externalDatabase.user={{ .Values.externalDatabase.user }}{{- end }}{{- if not (empty .Values.externalDatabase.password) }},externalDatabase.password={{ .Values.externalDatabase.password }}{{- end }}{{- if not (empty .Values.externalDatabase.database) }},externalDatabase.database={{ .Values.externalDatabase.database }}{{- end }},externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST
+{{- end }}

--- a/stable/nextcloud/templates/NOTES.txt
+++ b/stable/nextcloud/templates/NOTES.txt
@@ -1,9 +1,9 @@
 {{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
 
 {{- if empty (include "nextcloud.host" .) -}}
-###############################################################################
-### ERROR: You did not provide an external host in your 'helm install' call ###
-###############################################################################
+#################################################################################
+### WARNING: You did not provide an external host in your 'helm install' call ###
+#################################################################################
 
 This deployment will be incomplete until you configure nextcloud with a resolvable
 host. To configure nextcloud with the URL of your service:
@@ -62,11 +62,12 @@ host. To configure nextcloud with the URL of your service:
 
 {{- else -}}
 
-########################################################################################
-### ERROR: You did not provide an external database host in your 'helm install' call ###
-########################################################################################
+#######################################################################################################
+## WARNING: You did not provide an external database host in your 'helm install' call                ##
+## Running Nextcloud with the integrated sqlite database is not recommended for production instances ##
+#######################################################################################################
 
-This deployment will be incomplete until you configure nextcloud with a resolvable database
+For better performance etc. you have to configure nextcloud with a resolvable database
 host. To configure nextcloud to use and external database host:
 
 

--- a/stable/nextcloud/templates/_helpers.tpl
+++ b/stable/nextcloud/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nextcloud.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "nextcloud.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "nextcloud.mariadb.fullname" -}}
+{{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Get the user defined LoadBalancerIP for this release.
+Note, returns 127.0.0.1 if using ClusterIP.
+*/}}
+{{- define "nextcloud.serviceIP" -}}
+{{- if eq .Values.service.type "ClusterIP" -}}
+127.0.0.1
+{{- else -}}
+{{- index .Values (printf "%sLoadBalancerIP" .Chart.Name) | default "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Gets the host to be used for this application.
+If not using ClusterIP, or if a host or LoadBalancerIP is not defined, the value will be empty.
+*/}}
+{{- define "nextcloud.host" -}}
+{{- $host := index .Values (printf "%sHost" .Chart.Name) | default "" -}}
+{{- default (include "nextcloud.serviceIP" .) $host -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nextcloud.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/nextcloud/templates/_helpers.tpl
+++ b/stable/nextcloud/templates/_helpers.tpl
@@ -9,10 +9,19 @@ Expand the name of the chart.
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "nextcloud.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/nextcloud/templates/db-secret.yaml
+++ b/stable/nextcloud/templates/db-secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.mariadb.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s" .Release.Name "db"  }}
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+data:
+  db-password: {{ default "" .Values.mariadb.db.password | b64enc | quote }}
+  db-username: {{ default "" .Values.mariadb.db.user | b64enc | quote }}
+{{- end }}

--- a/stable/nextcloud/templates/deployment.yaml
+++ b/stable/nextcloud/templates/deployment.yaml
@@ -1,0 +1,132 @@
+{{- if include "nextcloud.host" . -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "nextcloud.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end}}
+      {{- end }}
+      containers:
+      - name: {{ template "nextcloud.fullname" . }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+        env:
+        {{- if .Values.internalDatabase.enabled }}
+        - name: SQLITE_DATABASE
+          value: {{ .Values.internalDatabase.name | quote }}
+        {{- else if .Values.mariadb.enabled }}
+        - name: MYSQL_HOST
+          value: {{ template "nextcloud.mariadb.fullname" . }}
+        - name: MYSQL_DATABASE
+          value: {{ .Values.mariadb.db.name | quote }}
+        - name: MYSQL_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "%s-%s" .Release.Name "db"  }}
+              key: db-username
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "%s-%s" .Release.Name "db"  }}
+              key: db-password
+        {{- else }}
+        - name: MYSQL_HOST
+          value: {{ .Values.externalDatabase.host | quote }}
+        - name: MYSQL_DATABASE
+          value: {{ .Values.externalDatabase.database | quote }}
+        - name: MYSQL_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "%s-%s" .Release.Name "db" }}
+              key: db-username
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "%s-%s" .Release.Name "db" }}
+              key: db-password
+        {{- end }}
+        - name: NEXTCLOUD_ADMIN_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "nextcloud.fullname" . }}
+              key: nextcloud-username
+        - name: NEXTCLOUD_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "nextcloud.fullname" . }}
+              key: nextcloud-password
+        - name: NEXTCLOUD_TRUSTED_DOMAINS
+          value: {{ .Values.nextcloud.host }}
+        ports:
+        - name: http
+          containerPort: 80
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /status.php
+            port: http
+            httpHeaders:
+            - name: Host
+              value: {{ include "nextcloud.host" . | quote }}
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 6
+        readinessProbe:
+          httpGet:
+            path: /status.php
+            port: http
+            httpHeaders:
+            - name: Host
+              value: {{ include "nextcloud.host" . | quote }}
+          initialDelaySeconds: 30
+          timeoutSeconds: 3
+          periodSeconds: 5
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+        - name: nextcloud-data
+          mountPath: /var/www/html/
+          subPath: root
+        - name: nextcloud-data
+          mountPath: /var/www/html/data
+          subPath: data
+        - name: nextcloud-data
+          mountPath: /var/www/html/config
+          subPath: config
+        - name: nextcloud-data
+          mountPath: /var/www/html/custom_apps
+          subPath: custom_apps
+        - name: nextcloud-data
+          mountPath: /var/www/html/themes
+          subPath: themes
+      volumes:
+      - name: nextcloud-data
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "nextcloud.fullname" . }}-nextcloud{{- end }}
+      {{- else }}
+        emptyDir: {}
+      {{- end }}
+{{- end -}}

--- a/stable/nextcloud/templates/deployment.yaml
+++ b/stable/nextcloud/templates/deployment.yaml
@@ -29,9 +29,9 @@ spec:
       {{- end}}
       {{- end }}
       containers:
-      - name: {{ template "nextcloud.fullname" . }}
+      - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         {{- if .Values.internalDatabase.enabled }}
         - name: SQLITE_DATABASE
@@ -121,6 +121,18 @@ spec:
         - name: nextcloud-data
           mountPath: /var/www/html/themes
           subPath: themes
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       volumes:
       - name: nextcloud-data
       {{- if .Values.persistence.enabled }}

--- a/stable/nextcloud/templates/ingress.yaml
+++ b/stable/nextcloud/templates/ingress.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "nextcloud.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+{{- end }}
+spec:
+  rules:
+  - host: {{ .Values.nextcloud.host }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ template "nextcloud.fullname" . }}
+          servicePort: {{ .Values.service.port }}
+{{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+{{- end -}}
+{{- end }}

--- a/stable/nextcloud/templates/nextcloud-pvc.yaml
+++ b/stable/nextcloud/templates/nextcloud-pvc.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.persistence.enabled -}}
+{{- if not .Values.persistence.existingClaim -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "nextcloud.fullname" . }}-nextcloud
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/stable/nextcloud/templates/secrets.yaml
+++ b/stable/nextcloud/templates/secrets.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "nextcloud.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+data:
+  nextcloud-username: {{ .Values.nextcloud.username | b64enc | quote }}
+  {{ if .Values.nextcloud.password }}
+  nextcloud-password: {{ .Values.nextcloud.password | b64enc | quote }}
+  {{ else }}
+  nextcloud-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ end }}
+  

--- a/stable/nextcloud/templates/service.yaml
+++ b/stable/nextcloud/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "nextcloud.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if eq .Values.service.type "LoadBalancer" }}
+  loadBalancerIP: {{ default "" .Values.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+  - port: {{ .Values.service.port }}
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}

--- a/stable/nextcloud/templates/tests/test-connection.yaml
+++ b/stable/nextcloud/templates/tests/test-connection.yaml
@@ -14,5 +14,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args:  ['--header', 'Host: {{ .Values.nextcloud.host }}', '{{ include "nextcloud.fullname" . }}:{{ .Values.service.port }}']
+      args:  ['--header', 'Host: {{ .Values.nextcloud.host }}', '{{ include "nextcloud.fullname" . }}:{{ .Values.service.port }}/status.php']
   restartPolicy: Never

--- a/stable/nextcloud/templates/tests/test-connection.yaml
+++ b/stable/nextcloud/templates/tests/test-connection.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "nextcloud.fullname" . }}-test-connection"
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['--header', 'Host: {{ .Values.nextcloud.host }}', '{{ include "nextcloud.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/stable/nextcloud/values-mariadb.yaml
+++ b/stable/nextcloud/values-mariadb.yaml
@@ -1,0 +1,5 @@
+internalDatabase:
+  enabled: false
+
+mariadb:
+  enabled: true

--- a/stable/nextcloud/values.yaml
+++ b/stable/nextcloud/values.yaml
@@ -1,0 +1,147 @@
+## Official nextcloud image version
+## ref: https://hub.docker.com/r/library/nextcloud/tags/
+##
+image:
+  repository: nextcloud
+  tag: 15.0.2-apache
+  pullPolicy: IfNotPresent
+  # pullSecrets:
+  #   - myRegistrKeySecretName
+
+# Number of replicas to be deployed
+replicaCount: 1
+
+## Allowing use of ingress controllers
+## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
+##
+ingress:
+  enabled: true
+  annotations: {}
+  #  nginx.ingress.kubernetes.io/proxy-body-size: 4G
+  #  kubernetes.io/tls-acme: "true"
+  #  certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+  #  nginx.ingress.kubernetes.io/server-snippet: |-
+  #    add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
+  #    add_header X-Robots-Tag none;
+  #    add_header X-Download-Options noopen;
+  #    add_header X-Permitted-Cross-Domain-Policies none;
+  #    add_header X-Content-Type-Options nosniff;
+  #    add_header X-XSS-Protection "1; mode=block";
+  #    add_header Referrer-Policy no-referrer;
+  #    rewrite ^/.well-known/webfinger /public.php?service=webfinger last;
+  #    rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
+  #    rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json;
+  #    location = /.well-known/carddav {
+  #      return 301 $scheme://$host/remote.php/dav;
+  #    }
+  #    location = /.well-known/caldav {
+  #      return 301 $scheme://$host/remote.php/dav;
+  #    }
+  #    location = /robots.txt {
+  #      allow all;
+  #      log_not_found off;
+  #      access_log off;
+  #    }
+  #    location ~ \.(?:png|html|ttf|ico|jpg|jpeg)$ {
+  #      try_files $uri /index.php$request_uri;
+  #      # Optional: Don't log access to other assets
+  #      access_log off;
+  #    }
+  #    location / {
+  #      rewrite ^ /index.php$request_uri;
+  #    }
+  #    location ~ ^/(?:build|tests|config|lib|3rdparty|templates|data)/ {
+  #      deny all;
+  #    }
+  #    location ~ ^/(?:\.|autotest|occ|issue|indie|db_|console) {
+  #      deny all;
+  #    }
+  #  tls:
+  #    - secretName: nextcloud-tls
+  #      hosts:
+  #        - nextcloud.kube.home
+
+nextcloud:
+  host: nextcloud.kube.home
+  username: admin
+  password: changeme
+
+
+internalDatabase:
+  enabled: true
+  name: nextcloud
+
+
+##
+## External database configuration
+##
+externalDatabase:
+  enabled: false
+
+  ## Database host
+  host:
+
+  ## Database user
+  user: nextcloud
+
+  ## Database password
+  password:
+
+  ## Database name
+  database: nextcloud
+
+##
+## MariaDB chart configuration
+##
+mariadb:
+  ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  enabled: false
+
+  db:
+    name: nextcloud
+    user: nextcloud
+    password: changeme
+
+  ## Enable persistence using Persistent Volume Claims
+  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    enabled: false
+    accessMode: ReadWriteOnce
+    size: 8Gi
+
+service:
+  type: ClusterIP
+  port: 8080
+  loadBalancerIP: nil
+
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  enabled: true
+  ## nextcloud data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+
+  ## A manually managed Persistent Volume and Claim
+  ## Requires persistence.enabled: true
+  ## If defined, PVC must be created manually before volume will be bound
+  # existingClaim:
+
+  accessMode: ReadWriteOnce
+  size: 8Gi
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources: {}
+#  requests:
+#    memory: 512Mi
+#    cpu: 300m

--- a/stable/nextcloud/values.yaml
+++ b/stable/nextcloud/values.yaml
@@ -18,7 +18,7 @@ replicaCount: 1
 ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ##
 ingress:
-  enabled: true
+  enabled: false
   annotations: {}
   #  nginx.ingress.kubernetes.io/proxy-body-size: 4G
   #  kubernetes.io/tls-acme: "true"

--- a/stable/nextcloud/values.yaml
+++ b/stable/nextcloud/values.yaml
@@ -8,6 +8,9 @@ image:
   # pullSecrets:
   #   - myRegistrKeySecretName
 
+nameOverride: ""
+fullnameOverride: ""
+
 # Number of replicas to be deployed
 replicaCount: 1
 
@@ -120,7 +123,7 @@ service:
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##
 persistence:
-  enabled: true
+  enabled: false
   ## nextcloud data Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning
@@ -138,10 +141,20 @@ persistence:
   accessMode: ReadWriteOnce
   size: 8Gi
 
-## Configure resource requests and limits
-## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-##
 resources: {}
-#  requests:
-#    memory: 512Mi
-#    cpu: 300m
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds nextcloud to helm stable. It´s inspired from affix´ PR #5180 which is now stale for about half a year. Thx for his work on this point.

Nevertheless I wanted to get this done, refactored the chart and created a new PR fro it.

* corrected nextcloud image env var usage
* default helm install uses nextclouds integrated sqllite db with env-var-based auto-configuration
* updated to use up to date mariadb chart optionally
* simplified pvc usage with one pv and volume subPath-usage 
* inserted test-connection Pod

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
