### PR TITLE
[stable/prometheus-operator] fix conditional rule inserts

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 2.1.1
+version: 2.1.2
 appVersion: 0.26.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/hack/sync_prometheus_rules.py
+++ b/stable/prometheus-operator/hack/sync_prometheus_rules.py
@@ -146,6 +146,20 @@ def add_rules_conditions(rules, indent=4):
             except ValueError:
                 # we found the last alert in file if there are no alerts after it
                 next_index = len(rules)
+
+            # depending on the rule ordering in alert_condition_map it's possible that an if statement from another rule is present at the end of this block.
+            found_block_end = False
+            last_line_index = next_index
+            while not found_block_end:
+                last_line_index = rules.rindex('\n', index, last_line_index - 1) # find the starting position of the last line
+                last_line = rules[last_line_index + 1:next_index]
+
+                if last_line.startswith('{{- if'):
+                    next_index = last_line_index + 1 # move next_index back if the current block ends in an if statement
+                    continue
+
+                found_block_end = True
+
             rules = rules[:next_index] + '{{- end }}\n' + rules[next_index:]
     return rules
 

--- a/stable/prometheus-operator/templates/alertmanager/rules/kubernetes-absent.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/rules/kubernetes-absent.yaml
@@ -38,8 +38,8 @@ spec:
       for: 15m
       labels:
         severity: critical
-{{- if .Values.kubeApiServer.enabled }}
 {{- end }}
+{{- if .Values.kubeApiServer.enabled }}
     - alert: KubeAPIDown
       annotations:
         message: KubeAPI has disappeared from Prometheus target discovery.


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

There's a small bug in the script that syncs alerting rules from the coreos/prometheus-operator repo. It results in a few conditional blocks either including too many rules or including no rules. [See example here.](https://github.com/helm/charts/blob/c3d847f9797f08b457741c02e07de54cca8686d7/stable/prometheus-operator/templates/alertmanager/rules/kubernetes-absent.yaml#L32-L51)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
