### PR TITLE
[stable/fluent-bit] remove hard coded name for daemonset

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 1.4.0
+version: 1.4.1
 appVersion: 1.0.3
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/daemonset.yaml
+++ b/stable/fluent-bit/templates/daemonset.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: fluent-bit
+  name: {{ template "fluent-bit.fullname" . }}
   labels:
     app: {{ template "fluent-bit.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Name of the daemonset is currently `fluent-bit` but this causes a conflict when the chart is installed more than once in the same cluster. It's also very unconventional compared to other charts.

The standard value for this is `{{ template "fluent-bit.fullname" . }}` so I've use that.

#### Special notes for your reviewer:

Why would you want to install the chart more than once? For example, we were testing 2 logging solutions so needed more than a single daemonset running in the cluster. We required one for Graylog and one for Splunk 🙂

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
