### PR TITLE
Add advanced.config to ConfigMap

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.8
-version: 1.18.1
+version: 1.19.0
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -69,6 +69,7 @@ and their default values.
 | `existingSecret`                               | Use an existing secret for password & erlang cookie                                                                                                                                                   | `""`                                                       |
 | `extraPlugins`                                 | Additional plugins to add to the default configmap                                                                                                                                                    | `rabbitmq_shovel, rabbitmq_shovel_management, rabbitmq_federation, rabbitmq_federation_management,` |
 | `extraConfig`                                  | Additional configuration to add to default configmap                                                                                                                                                  | `{}`                                                         |
+| `advancedConfig`                               | Additional configuration in classic config format                                                                                                                                                   | `""`                                                           |
 | `definitions.users`                            | Additional users | `""` |
 | `definitions.vhosts`                           | Additional vhosts | `""` |
 | `definitions.parameters`                       | Additional parameters | `""` |
@@ -113,7 +114,7 @@ and their default values.
 | `rabbitmqCert.certfile`                        | base64 encoded server certificate (overwrites existing Secret)                                                                                                                                        | ``                                                         |
 | `rabbitmqCert.existingSecret`                  | Name of an existing `Secret` to mount for amqps                                                                                                                                                       | `""`                                                       |
 | `rabbitmqCert.keyfile`                         | base64 encoded server private key (overwrites existing Secret)                                                                                                                                        | ``                                                         |
-| `rabbitmqClusterPartitionHandling`             | [Automatic Partition Handling Strategy (split brain handling)](https://www.rabbitmq.com/partitions.html#automatic-handling)                                                                           | `autoheal`                                                 | 
+| `rabbitmqClusterPartitionHandling`             | [Automatic Partition Handling Strategy (split brain handling)](https://www.rabbitmq.com/partitions.html#automatic-handling)                                                                           | `autoheal`                                                 |
 | `extraVolumes`                             | Extra volumes to attach to the statefulset                                                                                                                                                           | `[]`                                                     |
 | `extraVolumeMounts`                             | Extra volume mounts to mount to the statefulset                                                                                                                                                           | `[]`                                                     |
 | `rabbitmqEpmdPort`                             | EPMD port used for cross cluster replication                                                                                                                                                          | `4369`                                                     |
@@ -225,7 +226,7 @@ $ helm install --name my-release --set existingConfigMap=true stable/rabbitmq-ha
 
 Similar to custom ConfigMap, `existingSecret` can be used to override the default secret.yaml provided, and
 `rabbitmqCert.existingSecret` can be used to override the default certificates. The custom secret must provide
-the following keys: 
+the following keys:
 
 * `rabbitmq-user`
 * `rabbitmq-password`

--- a/stable/rabbitmq-ha/templates/configmap.yaml
+++ b/stable/rabbitmq-ha/templates/configmap.yaml
@@ -114,3 +114,8 @@ data:
 {{ .Values.extraConfig | indent 4 }}
 
 {{- end }}
+
+{{- if .Values.advancedConfig }}
+  advanced.config: |
+{{ .Values.advancedConfig | indent 4 }}
+{{- end }}

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -13,6 +13,10 @@ managementPassword: E9R3fjZm4ejFkVFE
 extraConfig: |
 #  queue_master_locator = min-masters
 
+## Place advanced.config file in /etc/rabbitmq/advanced.config
+## Ref: https://www.rabbitmq.com/configure.html#advanced-config-file
+advancedConfig: |
+
 ## Definitions specification within the secret, will always be mounted
 ## at /etc/definitions/defintions.json
 definitionsSource: definitions.json


### PR DESCRIPTION
#### What this PR does / why we need it:

* adds `advanced.config` to ConfigMap with a possibility to list classic format Erlang directives in it

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
