### PR TITLE
[stable/prestashop] Avoid setting SMTP env. variables when the corresponding values are not set

### DIFF
--- a/stable/prestashop/Chart.yaml
+++ b/stable/prestashop/Chart.yaml
@@ -1,5 +1,5 @@
 name: prestashop
-version: 6.1.1
+version: 6.1.2
 appVersion: 1.7.5-0
 description: A popular open source ecommerce solution. Professional tools are easily accessible to increase online sales including instant guest checkout, abandoned cart reminders and automated Email marketing.
 keywords:

--- a/stable/prestashop/templates/deployment.yaml
+++ b/stable/prestashop/templates/deployment.yaml
@@ -103,19 +103,29 @@ spec:
           value: {{ .Values.prestashopFirstName | quote }}
         - name: PRESTASHOP_LAST_NAME
           value: {{ .Values.prestashopLastName | quote }}
+        {{- if .Values.smtpHost }}
         - name: SMTP_HOST
           value: {{ .Values.smtpHost | quote }}
+        {{- end }}
+        {{- if .Values.smtpPort }}
         - name: SMTP_PORT
           value: {{ .Values.smtpPort | quote }}
+        {{- end }}
+        {{- if .Values.smtpUser }}
         - name: SMTP_USER
           value: {{ .Values.smtpUser | quote }}
+        {{- end }}
+        {{- if .Values.smtpPassword }}
         - name: SMTP_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "prestashop.fullname" . }}
               key: smtp-password
+        {{- end }}
+        {{- if .Values.smtpProtocol }}
         - name: SMTP_PROTOCOL
           value: {{ .Values.smtpProtocol | quote }}
+        {{- end }}
         ports:
         - name: http
           containerPort: 80

--- a/stable/prestashop/templates/secrets.yaml
+++ b/stable/prestashop/templates/secrets.yaml
@@ -9,9 +9,11 @@ metadata:
     heritage: {{ .Release.Service | quote }}
 type: Opaque
 data:
-  {{ if .Values.prestashopPassword }}
+  {{- if .Values.prestashopPassword }}
   prestashop-password: {{ default "" .Values.prestashopPassword | b64enc | quote }}
-  {{ else }}
+  {{- else }}
   prestashop-password: {{ randAlphaNum 10 | b64enc | quote }}
-  {{ end }}
-  smtp-password: {{ default "" .Values.smtpPassword | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.smtpPassword }}
+  smtp-password: {{ .Values.smtpPassword | b64enc | quote }}
+  {{- end }}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR avoids setting SMTP env. variables when the corresponding values are not set.

#### Which issue this PR fixes

  - fixes https://github.com/helm/charts/issues/10732

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
