### PR TITLE
Allow for relabeling in the apiserver ServiceMonitor

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 2.0.0
+version: 2.0.1
 appVersion: 0.26.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -234,6 +234,7 @@ The following tables lists the configurable parameters of the prometheus-operato
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
 | `kubeApiServer.enabled` | Deploy `serviceMonitor` to scrape the Kubernetes API server | `true` |
+| `kubeApiServer.relabelings` | Relablings for the API Server ServiceMonitor | `[]` |
 | `kubeApiServer.tlsConfig.serverName` | Name of the server to use when validating TLS certificate | `kubernetes` |
 | `kubeApiServer.tlsConfig.insecureSkipVerify` | Skip TLS certificate validation when scraping | `false` |
 | `kubeApiServer.serviceMonitor.jobLabel` | The name of the label on the target service to use as the job name in prometheus | `component` |

--- a/stable/prometheus-operator/templates/exporters/kube-api-server/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-api-server/servicemonitor.yaml
@@ -12,6 +12,10 @@ spec:
     interval: 30s
     port: https
     scheme: https
+{{- if .Values.kubeApiServer.relabelings }}
+    relabelings:
+{{ toYaml .Values.kubeApiServer.relabelings | indent 6 }}
+{{- end }}
     tlsConfig:
       caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
       serverName: {{ .Values.kubeApiServer.tlsConfig.serverName }}

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -339,6 +339,18 @@ kubeApiServer:
     serverName: kubernetes
     insecureSkipVerify: false
 
+  ## If your API endpoint address is not reachble (as in AKS) you can replace it with the kubernetes service
+  ##
+  relabelings: []
+  # - sourceLabels:
+  #     - __meta_kubernetes_namespace
+  #     - __meta_kubernetes_service_name
+  #     - __meta_kubernetes_endpoint_port_name
+  #   action: keep
+  #   regex: default;kubernetes;https
+  # - targetLabel: __address__
+  #   replacement: kubernetes.default.svc:443
+
   serviceMonitor:
     jobLabel: component
     selector:

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -339,7 +339,7 @@ kubeApiServer:
     serverName: kubernetes
     insecureSkipVerify: false
 
-  ## If your API endpoint address is not reachble (as in AKS) you can replace it with the kubernetes service
+  ## If your API endpoint address is not reachable (as in AKS) you can replace it with the kubernetes service
   ##
   relabelings: []
   # - sourceLabels:


### PR DESCRIPTION
#### What this PR does / why we need it:
This allows fixing the ServiceMonitor for API Server in case endpoint address is not reachable (as in AKS)

#### Which issue this PR fixes
  - https://github.com/coreos/prometheus-operator/issues/1522  
  - https://github.com/Azure/AKS/issues/552

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

CC @gianrubio