### PR TITLE
Allow metrcs-server to start in hostNetwork mode

### DIFF
--- a/stable/metrics-server/Chart.yaml
+++ b/stable/metrics-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.3.1
 description: Metrics Server is a cluster-wide aggregator of resource usage data.
 name: metrics-server
-version: 2.1.1
+version: 2.2.0
 keywords:
 - metrics-server
 home: https://github.com/kubernetes-incubator/metrics-server

--- a/stable/metrics-server/README.md
+++ b/stable/metrics-server/README.md
@@ -10,6 +10,7 @@ Parameter | Description | Default
 `serviceAccount.create` | If `true`, create a new service account | `true`
 `serviceAccount.name` | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template | ``
 `apiService.create` | Create the v1beta1.metrics.k8s.io API service | `true`
+`hostNetwork.enable` | Enable hostNetwork mode | `false`
 `image.repository` | Image repository | `gcr.io/google_containers/metrics-server-amd64`
 `image.tag` | Image tag | `v0.3.1`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`

--- a/stable/metrics-server/templates/metrics-server-deployment.yaml
+++ b/stable/metrics-server/templates/metrics-server-deployment.yaml
@@ -20,6 +20,9 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ template "metrics-server.serviceAccountName" . }}
+{{ if .Values.hostNetwork.enabled }}
+      hostNetwork: true
+{{ end }}
       containers:
         - name: metrics-server
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/metrics-server/values.yaml
+++ b/stable/metrics-server/values.yaml
@@ -17,6 +17,14 @@ apiService:
   # work with this release.
   create: true
 
+hostNetwork:
+  # Specifies if metrics-server should be started in hostNetwork mode.
+  #
+  # You would require this enabled if you use alternate overlay networking for pods and
+  # API server unable to communicate with metrics-server. As an example, this is required
+  # if you use Weave netwok on EKS
+  enabled: false
+
 image:
   repository: gcr.io/google_containers/metrics-server-amd64
   tag: v0.3.1


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This allows to deploy metrics-server in hosNetwork mode. This is required when Weave used on EKS.

#### Special notes for your reviewer:
[Here](https://github.com/weaveworks/weave/issues/3335#issuecomment-458181081) is the link for comment in discussion

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
