### PR TITLE
[stable/drone] fixing `server.protocol` and NOTES.txt

### DIFF
--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -1,7 +1,7 @@
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 2.0.0-rc.2
+version: 2.0.0-rc.3
 appVersion: 1.0.0-rc.4
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/stable/drone/templates/NOTES.txt
+++ b/stable/drone/templates/NOTES.txt
@@ -6,7 +6,7 @@
 {{- if .Values.ingress.enabled }}
 From outside the cluster, the server URL(s) are:
 {{- range .Values.ingress.hosts }}
-     http://{{ . }}
+     {{ $.Values.server.protocol }}://{{ . }}
 {{- end }}
 
 {{- else if contains "NodePort" .Values.service.type }}

--- a/stable/drone/values.yaml
+++ b/stable/drone/values.yaml
@@ -110,8 +110,8 @@ server:
   ##
   # host: "drone.domain.io"
 
-  ## protocol should be http:// or https://
-  protocol: http://
+  ## protocol should be http or https
+  protocol: http
 
   ## Initial admin user
   ## Leaving this blank may make it impossible to log into drone.


### PR DESCRIPTION
#### What this PR does / why we need it:

I think this value [should be without](https://docs.drone.io/intro/github/single-machine/#drone-server-proto) `://`?

Also updating `NOTES.txt` to use this value when ingress is used.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
