### PR TITLE
[stable/drone] adding missing "watch" verb for ClusterRole

### DIFF
--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -1,7 +1,7 @@
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 2.0.0-rc.2
+version: 2.0.0-rc.4
 appVersion: 1.0.0-rc.4
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/stable/drone/templates/role-pipeline.yaml
+++ b/stable/drone/templates/role-pipeline.yaml
@@ -21,6 +21,7 @@ rules:
       - "delete"
       - "get"
       - "list"
+      - "watch"
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
#### What this PR does / why we need it:

If this is not present I get this error repeated over and over from the job pod:

```
E0129 14:28:22.416437       1 reflector.go:251] k8s.io/client-go/informers/factory.go:132: Failed to watch *v1.Pod: unknown (get pods)
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
