### PR TITLE
[stable/prometheus] extraEmptyDir and `configPath` functionality

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 8.4.6
+version: 8.4.7
 appVersion: 2.6.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 8.4.5
+version: 8.4.6
 appVersion: 2.6.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -277,6 +277,7 @@ Parameter | Description | Default
 `server.service.nodePort` | Port to be used as the service NodePort (ignored if `server.service.type` is not `NodePort`) | `0`
 `server.service.servicePort` | Prometheus server service port | `80`
 `server.service.type` | type of Prometheus server service to create | `ClusterIP`
+`server.sidecarContainers` | array of snippets with your sidecar containers for prometheus server | `""`
 `serviceAccounts.alertmanager.create` | If true, create the alertmanager service account | `true`
 `serviceAccounts.alertmanager.name` | name of the alertmanager service account to use or create | `{{ prometheus.alertmanager.fullname }}`
 `serviceAccounts.kubeStateMetrics.create` | If true, create the kubeStateMetrics service account | `true`

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -237,6 +237,7 @@ Parameter | Description | Default
 `server.prefixURL` | The prefix slug at which the server can be accessed | ``
 `server.baseURL` | The external url at which the server can be accessed | ``
 `server.extraHostPathMounts` | Additional Prometheus server hostPath mounts | `[]`
+`server.extraEmptyDirMounts` | Additional emptyDir mounts | `[]`
 `server.extraConfigmapMounts` | Additional Prometheus server configMap mounts | `[]`
 `server.extraSecretMounts` | Additional Prometheus server Secret mounts | `[]`
 `server.configMapOverrideName` | Prometheus server ConfigMap override where full-name is `{{.Release.Name}}-{{.Values.server.configMapOverrideName}}` and setting this value will prevent the default server ConfigMap from being generated | `""`
@@ -278,6 +279,7 @@ Parameter | Description | Default
 `server.service.servicePort` | Prometheus server service port | `80`
 `server.service.type` | type of Prometheus server service to create | `ClusterIP`
 `server.sidecarContainers` | array of snippets with your sidecar containers for prometheus server | `""`
+`server.configPath` | path to configuration file inside the container | `"/etc/config/prometheus.yml"`
 `serviceAccounts.alertmanager.create` | If true, create the alertmanager service account | `true`
 `serviceAccounts.alertmanager.name` | name of the alertmanager service account to use or create | `{{ prometheus.alertmanager.fullname }}`
 `serviceAccounts.kubeStateMetrics.create` | If true, create the kubeStateMetrics service account | `true`

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -85,7 +85,7 @@ spec:
           {{- if .Values.server.retention }}
             - --storage.tsdb.retention={{ .Values.server.retention }}
           {{- end }}
-            - --config.file=/etc/config/prometheus.yml
+            - --config.file={{ .Values.server.configPath }}
             - --storage.tsdb.path={{ .Values.server.persistentVolume.mountPath }}
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
@@ -139,6 +139,12 @@ spec:
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
           {{- end }}
+          {{- range .Values.server.extraEmptyDirMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              subPath: {{ .subPath }}
+              readOnly: {{ .readOnly }}
+          {{- end }}
       {{- if .Values.server.sidecarContainers }}
       {{- toYaml .Values.server.sidecarContainers | nindent 8 }}
       {{- end }}
@@ -174,6 +180,10 @@ spec:
         {{- else }}
           emptyDir: {}
         {{- end -}}
+      {{- range .Values.server.extraEmptyDirMounts }}
+        - name: {{ .name }}
+          emptyDir: {}
+      {{- end }}
       {{- range .Values.server.extraHostPathMounts }}
         - name: {{ .name }}
           hostPath:

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -139,6 +139,9 @@ spec:
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
           {{- end }}
+      {{- if .Values.server.sidecarContainers }}
+      {{- toYaml .Values.server.sidecarContainers | nindent 8 }}
+      {{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
        {{ toYaml .Values.imagePullSecrets | indent 2 }}

--- a/stable/prometheus/templates/server-statefulset.yaml
+++ b/stable/prometheus/templates/server-statefulset.yaml
@@ -136,6 +136,9 @@ spec:
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
           {{- end }}
+       {{- if .Values.server.sidecarContainers }}
+       {{- toYaml .Values.server.sidecarContainers | nindent 8 }}
+       {{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
        {{ toYaml .Values.imagePullSecrets | indent 2 }}

--- a/stable/prometheus/templates/server-statefulset.yaml
+++ b/stable/prometheus/templates/server-statefulset.yaml
@@ -82,7 +82,7 @@ spec:
           {{- if .Values.server.retention }}
             - --storage.tsdb.retention={{ .Values.server.retention }}
           {{- end }}
-            - --config.file=/etc/config/prometheus.yml
+            - --config.file={{ .Values.server.configPath }}
             - --storage.tsdb.path={{ .Values.server.persistentVolume.mountPath }}
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
@@ -136,6 +136,12 @@ spec:
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
           {{- end }}
+          {{- range .Values.server.extraEmptyDirMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              subPath: {{ .subPath }}
+              readOnly: {{ .readOnly }}
+          {{- end }}
        {{- if .Values.server.sidecarContainers }}
        {{- toYaml .Values.server.sidecarContainers | nindent 8 }}
        {{- end }}
@@ -164,6 +170,10 @@ spec:
         - name: config-volume
           configMap:
             name: {{ if .Values.server.configMapOverrideName }}{{ .Release.Name }}-{{ .Values.server.configMapOverrideName }}{{- else }}{{ template "prometheus.server.fullname" . }}{{- end }}
+      {{- range .Values.server.extraEmptyDirMounts }}
+        - name: {{ .name }}
+          emptyDir: {}
+      {{- end }}
       {{- range .Values.server.extraHostPathMounts }}
         - name: {{ .name }}
           hostPath:

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -514,6 +514,9 @@ server:
   name: server
   sidecarContainers:
 
+  ## Path to a config file inside the container
+  ##
+  configPath: /etc/config/prometheus.yml
   ## Prometheus server container image
   ##
   image:
@@ -561,6 +564,12 @@ server:
     #   subPath: ""
     #   hostPath: /etc/kubernetes/certs
     #   readOnly: true
+
+  extraEmptyDirMounts: []
+    # - name: externally-generated-config
+    #   mountPath: /etc/shared-config/
+    #   subPath: prometheus
+    #   readOnly: false
 
   extraConfigmapMounts: []
     # - name: certs-configmap

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -512,6 +512,7 @@ server:
   ## Prometheus server container name
   ##
   name: server
+  sidecarContainers:
 
   ## Prometheus server container image
   ##


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Special notes for your reviewer:
The PR introduces `extraEmptyDir` (quite similar to extraHostPaths) and `configPath` (path to prometheus configuration file inside the container FS) functionality. 

Case: Thanos sidecar parses template of a prometheus config, generates output for prometheus and put it into shared emptyDir volume (https://github.com/improbable-eng/thanos/blob/master/docs/components/sidecar.md#reloader-configuration).  I haven't found a way to make it happen without this changes.

I need thanos to parse config template to support env variables evaluation in config file to make deduplication for thanos easy. 
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
