### PR TITLE
[stable/kibana]: remove ports from initContainers

### DIFF
--- a/stable/kibana/Chart.yaml
+++ b/stable/kibana/Chart.yaml
@@ -1,5 +1,5 @@
 name: kibana
-version: 1.3.0
+version: 1.4.0
 appVersion: 6.6.0
 description: Kibana is an open source data visualization plugin for Elasticsearch
 icon: https://raw.githubusercontent.com/elastic/kibana/master/src/ui/public/icons/kibana-color.svg

--- a/stable/kibana/README.md
+++ b/stable/kibana/README.md
@@ -69,7 +69,6 @@ The following table lists the configurable parameters of the kibana chart and th
 | `resources`                                   | pod resource requests & limits             | `{}`                                   |
 | `priorityClassName`                           | priorityClassName                          | `nil`                                  |
 | `service.externalPort`                        | external port for the service              | `443`                                  |
-| `service.disableInternalPort`                 | disable internal port when using sidecar   | `false`                                |
 | `service.internalPort`                        | internal port for the service              | `4180`                                 |
 | `service.authProxyPort`                       | port to use when using sidecar authProxy   | None:                                  |
 | `service.externalIPs`                         | external IP addresses                      | None:                                  |

--- a/stable/kibana/ci/authproxy-enabled.yaml
+++ b/stable/kibana/ci/authproxy-enabled.yaml
@@ -1,0 +1,3 @@
+---
+# disable internal port by setting authProxyEnabled
+authProxyEnabled: true

--- a/stable/kibana/ci/disabled-internal-port.yaml
+++ b/stable/kibana/ci/disabled-internal-port.yaml
@@ -1,4 +1,0 @@
----
-# disable internal service
-service:
-  disableInternalPort: true

--- a/stable/kibana/templates/deployment.yaml
+++ b/stable/kibana/templates/deployment.yaml
@@ -47,10 +47,6 @@ spec:
         - name: "{{ $key }}"
           value: "{{ $value }}"
         {{- end }}
-        ports:
-        - containerPort: {{ .Values.service.internalPort }}
-          name: {{ template "kibana.name" . }}
-          protocol: TCP
         volumeMounts:
         - name: {{ template "kibana.fullname" . }}-dashboards
           mountPath: "/kibanadashboards"
@@ -106,12 +102,6 @@ spec:
         - name: "{{ $key }}"
           value: "{{ $value }}"
         {{- end }}
-{{- if not .Values.service.disableInternalPort }}
-        ports:
-        - containerPort: {{ .Values.service.internalPort }}
-          name: {{ template "kibana.name" . }}
-          protocol: TCP
-{{- end }}
         volumeMounts:
         - name: plugins
           mountPath: /usr/share/kibana/plugins

--- a/stable/kibana/values.yaml
+++ b/stable/kibana/values.yaml
@@ -35,8 +35,6 @@ deployment:
 service:
   type: ClusterIP
   externalPort: 443
-  # disables the internal port if set to true; to be used with a sidecar
-  disableInternalPort: false
   internalPort: 5601
   # authProxyPort: 5602 To be used with authProxyEnabled and a proxy extraContainer
   ## External IP addresses of service


### PR DESCRIPTION


#### What this PR does / why we need it:
I've failed to notice that there are two ports entries in the initContainers in my previous two PRs and that the authProxyEnabled option disables the internal port for the main container. This removes the extra option I've introduced and converts the ci test to set authProxyEnabled to true instead.

#### Special notes for your reviewer:
I don't think the initContainers should expose ports. This PR removes the extra ports. Please let me know if this is OK and if any changes should be made.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
