### PR TITLE
[stable/prometheus-mongodb-exporter] Add MongoDB Exporter chart

### DIFF
--- a/stable/prometheus-mongodb-exporter/.helmignore
+++ b/stable/prometheus-mongodb-exporter/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/prometheus-mongodb-exporter/Chart.yaml
+++ b/stable/prometheus-mongodb-exporter/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+appVersion: "v0.6.1"
+description: A Prometheus exporter for MongoDB metrics
+home: https://github.com/percona/mongodb_exporter
+keywords:
+- exporter
+- metrics
+- mongodb
+- prometheus
+maintainers:
+- email: ssheehy@firescope.com
+  name: steven-sheehy
+name: prometheus-mongodb-exporter
+sources:
+- https://github.com/percona/mongodb_exporter
+version: 1.0.0

--- a/stable/prometheus-mongodb-exporter/OWNERS
+++ b/stable/prometheus-mongodb-exporter/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - steven-sheehy
+reviewers:
+  - steven-sheehy

--- a/stable/prometheus-mongodb-exporter/README.md
+++ b/stable/prometheus-mongodb-exporter/README.md
@@ -1,0 +1,64 @@
+# Prometheus MongoDB Exporter
+
+Installs the [MongoDB Exporter](https://github.com/percona/mongodb_exporter) for [Prometheus](https://prometheus.io/). The
+MongoDB Exporter collects and exports oplog, replica set, server status, sharding and storage engine metrics.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm upgrade --install my-release stable/prometheus-mongodb-exporter
+```
+
+This command deploys the MongoDB Exporter with the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Using the Chart
+
+To use the chart, ensure the `mongodb.uri` is populated with a valid [MongoDB URI](https://docs.mongodb.com/manual/reference/connection-string).
+If the MongoDB server requires authentication, credentials should be populated in the connection string as well. The MongoDB Exporter supports 
+connecting to either a MongoDB replica set member, shard, or standalone instance.
+
+The chart comes with a ServiceMonitor for use with the [Prometheus Operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator).
+If you're not using the Prometheus Operator, you can disable the ServiceMonitor by setting `serviceMonitor.enabled` to `false` and instead
+populate the `service.annotations` as below:
+
+```yaml
+service:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9216"
+```
+
+## Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `affinity` | Node/pod affinities | `{}` |
+| `annotations` | Annotations to be added to the pods | `{}` |
+| `extraArgs` | The extra command line arguments to pass to the MongoDB Exporter  | See values.yaml |
+| `fullnameOverride` | Override the full chart name | `` |
+| `image.pullPolicy` | MongoDB Exporter image pull policy | `IfNotPresent` |
+| `image.repository` | MongoDB Exporter image name | `ssalaues/mongodb-exporter` |
+| `image.tag` | MongoDB Exporter image tag | `0.6.1` |
+| `imagePullSecrets` | List of container registry secrets | `[]` |
+| `mongodb.uri` | The required [URI](https://docs.mongodb.com/manual/reference/connection-string) to connect to MongoDB | `` |
+| `nameOverride` | Override the application name  | `` |
+| `nodeSelector` | Node labels for pod assignment | `{}` |
+| `priorityClassName` | Pod priority class name | `` |
+| `replicas` | Number of replicas in the replica set | `1` |
+| `resources` | Pod resource requests and limits | `{}` |
+| `securityContext` | Security context for the pod | See values.yaml |
+| `service.annotations` | Annotations to be added to the service | `{}` |
+| `service.port` | The port to expose | `9216` |
+| `service.type` | The type of service to expose | `ClusterIP` |
+| `serviceMonitor.enabled` | Set to true if using the Prometheus Operator | `true` |
+| `serviceMonitor.interval` | Interval at which metrics should be scraped | `30s` |
+| `serviceMonitor.namespace` | The namespace where the Prometheus Operator is deployed | `` |
+| `serviceMonitor.additionalLabels` | Additional labels to add to the ServiceMonitor | `{}` |
+| `tolerations` | List of node taints to tolerate  | `[]` |
+
+## Limitations
+
+Connecting to MongoDB via TLS is currently not supported.
+

--- a/stable/prometheus-mongodb-exporter/ci/servicemonitor-disabled-values.yaml
+++ b/stable/prometheus-mongodb-exporter/ci/servicemonitor-disabled-values.yaml
@@ -1,0 +1,4 @@
+mongodb:
+  uri: mongodb://localhost:9216
+serviceMonitor:
+  enabled: false

--- a/stable/prometheus-mongodb-exporter/templates/NOTES.txt
+++ b/stable/prometheus-mongodb-exporter/templates/NOTES.txt
@@ -1,0 +1,13 @@
+Verify the application is working by running these commands:
+{{if contains "NodePort" .Values.service.type }}
+  NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "prometheus-mongodb-exporter.fullname" . }})
+  curl http://$NODE_IP:$NODE_PORT/metrics
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  # NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+  SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "prometheus-mongodb-exporter.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  curl http://$SERVICE_IP:{{ .Values.service.port }}/metrics
+{{- else if contains "ClusterIP" .Values.service.type }}
+  kubectl port-forward service/{{ include "prometheus-mongodb-exporter.fullname" . }} {{ .Values.service.port }}
+  curl http://127.0.0.1:{{ .Values.service.port }}/metrics
+{{- end }}

--- a/stable/prometheus-mongodb-exporter/templates/_helpers.tpl
+++ b/stable/prometheus-mongodb-exporter/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prometheus-mongodb-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "prometheus-mongodb-exporter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prometheus-mongodb-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/prometheus-mongodb-exporter/templates/deployment.yaml
+++ b/stable/prometheus-mongodb-exporter/templates/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "prometheus-mongodb-exporter.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "prometheus-mongodb-exporter.chart" . }}
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: mongodb-exporter
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+        - -mongodb.uri={{ required "A MongoDB URI is required" .Values.mongodb.uri }}
+        {{- toYaml .Values.extraArgs | nindent 8 }}
+        ports:
+        - name: metrics
+          containerPort: 9216
+          protocol: TCP
+        livenessProbe:
+          {{- toYaml .Values.livenessProbe | nindent 10 }}
+        readinessProbe:
+          {{- toYaml .Values.readinessProbe | nindent 10 }}
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      terminationGracePeriodSeconds: 30
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+

--- a/stable/prometheus-mongodb-exporter/templates/service.yaml
+++ b/stable/prometheus-mongodb-exporter/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "prometheus-mongodb-exporter.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "prometheus-mongodb-exporter.chart" . }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+spec:
+  ports:
+  - name: metrics
+    port: {{ .Values.service.port }}
+    protocol: TCP
+    targetPort: metrics
+  selector:
+    app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  type: {{ .Values.service.type }}
+

--- a/stable/prometheus-mongodb-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-mongodb-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,29 @@
+{{ if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "prometheus-mongodb-exporter.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "prometheus-mongodb-exporter.chart" . }}
+    {{- range $key, $value := .Values.serviceMonitor.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+spec:
+  endpoints:
+  - port: metrics
+    interval: {{ .Values.serviceMonitor.interval }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+

--- a/stable/prometheus-mongodb-exporter/templates/tests/test-connection.yaml
+++ b/stable/prometheus-mongodb-exporter/templates/tests/test-connection.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "prometheus-mongodb-exporter.fullname" . }}-test-connection"
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "prometheus-mongodb-exporter.chart" . }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+  - name: wget
+    image: busybox
+    command: ['wget']
+    args:  ['-qO-', '{{ include "prometheus-mongodb-exporter.fullname" . }}:{{ .Values.service.port }}/metrics']
+  restartPolicy: Never

--- a/stable/prometheus-mongodb-exporter/values.yaml
+++ b/stable/prometheus-mongodb-exporter/values.yaml
@@ -1,0 +1,73 @@
+affinity: {}
+
+annotations: {}
+
+extraArgs:
+- -collect.collection=true
+- -collect.database=true
+- -collect.indexusage=true
+- -collect.topmetrics=true
+
+fullnameOverride: ""
+
+image:
+  pullPolicy: IfNotPresent
+  repository: ssalaues/mongodb-exporter
+  tag: 0.6.1
+
+imagePullSecrets: []
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: metrics
+  initialDelaySeconds: 10
+
+# mongodb://metrics-user:password@mongodb:27017
+mongodb:
+  uri:
+
+nameOverride: ""
+
+nodeSelector: {}
+
+priorityClassName: ""
+
+readinessProbe:
+  httpGet:
+    path: /
+    port: metrics
+  initialDelaySeconds: 10
+
+replicas: 1
+
+resources: {}
+# limits:
+#   cpu: 250mm
+#   memory: 192Mi
+# requests:
+#   cpu: 100mm
+#   memory: 128Mi
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["all"]
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 10000
+
+service:
+  annotations: {}
+  #  prometheus.io/scrape: "true"
+  #  prometheus.io/port: "9216"
+  port: 9216
+  type: ClusterIP
+
+serviceMonitor:
+  enabled: true
+  interval: 30s
+  namespace:
+  additionalLabels: {}
+
+tolerations: []


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds a Prometheus MongoDB Exporter chart. There was a previous PR to add one but it was abandoned.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
