### PR TITLE
[fluentd] Removing ingress.hosts.*.protocol param from example configuration

### DIFF
--- a/stable/fluentd/Chart.yaml
+++ b/stable/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Fluentd Elasticsearch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd
-version: 1.4.0
+version: 1.4.1
 appVersion: v2.3.1
 home: https://www.fluentd.org/
 sources:

--- a/stable/fluentd/values.yaml
+++ b/stable/fluentd/values.yaml
@@ -37,7 +37,6 @@ ingress:
   # Used to create an Ingress and Service record.
   # hosts:
   #   - name: "http-input.local"
-  #     protocol: TCP
   #     serviceName: http-input
   #     servicePort: 9880
   annotations:


### PR DESCRIPTION
Parameter ingress.hosts.*.protocol located in values.yaml (as example of ingress hosts configuration) is confusing because it's not used anywhere and despite of that ingress will always expose service on http protocol.

Removing this unnecessary and unused param.