### PR TITLE
Fix drone server protocol

### DIFF
--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -1,7 +1,7 @@
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 2.0.0-rc.4
+version: 2.0.0-rc.5
 appVersion: 1.0.0-rc.4
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/stable/drone/templates/deployment-server.yaml
+++ b/stable/drone/templates/deployment-server.yaml
@@ -60,7 +60,7 @@ spec:
           {{- else }}
             value: "{{ template "drone.fullname" . }}"
           {{- end }}
-          - name: DRONE_SERVER_PROTOCOL
+          - name: DRONE_SERVER_PROTO
             value: {{ .Values.server.protocol }}
           {{- if .Values.server.adminUser }}
           - name: DRONE_USER_CREATE


### PR DESCRIPTION
#### What this PR does / why we need it:
This fixes the environment variable name for the drone server protocol.
Regarding to the [documentation](https://docs.drone.io/reference/server/drone-server-proto/) the key is `DRONE_SERVER_PROTO` instead of `DRONE_SERVER_PROTOCOL`.

#### Checklist
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [X] Variables are documented in the README.md
