### PR TITLE
[casssandra] Toggle for enabling hostNetwork in Cassandra pods

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,5 +1,5 @@
 name: cassandra
-version: 0.10.3
+version: 0.10.4
 appVersion: 3.11.3
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/README.md
+++ b/incubator/cassandra/README.md
@@ -88,6 +88,7 @@ The following table lists the configurable parameters of the Cassandra chart and
 | `config.cluster_name`                | The name of the cluster.                        | `cassandra`                                                |
 | `config.cluster_size`                | The number of nodes in the cluster.             | `3`                                                        |
 | `config.seed_size`                   | The number of seed nodes used to bootstrap new clients joining the cluster.                            | `2` |
+| `config.seeds`                       | The comma-separated list of seed nodes.         | Automatically generated according to `.Release.Name` and `config.seed_size` |
 | `config.num_tokens`                  | Initdb Arguments                                | `256`                                                      |
 | `config.dc_name`                     | Initdb Arguments                                | `DC1`                                                      |
 | `config.rack_name`                   | Initdb Arguments                                | `RAC1`                                                     |

--- a/incubator/cassandra/templates/statefulset.yaml
+++ b/incubator/cassandra/templates/statefulset.yaml
@@ -30,6 +30,7 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:
+      hostNetwork: {{ .Values.hostNetwork }}
 {{- if .Values.selector }}
 {{ toYaml .Values.selector | indent 6 }}
 {{- end }}
@@ -86,7 +87,11 @@ spec:
         {{- $seed_size := default 1 .Values.config.seed_size | int -}}
         {{- $global := . }}
         - name: CASSANDRA_SEEDS
+          {{- if .Values.hostNetwork }}
+          value: {{ required "You must fill \".Values.config.seeds\" with list of Cassandra seeds when hostNetwork is set to true" .Values.config.seeds | quote }}
+          {{- else }}
           value: "{{- range $i, $e := until $seed_size }}{{ template "cassandra.fullname" $global }}-{{ $i }}.{{ template "cassandra.fullname" $global }}.{{ $global.Release.Namespace }}.svc.{{ $global.Values.config.cluster_domain }}{{- if (lt ( add1 $i ) $seed_size ) }},{{- end }}{{- end }}"
+          {{- end }}     
         - name: MAX_HEAP_SIZE
           value: {{ default "8192M" .Values.config.max_heap_size | quote }}
         - name: HEAP_NEWSIZE

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -148,6 +148,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   # name:
 
+# Use host network for Cassandra pods
+# You must pass seed list into config.seeds property if set to true
+hostNetwork: false
+
 ## Backup cronjob configuration
 ## Ref: https://github.com/nuvo/cain
 backup:


### PR DESCRIPTION
Signed-off-by: Nikita Akhnin nike.ahnin@gmail.com

#### What this PR does / why we need it:
This PR adds ability for enabling hostNetwork in Cassandra pods. It might be useful for cases when Cassandra nodes should be fully accessible outside of K8s cluster.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
