### PR TITLE
[stable/kube-state-metrics] Provide else statement or other wise helm lint and template wont work.

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - metric
 - monitoring
 - prometheus
-version: 0.13.0
+version: 0.13.1
 appVersion: 1.4.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/templates/psp-clusterrole.yaml
+++ b/stable/kube-state-metrics/templates/psp-clusterrole.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 {{- else }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 metadata:
   labels:

--- a/stable/kube-state-metrics/templates/psp-clusterrole.yaml
+++ b/stable/kube-state-metrics/templates/psp-clusterrole.yaml
@@ -4,6 +4,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- end }}
 metadata:
   labels:

--- a/stable/kube-state-metrics/templates/psp-clusterrolebinding.yaml
+++ b/stable/kube-state-metrics/templates/psp-clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 {{- else }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 {{- end }}
 kind: ClusterRoleBinding
 metadata:

--- a/stable/kube-state-metrics/templates/psp-clusterrolebinding.yaml
+++ b/stable/kube-state-metrics/templates/psp-clusterrolebinding.yaml
@@ -3,6 +3,8 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
 apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- end }}
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
#### What this PR does / why we need it:
Recently the kube-state-metrics chart was patched to support PSPs. This introduced the usage of `.Capabilities` to the chart. Unfortunately without an `else`-statement the chart can not be used with `helm lint` or `helm template` (see https://github.com/helm/helm/issues/3377). To fix this a sensible default in an `else`-statement is provided.

#### Which issue this PR fixes
Fixed usage with `helm template` and `helm lint`

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
