### PR TITLE
[stable/lamp] Make php-fpm configurable

### DIFF
--- a/stable/lamp/Chart.yaml
+++ b/stable/lamp/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Modular and transparent LAMP stack chart supporting PHP-FPM, Release Cloning, LoadBalancer, Ingress, SSL and lots more!
 name: lamp
-version: 1.0.0
+version: 1.1.0
 appVersion: 7
 home: https://github.com/lead4good/helm-lamp-stack
 maintainers:

--- a/stable/lamp/README.md
+++ b/stable/lamp/README.md
@@ -162,6 +162,7 @@ FPM is enabled by default, this creates an additional HTTPD container which rout
 | `php.sockets` | If FPM is enabled, enables communication between HTTPD and PHP via sockets instead of TCP | true |
 | `php.oldHTTPRoot` | Additionally mounts the webroot at `php.oldHTTPRoot` to compensate for absolute path file links  | _empty_ |
 | `php.ini` | additional PHP config values, see examples on how to use | _empty_ |
+| `php.fpm` | addditonal PHP FPM config values | _empty_ |
 | `php.copyRoot` | if true, copies the containers web root `/var/www/html` into persistent storage. This must be enabled, if the container already comes with files installed to `/var/www/html`  | false |
 | `php.persistentSubpaths` | instead of enabling persistence for the whole webroot, only subpaths of webroot can be enabled for persistence. Have a look at the [nextcloud example](examples/nextcloud.yaml) to see how it works | _empty_ |
 | `php.resources` | PHP container resource requests/limits | `resources` |

--- a/stable/lamp/templates/configmap-php.yaml
+++ b/stable/lamp/templates/configmap-php.yaml
@@ -24,5 +24,8 @@ data:
     [www]
     listen = /var/run/php/php-fpm.sock
     listen.mode = 0666
+  {{- if .Values.php.fpm }}
+{{ .Values.php.fpm  | indent 4 }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/stable/lamp/values.yaml
+++ b/stable/lamp/values.yaml
@@ -47,6 +47,10 @@ php:
   # ini: |
   #   short_open_tag=On
 
+  ## php-fpm.conf: additional PHP FPM config values
+  # fpm: |
+  #   pm.max_children = 120
+
   ## php.copyRoot if true, copies the containers web root `/var/www/html` into
   copyRoot: false
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Allows user of the `stable/lamp` chart to override php fpm configuration in the php container. This is needed so the fpm config can be tuned. Things like configuring the worker pool size and overriding what variables get passed to php via fpm can be done from the fpm config file.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md