### PR TITLE
[stable/prometheus-operator] Fixed configmap-dashboard error if no files where provided

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 2.2.6
+version: 2.2.7
 appVersion: 0.26.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/templates/grafana/configmap-dashboards.yaml
+++ b/stable/prometheus-operator/templates/grafana/configmap-dashboards.yaml
@@ -1,8 +1,10 @@
 {{- if and .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- $files := .Files.Glob "dashboards/*.json" }}
+{{- if $files }}
 apiVersion: v1
 kind: ConfigMapList
 items:
-{{- range $path, $fileContents := .Files.Glob "dashboards/*.json" }}
+{{- range $path, $fileContents := $files }}
 {{- $dashboardName := regexReplaceAll "(^.*/)(.*)\\.json$" $path "${2}" }}
 - apiVersion: v1
   kind: ConfigMap
@@ -16,5 +18,6 @@ items:
 {{ include "prometheus-operator.labels" $ | indent 6 }}
   data:
     {{ $dashboardName }}.json: {{ $.Files.Get $path | toJson }}
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Niklas Voss <niklas.voss@gmail.com>

#### What this PR does / why we need it:
The current chart version does not work for me, because if no dashboard files are found. Helm tries to apply an empty `ConfigMapList` to avoid this. The chart should not create the resource, if no files are provided.

#### Which issue this PR fixes
Fixes empty `ConfigMapList` which the apiserver will deny.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
