### PR TITLE
[stable/drone] adding permission to update deployments for pipeline clusterrole

### DIFF
--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -1,7 +1,7 @@
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 2.0.0-rc.5
+version: 2.0.0-rc.6
 appVersion: 1.0.0-rc.4
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/stable/drone/templates/role-pipeline.yaml
+++ b/stable/drone/templates/role-pipeline.yaml
@@ -10,6 +10,16 @@ metadata:
     heritage: "{{ .Release.Service }}"
 rules:
   - apiGroups:
+      - extensions
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
       - ""
     resources:
       - namespaces
@@ -17,15 +27,15 @@ rules:
       - secrets
       - pods
     verbs:
-      - "create"
-      - "delete"
-      - "get"
-      - "list"
-      - "watch"
+      - create
+      - delete
+      - get
+      - list
+      - watch
   - apiGroups:
       - ""
     resources:
-      - "pods/log"
+      - pods/log
     verbs:
-      - "get"
+      - get
 {{ end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently the service account that is used in pipelines has no access to update deployments. This means plugins like [Kubernetes](http://plugins.drone.io/mactynow/drone-kubernetes/) plugin fail with a RBAC permissions error.

I think it's fair to add patch/update for deployments considering create/delete is already in place for other resources.

Not today but in the future I think perhaps the pipeline role should have much more minimal permissions that can be changed in values to suit the user.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
