### PR TITLE
[stable/kibana] Support headless service/clusterIP and service port name

### DIFF
--- a/stable/kibana/Chart.yaml
+++ b/stable/kibana/Chart.yaml
@@ -1,5 +1,5 @@
 name: kibana
-version: 1.4.0
+version: 1.4.1
 appVersion: 6.6.0
 description: Kibana is an open source data visualization plugin for Elasticsearch
 icon: https://raw.githubusercontent.com/elastic/kibana/master/src/ui/public/icons/kibana-color.svg

--- a/stable/kibana/README.md
+++ b/stable/kibana/README.md
@@ -70,12 +70,14 @@ The following table lists the configurable parameters of the kibana chart and th
 | `priorityClassName`                           | priorityClassName                          | `nil`                                  |
 | `service.externalPort`                        | external port for the service              | `443`                                  |
 | `service.internalPort`                        | internal port for the service              | `4180`                                 |
+| `service.portName`                            | service port name                          | None:                                  |
 | `service.authProxyPort`                       | port to use when using sidecar authProxy   | None:                                  |
 | `service.externalIPs`                         | external IP addresses                      | None:                                  |
 | `service.loadBalancerIP`                      | Load Balancer IP address                   | None:                                  |
 | `service.loadBalancerSourceRanges`            | Limit load balancer source IPs to list of CIDRs (where available)) | `[]`           |
 | `service.nodePort`                            | NodePort value if service.type is NodePort | None:                                  |
 | `service.type`                                | type of service                            | `ClusterIP`                            |
+| `service.clusterIP`                           | static clusterIP or None for headless services | None:                              |
 | `service.annotations`                         | Kubernetes service annotations             | None:                                  |
 | `service.labels`                              | Kubernetes service labels                  | None:                                  |
 | `tolerations`                                 | List of node taints to tolerate            | `[]`                                   |

--- a/stable/kibana/templates/service.yaml
+++ b/stable/kibana/templates/service.yaml
@@ -24,6 +24,9 @@ spec:
     {{- end }}
   {{- end }}
   type: {{ .Values.service.type }}
+  {{- if and (eq .Values.service.type "ClusterIP") .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.externalPort }}
 {{- if not .Values.authProxyEnabled }}
@@ -35,6 +38,9 @@ spec:
 {{ if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
       nodePort: {{ .Values.service.nodePort }}
 {{ end }}
+{{- if .Values.service.portName }}
+      name: {{ .Values.service.portName }}
+{{- end }}
 {{- if .Values.service.externalIPs }}
   externalIPs:
 {{ toYaml .Values.service.externalIPs | indent 4 }}

--- a/stable/kibana/values.yaml
+++ b/stable/kibana/values.yaml
@@ -34,6 +34,8 @@ deployment:
 
 service:
   type: ClusterIP
+  # clusterIP: None
+  # portName: kibana-svc
   externalPort: 443
   internalPort: 5601
   # authProxyPort: 5602 To be used with authProxyEnabled and a proxy extraContainer


### PR DESCRIPTION
Support headless service/clusterIP and service port name.
Fixes https://github.com/helm/charts/issues/11042.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
