### PR TITLE
[newrelic-infra] Add cluster name custom attribute

### DIFF
--- a/stable/newrelic-infrastructure/Chart.yaml
+++ b/stable/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 0.7.0
+version: 0.8.0
 appVersion: 1.3.1
 home: https://hub.docker.com/r/newrelic/infrastructure/
 source:

--- a/stable/newrelic-infrastructure/templates/daemonset.yaml
+++ b/stable/newrelic-infrastructure/templates/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
                   apiVersion: "v1"
                   fieldPath: "spec.nodeName"
             - name: "NRIA_CUSTOM_ATTRIBUTES"
-              value: '{"clusterName":"$(CLUSTER_NAME)"}'
+              value: {{ .Values.customAttribues }}
             - name: "NRIA_PASSTHROUGH_ENVIRONMENT"
               value: "KUBERNETES_SERVICE_HOST,KUBERNETES_SERVICE_PORT,CLUSTER_NAME,CADVISOR_PORT,NRK8S_NODE_NAME,KUBE_STATE_METRICS_URL,TIMEOUT"
             {{- if .Values.verboseLog }}

--- a/stable/newrelic-infrastructure/templates/daemonset.yaml
+++ b/stable/newrelic-infrastructure/templates/daemonset.yaml
@@ -57,6 +57,8 @@ spec:
                 fieldRef:
                   apiVersion: "v1"
                   fieldPath: "spec.nodeName"
+            - name: "NRIA_CUSTOM_ATTRIBUTES"
+              value: '{"clusterName":"$(CLUSTER_NAME)"}'
             - name: "NRIA_PASSTHROUGH_ENVIRONMENT"
               value: "KUBERNETES_SERVICE_HOST,KUBERNETES_SERVICE_PORT,CLUSTER_NAME,CADVISOR_PORT,NRK8S_NODE_NAME,KUBE_STATE_METRICS_URL,TIMEOUT"
             {{- if .Values.verboseLog }}

--- a/stable/newrelic-infrastructure/values.yaml
+++ b/stable/newrelic-infrastructure/values.yaml
@@ -91,4 +91,4 @@ tolerations: []
 updateStrategy: RollingUpdate
 
 # Custom attributes to be passed to the New Relic agent
-customAttribues: '{"clusterName":"$(CLUSTER_NAME)"}'
+customAttribues: "'{\"clusterName\":\"$(CLUSTER_NAME)\"}'"

--- a/stable/newrelic-infrastructure/values.yaml
+++ b/stable/newrelic-infrastructure/values.yaml
@@ -89,3 +89,6 @@ nodeSelector: {}
 tolerations: []
 
 updateStrategy: RollingUpdate
+
+# Custom attributes to be passed to the New Relic agent
+customAttribues: '{"clusterName":"$(CLUSTER_NAME)"}'


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds the cluster name as a custom attribute so that you can filter nodes in New Relic Infrastructure hosts page based on the cluster they belong to.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
