### PR TITLE
[stable/drone] bump version to rc5, simplify container names

### DIFF
--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -1,8 +1,8 @@
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 2.0.0-rc.6
-appVersion: 1.0.0-rc.4
+version: 2.0.0-rc.7
+appVersion: 1.0.0-rc.5
 description: Drone is a Continuous Delivery system built on container technology
 keywords:
 - continuous-delivery

--- a/stable/drone/templates/deployment-agent.yaml
+++ b/stable/drone/templates/deployment-agent.yaml
@@ -45,7 +45,7 @@ spec:
           protocol: TCP
         env:
           - name: DRONE_RPC_SERVER
-            value: {{ .Values.agent.rpc_server }}
+            value: {{ template "drone.fullname" . }}-grpc:9000
           - name: DRONE_RPC_SECRET
             valueFrom:
               secretKeyRef:

--- a/stable/drone/templates/deployment-agent.yaml
+++ b/stable/drone/templates/deployment-agent.yaml
@@ -36,7 +36,7 @@ spec:
 {{- end }}
       serviceAccountName: {{ template "drone.serviceAccountName" . }}
       containers:
-      - name: {{ template "drone.fullname" . }}-agent
+      - name: agent
         image: "{{ .Values.images.agent.repository }}:{{ .Values.images.agent.tag }}"
         imagePullPolicy: {{ .Values.images.agent.pullPolicy }}
         ports:
@@ -45,7 +45,7 @@ spec:
           protocol: TCP
         env:
           - name: DRONE_RPC_SERVER
-            value: {{ template "drone.fullname" . }}-grpc:9000
+            value: {{ .Values.agent.rpc_server }}
           - name: DRONE_RPC_SECRET
             valueFrom:
               secretKeyRef:
@@ -72,7 +72,7 @@ spec:
           hostPath:
             path: /var/run/docker.sock
 {{- else }}
-      - name: {{ template "drone.fullname" . }}-dind
+      - name: dind
         image: "{{ .Values.images.dind.repository }}:{{ .Values.images.dind.tag }}"
         imagePullPolicy: {{ .Values.images.dind.pullPolicy }}
 {{- if .Values.dind.command }}

--- a/stable/drone/templates/deployment-server.yaml
+++ b/stable/drone/templates/deployment-server.yaml
@@ -40,7 +40,7 @@ spec:
 {{- end }}
       serviceAccountName: {{ template "drone.serviceAccountName" . }}
       containers:
-      - name: {{ template "drone.fullname" . }}-server
+      - name: server
         image: "{{ .Values.images.server.repository }}:{{ .Values.images.server.tag }}"
         imagePullPolicy: {{ .Values.images.server.pullPolicy }}
         env:

--- a/stable/drone/values.yaml
+++ b/stable/drone/values.yaml
@@ -4,7 +4,7 @@ images:
   ##
   server:
     repository: "docker.io/drone/drone"
-    tag: 1.0.0-rc.4
+    tag: 1.0.0-rc.5
     pullPolicy: IfNotPresent
 
   ## The official drone (agent) image, change tag to use a different version.
@@ -12,7 +12,7 @@ images:
   ##
   agent:
     repository: "docker.io/drone/agent"
-    tag: 1.0.0-rc.4
+    tag: 1.0.0-rc.5
     pullPolicy: IfNotPresent
 
   ## The official docker (dind) image, change tag to use a different version.


### PR DESCRIPTION
#### What this PR does / why we need it:

- Bump drone version to new RC5 release
- Remove `fullname` from container names otherwise they end up with names like `drone-agent-drone-dind` or `rousing-chipmunk-drone-dind` which makes getting logs a pain.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
