### PR TITLE
[incubator/vault] Add loadBalancerIP to configure static LB IP

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.14.6
+version: 0.14.7
 appVersion: 1.0.1
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -62,6 +62,7 @@ The following table lists the configurable parameters of the Vault chart and the
 | `resources.limits.cpu`            | Container requested CPU                  | `nil`                               |
 | `resources.limits.memory`         | Container requested memory               | `nil`                               |
 | `affinity`                        | Affinity settings                        | See values.yaml                     |
+| `service.loadBalancerIP`          | Assign a static IP to the loadbalancer   | `nil`                               |
 | `service.loadBalancerSourceRanges`| IP whitelist for service type loadbalancer   | `[]`                            |
 | `service.annotations`             | Annotations for service                  | `{}`                                |
 | `annotations`                     | Annotations for deployment               | `{}`                                |

--- a/incubator/vault/templates/service.yaml
+++ b/incubator/vault/templates/service.yaml
@@ -17,6 +17,9 @@ spec:
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
   {{- if eq .Values.service.type "LoadBalancer" }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   loadBalancerSourceRanges:
     {{- range .Values.service.loadBalancerSourceRanges }}
     - {{ . }}

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -28,6 +28,8 @@ service:
   name: vault
   type: ClusterIP
   # type: LoadBalancer
+  # Assign a static LB IP
+  # loadBalancerIP: 203.0.113.32
   loadBalancerSourceRanges: []
   #  - 10.0.0.0/8
   #  - 130.211.204.2/32


### PR DESCRIPTION
#### What this PR does / why we need it:

This adds a loadBalancerIP variable to configure a static loadbalancer IP for example for use in GCP. 

#### Which issue this PR fixes
  - fixes #6296 (already closed due to inactivity)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
