### PR TITLE
[stable/sonatype-nexus] Reuse nexus.fullname template in nexus.proxy-ks.name

### DIFF
--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,5 +1,5 @@
 name: sonatype-nexus
-version: 1.16.0
+version: 1.16.1
 appVersion: 3.15.2-01
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/templates/_helpers.tpl
+++ b/stable/sonatype-nexus/templates/_helpers.tpl
@@ -36,8 +36,7 @@ Create a default fully qualified name for proxy keystore secret.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "nexus.proxy-ks.name" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s-%s"  $name .Release.Name "-proxy-ks" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" (include "nexus.fullname" .) "proxy-ks" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*  Manage the labels for each entity  */}}


### PR DESCRIPTION
Get rid of double dash and use a shorter name when the release name contains chart name

#### What this PR does / why we need it:

The name of the proxy keystore secret was not generated in the same way as the other resources in the chart. It contained an extra dash and did not get shortened when the release name contained chart name.

For example, the output from the original version of the chart:

```
$ helm template . -x templates/proxy-ks-secret.yaml --set=nexusProxy.env.cloudIamAuthEnabled=true --set=nexusProxy.secrets.keystore= --set=nexusProxy.secrets.password=
---
# Source: sonatype-nexus/templates/proxy-ks-secret.yaml

apiVersion: v1
kind: Secret
metadata:
  name: sonatype-nexus-release-name--proxy-ks
  labels:
    app: sonatype-nexus
    fullname: release-name-sonatype-nexus
    chart: sonatype-nexus-1.15.1
    release: release-name
    heritage: Tiller
type: Opaque
data:
  keystore: 
  password: 

$ helm template . -x templates/proxy-ks-secret.yaml --set=nexusProxy.env.cloudIamAuthEnabled=true --set=nexusProxy.secrets.keystore= --set=nexusProxy.secrets.password= --name=sonatype-nexus
---
# Source: sonatype-nexus/templates/proxy-ks-secret.yaml

apiVersion: v1
kind: Secret
metadata:
  name: sonatype-nexus-sonatype-nexus--proxy-ks
  labels:
    app: sonatype-nexus
    fullname: sonatype-nexus
    chart: sonatype-nexus-1.15.1
    release: sonatype-nexus
    heritage: Tiller
type: Opaque
data:
  keystore: 
  password: 
```

...and the output from the PR:

```
$ helm template . -x templates/proxy-ks-secret.yaml --set=nexusProxy.env.cloudIamAuthEnabled=true --set=nexusProxy.secrets.keystore= --set=nexusProxy.secrets.password=
---
# Source: sonatype-nexus/templates/proxy-ks-secret.yaml

apiVersion: v1
kind: Secret
metadata:
  name: release-name-sonatype-nexus-proxy-ks
  labels:
    app: sonatype-nexus
    fullname: release-name-sonatype-nexus
    chart: sonatype-nexus-1.15.1
    release: release-name
    heritage: Tiller
type: Opaque
data:
  keystore: 
  password: 

$ helm template . -x templates/proxy-ks-secret.yaml --set=nexusProxy.env.cloudIamAuthEnabled=true --set=nexusProxy.secrets.keystore= --set=nexusProxy.secrets.password= --name=sonatype-nexus
---
# Source: sonatype-nexus/templates/proxy-ks-secret.yaml

apiVersion: v1
kind: Secret
metadata:
  name: sonatype-nexus-proxy-ks
  labels:
    app: sonatype-nexus
    fullname: sonatype-nexus
    chart: sonatype-nexus-1.15.1
    release: sonatype-nexus
    heritage: Tiller
type: Opaque
data:
  keystore: 
  password: 
```

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
