### PR TITLE
[stable/redis-ha] Add Optional Prometheus Exporter Sidecar

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -18,3 +18,4 @@ details:
 sources:
 - https://redis.io/download
 - https://github.com/scality/Zenko/tree/development/1.0/kubernetes/zenko/charts/redis-ha
+- https://github.com/oliver006/redis_exporter

--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.1.3
+version: 3.1.4
 appVersion: 5.0.3
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/README.md
+++ b/stable/redis-ha/README.md
@@ -9,8 +9,8 @@ $ helm install stable/redis-ha
 ```
 
 By default this chart install 3 pods total:
- * one pod containing a redis master, sentinel container and a prometheus metrics exporter
- * two pods each containing a redis slave, sentinel containers and a prometheus metrics exporter
+ * one pod containing a redis master and sentinel container (optional prometheus metrics exporter sidecar available)
+ * two pods each containing a redis slave and sentinel containers (optional prometheus metrics exporter sidecars available)
 
 ## Introduction
 

--- a/stable/redis-ha/README.md
+++ b/stable/redis-ha/README.md
@@ -9,8 +9,8 @@ $ helm install stable/redis-ha
 ```
 
 By default this chart install 3 pods total:
- * one pod containing a redis master and sentinel containers
- * two pods each containing redis slave and sentinel containers.
+ * one pod containing a redis master, sentinel container and a prometheus metrics exporter
+ * two pods each containing a redis slave, sentinel containers and a prometheus metrics exporter
 
 ## Introduction
 
@@ -73,7 +73,11 @@ The following table lists the configurable parameters of the Redis chart and the
 | `nodeSelector`                   | Node labels for pod assignment                                                                                               | `{}`                                                      |
 | `tolerations`                    | Toleration labels for pod assignment                                                                                         | `[]`                                                      |
 | `podAntiAffinity.server`         | Antiaffinity for pod assignment of servers, `hard` or `soft`                                                                 | `Hard node and soft zone anti-affinity`                   |
-
+| `exporter.enabled`               | If `true`, the prometheus exporter sidecar is enabled                                                                        | `false`                                                   |
+| `exporter.image`                 | Exporter image                                                                                                               | `oliver006/redis_exporter`                                |
+| `exporter.tag`                   | Exporter tag                                                                                                                 | `v0.28.0`                                                 |
+| `exporter.annotations`           | Prometheus scrape annotations                                                                                                |  `{prometheus.io/path: /metrics, prometheus.io/port: "9121", prometheus.io/scrape: "true"}`                                                     |
+| `exporter.extraArgs`             | Additional args for the exporter                                                                                           | `{}`                                                      |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/stable/redis-ha/templates/redis-ha-statefulset.yaml
@@ -22,6 +22,9 @@ spec:
       {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
+      {{- if .Values.exporter.enabled }}
+{{ toYaml .Values.exporter.annotations | indent 8 }}
+      {{- end }}
       labels:
         release: {{ .Release.Name }}
         app: {{ template "redis-ha.name" . }}
@@ -147,6 +150,25 @@ spec:
           name: data
         - mountPath: /probes
           name: probes
+{{- if .Values.exporter.enabled }}
+      - name: redis-exporter
+        image: "{{ .Values.exporter.image }}:{{ .Values.exporter.tag }}"
+        imagePullPolicy: {{ .Values.exporter.pullPolicy }}
+        args:
+        {{- range $key, $value := .Values.extraArgs }}
+          - --{{ $key }}={{ $value }}
+        {{- end }}
+        env:
+          - name: REDIS_ADDR
+            value: redis://localhost:6379
+        {{- if .Values.auth }}
+          - name: REDIS_PASSWORD
+            value: {{ .Values.redisPassword }}
+        {{- end }}
+        ports:
+          - name: exporter-port
+            containerPort: 9121
+{{- end }}
       volumes:
       - name: config
         configMap:

--- a/stable/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/stable/redis-ha/templates/redis-ha-statefulset.yaml
@@ -23,7 +23,9 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
       {{- if .Values.exporter.enabled }}
-{{ toYaml .Values.exporter.annotations | indent 8 }}
+        prometheus.io/port: "{{ .Values.exporter.port }}"
+        prometheus.io/scrape: "true"
+        prometheus.io/path: {{ .Values.exporter.scrapePath }}
       {{- end }}
       labels:
         release: {{ .Release.Name }}
@@ -163,11 +165,27 @@ spec:
             value: redis://localhost:6379
         {{- if .Values.auth }}
           - name: REDIS_PASSWORD
-            value: {{ .Values.redisPassword }}
+            valueFrom:
+              secretKeyRef:
+              {{- if .Values.existingSecret }}
+                name: {{ .Values.existingSecret }}
+              {{- else }}
+                name: {{ template "redis-ha.fullname" . }}
+              {{- end }}
+                key: auth
         {{- end }}
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.exporter.scrapePath }}
+            port: {{ .Values.exporter.port }}
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+          periodSeconds: 15
+        resources:
+        {{ toYaml .Values.exporter.resources | indent 10 }}
         ports:
           - name: exporter-port
-            containerPort: 9121
+            containerPort: {{ .Values.exporter.port }}
 {{- end }}
       volumes:
       - name: config

--- a/stable/redis-ha/values.yaml
+++ b/stable/redis-ha/values.yaml
@@ -98,11 +98,12 @@ exporter:
   tag: v0.28.0
   pullPolicy: IfNotPresent
 
-  # Annotations for prometheus
-  annotations:
-    prometheus.io/port: "9121"
-    prometheus.io/scrape: "true"
-    prometheus.io/path: /metrics
+  # prometheus port & scrape path
+  port: 9121
+  scrapePath: /metrics
+
+  # cpu/memory resource limits/requests
+  resources: {}
 
   # Additional args for redis exporter
   extraArgs: {}

--- a/stable/redis-ha/values.yaml
+++ b/stable/redis-ha/values.yaml
@@ -91,6 +91,22 @@ affinity: |
               release: {{ .Release.Name }}
           topologyKey: failure-domain.beta.kubernetes.io/zone
 
+# Prometheus exporter specific configuration options
+exporter:
+  enabled: false
+  image: oliver006/redis_exporter
+  tag: v0.28.0
+  pullPolicy: IfNotPresent
+
+  # Annotations for prometheus
+  annotations:
+    prometheus.io/port: "9121"
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+
+  # Additional args for redis exporter
+  extraArgs: {}
+
 podDisruptionBudget: {}
   # maxUnavailable: 1
   # minAvailable: 1


### PR DESCRIPTION
Added support for an optional prometheus exporter sidecar container in each Redis pod.

Signed-off-by: Tim Mitrovich <tim@mitrovich.net>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR adds support for (optionally) injecting a prometheus Redis exporter container in each Redis pod as a sidecar. This addition makes it really easy to add metrics scraping to all Redis pods without having to install the exporters as separate pods. The exporter sidecar is disabled by default so until the sidecar is enabled, this chart will behave as it always have. That way existing users won't "accidentally" get the sidecar, but those that do want it can easily turn it on.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #11084 
  - fixes #5977

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
