### PR TITLE
[stable/elasticsearch] Fix statefulset serviceName to point to discovery service

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.18.0
+version: 1.18.1
 appVersion: 6.6.0
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/stable/elasticsearch/templates/master-statefulset.yaml
+++ b/stable/elasticsearch/templates/master-statefulset.yaml
@@ -9,7 +9,7 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "elasticsearch.master.fullname" . }}
 spec:
-  serviceName: {{ template "elasticsearch.master.fullname" . }}
+  serviceName: {{ template "elasticsearch.fullname" . }}-discovery
   replicas: {{ .Values.master.replicas }}
   template:
     metadata:


### PR DESCRIPTION
#### What this PR does / why we need it:

I believe that the `serviceName` for the statefulset should match the name of the discovery service so that the master nodes can be reached at the `<pod_name>.<service_name>` hostname, the convention for headless services.

#### Which issue this PR fixes

This change should allow a master pod to be available at something like `release-elasticsearch-master-1.release-elasticsearch-discovery`.  Previously, the pod was not available at the `<pod_name>.<service_name>` address because the serviceName in the statefulSet was incorrect.

#### Special notes for your reviewer:

If there's some special reason that the `serviceName` was not matching the discovery's service name, just let me know and disregard the PR.  Thanks!

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
