### PR TITLE
[stable/mysql] allow disabling readiness/liveness checks

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.14.0
+version: 0.15.0
 appVersion: 5.7.14
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -84,6 +84,7 @@ spec:
         ports:
         - name: mysql
           containerPort: 3306
+        {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           exec:
             command:
@@ -100,6 +101,8 @@ spec:
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.livenessProbe.successThreshold }}
           failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           exec:
             command:
@@ -116,6 +119,7 @@ spec:
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        {{- end }}
         volumeMounts:
         - name: data
           mountPath: /var/lib/mysql

--- a/stable/mysql/values.yaml
+++ b/stable/mysql/values.yaml
@@ -67,6 +67,7 @@ nodeSelector: {}
 tolerations: []
 
 livenessProbe:
+  enabled: true
   initialDelaySeconds: 30
   periodSeconds: 10
   timeoutSeconds: 5
@@ -74,6 +75,7 @@ livenessProbe:
   failureThreshold: 3
 
 readinessProbe:
+  enabled: true
   initialDelaySeconds: 5
   periodSeconds: 10
   timeoutSeconds: 1


### PR DESCRIPTION
When using the /docker-entrypoint-initdb.d/ feature of the mysql
container it can take minutes to load the container. We don't
necessarily know how long that will take.

Add an enabled flag to the checks so that we can run the container
without checks if required.