### PR TITLE
[stable/mysqldump] add missing rc variable which makes successful jobs fail

### DIFF
--- a/stable/mysqldump/Chart.yaml
+++ b/stable/mysqldump/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 2.3.0
+appVersion: 2.3.1
 description: A Helm chart to help backup MySQL databases using mysqldump
 name: mysqldump
-version: 2.3.0
+version: 2.3.1
 keywords:
 - mysql
 - mysqldump

--- a/stable/mysqldump/templates/configmap.yaml
+++ b/stable/mysqldump/templates/configmap.yaml
@@ -55,7 +55,7 @@ data:
     echo "Backing up single db ${MYSQL_DB}"
     {{ if .Values.saveToDirectory }}mkdir -p "${BACKUP_DIR}"/"${MYSQL_DB}"{{ end }}
     mysqldump ${MYSQL_OPTS} -h ${MYSQL_HOST} -P ${MYSQL_PORT} -u ${MYSQL_USERNAME}{{ if .Values.mysql.password }} -p${MYSQL_PASSWORD}{{ end }} --databases ${MYSQL_DB} | gzip > ${BACKUP_DIR}/{{ if .Values.saveToDirectory }}${MYSQL_DB}/{{ end }}${TIMESTAMP}_${MYSQL_DB}.sql.gz
-
+    rc=$?
     {{ else if and (.Values.allDatabases.enabled) (eq .Values.allDatabases.singleBackupFile false)}}
     for MYSQL_DB in $(mysql -h "${MYSQL_HOST}" -u ${MYSQL_USERNAME}{{ if .Values.mysql.password }} -p${MYSQL_PASSWORD}{{ end }} -B -N -e "SHOW DATABASES;"|egrep -v '^(information|performance)_schema$'); do
       echo "Backing up db ${MYSQL_DB}"


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Without this PR, there is an error for the mysqldump script when used with following config:
```yaml
mysql:
  host: cloudsql
  username: username
  password: foobar
  port: 3306
  # db for single db backup
  db: mydb

# use --all-databases
allDatabases:
  enabled: false
  # creates single backup file with all databases
  singleBackupFile: false

# options to pass to mysqldump
options: "--opt --single-transaction --events --routines --triggers "

# save sql backup to a directory named like the database or "alldatabases"
saveToDirectory: false

## set to `now` to get a one time job, or a cronjob schedule like `0 0 * * *`
## to get a cronjob.
schedule: "0 */3 * * *"

persistence:
  enabled: true
  size: 1Gi
  accessMode: ReadWriteMany
  reclaimPolicy: delete
  storageClass: "nfs"

# delete backups older than 10 days
housekeeping:
  enabled: true
  keepDays: 10

# upload backup
upload:
  googlestoragebucket:
    enabled: true
    # bucketname with gs:// prefix
    bucketname: gs://mybucket
    # jsonKeyfile of you serviceaccount as string
    # secretFileName specifies the keyfile name inside the secret
    secretFileName: google-cloud-serviceaccount.json
    # existingSecret can be enabled to use an existing secret
    existingSecret: google-cloud-serviceaccount
    # serviceAccountName to set a specific service account name
    # serviceAccountName
    # usingGCPController to enable autogeneration and injection of the service account
    usingGCPController: false
```

The missing rc Variable will always cause the backup script to fail, though it was actually successful. The BackoffLimit will then immediately start another Job, so I end up with 2 dumps exectued almost in parallel, but kubernetes seeing an error.

Here's the generated (faulty) script:
```yaml
data:
  backup.sh: |-
    #!/bin/sh
    #
    # mysql backup script
    #
    
    BACKUP_DIR="/backup"
    TIMESTAMP="$(date +%Y%m%d%H%M%S)"

    echo "test mysql connection"
    if [ -z "$(mysql -h ${MYSQL_HOST} -u ${MYSQL_USERNAME} -p${MYSQL_PASSWORD} -B -N -e 'SHOW DATABASES;')" ]; then
      echo "mysql connection failed! exiting..."
      exit 1
    fi

    echo "started" > ${BACKUP_DIR}/${TIMESTAMP}.state

    
    echo "delete old backups"
    find ${BACKUP_DIR} -maxdepth 2 -mtime +${KEEP_DAYS} -regex "^${BACKUP_DIR}/.*[0-9]*_.*\.sql\.gz$" -type f -exec rm {} \;
    
    MYSQL_DB="gcm"
    echo "Backing up single db ${MYSQL_DB}"
    
    mysqldump ${MYSQL_OPTS} -h ${MYSQL_HOST} -P ${MYSQL_PORT} -u ${MYSQL_USERNAME} -p${MYSQL_PASSWORD} --databases ${MYSQL_DB} | gzip > ${BACKUP_DIR}/${TIMESTAMP}_${MYSQL_DB}.sql.gz

    
    echo "upload files to google storage bucket gs://mybucket"
    gcloud auth activate-service-account --key-file /root/gcloud/google-cloud-serviceaccount.json
    gsutil -m rsync -r -x '.*\.state' -d ${BACKUP_DIR}/ gs://mybucket
    rcu=$?
    

    if [ "$rcu" != "0" ]; then
      echo "upload failed"
      exit 1
    fi
    
    #######
    # FIXME: this is where it breaks, rc is never set
    #######
    if [ "$rc" != "0" ]; then
      echo "backup failed"
      exit 1
    fi

    
    echo "complete" > ${BACKUP_DIR}/${TIMESTAMP}.state
    echo "Backup successful! :-)"

```


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped