### PR TITLE
[stable/kube-state-metrics] Use rbac.authorization.k8s.io/v1 apiVersion in RBAC resources

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - metric
 - monitoring
 - prometheus
-version: 0.13.0
+version: 0.13.1
 appVersion: 1.4.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/templates/psp-clusterrole.yaml
+++ b/stable/kube-state-metrics/templates/psp-clusterrole.yaml
@@ -1,10 +1,6 @@
 {{- if and .Values.podSecurityPolicy.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
-{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
-apiVersion: rbac.authorization.k8s.io/v1alpha1
-{{- end }}
 metadata:
   labels:
     app: {{ template "kube-state-metrics.name" . }}

--- a/stable/kube-state-metrics/templates/psp-clusterrolebinding.yaml
+++ b/stable/kube-state-metrics/templates/psp-clusterrolebinding.yaml
@@ -1,9 +1,5 @@
 {{- if and .Values.podSecurityPolicy.enabled -}}
-{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
-apiVersion: rbac.authorization.k8s.io/v1alpha1
-{{- end }}
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This chart was not possible to be deployed using `helm template` because the apiVersion would not be set since it had no `else` condition. This change switches to `rbac.authorization.k8s.io/v1` which has been around since Kubernetes 1.8.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
