### PR TITLE
[stable/redis-ha] Implement stable sentinel IDs by pregenerating them

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.1.4
+version: 3.1.5
 appVersion: 5.0.3
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/redis-ha-configmap.yaml
+++ b/stable/redis-ha/templates/redis-ha-configmap.yaml
@@ -51,7 +51,8 @@ data:
 
     sentinel_update() {
         echo "Updating sentinel config"
-        sed -i "1s/^/$(cat sentinel-id)\\n/" "$SENTINEL_CONF"
+        eval MY_SENTINEL_ID=\${SENTINEL_ID_$INDEX}
+        sed -i "1s/^/sentinel myid $MY_SENTINEL_ID\\n/" "$SENTINEL_CONF"
         sed -i "2s/^/sentinel monitor $MASTER_GROUP $1 $REDIS_PORT $QUORUM \\n/" "$SENTINEL_CONF"
         echo "sentinel announce-ip $ANNOUNCE_IP" >> $SENTINEL_CONF
         echo "sentinel announce-port $SENTINEL_PORT" >> $SENTINEL_CONF
@@ -65,9 +66,6 @@ data:
     }
 
     copy_config() {
-        if [ -f "$SENTINEL_CONF" ]; then
-            grep "sentinel myid" "$SENTINEL_CONF" > sentinel-id || true
-        fi
         cp /readonly-config/redis.conf "$REDIS_CONF"
         cp /readonly-config/sentinel.conf "$SENTINEL_CONF"
     }

--- a/stable/redis-ha/templates/redis-ha-configmap.yaml
+++ b/stable/redis-ha/templates/redis-ha-configmap.yaml
@@ -51,7 +51,7 @@ data:
 
     sentinel_update() {
         echo "Updating sentinel config"
-        eval MY_SENTINEL_ID=\${SENTINEL_ID_$INDEX}
+        eval MY_SENTINEL_ID="\${SENTINEL_ID_$INDEX}"
         sed -i "1s/^/sentinel myid $MY_SENTINEL_ID\\n/" "$SENTINEL_CONF"
         sed -i "2s/^/sentinel monitor $MASTER_GROUP $1 $REDIS_PORT $QUORUM \\n/" "$SENTINEL_CONF"
         echo "sentinel announce-ip $ANNOUNCE_IP" >> $SENTINEL_CONF

--- a/stable/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/stable/redis-ha/templates/redis-ha-statefulset.yaml
@@ -59,7 +59,7 @@ spec:
 {{- $replicas := int .Values.replicas -}}
 {{- range $i := until $replicas -}}
         - name: SENTINEL_ID_{{ $i }}
-          value: {{ printf "%s\nindex: %d" (include "labels.yaml" $) $i | sha1sum }}
+          value: {{ printf "%s\nindex: %d" (include "labels.standard" $) $i | sha1sum }}
 {{ end -}}
 {{- if .Values.auth }}
         - name: AUTH

--- a/stable/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/stable/redis-ha/templates/redis-ha-statefulset.yaml
@@ -55,8 +55,13 @@ spec:
         - sh
         args:
         - /readonly-config/init.sh
-{{- if .Values.auth }}
         env:
+{{- $replicas := int .Values.replicas -}}
+{{- range $i := until $replicas -}}
+        - name: SENTINEL_ID_{{ $i }}
+          value: {{ printf "%s\nindex: %d" (include "labels.yaml" $) $i | sha1sum }}
+{{ end -}}
+{{- if .Values.auth }}
         - name: AUTH
           valueFrom:
             secretKeyRef:

--- a/stable/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/stable/redis-ha/templates/redis-ha-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
         - /readonly-config/init.sh
         env:
 {{- $replicas := int .Values.replicas -}}
-{{- range $i := until $replicas -}}
+{{- range $i := until $replicas }}
         - name: SENTINEL_ID_{{ $i }}
           value: {{ printf "%s\nindex: %d" (include "labels.standard" $) $i | sha1sum }}
 {{ end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

In the course of reworking the failover mechanisms in PR #10032, the proliferation of stale sentinel IDs was prevented by recovering the old ID from the old config file (from persistent storage) on startup.

However, the redis-ha chart can be used with volatile data and an emptyDir. The sentinel ID will be lost on termination and again randomly generated on startup.

This PR makes sentinel IDs stable by simple pre-generating them and storing the as ENV vars on the init container.

In this approach I take the unique label combination + StatefulSet pod index and take the SHA1 of that:
```
    Environment:              
      SENTINEL_ID_0:  e2f7f63e2872ee7884a3887a043457bc6bff1fb4
      SENTINEL_ID_1:  10257ae861ee58ad3a0c32cda22ba7f62887e5c2
      SENTINEL_ID_2:  ba97a7362cc6e46973f0fe45c895cd5b57a60000
```

However, I could image that this would work just as well, not sure:
```
    Environment:                                              
      SENTINEL_ID_0:  1111111111111111111111111111111111111111
      SENTINEL_ID_1:  2222222222222222222222222222222222222222
      SENTINEL_ID_2:  3333333333333333333333333333333333333333
```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
