### PR TITLE
[stable/mysqldump] option to run additional shell steps

### DIFF
--- a/stable/mysqldump/Chart.yaml
+++ b/stable/mysqldump/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 2.3.2
+appVersion: 2.4.0
 description: A Helm chart to help backup MySQL databases using mysqldump
 name: mysqldump
-version: 2.3.2
+version: 2.4.0
 keywords:
 - mysql
 - mysqldump

--- a/stable/mysqldump/Chart.yaml
+++ b/stable/mysqldump/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 2.3.1
+appVersion: 2.3.2
 description: A Helm chart to help backup MySQL databases using mysqldump
 name: mysqldump
-version: 2.3.1
+version: 2.3.2
 keywords:
 - mysql
 - mysqldump

--- a/stable/mysqldump/README.md
+++ b/stable/mysqldump/README.md
@@ -57,6 +57,7 @@ The following tables lists the configurable parameters of the mysqldump chart an
 | schedule                                      | crontab schedule to run on. set as `now` to run as a one time job              | "0/5 \* \* \* \*"            |
 | options                                       | options to pass onto MySQL                                                     | "--opt --single-transaction" |
 | debug                                         | print some extra debug logs during backup                                      | false                        |
+| additionalSteps                               | run these extra shell steps after all backup jobs completed                    | []                           |
 | successfulJobsHistoryLimit                    | number of successful jobs to remember                                          | 5                            |
 | failedJobsHistoryLimit                        | number of failed jobs to remember                                              | 5                            |
 | persistentVolumeClaim                         | existing Persistent Volume Claim to backup to, leave blank to create a new one |                              |

--- a/stable/mysqldump/templates/NOTES.txt
+++ b/stable/mysqldump/templates/NOTES.txt
@@ -10,7 +10,7 @@ $ kubectl get pods --selector=job-name={{ template "mysqldump.fullname" . }} --s
 
 To see the logs from the backup job run:
 
-$ kubectl logs `kc get pods --selector=job-name=test-mysqldump --output=jsonpath={.items..metadata.name}`
+$ kubectl logs `kubectl get pods --selector=job-name=test-mysqldump --output=jsonpath={.items..metadata.name}`
 
 mysqldump contents can be found in:
 {{- if .Values.persistentVolumeClaim }}
@@ -19,7 +19,7 @@ $ kubectl get persistentvolumeclaim {{ .Values.persistentVolumeClaim }}
 {{- if .Values.persistence.enabled }}
 $ kubectl get persistentvolumeclaim {{ template "mysqldump.fullname" . }}
 {{- else }}
-$ kubectl logs `kc get pods --selector=job-name=test-mysqldump --output=jsonpath={.items..metadata.name}`
+$ kubectl logs `kubectl get pods --selector=job-name=test-mysqldump --output=jsonpath={.items..metadata.name}`
 {{- end -}}
 {{- end }}
 
@@ -35,8 +35,8 @@ $ kubectl get jobs --selector=cronjob-name={{ template "mysqldump.fullname" . }}
 
 To see the logs from the most recent backup job run:
 
-$ kubectl logs $(kc get pods --selector \
-  job-name=$(kc get jobs --selector=cronjob-name={{ template "mysqldump.fullname" . }} \
+$ kubectl logs $(kubectl get pods --selector \
+  job-name=$(kubectl get jobs --selector=cronjob-name={{ template "mysqldump.fullname" . }} \
   --output=jsonpath='{.items[-1:].metadata.name}') \
   --output=jsonpath={.items..metadata.name})
 
@@ -47,7 +47,7 @@ $ kubectl get persistentvolumeclaim {{ .Values.persistentVolumeClaim }}
 {{- if .Values.persistence.enabled }}
 $ kubectl get persistentvolumeclaim {{ template "mysqldump.fullname" . }}
 {{- else }}
-$ kubectl logs `kc get pods --selector=job-name=test-mysqldump --output=jsonpath={.items..metadata.name}`
+$ kubectl logs `kubectl get pods --selector=job-name=test-mysqldump --output=jsonpath={.items..metadata.name}`
 {{- end -}}
 {{- end }}
 

--- a/stable/mysqldump/templates/configmap.yaml
+++ b/stable/mysqldump/templates/configmap.yaml
@@ -103,6 +103,12 @@ data:
       exit 1
     fi
 
+    {{ if .Values.additionalSteps }}
+    {{- range .Values.additionalSteps }}
+    {{ . }}
+    {{- end }}
+    {{- end }}
+
     {{ if .Values.debug }}
     ls -alh ${BACKUP_DIR}
     {{ end }}

--- a/stable/mysqldump/values.yaml
+++ b/stable/mysqldump/values.yaml
@@ -40,6 +40,11 @@ debug: false
 successfulJobsHistoryLimit: 5
 failedJobsHistoryLimit: 5
 
+# additional steps for mysqldump shell script
+# will be inserted after all backup and upload jobs completed successfully.
+# Use "${BACKUP_DIR}/${TIMESTAMP}_${MYSQL_DB}.sql.gz" as dump file name.
+additionalSteps: []
+
 ## set persistentVolumeClaim to use a PVC that already exists.
 ## if set will override any settings under `persistence` otherwise
 ## if not set and `persistence.enabled` set to true, will create a PVC.

--- a/stable/mysqldump/values.yaml
+++ b/stable/mysqldump/values.yaml
@@ -43,7 +43,10 @@ failedJobsHistoryLimit: 5
 # additional steps for mysqldump shell script
 # will be inserted after all backup and upload jobs completed successfully.
 # Use "${BACKUP_DIR}/${TIMESTAMP}_${MYSQL_DB}.sql.gz" as dump file name.
+# see examples
 additionalSteps: []
+#  - gsutil cp "${BACKUP_DIR}/${TIMESTAMP}_${MYSQL_DB}.sql.gz" gs://mybucket/latest.sql.gz
+#  - echo "latest sql dump updated"
 
 ## set persistentVolumeClaim to use a PVC that already exists.
 ## if set will override any settings under `persistence` otherwise


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR introduces a new parameter for custom steps in the mysqldump script.
These steps will run after all dumps and backups finished successfully.
It's handy if you need to do additional $stuff with your dumps. Without it, and without the possibility to specify a dump file name, automation is a lot harder.

Also, the Notes.txt had probably custom aliases of `kc`, which obviously should be `kubectl` as not everybody aliased his `kubectl` to `kc`, thus returning an error message after installing the Chart and running suggested commands.

#### Special notes for your reviewer:

#### Checklist

- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
