### PR TITLE
[prometheus-rabbitmq-export] Add skip_verify to rabbitmq-exporter

### DIFF
--- a/stable/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/stable/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 0.3.0
+version: 0.3.1
 appVersion: v0.29.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/stable/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/stable/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 0.3.1
+version: 0.4.0
 appVersion: v0.29.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/stable/prometheus-rabbitmq-exporter/README.md
+++ b/stable/prometheus-rabbitmq-exporter/README.md
@@ -59,6 +59,7 @@ The following table lists the configurable parameters and their default values.
 | `rabbitmq.skip_queues`   | regex, matching queue names are not exported                           | `^$`                      |
 | `rabbitmq.include_vhost` | regex vhost filter. Only queues in matching vhosts are exported        | `.*`                      |
 | `rabbitmq.skip_vhost`    | regex, matching vhost names are not exported. First performs include_vhost, then skip_vhost | `^$` |
+| `rabbitmq.skip_verify    | true/0 will ignore certificate errors of the management plugin         | `false`                   |
 | `rabbitmq.exporters`     | List of enabled modules. Just "connections" is not enabled by default  | `exchange,node,overview,queue` |
 | `rabbitmq.output_format` | Log ouput format. TTY and JSON are suported                            | `TTY`                     |
 | `rabbitmq.timeout`       | timeout in seconds for retrieving data from management plugin          | `30`                      |

--- a/stable/prometheus-rabbitmq-exporter/templates/deployment.yaml
+++ b/stable/prometheus-rabbitmq-exporter/templates/deployment.yaml
@@ -44,6 +44,8 @@ spec:
               value: "{{ .Values.rabbitmq.include_vhost }}"
             - name: SKIP_QUEUES
               value: "{{ .Values.rabbitmq.skip_queues }}"
+            - name: SKIPVERIFY
+              value: "{{ .Values.rabbitmq.skip_verify }}"
             - name: SKIP_VHOST
               value: "{{ .Values.rabbitmq.skip_vhost }}"
             - name: RABBIT_EXPORTERS

--- a/stable/prometheus-rabbitmq-exporter/values.yaml
+++ b/stable/prometheus-rabbitmq-exporter/values.yaml
@@ -33,10 +33,10 @@ rabbitmq:
   url: http://myrabbit:15672
   user: guest
   password: guest
-  capabilities: bert,no_sort
   include_queues: ".*"
   include_vhost: ".*"
   skip_queues: "^$"
+  skip_verify: "false"
   skip_vhost: "^$"
   exporters: "exchange,node,overview,queue"
   output_format: "TTY"

--- a/stable/prometheus-rabbitmq-exporter/values.yaml
+++ b/stable/prometheus-rabbitmq-exporter/values.yaml
@@ -33,6 +33,7 @@ rabbitmq:
   url: http://myrabbit:15672
   user: guest
   password: guest
+  capabilities: bert,no_sort
   include_queues: ".*"
   include_vhost: ".*"
   skip_queues: "^$"


### PR DESCRIPTION
This PR adds the skip_verify env variable to prometheus-rabbitmq-exporter.