### PR TITLE
[stable/kiam] Better control of server address in agent CLI argument

### DIFF
--- a/stable/kiam/Chart.yaml
+++ b/stable/kiam/Chart.yaml
@@ -1,5 +1,5 @@
 name: kiam
-version: 2.0.1-rc7
+version: 2.0.1-rc8
 appVersion: 3.0-rc1
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/stable/kiam/README.md
+++ b/stable/kiam/README.md
@@ -105,6 +105,7 @@ Parameter | Description | Default
 `agent.host.iptables` | Add iptables rule | `false`
 `agent.host.interface` | Agent's host interface for proxying AWS metadata | `cali+`
 `agent.host.port` | Agent's listening port | `8181`
+`agent.serverHostOverride` | Override for server host | `null`
 `agent.log.jsonOutput` | Whether or not to output agent log in JSON format | `true`
 `agent.log.level` | Agent log level (`debug`, `info`, `warn` or `error`) | `info`
 `agent.nodeSelector` | Node labels for agent pod assignment | `{}`

--- a/stable/kiam/templates/agent-daemonset.yaml
+++ b/stable/kiam/templates/agent-daemonset.yaml
@@ -85,7 +85,11 @@ spec:
             - --cert=/etc/kiam/tls/{{ .Values.agent.tlsCerts.certFileName }}
             - --key=/etc/kiam/tls/{{ .Values.agent.tlsCerts.keyFileName }}
             - --ca=/etc/kiam/tls/{{ .Values.agent.tlsCerts.caFileName }}
+            {{- if .Values.agent.serverHostOverride }}
+            - --server-address={{ .Values.agent.serverHostOverride }}:{{ .Values.server.service.port }}
+            {{- else }}
             - --server-address={{ template "kiam.fullname" . }}-server:{{ .Values.server.service.port }}
+            {{- end }}
             {{- if .Values.agent.prometheus.scrape }}
             - --prometheus-listen-addr=0.0.0.0:{{ .Values.agent.prometheus.port }}
             - --prometheus-sync-interval={{ .Values.agent.prometheus.syncInterval }}

--- a/stable/kiam/values.yaml
+++ b/stable/kiam/values.yaml
@@ -25,6 +25,9 @@ agent:
     iptables: false
     port: 8181
     interface: cali+
+  ## Override for server host
+  ##
+  serverHostOverride:
   ## Prometheus metrics
   ##
   prometheus:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Allow overriding server address in agent command line argument (e.g. connecting via `localhost` when the agent and server daemonsets are running on the same node group).

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [*] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [*] Chart Version bumped
- [*] Variables are documented in the README.md
