### PR TITLE
[stable/prometheus-operator] update dependencies for kube-state-metrics rbac fix

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 2.1.5
+version: 2.1.6
 appVersion: 0.26.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/requirements.lock
+++ b/stable/prometheus-operator/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.13.0
+  version: 0.13.1
 - name: prometheus-node-exporter
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 1.1.0
 - name: grafana
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.25.0
+  version: 1.25.4
 digest: sha256:db064dc47d3363e31d6e317385b29bffc30929ed42a0d2951109184e907721e2
-generated: 2019-01-15T16:00:38.946498-08:00
+generated: 2019-02-04T01:26:34.155884-08:00


### PR DESCRIPTION
#### What this PR does / why we need it:

Updating the requirements.lock file to benefit from a fix I made to kube-state-metrics: https://github.com/helm/charts/pull/11094, where apiVersion was omitted when rendered using `helm template`. This benefits prometheus-operator since the chart can also now be installed by running `helm template`. 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
