### PR TITLE
Fix Systemd Unit filtering

### DIFF
--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -42,7 +42,7 @@ data:
         Name            systemd
         Tag             {{ .Values.input.systemd.tag }}
 {{- range $value := .Values.input.systemd.filters.systemdUnit }}
-        Systemd_Filter  _SYSTEMD_UNIT="{{ $value }}"
+        Systemd_Filter  _SYSTEMD_UNIT={{ $value }}
 {{- end }}
         Max_Entries     {{ .Values.input.systemd.maxEntries }}
         Read_From_Tail  {{ .Values.input.systemd.readFromTail }}


### PR DESCRIPTION
[stable/fluent-bit] Remove extraneous double quotes from input configuration

I've noticed there are some extra enclosing double quotes on fluent-bit's systemd input configuration which prevent it from working.