### PR TITLE
Provide the capability to use LDAP Authentication

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,6 +1,6 @@
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 0.15.0
+version: 0.16.0
 appVersion: 1.10.0
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -168,6 +168,7 @@ postgresUser, postgresPassword, and redisPassword etc. is defined. If not specif
 
 Map each specific secret to specific environment variables in your values.yaml. Where envVar is the airflow environment
 variable to populate and secretKey is the key that contains your secret value in your kubernetes secret:
+```
 existingAirflowSecret: my-airflow-secrets
 airflow:
     secretsMapping:
@@ -182,7 +183,7 @@ airflow:
 
       - envVar: REDIS_PASSWORD
         secretKey: airflowRedisPassword
-
+```
 
 ### Local binaries
 

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -168,7 +168,7 @@ postgresUser, postgresPassword, and redisPassword etc. is defined. If not specif
 
 Map each specific secret to specific environment variables in your values.yaml. Where envVar is the airflow environment
 variable to populate and secretKey is the key that contains your secret value in your kubernetes secret:
-```
+```yaml
 existingAirflowSecret: my-airflow-secrets
 airflow:
     secretsMapping:

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -159,12 +159,30 @@ $ kubectl create secret generic redshift-user --from-file=redshift-user=~/secret
 ```
 Where `redshift-user.txt` contains the user secret as a single text string.
 
-### Use precreated secret for postgres and redis
+### Use precreated secret for airflow secrets or environment variables
 
-You can use a precreated secret for the connection credentials to both postgresql and redis. To do
+You can use a precreated secret for the connection credentials, or general environment variables. To do
 so specify in values.yaml `existingAirflowSecret`, where the value is the name of the secret which has
-postgresUser, postgresPassword, and redisPassword defined. If not specified, it will fall back to using
+postgresUser, postgresPassword, and redisPassword etc. is defined. If not specified, it will fall back to using
 `secrets.yaml` to store the connection credentials by default.
+
+Map each specific secret to specific environment variables in your values.yaml. Where envVar is the airflow environment
+variable to populate and secretKey is the key that contains your secret value in your kubernetes secret:
+existingAirflowSecret: my-airflow-secrets
+airflow:
+    secretsMapping:
+      - envVar: AIRFLOW__LDAP__BIND_PASSWORD
+        secretKey: ldapBindPassword
+
+      - envVar: POSTGRES_USER
+        secretKey: airflowPostgresUser
+
+      - envVar: POSTGRES_PASSWORD
+        secretKey: airflowPostgresPassword
+
+      - envVar: REDIS_PASSWORD
+        secretKey: airflowRedisPassword
+
 
 ### Local binaries
 
@@ -254,6 +272,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `airflow.webReplicas`                    | how many replicas for web server                        | `1`                       |
 | `airflow.config`                         | custom airflow configuration env variables              | `{}`                      |
 | `airflow.podDisruptionBudget`            | control pod disruption budget                           | `{'maxUnavailable': 1}`   |
+| `airflow.secretsMapping`		           | override any environment variable with a secret	     | 				             |
 | `workers.enabled`                        | enable workers                                          | `true`                    |
 | `workers.replicas`                       | number of workers pods to launch                        | `1`                       |
 | `workers.resources`                      | custom resource configuration for worker pod            | `{}`                      |

--- a/stable/airflow/templates/_helpers.tpl
+++ b/stable/airflow/templates/_helpers.tpl
@@ -75,3 +75,26 @@ Create the name for the airflow secret.
         {{ template "airflow.fullname" . }}
     {{- end -}}
 {{- end -}}
+
+{{/*
+Map environment vars to secrets
+*/}}
+{{- define "airflow.mapenvsecrets" -}}
+    {{- $secretName := .Release.Name | trunc 63 | trimSuffix "-" }}
+    {{- $mapping := .Values.airflow.defaultSecretsMapping }}
+    {{- if .Values.existingAirflowSecret }}
+      {{- $secretName = .Values.existingAirflowSecret }}
+      {{- if .Values.airflow.secretsMapping }}
+        {{- $mapping = .Values.airflow.secretsMapping }}
+      {{- end }}
+    {{- end }}
+    {{- range $val := $mapping }}
+      {{- if $val }}
+  - name: {{ $val.envVar }}
+    valueFrom:
+      secretKeyRef:
+        name: {{ $secretName }}
+        key: {{ $val.secretKey }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/stable/airflow/templates/deployments-flower.yaml
+++ b/stable/airflow/templates/deployments-flower.yaml
@@ -45,21 +45,7 @@ spec:
             - configMapRef:
                 name: "{{ template "airflow.fullname" . }}-env"
           env:
-            - name: POSTGRES_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "airflow.secret" . }}
-                  key: postgresUser
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "airflow.secret" . }}
-                  key: postgresPassword
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "airflow.secret" . }}
-                  key: redisPassword
+          {{- include "airflow.mapenvsecrets" . | indent 10 }}
           ports:
             - name: flower
               containerPort: 5555

--- a/stable/airflow/templates/deployments-scheduler.yaml
+++ b/stable/airflow/templates/deployments-scheduler.yaml
@@ -67,21 +67,7 @@ spec:
           - configMapRef:
               name: "{{ template "airflow.fullname" . }}-env"
           env:
-            - name: POSTGRES_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "airflow.secret" . }}
-                  key: postgresUser
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "airflow.secret" . }}
-                  key: postgresPassword
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "airflow.secret" . }}
-                  key: redisPassword
+          {{- include "airflow.mapenvsecrets" . | indent 10 }}
           volumeMounts:
           {{- if .Values.persistence.enabled }}
             - name: dags-data

--- a/stable/airflow/templates/deployments-web.yaml
+++ b/stable/airflow/templates/deployments-web.yaml
@@ -70,21 +70,7 @@ spec:
             - configMapRef:
                 name: "{{ template "airflow.fullname" . }}-env"
           env:
-            - name: POSTGRES_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "airflow.secret" . }}
-                  key: postgresUser
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "airflow.secret" . }}
-                  key: postgresPassword
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "airflow.secret" . }}
-                  key: redisPassword
+            {{- include "airflow.mapenvsecrets" . | indent 10 }}
           volumeMounts:
           {{- if .Values.persistence.enabled }}
             - name: dags-data

--- a/stable/airflow/templates/statefulsets-workers.yaml
+++ b/stable/airflow/templates/statefulsets-workers.yaml
@@ -75,21 +75,7 @@ spec:
             - configMapRef:
                 name: "{{ template "airflow.fullname" . }}-env"
           env:
-            - name: POSTGRES_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "airflow.secret" . }}
-                  key: postgresUser
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "airflow.secret" . }}
-                  key: postgresPassword
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "airflow.secret" . }}
-                  key: redisPassword
+          {{- include "airflow.mapenvsecrets" . | indent 10 }}
           volumeMounts:
           {{- $secretsDir := .Values.workers.secretsDir -}}
           {{- range .Values.workers.secrets }}

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -4,6 +4,36 @@
 ##
 ## common settings and setting for the webserver
 airflow:
+
+  ##
+  ## secretsMapping can be overridden in values.yaml as such:
+  ## secretsMapping:
+  ## - envVar: AIRFLOW__LDAP__BIND_PASSWORD
+  ##   secretName: ldapBindPassword
+  ## - envVar: AIRFLOW__ATLAS__PASSWORD
+  ##   secretName: atlasPassword
+  ## - envVar: AIRFLOW__SMTP__PASSWORD
+  ##   secretName: smtpPassword
+  ## - envVar: AIRFLOW__KUBERNETES__GIT_PASSWORD
+  ##   secretName: kubernetesGitPassword
+  ## - envVar: POSTGRES_USER
+  ##   secretName: postgresUser
+  ## - envVar: POSTGRES_PASSWORD
+  ##   secretName: postgresPassword
+  ## - envVar: REDIS_PASSWORD
+  ##   secretName: redisPassword
+  secretsMapping:
+
+
+  ## used only when existingAirflowSecrets is false
+  defaultSecretsMapping:
+  - envVar: POSTGRES_USER
+    secretKey: postgresUser
+  - envVar: POSTGRES_PASSWORD
+    secretKey: postgresPassword
+  - envVar: REDIS_PASSWORD
+    secretKey: redisPassword
+
   ##
   ## You will need to define your fernet key:
   ## Generate fernetKey with:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Currently there is no way  (short of forking the repository) to provide an LDAP password as a Kubernetes Secret to the Airflow Web Pod. The only supported secrets are Postgres and Redis. I've added the capability to set an ldap.bind.password in values.yaml which will be deployed as part of the default airflow secrets. If LDAP backend is disabled, this will have no effect.

Due to the above, created a generic solution that will map any env var in the deployment and stateful set to a given secret in an existingAirflowSecret.

Secrets can be mapped in your values.yaml like so:
airflow:
  existingAirflowSecret: my-airflow-secrets
  secretsMapping:
  - envVar: AIRFLOW__LDAP__BIND_PASSWORD
    secretName: ldapBindPassword
  - envVar: POSTGRES_USER
    secretName: airflowPostgresUser
  - envVar: POSTGRES_PASSWORD
    secretName: airflowPostgresPassword
  - envVar: REDIS_PASSWORD
    secretName: airflowRedisPassword

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
