### PR TITLE
fix ldap and smtp indention in values.yaml

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 1.26.0
+version: 1.26.1
 appVersion: 5.4.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -285,9 +285,9 @@ grafana.ini:
   smtp:
   # `existingSecret` is a reference to an existing secret containing the smtp configuration
   # for Grafana.
-    existingSecret: ""
-    userKey: "user"
-    passwordKey: "password"
+  # existingSecret: ""
+  # userKey: "user"
+  # passwordKey: "password"
 
 ## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
 ## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -262,7 +262,7 @@ grafana.ini:
 ## NOTE: To enable the grafana.ini must be configured with auth.ldap.enabled
 ## ref: http://docs.grafana.org/installation/configuration/#auth-ldap
 ## ref: http://docs.grafana.org/installation/ldap/#configuration
-  ldap:
+  # ldap:
   # `existingSecret` is a reference to an existing secret containing the ldap configuration
   # for Grafana in a key `ldap-toml`.
   #  existingSecret: ""

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -262,12 +262,12 @@ grafana.ini:
 ## NOTE: To enable the grafana.ini must be configured with auth.ldap.enabled
 ## ref: http://docs.grafana.org/installation/configuration/#auth-ldap
 ## ref: http://docs.grafana.org/installation/ldap/#configuration
-ldap:
+  ldap:
   # `existingSecret` is a reference to an existing secret containing the ldap configuration
   # for Grafana in a key `ldap-toml`.
-  existingSecret: ""
+  #  existingSecret: ""
   # `config` is the content of `ldap.toml` that will be stored in the created secret
-  config: ""
+  #  config: ""
   # config: |-
   #   verbose_logging = true
 
@@ -282,12 +282,12 @@ ldap:
 ## Grafana's SMTP configuration
 ## NOTE: To enable, grafana.ini must be configured with smtp.enabled
 ## ref: http://docs.grafana.org/installation/configuration/#smtp
-smtp:
+  smtp:
   # `existingSecret` is a reference to an existing secret containing the smtp configuration
   # for Grafana.
-  existingSecret: ""
-  userKey: "user"
-  passwordKey: "password"
+    existingSecret: ""
+    userKey: "user"
+    passwordKey: "password"
 
 ## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
 ## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards


### PR DESCRIPTION
Signed-off-by: Morteza Khazamipour <mormoroth@gmail.com>

#### What this PR does / why we need it:
The indention is not correct to add smtp and ldap configuration to grafana.ini and any changes to smtp and ldap does not take effect.

#### Special notes for your reviewer:
Sorry for opening another PR, the bot made me confused.
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
