### PR TITLE
stable/minio: Bugfix for GCS gateway in deployment.yaml

### DIFF
--- a/stable/minio/templates/deployment.yaml
+++ b/stable/minio/templates/deployment.yaml
@@ -116,10 +116,7 @@ spec:
                   key: secretkey
             {{- if .Values.gcsgateway.enabled }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "minio.fullname" . }}
-                  key: gcs_key.json
+              value: /etc/credentials/gcs_key.json
             {{- end }}
             {{- range $key, $val := .Values.environment }}
             - name: {{ $key }}


### PR DESCRIPTION
The minio server expects a filename, not the actual content.

#### Checklist

- [ ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
