### PR TITLE
[stable/elastalert] Allow adding additional global config options

### DIFF
--- a/stable/elastalert/Chart.yaml
+++ b/stable/elastalert/Chart.yaml
@@ -1,6 +1,6 @@
 description: ElastAlert is a simple framework for alerting on anomalies, spikes, or other patterns of interest from data in Elasticsearch.
 name: elastalert
-version: 0.10.0
+version: 0.11.0
 appVersion: 0.1.38
 home: https://github.com/Yelp/elastalert
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg

--- a/stable/elastalert/README.md
+++ b/stable/elastalert/README.md
@@ -68,6 +68,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `elasticsearch.caCerts` | path to a CA cert bundle to use to verify SSL connections | /certs/ca.pem          |
 | `elasticsearch.certsVolumes` | certs volumes, required to mount ssl certificates when elasticsearch has tls enabled | `NULL` |
 | `elasticsearch.certsVolumeMounts` | mount certs volumes, required to mount ssl certificates when elasticsearch has tls enabled | `NULL` |
+| `extraConfigOptions` | Additional options to propagate to all rules, cannot be `alert`, `type`, `name` or `index` | `{}` |
 | `resources`              | Container resource requests and limits            | {}                              |
 | `rules`                  | Rule and alert configuration for Elastalert       | {} example shown in values.yaml |
 | `runIntervalMins`        | Default interval between alert checks, in minutes | 1                               |

--- a/stable/elastalert/templates/config.yaml
+++ b/stable/elastalert/templates/config.yaml
@@ -42,3 +42,4 @@ data:
 {{- end }}
     alert_time_limit:
       minutes: {{ .Values.alertRetryLimitMins }}
+{{ toYaml .Values.extraConfigOptions | indent 4 }}

--- a/stable/elastalert/values.yaml
+++ b/stable/elastalert/values.yaml
@@ -64,6 +64,14 @@ elasticsearch:
   #     mountPath: /certs
   #     readOnly: true
 
+extraConfigOptions: {}
+  # # Options to propagate to all rules, e.g. a common slack_webhook_url or kibana_url
+  # # Please note at the time of implementing this value, it will not work for required_locals
+  # # Which MUST be set at the rule level, these are: ['alert', 'type', 'name', 'index']
+  # generate_kibana_link: true
+  # kibana_url: https://kibana.yourdomain.com
+  # slack_webhook_url: dummy
+
 # Command and args override for container e.g. (https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/)
 # command: ["YOUR_CUSTOM_COMMAND"]
 # args: ["YOUR", "CUSTOM", "ARGS"]


### PR DESCRIPTION
#### What this PR does / why we need it:

In case one uses one or more common options for all their rules (e.g. perhaps only a single `slack_url` and `kibana_url`), it is repetitive to mention that in every rule description.
This PR is based off of conversation from https://github.com/Yelp/elastalert/issues/2111 where it was explained that common rule options can be placed in config file, with the exception of:
`required_locals = frozenset(['alert', 'type', 'name', 'index'])`


#### Which issue this PR fixes
n/a

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
