### PR TITLE
feat(keycloak): add availability to expose extra port on sts

### DIFF
--- a/stable/keycloak/Chart.yaml
+++ b/stable/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 4.3.0
+version: 4.4.0
 appVersion: 4.8.3.Final
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/stable/keycloak/README.md
+++ b/stable/keycloak/README.md
@@ -57,6 +57,7 @@ Parameter | Description | Default
 `keycloak.extraEnv` | Allows the specification of additional environment variables for Keycloak. Passed through the `tpl` function and thus to be configured a string | `""`
 `keycloak.extraVolumeMounts` | Add additional volumes mounts, e. g. for custom themes. Passed through the `tpl` function and thus to be configured a string | `""`
 `keycloak.extraVolumes` | Add additional volumes, e. g. for custom themes. Passed through the `tpl` function and thus to be configured a string | `""`
+`keycloak.extraPorts` | Add additional ports, e. g. for custom admin console port. Passed through the `tpl` function and thus to be configured a string | `""`
 `keycloak.podDisruptionBudget` | Pod disruption budget | `{}`
 `keycloak.resources` | Pod resource requests and limits | `{}`
 `keycloak.affinity` | Pod affinity. Passed through the `tpl` function and thus to be configured a string | `Hard node and soft zone anti-affinity`

--- a/stable/keycloak/templates/statefulset.yaml
+++ b/stable/keycloak/templates/statefulset.yaml
@@ -103,6 +103,9 @@ spec:
               containerPort: 7600
               protocol: TCP
           {{- end }}
+{{- with .Values.keycloak.extraPorts }}
+{{ tpl . $ | indent 12 }}
+{{- end }}
           livenessProbe:
             httpGet:
               path: {{ if ne .Values.keycloak.basepath "" }}/{{ .Values.keycloak.basepath }}{{ end }}/

--- a/stable/keycloak/values.yaml
+++ b/stable/keycloak/values.yaml
@@ -141,6 +141,9 @@ keycloak:
   extraVolumes: |
   extraVolumeMounts: |
 
+  ## Add additional ports, eg. for custom admin console
+  extraPorts: |
+
   podDisruptionBudget: {}
     # maxUnavailable: 1
     # minAvailable: 1


### PR DESCRIPTION
#### What this PR does / why we need it:
In order to configure a port restriction on Keycloak admin console (https://github.com/keycloak/keycloak-documentation/blob/master/server_admin/topics/threat/admin.adoc#port-restriction) let the possibilty to the users to expose a custom port on the statefulset

#### Which issue this PR fixes
None

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
