### PR TITLE
[stable/traefik] Use unprivileged ports

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: traefik
 version: 1.60.0
-appVersion: 1.7.7
+appVersion: 1.7.8
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:
 - traefik

--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: traefik
-version: 1.60.0
-appVersion: 1.7.8
+version: 1.60.1
+appVersion: 1.7.7
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:
 - traefik

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -31,7 +31,7 @@ data:
     {{- end }}
     [entryPoints]
       [entryPoints.http]
-      address = ":80"
+      address = ":8080"
       compress = {{ .Values.gzip.enabled }}
       {{- if .Values.whiteListSourceRange }}
       {{ template "traefik.whiteListSourceRange" . }}
@@ -57,7 +57,7 @@ data:
       {{- if .Values.whiteListSourceRange }}
       {{ template "traefik.whiteListSourceRange" . }}
       {{- end }}
-      address = ":443"
+      address = ":8443"
       compress = {{ .Values.gzip.enabled }}
       {{- if .Values.proxyProtocol.enabled }}
         [entryPoints.https.proxyProtocol]
@@ -104,7 +104,7 @@ data:
       {{- end }}
       {{- if .Values.dashboard.enabled }}
       [entryPoints.traefik]
-      address = ":8080"
+      address = ":8000"
         {{- if .Values.dashboard.auth }}
         {{- if .Values.dashboard.auth.basic }}
         [entryPoints.traefik.auth]

--- a/stable/traefik/templates/dashboard-service.yaml
+++ b/stable/traefik/templates/dashboard-service.yaml
@@ -22,5 +22,5 @@ spec:
   ports:
   - name: dashboard-http
     port: 80
-    targetPort: 8080
+    targetPort: dash
 {{- end }}

--- a/stable/traefik/templates/deployment.yaml
+++ b/stable/traefik/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
             memory: {{ .Values.memoryLimit | quote }}
         readinessProbe:
           tcpSocket:
-            port: 80
+            port: 8080
           failureThreshold: 1
           initialDelaySeconds: 10
           periodSeconds: 10
@@ -77,7 +77,7 @@ spec:
           timeoutSeconds: 2
         livenessProbe:
           tcpSocket:
-            port: 80
+            port: 8080
           failureThreshold: 3
           initialDelaySeconds: 10
           periodSeconds: 10
@@ -108,7 +108,7 @@ spec:
         {{- end }}
         ports:
         - name: http
-          containerPort: 80
+          containerPort: 8080
           {{- if .Values.deployment.hostPort.httpEnabled }}
           hostPort: 80
           {{- end }}
@@ -117,14 +117,14 @@ spec:
           containerPort: 8880
           protocol: TCP
         - name: https
-          containerPort: 443
+          containerPort: 8443
           {{- if .Values.deployment.hostPort.httpsEnabled }}
           hostPort: 443
           {{- end }}
           protocol: TCP
         {{- if .Values.dashboard.enabled }}
         - name: dash
-          containerPort: 8080
+          containerPort: 8000
           {{- if .Values.deployment.hostPort.dashboardEnabled }}
           hostPort: 8080
           {{- end }}


### PR DESCRIPTION
Don't use low ports because some k8s environments might not allow it.

Move:
http    80 -> 8080
https  443 -> 8443
dash  8080 -> 8000

Signed-off-by: Sebastian Poehn <sebastian.poehn@gmail.com>

#### What this PR does / why we need it:
* Don't use low ports because some k8s environments might not allow it.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
