### PR TITLE
[stable/oauth2-proxy] Allow defining a custom secret

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 0.7.0
+version: 0.8.0
 apiVersion: v1
 appVersion: 3.0.0
 home: http://www.videntity.com/

--- a/stable/oauth2-proxy/README.md
+++ b/stable/oauth2-proxy/README.md
@@ -48,6 +48,7 @@ Parameter | Description | Default
 `config.clientSecret` | oauth client secret | `""`
 `config.cookieSecret` | server specific cookie for the secret; create a new one with `python -c 'import os,base64; print base64.b64encode(os.urandom(16))'` | `""`
 `config.configFile` | custom [oauth2_proxy.cfg](https://github.com/pusher/oauth2_proxy/blob/master/contrib/oauth2_proxy.cfg.example) contents for settings not overridable via environment nor command line | `""`
+`config.existingSecret` | existing Kubernetes secret to use for OAuth2 credentials. See [secret template](https://github.com/helm/charts/blob/master/stable/oauth2-proxy/templates/secret.yaml) for the required values | `""`
 `extraArgs` | key:value list of extra arguments to give the binary | `{}`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `image.repository` | Image repository | `a5huynh/oauth2_proxy`
@@ -59,7 +60,7 @@ Parameter | Description | Default
 `podLabels` | additional labesl to add to each pod | `{}`
 `replicaCount` | desired number of pods | `1`
 `resources` | pod resource requests & limits | `{}`
-`priorityClassName` | priorityClassName | `nil` 
+`priorityClassName` | priorityClassName | `nil`
 `service.port` | port for the service | `80`
 `service.type` | type of service | `ClusterIP`
 `tolerations` | List of node taints to tolerate | `[]`

--- a/stable/oauth2-proxy/README.md
+++ b/stable/oauth2-proxy/README.md
@@ -48,7 +48,7 @@ Parameter | Description | Default
 `config.clientSecret` | oauth client secret | `""`
 `config.cookieSecret` | server specific cookie for the secret; create a new one with `python -c 'import os,base64; print base64.b64encode(os.urandom(16))'` | `""`
 `config.configFile` | custom [oauth2_proxy.cfg](https://github.com/pusher/oauth2_proxy/blob/master/contrib/oauth2_proxy.cfg.example) contents for settings not overridable via environment nor command line | `""`
-`config.existingSecret` | existing Kubernetes secret to use for OAuth2 credentials. See [secret template](https://github.com/helm/charts/blob/master/stable/oauth2-proxy/templates/secret.yaml) for the required values | `""`
+`config.existingSecret` | existing Kubernetes secret to use for OAuth2 credentials. See [secret template](https://github.com/helm/charts/blob/master/stable/oauth2-proxy/templates/secret.yaml) for the required values | `nil`
 `extraArgs` | key:value list of extra arguments to give the binary | `{}`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `image.repository` | Image repository | `a5huynh/oauth2_proxy`

--- a/stable/oauth2-proxy/templates/_helpers.tpl
+++ b/stable/oauth2-proxy/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "oauth2-proxy.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Get the secret name.
+*/}}
+{{- define "oauth2-proxy.secretName" -}}
+{{- if .Values.config.existingSecret -}}
+{{- printf "%s" .Values.config.existingSecret -}}
+{{- else -}}
+{{- printf "%s" (include "oauth2-proxy.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/stable/oauth2-proxy/templates/deployment.yaml
+++ b/stable/oauth2-proxy/templates/deployment.yaml
@@ -55,17 +55,17 @@ spec:
         - name: OAUTH2_PROXY_CLIENT_ID
           valueFrom:
             secretKeyRef:
-              name:  {{ template "oauth2-proxy.fullname" . }}
+              name:  {{ template "oauth2-proxy.secretName" . }}
               key: client-id
         - name: OAUTH2_PROXY_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
-              name:  {{ template "oauth2-proxy.fullname" . }}
+              name:  {{ template "oauth2-proxy.secretName" . }}
               key: client-secret
         - name: OAUTH2_PROXY_COOKIE_SECRET
           valueFrom:
             secretKeyRef:
-              name:  {{ template "oauth2-proxy.fullname" . }}
+              name:  {{ template "oauth2-proxy.secretName" . }}
               key: cookie-secret
         ports:
           - containerPort: 4180

--- a/stable/oauth2-proxy/templates/secret.yaml
+++ b/stable/oauth2-proxy/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.existingSecret }}
+{{- if not .Values.config.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/oauth2-proxy/templates/secret.yaml
+++ b/stable/oauth2-proxy/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,3 +13,4 @@ data:
   cookie-secret: {{ .Values.config.cookieSecret | b64enc | quote }}
   client-secret: {{ .Values.config.clientSecret | b64enc | quote }}
   client-id: {{ .Values.config.clientID | b64enc | quote }}
+{{- end -}}

--- a/stable/oauth2-proxy/values.yaml
+++ b/stable/oauth2-proxy/values.yaml
@@ -12,6 +12,9 @@ config:
   #   pass_basic_auth = false
   #   pass_access_token = true
   configFile: ""
+  # Use an existing secret for OAuth2 credentials
+  # Example:
+  # existingSecret: secret
 
 image:
   repository: "quay.io/pusher/oauth2_proxy"


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
* Add an ability to specify an existing `secret` for OAuth2 credentials. Just like the `stable/postgresql` chart does with the `PGPASSWORD`

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
