### PR TITLE
Add ability to drop metrics from cAdvisor

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 2.3.0
+version: 2.3.1
 appVersion: 0.26.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -264,6 +264,7 @@ The following tables lists the configurable parameters of the prometheus-operato
 | `kubelet.enabled` | Deploy servicemonitor to scrape the kubelet service. See also `prometheusOperator.kubeletService` | `true` |
 | `kubelet.namespace` | Namespace where the kubelet is deployed. See also `prometheusOperator.kubeletService.namespace` | `kube-system` |
 | `kubelet.serviceMonitor.https` | Enable scraping of the kubelet over HTTPS. For more information, see https://github.com/coreos/prometheus-operator/issues/926 | `false` |
+| `kubelet.serviceMonitor.cAdvisorMetricRelabelings` | The `metric_relabel_configs` for scraping cAdvisor. | `` |
 | `kubeControllerManager.enabled` | Deploy a `service` and `serviceMonitor` to scrape the Kubernetes controller-manager | `true` |
 | `kubeControllerManager.endpoints` | Endpoints where Controller-manager runs. Provide this if running Controller-manager outside the cluster | `[]` |
 | `kubeControllermanager.service.port` | Controller-manager port for the service runs on | `10252` |

--- a/stable/prometheus-operator/ci/test-values.yaml
+++ b/stable/prometheus-operator/ci/test-values.yaml
@@ -386,6 +386,18 @@ kubelet:
     ## https://github.com/coreos/prometheus-operator/issues/926
     ##
     https: false
+    cAdvisorMetricRelabelings:
+    - sourceLabels: [__name__, image]
+      separator: ;
+      regex: container_([a-z_]+);
+      replacement: $1
+      action: drop
+    - sourceLabels: [__name__]
+      separator: ;
+      regex: container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)
+      replacement: $1
+      action: drop
+
 
 ## Component scraping the kube controller manager
 ##

--- a/stable/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
@@ -34,6 +34,10 @@ spec:
     path: /metrics/cadvisor
     interval: 30s
     honorLabels: true
+{{- if .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings }}
+    metricRelabelings:
+{{ toYaml .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings | indent 4 }}
+{{- end }}
   {{- end }}
   jobLabel: k8s-app
   namespaceSelector:

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -398,6 +398,18 @@ kubelet:
     ## https://github.com/coreos/prometheus-operator/issues/926
     ##
     https: false
+    # cAdvisorMetricRelabelings:
+    # - sourceLabels: [__name__, image]
+    #   separator: ;
+    #   regex: container_([a-z_]+);
+    #   replacement: $1
+    #   action: drop
+    # - sourceLabels: [__name__]
+    #   separator: ;
+    #   regex: container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)
+    #   replacement: $1
+    #   action: drop
+
 
 ## Component scraping the kube controller manager
 ##


### PR DESCRIPTION
@gianrubio 

#### What this PR does / why we need it:
Lots of cAdvisor metrics are simply `0` and can be dropped safely. This reduces a significant number of series in large Kubernetes clusters.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md