### PR TITLE
Fix gcs credentials location

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Minio is a high performance distributed object storage server, designed for large-scale private cloud infrastructure.
 name: minio
-version: 2.4.1
+version: 2.4.2
 appVersion: RELEASE.2019-01-16T21-44-08Z
 keywords:
 - storage

--- a/stable/minio/templates/deployment.yaml
+++ b/stable/minio/templates/deployment.yaml
@@ -116,10 +116,7 @@ spec:
                   key: secretkey
             {{- if .Values.gcsgateway.enabled }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "minio.fullname" . }}
-                  key: gcs_key.json
+              value: "/etc/credentials/gcs_key.json"
             {{- end }}
             {{- range $key, $val := .Values.environment }}
             - name: {{ $key }}


### PR DESCRIPTION
#### What this PR does / why we need it:
At the moment the Chart exports the `GOOGLE_APPLICATION_CREDENTIALS` as an env containing the json credentials of the service account.
Instead `minio gateway gcs` expects a path where to find the json file.
This PR fixes this behaviour.

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped

@wlan0 @nitisht Can you please review?
