### PR TITLE
Run atlantis container as atlantis user instead of root

### DIFF
--- a/stable/atlantis/Chart.yaml
+++ b/stable/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.4.11"
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 1.1.2
+version: 1.1.3
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/stable/atlantis/templates/statefulset.yaml
+++ b/stable/atlantis/templates/statefulset.yaml
@@ -61,7 +61,6 @@ spec:
               exec:
                 command: ["/bin/sh", "-c", "cp /etc/secret-gitconfig/gitconfig /home/atlantis/.gitconfig && chown atlantis /home/atlantis/.gitconfig"]
           {{- end}}
-          command: ["atlantis"]
           args:
             - server
           {{- if .Values.allowRepoConfig }}


### PR DESCRIPTION
Signed-off-by: Chris O'Brien <chrisob91@gmail.com>
@jkodroff @callmeradical @jeff-knurek @lkysow

#### What this PR does / why we need it:
Since atlantis v0.4.12 (specifically [this PR](https://github.com/runatlantis/atlantis/pull/346)), any custom gitconfig options are ignored, as the container/pod is running as `root` instead of `atlantis`.

#### Which issue this PR fixes
~Run the pod as UID 100, AKA the `atlantis` user.~ 
Remove the `atlantis` command from the pod spec so as not to bypass `docker-entrypoint.sh`, which `gosu`s to the `atlantis` user.

#### Special notes for your reviewer:
Tested and working, my custom gitconfig specified in `values.yaml` works again.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
