### PR TITLE
[stable/kibana] Add support for user-defined init containers

### DIFF
--- a/stable/kibana/Chart.yaml
+++ b/stable/kibana/Chart.yaml
@@ -1,5 +1,5 @@
 name: kibana
-version: 1.4.1
+version: 1.5.0
 appVersion: 6.6.0
 description: Kibana is an open source data visualization plugin for Elasticsearch
 icon: https://raw.githubusercontent.com/elastic/kibana/master/src/ui/public/icons/kibana-color.svg

--- a/stable/kibana/README.md
+++ b/stable/kibana/README.md
@@ -106,6 +106,7 @@ The following table lists the configurable parameters of the kibana chart and th
 | `securityContext.fsGroup`                     | fsGroup id to run in pods                  | `2000`                                  |
 | `extraConfigMapMounts`                        | Additional configmaps to be mounted        | `[]`                                    |
 | `deployment.annotations`                      | Annotations for deployment                 | `{}`                                    |
+| `initContainers`                              | List of init containers to add to the kibana deployment | `[]`                       |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/kibana/README.md
+++ b/stable/kibana/README.md
@@ -106,7 +106,7 @@ The following table lists the configurable parameters of the kibana chart and th
 | `securityContext.fsGroup`                     | fsGroup id to run in pods                  | `2000`                                  |
 | `extraConfigMapMounts`                        | Additional configmaps to be mounted        | `[]`                                    |
 | `deployment.annotations`                      | Annotations for deployment                 | `{}`                                    |
-| `initContainers`                              | List of init containers to add to the kibana deployment | `[]`                       |
+| `initContainers`                              | Init containers to add to the kibana deployment | `{}`                               |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/kibana/ci/initcontainers-values.yaml
+++ b/stable/kibana/ci/initcontainers-values.yaml
@@ -1,0 +1,23 @@
+---
+# enable user-defined init containers
+
+initContainers:
+  es-check:
+    image: "appropriate/curl:latest"
+    imagePullPolicy: "IfNotPresent"
+    command:
+      - "/bin/sh"
+      - "-c"
+      - |
+        is_down=true
+        while "$is_down"; do
+          if curl -sSf --fail-early --connect-timeout 5 http://elasticsearch:9200; then
+            is_down=false
+          else
+            sleep 5
+          fi
+        done
+
+  echo-container:
+    image: busybox
+    command: ['sh', '-c', 'echo Hello from init container! && sleep 3']

--- a/stable/kibana/ci/initcontainers-values.yaml
+++ b/stable/kibana/ci/initcontainers-values.yaml
@@ -2,22 +2,17 @@
 # enable user-defined init containers
 
 initContainers:
-  es-check:
-    image: "appropriate/curl:latest"
+  numbers-container:
+    image: "busybox"
     imagePullPolicy: "IfNotPresent"
     command:
       - "/bin/sh"
       - "-c"
       - |
-        is_down=true
-        while "$is_down"; do
-          if curl -sSf --fail-early --connect-timeout 5 http://elasticsearch:9200; then
-            is_down=false
-          else
-            sleep 5
-          fi
+        for i in $(seq 1 10); do
+          echo $i
         done
 
   echo-container:
-    image: busybox
+    image: "busybox"
     command: ['sh', '-c', 'echo Hello from init container! && sleep 3']

--- a/stable/kibana/templates/deployment.yaml
+++ b/stable/kibana/templates/deployment.yaml
@@ -29,8 +29,11 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
-{{- if or (.Values.dashboardImport.dashboards) (.Values.plugins.enabled) }}
+{{- if or (.Values.initContainers) (.Values.dashboardImport.dashboards) (.Values.plugins.enabled) }}
       initContainers:
+{{- if .Values.initContainers }}
+{{ toYaml .Values.initContainers | indent 8 }}
+{{- end }}
 {{- if .Values.dashboardImport.dashboards }}
       - name: {{ .Chart.Name }}-dashboardimport
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/kibana/templates/deployment.yaml
+++ b/stable/kibana/templates/deployment.yaml
@@ -32,7 +32,10 @@ spec:
 {{- if or (.Values.initContainers) (.Values.dashboardImport.dashboards) (.Values.plugins.enabled) }}
       initContainers:
 {{- if .Values.initContainers }}
-{{ toYaml .Values.initContainers | indent 8 }}
+{{- range $key, $value := .Values.initContainers }}
+        - name: "{{ $key }}"
+{{ toYaml $value | indent 10 }}
+{{- end }}
 {{- end }}
 {{- if .Values.dashboardImport.dashboards }}
       - name: {{ .Chart.Name }}-dashboardimport

--- a/stable/kibana/values.yaml
+++ b/stable/kibana/values.yaml
@@ -193,3 +193,22 @@ extraConfigMapMounts: []
   #   configMap: kibana-logtrail
   #   mountPath: /usr/share/kibana/plugins/logtrail/logtrail.json
   #   subPath: logtrail.json
+
+# Add your own init container or uncomment and modify the given example.
+initContainers: []
+  ## Don't start kibana till Elasticsearch is reachable
+  # - name: es-check
+  #   image: "appropriate/curl:latest"
+  #   imagePullPolicy: "IfNotPresent"
+  #   command:
+  #     - "/bin/sh"
+  #     - "-c"
+  #     - |
+  #       is_down=true
+  #       while "$is_down"; do
+  #         if curl -sSf --fail-early --connect-timeout 5 http://elasticsearch:9200; then
+  #           is_down=false
+  #         else
+  #           sleep 5
+  #         fi
+  #       done

--- a/stable/kibana/values.yaml
+++ b/stable/kibana/values.yaml
@@ -195,9 +195,10 @@ extraConfigMapMounts: []
   #   subPath: logtrail.json
 
 # Add your own init container or uncomment and modify the given example.
-initContainers: []
+initContainers: {}
   ## Don't start kibana till Elasticsearch is reachable
-  # - name: es-check
+  ##
+  # es-check:  # <- will be used as container name
   #   image: "appropriate/curl:latest"
   #   imagePullPolicy: "IfNotPresent"
   #   command:

--- a/stable/kibana/values.yaml
+++ b/stable/kibana/values.yaml
@@ -196,7 +196,8 @@ extraConfigMapMounts: []
 
 # Add your own init container or uncomment and modify the given example.
 initContainers: {}
-  ## Don't start kibana till Elasticsearch is reachable
+  ## Don't start kibana till Elasticsearch is reachable.
+  ## Ensure that it is available at http://elasticsearch:9200
   ##
   # es-check:  # <- will be used as container name
   #   image: "appropriate/curl:latest"


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Allows to define custom init containers. This is useful for e.g. checking if elasticsearch is already up and running (before starting kibana container), creating custom ES indexes for kibana upfront, etc. More generic example use-cases can be found here: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#examples

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
