### PR TITLE
[stable/jenkins] OverwriteConfig affects all custom configuration files

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.28.11
+version: 0.29.0
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -71,7 +71,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Master.ExtraPorts`               | Open extra ports, for other uses     | Not set                                                                      |
 | `Master.CustomConfigMap`          | Use a custom ConfigMap               | `false`                                                                      |
 | `Master.AdditionalConfig`          | Add additional config files         | `{}`                                                                      |
-| `Master.OverwriteConfig`          | Replace config w/ ConfigMap on boot  | `false`                                                                      |
+| `Master.OverwriteConfig`          | Overwrite configs and init scripts on boot  | `false`                                                                      |
 | `Master.Ingress.Annotations`      | Ingress annotations                  | `{}`                                                                         |
 | `Master.Ingress.Path`             | Ingress path                         | Not set                                                                         |
 | `Master.Ingress.TLS`              | Ingress TLS configuration            | `[]`                                                                         |

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -218,10 +218,14 @@ data:
     yes n | cp -i /var/jenkins_config/config.xml /var/jenkins_home;
     yes n | cp -i /var/jenkins_config/jenkins.CLI.xml /var/jenkins_home;
     yes n | cp -i /var/jenkins_config/jenkins.model.JenkinsLocationConfiguration.xml /var/jenkins_home;
+{{- end }}
 {{- if .Values.Master.AdditionalConfig }}
 {{- range $key, $val := .Values.Master.AdditionalConfig }}
+    {{- if .Values.Master.OverwriteConfig }}
     cp /var/jenkins_config/{{- $key }} /var/jenkins_home;
-{{- end }}
+    {{- else  }}
+    yes n | cp -i /var/jenkins_config/{{- $key }} /var/jenkins_home;
+    {{- end }}
 {{- end }}
 {{- end }}
 {{- if .Values.Master.InstallPlugins }}
@@ -233,22 +237,42 @@ data:
     yes n | cp -i /usr/share/jenkins/ref/plugins/* /var/jenkins_plugins/;
 {{- end }}
 {{- if .Values.Master.ScriptApproval }}
+    {{- if .Values.Master.OverwriteConfig }}
+    cp /var/jenkins_config/scriptapproval.xml /var/jenkins_home/scriptApproval.xml;
+    {{- else }}
     yes n | cp -i /var/jenkins_config/scriptapproval.xml /var/jenkins_home/scriptApproval.xml;
+    {{- end }}
 {{- end }}
 {{- if .Values.Master.InitScripts }}
     mkdir -p /var/jenkins_home/init.groovy.d/;
+    {{- if .Values.Master.OverwriteConfig }}
+    cp /var/jenkins_config/*.groovy /var/jenkins_home/init.groovy.d/;
+    {{- else }}
     yes n | cp -i /var/jenkins_config/*.groovy /var/jenkins_home/init.groovy.d/;
+    {{- end }}
 {{- end }}
 {{- if .Values.Master.CredentialsXmlSecret }}
+    {{- if .Values.Master.OverwriteConfig }}
+    cp /var/jenkins_credentials/credentials.xml /var/jenkins_home;
+    {{- else }}
     yes n | cp -i /var/jenkins_credentials/credentials.xml /var/jenkins_home;
+    {{- end }}
 {{- end }}
 {{- if .Values.Master.SecretsFilesSecret }}
+    {{- if .Values.Master.OverwriteConfig }}
+    cp /var/jenkins_secrets/* /usr/share/jenkins/ref/secrets/;
+    {{- else }}
     yes n | cp -i /var/jenkins_secrets/* /usr/share/jenkins/ref/secrets/;
+    {{- end }}
 {{- end }}
 {{- if .Values.Master.Jobs }}
     for job in $(ls /var/jenkins_jobs); do
       mkdir -p /var/jenkins_home/jobs/$job
+      {{- if .Values.Master.OverwriteConfig }}
+      cp /var/jenkins_jobs/$job /var/jenkins_home/jobs/$job/config.xml
+      {{- else }}
       yes n | cp -i /var/jenkins_jobs/$job /var/jenkins_home/jobs/$job/config.xml
+      {{- end }}
     done
 {{- end }}
 {{- range $key, $val := .Values.Master.InitScripts }}


### PR DESCRIPTION
Before, `Master.OverwriteConfig` would only overwrite the main
config.xml file. With this change, all custom configuration files and
init scripts are overwritten upon boot.

This allows for a more ephemeral set-up, while still maintaining the
persistence of other files (such as jobs).

The following files are overwritten with this change:

- `config.xml`
- `jenkins.CLI.xml`
- `jenkins.model.JenkinsLocationConfiguration.xml`
- `scriptApproval.xml`
- `credentials.xml`
- `jobs/<job>/config.xml`
- `secrets/*`
- `init.groovy.d/*`

---

closes #10372 and #9468

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
