### PR TITLE
Add psp support to node problem detector

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,5 +1,5 @@
 name: node-problem-detector
-version: "1.3.1"
+version: "1.4.0"
 appVersion: v0.6.1
 home: https://github.com/kubernetes/node-problem-detector
 description: Installs the node-problem-detector daemonset for monitoring extra attributes on nodes

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -34,24 +34,26 @@ Custom System log monitor config files can be created, see [here](https://github
 
 The following table lists the configurable parameters for this chart and their default values.
 
-| Parameter                             | Description                                | Default                                                      |
-|---------------------------------------|--------------------------------------------|--------------------------------------------------------------|
-| `affinity`                            | Map of node/pod affinities                 | `{}`                                                         |
-| `annotations`                         | Optional daemonset annotations             | `{}`                                                         |
-| `fullnameOverride`                    | Override the fullname of the chart         | `nil`                                                        |
-| `image.pullPolicy`                    | Image pull policy                          | `IfNotPresent`                                               |
-| `image.repository`                    | Image                                      | `k8s.gcr.io/node-problem-detector`                           |
-| `image.tag`                           | Image tag                                  | `v0.6.1`                                                     |
-| `nameOverride`                        | Override the name of the chart             | `nil`                                                        |
-| `rbac.create`                         | RBAC                                       | `true`                                                       |
-| `hostNetwork`                         | Run pod on host network                    | `false`                                                      |
-| `resources`                           | Pod resource requests and limits           | `{}`                                                         |
-| `settings.custom_monitor_definitions` | User-specified custom monitor definitions  | `{}`                                                         |
-| `settings.log_monitors`               | System log monitor config files            | `/config/kernel-monitor.json`, `/config/docker-monitor.json` |
-| `settings.custom_plugin_monitors`     | Custom plugin monitor config files         | `[]`                                                         |
-| `serviceAccount.create`               | Whether a ServiceAccount should be created | `true`                                                       |
-| `serviceAccount.name`                 | Name of the ServiceAccount to create       | Generated value from template                                |
-| `tolerations`                         | Optional daemonset tolerations             | `[]`                                                         |
+| Parameter                             | Description                                   | Default                                                      |
+|---------------------------------------|-----------------------------------------------|--------------------------------------------------------------|
+| `affinity`                            | Map of node/pod affinities                    | `{}`                                                         |
+| `annotations`                         | Optional daemonset annotations                | `{}`                                                         |
+| `fullnameOverride`                    | Override the fullname of the chart            | `nil`                                                        |
+| `image.pullPolicy`                    | Image pull policy                             | `IfNotPresent`                                               |
+| `image.repository`                    | Image                                         | `k8s.gcr.io/node-problem-detector`                           |
+| `image.tag`                           | Image tag                                     | `v0.6.1`                                                     |
+| `nameOverride`                        | Override the name of the chart                | `nil`                                                        |
+| `rbac.create`                         | RBAC                                          | `true`                                                       |
+| `rbac.pspEnabled`                     | Enables psp support                           | `false`                                                      |
+| `rbac.psp`                            | Specifies what psp to bind to service account | `null`                                                       |
+| `hostNetwork`                         | Run pod on host network                       | `false`                                                      |
+| `resources`                           | Pod resource requests and limits              | `{}`                                                         |
+| `settings.custom_monitor_definitions` | User-specified custom monitor definitions     | `{}`                                                         |
+| `settings.log_monitors`               | System log monitor config files               | `/config/kernel-monitor.json`, `/config/docker-monitor.json` |
+| `settings.custom_plugin_monitors`     | Custom plugin monitor config files            | `[]`                                                         |
+| `serviceAccount.create`               | Whether a ServiceAccount should be created    | `true`                                                       |
+| `serviceAccount.name`                 | Name of the ServiceAccount to create          | Generated value from template                                |
+| `tolerations`                         | Optional daemonset tolerations                | `[]`                                                         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
 

--- a/stable/node-problem-detector/templates/clusterrole.yaml
+++ b/stable/node-problem-detector/templates/clusterrole.yaml
@@ -29,4 +29,18 @@ rules:
   - create
   - patch
   - update
+  {{- if .Values.rbac.pspEnabled }}
+- apiGroups:
+  - extensions
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  {{- if .Values.rbac.psp }}
+  - {{ .Values.rbac.psp }}
+  {{ else }}
+  - privileged-{{ template "node-problem-detector.fullname" . }}
+  {{- end }}
+  verbs:
+  - use
+  {{- end -}}
 {{- end -}}

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -45,6 +45,7 @@ spec:
           volumeMounts:
             - name: log
               mountPath: /var/log
+              readOnly: true
             - name: localtime
               mountPath: /etc/localtime
               readOnly: true

--- a/stable/node-problem-detector/templates/psp.yaml
+++ b/stable/node-problem-detector/templates/psp.yaml
@@ -1,0 +1,26 @@
+{{- if and (.Values.rbac.pspEnabled) (not .Values.rbac.psp) }}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: privileged-{{ template "node-problem-detector.fullname" . }}
+spec:
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+  hostPID: true
+  hostIPC: true
+  hostNetwork: true
+  hostPorts:
+  - min: 1
+    max: 65536
+{{- end }}

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -46,6 +46,10 @@ fullnameOverride: ""
 
 rbac:
   create: true
+  pspEnabled: true
+  # The psp to use. If not set and psp is enabled an all powerful
+  # psp is created with a name generated using the fullname template
+  psp:
 
 # Flag to run Node Problem Detector on the host's network. This is typically
 # not recommended, but may be useful for certain use cases.


### PR DESCRIPTION
#### What this PR does / why we need it:
The node problem detector uses host mounts which may require a pod security policy to work. This PR can create a psp or use an existing one to allow for pod creation. 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
