### PR TITLE
[stable/elasticsearch-curator] add dry-run option to chart

### DIFF
--- a/stable/elasticsearch-curator/Chart.yaml
+++ b/stable/elasticsearch-curator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "5.5.4"
 description: A Helm chart for Elasticsearch Curator
 name: elasticsearch-curator
-version: 1.1.0
+version: 1.2.0
 home: https://github.com/elastic/curator
 keywords:
 - curator

--- a/stable/elasticsearch-curator/README.md
+++ b/stable/elasticsearch-curator/README.md
@@ -40,6 +40,7 @@ their default values.
 | `cronjob.failedJobsHistoryLimit`     | Specify the number of failed Jobs to keep             | `nil`                                        |
 | `cronjob.successfulJobsHistoryLimit` | Specify the number of completed Jobs to keep          | `nil`                                        |
 | `pod.annotations`                    | Annotations to add to the pod                         | {}                                           |
+| `dryrun`                              | Run Curator in dry-run mode                          |  `false`                                     |
 | `configMaps.action_file_yml`         | Contents of the Curator action_file.yml               | See values.yaml                              |
 | `configMaps.config_yml`              | Contents of the Curator config.yml (overrides config) | See values.yaml                              |
 | `resources`                          | Resource requests and limits                          | {}                                           |

--- a/stable/elasticsearch-curator/templates/cronjob.yaml
+++ b/stable/elasticsearch-curator/templates/cronjob.yaml
@@ -60,7 +60,11 @@ spec:
 {{ toYaml .Values.extraVolumeMounts | indent 16 }}
 {{- end }}
               command: [ "curator" ]
+{{- if .Values.dryrun }}
+              args: [ "--dry-run", "--config", "/etc/es-curator/config.yml", "/etc/es-curator/action_file.yml" ]
+{{- else }}
               args: [ "--config", "/etc/es-curator/config.yml", "/etc/es-curator/action_file.yml" ]
+{{- end }}
               resources:
 {{ toYaml .Values.resources | indent 16 }}
     {{- with .Values.nodeSelector }}

--- a/stable/elasticsearch-curator/values.yaml
+++ b/stable/elasticsearch-curator/values.yaml
@@ -22,6 +22,9 @@ hooks:
   install: false
   upgrade: false
 
+# run curator in dry-run mode
+dryrun: false
+
 configMaps:
   # Delete indices older than 7 days
   action_file_yml: |-


### PR DESCRIPTION
Signed-off-by: Gerald Barker <gerald.barker@gmail.com>

#### What this PR does / why we need it:
Allows the curator cronjob to run in dry-run mode to allow easy testing of jobs within a kubernetes cluster

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
