### PR TITLE
[stable/prometheus-node-exporter] Fix imagePullSecrets value path

### DIFF
--- a/stable/prometheus-node-exporter/Chart.yaml
+++ b/stable/prometheus-node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.17.0"
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 1.3.0
+version: 1.3.1
 home: https://github.com/prometheus/node_exporter/
 sources:
 - https://github.com/prometheus/node_exporter/

--- a/stable/prometheus-node-exporter/templates/serviceaccount.yaml
+++ b/stable/prometheus-node-exporter/templates/serviceaccount.yaml
@@ -10,6 +10,6 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 imagePullSecrets: 
-{{ toYaml .Values.imagePullSecrets | indent 2 }}    
+{{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Signed-off-by: Tanguy Buchier <tanguy.buchier@gmail.com>

#### What this PR does / why we need it:
Use the correct path for the value imagePullSecrets
.Values.serviceAccount.imagePullSecrets instead of .Values.imagePullSecrets

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
