### PR TITLE
[stable/jenkins] Allow disabling persistence of home path

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.28.11
+version: 0.29.0
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -195,15 +195,16 @@ It is possible to mount several volumes using `Persistence.volumes` and `Persist
 
 ### Persistence Values
 
-| Parameter                   | Description                     | Default         |
-| --------------------------- | ------------------------------- | --------------- |
-| `Persistence.Enabled`       | Enable the use of a Jenkins PVC | `true`          |
-| `Persistence.ExistingClaim` | Provide the name of a PVC       | `nil`           |
-| `Persistence.AccessMode`    | The PVC access mode             | `ReadWriteOnce` |
-| `Persistence.Size`          | The size of the PVC             | `8Gi`           |
-| `Persistence.SubPath`       | SubPath for jenkins-home mount  | `nil`           |
-| `Persistence.volumes`       | Additional volumes              | `nil`           |
-| `Persistence.mounts`        | Additional mounts               | `nil`           |
+| Parameter                     | Description                        | Default         |
+| ---------------------------   | -------------------------------    | --------------- |
+| `Persistence.Enabled`         | Enable the use of a Jenkins PVC    | `true`          |
+| `Persistence.ExistingClaim`   | Provide the name of a PVC          | `nil`           |
+| `Persistence.AccessMode`      | The PVC access mode                | `ReadWriteOnce` |
+| `Persistence.Size`            | The size of the PVC                | `8Gi`           |
+| `Persistence.SubPath`         | SubPath for jenkins-home mount     | `nil`           |
+| `Persistence.volumes`         | Additional volumes                 | `nil`           |
+| `Persistence.mounts`          | Additional mounts                  | `nil`           |
+| `Persistence.PersistHomePath` | Enable persistence of jenkins-home | `true`          |
 
 #### Existing PersistentVolumeClaim
 

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -246,7 +246,7 @@ spec:
       - name: secrets-dir
         emptyDir: {}
       - name: jenkins-home
-      {{- if .Values.Persistence.Enabled }}
+      {{- if .Values.Persistence.PersistHomePath }}
         persistentVolumeClaim:
           claimName: {{ .Values.Persistence.ExistingClaim | default (include "jenkins.fullname" .) }}
       {{- else }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -219,6 +219,16 @@ Persistence:
   ##
   # StorageClass: "-"
 
+  # If `PersistHomePath` is set to `false`, but `Enabled` is set to `true`,
+  # then you can add any custom paths using `volumes` and `mounts` to persist
+  # data, without being forced to also persist the default Jenkins home path.
+  #
+  # This is useful if you want to set up an almost stateless Jenkins set-up
+  # that is bootstrapped at boot, and ignore any configuration changes made
+  # via the Jenkins UI, while still being able to persist data such as job
+  # history, or user profiles.
+  PersistHomePath: true
+
   Annotations: {}
   AccessMode: ReadWriteOnce
   Size: 8Gi


### PR DESCRIPTION
This change allows using the persistence feature of this chart, without
being forced to persist the Jenkins home folder.

This is useful if you want to set up an almost stateless Jenkins set-up
that is bootstrapped on startup, and ignore any configuration changes made
via the Jenkins UI, while still being able to persist data such as job
history, or user profiles.

---

We've been using this kind of set-up for almost two years at our company
now, and it served us very well (it helps to prevent accidental changes
through the Jenkins UI that you then forget to "backport" to the repository
that contains all the configuration in code).

We've had to fork the Jenkins chart two years ago because it was lacking a
lot of features back then, but we took another look this time, and noticed
that our set-up was almost entirely supported out of the box, which is
awesome.

This was the one part that is still missing. If this change is unacceptable,
we can keep using our fork, but I think this might be useful to others as well.

I'm aware that this adds _another_ flag to the Jenkins chart, but I was
unable to make this work with the existing set of flags, without causing
breaking changes.

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
