### PR TITLE
[stable/prometheus-operator] allow setting sessionAffinity

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 2.1.5
+version: 2.1.6
 appVersion: 0.26.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -143,6 +143,7 @@ The following tables lists the configurable parameters of the prometheus-operato
 | `prometheus.service.externalIPs` | List of IP addresses at which the Prometheus server service is available  | `[]` |
 | `prometheus.service.loadBalancerIP` |  Prometheus Loadbalancer IP | `""` |
 | `prometheus.service.loadBalancerSourceRanges` | Prometheus Load Balancer Source Ranges | `[]` |
+| `prometheus.service.sessionAffinity` | Prometheus Service Session Affinity | `""` |
 | `prometheus.additionalServiceMonitors` | List of `serviceMonitor` objects to create. See https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitorspec | `[]` |
 | `prometheus.prometheusSpec.podMetadata` | Standard object’s metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata Metadata Labels and Annotations gets propagated to the prometheus pods. | `{}` |
 | `prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues` | If true, a nil or {} value for prometheus.prometheusSpec.serviceMonitorSelector will cause the prometheus resource to be created with selectors based on values in the helm deployment, which will also match the servicemonitors created | `true` |

--- a/stable/prometheus-operator/templates/prometheus/service.yaml
+++ b/stable/prometheus-operator/templates/prometheus/service.yaml
@@ -37,5 +37,8 @@ spec:
   selector:
     app: prometheus
     prometheus: {{ template "prometheus-operator.fullname" . }}-prometheus
+{{- if .Values.prometheus.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.prometheus.service.sessionAffinity }}
+{{- end }}
   type: "{{ .Values.prometheus.service.type }}"
 {{- end }}

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -684,6 +684,8 @@ prometheus:
     ##
     type: ClusterIP
 
+    sessionAffinity: ""
+
   rbac:
     ## Create role bindings in the specified namespaces, to allow Prometheus monitoring
     ## a role binding in the release namespace will always be created.


### PR DESCRIPTION
#### What this PR does / why we need it:

In scenarios where a client (e.g. Grafana) uses multiple Prometheus instances (through a K8s service), it is favorable to specify the sessionAffinity to avoid "jumping graphs".

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
