### PR TITLE
[stable/mongodb] use existing configmaps as init scripts

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mongodb
-version: 5.3.2
+version: 5.4.0
 appVersion: 4.0.6
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/README.md
+++ b/stable/mongodb/README.md
@@ -105,6 +105,7 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `readinessProbe.failureThreshold`                  | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | `6`                                                     |
 | `readinessProbe.successThreshold`                  | Minimum consecutive successes for the probe to be considered successful after having failed. | `1`                                                     |
 | `configmap`                                        | MongoDB configuration file to be used                                                        | `nil`                                                   |
+| `initdbScriptsConfigMap`                           | ConfigMap with the initdb scripts                                                            | `nil`                                                   |
 | `metrics.enabled`                                  | Start a side-car prometheus exporter                                                         | `false`                                                 |
 | `metrics.image.registry`                           | MongoDB exporter image registry                                                              | `docker.io`                                             |
 | `metrics.image.repository`                         | MongoDB exporter image name                                                                  | `forekshub/percona-mongodb-exporter`                    |
@@ -172,6 +173,8 @@ Some characteristics of this chart are:
 The [Bitnami MongoDB](https://github.com/bitnami/bitnami-docker-mongodb) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder `files/docker-entrypoint-initdb.d` so they can be consumed as a ConfigMap.
 
 The allowed extensions are `.sh`, and `.js`.
+
+Alternatively, you can also set an external ConfigMap with all the initialization scripts. This is done by setting the `initdbScriptsConfigMap` parameter. Note that this will override the previous option.
 
 ## Persistence
 

--- a/stable/mongodb/templates/_helpers.tpl
+++ b/stable/mongodb/templates/_helpers.tpl
@@ -86,3 +86,15 @@ Return the proper image name (for the metrics image)
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 
+
+{{ template "mongodb.initdbScriptsCM" . }}
+{{/*
+Get the initialization scripts ConfigMap name.
+*/}}
+{{- define "mongodb.initdbScriptsCM" -}}
+{{- if .Values.initdbScriptsConfigMap -}}
+{{- printf "%s" .Values.initdbScriptsConfigMap -}}
+{{- else -}}
+{{- printf "%s-init-scripts" (include "mongodb.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/stable/mongodb/templates/deployment-standalone.yaml
+++ b/stable/mongodb/templates/deployment-standalone.yaml
@@ -139,7 +139,7 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /bitnami/mongodb
-        {{- if  (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") }}
+        {{- if or (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") .Values.initdbScriptsConfigMap }}
         - name: custom-init-scripts
           mountPath: /docker-entrypoint-initdb.d
         {{- end }}
@@ -184,10 +184,10 @@ spec:
 {{ toYaml .Values.metrics.resources | indent 10 }}
 {{- end }}
       volumes:
-      {{- if  (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") }}
+      {{- if or (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") .Values.initdbScriptsConfigMap }}
       - name: custom-init-scripts
         configMap:
-          name: {{ template "mongodb.fullname" . }}-init-scripts
+          name: {{ template "mongodb.initdbScriptsCM" . }}
       {{- end }}
       - name: data
       {{- if .Values.persistence.enabled }}

--- a/stable/mongodb/templates/initialization-configmap.yaml
+++ b/stable/mongodb/templates/initialization-configmap.yaml
@@ -1,4 +1,4 @@
-{{ if  (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") }}
+{{ if and (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,js}") (not .Values.initdbScriptsConfigMap) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/mongodb/templates/statefulset-primary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-primary-rs.yaml
@@ -160,7 +160,7 @@ spec:
           volumeMounts:
             - name: datadir
               mountPath: /bitnami/mongodb
-            {{- if  (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") }}
+            {{- if or (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") .Values.initdbScriptsConfigMap }}
             - name: custom-init-scripts
               mountPath: /docker-entrypoint-initdb.d
             {{- end }}
@@ -205,10 +205,10 @@ spec:
 {{ toYaml .Values.metrics.resources | indent 12 }}
 {{- end }}
       volumes:
-        {{- if  (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") }}
+        {{- if or (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") .Values.initdbScriptsConfigMap }}
         - name: custom-init-scripts
           configMap:
-            name: {{ template "mongodb.fullname" . }}-init-scripts
+            name: {{ template "mongodb.initdbScriptsCM" . }}
         {{- end }}
         {{- if .Values.configmap }}
         - name: config

--- a/stable/mongodb/values-production.yaml
+++ b/stable/mongodb/values-production.yaml
@@ -231,6 +231,13 @@ configmap:
 #    authorization: enabled
 #    keyFile: /opt/bitnami/mongodb/conf/keyfile
 
+## initdb scripts
+## Specify ConfigMap with scripts to be run at first boot
+## Alternatively, you can put your scripts under the files/docker-entrypoint-initdb.d directory
+## Note: This will override initdbScripts
+##
+# initdbScriptsConfigMap:
+
 ## Prometheus Exporter / Metrics
 ##
 metrics:

--- a/stable/mongodb/values.yaml
+++ b/stable/mongodb/values.yaml
@@ -231,6 +231,13 @@ configmap:
 #    authorization: enabled
 #    #keyFile: /opt/bitnami/mongodb/conf/keyfile
 
+## initdb scripts
+## Specify ConfigMap with scripts to be run at first boot
+## Alternatively, you can put your scripts under the files/docker-entrypoint-initdb.d directory
+## Note: This will override initdbScripts
+##
+# initdbScriptsConfigMap:
+
 ## Prometheus Exporter / Metrics
 ##
 metrics:


### PR DESCRIPTION
Signed-off-by: Louise Champ <louise@livewyer.com>

#### What this PR does / why we need it:

This PR allows the user to use an existing configMap with **initdb scripts** when deploying the MongoDB chart.

#### Special notes for your reviewer:

Implementation of this code is based upon the same functionality added previously to the MariaDB chart.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
