### PR TITLE
Update chart for new cluster-checks feature

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 name: datadog
 version: 1.23.0
-appVersion: 6.9.0
+appVersion: 6.10.1
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.23.0
+version: 1.24.0
 appVersion: 6.10.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -219,7 +219,7 @@ helm install --name <RELEASE_NAME> \
 | `datadog.appKey`                         | Datadog APP key required to use metricsProvider                                           | `Nil` You must provide your own key         |
 | `datadog.appKeyExistingSecret`           | If set, use the secret with a provided name instead of creating a new one                 | `nil`                                       |
 | `image.repository`                       | The image repository to pull from                                                         | `datadog/agent`                             |
-| `image.tag`                              | The image tag to pull                                                                     | `6.9.0`                                     |
+| `image.tag`                              | The image tag to pull                                                                     | `6.10.1`                                     |
 | `image.pullPolicy`                       | Image pull policy                                                                         | `IfNotPresent`                              |
 | `image.pullSecrets`                      | Image pull secrets                                                                        | `nil`                                       |
 | `nameOverride`                           | Override name of app                                                                      | `nil`                                       |

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -277,7 +277,7 @@ helm install --name <RELEASE_NAME> \
 | `clusterAgent.token`                     | A cluster-internal secret for agent-to-agent communication. Must be 32+ characters a-zA-Z | Generates a random value                    |
 | `clusterAgent.containerName`             | The container name for the Cluster Agent                                                  | `cluster-agent`                             |
 | `clusterAgent.image.repository`          | The image repository for the cluster-agent                                                | `datadog/cluster-agent`                     |
-| `clusterAgent.image.tag`                 | The image tag to pull                                                                     | `1.0.0`                                     |
+| `clusterAgent.image.tag`                 | The image tag to pull                                                                     | `1.2.0`                                     |
 | `clusterAgent.image.pullPolicy`          | Image pull policy                                                                         | `IfNotPresent`                              |
 | `clusterAgent.image.pullSecrets`         | Image pull secrets                                                                        | `nil`                                       |
 | `clusterAgent.metricsProvider.enabled`   | Enable Datadog metrics as a source for HPA scaling                                        | `false`                                     |

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -53,7 +53,7 @@ The Leader Election is enabled by default in the chart for the Cluster Agent. On
 
 #### Cluster Agent Token
 
-You can specify the Datadog Cluster Agent token used to secure the communication between the Cluster Agent(s)q and the Agents with `clusterAgent.token`.
+You can specify the Datadog Cluster Agent token used to secure the communication between the Cluster Agent(s) and the Agents with `clusterAgent.token`.
 
 **If you don't specify a token, a random one is generated at each deployment so you must use `--recreate-pods` to ensure all pod use the same token.** see[Datadog Chart notes](https://github.com/helm/charts/blob/57d3030941ad2ec2d6f97c86afdf36666658a884/stable/datadog/templates/NOTES.txt#L49-L59) to learn more.
 
@@ -265,7 +265,7 @@ helm install --name <RELEASE_NAME> \
 | `daemonset.useHostPort`                  | If true, use the same ports for both host and container                                   | `nil`                                       |
 | `daemonset.priorityClassName`            | Which Priority Class to associate with the daemonset                                      | `nil`                                       |
 | `datadog.leaderElection`                 | Enable the leader Election feature                                                        | `false`                                     |
-| `datadog.leaderLeaseDuration`            | The duration for which a leader stays elected.                                            | `nil`                                       |
+| `datadog.leaderLeaseDuration`            | The duration for which a leader stays elected.                                            | 60 sec, 15 if Cluster Checks enabled        |
 | `datadog.collectEvents`                  | Enable Kubernetes event collection. Requires leader election.                             | `false`                                     |
 | `deployment.affinity`                    | Node / Pod affinities                                                                     | `{}`                                        |
 | `deployment.tolerations`                 | List of node taints to tolerate                                                           | `[]`                                        |
@@ -281,6 +281,8 @@ helm install --name <RELEASE_NAME> \
 | `clusterAgent.image.pullPolicy`          | Image pull policy                                                                         | `IfNotPresent`                              |
 | `clusterAgent.image.pullSecrets`         | Image pull secrets                                                                        | `nil`                                       |
 | `clusterAgent.metricsProvider.enabled`   | Enable Datadog metrics as a source for HPA scaling                                        | `false`                                     |
+| `clusterAgent.clusterChecks.enabled`   | Enable Cluster Checks on both the Cluster Agent and the Agent daemonset |  `false`                  |
+| `clusterAgent.confd`                     | Additional check configurations (static and Autodiscovery) | `nil`             |
 | `clusterAgent.resources.requests.cpu`    | CPU resource requests                                                                     | `200m`                                      |
 | `clusterAgent.resources.limits.cpu`      | CPU resource limits                                                                       | `200m`                                      |
 | `clusterAgent.resources.requests.memory` | Memory resource requests                                                                  | `256Mi`                                     |

--- a/stable/datadog/templates/cluster-agent-confd-configmap.yaml
+++ b/stable/datadog/templates/cluster-agent-confd-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: { template "datadog.fullname" . }}-cluster-agent-confd
+  name: {{ template "datadog.fullname" . }}-cluster-agent-confd
   labels:
     app: "{{ template "datadog.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/stable/datadog/templates/cluster-agent-confd-configmap.yaml
+++ b/stable/datadog/templates/cluster-agent-confd-configmap.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.clusterAgent.confd }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: { template "datadog.fullname" . }}-cluster-agent-confd
+  labels:
+    app: "{{ template "datadog.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+  annotations:
+    checksum/confd-config: {{ tpl (toYaml .Values.clusterAgent.confd) . | sha256sum }}
+data:
+{{ tpl (toYaml .Values.clusterAgent.confd) . | indent 2 }}
+{{- end -}}

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -18,6 +18,20 @@ spec:
       labels:
         app: {{ template "datadog.fullname" . }}-cluster-agent
       name: {{ template "datadog.fullname" . }}-cluster-agent
+      annotations:
+        ad.datadoghq.com/{{ .Values.clusterAgent.containerName }}.check_names: '["prometheus"]'
+        ad.datadoghq.com/{{ .Values.clusterAgent.containerName }}.init_configs: '[{}]'
+        ad.datadoghq.com/{{ .Values.clusterAgent.containerName }}.instances: |
+          [{
+            "prometheus_url": "http://%%host%%:5000/metrics",
+            "namespace": "datadog.cluster_agent",
+            "metrics": [
+              "go_goroutines", "go_memstats_*", "process_*",
+              "api_requests",
+              "datadog_requests", "external_metrics",
+              "cluster_checks_*"
+            ]
+          }]
     spec:
       {{- if .Values.clusterAgent.image.pullSecrets }}
       imagePullSecrets:

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -144,7 +144,7 @@ spec:
       volumes:
         - name: confd
           configMap:
-            name: {{ template "datadog.clusterAgentConfd.fullname"  . }}
+            name: {{ template "datadog.fullname" . }}-cluster-agent-confd
 {{- end }}
       {{- if .Values.clusterAgent.tolerations }}
       tolerations:

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -67,6 +67,18 @@ spec:
                 name: {{ template "datadog.appKeySecretName" . }}
                 key: app-key
           {{- end }}
+          {{- if .Values.clusterAgent.clusterChecks.enabled }}
+          - name: DD_CLUSTER_CHECKS_ENABLED
+            value: {{ .Values.clusterAgent.clusterChecks.enabled | quote }}
+          - name: DD_EXTRA_CONFIG_PROVIDERS
+            value: "kube_services"
+          - name: DD_EXTRA_LISTENERS
+            value: "kube_services"
+          {{- end }}
+          {{- if .Values.datadog.clusterName }}
+          - name: DD_CLUSTER_NAME
+            value: {{ .Values.datadog.clusterName | quote }}
+          {{- end }}
           {{- if .Values.datadog.site }}
           - name: DD_SITE
             value: {{ .Values.datadog.site | quote }}
@@ -84,6 +96,9 @@ spec:
           {{- if .Values.datadog.leaderLeaseDuration }}
           - name: DD_LEADER_LEASE_DURATION
             value: {{ .Values.datadog.leaderLeaseDuration | quote }}
+          {{- else if .Values.clusterAgent.clusterChecks.enabled }}
+          - name: DD_LEADER_LEASE_DURATION
+            value: "15"
           {{- end }}
           {{- if .Values.datadog.collectEvents }}
           - name: DD_COLLECT_KUBERNETES_EVENTS
@@ -120,6 +135,16 @@ spec:
             port: 443
             path: /healthz
             scheme: HTTPS
+{{- end }}
+{{- if .Values.clusterAgent.confd }}
+        volumeMounts:
+          - name: confd
+            mountPath: /conf.d
+            readOnly: true
+      volumes:
+        - name: confd
+          configMap:
+            name: {{ template "datadog.clusterAgentConfd.fullname"  . }}
 {{- end }}
       {{- if .Values.clusterAgent.tolerations }}
       tolerations:

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -68,6 +68,10 @@ spec:
               secretKeyRef:
                 name: {{ template "datadog.apiSecretName" . }}
                 key: api-key
+          {{- if .Values.datadog.clusterName }}
+          - name: DD_CLUSTER_NAME
+            value: {{ .Values.datadog.clusterName | quote }}
+          {{- end }}
           {{- if .Values.datadog.site }}
           - name: DD_SITE
             value: {{ .Values.datadog.site | quote }}
@@ -171,6 +175,10 @@ spec:
           {{- if .Values.datadog.useDogStatsDSocketVolume }}
           - name: DD_DOGSTATSD_SOCKET
             value: "/var/run/datadog/dsd.socket"
+          {{- end }}
+          {{- if .Values.clusterAgent.clusterChecks.enabled }}
+          - name: DD_EXTRA_CONFIG_PROVIDERS
+            value: "clusterchecks"
           {{- end }}
 {{- if .Values.datadog.env }}
 {{ toYaml .Values.datadog.env | indent 10 }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -71,7 +71,8 @@ datadog:
 
   ## @param clusterName - string - optional
   ## Set a unique cluster name to allow scoping hosts and Cluster Checks easily
-  # clusterName: ""
+  #
+  #  clusterName: <CLUSTER_NAME>
 
   ## @param name - string - required
   ## Daemonset/Deployment container name
@@ -303,7 +304,7 @@ clusterAgent:
   ## Enable the Cluster Checks feature on both the cluster-agents and the daemonset
   ## ref: https://docs.datadoghq.com/agent/autodiscovery/clusterchecks/
   ## Autodiscovery via Kube Service annotations is automatically enabled
-  ##
+  #
   clusterChecks:
     enabled: false
 
@@ -311,14 +312,15 @@ clusterAgent:
   ## Provide additional cluster check configurations
   ## Each key will become a file in /conf.d
   ## ref: https://docs.datadoghq.com/agent/autodiscovery/
-  # confd:
-  #   mysql.yaml: |-
-  #     cluster_check: true
-  #     instances:
-  #      - server: '<EXTERNAL_IP>'
-  #        port: 3306
-  #        user: datadog
-  #        pass: '<YOUR_CHOSEN_PASSWORD>'
+  #
+  #  confd:
+  #    mysql.yaml: |-
+  #      cluster_check: true
+  #      instances:
+  #       - server: '<EXTERNAL_IP>'
+  #         port: 3306
+  #         user: datadog
+  #         pass: '<YOUR_CHOSEN_PASSWORD>'
 
   ## @param resources - object -required
   ## Datadog cluster-agent resource requests and limits.

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -69,6 +69,10 @@ datadog:
   #    seLinuxOptions:
   #      seLinuxLabel: "spc_t"
 
+  ## @param clusterName - string - optional
+  ## Set a unique cluster name to allow scoping hosts and Cluster Checks easily
+  # clusterName: ""
+
   ## @param name - string - required
   ## Daemonset/Deployment container name
   ## See clusterAgent.containerName if clusterAgent.enabled = true
@@ -286,6 +290,7 @@ clusterAgent:
   ## ref:
   #
   token: ""
+
   replicas: 1
 
   ## @param metricsProvider - object - required
@@ -293,6 +298,27 @@ clusterAgent:
   #
   metricsProvider:
     enabled: false
+
+  ## @param clusterChecks - object - required
+  ## Enable the Cluster Checks feature on both the cluster-agents and the daemonset
+  ## ref: https://docs.datadoghq.com/agent/autodiscovery/clusterchecks/
+  ## Autodiscovery via Kube Service annotations is automatically enabled
+  ##
+  clusterChecks:
+    enabled: false
+
+  ## @param confd - list of objects - optional
+  ## Provide additional cluster check configurations
+  ## Each key will become a file in /conf.d
+  ## ref: https://docs.datadoghq.com/agent/autodiscovery/
+  # confd:
+  #   mysql.yaml: |-
+  #     cluster_check: true
+  #     instances:
+  #      - server: '<EXTERNAL_IP>'
+  #        port: 3306
+  #        user: datadog
+  #        pass: '<YOUR_CHOSEN_PASSWORD>'
 
   ## @param resources - object -required
   ## Datadog cluster-agent resource requests and limits.

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -18,7 +18,7 @@ image:
   ## Define the Agent version to use.
   ## Use 6.9.0-jmx to enable jmx fetch collection
   #
-  tag: 6.9.0
+  tag: 6.10.1
 
   ## @param pullPolicy - string - required
   ## The Kubernetes pull policy.

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -282,7 +282,7 @@ clusterAgent:
   containerName: cluster-agent
   image:
     repository: datadog/cluster-agent
-    tag: 1.1.0
+    tag: 1.2.0
     pullPolicy: IfNotPresent
 
   ## @param token - string - required


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes

- Add prometheus annotations on the cluster-agent container
- Add a confd configmap to the cluster-agent deployment to pass static cluster-check configs
- Update cluster-agent to 1.2.0 and agent to 6.10.1
- Add boolean to enable clusterChecks

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
