### PR TITLE
Atlantis 450

### DIFF
--- a/stable/atlantis/Chart.yaml
+++ b/stable/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.4.11"
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 1.1.3
+version: 1.1.4
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/stable/atlantis/templates/statefulset.yaml
+++ b/stable/atlantis/templates/statefulset.yaml
@@ -87,7 +87,7 @@ spec:
           - name: ATLANTIS_DATA_DIR
             value: /atlantis-data
           - name: ATLANTIS_REPO_WHITELIST
-            value: {{ .Values.orgWhitelist }}
+            value: {{ toYaml .Values.orgWhitelist }}
           - name: ATLANTIS_PORT
             value: "4141"
           {{- if .Values.atlantisUrl }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Because Atlantis allows a `*` to represent a whitelist of all github organizations, if one used `--set orgWhitelist='*'` then it would insert that value literally into the StatefulSet yaml, causing a parse error

#### Which issue this PR fixes

fixes: runatlantis/atlantis#450

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
