### PR TITLE
Indent lines related to EnableRawHtmlMarkupFormatter

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.28.11
+version: 0.28.12
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -30,9 +30,9 @@ data:
       <workspaceDir>${JENKINS_HOME}/workspace/${ITEM_FULLNAME}</workspaceDir>
       <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
 {{- if .Values.Master.EnableRawHtmlMarkupFormatter }}
-  <markupFormatter class="hudson.markup.RawHtmlMarkupFormatter" plugin="antisamy-markup-formatter">
-    <disableSyntaxHighlighting>true</disableSyntaxHighlighting>
-  </markupFormatter>
+      <markupFormatter class="hudson.markup.RawHtmlMarkupFormatter" plugin="antisamy-markup-formatter">
+        <disableSyntaxHighlighting>true</disableSyntaxHighlighting>
+      </markupFormatter>
 {{- else }}
       <markupFormatter class="hudson.markup.EscapedMarkupFormatter"/>
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

#### What this PR does / why we need it:
Fixes issue with indentation of config.yaml which is causing linting errors.

#### Which issue this PR fixes
  - fixes #11251 

#### Special notes for your reviewer:
I am not 100% sure if this is the fix, however when I indented the lines in this commit my linting errors went away:

Before indentation:
```
helm lint -f jenkins-values.yml charts/stable/jenkins                                                                                                           [13:05:28]
==> Linting charts/stable/jenkins
[ERROR] templates/config.yaml: unable to parse YAML
        error converting YAML to JSON: yaml: line 25: could not find expected ':'

Error: 1 chart(s) linted, 1 chart(s) failed
```

After indentation:
```
helm lint -f jenkins-values.yml charts/stable/jenkins                                                                                                           [13:06:10]
==> Linting charts/stable/jenkins
Lint OK

1 chart(s) linted, no failures
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md, *_variables are already documented_*
