### PR TITLE
[stable/unbound] Add support for externalIP, stubZones and localZones properties

### DIFF
--- a/stable/unbound/Chart.yaml
+++ b/stable/unbound/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Unbound is a fast caching DNS resolver
 home: https://www.unbound.net/
 name: unbound
-version: 0.1.2
+version: 0.1.3
 appVersion: 1.6.7
 sources:
 - http://unbound.nlnetlabs.nl/svn/

--- a/stable/unbound/Chart.yaml
+++ b/stable/unbound/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Unbound is a fast caching DNS resolver
 home: https://www.unbound.net/
 name: unbound
-version: 0.1.3
+version: 1.0.0
 appVersion: 1.6.7
 sources:
 - http://unbound.nlnetlabs.nl/svn/

--- a/stable/unbound/README.md
+++ b/stable/unbound/README.md
@@ -82,6 +82,7 @@ unbound.serverPort: 53
 | allowedIpRanges          | []                          |
 | forwardZones             | []                          |
 | localRecords             | []                          |
+| localZones               | []                          |
 
 ### Configuration changes
 

--- a/stable/unbound/README.md
+++ b/stable/unbound/README.md
@@ -81,6 +81,7 @@ unbound.serverPort: 53
 | affinity                 | {}                          |
 | allowedIpRanges          | []                          |
 | forwardZones             | []                          |
+| stubZones                | []                          |
 | localRecords             | []                          |
 | localZones               | []                          |
 

--- a/stable/unbound/README.md
+++ b/stable/unbound/README.md
@@ -63,6 +63,7 @@ unbound.serverPort: 53
 | Property                 | Default value               |
 | ------------------------ | --------------------------- |
 | replicaCount             | 1                           |
+| externalIP               | ""                          |
 | unbound.image.repository | markbnj/unbound-docker      |
 | unbound.image.tag        | 0.1.0                       |
 | unbound.image.pullPolicy | IfNotPresent                |

--- a/stable/unbound/templates/configmap.yaml
+++ b/stable/unbound/templates/configmap.yaml
@@ -51,3 +51,15 @@ data:
         forward-addr: {{ . }}
         {{- end }}
     {{- end }}
+
+    {{- range .Values.stubZones }}
+
+    stub-zone:
+        name: {{ .name }}
+        {{- range .stubHosts }}
+        stub-host: {{ . }}
+        {{- end }}
+        {{- range .stubIps }}
+        stub-addr: {{ . }}
+        {{- end }}
+    {{- end }}

--- a/stable/unbound/templates/configmap.yaml
+++ b/stable/unbound/templates/configmap.yaml
@@ -40,6 +40,10 @@ data:
         local-data: "health.check.unbound A 127.0.0.1"
         local-data-ptr: "127.0.0.1 health.check.unbound"
 
+    {{- range .Values.localZones }}
+        local-zone: "{{ .name }}" {{ .localType }}
+    {{- end }}
+
     {{- range .Values.forwardZones }}
 
     forward-zone:

--- a/stable/unbound/templates/service.yaml
+++ b/stable/unbound/templates/service.yaml
@@ -8,6 +8,10 @@ metadata:
     release: {{ .Release.Name  }}
     heritage: {{ .Release.Service }}
 spec:
+  {{- if .Values.externalIP }}
+  externalIPs:
+    - {{ .Values.externalIP }}
+  {{- end }}
   selector:
     app: {{ template "unbound.name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds support for the following properties:

- externalIP: allow to define an externalIP on the service
- stubZones: allow to define multiple stub-zone statements in the unbound configuration
- localZones: allow to define multiple local-zone statements in the unbound configuration

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
