### PR TITLE
Chart to easily configure custom rbac permissions

### DIFF
--- a/stable/cluster-customrbac/Chart.yaml
+++ b/stable/cluster-customrbac/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+name: cluster-customrbac
+version: 0.1.0
+description: A chart to manage custom RBAC permissions on a Kubernetes cluster
+icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
+keywords:
+- kubernetes
+- RBAC
+maintainers:
+- name: marckhouzam
+  email: marc.khouzam@ville.montreal.qc.ca
+- name: wjeanneau
+  email: william.jeanneau@gmail.com

--- a/stable/cluster-customrbac/Chart.yaml
+++ b/stable/cluster-customrbac/Chart.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 name: cluster-customrbac
 version: 0.1.0
+appVersion: none
 description: A chart to manage custom RBAC permissions on a Kubernetes cluster
+home: https://kubernetes.io/docs/reference/access-authn-authz/rbac
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 keywords:
 - kubernetes

--- a/stable/cluster-customrbac/README.md
+++ b/stable/cluster-customrbac/README.md
@@ -1,0 +1,81 @@
+# Kubernetes Custom RBAC Chart
+
+Helm chart to manage custom
+[RBAC permissions](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+of a Kubernetes cluster.
+
+## TL;DR;
+
+Create `<your_config_file.yaml>` based on `values.yaml`.
+For example:
+
+```yaml
+customrbac:
+  rolebindings:
+  - rolekind: clusterrole
+    rolename: cluster-admin
+    bindings:
+    - namespace: kube-system
+      subjects:
+        users:
+        - elon.musk@example.com
+        - neo@example.com
+```
+
+then run:
+
+```bash
+$ helm install stable/cluster-customrbac -f <your_config_file.yaml>
+```
+
+## Chart Details
+This chart allows to manage custom [RBAC permissions](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+of a Kubernetes cluster in a simplified manner.
+Through the use of standard-format Helm configuration files, one can define custom RBAC permissions that
+will be created in the cluster.
+
+Advantages in using the chart:
+- Streamlined RBAC configuration through a simplified YAML format
+- Definition of all `roles`, `rolebindings`, `clusterroles` and `clusterrolebindings` using a single configuration file or one file per type of entity, instead of having to create one Kubernetes YAML file for **each** instance of **each** entity (which can lead to dozens or hundreds of files).
+- Greatly simplified way to modify RBAC permissions through use of HELM (e.g., removal of existing RBAC permissions by simply removing entries in the configuration file and re-deploying the chart)
+
+## Prerequisites
+
+- RBAC must be enabled in your Kubernetes cluster.
+- You must create an RBAC configuration file to feed into the chart
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release stable/cluster-customrbac -f <your_config_file.yaml>
+```
+
+The command deploys the RBAC permissions as specified in `<your_config_file.yaml>`.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes the Kubernetes RBAC entities that were created by the deployment.
+
+If you so wish, you can manage different sets of RBAC permissions through different configurations and releases of this same chart.
+
+## Configuration
+
+Configuration should be specified from within one or more YAML files and fed into the chart using the -f flag.
+Please see the `values.yaml` file for how to setup your own configuration file.
+You can choose to split the configuration into multiple YAML files; for example, you could choose to use
+one file for `rolebindings` definitions, and a different one for `roles` definitions. Basically, each of the
+four types of configuration could be in its own file (`roles`, `rolebindings`, `clusterroles` and `clusterrolebindings`).
+However, all the configuration of a single of the four types must be in the same configuration file; this is because
+HELM does not allow to separate the elements of an array into different files.
+
+For more information please refer to the Kubernetes documentation for
+[RBAC permissions.](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+

--- a/stable/cluster-customrbac/templates/NOTES.txt
+++ b/stable/cluster-customrbac/templates/NOTES.txt
@@ -1,0 +1,7 @@
+RBAC permissions in your cluster now match your specified configuration file(s).
+
+To verify these RBAC permissions you can run the following commands:
+  $ kubectl get clusterroles
+  $ kubectl get roles --all-namespaces
+  $ kubectl get clusterrolebindings
+  $ kubectl get rolebindings --all-namespaces

--- a/stable/cluster-customrbac/templates/_helpers.tpl
+++ b/stable/cluster-customrbac/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- printf "%s" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/cluster-customrbac/templates/bogusrole.yaml
+++ b/stable/cluster-customrbac/templates/bogusrole.yaml
@@ -1,0 +1,13 @@
+# This is an empty clusterrole that is only created if this chart was deployed
+# without any configuration.
+# It is mainly aimed at making work the command
+#  helm install .
+# although it will not have any value for the user.
+{{ if and (and (not .Values.customrbac.clusterroles) (not .Values.customrbac.clusterrolebindings)) (and (not .Values.customrbac.roles) (not .Values.customrbac.rolebindings)) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  # Prefix with a ~ to make this clusterrole be listed last to make it easier to be noticed
+  name: ~WARNING-CUSTOMRBAC-DID-NOT-CREATE-ANYTHING~
+rules:
+{{- end }}

--- a/stable/cluster-customrbac/templates/clusterrole.yaml
+++ b/stable/cluster-customrbac/templates/clusterrole.yaml
@@ -1,0 +1,9 @@
+{{- range $role := .Values.customrbac.clusterroles }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $role.name }}
+rules:
+{{ $role.rules | toYaml }}
+{{- end }}

--- a/stable/cluster-customrbac/templates/clusterrolebinding.yaml
+++ b/stable/cluster-customrbac/templates/clusterrolebinding.yaml
@@ -1,0 +1,27 @@
+{{- range $binding := .Values.customrbac.clusterrolebindings }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $.Release.Name }}-{{ $binding.clusterrolename }}-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $binding.clusterrolename | quote }}
+subjects:
+    {{- range $user := $binding.subjects.users }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ $user | quote }}
+    {{- end }}
+    {{- range $group := $binding.subjects.groups }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: {{ $group | quote }}
+    {{- end }}
+    {{- range $account := $binding.subjects.serviceaccounts }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: ServiceAccount
+  name: {{ $account | quote }}
+    {{- end }}
+{{- end }}

--- a/stable/cluster-customrbac/templates/role.yaml
+++ b/stable/cluster-customrbac/templates/role.yaml
@@ -1,0 +1,10 @@
+{{- range $role := .Values.customrbac.roles }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $role.name }}
+  namespace: {{ $role.namespace }}
+rules:
+{{ $role.rules | toYaml }}
+{{- end }}

--- a/stable/cluster-customrbac/templates/rolebinding.yaml
+++ b/stable/cluster-customrbac/templates/rolebinding.yaml
@@ -1,0 +1,34 @@
+{{- range $rbac := .Values.customrbac.rolebindings }}
+  {{- range $binding := $rbac.bindings }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $.Release.Name }}-{{ $rbac.rolename }}-{{ $binding.namespace }}-binding
+  namespace: {{ $binding.namespace | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  {{- if eq (lower $rbac.rolekind) "role" }}
+  kind: Role
+  {{- else }}
+  kind: ClusterRole
+  {{- end }}
+  name: {{ $rbac.rolename | quote }}
+subjects:
+    {{- range $user := $binding.subjects.users }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ $user | quote }}
+    {{- end }}
+    {{- range $group := $binding.subjects.groups }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: {{ $group | quote }}
+    {{- end }}
+    {{- range $account := $binding.subjects.serviceaccounts }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: ServiceAccount
+  name: {{ $account | quote }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/stable/cluster-customrbac/values.yaml
+++ b/stable/cluster-customrbac/values.yaml
@@ -1,0 +1,80 @@
+# Default values for cluster-customrbac.
+#
+# This is a YAML-formatted file.
+#
+# As it stands, this file does not request the creation
+# of any RBAC permissions; instead it shows how to define
+# your own set of:
+#   roles, clusterroles, rolebindings and clusterrolebindings.
+#
+# Because separating multiple entries of an array into different
+# yaml files is not supported, this values.yaml file cannot
+# define any objects; if it did, its array entries would cause
+# conflicts with the actual user-defined configuration array entries.
+#
+customrbac:
+  clusterroles: []
+  # - name: clusterole1
+  #   rules:
+  #   - apiGroups:
+  #     - ""
+  #     resources:
+  #     - namespaces
+  #     verbs:
+  #     - get
+  #     - list
+  #     - watch
+  clusterrolebindings: []
+  # - clusterrolename: clusterrole1
+  #   subjects:
+  #     users:
+  #     - user1
+  #     - user2
+  #     groups:
+  #     - group1
+  #     - group2
+  #     serviceaccounts:
+  #     - account1
+  #     - account2
+  # - clusterrolename: clusterrole2
+  #   subjects:
+  #   ...
+  roles: []
+  # - name: role1
+  #   namespace: namespace1
+  #   rules:
+  #   - apiGroups:
+  #     - ""
+  #     resources:
+  #     - namespaces
+  #     verbs:
+  #     - get
+  #     - list
+  #     - watch
+  rolebindings: []
+  # - rolekind: "role" or "clusterrole"
+  #   rolename: role1
+  #   bindings:
+  #   - namespace: namespace1
+  #     subjects:
+  #       users:
+  #       - user1
+  #       - user2
+  #       groups:
+  #       - group1
+  #       - group2
+  #       serviceaccounts:
+  #       - account1
+  #       - account2
+  #   - namespace: namespace2
+  #     subjects:
+  #     ...
+  # - rolekind: "role" or "clusterrole"
+  #   rolename: role2
+  #   bindings:
+  #   - namespace: namespace1
+  #     subjects:
+  #     ...
+  #   - namespace: namespace3
+  #     subjects:
+  #     ...


### PR DESCRIPTION
Signed-off-by: Marc Khouzam <marc.khouzam@ville.montreal.qc.ca>
Signed-off-by: William Jeanneau <william.jeanneau@gmail.com>

#### What this PR does / why we need it:

This PR provides a chart that allows to manage custom [RBAC permissions](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
of a Kubernetes cluster in a simplified manner.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
