### PR TITLE
[stable/prometheus-operator] Add custom PrometheusRules

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 2.2.3
+version: 2.2.4
 appVersion: 0.26.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -207,6 +207,7 @@ The following tables lists the configurable parameters of the prometheus-operato
 | `alertmanager.service.externalIPs` | List of IP addresses at which the Alertmanager server service is available  | `[]` |
 | `alertmanager.service.loadBalancerIP` |  Alertmanager Loadbalancer IP | `""` |
 | `alertmanager.service.loadBalancerSourceRanges` | Alertmanager Load Balancer Source Ranges | `[]` |
+| `alertmanager.additionalPrometheusRules` | List of `prometheusRule` objects to create. See https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusrulespec | `[]` |
 | `alertmanager.config` | Provide YAML to configure Alertmanager. See https://prometheus.io/docs/alerting/configuration/#configuration-file. The default provided works to suppress the DeadMansSwitch alert from `defaultRules.create` | `{"global":{"resolve_timeout":"5m"},"route":{"group_by":["job"],"group_wait":"30s","group_interval":"5m","repeat_interval":"12h","receiver":"null","routes":[{"match":{"alertname":"DeadMansSwitch"},"receiver":"null"}]},"receivers":[{"name":"null"}]}` |
 | `alertmanager.alertmanagerSpec.podMetadata` | Standard object’s metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata Metadata Labels and Annotations gets propagated to the prometheus pods. | `{}` |
 | `alertmanager.alertmanagerSpec.image.tag` | Tag of Alertmanager container image to be deployed. | `v0.15.3` |

--- a/stable/prometheus-operator/ci/test-values.yaml
+++ b/stable/prometheus-operator/ci/test-values.yaml
@@ -292,6 +292,14 @@ alertmanager:
     ##
     additionalPeers: []
 
+  additionalPrometheusRules: []
+  #  - name: my_rule_file
+  #    groups:
+  #      - name: my_group
+  #        rules:
+  #        - record: my_record
+  #          expr: 100 * my_record
+
 ## Using default values from https://github.com/helm/charts/blob/master/stable/grafana/values.yaml
 ##
 grafana:

--- a/stable/prometheus-operator/templates/alertmanager/prometheusrules.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/prometheusrules.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.alertmanager.enabled .Values.alertmanager.additionalPrometheusRules }}
+{{- range .Values.alertmanager.additionalPrometheusRules }}
+apiVersion: {{ printf "%s/v1" ($.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
+kind: PrometheusRule
+metadata:
+  name: {{ template "prometheus-operator.name" $ }}-{{ .name }}
+  labels:
+    app: {{ template "prometheus-operator.name" $ }}
+{{ include "prometheus-operator.labels" $ | indent 4 }}
+    {{- if .additionalLabels }}
+{{ toYaml .additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  groups:
+{{ toYaml .groups| indent 4 }}
+{{- end }}
+{{- end }}

--- a/stable/prometheus-operator/templates/prometheus/servicemonitors.yaml
+++ b/stable/prometheus-operator/templates/prometheus/servicemonitors.yaml
@@ -1,29 +1,26 @@
 {{- if and .Values.prometheus.enabled .Values.prometheus.additionalServiceMonitors }}
-apiVersion: v1
-kind: List
-items:
 {{- range .Values.prometheus.additionalServiceMonitors }}
-  - apiVersion: {{ printf "%s/v1" ($.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
-    kind: ServiceMonitor
-    metadata:
-      name: {{ .name }}
-      labels:
-        app: {{ template "prometheus-operator.name" $ }}-prometheus
-{{ include "prometheus-operator.labels" $ | indent 8 }}
-        {{- if .additionalLabels }}
-{{ toYaml .additionalLabels | indent 8 }}
-        {{- end }}
-    spec:
-      endpoints:
-{{ toYaml .endpoints | indent 8 }}
-    {{- if .jobLabel }}
-      jobLabel: {{ .jobLabel }}
+apiVersion: {{ printf "%s/v1" ($.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
+kind: ServiceMonitor
+metadata:
+  name: {{ template "prometheus-operator.name" $ }}-{{ .name }}
+  labels:
+    app: {{ template "prometheus-operator.name" $ }}-prometheus
+{{ include "prometheus-operator.labels" $ | indent 4 }}
+    {{- if .additionalLabels }}
+{{ toYaml .additionalLabels | indent 4 }}
     {{- end }}
-    {{- if .namespaceSelector }}
-      namespaceSelector:
-{{ toYaml .namespaceSelector | indent 8 }}
-    {{- end }}
-      selector:
-{{ toYaml .selector | indent 8 }}
+spec:
+  endpoints:
+{{ toYaml .endpoints | indent 4 }}
+{{- if .jobLabel }}
+  jobLabel: {{ .jobLabel }}
+{{- end }}
+{{- if .namespaceSelector }}
+  namespaceSelector:
+{{ toYaml .namespaceSelector | indent 4 }}
+{{- end }}
+  selector:
+{{ toYaml .selector | indent 4 }}
 {{- end }}
 {{- end }}

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -292,6 +292,14 @@ alertmanager:
     ##
     additionalPeers: []
 
+  additionalPrometheusRules: []
+  #  - name: my_rule_file
+  #    groups:
+  #      - name: my_group
+  #        rules:
+  #        - record: my_record
+  #          expr: 100 * my_record
+
 ## Using default values from https://github.com/helm/charts/blob/master/stable/grafana/values.yaml
 ##
 grafana:


### PR DESCRIPTION
#### What this PR does / why we need it:

This commit allows the specification of custom PrometheusRule
resources via alertmanager.additionalPrometheusRules.

To assist the implementation, the ServiceMonitor manifest has also been
updated to remove the v1 List type, which was subsequently clobbered.

Signed-off-by: Ash Caire <ash.caire@gmail.com>

@gianrubio

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md