### PR TITLE
update clusterrole rbacs to be able to fetch clusterresourcequotas from openshift

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.19.0
+version: 1.20.0
 appVersion: 6.9.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/agent-clusterrole.yaml
+++ b/stable/datadog/templates/agent-clusterrole.yaml
@@ -22,6 +22,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups: ["quota.openshift.io"]
+  resources:
+  - clusterresourcequotas
+  verbs:
+  - get
+  - list
 - apiGroups:
   - "autoscaling"
   resources:

--- a/stable/datadog/templates/clusterrole.yaml
+++ b/stable/datadog/templates/clusterrole.yaml
@@ -23,6 +23,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups: ["quota.openshift.io"]
+  resources:
+  - clusterresourcequotas
+  verbs:
+  - get
+  - list
 {{- if .Values.datadog.collectEvents }}
 - apiGroups:
   - ""


### PR DESCRIPTION
Signed-off-by: Simon Guerrier <simon.guerrier@datadoghq.com>

#### What this PR does / why we need it:
This PR updates the clusterrole rbacs (agent and DCA) to be able to fetch clusterresourcequotas from openshift correctly.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
