### PR TITLE
[stable/traefik] Add Forward Authentication on https entrypoint

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.60.0
+version: 1.61.0
 appVersion: 1.7.7
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -127,6 +127,9 @@ The following table lists the configurable parameters of the Traefik chart and t
 | `ssl.defaultCert`                      | Base64 encoded default certificate                                                                                           | A self-signed certificate                         |
 | `ssl.defaultKey`                       | Base64 encoded private key for the certificate above                                                                         | The private key for the certificate above         |
 | `ssl.auth.basic`                       | Basic auth for all SSL endpoints, see Authentication section                                          | unset by default; this means basic auth is disabled |
+| `ssl.auth.forward.address`             | Sets the URL of the authentication server for forward auth on all SSL entrypoints.                    | None |
+| `ssl.auth.forward.trustForwardHeader`  | Trust existing X-Forwarded-* headers.                                                                 | `false` |
+| `ssl.auth.forward.authResponseHeaders` | Copy headers from the authentication server to the request.                                           | `[]` |
 | `acme.enabled`                         | Whether to use Let's Encrypt to obtain certificates                                                                          | `false`                                           |
 | `acme.challengeType`                   | Type of ACME challenge to perform domain validation. `tls-sni-01` (deprecated), `tls-alpn-01` (recommended), `http-01` or `dns-01` | `tls-sni-01`                                |
 | `acme.delayBeforeCheck`         | By default, the provider will verify the TXT DNS challenge record before letting ACME verify. If delayBeforeCheck is greater than zero, this check is delayed for the configured duration in seconds. Useful when Traefik cannot resolve external DNS queries. | `0` |

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -130,6 +130,10 @@ The following table lists the configurable parameters of the Traefik chart and t
 | `ssl.auth.forward.address`             | Sets the URL of the authentication server for forward auth on all SSL entrypoints.                    | None |
 | `ssl.auth.forward.trustForwardHeader`  | Trust existing X-Forwarded-* headers.                                                                 | `false` |
 | `ssl.auth.forward.authResponseHeaders` | Copy headers from the authentication server to the request.                                           | `[]` |
+| `ssl.auth.forward.tls.ca`              | Base64 encoded CA certificate for the TLS connection with the authentication server.                  | None |
+| `ssl.auth.forward.tls.caOptional`      | Checks the certificates if present but do not force to be signed by a specified CA.                   | `false` |
+| `ssl.auth.forward.tls.cert`            | Base64 encoded certificate for the TLS connection with the authentication server.                     | None |
+| `ssl.auth.forward.tls.key`             | Base64 encoded private key for the certificate above.                                                 | None |
 | `acme.enabled`                         | Whether to use Let's Encrypt to obtain certificates                                                                          | `false`                                           |
 | `acme.challengeType`                   | Type of ACME challenge to perform domain validation. `tls-sni-01` (deprecated), `tls-alpn-01` (recommended), `http-01` or `dns-01` | `tls-sni-01`                                |
 | `acme.delayBeforeCheck`         | By default, the provider will verify the TXT DNS challenge record before letting ACME verify. If delayBeforeCheck is greater than zero, this check is delayed for the configured duration in seconds. Useful when Traefik cannot resolve external DNS queries. | `0` |

--- a/stable/traefik/templates/auth-forward-cert-secret.yaml
+++ b/stable/traefik/templates/auth-forward-cert-secret.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.ssl.enabled }}
+{{- if .Values.ssl.auth.forward }}
+{{- if .Values.ssl.auth.forward.tls }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "traefik.fullname" . }}-auth-forward-cert
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+type: Opaque
+data:
+  tls_ca.crt: {{ .Values.ssl.auth.forward.tls.ca }}
+  tls.crt: {{ .Values.ssl.auth.forward.tls.cert }}
+  tls.key: {{ .Values.ssl.auth.forward.tls.key }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -80,11 +80,26 @@ data:
           KeyFile = "/ssl/tls.key"
       {{- end }}
         {{- if .Values.ssl.auth }}
-        {{- if .Values.ssl.auth.basic }}
         [entryPoints.https.auth]
+          {{- if .Values.ssl.auth.basic }}
           [entryPoints.https.auth.basic]
             users = [{{ range $key, $value := .Values.ssl.auth.basic }}"{{ $key }}:{{ $value }}",{{ end }}]
-        {{- end }}
+          {{- end }}
+          {{- if .Values.ssl.auth.forward }}
+          [entryPoints.https.auth.forward]
+            address = {{ .Values.ssl.auth.forward.address | quote }}
+            {{- if .Values.ssl.auth.forward.trustForwardHeader }}
+            trustForwardHeader = true
+            {{- end }}
+            {{- if .Values.ssl.auth.forward.authResponseHeaders }}
+            authResponseHeaders = [
+                {{- range $idx, $element := .Values.ssl.auth.forward.authResponseHeaders }}
+                    {{- if $idx }}, {{ end }}
+                    {{- $element | quote }}
+                {{- end -}}
+                ]
+            {{- end}}
+          {{- end }}
         {{- end }}
       {{- else }}
       [entryPoints.httpn]

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -99,6 +99,13 @@ data:
                 {{- end -}}
                 ]
             {{- end}}
+              {{- if .Values.ssl.auth.forward.tls }}
+              [entryPoints.https.auth.forward.tls]
+                ca = "/ssl_auth_forward/tls_ca.crt"
+                caOptional = {{ default false .Values.ssl.auth.forward.tls.caOptional }}
+                cert = "/ssl_auth_forward/tls.crt"
+                key = "/ssl_auth_forward/tls.key"
+              {{- end }}
           {{- end }}
         {{- end }}
       {{- else }}

--- a/stable/traefik/templates/deployment.yaml
+++ b/stable/traefik/templates/deployment.yaml
@@ -102,6 +102,14 @@ spec:
         - mountPath: /ssl
           name: ssl
         {{- end }}
+        {{- if .Values.ssl.enabled }}
+        {{- if .Values.ssl.auth.forward }}
+        {{- if .Values.ssl.auth.forward.tls }}
+        - mountPath: /ssl_auth_forward
+          name: ssl-auth-forward
+        {{- end }}
+        {{- end }}
+        {{- end }}
         {{- if .Values.acme.enabled }}
         - mountPath: /acme
           name: acme
@@ -144,6 +152,15 @@ spec:
       - name: ssl
         secret:
           secretName: {{ template "traefik.fullname" . }}-default-cert
+      {{- end }}
+      {{- if .Values.ssl.enabled }}
+      {{- if .Values.ssl.auth.forward }}
+      {{- if .Values.ssl.auth.forward.tls }}
+      - name: ssl-auth-forward
+        secret:
+          secretName: {{ template "traefik.fullname" . }}-auth-forward-cert
+      {{- end }}
+      {{- end }}
       {{- end }}
       {{- if .Values.acme.enabled }}
       - name: acme

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -90,6 +90,11 @@ ssl:
     # basic:
     #   testuser: $apr1$JXRA7j2s$LpVns9vsme8FHN0r.aSt11
 
+    # forward:
+    #   address: ""
+    #   trustForwardHeader: false
+    #   authResponseHeaders: []
+
 kvprovider:
   ## If you want to run Traefik in HA mode, you will need to setup a KV Provider. Therefore you can choose one of
   ## * etcd

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -94,11 +94,11 @@ ssl:
     #   address: ""
     #   trustForwardHeader: false
     #   authResponseHeaders: []
-    #     tls:
-    #       ca: ""
-    #       caOptional: false
-    #       cert: ""
-    #       key: ""
+    #   tls:
+    #     ca: ""
+    #     caOptional: false
+    #     cert: ""
+    #     key: ""
 
 kvprovider:
   ## If you want to run Traefik in HA mode, you will need to setup a KV Provider. Therefore you can choose one of

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -94,6 +94,11 @@ ssl:
     #   address: ""
     #   trustForwardHeader: false
     #   authResponseHeaders: []
+    #     tls:
+    #       ca: ""
+    #       caOptional: false
+    #       cert: ""
+    #       key: ""
 
 kvprovider:
   ## If you want to run Traefik in HA mode, you will need to setup a KV Provider. Therefore you can choose one of


### PR DESCRIPTION
#### What this PR does / why we need it:
Makes it possible to enable _Forward Authentication_ on https entrypoint. Authentication server connection may optionally use TLS with certificates set in values.

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
