### PR TITLE
[stable/coredns] Add service configuration fields

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,5 +1,5 @@
 name: coredns
-version: 1.3.0
+version: 1.3.1
 appVersion: 1.4.0
 description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services
 keywords:

--- a/stable/coredns/templates/service.yaml
+++ b/stable/coredns/templates/service.yaml
@@ -24,6 +24,12 @@ spec:
   {{- if .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   ports:
 {{ include "coredns.servicePorts" . | indent 2 -}}
   type: {{ default "ClusterIP" .Values.serviceType }}

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -21,6 +21,8 @@ serviceType: "ClusterIP"
 
 service:
 # clusterIP: ""
+# loadBalancerIP: ""
+# externalTrafficPolicy: ""
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9153"


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds the `externalTrafficPolicy` and `loadBalancerIP` fields to CoreDNS' service. These are useful if you're using CoreDNS to expose DNS outside of the cluster.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
