### PR TITLE
[stable/sysdig] Revert the checksum annotations

### DIFF
--- a/stable/sysdig/CHANGELOG.md
+++ b/stable/sysdig/CHANGELOG.md
@@ -3,6 +3,12 @@
 This file documents all notable changes to Sysdig Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.3.1
+
+### Minor Changes
+
+* Revert v1.2.1 changes. The agent automatically restarts when detects a change in the configuration.
+
 ## v1.3.0
 
 ### Major Changes
@@ -11,6 +17,12 @@ numbering uses [semantic versioning](http://semver.org).
 * Check running file on readinessProbe instead of relaying on logs.
 * Mount /run and /var/run instead of Docker socket. It allows to access CRI / containerd socket.
 * Avoid floating references for the image.
+
+## v1.2.2
+
+### Minor Changes
+
+* Fix value in the agent tags example.
 
 ## v1.2.1
 

--- a/stable/sysdig/Chart.yaml
+++ b/stable/sysdig/Chart.yaml
@@ -1,5 +1,5 @@
 name: sysdig
-version: 1.3.0
+version: 1.3.1
 appVersion: 0.88.1
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/stable/sysdig/templates/daemonset.yaml
+++ b/stable/sysdig/templates/daemonset.yaml
@@ -15,9 +15,6 @@ spec:
       labels:
         app: {{ template "sysdig.fullname" .}}
         role: monitoring
-      annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        checksum/custom-app-checks: {{ include (print $.Template.BasePath "/configmap-custom-app-checks.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ template "sysdig.serviceAccountName" .}}
       tolerations:


### PR DESCRIPTION
The sysdig agent automatically restarts when it detects a configuration
change.

Signed-off-by: Néstor Salceda <nestor.salceda@sysdig.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR reverts the checksum annotations used for the rolling upgrade. The sysdig agent automatically restarts when it detects a configuration change.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

I also filled the Changelog entry for the 1.2.2 version.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
