### PR TITLE
[stable/kong] Integrated optional support for hostPort on admin, proxy and tls.

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.9.2
+version: 0.9.3
 appVersion: 1.0.2

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -51,7 +51,7 @@ and their default values.
 | Parameter                      | Description                                                                      | Default             |
 | ------------------------------ | -------------------------------------------------------------------------------- | ------------------- |
 | image.repository               | Kong image                                                                       | `kong`              |
-| image.tag                      | Kong image version                                                               | `1.0.2`            |
+| image.tag                      | Kong image version                                                               | `1.0.2`             |
 | image.pullPolicy               | Image pull policy                                                                | `IfNotPresent`      |
 | image.pullSecrets              | Image pull secrets                                                               | `null`              |
 | replicaCount                   | Kong instance count                                                              | `1`                 |
@@ -59,6 +59,7 @@ and their default values.
 | admin.servicePort              | TCP port on which the Kong admin service is exposed                              | `8444`              |
 | admin.containerPort            | TCP port on which Kong app listens for admin traffic                             | `8444`              |
 | admin.nodePort                 | Node port when service type is `NodePort`                                        |                     |
+| admin.hostPort                 | Host port to use for admin traffic                                               |                     |
 | admin.type                     | k8s service type, Options: NodePort, ClusterIP, LoadBalancer                     | `NodePort`          |
 | admin.loadBalancerIP           | Will reuse an existing ingress static IP for the admin service                   | `null`              |
 | admin.loadBalancerSourceRanges | Limit admin access to CIDRs if set and service type is `LoadBalancer`            | `[]`                |
@@ -67,14 +68,16 @@ and their default values.
 | admin.ingress.hosts            | List of ingress hosts.                                                           | `[]`                |
 | admin.ingress.path             | Ingress path.                                                                    | `/`                 |
 | admin.ingress.annotations      | Ingress annotations. See documentation for your ingress controller for details   | `{}`                |
-| proxy.http.enabled             | Enables http on the proxy                                                        | true               |
+| proxy.http.enabled             | Enables http on the proxy                                                        | true                |
 | proxy.http.servicePort         | Service port to use for http                                                     | 80                  |
 | proxy.http.containerPort       | Container port to use for http                                                   | 8000                |
 | proxy.http.nodePort            | Node port to use for http                                                        | 32080               |
+| proxy.http.hostPort            | Host port to use for http                                                        |                     |
 | proxy.tls.enabled              | Enables TLS on the proxy                                                         | true                |
 | proxy.tls.containerPort        | Container port to use for TLS                                                    | 8443                |
 | proxy.tls.servicePort          | Service port to use for TLS                                                      | 8443                |
 | proxy.tls.nodePort             | Node port to use for TLS                                                         | 32443               |
+| proxy.tls.hostPort             | Host port to use for TLS                                                         |                     |
 | proxy.type                     | k8s service type. Options: NodePort, ClusterIP, LoadBalancer                     | `NodePort`          |
 | proxy.loadBalancerSourceRanges | Limit proxy access to CIDRs if set and service type is `LoadBalancer`            | `[]`                |
 | proxy.loadBalancerIP           | To reuse an existing ingress static IP for the admin service                     |                     |

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -110,15 +110,24 @@ spec:
         ports:
         - name: admin
           containerPort: {{ .Values.admin.containerPort }}
+          {{- if .Values.admin.hostPort }}
+          hostPort: {{ .Values.admin.hostPort }}
+          {{- end}}
           protocol: TCP
         {{- if .Values.proxy.http.enabled }}
         - name: proxy
           containerPort: {{ .Values.proxy.http.containerPort }}
+          {{- if .Values.proxy.http.hostPort }}
+          hostPort: {{ .Values.proxy.http.hostPort }}
+          {{- end}}
           protocol: TCP
         {{- end }}
         {{- if .Values.proxy.tls.enabled }}
         - name: proxy-tls
           containerPort: {{ .Values.proxy.tls.containerPort }}
+          {{- if .Values.proxy.tls.hostPort }}
+          hostPort: {{ .Values.proxy.tls.hostPort }}
+          {{- end}}
           protocol: TCP
         {{- end }}
         readinessProbe:


### PR DESCRIPTION
Signed-off-by: Patrick Hütter <p.huetter@encircle360.com>

#### What this PR does / why we need it:
This adds hostPort feature to the stable/kong helm chart. With this setting it's possible to run kong as ingress controller on self-hosted kubernetes clusters for example on port 80 and 443 directly accessible from the hosts public IP. It helps also on k8s clusters where the service node port range starts after standard ports like port 80 for http or 443 for https.

#### Which issue this PR fixes
  - fixes #11299

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
