### PR TITLE
Support configuration of externalTrafficPolicy for services from type NodePort

### DIFF
--- a/stable/chartmuseum/Chart.yaml
+++ b/stable/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 1.9.0
+version: 1.9.1
 appVersion: 0.8.1
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/helm/chartmuseum/master/logo2.png

--- a/stable/chartmuseum/README.md
+++ b/stable/chartmuseum/README.md
@@ -131,6 +131,7 @@ their default values. See values.yaml for all available options.
 | `gcp.secret.key`                       | Secret key for te GCP json file             | `credentials.json`                                  |
 | `service.type`                         | Kubernetes Service type                     | `ClusterIP`                                          |
 | `service.clusterIP`                    | Static clusterIP or None for headless services| `nil`                                              |
+| `service.externalTrafficPolicy`        | Source IP preservation (only for Service type NodePort)  | `Local`                                         |
 | `service.servicename`                  | Custom name for service                     | ``                                                  |
 | `service.labels`                       | Additional labels for service               | `{}`                                                |
 | `deployment.labels`                    | Additional labels for deployment            | `{}`                                                |

--- a/stable/chartmuseum/templates/service.yaml
+++ b/stable/chartmuseum/templates/service.yaml
@@ -17,6 +17,9 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
   {{- if eq .Values.service.type "ClusterIP" }}
   {{- if .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP }}

--- a/stable/chartmuseum/values.yaml
+++ b/stable/chartmuseum/values.yaml
@@ -118,6 +118,7 @@ replica:
 service:
   servicename:
   type: ClusterIP
+  externalTrafficPolicy: Local
   # clusterIP: None
   externalPort: 8080
   nodePort:


### PR DESCRIPTION
@jdolitsky
@goruha


#### What this PR does / why we need it:

Adding externalTrafficPolicy to service definition to preserve the client source IP by default.

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md