### PR TITLE
[stable/fluent-bit] Parametrize flush interval and log level in the S…

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 1.6.0
+version: 1.6.1
 appVersion: 1.0.4
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 1.6.1
+version: 1.7.0
 appVersion: 1.0.4
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -87,6 +87,8 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `extraPorts`                       | List of extra ports                        |                       |
 | `extraVolumeMounts`                | Mount an extra volume, required to mount ssl certificates when elasticsearch has tls enabled |          |
 | `extraVolume`                      | Extra volume                               |                                                |
+| `service.flush`                    | Interval to flush output (seconds)        | `1`                   |
+| `service.logLevel`                 | Diagnostic level (error/warning/info/debug/trace)        | `info`                   |
 | `filter.enableExclude`                   | Enable the use of monitoring for a pod annotation of `fluentbit.io/exclude: true`. If present, discard logs from that pod.         | `true`                                 |
 | `filter.enableParser`                   | Enable the use of monitoring for a pod annotation of `fluentbit.io/parser: parser_name`. parser_name must be the name of a parser contained within parsers.conf         | `true`                                 |
 | `filter.kubeURL`                   | Optional custom configmaps                 | `https://kubernetes.default.svc:443`            |

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -11,9 +11,9 @@ metadata:
 data:
   fluent-bit-service.conf: |-
     [SERVICE]
-        Flush        1
+        Flush        {{ .Values.service.flush }} 
         Daemon       Off
-        Log_Level    info
+        Log_Level    {{ .Values.service.logLevel }}
         Parsers_File parsers.conf
 {{- if .Values.parsers.enabled }}
         Parsers_File parsers_custom.conf

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -178,6 +178,10 @@ tolerations: []
 nodeSelector: {}
 affinity: {}
 
+service:
+  flush: 1
+  logLevel: info
+
 input:
   tail:
     memBufLimit: 5MB


### PR DESCRIPTION
…ERVICE section

Signed-off-by: Marcin Kubrak <marcin.kubrak@gmail.com>

#### What this PR does / why we need it:

Flush interval and log level are hard coded in the config template. This PR allows for both values to be set in the values.yaml 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
