### PR TITLE
[stable:kube-state-metrics] update kube-state-metrics chart to support kube-state-metrics 1.5.0

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -5,8 +5,8 @@ keywords:
 - metric
 - monitoring
 - prometheus
-version: 0.13.1
-appVersion: 1.4.0
+version: 0.14.0
+appVersion: 1.5.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:
 - https://github.com/kubernetes/kube-state-metrics/

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -43,6 +43,7 @@ $ helm install stable/kube-state-metrics
 | `collectors.nodes`                    | Enable the nodes collector.                             | true                                        |
 | `collectors.persistentvolumeclaims`   | Enable the persistentvolumeclaims collector.            | true                                        |
 | `collectors.persistentvolumes`        | Enable the persistentvolumes collector.                 | true                                        |
+| `collectors.poddisruptionbudgets`     | Enable the poddisruptionbudgets collector.              | true
 | `collectors.pods`                     | Enable the pods collector.                              | true                                        |
 | `collectors.replicasets`              | Enable the replicasets collector.                       | true                                        |
 | `collectors.replicationcontrollers`   | Enable the replicationcontrollers collector.            | true                                        |

--- a/stable/kube-state-metrics/templates/clusterrole.yaml
+++ b/stable/kube-state-metrics/templates/clusterrole.yaml
@@ -74,13 +74,19 @@ rules:
   resources:
   - persistentvolumeclaims
   verbs: ["list", "watch"]
-{{ end }}
+{{ end -}}
 {{ if .Values.collectors.persistentvolumes }}
 - apiGroups: [""]
   resources:
   - persistentvolumes
   verbs: ["list", "watch"]
-{{ end }}
+{{ end -}}
+{{ if .Values.collectors.poddisruptionbudgets }}
+- apiGroups: ["policy"]
+  resources:
+    - poddisruptionbudgets
+  verbs: ["list", "watch"]
+{{ end -}}
 {{ if .Values.collectors.pods }}
 - apiGroups: [""]
   resources:

--- a/stable/kube-state-metrics/templates/deployment.yaml
+++ b/stable/kube-state-metrics/templates/deployment.yaml
@@ -67,6 +67,9 @@ spec:
 {{  if .Values.collectors.persistentvolumes  }}
         - --collectors=persistentvolumes
 {{  end  }}
+{{  if .Values.collectors.poddisruptionbudgets  }}
+        - --collectors=poddisruptionbudgets
+{{  end  }}
 {{  if .Values.collectors.pods  }}
         - --collectors=pods
 {{  end  }}

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -1,8 +1,8 @@
 # Default values for kube-state-metrics.
 prometheusScrape: true
 image:
-  repository: quay.io/coreos/kube-state-metrics
-  tag: v1.4.0
+  repository: k8s.gcr.io/kube-state-metrics
+  tag: v1.5.0
   pullPolicy: IfNotPresent
 service:
   port: 8080
@@ -66,6 +66,7 @@ collectors:
   nodes: true
   persistentvolumeclaims: true
   persistentvolumes: true
+  poddisruptionbudgets: true
   pods: true
   replicasets: true
   replicationcontrollers: true


### PR DESCRIPTION
Kube-state-metrics has a new release. Please check https://github.com/kubernetes/kube-state-metrics/tree/release-1.5