### PR TITLE
Replace Prestashop with Wordpress in README

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 5.2.1
+version: 5.2.2
 appVersion: 5.0.3
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -95,10 +95,10 @@ The following table lists the configurable parameters of the WordPress chart and
 | `ingress.enabled`                | Enable ingress controller resource         | `false`                                                 |
 | `ingress.certManager`            | Add annotations for cert-manager           | `false`                                                 |
 | `ingress.annotations`            | Ingress annotations                        | `[]`                                                    |
-| `ingress.hosts[0].name`          | Hostname to your PrestaShop installation   | `prestashop.local`                                      |
+| `ingress.hosts[0].name`          | Hostname to your Wordpress installation    | `wordpress.local`                                       |
 | `ingress.hosts[0].path`          | Path within the url structure              | `/`                                                     |
 | `ingress.hosts[0].tls`           | Utilize TLS backend in ingress             | `false`                                                 |
-| `ingress.hosts[0].tlsSecret`     | TLS Secret (certificates)                  | `prestashop.local-tls`                                  |
+| `ingress.hosts[0].tlsSecret`     | TLS Secret (certificates)                  | `wordpress.local-tls`                                   |
 | `ingress.secrets[0].name`        | TLS Secret Name                            | `nil`                                                   |
 | `ingress.secrets[0].certificate` | TLS Secret Certificate                     | `nil`                                                   |
 | `ingress.secrets[0].key`         | TLS Secret Key                             | `nil`                                                   |


### PR DESCRIPTION
#### What this PR does / why we need it:
The readme in the Wordpress charts contains references to Prestashop, this PR replaces them with Wordpress.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped