### PR TITLE
Update fluentd-kubernetes-sumologic to the latest (v2.3.0)

### DIFF
--- a/stable/sumologic-fluentd/Chart.yaml
+++ b/stable/sumologic-fluentd/Chart.yaml
@@ -1,6 +1,6 @@
 name: sumologic-fluentd
-version: 0.11.0
-appVersion: 2.1.0
+version: 0.12.0
+appVersion: 2.3.0
 description: Sumologic Log Collector
 keywords:
   - monitoring

--- a/stable/sumologic-fluentd/README.md
+++ b/stable/sumologic-fluentd/README.md
@@ -98,7 +98,7 @@ The following table lists the configurable parameters of the sumologic-fluentd c
 | `sumologic.proxyUri` | Add the uri of the proxy environment if present. | `Nil`
 | `sumologic.enableStatWatcher` | Option to control the enabling of [stat_watcher](https://docs.fluentd.org/v1.0/articles/in_tail#enable_stat_watcher). | `true`
 | `image.name` | The image repository and name to pull from | `sumologic/fluentd-kubernetes-sumologic` |
-| `image.tag` | The image tag to pull | `v2.1.0` |
+| `image.tag` | The image tag to pull | `v2.3.0` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `persistence.enabled` | Boolean value, used to turn on or off fluentd position file persistence, on nodes (requires Kubernetes >= 1.8) | `false` |
 | `persistence.hostPath` | The path, on each node, to a directory for fluentd pos files. You must create the directory on each node first or set `persistence.createPath` (requires Kubernetes >= 1.8) | `/var/run/fluentd-pos` |

--- a/stable/sumologic-fluentd/values.yaml
+++ b/stable/sumologic-fluentd/values.yaml
@@ -1,7 +1,7 @@
 # Default values for sumologic-fluentd.
 image:
   name: sumologic/fluentd-kubernetes-sumologic
-  tag: v2.1.0
+  tag: v2.3.0
   pullPolicy: IfNotPresent
 
 ## Annotations to add to the DaemonSet's Pods


### PR DESCRIPTION
#### What this PR does / why we need it:
Update `fluentd-kubernetes-sumologic` to the latest ([v2.3.0](https://github.com/SumoLogic/fluentd-kubernetes-sumologic/commit/e61bd629d1fdef745040cf4b6645f5d271569d97))

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped

FYI @bendrucker 