### PR TITLE
[incubator/fluentd-cloudwatch] Bumping image to latest stable version

### DIFF
--- a/incubator/fluentd-cloudwatch/Chart.yaml
+++ b/incubator/fluentd-cloudwatch/Chart.yaml
@@ -1,6 +1,6 @@
 name: fluentd-cloudwatch
-version: 0.7.1
-appVersion: v0.12.43-cloudwatch
+version: 0.8.0
+appVersion: v1.3.3-debian-cloudwatch-1.0
 description: A Fluentd CloudWatch Helm chart for Kubernetes.
 home: https://www.fluentd.org/
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png

--- a/incubator/fluentd-cloudwatch/README.md
+++ b/incubator/fluentd-cloudwatch/README.md
@@ -49,7 +49,7 @@ The following table lists the configurable parameters of the Fluentd Cloudwatch 
 | Parameter                          | Description                                                               | Default                               |
 | ---------------------------- | ------------------------------------------------------------------------- | --------------------------------------|
 | `image.repository`           | Image repository                                                          | `fluent/fluentd-kubernetes-daemonset` |
-| `image.tag`                  | Image tag                                                                 | `v0.12.43-cloudwatch`                 |
+| `image.tag`                  | Image tag                                                                 | `v1.3.3-debian-cloudwatch-1.0`        |
 | `image.pullPolicy`           | Image pull policy                                                         | `IfNotPresent`                        |
 | `resources.limits.cpu`       | CPU limit                                                                 | `100m`                                |
 | `resources.limits.memory`    | Memory limit                                                              | `200Mi`                               |
@@ -72,7 +72,7 @@ The following table lists the configurable parameters of the Fluentd Cloudwatch 
 | `nodeSelector`               | Node labels for pod assignment                                            | `{}`                                  |
 | `affinity`                   | Node affinity for pod assignment                                          | `{}`                                  |
 
-Starting with fluentd-kubernetes-daemonset v0.12.43-cloudwatch, the container runs as user fluentd. To be able to write pos files to the host system, you'll need to run fluentd as root. Add the following extraVars value to run as root.
+If using fluentd-kubernetes-daemonset v0.12.43-cloudwatch, the container runs as user fluentd. To be able to write pos files to the host system, you'll need to run fluentd as root. Add the following extraVars value to run as root.
 
 ```code
 "{ name: FLUENT_UID, value: '0' }"

--- a/incubator/fluentd-cloudwatch/values.yaml
+++ b/incubator/fluentd-cloudwatch/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: fluent/fluentd-kubernetes-daemonset
-  tag: v0.12.43-cloudwatch
+  tag: v1.3.3-debian-cloudwatch-1.0
 ## Specify an imagePullPolicy (Required)
 ## It's recommended to change this to 'Always' if the image tag is 'latest'
 ## ref: http://kubernetes.io/docs/user-guide/images/#updating-images


### PR DESCRIPTION
Signed-off-by: Robert James Hernandez <rob@sarcasticadmin.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

I was unable to successfully deploy this chart with the default image. It looks like its related to an outstanding issue with the image version `v0.12.43-cloudwatch`: https://github.com/fluent/fluentd-kubernetes-daemonset/issues/164

Running this chart with `helm` on `minikube` with the following configuration:

```
~ $ minikube version
minikube version
minikube version: v0.33.1

~ $ kubectl version
Client Version: version.Info{Major:"1", Minor:"13", GitVersion:"v1.13.2", GitCommit:"cff46ab41ff0bb44d8584413b598ad8360ec1def", GitTreeState:"clean", BuildDate:"2019-01-13T23:16:58Z", GoVersion:"go1.11.4", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"13", GitVersion:"v1.13.2", GitCommit:"cff46ab41ff0bb44d8584413b598ad8360ec1def", GitTreeState:"clean", BuildDate:"2019-01-10T23:28:14Z", GoVersion:"go1.11.4", Compiler:"gc", Platform:"linux/amd64"}

~ $ helm version
Client: &version.Version{SemVer:"v2.12.2", GitCommit:"7d2b0c73d734f6586ed222a567c5d103fed435be", GitTreeState:"clean"}
Server: &version.Version{SemVer:"v2.12.2", GitCommit:"7d2b0c73d734f6586ed222a567c5d103fed435be", GitTreeState:"clean"}
```

```
~$ helm install --name a-release \
                incubator/fluentd-cloudwatch \
		--set awsAccessKeyId=XXXXX \
		--set awsSecretAccessKey=XXXXX \
		--set logGroupName=mykubelogs \
		--set rbac.create=true
```

I was getting the following error in the container:

```
...
  enable_stat_watcher false
  format kubernetes
  multiline_flush_interval 5s
  path /var/log/glbc.log
  pos_file /var/log/fluentd-glbc.log.pos
  tag glbc
  format_firstline /^\w\d{4}/
  format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
  time_format %m%d %H:%M:%S.%N
</source> is not used.
2019-02-08 00:24:02 +0000 [warn]: parameter 'enable_stat_watcher' in <source>
  type tail
  enable_stat_watcher false
  format kubernetes
  multiline_flush_interval 5s
  path /var/log/cluster-autoscaler.log
  pos_file /var/log/fluentd-cluster-autoscaler.log.pos
  tag cluster-autoscaler
  format_firstline /^\w\d{4}/
  format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
  time_format %m%d %H:%M:%S.%N
</source> is not used.
2019-02-08 00:24:02 +0000 [error]: unexpected error error_class=Errno::EACCES error=#<Errno::EACCES: Permission denied @ rb_sysopen - /var/log/fluentd-containers.log.pos>
  2019-02-08 00:24:02 +0000 [error]: /fluentd/vendor/bundle/ruby/2.5.0/gems/fluentd-0.12.43/lib/fluent/plugin/in_tail.rb:145:in `initialize'
  2019-02-08 00:24:02 +0000 [error]: /fluentd/vendor/bundle/ruby/2.5.0/gems/fluentd-0.12.43/lib/fluent/plugin/in_tail.rb:145:in `open'
  2019-02-08 00:24:02 +0000 [error]: /fluentd/vendor/bundle/ruby/2.5.0/gems/fluentd-0.12.43/lib/fluent/plugin/in_tail.rb:145:in `start'
  2019-02-08 00:24:02 +0000 [error]: /fluentd/vendor/bundle/ruby/2.5.0/gems/fluentd-0.12.43/lib/fluent/root_agent.rb:115:in `block in start'
  2019-02-08 00:24:02 +0000 [error]: /fluentd/vendor/bundle/ruby/2.5.0/gems/fluentd-0.12.43/lib/fluent/root_agent.rb:114:in `each'
  2019-02-08 00:24:02 +0000 [error]: /fluentd/vendor/bundle/ruby/2.5.0/gems/fluentd-0.12.43/lib/fluent/root_agent.rb:114:in `start'
  2019-02-08 00:24:02 +0000 [error]: /fluentd/vendor/bundle/ruby/2.5.0/gems/fluentd-0.12.43/lib/fluent/engine.rb:237:in `start'
  2019-02-08 00:24:02 +0000 [error]: /fluentd/vendor/bundle/ruby/2.5.0/gems/fluentd-0.12.43/lib/fluent/engine.rb:187:in `run'
  2019-02-08 00:24:02 +0000 [error]: /fluentd/vendor/bundle/ruby/2.5.0/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:570:in `run_engine'
  2019-02-08 00:24:02 +0000 [error]: /fluentd/vendor/bundle/ruby/2.5.0/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:162:in `block in start'
  2019-02-08 00:24:02 +0000 [error]: /fluentd/vendor/bundle/ruby/2.5.0/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:366:in `main_process'
  2019-02-08 00:24:02 +0000 [error]: /fluentd/vendor/bundle/ruby/2.5.0/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:339:in `block in supervise'
  2019-02-08 00:24:02 +0000 [error]: /fluentd/vendor/bundle/ruby/2.5.0/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:338:in `fork'
  2019-02-08 00:24:02 +0000 [error]: /fluentd/vendor/bundle/ruby/2.5.0/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:338:in `supervise'
  2019-02-08 00:24:02 +0000 [error]: /fluentd/vendor/bundle/ruby/2.5.0/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:156:in `start'
  2019-02-08 00:24:02 +0000 [error]: /fluentd/vendor/bundle/ruby/2.5.0/gems/fluentd-0.12.43/lib/fluent/command/fluentd.rb:173:in `<top (required)>'
  2019-02-08 00:24:02 +0000 [error]: /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
  2019-02-08 00:24:02 +0000 [error]: /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
  2019-02-08 00:24:02 +0000 [error]: /fluentd/vendor/bundle/ruby/2.5.0/gems/fluentd-0.12.43/bin/fluentd:8:in `<top (required)>'
  2019-02-08 00:24:02 +0000 [error]: /fluentd/vendor/bundle/ruby/2.5.0/bin/fluentd:23:in `load'
  2019-02-08 00:24:02 +0000 [error]: /fluentd/vendor/bundle/ruby/2.5.0/bin/fluentd:23:in `<main>'
2019-02-08 00:24:02 +0000 [info]: shutting down fluentd
2019-02-08 00:24:02 +0000 [info]: shutting down filter type="kubernetes_metadata" plugin_id="object:2aebbc28d138"
2019-02-08 00:24:02 +0000 [info]: shutting down output type="null" plugin_id="object:2aebbc289c54"
2019-02-08 00:24:02 +0000 [info]: shutting down output type="cloudwatch_logs" plugin_id="object:2aebbc6e3278"
2019-02-08 00:24:02 +0000 [info]: process finished code=0
2019-02-08 00:24:02 +0000 [error]: fluentd main process died unexpectedly. restarting.
```

Updated the `appVersion` to the image recommended in the [fluentd-kubernetes-daemonset README.md](https://github.com/fluent/fluentd-kubernetes-daemonset#image-versions):

```
For production environments we strongly suggest to use Debian images.

Series | Description
-- | --
v1.x | stable
v0.12 | Old stable, no longer updated

```

I get the desired behavior:

```
...
2019-02-11 19:09:19 +0000 [info]: #0 starting fluentd worker pid=16 ppid=7 worker=0
2019-02-11 19:09:20 +0000 [info]: #0 following tail of /var/log/containers/hello-minikube-xxxxx-rkq25_default_hello-minikube-xxxx.log
...
2019-02-11 19:09:27 +0000 [info]: #0 fluentd worker is now running worker=0
2019-02-11 19:09:42 +0000 [info]: #0 stats - namespace_cache_size: 2, pod_cache_size: 18, namespace_cache_api_updates: 35, pod_cache_api_updates: 35, id_cache_miss: 35  
```

Additionally its no longer needed to set extraVars for setting `FLUENT_UID=0`

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - related to #11295 

#### Special notes for your reviewer:

For context the following pr was helpful for me:
  - https://github.com/fluent/fluentd-kubernetes-daemonset/pull/119

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
