### PR TITLE
Add redisHost variable, clear up postgresHost mysteries

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,6 +1,6 @@
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 0.16.0
+version: 0.17.0
 appVersion: 1.10.0
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -327,6 +327,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `postgresql.persistance.storageClass`    | Persistant class                                        | (undefined)               |
 | `postgresql.persistance.accessMode`      | Access mode                                             | `ReadWriteOnce`           |
 | `redis.enabled`                          | Create a Redis cluster                                  | `true`                    |
+| `redis.redisHost`                        | Redis Hostname                                          | (undefined)               |
 | `redis.password`                         | Redis password                                          | `airflow`                 |
 | `redis.master.persistence.enabled`       | Enable Redis PVC                                        | `false`                   |
 | `redis.cluster.enabled`                  | enable master-slave cluster                             | `false`                   |

--- a/stable/airflow/templates/_helpers.tpl
+++ b/stable/airflow/templates/_helpers.tpl
@@ -38,7 +38,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "airflow.postgresql.fullname" -}}
 {{- if .Values.postgresql.postgresHost }}
-    {{- printf "%s" .Values.postgresql.postgresHost -}}
+    {{- .Values.postgresql.postgresHost -}}
 {{- else }}
     {{- $name := default "postgresql" .Values.postgresql.nameOverride -}}
     {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
@@ -46,12 +46,16 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-Create a default fully qualified redis cluster name.
+Create a default fully qualified redis cluster name or use the `redisHost` value if defined
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "airflow.redis.fullname" -}}
-{{- $name := default "redis" .Values.redis.nameOverride -}}
-{{- printf "%s-%s-master" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.redis.redisHost }}
+    {{- .Values.redis.redisHost -}}
+{{- else }}
+  {{- $name := default "redis" .Values.redis.nameOverride -}}
+  {{- printf "%s-%s-master" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -379,11 +379,8 @@ postgresql:
   ## Set to false if bringing your own PostgreSQL.
   enabled: true
   ##
-  ## If bringing your own PostgreSQL, the full uri to use
-  ## e.g. postgres://airflow:changeme@my-postgres.com:5432/airflow?sslmode=disable
-  # uri:
-  ##
-  ## PostgreSQL hostname
+  ## If you are bringing your own PostgreSQL, you should set postgresHost and 
+  ## also probably service.port, postgresUser, postgresPassword, and postgresDatabase
   ## postgresHost:
   ##
   ## PostgreSQL port
@@ -421,7 +418,11 @@ redis:
   ## Set to false if bringing your own redis.
   enabled: true
   ##
+  ## If you are bringing your own redis, you can set the host in redisHost.
+  ## redisHost:
+  ##
   ## Redis password
+  ##
   password: airflow
   ##
   ## Master configuration

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -379,7 +379,7 @@ postgresql:
   ## Set to false if bringing your own PostgreSQL.
   enabled: true
   ##
-  ## If you are bringing your own PostgreSQL, you should set postgresHost and 
+  ## If you are bringing your own PostgreSQL, you should set postgresHost and
   ## also probably service.port, postgresUser, postgresPassword, and postgresDatabase
   ## postgresHost:
   ##


### PR DESCRIPTION
#### What this PR does / why we need it:

 * Removes postgresql.uri field that doesn't do anything
 * Clarified docs in a few places about the right place to configure
   postgresql
 * Added redisHost that works in the same way as postgresHost
 * Removed unnecessary extra printf's in the tempalte

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #11140

#### Special notes for your reviewer:

To clarify for any interested parties how this works for the Airflow chart:
 * `_helpers.tpl` has a template `airflow.redis.fullname` and `airflow.postgresql.fullname` that either takes the override or generates the expected default name
 * `configmap-airflow.yaml` is the main point of injection for all of Airflow
 * The containers use that as their template to inject a load of environment variables for Airflow to use (this layer of complexity is handy, this way the different pieces get the same config always)
 * Airflow pleasantly accepts the environment variables

@gsemet Here's another patch, since it's adding a feature I guess it's a major bump?

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
