### PR TITLE
[stable/jenkins] merge sidecard configs

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.31.0
+version: 0.32.0
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -74,7 +74,8 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Master.Ingress.Path`             | Ingress path                         | Not set                                                                         |
 | `Master.Ingress.TLS`              | Ingress TLS configuration            | `[]`                                                                         |
 | `Master.JCasC.ConfigScripts`      | List of Jenkins Config as Code scripts | False                                                                   |
-| `Master.Sidecar.configAutoReload` | Jenkins Config as Code auto-reload settings | False                                                                    |
+| `Master.Sidecars.configAutoReload` | Jenkins Config as Code auto-reload settings | False                                                                    |
+| `Master.Sidecars.others`          | Configures additional sidecar container(s) for Jenkins master | `{}`                                                           |
 | `Master.InitScripts`              | List of Jenkins init scripts         | Not set                                                                      |
 | `Master.CredentialsXmlSecret`     | Kubernetes secret that contains a 'credentials.xml' file | Not set                                                  |
 | `Master.SecretsFilesSecret`       | Kubernetes secret that contains 'secrets' files | Not set                                                           |
@@ -87,7 +88,6 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Master.Affinity`                 | Affinity settings                    | `{}`                                                                         |
 | `Master.Tolerations`              | Toleration labels for pod assignment | `{}`                                                                         |
 | `Master.PodAnnotations`           | Annotations for master pod           | `{}`                                                                         |
-| `Master.SidecarContainers`        | Configures sidecar container(s) for Jenkins master | `{}`                                                           |
 | `Master.CustomConfigMap`          | Deprecated: Use a custom ConfigMap               | `false`                                                                      |
 | `Master.AdditionalConfig`         | Deprecated: Add additional config files         | `{}`                                                                      |
 | `NetworkPolicy.Enabled`           | Enable creation of NetworkPolicy resources. | `false`                                                               |
@@ -241,7 +241,7 @@ ConfigScripts:
 
 Further JCasC examples can be found [here.](https://github.com/jenkinsci/configuration-as-code-plugin/tree/master/demos)
 ### Config as Code with and without auto-reload 
-Config as Code changes (to Master.JCasC.ConfigScripts) can either force a new pod to be created and only be applied at next startup, or can be auto-reloaded on-the-fly.  If you choose `Master.Sidecar.autoConfigReload.enabled: true`, a second, auxiliary container will be installed into the Jenkins master pod, known as a "sidecar".  This watches for changes to ConfigScripts, copies the content onto the Jenkins file-system and issues a CLI command via SSH to reload configuration.  The admin user (or account you specify in Master.AdminUser) will have a random SSH private key (RSA 4096) assigned unless you specify `Master.OwnSshKey: true`.  This will be saved to a k8s secret.  You can monitor this sidecar's logs using command `kubectl logs <master_pod> -c jenkins-sc-config -f`
+Config as Code changes (to Master.JCasC.ConfigScripts) can either force a new pod to be created and only be applied at next startup, or can be auto-reloaded on-the-fly.  If you choose `Master.Sidecars.autoConfigReload.enabled: true`, a second, auxiliary container will be installed into the Jenkins master pod, known as a "sidecar".  This watches for changes to ConfigScripts, copies the content onto the Jenkins file-system and issues a CLI command via SSH to reload configuration.  The admin user (or account you specify in Master.AdminUser) will have a random SSH private key (RSA 4096) assigned unless you specify `Master.OwnSshKey: true`.  This will be saved to a k8s secret.  You can monitor this sidecar's logs using command `kubectl logs <master_pod> -c jenkins-sc-config -f`
 
 ### Auto-reload with non-Jenkins identities
 When enabling LDAP or another non-Jenkins identity source, the built-in admin account will no longer exist.  Since the admin account is used by the sidecar to reload config, in order to use auto-reload, you must change the .Master.AdminUser to a valid username on your LDAP (or other) server.  If you use the matrix-auth plugin, this user must also be granted Overall\Administer rights in Jenkins.  Failure to do this will cause the sidecar container to fail to authenticate via SSH and enter a restart loop.  You can enable LDAP using the example above and add a Config as Code block for matrix security that includes:
@@ -254,7 +254,7 @@ ConfigScripts:
               grantedPermissions:
 			    - "Overall/Administer:<AdminUser_LDAP_username>"
 ```
-You can instead grant this permission via the UI.  When this is done, you can set `Master.Sidecar.configAutoReload.enabled: true` and upon the next Helm upgrade, auto-reload will be successfully enabled.
+You can instead grant this permission via the UI. When this is done, you can set `Master.Sidecars.configAutoReload.enabled: true` and upon the next Helm upgrade, auto-reload will be successfully enabled.
 
 ## RBAC
 

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -246,7 +246,7 @@ data:
 {{- if .Values.Master.ScriptApproval }}
     yes n | cp -i /var/jenkins_config/scriptapproval.xml /var/jenkins_home/scriptApproval.xml;
 {{- end }}
-{{- if and (.Values.Master.JCasC.enabled) (.Values.Master.Sidecar.configAutoReload.enabled) }}
+{{- if and (.Values.Master.JCasC.enabled) (.Values.Master.Sidecars.configAutoReload.enabled) }}
   {{- if not .Values.Master.InitScripts }}
     mkdir -p /var/jenkins_home/init.groovy.d/;
     yes n | cp -i /var/jenkins_config/*.groovy /var/jenkins_home/init.groovy.d/;
@@ -257,7 +257,7 @@ data:
     yes n | cp -i /var/jenkins_config/*.groovy /var/jenkins_home/init.groovy.d/;
 {{- end }}
 {{- if .Values.Master.JCasC.enabled }}
-  {{- if .Values.Master.Sidecar.configAutoReload.enabled }}
+  {{- if .Values.Master.Sidecars.configAutoReload.enabled }}
     bash -c 'ssh-keygen -y -f <(echo "${ADMIN_PRIVATE_KEY}") > /var/jenkins_home/key.pub'
   {{- else }}
     mkdir -p /var/jenkins_home/casc_configs;
@@ -282,7 +282,7 @@ data:
 {{ $val | indent 4 }}
 {{- end }}
 {{- if .Values.Master.JCasC.enabled }}
-  {{- if .Values.Master.Sidecar.configAutoReload.enabled }}
+  {{- if .Values.Master.Sidecars.configAutoReload.enabled }}
   init-add-ssh-key-to-admin.groovy: |-
     import jenkins.security.*
     import hudson.model.User
@@ -295,7 +295,7 @@ data:
     u.addProperty(keys_param)
     def inst = Jenkins.getInstance()
     def sshDesc = inst.getDescriptor("org.jenkinsci.main.modules.sshd.SSHD")
-    sshDesc.setPort({{ .Values.Master.Sidecar.configAutoReload.sshTcpPort | default 1044 }})
+    sshDesc.setPort({{ .Values.Master.Sidecars.configAutoReload.sshTcpPort | default 1044 }})
     sshDesc.getActualPort()
     sshDesc.save()
   {{- else }}

--- a/stable/jenkins/templates/jcasc_config.yaml
+++ b/stable/jenkins/templates/jcasc_config.yaml
@@ -1,5 +1,5 @@
 {{- $root := . }}
-{{- if and (.Values.Master.JCasC.enabled) (.Values.Master.Sidecar.configAutoReload.enabled) }}
+{{- if and (.Values.Master.JCasC.enabled) (.Values.Master.Sidecars.configAutoReload.enabled) }}
 {{- range $key, $val := .Values.Master.JCasC.ConfigScripts }}
 ---
 apiVersion: v1
@@ -7,7 +7,7 @@ kind: ConfigMap
 metadata:
   name: jenkins-config-{{ template "jenkins.fullname" $root }}-{{ $key }}
   labels:
-    {{ $.Values.Master.Sidecar.configAutoReload.label | default "jenkins_config" }}: "true"
+    {{ $.Values.Master.Sidecars.configAutoReload.label | default "jenkins_config" }}: "true"
     release: {{ $root.Release.Name }}
     chart: "{{ $root.Chart.Name }}-{{ $root.Chart.Version }}"
     component: "{{ $root.Release.Name }}-{{ $.Values.Master.Name }}"

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -78,7 +78,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "jenkins.fullname" . }}
                   key: jenkins-admin-user
-            {{- if or (.Values.Master.OwnSshKey) (.Values.Master.Sidecar.configAutoReload.enabled) }}
+            {{- if or (.Values.Master.OwnSshKey) (.Values.Master.Sidecars.configAutoReload.enabled) }}
             {{- if .Values.Master.JCasC.enabled }}
             - name: ADMIN_PRIVATE_KEY
               valueFrom:
@@ -130,21 +130,21 @@ spec:
               mountPath: /usr/share/jenkins/ref/secrets/
               name: secrets-dir
       containers:
-{{- if and (.Values.Master.JCasC.enabled) (.Values.Master.Sidecar.configAutoReload.enabled) }}
+{{- if and (.Values.Master.JCasC.enabled) (.Values.Master.Sidecars.configAutoReload.enabled) }}
         - name: {{ template "jenkins.name" . }}-sc-config
-          image: "{{ .Values.Master.Sidecar.image }}"
-          imagePullPolicy: {{ .Values.Master.Sidecar.imagePullPolicy }}
+          image: "{{ .Values.Master.Sidecars.configAutoReload.image }}"
+          imagePullPolicy: {{ .Values.Master.Sidecars.configAutoReload.imagePullPolicy }}
           env:
             - name: JENKINSRELOADCONFIG
               value: "true"
             - name: LABEL
-              value: "{{ .Values.Master.Sidecar.configAutoReload.label }}"
+              value: "{{ .Values.Master.Sidecars.configAutoReload.label }}"
             - name: FOLDER
-              value: "{{ .Values.Master.Sidecar.configAutoReload.folder }}"
+              value: "{{ .Values.Master.Sidecars.configAutoReload.folder }}"
             - name: NAMESPACE
-              value: "{{ .Values.Master.Sidecar.configAutoReload.searchNamespace }}"
+              value: "{{ .Values.Master.Sidecars.configAutoReload.searchNamespace }}"
             - name: SSH_PORT
-              value: "{{ .Values.Master.Sidecar.configAutoReload.sshTcpPort }}"
+              value: "{{ .Values.Master.Sidecars.configAutoReload.sshTcpPort }}"
             - name: JENKINS_PORT
               value: "{{ .Values.Master.ServicePort }}"
             {{- if .Values.Master.UseSecurity }}
@@ -153,7 +153,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "jenkins.fullname" . }}
                   key: jenkins-admin-user
-            {{- if or (.Values.Master.OwnSshKey) (.Values.Master.Sidecar.configAutoReload.enabled) }}
+            {{- if or (.Values.Master.OwnSshKey) (.Values.Master.Sidecars.configAutoReload.enabled) }}
             {{- if .Values.Master.JCasC.enabled }}
             - name: ADMIN_PRIVATE_KEY
               valueFrom:
@@ -164,10 +164,10 @@ spec:
             {{- end }}
             {{- end }}
           resources:
-{{ toYaml .Values.Master.Sidecar.resources | indent 12 }}
+{{ toYaml .Values.Master.Sidecars.configAutoReload.resources | indent 12 }}
           volumeMounts:
             - name: sc-config-volume
-              mountPath: {{ .Values.Master.Sidecar.configAutoReload.folder | quote }}
+              mountPath: {{ .Values.Master.Sidecars.configAutoReload.folder | quote }}
             - name: jenkins-home
               mountPath: /var/jenkins_home
               {{- if .Values.Persistence.SubPath }}
@@ -196,7 +196,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "jenkins.fullname" . }}
                   key: jenkins-admin-user
-            {{- if or (.Values.Master.OwnSshKey) (.Values.Master.Sidecar.configAutoReload.enabled) }}
+            {{- if or (.Values.Master.OwnSshKey) (.Values.Master.Sidecars.configAutoReload.enabled) }}
             {{- if .Values.Master.JCasC.enabled }}
             - name: ADMIN_PRIVATE_KEY
               valueFrom:
@@ -211,7 +211,7 @@ spec:
             {{- end }}
             {{- if .Values.Master.JCasC.enabled }}
             - name: CASC_JENKINS_CONFIG
-              value: {{ .Values.Master.Sidecar.configAutoReload.folder | default "/var/jenkins_home/casc_configs" | quote }}
+              value: {{ .Values.Master.Sidecars.configAutoReload.folder | default "/var/jenkins_home/casc_configs" | quote }}
             {{- end }}
           ports:
             - containerPort: 8080
@@ -295,12 +295,12 @@ spec:
               mountPath: /usr/share/jenkins/ref/secrets/
               name: secrets-dir
               readOnly: false
-{{- if .Values.Master.SidecarContainers}}
-{{ tpl (toYaml .Values.Master.SidecarContainers | indent 8) .}}
+{{- if .Values.Master.Sidecars.other}}
+{{ tpl (toYaml .Values.Master.Sidecars.other | indent 8) .}}
 {{- end }}
-            {{- if and (.Values.Master.JCasC.enabled) (.Values.Master.Sidecar.configAutoReload.enabled) }}
+            {{- if and (.Values.Master.JCasC.enabled) (.Values.Master.Sidecars.configAutoReload.enabled) }}
             - name: sc-config-volume
-              mountPath: {{ .Values.Master.Sidecar.configAutoReload.folder | default "/var/jenkins_home/casc_configs" | quote }}
+              mountPath: {{ .Values.Master.Sidecars.configAutoReload.folder | default "/var/jenkins_home/casc_configs" | quote }}
             {{- end }}
       volumes:
 {{- if .Values.Persistence.volumes }}

--- a/stable/jenkins/templates/secret.yaml
+++ b/stable/jenkins/templates/secret.yaml
@@ -15,7 +15,7 @@ data:
   {{ else }}
   jenkins-admin-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{ end }}
-  {{ if and (.Values.Master.JCasC.enabled) (.Values.Master.Sidecar.configAutoReload.enabled) }}
+  {{ if and (.Values.Master.JCasC.enabled) (.Values.Master.Sidecars.configAutoReload.enabled) }}
   {{ if not .Values.Master.OwnSshKey }}
   {{ ( include "jenkins.gen-key" . ) }}
   {{ end }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -178,22 +178,22 @@ Master:
         jenkins:
           systemMessage: Welcome to our CI\CD server.  This Jenkins is configured and managed 'as code'.
 
-  Sidecar:
-    image: shadwell/k8s-sidecar:0.0.2
-    imagePullPolicy: IfNotPresent
-    resources:
-    #   limits:
-    #     cpu: 100m
-    #     memory: 100Mi
-    #   requests:
-    #     cpu: 50m
-    #     memory: 50Mi
+  Sidecars:
     configAutoReload:
       # If enabled: true, Jenkins Configuration as Code will be reloaded on-the-fly without a reboot.  If false or not-specified,
       # jcasc changes will cause a reboot and will only be applied at the subsequent start-up.  Auto-reload uses the Jenkins CLI
       # over SSH to reapply config when changes to the ConfigScripts are detected.  The admin user (or account you specify in
       # Master.AdminUser) will have a random SSH private key (RSA 4096) assigned unless you specify OwnSshKey: true.  This will be saved to a k8s secret.
       enabled: false
+      image: shadwell/k8s-sidecar:0.0.2
+      imagePullPolicy: IfNotPresent
+      resources:
+        #   limits:
+        #     cpu: 100m
+        #     memory: 100Mi
+        #   requests:
+        #     cpu: 50m
+        #     memory: 50Mi
       # SSH port value can be set to any unused TCP port.  The default, 1044, is a non-standard SSH port that has been chosen at random.
       # Is only used to reload jcasc config from the sidecar container running in the Jenkins master pod.
       # This TCP port will not be open in the pod (unless you specifically configure this), so Jenkins will not be
@@ -209,6 +209,23 @@ Master:
       # It's also possible to specify ALL to search in all namespaces:
       # searchNamespace:
 
+    # Allows you to inject additional/other sidecars
+    other:
+    ## The example below runs the client for https://smee.io as sidecar container next to Jenkins,
+    ## that allows to trigger build behind a secure firewall.
+    ## https://jenkins.io/blog/2019/01/07/webhook-firewalls/#triggering-builds-with-webhooks-behind-a-secure-firewall
+    ##
+    ## Note: To use it you should go to https://smee.io/new and update the url to the generete one.
+    # - name: smee
+    #   image: docker.io/twalter/smee-client:1.0.2
+    #   args: ["--port", "{{ .Values.Master.ServicePort }}", "--path", "/github-webhook/", "--url", "https://smee.io/new"]
+    #   resources:
+    #     limits:
+    #       cpu: 50m
+    #       memory: 128Mi
+    #     requests:
+    #       cpu: 10m
+    #       memory: 32Mi
   # Node labels and tolerations for pod assignment
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
@@ -236,23 +253,6 @@ Master:
     #   hosts:
     #     - jenkins.cluster.local
   AdditionalConfig: {}
-
-  SidecarContainers:
-  ## The example below runs the client for https://smee.io as sidecar container next to Jenkins,
-  ## that allows to trigger build behind a secure firewall.
-  ## https://jenkins.io/blog/2019/01/07/webhook-firewalls/#triggering-builds-with-webhooks-behind-a-secure-firewall
-  ##
-  ## Note: To use it you should go to https://smee.io/new and update the url to the generete one.
-  # - name: smee
-  #  image: docker.io/twalter/smee-client:1.0.2
-  #  args: ["--port", "{{ .Values.Master.ServicePort }}", "--path", "/github-webhook/", "--url", "https://smee.io/new"]
-  #  resources:
-  #    limits:
-  #      cpu: 50m
-  #      memory: 128Mi
-  #    requests:
-  #      cpu: 10m
-  #      memory: 32Mi
 
 Agent:
   Enabled: true


### PR DESCRIPTION
- renamed Sidecar to Sidecars
- moved image, pullPolicy and resources below configAutoReload
- renamed SidecarContainers to Master.Sidecars.other
- increased chart version

Signed-off-by: Torsten Walter <mail@torstenwalter.de>

#### What this PR does / why we need it:
It consolidates the sidecar configurations for Jenkins.

#### Which issue this PR fixes
* fixes #11284

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
