### PR TITLE
Cutting version 1.0.0 release for kuberhealthy

### DIFF
--- a/stable/kuberhealthy/Chart.yaml
+++ b/stable/kuberhealthy/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
-appVersion: "0.1.1"
+appVersion: "1.0.0"
 home: https://comcast.github.io/kuberhealthy/
 description: The official Helm chart for Kuberhealthy.
 name: kuberhealthy
-version: 0.1.2
+version: 1.0.0
 maintainers:
   - name: integrii
     email: eric.greer@comcast.com

--- a/stable/kuberhealthy/README.md
+++ b/stable/kuberhealthy/README.md
@@ -37,7 +37,7 @@ app:
   name: "kuberhealthy" # what to name the kuberhealthy deployment
 image:
   repository: quay.io/comcast/kuberhealthy
-  tag: 0.1.1
+  tag: 1.0.0
 resources:
   requests:
     cpu: 100m

--- a/stable/kuberhealthy/values.yaml
+++ b/stable/kuberhealthy/values.yaml
@@ -11,7 +11,7 @@ prometheus:
 
 image:
   repository: quay.io/comcast/kuberhealthy
-  tag: 0.1.1
+  tag: 1.0.0
 
 resources:
   requests:


### PR DESCRIPTION
#### What this PR does / why we need it:
Kuberhealthy 1.0.0 was released, revving chart and tag versions
