### PR TITLE
[stable/mattermost] using team edition's push server

### DIFF
--- a/stable/mattermost-team-edition/Chart.yaml
+++ b/stable/mattermost-team-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Team Edition server.
 name: mattermost-team-edition
-version: 2.3.0
+version: 2.2.2
 appVersion: 5.7.1
 keywords:
 - mattermost

--- a/stable/mattermost-team-edition/Chart.yaml
+++ b/stable/mattermost-team-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Team Edition server.
 name: mattermost-team-edition
-version: 2.2.1
+version: 2.3.0
 appVersion: 5.7.1
 keywords:
 - mattermost

--- a/stable/mattermost-team-edition/templates/config.tpl
+++ b/stable/mattermost-team-edition/templates/config.tpl
@@ -155,7 +155,7 @@
         "ConnectionSecurity": {{ .Values.config.smtpConnection | default "" | quote }},
         "InviteSalt": "{{ randAlphaNum 32 }}",
         "SendPushNotifications": true,
-        "PushNotificationServer": "https://push.mattermost.com",
+        "PushNotificationServer": "https://push-test.mattermost.com",
         "PushNotificationContents": "generic",
         "EnableEmailBatching": false,
         "EmailBatchingBufferSize": 256,


### PR DESCRIPTION
#### What this PR does / why we need it: We have to use team edition's push notification server instead of enterprise edition's server

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md (no variables added)
