### PR TITLE
[stable/ambassador] Allow rbac to be namespaced

### DIFF
--- a/stable/ambassador/Chart.yaml
+++ b/stable/ambassador/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.50.1
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 1.0.0
+version: 1.1.0
 home: https://www.getambassador.io/
 sources:
   - https://github.com/datawire/ambassador

--- a/stable/ambassador/README.md
+++ b/stable/ambassador/README.md
@@ -62,6 +62,8 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `prometheusExporter.repository`    | Prometheus exporter image                                                       | `prom/statsd-exporter`        |
 | `prometheusExporter.tag`           | Prometheus exporter image                                                       | `v0.8.1`                      |
 | `rbac.create`                      | If `true`, create and use RBAC resources                                        | `true`                        |
+| `rbac.namespaced`                  | If `true`, permissions are namespace-scoped rather than cluster-scoped        | `false`                       |
+
 | `replicaCount`                     | Number of Ambassador replicas                                                   | `1`                           |
 | `resources`                        | CPU/memory resource requests/limits                                             | `{}`                          |
 | `securityContext`             | Set security context for pod                        | `{ "runAsUser": "8888" }`                        |

--- a/stable/ambassador/templates/rbac.yaml
+++ b/stable/ambassador/templates/rbac.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- if .Values.rbac.namespaced }}
+kind: Role
+{{- else }}
 kind: ClusterRole
+{{- end }}
 metadata:
   name: {{ include "ambassador.fullname" . }}
   labels:
@@ -21,7 +25,11 @@ rules:
     verbs: ["create", "update", "patch", "get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- if .Values.rbac.namespaced }}
+kind: RoleBinding
+{{- else }}
 kind: ClusterRoleBinding
+{{- end }}
 metadata:
   name: {{ include "ambassador.fullname" . }}
   labels:
@@ -31,7 +39,11 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
+  {{- if .Values.rbac.namespaced }}
+  kind: Role
+  {{- else }}
   kind: ClusterRole
+  {{- end }}
   name: {{ include "ambassador.fullname" . }}
 subjects:
   - name: {{ include "ambassador.serviceAccountName" . }}

--- a/stable/ambassador/values.yaml
+++ b/stable/ambassador/values.yaml
@@ -82,6 +82,7 @@ adminService:
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
+  namespaced: false
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION

#### What this PR does / why we need it:
[Seldon Core](https://github.com/SeldonIO/seldon-core) would like to instead of deploy ambassador within it's helm chart, use the stable repo's ambassador chart as a dependency. One missing feature is the ability to allow rbac to be namespace-scoped rather than cluster-scoped.

This PR allows the end user to configure rbac to be namespace scoped if they so desire.

#### Which issue this PR fixes

Please see:
https://github.com/SeldonIO/seldon-core/pull/445

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
