### PR TITLE
[stable/prometheus] Change AlertManager reload URL from localhost to 127.0.0.1

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 8.7.0
+version: 8.7.1
 appVersion: 2.7.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/alertmanager-deployment.yaml
+++ b/stable/prometheus/templates/alertmanager-deployment.yaml
@@ -81,7 +81,7 @@ spec:
           imagePullPolicy: "{{ .Values.configmapReload.image.pullPolicy }}"
           args:
             - --volume-dir=/etc/config
-            - --webhook-url=http://localhost:9093{{ .Values.alertmanager.prefixURL }}/-/reload
+            - --webhook-url=http://127.0.0.1:9093{{ .Values.alertmanager.prefixURL }}/-/reload
           resources:
 {{ toYaml .Values.configmapReload.resources | indent 12 }}
           volumeMounts:


### PR DESCRIPTION
#### What this PR does / why we need it:
Similar to https://github.com/helm/charts/pull/6788, but for AlertManager instead of Prometheus server.

Currently the AlertManager configmap reloader uses 'localhost' as host for the webhook URL. In some situations this might not resolve to the correct IP address. In our use-case it resolves to ::1, which is not reachable within our on-premise cluster. This PR will use 127.0.0.1 instead of localhost, just like was done for the Prometheus server configmap reloader.

#### Which issue this PR fixes

#### Special notes for your reviewer:
@mgoodness @gianrubio 

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped