### PR TITLE
CoreDNS - Allow exposing the metrics port vie the deployed service

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,5 +1,5 @@
 name: coredns
-version: 1.2.4
+version: 1.2.5
 appVersion: 1.3.1
 description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services
 keywords:

--- a/stable/coredns/templates/service.yaml
+++ b/stable/coredns/templates/service.yaml
@@ -25,5 +25,8 @@ spec:
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
   ports:
+{{- if eq ( index .Values.service.annotations "prometheus.io/scrape" ) "true" }}
+  - {"port": {{( int64 ( index .Values.service.annotations "prometheus.io/port" ))}}, "protocol": "TCP", "name": "metrics", "targetPort": 9153}
+{{- end }}
 {{ include "coredns.servicePorts" . | indent 2 -}}
   type: {{ default "ClusterIP" .Values.serviceType }}

--- a/stable/coredns/templates/service.yaml
+++ b/stable/coredns/templates/service.yaml
@@ -25,8 +25,8 @@ spec:
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
   ports:
-{{- if eq ( index .Values.service.annotations "prometheus.io/scrape" ) "true" }}
-  - {"port": {{( int64 ( index .Values.service.annotations "prometheus.io/port" ))}}, "protocol": "TCP", "name": "metrics", "targetPort": 9153}
+{{- if eq .Values.service.metrics.enabled true }}
+  - {port: {{ .Values.service.metrics.port }}, protocol: TCP, name: {{ .Values.service.metrics.name }}, targetPort: {{ .Values.service.metrics.port }}}
 {{- end }}
 {{ include "coredns.servicePorts" . | indent 2 -}}
   type: {{ default "ClusterIP" .Values.serviceType }}

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -21,6 +21,10 @@ serviceType: "ClusterIP"
 
 service:
 # clusterIP: ""
+  metrics:
+    enabled: true
+    port: 9153
+    name: metrics
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9153"

--- a/stable/kuberhealthy/Chart.yaml
+++ b/stable/kuberhealthy/Chart.yaml
@@ -3,12 +3,14 @@ appVersion: "1.0.0"
 home: https://comcast.github.io/kuberhealthy/
 description: The official Helm chart for Kuberhealthy.
 name: kuberhealthy
-version: 1.0.0
+version: 1.0.1
 maintainers:
   - name: integrii
     email: eric.greer@comcast.com
   - name: lolimjake
     email: jacob.martin@comcast.com
+  - name: ihoegen
+    email: ianhoegen@gmail.com
 keywords:
 - kuberhealthy
 - kubernetes

--- a/stable/kuberhealthy/OWNERS
+++ b/stable/kuberhealthy/OWNERS
@@ -1,6 +1,8 @@
 approvers:
 - integrii
 - lolimjake
+- ihoegen
 reviewers:
 - integrii
 - lolimjake
+- ihoegen

--- a/stable/kuberhealthy/README.md
+++ b/stable/kuberhealthy/README.md
@@ -31,7 +31,7 @@ prometheus:
   enabled: true # do we deploy a ServiceMonitor spec?
   name: "prometheus" # the name of the Prometheus deployment in your environment.
   enableScraping: true # add the Prometheus scrape annotation to Kuberhealthy pods
-  serviceMonitor: true # use a ServiceMonitor configuration
+  serviceMonitor: false # use a ServiceMonitor configuration, for if using Prometheus Operator
   enableAlerting: true # enable default Kuberhealthy alerts configuration
 app:
   name: "kuberhealthy" # what to name the kuberhealthy deployment

--- a/stable/kuberhealthy/values.yaml
+++ b/stable/kuberhealthy/values.yaml
@@ -6,7 +6,7 @@ prometheus:
   enabled: false
   name: "prometheus"
   enableScraping: true
-  serviceMonitor: true
+  serviceMonitor: false
   enableAlerting: true
 
 image:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Special notes for your reviewer:
To me, it looks like the service was no longer able to expose the metrics port (9153, by default) after this PR
https://github.com/helm/charts/pull/6073
I could be mistaken though. If this is somehow possible with the current version of the chart, I'd love to know how.
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped