### PR TITLE
[stable/sumologic-fluentd] treat secret as normal resource instead of hook

### DIFF
--- a/stable/sumologic-fluentd/Chart.yaml
+++ b/stable/sumologic-fluentd/Chart.yaml
@@ -1,5 +1,5 @@
 name: sumologic-fluentd
-version: 0.12.0
+version: 0.12.1
 appVersion: 2.3.0
 description: Sumologic Log Collector
 keywords:

--- a/stable/sumologic-fluentd/templates/secrets.yaml
+++ b/stable/sumologic-fluentd/templates/secrets.yaml
@@ -8,9 +8,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 type: Opaque
 data:
   collector-url: {{ default "MISSING" .Values.sumologic.collectorUrl | b64enc | quote }}


### PR DESCRIPTION
@flah00 @frankreno @darend @bendrucker

#### What this PR does / why we need it:

This change removes the hooks annotation from the secret:
```yaml
  annotations:
    "helm.sh/hook": pre-install,pre-upgrade
    "helm.sh/hook-delete-policy": "before-hook-creation"
```

Removing this makes the chart more deployable outside of Helm/Tiller, since some deploy tools (such as ours) does not handle helm hooks well.

Not sure the rational for making this a resource hook, but I see that it has been like this from the first commit. My guess is that Helm may not have sorted resources by their correct ordering at the time.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
