### PR TITLE
[stable/atlantis] fix naming for secret ref

### DIFF
--- a/stable/atlantis/Chart.yaml
+++ b/stable/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.4.11"
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 1.1.4
+version: 1.1.5
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/stable/atlantis/templates/statefulset.yaml
+++ b/stable/atlantis/templates/statefulset.yaml
@@ -121,7 +121,7 @@ spec:
           - name: ATLANTIS_GITLAB_TOKEN
             valueFrom:
               secretKeyRef:
-                name: {{ template "atlantis.name" . }}-webhook
+                name: {{ template "atlantis.fullname" . }}-webhook
                 key: gitlab_token
           - name: ATLANTIS_GITLAB_WEBHOOK_SECRET
             valueFrom:


### PR DESCRIPTION
the secret will be named according to the `.fullName`. Currently the pod cant start with the error "secrets-webhook" not found. It must be "my-full-atlantis-name-webhook"

#### What this PR does / why we need it:
Fixing include of gitlab token from `-webhook` secret

#### Which issue this PR fixes
- no known issue created for this

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
