### PR TITLE
[stable/sonarqube] bump version to 7.6

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 0.13.4
-appVersion: 7.4
+version: 0.13.5
+appVersion: 7.6
 keywords:
   - coverage
   - security

--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -40,7 +40,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | Parameter                                   | Description                               | Default                                    |
 | ------------------------------------------  | ----------------------------------------  | -------------------------------------------|
 | `image.repository`                          | image repository                          | `sonarqube`                                |
-| `image.tag`                                 | `sonarqube` image tag.                    | 6.5                                        |
+| `image.tag`                                 | `sonarqube` image tag.                    | `7.6-community`                                        |
 | `image.pullPolicy`                          | Image pull policy                         | `IfNotPresent`                             |
 | `image.pullSecret`                          | imagePullSecret to use for private repository      |                                   |
 | `command`                                   | command to run in the container           | `nil` (need to be set prior to 6.7.6, and 7.4)      |

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: sonarqube
-  tag: 7.4-community
+  tag: 7.6-community
   # If using a private repository, the name of the imagePullSecret to use
   # pullSecret: my-repo-secret
 


### PR DESCRIPTION
Bump version from 7.4 to 7.6.

#### What this PR does / why we need it:

Updates the default image version and appVersion to 7.6.

#### Special notes for your reviewer:
Test was done on AKS.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
