### PR TITLE
add servicemonitor creation on demand

### DIFF
--- a/stable/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/stable/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.4.0
+version: 0.4.1
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -75,7 +75,8 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | `livenessProbe`             | Liveness probe settings                                |                            |
 | `readinessProbe`            | Readiness probe settings                               |                            |
 | `serviceMonitor.enable`     | If enabled chart will create servicemonitor resource   | `false`                    |
-| `serviceMonitor.scrapeInterval` | period of scraping metrics from cloudwatch exporter| `60s`                      |
+| `serviceMonitor.scrapeInterval` | Period of scraping metrics from cloudwatch exporter| `60s`                      |
+| `serviceMonitor.scrapeTimeout` | Timeout for scraping metrics from cloudwatch exporter| `59s`                      |
 | `serviceMonitor.namespace` | Namespace in which serviceonitor resource will be created | `monitoring`             |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -73,6 +73,8 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | `affinity`                  | node/pod affinities                                    | `{}`                       |
 | `livenessProbe`             | Liveness probe settings                                |                            |
 | `readinessProbe`            | Readiness probe settings                               |                            |
+| `serviceMonitor.enable`     | If enabled cahrt will create servicemonitor resource   | `false`                    |
+| `serviceMonitor.scrapeInterval` | period of scraping metrics from cloudwatch exporter| `60`                       |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -73,7 +73,7 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | `affinity`                  | node/pod affinities                                    | `{}`                       |
 | `livenessProbe`             | Liveness probe settings                                |                            |
 | `readinessProbe`            | Readiness probe settings                               |                            |
-| `serviceMonitor.enable`     | If enabled cahrt will create servicemonitor resource   | `false`                    |
+| `serviceMonitor.enable`     | If enabled chart will create servicemonitor resource   | `false`                    |
 | `serviceMonitor.scrapeInterval` | period of scraping metrics from cloudwatch exporter| `60`                       |
 | `serviceMonitor.namespace` | Namespace in which serviceonitor resource will be created | `monitoring` |
 

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -74,8 +74,8 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | `livenessProbe`             | Liveness probe settings                                |                            |
 | `readinessProbe`            | Readiness probe settings                               |                            |
 | `serviceMonitor.enable`     | If enabled chart will create servicemonitor resource   | `false`                    |
-| `serviceMonitor.scrapeInterval` | period of scraping metrics from cloudwatch exporter| `60`                       |
-| `serviceMonitor.namespace` | Namespace in which serviceonitor resource will be created | `monitoring` |
+| `serviceMonitor.scrapeInterval` | period of scraping metrics from cloudwatch exporter| `60s`                      |
+| `serviceMonitor.namespace` | Namespace in which serviceonitor resource will be created | `monitoring`             |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -75,6 +75,7 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | `readinessProbe`            | Readiness probe settings                               |                            |
 | `serviceMonitor.enable`     | If enabled cahrt will create servicemonitor resource   | `false`                    |
 | `serviceMonitor.scrapeInterval` | period of scraping metrics from cloudwatch exporter| `60`                       |
+| `serviceMonitor.namespace` | Namespace in which serviceonitor resource will be created | `monitoring` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -54,7 +54,8 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | `image.tag`                 | Image tag                                              | `cloudwatch_exporter-0.5.0`                   |
 | `image.pullPolicy`          | Image pull policy                                      | `IfNotPresent`             |
 | `service.type`              | Service type                                           | `ClusterIP`                |
-| `service.port`              | The service port                                       | `80`                       |
+| `service.port`              | The service port                                       | `9106`                     |
+| `service.targetPort`        | The service target port                                | `9106`                     |
 | `service.portName`          | The name of the service port                           | `http`                     |
 | `service.annotations`       | Custom annotations for service                         | `{}`                       |
 | `service.labels`            | Additional custom labels for the service               | `{}`                       |

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -75,8 +75,8 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | `livenessProbe`             | Liveness probe settings                                |                            |
 | `readinessProbe`            | Readiness probe settings                               |                            |
 | `serviceMonitor.enable`     | If enabled chart will create servicemonitor resource   | `false`                    |
-| `serviceMonitor.scrapeInterval` | Period of scraping metrics from cloudwatch exporter| `60s`                      |
-| `serviceMonitor.scrapeTimeout` | Timeout for scraping metrics from cloudwatch exporter| `59s`                      |
+| `serviceMonitor.scrapeInterval` | Period of scraping metrics from cloudwatch exporter| `prometheus defaults`                      |
+| `serviceMonitor.scrapeTimeout` | Timeout for scraping metrics from cloudwatch exporter| `prometheus defaults`                      |
 | `serviceMonitor.namespace` | Namespace in which serviceonitor resource will be created | `monitoring`             |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
@@ -16,6 +16,7 @@ spec:
   endpoints:
   - port: {{ .Values.service.portName }}
     interval: {{ .Values.serviceMonitor.scrapeInterval }}
+    timeout: {{ .Values.serviceMonitor.scrapeTimeout }}
   selector:
     matchLabels:
       release: {{ .Release.Name }}

--- a/stable/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
@@ -16,7 +16,7 @@ spec:
   endpoints:
   - port: {{ .Values.service.portName }}
     interval: {{ .Values.serviceMonitor.scrapeInterval }}
-    timeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
   selector:
     matchLabels:
       release: {{ .Release.Name }}

--- a/stable/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "releaseName" . }}
-  namespace: {{ .Values.monitoring.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
   labels:
     app: {{ template "prometheus-cloudwatch-exporter.name" . }}
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}

--- a/stable/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.serviceMonitor.enable }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "releaseName" . }}
+  namespace: {{ .Values.monitoring.namespace }}
+  labels:
+    app: {{ template "prometheus-cloudwatch-exporter.name" . }}
+    chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    k8s-app: {{ template "prometheus-cloudwatch-exporter.name" . }}
+spec:
+  jobLabel: app
+  endpoints:
+  - port: {{ .Values.service.portName }}
+    interval: {{ .Values.serviceMonitor.scrapeInterval }}
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      app: {{ template "prometheus-cloudwatch-exporter.name" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+{{- end }}

--- a/stable/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "releaseName" . }}
+  name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
   namespace: {{ .Values.serviceMonitor.namespace }}
   labels:
     app: {{ template "prometheus-cloudwatch-exporter.name" . }}
@@ -15,8 +15,12 @@ spec:
   jobLabel: app
   endpoints:
   - port: {{ .Values.service.portName }}
+{{- if .Values.serviceMonitor.scrapeInterval }}
     interval: {{ .Values.serviceMonitor.scrapeInterval }}
+{{- end }}
+{{- if .Values.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+{{- end }}
   selector:
     matchLabels:
       release: {{ .Release.Name }}

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -11,7 +11,8 @@ image:
 
 service:
   type: ClusterIP
-  port: 80
+  port: 9106
+  targetPort: 9106
   portName: http
   annotations: {}
   labels: {}

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -110,3 +110,4 @@ readinessProbe:
 serviceMonitor:
   enable: false
   scrapeInterval: 60
+  prometheusNamespace: monitoring

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -106,3 +106,7 @@ readinessProbe:
   timeoutSeconds: 5
   successThreshold: 1
   failureThreshold: 3
+
+serviceMonitor:
+  enable: false
+  scrapeInterval: 60

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -111,4 +111,5 @@ readinessProbe:
 serviceMonitor:
   enable: false
   scrapeInterval: 60s
+  scrapeTimeout: 59s
   namespace: monitoring

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -109,5 +109,5 @@ readinessProbe:
 
 serviceMonitor:
   enable: false
-  scrapeInterval: 60
+  scrapeInterval: 60s
   namespace: monitoring

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -110,4 +110,4 @@ readinessProbe:
 serviceMonitor:
   enable: false
   scrapeInterval: 60
-  prometheusNamespace: monitoring
+  namespace: monitoring

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -110,6 +110,6 @@ readinessProbe:
 
 serviceMonitor:
   enable: false
-  scrapeInterval: 60s
-  scrapeTimeout: 59s
+#  scrapeInterval: 60s
+#  scrapeTimeout: 59s
   namespace: monitoring


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
add servicemonitor creation so Prometheus operator can scrape metrics automatically
fix target port because it was not in default values and without it service is not accessable
#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
