### PR TITLE
Revert API_HOST endpoint variable from gate to deck service setting

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.7.0
+version: 1.7.1
 appVersion: 1.11.6
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/configmap/service-settings.yaml
+++ b/stable/spinnaker/templates/configmap/service-settings.yaml
@@ -18,14 +18,14 @@ data:
     {{- end }}
     skipLifeCycleManagement: true
   gate.yml: |-
-    env:
-      API_HOST: http://spin-gate.{{ .Release.Namespace }}:8084
     kubernetes:
     {{- if .Values.ingress.enabled }}
       useExecHealthCheck: false
       serviceType: NodePort
     {{- end }}
   deck.yml: |-
+    env:
+      API_HOST: http://spin-gate.{{ .Release.Namespace }}:8084
     kubernetes:
     {{- if .Values.ingress.enabled }}
       useExecHealthCheck: false


### PR DESCRIPTION
#### What this PR does / why we need it:

When using the 1.7.0 chart for Spinnaker, the API_HOST environment variable should be exposed to the spin-deck service so it can correctly create the apache config for the gate proxy. However, version 1.7.0 erroneously moved the API_HOST env variable from `deck.yml` to `gate.yml`, resulting in a broken gate proxy when deployed and a `kubectl port-forward` is used to connect to the UI.

#### Special notes for your reviewer:

Offending commit: https://github.com/helm/charts/commit/92c8dd63baa197a53be7b00c9c0e2e4fc72bf0c6

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped

#### Which issues this PR fixes

#11420