### PR TITLE
Update Ambassador default replicas and fix README Markdown

### DIFF
--- a/stable/ambassador/Chart.yaml
+++ b/stable/ambassador/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.50.1
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 1.1.0
+version: 1.1.1
 home: https://www.getambassador.io/
 sources:
   - https://github.com/datawire/ambassador
@@ -15,6 +15,6 @@ keywords:
 maintainers:
   - name: flydiverny
     email: markus@maga.se
-  - name: kflynn
+  - name: Flynn
     email: flynn@datawire.io
 engine: gotpl

--- a/stable/ambassador/Chart.yaml
+++ b/stable/ambassador/Chart.yaml
@@ -3,6 +3,7 @@ appVersion: 0.50.1
 description: A Helm chart for Datawire Ambassador
 name: ambassador
 version: 1.1.1
+icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:
   - https://github.com/datawire/ambassador

--- a/stable/ambassador/README.md
+++ b/stable/ambassador/README.md
@@ -62,12 +62,11 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `prometheusExporter.repository`    | Prometheus exporter image                                                       | `prom/statsd-exporter`        |
 | `prometheusExporter.tag`           | Prometheus exporter image                                                       | `v0.8.1`                      |
 | `rbac.create`                      | If `true`, create and use RBAC resources                                        | `true`                        |
-| `rbac.namespaced`                  | If `true`, permissions are namespace-scoped rather than cluster-scoped        | `false`                       |
-
-| `replicaCount`                     | Number of Ambassador replicas                                                   | `1`                           |
+| `rbac.namespaced`                  | If `true`, permissions are namespace-scoped rather than cluster-scoped          | `false`                       |
+| `replicaCount`                     | Number of Ambassador replicas                                                   | `3`                           |
 | `resources`                        | CPU/memory resource requests/limits                                             | `{}`                          |
-| `securityContext`             | Set security context for pod                        | `{ "runAsUser": "8888" }`                        |
-| `service.annotations`              | Annotations to apply to Ambassador service                                      | `{"getambassador.io/config":"---\napiVersion: ambassador/v1\nkind: Module\nname: ambassador\nconfig:\n  service_port: 8080"}` |
+| `securityContext`                  | Set security context for pod                                                    | `{ "runAsUser": "8888" }`     |
+| `service.annotations`              | Annotations to apply to Ambassador service                                      | See "Annotations" below       |
 | `service.externalTrafficPolicy`    | Sets the external traffic policy for the service                                | `""`                          |
 | `service.http.enabled`             | if port 80 should be opened for service                                         | `true`                        |
 | `service.http.nodePort`            | If explicit NodePort is required                                                | None                          |
@@ -85,27 +84,31 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `volumeMounts`                     | Volume mounts for the ambassador service                                        | `[]`                          |
 | `volumes`                          | Volumes for the ambassador service                                              | `[]`                          |
 
+
 **NOTE:** Make sure the configured `service.http.targetPort` and `service.https.targetPort` ports match your [Ambassador Module's](https://www.getambassador.io/reference/modules/#the-ambassador-module) `service_port` and `redirect_cleartext_from` configurations.
 
-If you intend to use `service.annotations`, remember to include the annotation key, for example:
+### Annotations
+
+The default annotation applied to the Ambassador service is
 
 ```
-service:
-  type: LoadBalancer
-
-  http:
-    port: 80
-    targetPort: 8080
-
-  annotations:
-    getambassador.io/config: |
-      ---
-      apiVersion: ambassador/v1
-      kind: Module
-      name: ambassador
-      config:
-        redirect_cleartext_from: 8080
+getambassador.io/config: |
+  ---
+  apiVersion: ambassador/v1
+  kind: Module
+  name: ambassador
+  config:
+    service_port: 8080
 ```
+
+If you intend to use `service.annotations`, remember to include the `getambassador.io/config` annotation key as above,
+and remember that you'll have to escape newlines. For example, the annotation above could be defined as
+
+```
+service.annotations: { "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Module\nname: ambassador\nconfig:\n  service_port: 8080" }
+```
+
+### Specifying Values
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/ambassador/values.yaml
+++ b/stable/ambassador/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
+replicaCount: 3
 daemonSet: false
 
 ambassador:


### PR DESCRIPTION
This PR updates the Ambassador chart to default to 3 replicas, in line with what Datawire has always recommended for Ambassador, and to correct some broken Markdown in README.md.

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
