### PR TITLE
Upgrade k8s-sidecar

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 2.0.0
+version: 2.0.1
 appVersion: 5.4.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -292,7 +292,7 @@ smtp:
 ## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
 ## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards
 sidecar:
-  image: xuxinkun/k8s-sidecar:0.0.7
+  image: kiwigrid/k8s-sidecar:0.0.10
   imagePullPolicy: IfNotPresent
   resources:
 #   limits:


### PR DESCRIPTION
Point the k8s-sidecar image back to the original repo and bump the version.

Signed-off-by: Vlad Duta <vlad90vl@gmail.com>

#### What this PR does / why we need it:
The base repository now contains xuxinkun's patch:
https://github.com/xuxinkun/k8s-sidecar/commit/c3612666023b468bfc2752e3c88ca60cf258bb50
https://github.com/kiwigrid/k8s-sidecar/commit/c3612666023b468bfc2752e3c88ca60cf258bb50

It also includes a recent fix to a common issue that causes grafana to keep restarting:
Original issue report: https://github.com/helm/charts/issues/9136
Sidecar fix: https://github.com/kiwigrid/k8s-sidecar/pull/14

#### Which issue this PR fixes
  - fixes https://github.com/helm/charts/issues/9136

#### Special notes for your reviewer:
@zanhsieh @rtluckie @maorfr @xuxinkun 

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
