### PR TITLE
[stable/kube2iam] adds Prometheus ServiceMonitor resource to kube2iam

### DIFF
--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube2iam
-version: 0.10.0
+version: 0.11.0
 appVersion: 0.10.4
 description: Provide IAM credentials to pods based on annotations.
 keywords:

--- a/stable/kube2iam/README.md
+++ b/stable/kube2iam/README.md
@@ -47,12 +47,17 @@ Parameter | Description | Default
 `host.ip` | IP address of host | `$(HOST_IP)`
 `host.iptables` | Add iptables rule | `false`
 `host.interface` | Host interface for proxying AWS metadata | `docker0`
+`host.port` | Port to listen on | `8181`
 `image.repository` | Image | `jtblin/kube2iam`
 `image.tag` | Image tag | `0.10.4`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `nodeSelector` | node labels for pod assignment | `{}`
 `podAnnotations` | annotations to be added to pods | `{}`
 `priorityClassName` | priorityClassName to be added to pods | `{}`
+`prometheus.metricsPort` | Port to expose prometheus metrics on (if unspecified, `host.port` is used) | `host.port`
+`prometheus.serviceMonitor.enabled` | If true, create a Prometheus Operator ServiceMonitor resource | `false`
+`prometheus.serviceMonitor.interval` | Interval at which the metrics endpoint is scraped | `10s`
+`prometheus.serviceMonitor.namespace` | An alternative namespace in which to install the ServiceMonitor | `""`
 `rbac.create` | If true, create & use RBAC resources | `false`
 `rbac.serviceAccountName` | existing ServiceAccount to use (ignored if rbac.create=true) | `default`
 `resources` | pod resource requests & limits | `{}`

--- a/stable/kube2iam/templates/daemonset.yaml
+++ b/stable/kube2iam/templates/daemonset.yaml
@@ -43,6 +43,9 @@ spec:
             - --verbose
           {{- end }}
             - --app-port={{ .Values.host.port }}
+          {{- if .Values.prometheus.metricsPort }}
+            - --metrics-port={{ .Values.prometheus.metricsPort }}
+          {{- end }}
           env:
             - name: HOST_IP
               valueFrom:
@@ -73,7 +76,12 @@ spec:
               value: {{ quote $value }}
           {{- end }}
           ports:
-            - containerPort: {{ .Values.host.port }}
+            - name: http
+              containerPort: {{ .Values.host.port }}
+            {{- if .Values.prometheus.metricsPort }}
+            - name: metrics
+              containerPort: {{ .Values.prometheus.metricsPort }}
+            {{- end}}
         {{- if .Values.probe }}
           livenessProbe:
             httpGet:

--- a/stable/kube2iam/templates/service.yaml
+++ b/stable/kube2iam/templates/service.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.prometheus.serviceMonitor.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+  name: {{ template "kube2iam.fullname" . }}-metrics
+  labels:
+    app: {{ template "kube2iam.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    app: {{ template "kube2iam.name" . }}
+    release: {{ .Release.Name }}
+  ports:
+    {{- if .Values.prometheus.metricsPort }}
+    - name: metrics
+      port: {{ .Values.prometheus.metricsPort }}
+      targetPort: {{ .Values.prometheus.metricsPort }}
+    {{- else }}
+    - name: http
+      port: {{ .Values.host.port }}
+      targetPort: {{ .Values.host.port }}
+    {{- end }}
+      protocol: TCP
+{{ end }}

--- a/stable/kube2iam/templates/servicemonitor.yaml
+++ b/stable/kube2iam/templates/servicemonitor.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.prometheus.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "kube2iam.fullname" . }}
+  {{- if .Values.prometheus.serviceMonitor.namespace }}
+  namespace: {{ .Values.prometheus.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "kube2iam.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "kube2iam.name" . }}
+      release: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    {{- if .Values.prometheus.metricsPort }}
+    - port: metrics
+    {{- else }}
+    - port: http
+    {{- end }}
+      interval: {{ .Values.prometheus.serviceMonitor.interval }}
+      path: /metrics
+{{- end -}}

--- a/stable/kube2iam/values.yaml
+++ b/stable/kube2iam/values.yaml
@@ -14,6 +14,18 @@ host:
   interface: docker0
   port: 8181
 
+prometheus:
+  # Port to expose the /metrics endpoint on. If unset, defaults to `host.port`
+  # metricsPort: 8181
+
+  serviceMonitor:
+    # Create prometheus-operator ServiceMonitor
+    enabled: false
+    # Interval at which the metrics endpoint is scraped
+    interval: 10s
+    # Alternative namespace to install the ServiceMonitor in
+    namespace: ""
+
 image:
   repository: jtblin/kube2iam
   tag: 0.10.4


### PR DESCRIPTION


<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Adds the ability to create a prometheus operator ServiceMonitor resource that configures prometheus to scrape kube2iam's [`/metrics` endpoint](https://github.com/jtblin/kube2iam#metrics).

#### Special notes for your reviewer:
Since kube2iam itself handles defaulting the `--metrics-port` parameter to the value of `--app-port`, I wasn't sure how best to handle the config of it. I didn't want to specify `8181` in the included `values.yaml` so I documented the parameter but left it commented out. Let me know if you'd prefer a different approach here.

CC @jmcarp / @icereval / @mgoodness 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
