### PR TITLE
[stable/mariadb] Add PodDisruptionBudget for MariaDB

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb
-version: 5.6.0
+version: 5.7.0
 appVersion: 10.1.38
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -103,6 +103,9 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `master.readinessProbe.timeoutSeconds`    | When the probe times out (master)                   | `1`                                                               |
 | `master.readinessProbe.successThreshold`  | Minimum consecutive successes for the probe (master)| `1`                                                               |
 | `master.readinessProbe.failureThreshold`  | Minimum consecutive failures for the probe (master) | `3`                                                               |
+| `master.podDisruptionBudget.enabled`      | If true, create a pod disruption budget for master pods. | `false`                                                      |
+| `master.podDisruptionBudget.minAvailable` | Minimum number / percentage of pods that should remain scheduled | `1`                                                  |
+| `master.podDisruptionBudget.maxUnavailable`| Maximum number / percentage of pods that may be made unavailable | `nil`                                               |
 | `slave.replicas`                          | Desired number of slave replicas                    | `1`                                                               |
 | `slave.annotations[].key`                 | key for the the annotation list item                | `nil`                                                             |
 | `slave.annotations[].value`               | value for the the annotation list item              | `nil`                                                             |
@@ -129,6 +132,9 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `slave.readinessProbe.timeoutSeconds`     | When the probe times out (slave)                    | `1`                                                               |
 | `slave.readinessProbe.successThreshold`   | Minimum consecutive successes for the probe (slave) | `1`                                                               |
 | `slave.readinessProbe.failureThreshold`   | Minimum consecutive failures for the probe (slave)  | `3`                                                               |
+| `slave.podDisruptionBudget.enabled`       | If true, create a pod disruption budget for slave pods. | `false`                                                       |
+| `slave.podDisruptionBudget.minAvailable`  | Minimum number / percentage of pods that should remain scheduled | `1`                                                  |
+| `slave.podDisruptionBudget.maxUnavailable`| Maximum number / percentage of pods that may be made unavailable | `nil`                                                |
 | `metrics.enabled`                         | Start a side-car prometheus exporter                | `false`                                                           |
 | `metrics.image.registry`                  | Exporter image registry                             | `docker.io`                                                       |
 | `metrics.image.repository`                | Exporter image name                                 | `prom/mysqld-exporter`                                            |

--- a/stable/mariadb/templates/master-pdb.yaml
+++ b/stable/mariadb/templates/master-pdb.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.master.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "mariadb.fullname" . }}
+  labels:
+    app: "{{ template "mariadb.name" . }}"
+    component: "master"
+    chart: {{ template "mariadb.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+spec:
+{{- if .Values.master.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.master.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.master.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.master.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: "{{ template "mariadb.name" . }}"
+      component: "master"
+      release: {{ .Release.Name | quote }}
+{{- end }}

--- a/stable/mariadb/templates/slave-pdb.yaml
+++ b/stable/mariadb/templates/slave-pdb.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.replication.enabled }}
+{{- if .Values.slave.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "mariadb.fullname" . }}
+  labels:
+    app: "{{ template "mariadb.name" . }}"
+    component: "slave"
+    chart: {{ template "mariadb.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+spec:
+{{- if .Values.slave.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.slave.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.slave.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.slave.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: "{{ template "mariadb.name" . }}"
+      component: "slave"
+      release: {{ .Release.Name | quote }}
+{{- end }}
+{{- end }}

--- a/stable/mariadb/values-production.yaml
+++ b/stable/mariadb/values-production.yaml
@@ -234,6 +234,11 @@ master:
     successThreshold: 1
     failureThreshold: 3
 
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    # maxUnavailable: 1
+
 slave:
   replicas: 2
 
@@ -329,6 +334,11 @@ slave:
     timeoutSeconds: 1
     successThreshold: 1
     failureThreshold: 3
+
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    # maxUnavailable: 1
 
 metrics:
   enabled: true

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -234,6 +234,11 @@ master:
     successThreshold: 1
     failureThreshold: 3
 
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    # maxUnavailable: 1
+
 slave:
   replicas: 1
 
@@ -328,6 +333,11 @@ slave:
     timeoutSeconds: 1
     successThreshold: 1
     failureThreshold: 3
+
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    # maxUnavailable: 1
 
 metrics:
   enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds option to enable [PodDisruptionBudget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/) for MariaDB master and slave StatefulSets.

#### Which issue this PR fixes
none

#### Special notes for your reviewer:
have a nice day :)

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
