### PR TITLE
[stable/sonarqube] Option for settings encryption secret

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,6 +1,6 @@
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 0.14.1
+version: 0.15.0
 appVersion: 7.6
 keywords:
   - coverage

--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -60,6 +60,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `persistence.accessMode`                    | Volumes access mode to be set             | `ReadWriteOnce`                            |
 | `persistence.size`                          | Size of the volume                        | None                                     |
 | `sonarProperties`                           | Custom `sonar.properties` file            | None                                       |
+| `sonarSecretKey`                            | Name of existing secret used for settings encryption | None                            |
 | `database.type`                             | Set to "mysql" to use mysql database       | `postgresql`|
 | `postgresql.enabled`                        | Set to `false` to use external server / mysql database     | `true`                                     |
 | `postgresql.postgresServer`                 | Hostname of the external Postgresql server| `null`                                     |

--- a/stable/sonarqube/templates/config.yaml
+++ b/stable/sonarqube/templates/config.yaml
@@ -9,7 +9,13 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
+  {{- if and .Values.sonarSecretKey (not .Values.sonarProperties) }}
+  sonar.properties: sonar.secretKeyPath=/opt/sonarqube/secret/sonar-secret.txt    
+  {{- end }}
   {{- if .Values.sonarProperties }}
   sonar.properties:
-{{ toYaml .Values.sonarProperties | indent 4}}
-  {{- end}}
+{{ toYaml .Values.sonarProperties | indent 4 }}
+  {{- end }}
+    {{- if and .Values.sonarSecretKey .Values.sonarProperties }}
+      sonar.secretKeyPath=/opt/sonarqube/secret/sonar-secret.txt
+    {{- end }}

--- a/stable/sonarqube/templates/deployment.yaml
+++ b/stable/sonarqube/templates/deployment.yaml
@@ -119,6 +119,10 @@ spec:
             - mountPath: /opt/sonarqube/conf/
               name: config
             {{- end }}
+            {{- if .Values.sonarSecretKey }}
+            - mountPath: /opt/sonarqube/secret/
+              name: secret
+            {{- end }}
             - mountPath: /opt/sonarqube/data
               name: sonarqube
               subPath: data
@@ -149,6 +153,14 @@ spec:
           items:
           - key: sonar.properties
             path: sonar.properties
+      {{- end }}
+      {{- if .Values.sonarSecretKey }}
+      - name: secret
+        secret: 
+          secretName: {{ .Values.sonarSecretKey }}
+          items:
+          - key: sonar-secret.txt
+            path: sonar-secret.txt
       {{- end }}
       - name: install-plugins
         configMap:

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -126,6 +126,11 @@ plugins:
 #   sonar.security.realm=LDAP
 #   ldap.url=ldaps://organization.com
 
+# Kubernetes secret that contains the encryption key for the sonarqube instance.
+# The secret must contain the key 'sonar-secret.txt'.
+# The 'sonar.secretKeyPath' property will be set automatically.
+# sonarSecretKey: "settings-encryption-secret"
+
 ## Configuration value to select database type
 ## Option to use "postgresql" or "mysql" database type, by default "postgresql" is chosen
 ## Set the "enable" field to true of the database type you select (if you want to use internal database) and false of the one you don't select


### PR DESCRIPTION
Add another option to use a Kubernetes Secret for settings
encryption by setting the the sonar.secretKeyPath property
and mounting the actual secret file as a volume.

Signed-off-by: Jannis Oeltjen <oss@jcoeltjen.de>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR adds another option to be able to set the secret used by the [Settings Encryption](https://docs.sonarqube.org/latest/instance-administration/security/#header-6) feature to a value stored in a Kubernetes Secret.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #10675

#### Special notes for your reviewer:
Tested on AKS for both cases of having custom `sonar.properties` set and without this option set.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
