### PR TITLE
[airflow] allow multiple existing secrets to be used

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,6 +1,6 @@
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 0.17.2
+version: 0.17.3
 appVersion: 1.10.0
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/templates/_helpers.tpl
+++ b/stable/airflow/templates/_helpers.tpl
@@ -97,7 +97,11 @@ Map environment vars to secrets
   - name: {{ $val.envVar }}
     valueFrom:
       secretKeyRef:
+        {{- if $val.secretName }}
+        name: {{ $val.secretName }}
+        {{- else }}
         name: {{ $secretName }}
+        {{- end }}
         key: {{ $val.secretKey }}
       {{- end }}
     {{- end }}

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -5,27 +5,33 @@
 ## common settings and setting for the webserver
 airflow:
 
-  ##
-  ## secretsMapping can be overridden in values.yaml as such:
+  ## When existingAirflowSecret is defined, secretsMapping can be 
+  ## overridden. When no secretName is given then the value of 
+  ## existingAirflowSecret is assumed.
   ## secretsMapping:
   ## - envVar: AIRFLOW__LDAP__BIND_PASSWORD
-  ##   secretName: ldapBindPassword
+  ##   secretName: ldap
+  ##   secretKey: ldapBindPassword
   ## - envVar: AIRFLOW__ATLAS__PASSWORD
-  ##   secretName: atlasPassword
+  ##   secretKey: atlasPassword
   ## - envVar: AIRFLOW__SMTP__PASSWORD
-  ##   secretName: smtpPassword
+  ##   secretKey: smtpPassword
   ## - envVar: AIRFLOW__KUBERNETES__GIT_PASSWORD
-  ##   secretName: kubernetesGitPassword
+  ##   secretKey: kubernetesGitPassword
   ## - envVar: POSTGRES_USER
-  ##   secretName: postgresUser
+  ##   secretName: postgres
+  ##   secretKey: postgresUser
   ## - envVar: POSTGRES_PASSWORD
-  ##   secretName: postgresPassword
+  ##   secretName: postgres
+  ##   secretKey: postgresPassword
   ## - envVar: REDIS_PASSWORD
-  ##   secretName: redisPassword
+  ##   secretName: redis
+  ##   secretKey: redisPassword
   secretsMapping:
 
 
-  ## used only when existingAirflowSecrets is false
+  ## Used only when existingAirflowSecret is null, in which case
+  ## a secret will be created with a default name and the following mapping.
   defaultSecretsMapping:
   - envVar: POSTGRES_USER
     secretKey: postgresUser

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -5,8 +5,8 @@
 ## common settings and setting for the webserver
 airflow:
 
-  ## When existingAirflowSecret is defined, secretsMapping can be 
-  ## overridden. When no secretName is given then the value of 
+  ## When existingAirflowSecret is defined, secretsMapping can be
+  ## overridden. When no secretName is given then the value of
   ## existingAirflowSecret is assumed.
   ## secretsMapping:
   ## - envVar: AIRFLOW__LDAP__BIND_PASSWORD


### PR DESCRIPTION
Signed-off-by: Jason White <jwhite@neighborly.com>


For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

@gsemet this PR allows multiple existing secrets to be used in the Airflow chart. For example, if I am bringing my own Postgres and Redis, and they have passwords stored in separate secrets, I would like the Airflow chart to be able to retrieve those passwords from the separate secrets.

#### Which issue this PR fixes

fixes #11425 

#### Special notes for your reviewer:

Their was also an mistake in the commented instructions for `secretsMapping`. All of the `secretName` keys should have been `secretKey`. I have fixed this as well.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
