### PR TITLE
Add optional support for configuring Prometheus scrape ServiceMonitor

### DIFF
--- a/stable/filebeat/Chart.yaml
+++ b/stable/filebeat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart to collect Kubernetes logs with filebeat
 icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.svg
 name: filebeat
-version: 1.3.0
+version: 1.4.0
 appVersion: 6.6.0
 home: https://www.elastic.co/products/beats/filebeat
 sources:

--- a/stable/filebeat/templates/servicemonitor.yaml
+++ b/stable/filebeat/templates/servicemonitor.yaml
@@ -7,12 +7,12 @@ metadata:
 {{ toYaml .Values.monitoring.serviceMonitor.labels | indent 4}}
 {{- end }}
   name: {{ template "filebeat.fullname" . }}-prometheus-exporter
+{{- if .Values.monitoring.serviceMonitor.namespace }}
   namespace: {{ .Values.monitoring.serviceMonitor.namespace }}
+{{- end }}
 spec:
   endpoints:
-  - interval: {{ .Values.monitoring.serviceMonitor.interval }}
-    path: {{ .Values.monitoring.serviceMonitor.telemetryPath }}
-    targetPort: {{ .Values.monitoring.exporterPort }}
+  - targetPort: {{ .Values.monitoring.exporterPort }}
   jobLabel: {{ template "filebeat.fullname" . }}-prometheus-exporter
   namespaceSelector:
     matchNames:

--- a/stable/filebeat/templates/servicemonitor.yaml
+++ b/stable/filebeat/templates/servicemonitor.yaml
@@ -13,6 +13,12 @@ metadata:
 spec:
   endpoints:
   - targetPort: {{ .Values.monitoring.exporterPort }}
+{{- if .Values.monitoring.serviceMonitor.interval }}
+    interval: {{ .Values.monitoring.serviceMonitor.interval }}
+{{- end }}
+{{- if .Values.monitoring.serviceMonitor.telemetryPath }}
+    path: {{ .Values.monitoring.serviceMonitor.telemetryPath }}
+{{- end }}
   jobLabel: {{ template "filebeat.fullname" . }}-prometheus-exporter
   namespaceSelector:
     matchNames:

--- a/stable/filebeat/templates/servicemonitor.yaml
+++ b/stable/filebeat/templates/servicemonitor.yaml
@@ -1,0 +1,24 @@
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.monitoring.serviceMonitor.enabled ) ( .Values.monitoring.enabled ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+{{- if .Values.monitoring.serviceMonitor.labels }}
+  labels:
+{{ toYaml .Values.monitoring.serviceMonitor.labels | indent 4}}
+{{- end }}
+  name: {{ template "filebeat.fullname" . }}-prometheus-exporter
+  namespace: {{ .Values.monitoring.serviceMonitor.namespace }}
+spec:
+  endpoints:
+  - interval: {{ .Values.monitoring.serviceMonitor.interval }}
+    path: {{ .Values.monitoring.serviceMonitor.telemetryPath }}
+    targetPort: {{ .Values.monitoring.exporterPort }}
+  jobLabel: {{ template "filebeat.fullname" . }}-prometheus-exporter
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "filebeat.name" . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/stable/filebeat/values.yaml
+++ b/stable/filebeat/values.yaml
@@ -145,6 +145,17 @@ podSecurityPolicy:
 ## Dont forget to enable http on config.http.enabled (exposing filebeat stats)
 monitoring:
   enabled: true
+  serviceMonitor:
+    # When set true and if Prometheus Operator is installed then use a ServiceMonitor to configure scraping
+    enabled: true
+    # Set the namespace the ServiceMonitor should be deployed
+    namespace: monitoring
+    # Set how frequently Prometheus should scrape
+    interval: 30s
+    # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
+    #labels:
+    # Set path to beats-exporter telemtery-path
+    telemetryPath: /metrics
   image:
     repository: trustpilot/beat-exporter
     tag: 0.1.1

--- a/stable/filebeat/values.yaml
+++ b/stable/filebeat/values.yaml
@@ -150,6 +150,10 @@ monitoring:
     enabled: true
     # Set the namespace the ServiceMonitor should be deployed
     # namespace: monitoring
+    # Set how frequently Prometheus should scrape
+    # interval: 30s
+    # Set path to beats-exporter telemtery-path
+    # telemetryPath: /metrics
     # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
     # labels:
   image:

--- a/stable/filebeat/values.yaml
+++ b/stable/filebeat/values.yaml
@@ -149,13 +149,9 @@ monitoring:
     # When set true and if Prometheus Operator is installed then use a ServiceMonitor to configure scraping
     enabled: true
     # Set the namespace the ServiceMonitor should be deployed
-    namespace: monitoring
-    # Set how frequently Prometheus should scrape
-    interval: 30s
+    # namespace: monitoring
     # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
     # labels:
-    # Set path to beats-exporter telemtery-path
-    telemetryPath: /metrics
   image:
     repository: trustpilot/beat-exporter
     tag: 0.1.1

--- a/stable/filebeat/values.yaml
+++ b/stable/filebeat/values.yaml
@@ -153,7 +153,7 @@ monitoring:
     # Set how frequently Prometheus should scrape
     interval: 30s
     # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
-    #labels:
+    # labels:
     # Set path to beats-exporter telemtery-path
     telemetryPath: /metrics
   image:


### PR DESCRIPTION
Add optional support for configuring Prometheus scrape via Prometheus-Operator ServiceMonitor

Signed-off-by: thomasriley <twriley@outlook.com>

#### What this PR does / why we need it:
The beat-exporter was recently added for exporting Prometheus metrics from Filebeat. This PR adds support for configuring the scraping of those Metrics in Prometheus using the Prometheus-Operator ServiceMonitor. This is entirely optional via values but will only be available if you have the Prometheus-Operator APIVersion installed in Kubernetes.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md