### PR TITLE
[stable/cluster-autoscaler] break templating engine when unexpected results might occur

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 0.11.2
+version: 0.11.3
 appVersion: 1.13.1
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/templates/deployment.yaml
+++ b/stable/cluster-autoscaler/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
             but should be shown as a string instead.
           */ -}}
           {{- range $key, $value := .Values.extraArgs }}
-          - --{{ $key }}{{ if not (eq $value "") }}={{ $value }}{{ end }}
+            - --{{ $key }}{{ if not (eq $value "") }}={{ $value }}{{ end }}
           {{- end }}
 
           env:

--- a/stable/cluster-autoscaler/templates/deployment.yaml
+++ b/stable/cluster-autoscaler/templates/deployment.yaml
@@ -60,8 +60,13 @@ spec:
           {{- if eq .Values.cloudProvider "gce" }}
             - --cloud-config={{ .Values.cloudConfigPath }}
             {{- end }}
+          {{- /*
+            Unfortunately there is no isset function or way to check if a variable is nil, so break the
+            templating engine rather than producing unexpected results if the var will evaluate to false
+            but should be shown as a string instead.
+          */ -}}
           {{- range $key, $value := .Values.extraArgs }}
-            - --{{ $key }}{{ if $value }}={{ $value }}{{ end }}
+          - --{{ $key }}{{ if not (eq $value "") }}={{ $value }}{{ end }}
           {{- end }}
 
           env:

--- a/stable/cluster-autoscaler/values.yaml
+++ b/stable/cluster-autoscaler/values.yaml
@@ -53,24 +53,24 @@ image:
 tolerations: []
 
 extraArgs:
-  v: 4
-  stderrthreshold: info
-  logtostderr: true
-  # write-status-configmap: true
-  # leader-elect: true
-  # skip-nodes-with-local-storage: false
-  # expander: least-waste
-  # scale-down-enabled: true
-  # balance-similar-node-groups: true
-  # min-replica-count: 2
-  # scale-down-utilization-threshold: 0.5
-  # scale-down-non-empty-candidates-count: 5
-  # max-node-provision-time: 15m0s
-  # scan-interval: 10s
-  # scale-down-delay: 10m
-  # scale-down-unneeded-time: 10m
-  # skip-nodes-with-local-storage: false
-  # skip-nodes-with-system-pods: true
+  v: "4"
+  stderrthreshold: "info"
+  logtostderr: "true"
+  # write-status-configmap: "true"
+  # leader-elect: "true"
+  # skip-nodes-with-local-storage: "false"
+  # expander: "least-waste"
+  # scale-down-enabled: "true"
+  # balance-similar-node-groups: "true"
+  # min-replica-count: "2"
+  # scale-down-utilization-threshold: "0.5"
+  # scale-down-non-empty-candidates-count: "5"
+  # max-node-provision-time: "15m0s"
+  # scan-interval: "10s"
+  # scale-down-delay: "10m"
+  # scale-down-unneeded-time: "10m"
+  # skip-nodes-with-local-storage: "false"
+  # skip-nodes-with-system-pods: "true"
 
 ## Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity


### PR DESCRIPTION
#### What this PR does / why we need it:

This squashes a very annoying and somewhat subtle bug, where cluster-autoscaler extraArgs values are evaluated as booleans. This means that `false`, `0`, etc. Are all false, and not rendered in output, producing surprising results. For example:

```yaml
extraArgs:
  scale-down-enabled: false
```

Yields:

```yaml
            - --scale-down-enabled
```

Which is the opposite of what the user expected.

This PR does the best thing we can do, which is to break the templating engine when anything other than a string is used:

```
helm template Documents/charts/stable/cluster-autoscaler/
Error: render error in "cluster-autoscaler/templates/deployment.yaml": template: cluster-autoscaler/templates/deployment.yaml:72:37: executing "cluster-autoscaler/templates/deployment.yaml" at <eq $value "">: error calling eq: incompatible types for comparison
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
