### PR TITLE
[stable/ark] Support backup location prefixes

### DIFF
--- a/stable/ark/Chart.yaml
+++ b/stable/ark/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.10.1
 description: A Helm chart for ark
 name: ark
-version: 3.0.0
+version: 3.0.1
 home: https://github.com/heptio/ark
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/stable/ark/README.md
+++ b/stable/ark/README.md
@@ -66,6 +66,7 @@ Parameter | Description | Default
 `configuration.persistentVolumeProvider.config.apiTimeout` | The API timeout (Azure only) |
 `configuration.backupStorageProvider.name` | The name of the cloud provider that will be used to actually store the backups (`aws`, `azure`, `gcp`) | ``
 `configuration.backupStorageProvider.bucket` | The storage bucket where backups are to be uploaded | ``
+`configuration.backupStorageProvider.prefix` | The directory inside a storage bucket where backups are to be uploaded | ``
 `configuration.backupStorageProvider.config.region` | The cloud provider region (AWS only) | ``
 `configuration.backupStorageProvider.config.s3ForcePathStyle` | Set to `true` for a local storage service like Minio | ``
 `configuration.backupStorageProvider.config.s3Url` | S3 url (primarily used for local storage services like Minio) | ``

--- a/stable/ark/templates/backupstoragelocation.yaml
+++ b/stable/ark/templates/backupstoragelocation.yaml
@@ -14,6 +14,9 @@ spec:
   provider: {{ .name  }}
   objectStorage:
     bucket: {{ .bucket  }}
+    {{- with .prefix }}
+    prefix: {{ . }}
+    {{- end }}
 {{- with .config }}
   config:
   {{- with .region }}

--- a/stable/ark/values.yaml
+++ b/stable/ark/values.yaml
@@ -33,6 +33,7 @@ configuration:
   backupStorageProvider:
     name:
     bucket:
+    # prefix:
     config: {}
     #  region:
     #  s3ForcePathStyle:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it: Supports prefixes in backup buckets, needed in case you have other objects in the bucket, so that ark verifies the backup directory structure correctly.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md