### PR TITLE
[stable/prometheus-cloudwatch-exporter] Adjust service targetPort to reference container port name.

### DIFF
--- a/stable/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/stable/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.4.0
+version: 0.4.1
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -61,13 +61,13 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - name: {{ .Values.service.portName }}
+            - name: containerPort
               containerPort: 9106
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /-/healthy
-              port: {{ .Values.service.portName }}
+              port: containerPort
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds}}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -76,7 +76,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: {{ .Values.service.portName }}
+              port: containerPort
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds}}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -61,13 +61,13 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - name: containerPort
+            - name: container-port
               containerPort: 9106
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /-/healthy
-              port: containerPort
+              port: container-port
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds}}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -76,7 +76,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: containerPort
+              port: container-port
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds}}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/stable/prometheus-cloudwatch-exporter/templates/service.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/service.yaml
@@ -16,7 +16,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.targetPort }}
+      targetPort: containerPort
       protocol: TCP
       name: {{ .Values.service.portName }}
   selector:

--- a/stable/prometheus-cloudwatch-exporter/templates/service.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/service.yaml
@@ -16,7 +16,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: containerPort
+      targetPort: container-port
       protocol: TCP
       name: {{ .Values.service.portName }}
   selector:


### PR DESCRIPTION
#### What this PR does / why we need it:
Since there is no default `targetPort` for the service defined, it will use the same port as service port (`80`) which is wrong since the container port is `9106`. The PR adjusts the service port configuration to use the port of the container as target port for the service configuration. 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
