### PR TITLE
[stable/datadog] Enable dogstatsd over unix domain socket

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.20.0
+version: 1.21.0
 appVersion: 6.9.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -83,6 +83,8 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `datadog.tags`              | Set host tags                      | `nil`                                     |
 | `datadog.nonLocalTraffic` | Enable statsd reporting from any external ip | `False`                           |
 | `datadog.useCriSocketVolume` | Enable mounting the container runtime socket in Agent containers | `True` |
+| `datadog.dogstatsdOriginDetection` | Enable origin detection for container tagging | `False`                 |
+| `datadog.useDogStatsDSocketVolume` | Enable dogstatsd over Unix Domain Socket | `False`                      |
 | `datadog.volumes`           | Additional volumes for the daemonset or deployment | `nil`                     |
 | `datadog.volumeMounts`      | Additional volumeMounts for the daemonset or deployment | `nil`                |
 | `datadog.podAnnotationsAsTags` | Kubernetes Annotations to Datadog Tags mapping | `nil`                      |

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -84,6 +84,10 @@ spec:
           - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
             value: {{ .Values.datadog.nonLocalTraffic | quote }}
           {{- end }}
+          {{- if .Values.datadog.dogstatsdOriginDetection }}
+          - name: DD_DOGSTATSD_ORIGIN_DETECTION
+            value: {{ .Values.datadog.dogstatsdOriginDetection | quote }}
+          {{- end }}
           {{- if .Values.datadog.tags }}
           - name: DD_TAGS
             value: {{ .Values.datadog.tags | quote }}
@@ -164,6 +168,10 @@ spec:
           - name: DD_HEALTH_PORT
             value: "5555"
           {{- end }}
+          {{- if .Values.datadog.useDogStatsDSocketVolume }}
+          - name: DD_DOGSTATSD_SOCKET
+            value: "/var/run/datadog/dsd.socket"
+          {{- end }}
 {{- if .Values.datadog.env }}
 {{ toYaml .Values.datadog.env | indent 10 }}
 {{- end }}
@@ -172,6 +180,10 @@ spec:
           - name: runtimesocket
             mountPath: {{ default "/var/run/docker.sock" .Values.datadog.criSocketPath | quote }}
             readOnly: true
+          {{- end }}
+          {{- if .Values.datadog.useDogStatsDSocketVolume }}
+          - name: dsdsocket
+            mountPath: "/var/run/datadog"
           {{- end }}
           - name: procdir
             mountPath: /host/proc
@@ -222,6 +234,11 @@ spec:
         - hostPath:
             path: {{ default "/var/run/docker.sock" .Values.datadog.criSocketPath | quote }}
           name: runtimesocket
+        {{- end }}
+        {{- if .Values.datadog.useDogStatsDSocketVolume }}
+        - hostPath:
+            path: "/var/run/datadog/"
+          name: dsdsocket
         {{- end }}
         - hostPath:
             path: /proc

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -70,6 +70,10 @@ spec:
           - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
             value: {{ .Values.datadog.nonLocalTraffic | quote }}
           {{- end }}
+          {{- if .Values.datadog.dogstatsdOriginDetection }}
+          - name: DD_DOGSTATSD_ORIGIN_DETECTION
+            value: {{ .Values.datadog.dogstatsdOriginDetection | quote }}
+          {{- end }}
           {{- if .Values.datadog.tags }}
           - name: DD_TAGS
             value: {{ .Values.datadog.tags | quote }}
@@ -88,6 +92,10 @@ spec:
           - name: DD_CRI_SOCKET_PATH
             value: {{ .Values.datadog.criSocketPath | quote }}
           {{- end }}
+          {{- if .Values.datadog.useDogStatsDSocketVolume }}
+          - name: DD_DOGSTATSD_SOCKET
+            value: "/var/run/datadog/dsd.socket"
+          {{- end }}
 {{- if .Values.datadog.env }}
 {{ toYaml .Values.datadog.env | indent 10 }}
 {{- end }}
@@ -96,6 +104,10 @@ spec:
           - name: runtimesocket
             mountPath: {{ default "/var/run/docker.sock" .Values.datadog.criSocketPath | quote }}
             readOnly: true
+          {{- end }}
+          {{- if .Values.datadog.useDogStatsDSocketVolume }}
+          - name: dsdsocket
+            mountPath: "/var/run/datadog"
           {{- end }}
           - name: procdir
             mountPath: /host/proc
@@ -133,6 +145,11 @@ spec:
         - hostPath:
             path: {{ default "/var/run/docker.sock" .Values.datadog.criSocketPath | quote }}
           name: runtimesocket
+        {{- end }}
+        {{- if .Values.datadog.useDogStatsDSocketVolume }}
+        - hostPath:
+            path: "/var/run/datadog/"
+          name: dsdsocket
         {{- end }}
         - hostPath:
             path: /proc

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -171,8 +171,18 @@ datadog:
   ##
   # nonLocalTraffic: true
 
+  ## Enable origin detection for container tagging
+  ## https://docs.datadoghq.com/developers/dogstatsd/unix_socket/#using-origin-detection-for-container-tagging
+  ##
+  # dogstatsdOriginDetection: true
+
   ## Enable container runtime socket volume mounting
   useCriSocketVolume: true
+
+  ## Enable dogstatsd over Unix Domain Socket
+  ## ref: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/
+  ##
+  # useDogStatsDSocketVolume: true
 
   ## Set host tags.
   ## ref: https://github.com/DataDog/docker-dd-agent#environment-variables


### PR DESCRIPTION

#### What this PR does / why we need it:
This PR enables DogStatsD over Unix Domain Socket and adds support for DD_DOGSTATSD_ORIGIN_DETECTION environment variable. All metrics received via UDS will be tagged by the same container tags as Autodiscovery metrics allowing to identify source of a metric. More info [here](https://docs.datadoghq.com/developers/dogstatsd/unix_socket/)
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
