### PR TITLE
[stable/jenkins] Fix markdown syntax in README

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.32.6
+version: 0.32.7
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -115,13 +115,13 @@ Some third-party systems, e.g. GitHub, use HTML-formatted data in their payload 
 | `Agent.Privileged`         | Agent privileged container                      | `false`                |
 | `Agent.resources`          | Resources allocation (Requests and Limits)      | `{requests: {cpu: 200m, memory: 256Mi}, limits: {cpu: 200m, memory: 256Mi}}`|
 | `Agent.volumes`            | Additional volumes                              | `nil`                  |
-| `Agent.envVars             | Environment variables for the slave Pod         | Not set                |
-| `Agent.Command             | Executed command when side container starts     | Not set                |
-| `Agent.Args                | Arguments passed to executed command            | Not set                |
-| `Agent.SideContainerName   | Side container name in agent                    | jnlp                   |
-| `Agent.TTYEnabled          | Allocate pseudo tty to the side container       | false                  |
-| `Agent.ContainerCap        | Maximum number of agent                         | 10                     |
-| `Agent.PodName             | slave Pod base name                             | Not set                |
+| `Agent.envVars`            | Environment variables for the slave Pod         | Not set                |
+| `Agent.Command`            | Executed command when side container starts     | Not set                |
+| `Agent.Args`               | Arguments passed to executed command            | Not set                |
+| `Agent.SideContainerName`  | Side container name in agent                    | jnlp                   |
+| `Agent.TTYEnabled`         | Allocate pseudo tty to the side container       | false                  |
+| `Agent.ContainerCap`       | Maximum number of agent                         | 10                     |
+| `Agent.PodName`            | slave Pod base name                             | Not set                |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.


### PR DESCRIPTION
Fixes code formatting in `README` for jenkins chart
