### PR TITLE
Add security context config to logstash chart

### DIFF
--- a/stable/logstash/Chart.yaml
+++ b/stable/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 1.5.0
+version: 1.5.1
 appVersion: 6.6.0
 sources:
 - https://www.docker.elastic.co

--- a/stable/logstash/README.md
+++ b/stable/logstash/README.md
@@ -115,3 +115,5 @@ The following table lists the configurable parameters of the chart and its defau
 | `inputs`                        | Logstash inputs configuration                      | beats                                            |
 | `filters`                       | Logstash filters configuration                     | `nil`                                            |
 | `outputs`                       | Logstash outputs configuration                     | elasticsearch                                    |
+| `securityContext.fsGroup`                          | Group ID for the container                                                                   | `1000`                                                  |
+| `securityContext.runAsUser`                        | User ID for the container                                                                    | `1000`                                                  |

--- a/stable/logstash/templates/statefulset.yaml
+++ b/stable/logstash/templates/statefulset.yaml
@@ -39,8 +39,8 @@ spec:
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
       securityContext:
-        runAsUser: 1000
-        fsGroup: 1000
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}

--- a/stable/logstash/values.yaml
+++ b/stable/logstash/values.yaml
@@ -90,6 +90,10 @@ nodeSelector: {}
 
 tolerations: []
 
+securityContext:
+  fsGroup: 1000
+  runAsUser: 1000
+
 affinity: {}
   # podAntiAffinity:
   #   requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR exposes the security context configuration of the logstash deployment object to the user via the `values.yaml`. I tried to copy how it is done from the MongoDB chart.

I needed to be ableto change the security context settings to use this chart on an openshift flavoured cluster.

cc @rendhalver @jar361 @christian-roggia


#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
