### PR TITLE
Add Synapse chart to incubator

### DIFF
--- a/incubator/synapse/.helmignore
+++ b/incubator/synapse/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+# OWNERS file for Kubernetes
+OWNERS

--- a/incubator/synapse/Chart.yaml
+++ b/incubator/synapse/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+appVersion: 0.99.1.1
+description: The reference implementation for a Matrix.org chat server
+name: synapse
+version: 0.0.1
+keywords:
+  - synapse
+  - chat
+  - matrix
+  - riot
+home: https://github.com/matrix-org/synapse
+sources:
+  - https://github.com/matrix-org/synapse
+  - https://github.com/helm/charts/tree/master/incubator/synapse
+maintainers:
+  - name: mcronce
+    email: mike@quadra-tec.net

--- a/incubator/synapse/OWNERS
+++ b/incubator/synapse/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- mcronce
+reviewers:
+- mcronce

--- a/incubator/synapse/README.md
+++ b/incubator/synapse/README.md
@@ -1,0 +1,112 @@
+# Synapse
+This is a helm chart for [Synapse][github], the reference implementation for a [Matrix][matrix] chat server.
+
+## TL;DR;
+```console
+helm install --set server_name=matrix.example.org incubator/synapse
+```
+
+## Installing the Chart
+To install the chart with the release name `my-release`:
+
+```console
+helm install --name my-release incubator/synapse
+```
+
+## Uninstalling the Chart
+To uninstall/delete the `my-release` deployment:
+
+```console
+helm delete my-release --purge
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+The following tables lists the configurable parameters of the Synapse chart and their default values.
+
+| Parameter                                      | Description                                                                                                            | Default                           |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `server_name`                                  | Public hostname of the server                                                                                          | Required                          |
+| `image.repository`                             | Image repository                                                                                                       | `matrixdotorg/synapse`            |
+| `image.tag`                                    | Image tag. Possible values listed [here][docker].                                                                      | `v0.99.1rc1-py3`                  |
+| `image.pullPolicy`                             | Image pull policy                                                                                                      | `IfNotPresent`                    |
+| `extraLabels`                                  | Additional labels to apply to all created resources                                                                    | `{}`                              |
+| `settings.uid`                                 | Run the server as user UID                                                                                             | `991`                             |
+| `settings.git`                                 | Run the server as group GID                                                                                            | `991`                             |
+| `settings.report_stats`                        | Whether or not to report anonymous usage stats to Matrix (`yes` or `no`)                                               | `yes`                             |
+| `settings.tls.enabled`                         | Whether or not the server should expose TLS                                                                            | `false`                           |
+| `settings.tls.acme`                            | If TLS is enabled, whether or not the server should use ACME to retrieve TLS certs                                     | `true`                            |
+| `settings.registration.enabled`                | Whether or not to allow new users to register                                                                          | `true`                            |
+| `settings.guest`                               | Whether or not to allow guests to enter the server                                                                     | `false`                           |
+| `settings.event_cache_size`                    | The event cache size                                                                                                   | `"10K"`                           |
+| `settings.recaptcha.enabled`                   | Whether or not to require users to pass a ReCAPTCHA challenge when registering                                         | `false`                           |
+| `settings.recaptcha.secret.name_override`      | Override for the name of the ReCAPTCHA secret                                                                          | ``                                |
+| `settings.recaptcha.secret.deploy.enabled`     | Whether or not to deploy the ReCAPTCHA secret as part of the chart                                                     | `true`                            |
+| `settings.recaptcha.secret.deploy.public_key`  | Public key for ReCAPTCHA (required if `settings.recaptcha.secret.deploy.enabled` is set to `true`)                     | ``                                |
+| `settings.recaptcha.secret.deploy.private_key` | Private key for ReCAPTCHA (required if `settings.recaptcha.secret.deploy.enabled` is set to `true`)                    | ``                                |
+| `settings.turn.uris`                           | Comma-separated list of TURN URIs to enable TURN on this server                                                        | `[]`                              |
+| `settings.turn.secret.name_override`           | Override for the name of the TURN secret                                                                               | ``                                |
+| `settings.turn.secret.deploy.enabled`          | Whether or not to deploy the TURN secret as part of the chart                                                          | `true`                            |
+| `settings.turn.secret.deploy.value`            | The TURN shared secret, if enabled (required if `settings.turn.secret.deploy.enabled` is set to `true`)                | ``                                |
+| `settings.max_upload_size`                     | Maximum size, in bytes, of files uploaded to the server                                                                | `"10M"`                           |
+| `postgresql.deploy`                            | Whether or not to deploy `stable/postgresql` as a subchart                                                             | `false`                           |
+| `postgresql.client.image.repository`           | Image repository for PostgreSQL client container                                                                       | `postgres`                        |
+| `postgresql.client.image.tag`                  | Image tag for PostgreSQL client container. Possible values listed [here][postgres-docker].                             | `11.2-alpine`                     |
+| `postgresql.client.image.pullPolicy`           | Image pull policy fpr PostgreSQL client contianer                                                                      | `IfNotPresent`                    |
+| `postgresql.nameOverride`                      | Override for Postgres subchart artifacts' names                                                                        | `db`                              |
+| `postgresql`                                   | There are many other options for [the Postgres subchart][postgres-chart]                                               |                                   |
+| `database.mode`                                | Which database type to run; valid options are `sqlite` and `postgres`                                                  | `sqlite`                          |
+| `database.secret.name_override`                | Override for the name of the secret containing database credentials                                                    | ``                                |
+| `database.secret.deploy.enabled`               | Whether or not to deploy the database secret as part of the chart                                                      | `true`                            |
+| `database.secret.deploy.username`              | If deploying the database secret, use this username                                                                    | `synapse`                         |
+| `database.secret.deploy.password`              | If deploying the database secret, use this password                                                                    | 16 random alphanmueric characters |
+| `database.host`                                | IP or hostname for database access; if in Postgres mode and `postgresql.deploy` is set to `false`, this is required    |                                   |
+| `database.port`                                | Port for database access                                                                                               | `5432`                            |
+| `database.name`                                | Name of database to access                                                                                             | `synapse`                         |
+| `service.annotations`                          | Annotations for Service resource                                                                                       | `{}`                              |
+| `service.type`                                 | Type of service to deploy                                                                                              | `ClusterIP`                       |
+| `service.clusterIP`                            | ClusterIP of service; if blank, it will be selected at random from the cluster CIDR range                              | `""`                              |
+| `service.port`                                 | Port to expose service                                                                                                 | `8008`                            |
+| `service.externalIPs`                          | External IPs for service                                                                                               | `[]`                              |
+| `service.loadBalancerIP`                       | Load balancer IP                                                                                                       | `""`                              |
+| `service.loadBalancerSourceRanges`             | List of IP CIDRs allowed to access the load balancer (if supported)                                                    | `[]`                              |
+| `ingress.enabled`                              | Whether or not to deploy the Ingress resource                                                                          | `false`                           |
+| `ingress.class`                                | Ingress class (included in annotations)                                                                                | ``                                |
+| `ingress.annotations`                          | Ingress annotations                                                                                                    | `{}`                              |
+| `ingress.path`                                 | Ingress path                                                                                                           | `/`                               |
+| `ingress.hosts`                                | Ingress accepted hostnames                                                                                             | `[synapse]`                       |
+| `ingress.tls`                                  | Ingress TLS configuration                                                                                              | `[]`                              |
+| `persistence.data.enabled`                     | Use persistent volume to store data                                                                                    | `true`                            |
+| `persistence.data.size`                        | Size of persistent volume claim                                                                                        | `8Gi`                             |
+| `persistence.data.existingClaim`               | Use an existing PVC to persist data                                                                                    | ``                                |
+| `persistence.data.storageClass`                | Type of persistent volume claim                                                                                        | ``                                |
+| `persistence.data.accessMode`                  | PVC access mode                                                                                                        | `[]`                              |
+| `resources`                                    | CPU/Memory resource requests/limits                                                                                    | `{}`                              |
+| `nodeSelector`                                 | Node labels for pod assignment                                                                                         | `{}`                              |
+| `tolerations`                                  | Toleration labels for pod assignment                                                                                   | `[]`                              |
+| `affinity`                                     | Affinity settings for pod assignment                                                                                   | `{}`                              |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+helm install --name my-release \
+	--set server_name="matrix.example.com" \
+	--set ingress.enabled=true \
+	incubator/synapse
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+helm install --name my-release -f values.yaml incubator/synapse
+```
+
+Read through the [values.yaml](values.yaml) file.
+
+[docker]: https://hub.docker.com/r/matrixdotorg/synapse
+[github]: https://github.com/matrix-org/synapse
+[matrix]: https://matrix.org/blog/home/
+[postgres-docker]: https://hub.docker.com/r/bitnami/postgresql
+[postgres-chart]: https://github.com/helm/charts/tree/master/stable/postgresql
+

--- a/incubator/synapse/requirements.lock
+++ b/incubator/synapse/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 3.11.4
+digest: sha256:24f26bd5c0f1ab9f973d6a8ede9d6957103042ac86acf6602676482ad7959eb0
+generated: 2019-02-18T09:55:04.111356-05:00

--- a/incubator/synapse/requirements.yaml
+++ b/incubator/synapse/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+  - name: postgresql
+    version: 3.x.x
+    repository: https://kubernetes-charts.storage.googleapis.com/
+    condition: postgresql.deploy

--- a/incubator/synapse/templates/NOTES.txt
+++ b/incubator/synapse/templates/NOTES.txt
@@ -1,0 +1,5 @@
+Synapse has been installed. You can access the server from within the k8s cluster using:
+
+  {{ template "synapse.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+

--- a/incubator/synapse/templates/_helpers.tpl
+++ b/incubator/synapse/templates/_helpers.tpl
@@ -1,0 +1,66 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "synapse.name" -}}
+  {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "synapse.fullname" -}}
+  {{- if .Values.fullnameOverride -}}
+    {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+  {{- else -}}
+    {{- $name := default .Chart.Name .Values.nameOverride -}}
+    {{- if contains $name .Release.Name -}}
+      {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+      {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Throw this in here because we can't call templates from subcharts.
+*/}}
+{{- define "postgresql.fullname" -}} 
+  {{- $values := default .Values .Values.postgresql -}}
+  {{- if $values.fullnameOverride -}} 
+    {{- printf $values.fullnameOverride | trunc 56 | trimSuffix "-" -}} 
+  {{- else -}} 
+    {{- $name := default .Chart.Name $values.nameOverride -}} 
+    {{- printf "%s-%s" .Release.Name $name | trunc 56 | trimSuffix "-" -}} 
+  {{- end -}} 
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "synapse.chart" -}}
+  {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Generate chart secret name
+*/}}
+{{- define "synapse.secretName" -}}
+  {{- default (include "synapse.fullname" .) .Values.secret.nameOverride -}}
+{{- end -}}
+
+{{/*
+Generate all the labels for chart-deployed resources
+*/}}
+{{- define "synapse.labels" -}}
+app.kubernetes.io/name: {{ template "synapse.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ template "synapse.chart" . }}
+{{- if .Values.extraLabels -}}
+{{- toYaml .Values.extraLabels -}}
+{{- end -}}
+{{- end -}}
+

--- a/incubator/synapse/templates/ingress.yaml
+++ b/incubator/synapse/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ingress.enabled -}} 
+{{- $fullName := include "synapse.fullname" . -}}
+{{- $servicePort := .Values.service.port -}} 
+{{- $ingressPath := .Values.ingress.path -}} 
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+  annotations:
+    kubernetes.io/ingress.class: {{ required "If ingress.enabled is set to true, ingress.class is required" .Values.ingress.class | quote }}
+    {{- if .Values.ingress.annotations }}
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $servicePort }}
+    {{- end }}
+{{- end }}

--- a/incubator/synapse/templates/job-initdb.yaml
+++ b/incubator/synapse/templates/job-initdb.yaml
@@ -1,0 +1,73 @@
+{{- if .Values.postgresql.deploy }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: "post-install"
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: "hook-succeeded"
+  name: {{ template "synapse.fullname" . }}-initdb
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: initdb
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "synapse.name" . }}
+        chart: {{ template "synapse.chart" . }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+        component: initdb
+    spec:
+      restartPolicy: OnFailure
+      initContainers:
+        - name: test-db
+          image: "{{ .Values.postgresql.client.image.repository }}:{{ .Values.postgresql.client.image.tag }}"
+          imagePullPolicy: {{ .Values.postgresql.client.image.pullPolicy | quote }}
+          command: [
+            "bash", "-ex", "-c",
+            "echo \"SHOW DATABASES\" | psql"
+          ]
+          env:
+            - name: PGHOST
+              value: {{ template "postgresql.fullname" . }}
+            - name: PGUSER
+              value: postgres
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (printf "%s-%s" (include "synapse.fullname" .) .Values.postgresql.nameOverride) .Values.postgresql.existingSecret | quote }}
+                  key: postgresql-password
+      containers:
+        - name: create-database
+          image: "{{ .Values.postgresql.client.image.repository }}:{{ .Values.postgresql.client.image.tag }}"
+          imagePullPolicy: {{ .Values.postgresql.client.image.pullPolicy | quote }}
+          command: [
+            "bash", "-ex", "-c",
+            "psql -tc \"SELECT 1 FROM pg_database WHERE datname = '${DB_NAME}'\" | grep -q 1 || psql -c \"CREATE DATABASE ${DB_NAME}\"; psql -tc \"SELECT 1 FROM pg_roles WHERE rolname = '${DB_USERNAME}'\" | grep 1 || psql -tc \"CREATE USER ${DB_USERNAME} WITH PASSWORD '${DB_PASSWORD}'\"; psql -c \"GRANT CONNECT,CREATE,TEMP ON DATABASE ${DB_NAME} TO ${DB_USERNAME}\";"
+          ]
+          env:
+            - name: DB_NAME
+              value: {{ .Values.database.name | quote }}
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (printf "%s-%s" (include "synapse.fullname" .) "database") .Values.database.secret.name_override | quote }}
+                  key: postgresql-username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (printf "%s-%s" (include "synapse.fullname" .) "database") .Values.database.secret.name_override | quote }}
+                  key: postgresql-password
+            - name: PGHOST
+              value: {{ template "postgresql.fullname" . }}
+            - name: PGUSER
+              value: postgres
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: synapse-db-root
+                  key: postgresql-password
+{{- end }}
+

--- a/incubator/synapse/templates/pvc.yaml
+++ b/incubator/synapse/templates/pvc.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.persistence.data.enabled (not .Values.persistence.data.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "synapse.fullname" . }}-data
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  accessModes:
+    - {{ .Values.persistence.data.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.data.size | quote }}
+  {{- if .Values.persistence.data.storageClass }}
+  {{- if not .Values.persistence.data.storageClass }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.persistence.data.storageClass | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/incubator/synapse/templates/secret-database-root.yaml
+++ b/incubator/synapse/templates/secret-database-root.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.database.secret.deploy.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ default (printf "%s-%s" (include "synapse.fullname" .) .Values.postgresql.nameOverride) .Values.postgresql.existingSecret | quote }}
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: initdb
+type: Opaque
+data:
+  postgresql-password: {{ randAlphaNum 16 | b64enc | quote }}
+{{- end }}
+

--- a/incubator/synapse/templates/secret-database.yaml
+++ b/incubator/synapse/templates/secret-database.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.database.secret.deploy.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ default (printf "%s-%s" (include "synapse.fullname" .) "database") .Values.database.secret.name_override | quote }}
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+type: Opaque
+data:
+  postgresql-username: {{ default "synapse" .Values.database.secret.deploy.username | b64enc | quote }}
+  postgresql-password: {{ default (randAlphaNum 16) .Values.database.secret.deploy.password | b64enc | quote }}
+{{- end }}
+

--- a/incubator/synapse/templates/secret-recaptcha.yaml
+++ b/incubator/synapse/templates/secret-recaptcha.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.settings.recaptcha.enabled .Values.settings.recaptcha.secret.deploy.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ default (printf "%s-%s" (include "synapse.fullname" .) "recaptcha") .Values.settings.recaptcha.secret.name_override | quote }}
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+type: Opaque
+data:
+  public-key: {{ required "If settings.recaptcha.secret.deploy.enabled is set to true, settings.recaptcha.secret.deploy.public_key must be set" .Values.settings.recaptcha.secret.deploy.public_key | b64enc | quote }}
+  private-key: {{ required "If settings.recaptcha.secret.deploy.enabled is set to true, settings.recaptcha.secret.deploy.private_key must be set" .Values.settings.recaptcha.secret.deploy.private_key | b64enc | quote }}
+{{- end }}
+

--- a/incubator/synapse/templates/secret-registration.yaml
+++ b/incubator/synapse/templates/secret-registration.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.settings.registration.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s" (include "synapse.fullname" .) "registration" | quote }}
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+type: Opaque
+data:
+  shared-secret: {{ randAlphaNum 32 | b64enc | quote }}
+  macaroon-key: {{ randAlphaNum 32 | b64enc | quote }}
+{{- end }}
+

--- a/incubator/synapse/templates/secret-turn.yaml
+++ b/incubator/synapse/templates/secret-turn.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.settings.turn.uris .Values.settings.turn.secret.deploy.enabled }}
+{{- if not .Values.settings.turn.secret.deploy.value }}
+{{- fail "If settings.turn.uris is populated and settings.turn.secret.deploy.enabled is set to true, settings.turn.secret.deploy.value must be set" }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ default (printf "%s-%s" (include "synapse.fullname" .) "turn") .Values.settings.turn.secret.name_override | quote }}
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+type: Opaque
+data:
+  value: {{ .Values.settings.turn.secret.deploy.value | b64enc | quote }}
+{{- end }}
+

--- a/incubator/synapse/templates/service.yaml
+++ b/incubator/synapse/templates/service.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  {{- if .Values.service.annotations }}
+  annotations:
+  {{- toYaml .Values.service.annotations | nindent 4 }}
+  {{- end }}
+  name: {{ template "synapse.fullname" . }}
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  clusterIP: {{ .Values.service.clusterIP | quote }}
+  {{- if .Values.service.externalIPs }}
+  externalIPs:
+  {{- toYaml .Values.service.externalIPs | nindent 4 }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP | quote }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.service.port }}
+      targetPort: http
+  selector:
+    {{- include "synapse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+  type: {{ .Values.service.type }}

--- a/incubator/synapse/templates/statefulset.yaml
+++ b/incubator/synapse/templates/statefulset.yaml
@@ -1,0 +1,143 @@
+apiVersion: apps/v1beta2
+kind: StatefulSet
+metadata:
+  name:  {{ template "synapse.fullname" . }}
+  labels:
+    {{- include "synapse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "synapse.labels" . | nindent 6 }}
+      app.kubernetes.io/component: server
+  template:
+    metadata:
+      labels:
+        {{- include "synapse.labels" . | nindent 8 }}
+        app.kubernetes.io/component: server
+    spec:
+      containers:
+        - name: synapse
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8008
+          env:
+            {{- if .Values.settings.uid }}
+            - name: UID
+              value: {{ .Values.settings.uid | quote }}
+            {{- end }}
+            {{- if .Values.settings.pid }}
+            - name: PID
+              value: {{ .Values.settings.pid | quote }}
+            {{- end }}
+            - name: SYNAPSE_SERVER_NAME
+              value: {{ required "server_name must be set to the public hostname of the server" .Values.server_name | quote }}
+            - name: SYNAPSE_REPORT_STATS
+              value: {{ .Values.settings.report_stats | quote }}
+            {{- if .Values.settings.tls.enable }}
+            {{- if .Values.settings.tls.acme }}
+            - name: SYNAPSE_ACME
+              value: "1"
+            {{- end }}
+            {{- else }}
+            - name: SYNAPSE_NO_TLS
+              value: "1"
+            {{- end }}
+            {{- if .Values.settings.registration.enabled }}
+            - name: SYNAPSE_ENABLE_REGISTRATION
+              value: "1"
+            {{- if .Values.settings.recaptcha.enabled }}
+            - name: SYNAPSE_RECAPTCHA_PUBLIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (printf "%s-%s" (include "synapse.fullname" .) "recaptcha") .Values.settings.recaptcha.secret.name_override | quote }}
+                  key: public-key
+            - name: SYNAPSE_RECAPTCHA_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (printf "%s-%s" (include "synapse.fullname" .) "recaptcha") .Values.settings.recaptcha.secret.name_override | quote }}
+                  key: private-key
+            {{- end }}
+            {{- else }}
+            - name: SYNAPSE_REGISTRATION_SHARED_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ printf "%s-%s" (include "synapse.fullname" .) "registration" | quote }}
+                  key: shared-secret
+            - name: SYNAPSE_MACAROON_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ printf "%s-%s" (include "synapse.fullname" .) "registration" | quote }}
+                  key: macaroon-key
+            {{- end }}
+            {{- if .Values.settings.guest }}
+            - name: SYNAPSE_ALLOW_GUEST
+              value: "1"
+            {{- end }}
+            - name: SYNAPSE_EVENT_CACHE_SIZE
+              value: {{ .Values.settings.event_cache_size | quote }}
+            {{- if .Values.settings.turn.uris }}
+            - name: SYNAPSE_TURN_URIS
+              value: {{ join "," .values.settings.turn.uris | quote }}
+            - name: SYNAPSE_TURN_SECRET
+              valueFrom:
+                secretKeyref:
+                  name: {{ default (printf "%s-%s" (include "synapse.fullname" .) "turn") .Values.settings.turn.secret.name_override | quote }}
+                  key: value
+            {{- end }}
+            - name: SYNAPSE_MAX_UPLOAD_SIZE
+              value: {{ .Values.settings.max_upload_size | quote }}
+            {{- if eq .Values.database.mode "postgresql" }}
+            - name: POSTGRES_HOST
+              {{- if .Values.postgresql.deploy }}
+              value: {{ template "postgresql.fullname" . }}
+              {{- else }}
+              value: {{ required "When database.mode is set to \"postgresql\" and postgresql.deploy is set to false, database.host is required" .Values.database.host | quote }}
+              {{- end }}
+            - name: POSTGRES_PORT
+              value: {{ .Values.database.port | quote }}
+            - name: POSTGRES_DB
+              value: {{ .Values.database.name | quote }}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (printf "%s-%s" (include "synapse.fullname" .) "database") .Values.database.secret.name_override | quote }}
+                  key: postgresql-username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (printf "%s-%s" (include "synapse.fullname" .) "database") .Values.database.secret.name_override | quote }}
+                  key: postgresql-password
+            {{- else if not (eq .Values.database.mode "sqlite") }}
+            {{- fail "database.mode must be set to one of \"sqlite\" or \"postgresql\"" }}
+            {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 2
+            failureThreshold: 5
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      volumes:
+        - name: data
+          {{- if .Values.persistence.data.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.data.existingClaim | default (printf "%s-%s" (include "synapse.fullname" .) "data") }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+

--- a/incubator/synapse/values.yaml
+++ b/incubator/synapse/values.yaml
@@ -1,0 +1,125 @@
+# Default values for synapse.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This is required
+server_name:
+
+# TODO:  I don't think this can be safely scaled, but find out for sure
+# replicaCount: 1
+
+image:
+  # From repository https://github.com/matrix-org/synapse
+  repository: matrixdotorg/synapse
+  tag: v0.99.1.1-py3
+  pullPolicy: IfNotPresent
+
+## Add additional labels to all resources
+extraLabels: {}
+
+settings:
+  uid: "991"
+  gid: "991"
+  report_stats: yes
+  tls:
+    enabled: false
+    acme: true
+  registration:
+    enabled: true
+  guest: false
+  event_cache_size: "10K"
+  recaptcha:
+    enabled: false
+    secret:
+      name_override:
+      deploy:
+        enabled: true
+        public_key:
+        private_key:
+  turn:
+    uris: []
+    secret:
+      name_override:
+      deploy:
+        enabled: true
+        value:
+  max_upload_size: "10M"
+
+postgresql:
+  deploy: false
+  client:
+    image:
+      repository: postgres
+      tag: 11.2-alpine
+      pullPolicy: IfNotPresent
+  nameOverride: db
+  existingSecret: synapse-db-root
+
+database:
+  # Can be "sqlite" or "postgresql"
+  mode: sqlite
+  secret:
+    name_override:
+    deploy:
+      enabled: true
+      username: synapse
+      password:
+  host:
+  port: 5432
+  name: synapse
+
+service:
+  annotations: {}
+  type: ClusterIP
+  clusterIP: ""
+
+  port: 8008
+  ## List of IP addresses at which the service is available
+  ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+  ##
+  externalIPs: []
+
+  loadBalancerIP: ""
+  loadBalancerSourceRanges: []
+
+ingress:
+  enabled: false
+  class:
+  annotations: {}
+  path: /
+  hosts:
+    - synapse
+  tls: []
+    # - secretName: synapse-tls
+    #    hosts:
+    #      - synapse
+
+## Persist configuration to a persistent volume
+persistence:
+  ## database data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If unset, storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  data:
+    enabled: true
+    existingClaim:
+    storageClass:
+    accessMode: ReadWriteMany
+    size: 8Gi
+
+resources:
+  # requests:
+  #   cpu: "100m"
+  #   memory: "256Mi"
+  # limits:
+  #   cpu: "500m"
+  #   memory: "512Mi"
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds a chart for Synapse, the reference implementation for a Matrix chat server, to incubator

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
This does require a variable set to deploy successfully - `server_name`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
