### PR TITLE
[stable/concourse] Allow specifying sidecar containers

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 3.7.5
+version: 3.8.0
 appVersion: 4.2.2
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -97,6 +97,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.service.loadBalancerSourceRanges` | Concourse Web Service Load Balancer Source IP ranges | `nil` |
 | `web.service.tsaNodePort` | Sets the nodePort for tsa when using `NodePort` | `nil` |
 | `web.service.type` | Concourse Web service type | `ClusterIP` |
+| `web.sidecarContainers` | Array of extra containers to run alongside the Concourse web container | `nil` |
 | `web.syslogSecretsPath` | Specify the mount directory of the web syslog secrets | `/concourse-syslog` |
 | `web.tolerations` | Tolerations for the web nodes | `[]` |
 | `web.vaultSecretsPath` | Specify the mount directory of the web vault secrets | `/concourse-vault` |
@@ -115,6 +116,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `worker.fatalErrors` | Newline delimited strings which, when logged, should trigger a restart of the worker | *See [values.yaml](values.yaml)* |
 | `worker.updateStrategy` | `OnDelete` or `RollingUpdate` (requires Kubernetes >= 1.7) | `RollingUpdate` |
 | `worker.podManagementPolicy` | `OrderedReady` or `Parallel` (requires Kubernetes >= 1.7) | `Parallel` |
+| `worker.sidecarContainers` | Array of extra containers to run alongside the Concourse worker container | `nil` |
 | `worker.hardAntiAffinity` | Should the workers be forced (as opposed to preferred) to be on different nodes? | `false` |
 | `worker.emptyDirSize` | When persistance is disabled this value will be used to limit the emptyDir volume size | `nil` |
 | `persistence.enabled` | Enable Concourse persistence using Persistent Volume Claims | `true` |

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -35,6 +35,9 @@ spec:
       {{- end }}
       {{- end }}
       containers:
+      {{- if .Values.web.sidecarContainers }}
+      {{- toYaml .Values.web.sidecarContainers | nindent 8 }}
+      {{- end }}
         - name: {{ template "concourse.web.fullname" . }}
           {{- if .Values.imageDigest }}
           image: "{{ .Values.image }}@{{ .Values.imageDigest }}"

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -40,6 +40,9 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds }}
       containers:
+      {{- if .Values.worker.sidecarContainers }}
+      {{- toYaml .Values.worker.sidecarContainers | nindent 8 }}
+      {{- end }}
         - name: {{ template "concourse.worker.fullname" . }}
           {{- if .Values.imageDigest }}
           image: "{{ .Values.image }}@{{ .Values.imageDigest }}"

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1093,6 +1093,16 @@ web:
   ##
   replicas: 1
 
+  ## Array of extra containers to run alongside the Concourse Web
+  ## container.
+  ##
+  ## Example:
+  ## - name: myapp-container
+  ##   image: busybox
+  ##   command: ['sh', '-c', 'echo Hello && sleep 3600']
+  ##
+  sidecarContainers:
+
   ## Configures the liveness probe used to determine if the Web component is up.
   ## ps.: if you're upgrading Concourse from one version  to another, the probe will
   ## probably fail for some time before migrations are finished - in such situations,
@@ -1280,6 +1290,16 @@ worker:
   ## Number of replicas.
   ##
   replicas: 2
+
+  ## Array of extra containers to run alongside the Concourse worker
+  ## container.
+  ##
+  ## Example:
+  ## - name: myapp-container
+  ##   image: busybox
+  ##   command: ['sh', '-c', 'echo Hello && sleep 3600']
+  ##
+  sidecarContainers:
 
   ## Minimum number of workers available after an eviction
   ## Ref: https://kubernetes.io/docs/admin/disruptions/


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR allows people to inject their own sidecars to both `worker` and `web`.

My immediate use for it was to test a health checker (https://github.com/cirocosta/concourse-worker-health-checker) for the worker, but I can totally see this being used by people for other uses common across the k8s ecosystem.


#### Which issue this PR fixes


#### Special notes for your reviewer:

Sample `values.yaml`:

```
worker:
  sidecarContainers:
    - name: health-checker
      image: cirocosta/concourse-worker-health-checker
      command:
      - /bin/sh
      - -c
      - 'for i in $(seq 1 1000); do checker ; sleep 10;  done'
```

leading to:

```
Containers:
  health-checker:
    Image:         cirocosta/concourse-worker-health-checker
    Command:
      /bin/sh
      -c
      for i in $(seq 1 1000); do checker ; sleep 10;  done
    State:          Running
      Started:      Mon, 18 Feb 2019 16:29:50 -0500
    Ready:          True
    ...
  dev-worker:
    Container ID:  docker://3dda9f2bdccb6556fa07db46f28a9b7118be56f556e97c5ddfdb5d894e123c45
    Image:         concourse/concourse:4.2.2
    Image ID:      docker-pullable://concourse/concourse@sha256:66ae399ed0879a687f095b6929777be9600b9ead026ab0363fb0f8080ee332da
    ...
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

cc @william-tran 
