### PR TITLE
Add optional support for configuring Prometheus scrape ServiceMonitor (#11451)

### DIFF
--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -42,6 +42,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Master.AuthorizationStrategy`    | Jenkins XML job config for AuthorizationStrategy | Not set                                                                      |
 | `Master.DeploymentLabels`         | Custom Deployment labels             | Not set                                                                      |
 | `Master.ServiceLabels`            | Custom Service labels                | Not set                                                                      |
+| `Master.PodLabels`                | Custom Pod labels                    | Not set                                                                      |
 | `Master.AdminUser`                | Admin username (and password) created as a secret if useSecurity is true | `admin`                                  |
 | `Master.AdminPassword`            | Admin password (and user) created as a secret if useSecurity is true | Random value                                  |
 | `Master.JenkinsAdminEmail`        | Email address for the administrator of the Jenkins instance | Not set                                               |

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -30,6 +30,9 @@ spec:
         release: {{ .Release.Name | quote }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         component: "{{ .Release.Name }}-{{ .Values.Master.Component }}"
+        {{- range $key, $val := .Values.Master.PodLabels }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end}}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
         {{- if .Values.Master.PodAnnotations }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -72,12 +72,14 @@ Master:
   # Master Service annotations
   ServiceAnnotations: {}
   # Master Custom Labels
-  DeploymentLabels:
+  DeploymentLabels: {}
   #   foo: bar
   #   bar: foo
   # Master Service Labels
   ServiceLabels: {}
   #   service.beta.kubernetes.io/aws-load-balancer-backend-protocol: https
+  # Put labels on jeknins-master pod
+  PodLabels: {}
   # Used to create Ingress record (should used with ServiceType: ClusterIP)
   # HostName: jenkins.cluster.local
   # NodePort: <to set explicitly, choose port between 30000-32767


### PR DESCRIPTION

* Add optional support for configuring Prometheus scrape via Prometheus-Operator ServiceMonitor

Signed-off-by: thomasriley <twriley@outlook.com>

* Bump Chart version

Signed-off-by: thomasriley <twriley@outlook.com>

* Fix linting error

Signed-off-by: thomasriley <twriley@outlook.com>

* Make the namespace value optional and remove the unnecessary telemetryPath & interval options

Signed-off-by: thomasriley <twriley@outlook.com>

* Re-add interval and metrics path options but make them optional

Signed-off-by: thomasriley <twriley@outlook.com>