### PR TITLE
[stable/sonatype-nexus] Reorder host names in ingress

### DIFF
--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,5 +1,5 @@
 name: sonatype-nexus
-version: 1.16.1
+version: 1.16.2
 appVersion: 3.15.2-01
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/templates/ingress.yaml
+++ b/stable/sonatype-nexus/templates/ingress.yaml
@@ -11,14 +11,14 @@ metadata:
     {{- end }}
 spec:
   rules:
-    - host: {{ .Values.nexusProxy.env.nexusDockerHost }}
+    - host: {{ .Values.nexusProxy.env.nexusHttpHost }}
       http:
         paths:
           - backend:
               serviceName: {{ template "nexus.fullname" . }}
               servicePort: {{ .Values.nexusProxy.port }}
             path: {{ .Values.ingress.path }}
-    - host: {{ .Values.nexusProxy.env.nexusHttpHost }}
+    - host: {{ .Values.nexusProxy.env.nexusDockerHost }}
       http:
         paths:
           - backend:
@@ -28,8 +28,8 @@ spec:
 {{- if .Values.ingress.tls.enabled }}
   tls:
     - hosts:
-        - {{ .Values.nexusProxy.env.nexusDockerHost }}
         - {{ .Values.nexusProxy.env.nexusHttpHost }}
+        - {{ .Values.nexusProxy.env.nexusDockerHost }}
       {{- if .Values.ingress.tls.secretName }}
       secretName: {{ .Values.ingress.tls.secretName | quote }}
       {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Make `nexusHttpHost` the first in the list of TLS hosts.

This is to ensure that the common name (as displayed in the browser) in the generated Let's Encrypt TLS certificate is the `nexusHttpHost`, while `nexusDockerHost` is added to subject alternative names.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

N/A

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
