### PR TITLE
[stable/concourse] set keepNamespaces to false when testing on ci

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 3.7.3
+version: 3.7.4
 appVersion: 4.2.2
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/ci/default-values.yaml
+++ b/stable/concourse/ci/default-values.yaml
@@ -1,0 +1,4 @@
+concourse:
+  web:
+    kubernetes:
+      keepNamespaces: false


### PR DESCRIPTION
#### What this PR does / why we need it:
I was doing some maintenance in the CI for Helm and notice the concourse created a bunch of namespaces and those are not used.

I saw in the values there is an option to delete those namespaces when deleting the chart.
Adding a ci test to use that to test and remove the namespace after since we don't need those hanging around in the CI cluster.

@cirocosta if you think we can set that to false in the values I can change as well

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
