### PR TITLE
kube-spot-termination-notice-handler - Config of pods securityContext

### DIFF
--- a/stable/k8s-spot-termination-handler/Chart.yaml
+++ b/stable/k8s-spot-termination-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.10.8-1"
 description: The K8s Spot Termination handler handles draining AWS Spot Instances in response to termination requests.
 name: k8s-spot-termination-handler
-version: 1.0.0
+version: 1.0.1
 keywords:
   - spot
   - termination

--- a/stable/k8s-spot-termination-handler/README.md
+++ b/stable/k8s-spot-termination-handler/README.md
@@ -41,3 +41,4 @@ Parameter | Description | Default
 `nodeSelector` | node labels for pod assignment | `{}`
 `tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
 `affinity` | node/pod affinities (requires Kubernetes >=1.6) | `{}`
+`securityContext` | security context for the pods | `{}`

--- a/stable/k8s-spot-termination-handler/templates/daemonset.yaml
+++ b/stable/k8s-spot-termination-handler/templates/daemonset.yaml
@@ -58,3 +58,7 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/stable/k8s-spot-termination-handler/values.yaml
+++ b/stable/k8s-spot-termination-handler/values.yaml
@@ -54,3 +54,7 @@ tolerations: []
   #   effect: "NoSchedule"
 
 affinity: {}
+
+# Configure securityContext of the pods
+securityContext: {}
+  # runAsUser: 65534


### PR DESCRIPTION
#### What this PR does / why we need it:

It allows us to configure securityContext on pods

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
