### PR TITLE
[stable/minio] fix for standalone mode for update strategy recreate

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Minio is a high performance distributed object storage server, designed for large-scale private cloud infrastructure.
 name: minio
-version: 2.4.12
+version: 2.4.13
 appVersion: RELEASE.2019-04-09T01-22-30Z
 keywords:
 - storage

--- a/stable/minio/templates/deployment.yaml
+++ b/stable/minio/templates/deployment.yaml
@@ -11,9 +11,13 @@ metadata:
 spec:
   strategy:
     type: {{ .Values.DeploymentUpdate.type }}
+    {{- if eq .Values.DeploymentUpdate.type "RollingUpdate" }}
     rollingUpdate:
       maxSurge: {{ .Values.DeploymentUpdate.maxSurge }}
       maxUnavailable: {{ .Values.DeploymentUpdate.maxUnavailable }}
+    {{- else }}
+    rollingUpdate: null
+    {{- end}}
   {{- if .Values.nasgateway.enabled }}
   replicas: {{ .Values.nasgateway.replicas }}
   {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

If you´re using update strategy recreate the property rollingUpdate isn´t permitted by kubernetes. In my case I cannot use RollingUpdate because I can´t provide ReadWriteMany Volumes for minio and I don´t want to use nfs volumes.

#### Special notes for your reviewer:

minio deployment mode "standalone"
update strategy recreate

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
