### PR TITLE
add securityContext to allow running with strict PSP

### DIFF
--- a/stable/kuberhealthy/Chart.yaml
+++ b/stable/kuberhealthy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0.0"
 home: https://comcast.github.io/kuberhealthy/
 description: The official Helm chart for Kuberhealthy.
 name: kuberhealthy
-version: 1.0.2
+version: 1.1.0
 maintainers:
   - name: integrii
     email: eric.greer@comcast.com

--- a/stable/kuberhealthy/README.md
+++ b/stable/kuberhealthy/README.md
@@ -54,6 +54,11 @@ deployment:
   maxUnavailable: 1
   imagePullPolicy: IfNotPresent
   namespace: kuberhealthy
+securityContext: # default container security context
+  runAsNonRoot: true
+  runAsUser: 999
+  fsGroup: 999
+  allowPrivilegeEscalation: false
 ```
 
 

--- a/stable/kuberhealthy/templates/deployment.yaml
+++ b/stable/kuberhealthy/templates/deployment.yaml
@@ -30,6 +30,8 @@ spec:
       automountServiceAccountToken: true
       containers:
       - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        securityContext:
+        {{- toYaml .Values.securityContext | nindent 10 -}}
         imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
         livenessProbe:
           failureThreshold: 3

--- a/stable/kuberhealthy/values.yaml
+++ b/stable/kuberhealthy/values.yaml
@@ -31,6 +31,12 @@ deployment:
   maxUnavailable: 1
   imagePullPolicy: IfNotPresent
 
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 999
+  fsGroup: 999
+  allowPrivilegeEscalation: false
+
 # Please remember that changing the service type to LoadBalancer
 # will expose Kuberhealthy to the internet, which could cause
 # error messages shown by Kuberhealthy to be exposed to the


### PR DESCRIPTION
#### What this PR does / why we need it:
Without a securityContext the pod will fail when running in a namespace with a restrictive (e.g. run as non-root) PSP.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
