### PR TITLE
[stable/grafana] re-add raw json dashboards in addition to files

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 2.0.1
+version: 2.0.2
 appVersion: 5.4.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -93,6 +93,38 @@ The command removes all the Kubernetes components associated with the chart and 
 | `rbac.pspEnabled`                         | Create PodSecurityPolicy (with `rbac.create`, grant roles permissions as well) | `true` |
 | `rbac.pspUseAppArmor`                     | Enforce AppArmor in created PodSecurityPolicy (requires `rbac.pspEnabled`)  | `true` |
 
+## Import dashboards
+
+There are a few methods to import dashboards to Grafana. Below are some examples and explanations as to how to use each method:
+
+```yaml
+dashboards:
+  default:
+    some-dashboard:
+      json: |
+        {
+          "annotations":
+
+          ...
+          # Complete json file here
+          ...
+
+          "title": "Some Dashboard",
+          "uid": "abcd1234",
+          "version": 1
+        }
+    custom-dashboard:
+      # This is a path to a file inside the dashboards directory inside the chart directory
+      file: dashboards/custom-dashboard.json
+    prometheus-stats:
+      # Ref: https://grafana.com/dashboards/2
+      gnetId: 2
+      revision: 2
+      datasource: Prometheus
+    local-dashboard:
+      url: https://raw.githubusercontent.com/user/repository/master/dashboards/dashboard.json
+```
+
 ## BASE64 dashboards
 
 Dashboards could be storaged in a server that does not return JSON directly and instead of it returns a Base64 encoded file (e.g. Gerrit)

--- a/stable/grafana/templates/dashboards-json-configmap.yaml
+++ b/stable/grafana/templates/dashboards-json-configmap.yaml
@@ -14,9 +14,14 @@ metadata:
     dashboard-provider: {{ $provider }}
 data:
 {{- range $key, $value := $dashboards }}
-{{- if hasKey $value "json" }}
+{{- if (or (hasKey $value "json") (hasKey $value "file")) }}
 {{ print $key | indent 2 }}.json:
-{{ toYaml ( $files.Get $value.json ) | indent 4}}
+{{- if hasKey $value "json" }}
+{{ $value.json | indent 4 }}
+{{- end }}
+{{- if hasKey $value "file" }}
+{{ toYaml ( $files.Get $value.file ) | indent 4}}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -210,21 +210,21 @@ dashboardProviders: {}
 ## dashboards per provider, use provider name as key.
 ##
 dashboards: {}
-#  default:
-#    some-dashboard:
-#      json: |
-#        $RAW_JSON
-#    custom-dashboard:
-#      file: dashboards/custom-dashboard.json
-#    prometheus-stats:
-#      gnetId: 2
-#      revision: 2
-#      datasource: Prometheus
-#    local-dashboard:
-#      url: https://example.com/repository/test.json
-#    local-dashboard-base64:
-#      url: https://example.com/repository/test-b64.json
-#      b64content: true
+  # default:
+  #   some-dashboard:
+  #     json: |
+  #       $RAW_JSON
+  #   custom-dashboard:
+  #     file: dashboards/custom-dashboard.json
+  #   prometheus-stats:
+  #     gnetId: 2
+  #     revision: 2
+  #     datasource: Prometheus
+  #   local-dashboard:
+  #     url: https://example.com/repository/test.json
+  #   local-dashboard-base64:
+  #     url: https://example.com/repository/test-b64.json
+  #     b64content: true
 
 ## Reference to external ConfigMap per provider. Use provider name as key and ConfiMap name as value.
 ## A provider dashboards must be defined either by external ConfigMaps or in values.yaml, not in both.

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -212,7 +212,10 @@ dashboardProviders: {}
 dashboards: {}
 #  default:
 #    some-dashboard:
-#      json: dashboards/custom-dashboard.json
+#      json: |
+#        $RAW_JSON
+#    custom-dashboard:
+#      file: dashboards/custom-dashboard.json
 #    prometheus-stats:
 #      gnetId: 2
 #      revision: 2


### PR DESCRIPTION
Signed-off-by: Maor Friedman <mafriedm@redhat.com>

#### What this PR does / why we need it:
This PR restores functionality lost as part of PR #10546 - the ability to define dashboards as raw json within values.yaml. It maintains the new functionality that was added as part of the same PR.

#### Which issue this PR fixes
  - fixes #11542 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
