### PR TITLE
[stable/fluent-bit] Fix extraEntries indentation

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 1.7.0
+version: 1.7.1
 appVersion: 1.0.4
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -47,7 +47,7 @@ data:
         Max_Entries     {{ .Values.input.systemd.maxEntries }}
         Read_From_Tail  {{ .Values.input.systemd.readFromTail }}
 {{- end }}
-{{ .Values.extraEntries.input | indent 8 }}
+{{ .Values.extraEntries.input | indent 4 }}
 
   fluent-bit-filter.conf: |-
     [FILTER]
@@ -65,7 +65,7 @@ data:
 {{- if .Values.filter.enableExclude }}
         K8S-Logging.Exclude On
 {{- end }}
-{{ .Values.extraEntries.filter | indent 8 }}
+{{ .Values.extraEntries.filter | indent 4 }}
 
   fluent-bit-output.conf: |-
 {{ if eq .Values.backend.type "test" }}
@@ -146,7 +146,7 @@ data:
 {{- end }}
         Format {{ .Values.backend.http.format }}
 {{- end }}
-{{ .Values.extraEntries.output | indent 8 }}
+{{ .Values.extraEntries.output | indent 4 }}
 
 
   fluent-bit.conf: |-


### PR DESCRIPTION
Signed-off-by: Heiko Nickerl <dev@heiko-nickerl.com>

#### What this PR does / why we need it:
This PR fixes the indentation of `[FILTER]`,`[OUTPUT]` and `[INPUT]` blocks which are specified via the `extraEntries.output`, `extraEntries.input` and `extraEntries.flilter` values. 

#### Which issue this PR fixes
  - fixes #11332 


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped

@kfox1111 @edsiper 