### PR TITLE
[stable/metricbeat] resources for each kind

### DIFF
--- a/stable/metricbeat/Chart.yaml
+++ b/stable/metricbeat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart to collect Kubernetes logs with metricbeat
 icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.svg
 name: metricbeat
-version: 1.0.0
+version: 1.1.0
 appVersion: 6.6.0
 home: https://www.elastic.co/products/beats/metricbeat
 sources:

--- a/stable/metricbeat/README.md
+++ b/stable/metricbeat/README.md
@@ -51,11 +51,15 @@ The following table lists the configurable parameters of the metricbeat chart an
 | `daemonset.podAnnotations`          | Pod annotations for daemonset | |
 | `daemonset.nodeSelector`            | Pod node selector for daemonset | `{}` |
 | `daemonset.tolerations`             | Pod taint tolerations for daemonset | `[{"key": "node-role.kubernetes.io/master", "operator": "Exists", "effect": "NoSchedule"}]` |
+| `daemonset.resources.requests.cpu`  | CPU resource requests for daemonset |                                           |
+| `daemonset.resources.limits.cpu`    | CPU resource limits for daemonset   |                                           |
 | `deployment.modules.<name>.config`  | The content of the modules configuration file consumed by metricbeat deployed as deployment, which is assumed to collect cluster-level metrics. See the [metricbeat.reference.yml](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-reference-yml.html) for full details ||
 | `deployment.modules.<name>.enabled` | If true, enable configuration ||
 | `deployment.podAnnotations`         | Pod annotations for deployment | |
 | `deployment.nodeSelector`           | Pod node selector for deployment | `{}` |
-| `deployment.tolerations`             | Pod taint tolerations for deployment | `[]` |
+| `deployment.tolerations`            | Pod taint tolerations for deployment | `[]` |
+| `deployment.resources.requests.cpu` | CPU resource requests for daemonset  |                                           |
+| `deployment.resources.limits.cpu`   | CPU resource limits for daemonset    |                                           |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/metricbeat/templates/daemonset.yaml
+++ b/stable/metricbeat/templates/daemonset.yaml
@@ -61,7 +61,11 @@ spec:
         securityContext:
           runAsUser: 0
         resources:
+{{- if .Values.daemonset.resources }}
+{{ toYaml .Values.daemonset.resources | indent 10 }}
+{{- else if .Values.resources }}
 {{ toYaml .Values.resources | indent 10 }}
+{{- end }}
         volumeMounts:
         - name: config
           mountPath: /usr/share/metricbeat/metricbeat.yml

--- a/stable/metricbeat/templates/deployment.yaml
+++ b/stable/metricbeat/templates/deployment.yaml
@@ -57,7 +57,11 @@ spec:
         securityContext:
           runAsUser: 0
         resources:
+{{- if .Values.deployment.resources }}
+{{ toYaml .Values.deployment.resources | indent 10 }}
+{{- else if .Values.resources }}
 {{ toYaml .Values.resources | indent 10 }}
+{{- end }}
         volumeMounts:
         - name: metricbeat-config
           mountPath: /usr/share/metricbeat/metricbeat.yml

--- a/stable/metricbeat/values.yaml
+++ b/stable/metricbeat/values.yaml
@@ -11,6 +11,7 @@ daemonset:
     operator: Exists
     effect: NoSchedule
   nodeSelector: {}
+  resources: {}
   config:
     metricbeat.config:
       modules:
@@ -75,6 +76,7 @@ deployment:
   podAnnotations: []
   tolerations: []
   nodeSelector: {}
+  resources: {}
   config:
     metricbeat.config:
       modules:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This pr adds `resource` field to each `daemonset` and `deployment` which set different resources.
As `kubectl top pods` below, metricbeat pod from deployment uses larger resources than ones from daemonsets. This is why I think resources for each kind is needed.
```plain
metricbeat-4rmb9                                                  10m          22Mi            
metricbeat-5x7wz                                                  9m           22Mi            
metricbeat-6db7c9dfd4-ncf8c                                       218m         133Mi           
metricbeat-7k6f7                                                  23m          38Mi            
metricbeat-7w8xt                                                  12m          23Mi            
metricbeat-9m9pj                                                  18m          35Mi            
metricbeat-j446n                                                  18m          26Mi            
metricbeat-nvm8v                                                  13m          29Mi            
metricbeat-t67jp                                                  13m          23Mi            
metricbeat-xdqnz                                                  20m          24Mi            
metricbeat-z5bqb                                                  32m          43Mi            
metricbeat-zdwms                                                  30m          46Mi
```

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
