### PR TITLE
[stable/mariadb] Fix 'MARIADB_MASTER_PORT_NUMBER' in templates/slave-statefulset.yaml

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 5.5.2
+version: 5.5.3
 appVersion: 10.1.38
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/templates/slave-statefulset.yaml
+++ b/stable/mariadb/templates/slave-statefulset.yaml
@@ -99,7 +99,7 @@ spec:
         - name: MARIADB_MASTER_HOST
           value: {{ template "mariadb.fullname" . }}
         - name: MARIADB_MASTER_PORT_NUMBER
-          value: "3306"
+          value: "{{ .Values.service.port }}"
         - name: MARIADB_MASTER_ROOT_USER
           value: "root"
         - name: MARIADB_MASTER_ROOT_PASSWORD


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
The value of `MARIADB_MASTER_PORT_NUMBER` was incorrectly set in `templates/slave-statefulset.yaml`.
Currently this value is set to '3306'.
```
        - name: MARIADB_MASTER_PORT_NUMBER
          value: "3306"
```
If you change the `service.port` property in `values.yaml` to '13306', the port of service will be set to 13306.
```
$ k -n test get svc
NAME                           TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                         AGE
helm-test-mariadb         ClusterIP      172.21.7.239    <none>          13306/TCP                       20h
helm-test-mariadb-slave   ClusterIP      172.21.34.120   <none>          13306/TCP                       20h
```
However, because the `MARIADB_MASTER_PORT_NUMBER` value in Slave is still '3306', replication fails.
Therefore, this value should be modified as follows:
```
        - name: MARIADB_MASTER_PORT_NUMBER
          value: "{{ .Values.service.port }}"
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
