### PR TITLE
[stable/ambassador] support targetPort specification

### DIFF
--- a/stable/ambassador/Chart.yaml
+++ b/stable/ambassador/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.50.2
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 1.1.3
+version: 1.1.4
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/stable/ambassador/templates/service.yaml
+++ b/stable/ambassador/templates/service.yaml
@@ -23,7 +23,7 @@ spec:
   ports:
     {{- if .Values.service.http.enabled }}
     - port: {{ .Values.service.http.port }}
-      targetPort: http
+      targetPort: {{ .Values.service.http.targetPort }}
       protocol: TCP
       name: http
       {{- with .Values.service.http.nodePort }}
@@ -32,7 +32,7 @@ spec:
     {{- end }}
     {{- if .Values.service.https.enabled }}
     - port: {{ .Values.service.https.port }}
-      targetPort: https
+      targetPort: {{ .Values.service.https.targetPort }}
       protocol: TCP
       name: https
       {{- with .Values.service.https.nodePort }}


### PR DESCRIPTION
Signed-off-by: Anthony Jones <anthony@wildinterior.co>

#### What this PR does / why we need it:

This PR adds support for configuring the targetPorts of the Ambassador service.

#### Special notes for your reviewer:

The [documentation already indicates](https://github.com/helm/charts/blob/master/stable/ambassador/README.md#configuration) that this is configurable and defaults to 8080 and 8443 for the http and https ports (matching the values file)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
