### PR TITLE
Nodeport support in rabbitmq ha

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.8
-version: 1.19.0
+version: 1.20.0
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/templates/ingress.yaml
+++ b/stable/rabbitmq-ha/templates/ingress.yaml
@@ -1,9 +1,10 @@
+{{- if .Values.ingress.enabled }}
+
 {{- $serviceName := include "rabbitmq-ha.fullname" . }}
-{{- if eq .Values.service.type "NodePort" }}
+{{- if .Values.ingress.useDiscoveryService }}
   {{- $serviceName = printf "%v-discovery"  $serviceName }}
 {{- end }}
 
-{{- if .Values.ingress.enabled }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/stable/rabbitmq-ha/templates/ingress.yaml
+++ b/stable/rabbitmq-ha/templates/ingress.yaml
@@ -1,10 +1,4 @@
 {{- if .Values.ingress.enabled }}
-
-{{- $serviceName := include "rabbitmq-ha.fullname" . }}
-{{- if .Values.ingress.useDiscoveryService }}
-  {{- $serviceName = printf "%v-discovery"  $serviceName }}
-{{- end }}
-
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/stable/rabbitmq-ha/templates/ingress.yaml
+++ b/stable/rabbitmq-ha/templates/ingress.yaml
@@ -23,7 +23,7 @@ spec:
         paths:
           - path: {{ .Values.ingress.path }}
             backend:
-              serviceName: {{ $serviceName }}
+              serviceName: {{ template "rabbitmq-ha.fullname" . }}
               servicePort: {{ .Values.rabbitmqManagerPort }}
 {{- if .Values.ingress.tls }}
   tls:

--- a/stable/rabbitmq-ha/templates/ingress.yaml
+++ b/stable/rabbitmq-ha/templates/ingress.yaml
@@ -1,3 +1,8 @@
+{{- $serviceName := include "rabbitmq-ha.fullname" . }}
+{{- if eq .Values.service.type "NodePort" }}
+  {{- $serviceName = printf "%v-discovery"  $serviceName }}
+{{- end }}
+
 {{- if .Values.ingress.enabled }}
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -23,7 +28,7 @@ spec:
         paths:
           - path: {{ .Values.ingress.path }}
             backend:
-              serviceName: {{ template "rabbitmq-ha.fullname" . }}
+              serviceName: {{ $serviceName }}
               servicePort: {{ .Values.rabbitmqManagerPort }}
 {{- if .Values.ingress.tls }}
   tls:

--- a/stable/rabbitmq-ha/templates/service.yaml
+++ b/stable/rabbitmq-ha/templates/service.yaml
@@ -39,17 +39,17 @@ spec:
     - name: http
       protocol: TCP
       port: {{ .Values.rabbitmqManagerPort }}
-      nodePort: {{ .Values.rabbitmqManagerNodePort }}
+      nodePort: {{ .Values.service.rabbitmqManagerNodePort }}
       targetPort: http
     - name: amqp
       protocol: TCP
       port: {{ .Values.rabbitmqNodePort }}
-      nodePort: {{ .Values.rabbitmqNodeNodePort }}
+      nodePort: {{ .Values.service.rabbitmqNodeNodePort }}
       targetPort: amqp
     - name: epmd
       protocol: TCP
       port: {{ .Values.rabbitmqEpmdPort }}
-      nodePort: {{ .Values.rabbitmqEpmdNodePort }}
+      nodePort: {{ .Values.service.rabbitmqEpmdNodePort }}
       targetPort: epmd
     {{- if .Values.rabbitmqSTOMPPlugin.enabled }}
     - name: stomp-tcp

--- a/stable/rabbitmq-ha/templates/service.yaml
+++ b/stable/rabbitmq-ha/templates/service.yaml
@@ -39,17 +39,17 @@ spec:
     - name: http
       protocol: TCP
       port: {{ .Values.rabbitmqManagerPort }}
-      nodePort: {{ .Values.service.rabbitmqManagerNodePort }}
+      nodePort: {{ .Values.service.managerNodePort }}
       targetPort: http
     - name: amqp
       protocol: TCP
       port: {{ .Values.rabbitmqNodePort }}
-      nodePort: {{ .Values.service.rabbitmqNodeNodePort }}
+      nodePort: {{ .Values.service.amqpNodePort }}
       targetPort: amqp
     - name: epmd
       protocol: TCP
       port: {{ .Values.rabbitmqEpmdPort }}
-      nodePort: {{ .Values.service.rabbitmqEpmdNodePort }}
+      nodePort: {{ .Values.service.epmdNodePort }}
       targetPort: epmd
     {{- if .Values.rabbitmqSTOMPPlugin.enabled }}
     - name: stomp-tcp

--- a/stable/rabbitmq-ha/templates/service.yaml
+++ b/stable/rabbitmq-ha/templates/service.yaml
@@ -21,7 +21,9 @@ metadata:
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
 spec:
+{{- if ne .Values.service.type "NodePort" }}
   clusterIP: "{{ .Values.service.clusterIP }}"
+{{- end }}
 {{- if .Values.service.externalIPs }}
   externalIPs:
 {{ toYaml .Values.service.externalIPs | indent 4 }}
@@ -37,14 +39,17 @@ spec:
     - name: http
       protocol: TCP
       port: {{ .Values.rabbitmqManagerPort }}
+      nodePort: {{ .Values.rabbitmqManagerNodePort }}
       targetPort: http
     - name: amqp
       protocol: TCP
       port: {{ .Values.rabbitmqNodePort }}
+      nodePort: {{ .Values.rabbitmqNodeNodePort }}
       targetPort: amqp
     - name: epmd
       protocol: TCP
       port: {{ .Values.rabbitmqEpmdPort }}
+      nodePort: {{ .Values.rabbitmqEpmdNodePort }}
       targetPort: epmd
     {{- if .Values.rabbitmqSTOMPPlugin.enabled }}
     - name: stomp-tcp

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -298,7 +298,7 @@ service:
   loadBalancerSourceRanges: []
   type: ClusterIP
 
-  ## Customize nodePort number when service type is NodePort
+  ## Customize nodePort number when the service type is NodePort
   ### Ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
   ###
   epmdNodePort: null

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -133,6 +133,13 @@ rabbitmqNodePort: 5672
 ## Manager port
 rabbitmqManagerPort: 15672
 
+## Customize nodePort number when service type is NodePort
+### Ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+###
+rabbitmqEpmdNodePort: null
+rabbitmqNodeNodePort: null
+rabbitmqManagerNodePort: null
+
 ## Set to true to precompile parts of RabbitMQ with HiPE, a just-in-time
 ## compiler for Erlang. This will increase server throughput at the cost of
 ## increased startup time. You might see 20-50% better performance at the cost

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -301,9 +301,9 @@ service:
   ## Customize nodePort number when service type is NodePort
   ### Ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
   ###
-  rabbitmqEpmdNodePort: null
-  rabbitmqNodeNodePort: null
-  rabbitmqManagerNodePort: null
+  epmdNodePort: null
+  amqpNodePort: null
+  managerNodePort: null
 
 podManagementPolicy: OrderedReady
 

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -414,6 +414,17 @@ ingress:
   ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
   tlsSecret: myTlsSecret
 
+  ## Connect ingress to the discovery service instead of the normal service
+  ## This is useful when ingress is still needed (which requires a ClusterIP Service type)
+  ##  but the primary service needs to be of a different type
+  ## For example: when the nginx-ingress service can only service http requests
+  ##  but the clients communicate with the rabbit server using a different protocol,
+  ##  using NodePort service type on the primary service will allow applications not on the
+  ##  same kuberentes cluster to communicate with the server using a protocol other than http.
+  ##  Then connecting the ingress to the discovery service will allow access to the web portal using nginx-ingress
+  ##
+  useDiscoveryService: false
+
   ## Ingress annotations done as key:value pairs
   annotations:
   #  kubernetes.io/ingress.class: nginx

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -133,13 +133,6 @@ rabbitmqNodePort: 5672
 ## Manager port
 rabbitmqManagerPort: 15672
 
-## Customize nodePort number when service type is NodePort
-### Ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
-###
-rabbitmqEpmdNodePort: null
-rabbitmqNodeNodePort: null
-rabbitmqManagerNodePort: null
-
 ## Set to true to precompile parts of RabbitMQ with HiPE, a just-in-time
 ## compiler for Erlang. This will increase server throughput at the cost of
 ## increased startup time. You might see 20-50% better performance at the cost
@@ -305,6 +298,13 @@ service:
   loadBalancerSourceRanges: []
   type: ClusterIP
 
+  ## Customize nodePort number when service type is NodePort
+  ### Ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  ###
+  rabbitmqEpmdNodePort: null
+  rabbitmqNodeNodePort: null
+  rabbitmqManagerNodePort: null
+
 podManagementPolicy: OrderedReady
 
 ## Statefulsets rolling update update strategy
@@ -413,17 +413,6 @@ ingress:
 
   ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
   tlsSecret: myTlsSecret
-
-  ## Connect ingress to the discovery service instead of the normal service
-  ## This is useful when ingress is still needed (which requires a ClusterIP Service type)
-  ##  but the primary service needs to be of a different type
-  ## For example: when the nginx-ingress service can only service http requests
-  ##  but the clients communicate with the rabbit server using a different protocol,
-  ##  using NodePort service type on the primary service will allow applications not on the
-  ##  same kuberentes cluster to communicate with the server using a protocol other than http.
-  ##  Then connecting the ingress to the discovery service will allow access to the web portal using nginx-ingress
-  ##
-  useDiscoveryService: false
 
   ## Ingress annotations done as key:value pairs
   annotations:


### PR DESCRIPTION
#### What this PR does / why we need it:

This adds the ability to use a NodePort service instead of ingress for external communication to the rabbit server. It also adds the option to use the discovery service for ingress instead of the primary rabbit service. This way the rabbit admin web portal can use ingress but applications talking to the rabbit server can use NodePort. The reason for it is our nginx-ingress service can only handle http requests but the applications connect to rabbit using a different protocol. So we want to use NodePort for external communication since it can handle other protocols and use ingress for the web portal.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
