### PR TITLE
kured - add psp configuration capabilities

### DIFF
--- a/stable/kured/Chart.yaml
+++ b/stable/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.1.0"
 description: A Helm chart for kured
 name: kured
-version: 1.1.0
+version: 1.1.1
 home: https://github.com/weaveworks/kured
 maintainers:
   - name: plumdog

--- a/stable/kured/README.md
+++ b/stable/kured/README.md
@@ -10,6 +10,7 @@ See https://github.com/weaveworks/kured
 | `image.pullSecrets`     | Image pull secrets                                                          | `[]`                       |
 | `extraArgs`             | Extra arguments to pass to `/usr/bin/kured`. See below.                     | `{}`                       |
 | `rbac.create`           | Create RBAC roles                                                           | `true`                     |
+| `podSecurityPolicy.create` | Create podSecurityPolicy                                                 | `false`                     |
 | `serviceAccount.create` | Create service account roles                                                | `true`                     |
 | `serviceAccount.name`   | Service account name to create (or use if `serviceAccount.create` is false) | (chart fullname)           |
 | `updateStrategy`        | Daemonset update strategy                                                   | `OnDelete`                 |

--- a/stable/kured/templates/podsecuritypolicy.yaml
+++ b/stable/kured/templates/podsecuritypolicy.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.podSecurityPolicy.create}}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "kured.fullname" . }}
+  labels:
+    app: {{ template "kured.name" . }}
+    chart: {{ template "kured.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  privileged: true
+  hostPID: true
+  allowedCapabilities: ['*']
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes: ['*']
+{{- end }}

--- a/stable/kured/templates/role.yaml
+++ b/stable/kured/templates/role.yaml
@@ -10,9 +10,16 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 rules:
-# Allow kured to lock/unlock itself
-- apiGroups:     ["extensions"]
-  resources:     ["daemonsets"]
-  resourceNames: ["{{ template "kured.fullname" . }}"]
-  verbs:         ["update"]
+  # Allow kured to lock/unlock itself
+  - apiGroups:     ["extensions"]
+    resources:     ["daemonsets"]
+    resourceNames: ["{{ template "kured.fullname" . }}"]
+    verbs:         ["update"]
+{{- if .Values.podSecurityPolicy.create }}
+  - apiGroups:     ["extensions"]
+    resources:     ["podsecuritypolicies"]
+    resourceNames: ["{{ template "kured.fullname" . }}"]
+    verbs:         ["use"]
+{{- end }}
+
 {{- end -}}

--- a/stable/kured/values.yaml
+++ b/stable/kured/values.yaml
@@ -10,6 +10,9 @@ extraArgs: {}
 rbac:
   create: true
 
+podSecurityPolicy:
+  create: false
+
 serviceAccount:
   create: true
   name:


### PR DESCRIPTION
This PR allow the configuration of pod security policy necessary to get kured running when the admission controller is enabled.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
