### PR TITLE
falco - add psp configuration capabilities

### DIFF
--- a/stable/falco/Chart.yaml
+++ b/stable/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: falco
-version: 0.5.6
+version: 0.5.7
 appVersion: 0.13.0
 description: Sysdig Falco
 keywords:

--- a/stable/falco/README.md
+++ b/stable/falco/README.md
@@ -51,6 +51,7 @@ The following table lists the configurable parameters of the Falco chart and the
 | `resources`                                     | Specify container resources                                          | `{}`                                                                                   |
 | `extraArgs`                                     | Specify additional container args                                    | `[]`                                                                                   |
 | `rbac.create`                                   | If true, create & use RBAC resources                                 | `true`                                                                                 |
+| `podSecurityPolicy.create`                      | If true, create & use podSecurityPolicy                              | `false`                                                                                |
 | `serviceAccount.create`                         | Create serviceAccount                                                | `true`                                                                                 |
 | `serviceAccount.name`                           | Use this value as serviceAccountName                                 | ` `                                                                                    |
 | `fakeEventGenerator.enabled`                    | Run falco-event-generator for sample events                          | `false`                                                                                |

--- a/stable/falco/templates/clusterrole.yaml
+++ b/stable/falco/templates/clusterrole.yaml
@@ -29,4 +29,14 @@ rules:
       - /healthz/*
     verbs:
       - get
+{{- if .Values.podSecurityPolicy.create }}
+  - apiGroups:
+      - extensions
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      - {{ template "falco.fullname" . }}
+    verbs:
+      - use
+{{- end }}
 {{- end }}

--- a/stable/falco/templates/podsecuritypolicy.yaml
+++ b/stable/falco/templates/podsecuritypolicy.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.podSecurityPolicy.create}}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "falco.fullname" . }}
+  labels:
+    app: {{ template "falco.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  privileged: true
+  hostNetwork: true
+  allowedCapabilities: ['*']
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes: ['*']
+{{- end }}

--- a/stable/falco/values.yaml
+++ b/stable/falco/values.yaml
@@ -23,6 +23,10 @@ rbac:
   # Create and use rbac resources
   create: true
 
+podSecurityPolicy:
+  # Create a podSecurityPolicy
+  create: false
+
 serviceAccount:
   # Create and use serviceAccount resources
   create: true


### PR DESCRIPTION
This PR allow the configuration of pod security policy necessary to get `sysdig-falco` running when the admission controller is enabled.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
