### PR TITLE
[stable/elasticsearch-exporter] Fix ServiceMonitor port

### DIFF
--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 1.1.2
+version: 1.1.3
 appVersion: 1.0.2
 home: https://github.com/justwatchcom/elasticsearch_exporter
 sources:

--- a/stable/elasticsearch-exporter/templates/servicemonitor.yaml
+++ b/stable/elasticsearch-exporter/templates/servicemonitor.yaml
@@ -16,7 +16,7 @@ spec:
   endpoints:
   - interval: 10s
     honorLabels: true
-    port: "{{ .Values.service.httpPort }}"
+    port: http
     path: {{ .Values.web.path }}
     scheme: http
   jobLabel: "{{ .Release.Name }}"


### PR DESCRIPTION
to use service port name instead of service port number

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
