### PR TITLE
kiam - add psp configuration capabilities

### DIFF
--- a/stable/kiam/Chart.yaml
+++ b/stable/kiam/Chart.yaml
@@ -1,5 +1,5 @@
 name: kiam
-version: 2.1.0
+version: 2.1.1
 appVersion: 3.0
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/stable/kiam/README.md
+++ b/stable/kiam/README.md
@@ -159,6 +159,8 @@ Parameter | Description | Default
 `serviceAccounts.agent.name` | Name of the agent service account to use or create | `{{ kiam.agent.fullname }}`
 `serviceAccounts.server.create` | If true, create the server service account | `true`
 `serviceAccounts.server.name` | Name of the server service account to use or create | `{{ kiam.server.fullname }}`
+`podSecurityPolicy.agent.create` | If true, create pertinent PodSecurityPolicy and bindings for the agent pods | `false`
+`podSecurityPolicy.server.create` | If true, create pertinent PodSecurityPolicy and bindings for the server pods | `false`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/kiam/templates/agent-daemonset.yaml
+++ b/stable/kiam/templates/agent-daemonset.yaml
@@ -41,10 +41,10 @@ spec:
     {{- end }}
       tolerations:
 {{ toYaml .Values.agent.tolerations | indent 8 }}
-      {{- if .Values.agent.affinity }}
+    {{- if .Values.agent.affinity }}
       affinity:
 {{ toYaml .Values.agent.affinity | indent 10 }}
-      {{- end }}
+    {{- end }}
       volumes:
         - name: tls
           secret:
@@ -63,10 +63,6 @@ spec:
       {{- end }}
       containers:
         - name: {{ template "kiam.name" . }}-{{ .Values.agent.name }}
-        {{- if .Values.agent.host.iptables }}
-          securityContext:
-            privileged: true
-        {{- end }}
           image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag }}"
           imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
           command:
@@ -107,6 +103,10 @@ spec:
             - name: {{ $name }}
               value: {{ quote $value }}
           {{- end }}
+        {{- with .Values.agent.securityContext }}
+          securityContext:
+{{ toYaml . | indent 12 }}
+        {{- end }}
           volumeMounts:
             - mountPath: /etc/kiam/tls
               name: tls

--- a/stable/kiam/templates/agent-podsecuritypolicy.yaml
+++ b/stable/kiam/templates/agent-podsecuritypolicy.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.podSecurityPolicy.agent.create}}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "kiam.fullname" . }}-agent
+  labels:
+    app: {{ template "kiam.name" . }}
+    chart: {{ template "kiam.chart" . }}
+    component: "{{ .Values.agent.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  # Required fields
+  hostNetwork: true
+  {{- if .Values.agent.host.iptables }}
+  privileged: true
+  allowPrivilegeEscalation: true
+  runAsUser:
+    rule: RunAsAny
+  {{- else }}
+  runAsUser:
+    rule: MustRunAsNonRoot
+  {{- end }}
+  volumes:
+    - hostPath
+    - secret
+  # Mandatory fields for valid PSP
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+{{- end }}

--- a/stable/kiam/templates/agent-role.yaml
+++ b/stable/kiam/templates/agent-role.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.podSecurityPolicy.agent.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app: {{ template "kiam.name" . }}
+    chart: {{ template "kiam.chart" . }}
+    component: "{{ .Values.agent.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "kiam.fullname" . }}-agent
+rules:
+  - apiGroups:
+      - extensions
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      - {{ template "kiam.fullname" . }}-agent
+    verbs:
+      - use
+{{- end -}}

--- a/stable/kiam/templates/agent-rolebinding.yaml
+++ b/stable/kiam/templates/agent-rolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.podSecurityPolicy.agent.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app: {{ template "kiam.name" . }}
+    chart: {{ template "kiam.chart" . }}
+    component: "{{ .Values.agent.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "kiam.fullname" . }}-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "kiam.fullname" . }}-agent
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "kiam.serviceAccountName.agent" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/stable/kiam/templates/server-daemonset.yaml
+++ b/stable/kiam/templates/server-daemonset.yaml
@@ -98,6 +98,10 @@ spec:
               value: {{ quote $value }}
           {{- end }}
         {{- end }}
+        {{- with .Values.server.securityContext }}
+          securityContext:
+{{ toYaml . | indent 12 }}
+        {{- end }}
           volumeMounts:
             - mountPath: /etc/kiam/tls
               name: tls

--- a/stable/kiam/templates/server-podsecuritypolicy.yaml
+++ b/stable/kiam/templates/server-podsecuritypolicy.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.podSecurityPolicy.server.create}}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "kiam.fullname" . }}-server
+  labels:
+    app: {{ template "kiam.name" . }}
+    chart: {{ template "kiam.chart" . }}
+    component: "{{ .Values.server.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  # Required fields
+  hostNetwork: {{ .Values.server.useHostNetwork }}
+  volumes:
+    - hostPath
+    - secret
+  # Mandatory fields for valid PSP
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+{{- end }}

--- a/stable/kiam/templates/server-role.yaml
+++ b/stable/kiam/templates/server-role.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.podSecurityPolicy.server.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app: {{ template "kiam.name" . }}
+    chart: {{ template "kiam.chart" . }}
+    component: "{{ .Values.server.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "kiam.fullname" . }}-server
+rules:
+  - apiGroups:
+      - extensions
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      - {{ template "kiam.fullname" . }}-server
+    verbs:
+      - use
+{{- end -}}

--- a/stable/kiam/templates/server-rolebinding.yaml
+++ b/stable/kiam/templates/server-rolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.podSecurityPolicy.server.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app: {{ template "kiam.name" . }}
+    chart: {{ template "kiam.chart" . }}
+    component: "{{ .Values.server.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "kiam.fullname" . }}-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "kiam.fullname" . }}-server
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "kiam.serviceAccountName.server" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/stable/kiam/values.yaml
+++ b/stable/kiam/values.yaml
@@ -94,6 +94,13 @@ agent:
   ##
   gatewayTimeoutCreation: 50ms
 
+  ## securityContext for the pods
+  ##
+  securityContext:
+    runAsUser: 65534  # run as nobody user | disable or set to root if agent.host.iptables = true
+    # privileged: true  # necessary if agent.host.iptables = true
+
+
   ## Base64-encoded PEM values for agent's CA certificate(s), certificate and private key
   ##
   tlsFiles:
@@ -200,6 +207,11 @@ server:
   probes:
     serverAddress: 127.0.0.1
 
+  ## securityContext for the pods
+  ##
+  securityContext:
+    runAsUser: 65534  # run as nobody user
+
   ## Base64-encoded PEM values for server's CA certificate(s), certificate and private key
   ##
   tlsFiles:
@@ -246,3 +258,10 @@ serviceAccounts:
   server:
     create: true
     name:
+
+# Create appropriate PodSecurityPolicies if necessary
+podSecurityPolicy:
+  agent:
+    create: false
+  server:
+    create: false


### PR DESCRIPTION
This PR allow the configuration of pod security policy necessary to get `uswitch/kiam` running when the admission controller is enabled.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
