### PR TITLE
Add ServiceMonitor endpoints config

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 1.3.1
+version: 1.3.2
 appVersion: 0.22.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -128,6 +128,7 @@ Parameter | Description | Default
 `controller.metrics.serviceMonitor.enabled` | Set this to `true` to create ServiceMonitor for Prometheus operator | `false`
 `controller.metrics.serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`
 `controller.metrics.serviceMonitor.namespace` | namespace where servicemonitor resource should be created | `the same namespace as nginx ingress`
+`controller.metrics.serviceMonitor.endpoints` | An array of ServiceMonitor endpoint configurations.  Can be used to filter out unwanted Prometheus targets. |<code>- port: metrics<br/>&nbsp;&nbsp;&nbsp;interval: 30s</code>
 `controller.customTemplate.configMapName` | configMap containing a custom nginx template | `""`
 `controller.customTemplate.configMapKey` | configMap key containing the nginx template | `""`
 `controller.headers` | configMap key:value pairs containing the [custom headers](https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers) for Nginx | `{}`

--- a/stable/nginx-ingress/templates/controller-servicemonitor.yaml
+++ b/stable/nginx-ingress/templates/controller-servicemonitor.yaml
@@ -17,8 +17,7 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-    - port: metrics
-      interval: 30s
+{{ toYaml .Values.controller.metrics.serviceMonitor.endpoints | indent 4 }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -278,6 +278,9 @@ controller:
 
     serviceMonitor:
       enabled: false
+      endpoints:
+        - port: metrics
+          interval: 30s
       additionalLabels: {}
       namespace: ""
 


### PR DESCRIPTION
Signed-off-by: Jeffrey Doto <jeffdoto@gmail.com>

#### What this PR does / why we need it:

This PR adds the ability to configure ServiceMonitor endpoints.

By allowing configuration, it allows the user of the chart to filter out unwanted Prometheus targets.  One case where this is useful is when using nginx TCP service key:value pairs, you may get unresolvable entries in your list of targets.  

By adding configuration like this:

```
     endpoints:
        - port: "stats"
          path: /metrics
        - port: "metrics"
          path: /metrics
```

You can more directly target what you want to scrape.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
