### PR TITLE
[incubator/vault] extraContainers x Resources, consulAgent x Affinity, volumeMount fixes

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.14.9
+version: 0.14.10
 appVersion: 1.0.1
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -56,6 +56,7 @@ The following table lists the configurable parameters of the Vault chart and the
 | `vault.extraEnv`                  | Extra env vars for Vault pods            | `{}`                                |
 | `vault.extraContainers`           | Sidecar containers to add to the vault pod | `{}`                              |
 | `vault.extraVolumes`              | Additional volumes to the controller pod | `{}`                                |
+| `vault.extraVolumeMounts`         | Additional volume mounts to the Vault container | `{}`                         |
 | `vault.customSecrets`             | Custom secrets available to Vault        | `[]`                                |
 | `vault.config`                    | Vault configuration                      | No default backend                  |
 | `replicaCount`                    | k8s replicas                             | `3`                                 |

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -86,12 +86,14 @@ spec:
         - name: {{ .secretName | replace "." "-"}}
           mountPath: {{ .mountPath }}
         {{- end }}
+        {{- if .Values.vault.extraVolumeMounts }}
+{{ toYaml .Values.vault.extraVolumeMounts | indent 8}}
+        {{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
 {{- if .Values.vault.extraContainers }}
 {{ toYaml .Values.vault.extraContainers | indent 6}}
 {{- end }}
-        resources:
-{{ toYaml .Values.resources | indent 10 }}
-      {{- if .Values.affinity }}
       {{- if .Values.consulAgent.join }}
       - name: {{ .Chart.Name }}-consul-agent
         image: "{{ .Values.consulAgent.repository }}:{{ .Values.consulAgent.tag }}"
@@ -122,6 +124,7 @@ spec:
               -join={{- .Values.consulAgent.join }} \
               -data-dir=/etc/consul
       {{- end }}
+      {{- if .Values.affinity }}
       affinity:
 {{ tpl .Values.affinity . | indent 8 }}
       {{- end }}

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -128,6 +128,13 @@ vault:
   #   - name: some-mount
   #     mountPath: /some/path
   extraVolumes: {}
+  ## Additional volumes to be added to the Vault Pod
+  # - name: vault-audit
+  #   emptyDir: {}
+  extraVolumeMounts: {}
+  ## Additional volume mounts to be added to the Vault container
+  # - name: vault-audit
+  #   mountPath: /vault/logs
   # Log level
   # https://www.vaultproject.io/docs/commands/server.html#log-level
   logLevel: "info"


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

1. Currently, if you add **`extraContainers`** via `values.yaml`, as well as **`resources`**, the `resources` are mounted to the (last) `extraContainer` added to the Vault Pod.  This PR corrects this logic, and ensures `resources` are properly provided to the Vault container by moving `extraContainer` logic below its definition in `deployment.yaml`. 
3. Currently, one can define `extraVolumes`, but cannot mount these volumes to the Vault container (or `extraContainers`). This is corrected in this PR by adding a new `extraVolumeMounts` option in `values.yaml` and `deployment.yaml` which now allows these volumes to be mounted.
2. Currently, if you do not provide an `affinity` to the Vault pod, the `consulAgent` will not launch.  This logic should be separate from the `affinity` definition itself. This PR moves `affinity`'s `if` statement below the `consulAgent` so that one is not dependent of the other. 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
