### PR TITLE
Adding optional additional airflow ConfigMaps

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,6 +1,6 @@
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 0.18.0
+version: 1.0.0
 appVersion: 1.10.0
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,6 +1,6 @@
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 0.17.4
+version: 0.18.0
 appVersion: 1.10.0
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -275,6 +275,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `airflow.config`                         | custom airflow configuration env variables              | `{}`                      |
 | `airflow.podDisruptionBudget`            | control pod disruption budget                           | `{'maxUnavailable': 1}`   |
 | `airflow.secretsMapping`		           | override any environment variable with a secret	     | 				             |
+| `airflow.extraConfigmapMounts`           | Additional configMap volume mounts on the airflow pods.         | `[]`                                          |
 | `workers.enabled`                        | enable workers                                          | `true`                    |
 | `workers.replicas`                       | number of workers pods to launch                        | `1`                       |
 | `workers.resources`                      | custom resource configuration for worker pod            | `{}`                      |
@@ -332,5 +333,6 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `redis.password`                         | Redis password                                          | `airflow`                 |
 | `redis.master.persistence.enabled`       | Enable Redis PVC                                        | `false`                   |
 | `redis.cluster.enabled`                  | enable master-slave cluster                             | `false`                   |
+
 
 Full and up-to-date documentation can be found in the comments of the `values.yaml` file.

--- a/stable/airflow/templates/deployments-scheduler.yaml
+++ b/stable/airflow/templates/deployments-scheduler.yaml
@@ -86,6 +86,11 @@ spec:
             - name: connections
               mountPath: /usr/local/connections
           {{- end}}
+          {{- range .Values.airflow.extraConfigmapMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              readOnly: {{ .readOnly }}
+          {{- end }}
           args:
             - "bash"
             - "-c"
@@ -154,4 +159,9 @@ spec:
           secret:
             secretName: {{ template "airflow.fullname" . }}-connections
             defaultMode: 0755
+        {{- end }}
+        {{- range .Values.airflow.extraConfigmapMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
         {{- end }}

--- a/stable/airflow/templates/deployments-web.yaml
+++ b/stable/airflow/templates/deployments-web.yaml
@@ -85,6 +85,11 @@ spec:
             - name: logs-data
               mountPath: {{ .Values.logs.path }}
           {{- end }}
+          {{- range .Values.airflow.extraConfigmapMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              readOnly: {{ .readOnly }}
+          {{- end }}
           args:
             - "bash"
             - "-c"
@@ -145,4 +150,9 @@ spec:
             secretName: {{ .Values.dags.git.secret }}
             defaultMode: 0700
         {{- end }}
+        {{- end }}
+        {{- range .Values.airflow.extraConfigmapMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
         {{- end }}

--- a/stable/airflow/templates/statefulsets-workers.yaml
+++ b/stable/airflow/templates/statefulsets-workers.yaml
@@ -93,6 +93,11 @@ spec:
             - name: dags-data
               mountPath: {{ .Values.dags.path }}
           {{- end }}
+          {{- range .Values.airflow.extraConfigmapMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              readOnly: {{ .readOnly }}
+          {{- end }}
           args:
             - "bash"
             - "-c"
@@ -149,5 +154,10 @@ spec:
             secretName: {{ .Values.dags.git.secret }}
             defaultMode: 0700
         {{- end }}
+        {{- end }}
+        {{- range .Values.airflow.extraConfigmapMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
         {{- end }}
 {{- end }}

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -1,14 +1,13 @@
 # Duplicate this file and put your customization here
 
-extraConfigmapMounts: []
+##
+## common settings and setting for the webserver
+airflow:
+  extraConfigmapMounts: []
   # - name: extra-metadata
   #   mountPath: /opt/metadata
   #   configMap: airflow-metadata
   #   readOnly: true
-
-##
-## common settings and setting for the webserver
-airflow:
 
   ## When existingAirflowSecret is defined, secretsMapping can be
   ## overridden. When no secretName is given then the value of

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -1,5 +1,10 @@
 # Duplicate this file and put your customization here
 
+extraConfigmapMounts: []
+  # - name: extra-metadata
+  #   mountPath: /opt/metadata
+  #   configMap: airflow-metadata
+  #   readOnly: true
 
 ##
 ## common settings and setting for the webserver


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a key to values.yaml to allow the end-user to inject additional ConfigMaps into Airflow.

I ran into a situation where I wanted to deploy some stuff at a different cadence from the DAGs, so this seemed to be a reasonable way to do it.

#### Which issue this PR fixes

n/a

#### Special notes for your reviewer:

This has been cribbed off of the Grafana chart because I figured that uniformity was good.

Thanks for taking ownership of the chart, @gsemet, @maver1ck. :)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
