### PR TITLE
[stable/redis-ha] Allow for custom labels on redis pod

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.1.6
+version: 3.2.0
 appVersion: 5.0.3
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/stable/redis-ha/templates/redis-ha-statefulset.yaml
@@ -31,7 +31,7 @@ spec:
         release: {{ .Release.Name }}
         app: {{ template "redis-ha.name" . }}
         {{- range $key, $value := .Values.labels }}
-          {{ $key }}: {{ $value }}
+        {{ $key }}: {{ $value }}
         {{- end }}
     spec:
       {{- if .Values.nodeSelector }}

--- a/stable/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/stable/redis-ha/templates/redis-ha-statefulset.yaml
@@ -30,6 +30,9 @@ spec:
       labels:
         release: {{ .Release.Name }}
         app: {{ template "redis-ha.name" . }}
+        {{- range $key, $value := .Values.labels }}
+          {{ $key }}: {{ $value }}
+        {{- end }}
     spec:
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/stable/redis-ha/values.yaml
+++ b/stable/redis-ha/values.yaml
@@ -8,6 +8,9 @@ image:
 ## replicas number for each component
 replicas: 3
 
+## Custom labels for the redis pod
+labels: {}
+
 ## Redis specific configuration options
 redis:
   port: 6379


### PR DESCRIPTION
Signed-off-by: Francesco Lanciana <francescolanciana@gmail.com>

#### What this PR does / why we need it:
* Added the ability to assign extra labels to the redis pod (in addition to the release and app labels)

Currently there is no way to assign custom labels to the redis pod, however it is occasionally necessary for custom labels to be assigned to the pod. An example may be a label that is used to enforce a certain network security policy (this is our particular use case). Without this we are completely unable to proceed with this particular helm chart.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
