### PR TITLE
Bookstack persistent volume patch

### DIFF
--- a/stable/bookstack/Chart.yaml
+++ b/stable/bookstack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.24.3
 description: BookStack is a simple, self-hosted, easy-to-use platform for organising and storing information.
 name: bookstack
-version: 1.0.1
+version: 1.0.2
 home: https://www.bookstackapp.com/
 icon: https://github.com/BookStackApp/website/blob/master/static/images/logo.png
 sources:

--- a/stable/bookstack/templates/deployment.yaml
+++ b/stable/bookstack/templates/deployment.yaml
@@ -96,7 +96,7 @@ spec:
         - name: uploads
         {{- if .Values.persistence.uploads.enabled }}
           persistentVolumeClaim:
-            claimName: {{ .Values.persistence.storage.existingClaim | default (printf "%s-%s" (include "bookstack.fullname" .) "uploads") }}
+            claimName: {{ .Values.persistence.uploads.existingClaim | default (printf "%s-%s" (include "bookstack.fullname" .) "uploads") }}
         {{- else }}
           emptyDir: {}
         {{- end }}


### PR DESCRIPTION
Just a correction about Bookstack persistent volumes, the documentation says to use the following command line with two PVC's (Volume Claims) :

$ helm upgrade --install test --set persistence.uploads.existingClaim=PVC_UPLOADS,persistence.storage.existingClaim=PVC_STORAGE stable/bookstack

But the PVC name was the same for both parameters in the code,

👍

Signed-off-by: Lucas Martins lucas_054@hotmail.fr