### PR TITLE
Add prometheus annotations

### DIFF
--- a/stable/filebeat/templates/service.yaml
+++ b/stable/filebeat/templates/service.yaml
@@ -2,6 +2,10 @@
 kind: Service
 apiVersion: v1
 metadata:
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "9479"
+    prometheus.io/scrape: "true"
   name: {{ template "filebeat.fullname" . }}-metrics
   namespace: {{ .Release.Namespace }}
   labels:


### PR DESCRIPTION
Signed-off-by: Artem Pastukhov <artem.pastukhov@gmail.com>
Add prometheus annotations for filebeat metrics server for  those who not use prometheus operator



- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
