### PR TITLE
Add prometheus annotations for filebeat chart

### DIFF
--- a/stable/filebeat/Chart.yaml
+++ b/stable/filebeat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart to collect Kubernetes logs with filebeat
 icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.svg
 name: filebeat
-version: 1.4.0
+version: 1.4.1
 appVersion: 6.6.0
 home: https://www.elastic.co/products/beats/filebeat
 sources:

--- a/stable/filebeat/templates/service.yaml
+++ b/stable/filebeat/templates/service.yaml
@@ -2,6 +2,10 @@
 kind: Service
 apiVersion: v1
 metadata:
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "9479"
+    prometheus.io/scrape: "true"
   name: {{ template "filebeat.fullname" . }}-metrics
   namespace: {{ .Release.Namespace }}
   labels:


### PR DESCRIPTION

#### What this PR does / why we need it:

Add prometheus annotations for metrics service on filebeat chart for those who have no prometheus operator


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
