### PR TITLE
[stable/cerebro] Add support for auth proxy sidecar containers

### DIFF
--- a/stable/cerebro/Chart.yaml
+++ b/stable/cerebro/Chart.yaml
@@ -7,7 +7,7 @@ sources:
  - https://github.com/lmenezes/cerebro-docker
  - https://github.com/lmenezes/cerebro
 name: cerebro
-version: 0.5.2
+version: 0.6.0
 maintainers:
 - name: davidkarlsen
   email: david@davidkarlsen.com

--- a/stable/cerebro/README.md
+++ b/stable/cerebro/README.md
@@ -37,32 +37,35 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the cerebro chart and their default values.
 
-|             Parameter               |            Description              |                    Default                |
-|-------------------------------------|-------------------------------------|-------------------------------------------|
-| `replicaCount`                      | Number of replicas                  | `1`                                       |
-| `image.repository`                  | The image to run                    | `lmenezes/cerebro`                        |
-| `image.tag`                         | The image tag to pull               | `0.8.1`                                   |
-| `image.pullPolicy`                  | Image pull policy                   | `IfNotPresent`                            |
-| `init.image.repository`             | The image to run                    | `docker.io/busybox`                       |
-| `init.image.tag`                    | The image tag to pull               | `musl`                                    |
-| `init.image.pullPolicy`             | Image pull policy                   | `IfNotPresent`                            |
-| `deployment.annotations`            | Annotations for deployment          | `{}`                                      |
-| `service.type`                      | Type of Service                     | `ClusterIP`                               |
-| `service.port`                      | Port for kubernetes service         | `80`                                      |
-| `service.annotations`               | Annotations to add to the service   | `{}`                                      |
-| `service.labels`                    | Labels to add to the service        | `{}`                                      |
-| `resources.requests.cpu`            | CPU resource requests               |                                           |
-| `resources.limits.cpu`              | CPU resource limits                 |                                           |
-| `resources.requests.memory`         | Memory resource requests            |                                           |
-| `resources.limits.memory`           | Memory resource limits              |                                           |
-| `ingress`                           | Settings for ingress                | `{}`                                      |
-| `nodeSelector`                      | Settings for nodeselector           | `{}`                                      |
-| `tolerations`                       | Settings for toleration             | `{}`                                      |
-| `affinity`                          | Settings for affinity               | `{}`                                      |
-| `config.basePath`                   | Application base path               | `/`                                       |
-| `config.restHistorySize`            | Rest request history size per user  | `50`                                      |
-| `config.hosts`                      | A list of known hosts               | `[]`                                      |
-| `config.secret`                     | Secret used to sign session cookies | `(random alphanumeric 64 length string)`  |
+| Parameter                   | Description                                                                      | Default                                  |
+| --------------------------- | -------------------------------------------------------------------------------- | ---------------------------------------- |
+| `replicaCount`              | Number of replicas                                                               | `1`                                      |
+| `image.repository`          | The image to run                                                                 | `lmenezes/cerebro`                       |
+| `image.tag`                 | The image tag to pull                                                            | `0.8.1`                                  |
+| `image.pullPolicy`          | Image pull policy                                                                | `IfNotPresent`                           |
+| `init.image.repository`     | The image to run                                                                 | `docker.io/busybox`                      |
+| `init.image.tag`            | The image tag to pull                                                            | `musl`                                   |
+| `init.image.pullPolicy`     | Image pull policy                                                                | `IfNotPresent`                           |
+| `deployment.annotations`    | Annotations for deployment                                                       | `{}`                                     |
+| `service.type`              | Type of Service                                                                  | `ClusterIP`                              |
+| `service.port`              | Port for kubernetes service                                                      | `80`                                     |
+| `service.targetPort`        | Target port for kubernetes service (change to proxy port if using proxy Sidecar) | `9000`                                   |
+| `service.annotations`       | Annotations to add to the service                                                | `{}`                                     |
+| `service.labels`            | Labels to add to the service                                                     | `{}`                                     |
+| `resources.requests.cpu`    | CPU resource requests                                                            |                                          |
+| `resources.limits.cpu`      | CPU resource limits                                                              |                                          |
+| `resources.requests.memory` | Memory resource requests                                                         |                                          |
+| `resources.limits.memory`   | Memory resource limits                                                           |                                          |
+| `ingress`                   | Settings for ingress                                                             | `{}`                                     |
+| `nodeSelector`              | Settings for nodeselector                                                        | `{}`                                     |
+| `tolerations`               | Settings for toleration                                                          | `{}`                                     |
+| `affinity`                  | Settings for affinity                                                            | `{}`                                     |
+| `config.basePath`           | Application base path                                                            | `/`                                      |
+| `config.restHistorySize`    | Rest request history size per user                                               | `50`                                     |
+| `config.hosts`              | A list of known hosts                                                            | `[]`                                     |
+| `config.secret`             | Secret used to sign session cookies                                              | `(random alphanumeric 64 length string)` |
+| `config.secret`             | Secret used to sign session cookies                                              | `(random alphanumeric 64 length string)` |
+| `extraContainers`           | Sidecar containers to add to the cerebro pod                                     | `""`                                     |
 
 
 

--- a/stable/cerebro/templates/deployment.yaml
+++ b/stable/cerebro/templates/deployment.yaml
@@ -58,6 +58,9 @@ spec:
               port: http
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+{{- with .Values.extraContainers }}
+{{ tpl . $ | indent 8 }}
+{{- end }}
       volumes:
         - name: db
           emptyDir: {}

--- a/stable/cerebro/templates/service.yaml
+++ b/stable/cerebro/templates/service.yaml
@@ -18,7 +18,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
       name: http
   selector:

--- a/stable/cerebro/values.yaml
+++ b/stable/cerebro/values.yaml
@@ -20,6 +20,7 @@ deployment:
 service:
   type: ClusterIP
   port: 80
+  targetPort: 9000
   annotations: {}
   labels: {}
 
@@ -54,3 +55,20 @@ config:
   # Secret used to sign session cookies. If empty it will be replaced with a
   # random 64 length string
   secret: ''
+
+extraContainers: |
+#   - name: proxy
+#     image: quay.io/pusher/oauth2_proxy:latest
+#     args:
+#       - -client-id=
+#       - -client-secret=
+#       - -cookie-secret=
+#       - -email-domain=*
+#       - -github-org=
+#       - -http-address=0.0.0.0:9001
+#       - -provider=github
+#       - -redirect-url=https://cerebro.your.domain.com/oauth2/callback
+#       - -upstream=http://127.0.0.1:9000
+#     ports:
+#       - name: http-proxy
+#         containerPort: 9001


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds support for sidecar proxy containers by:
- Support `extraContainers`
- Support changing service `targetPort`

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
