### PR TITLE
[stable/grafana] Bump sidecar version

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,6 +1,6 @@
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 1.0.0
+version: 1.0.1
 appVersion: 1.10.0
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/templates/_helpers.tpl
+++ b/stable/airflow/templates/_helpers.tpl
@@ -87,9 +87,9 @@ Map environment vars to secrets
     {{- $secretName := .Release.Name | trunc 63 | trimSuffix "-" }}
     {{- $mapping := .Values.airflow.defaultSecretsMapping }}
     {{- if .Values.existingAirflowSecret }}
-      {{- $secretName = .Values.existingAirflowSecret }}
+      {{- $secretName := .Values.existingAirflowSecret }}
       {{- if .Values.airflow.secretsMapping }}
-        {{- $mapping = .Values.airflow.secretsMapping }}
+        {{- $mapping := .Values.airflow.secretsMapping }}
       {{- end }}
     {{- end }}
     {{- range $val := $mapping }}

--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 2.0.2
+version: 2.0.3
 appVersion: 5.4.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -295,7 +295,7 @@ smtp:
 ## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
 ## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards
 sidecar:
-  image: kiwigrid/k8s-sidecar:0.0.10
+  image: kiwigrid/k8s-sidecar:0.0.11
   imagePullPolicy: IfNotPresent
   resources:
 #   limits:


### PR DESCRIPTION

#### What this PR does / why we need it:
Bumps kiwigrid k8s-sidecar to 0.0.11, please see https://github.com/kiwigrid/k8s-sidecar/releases/tag/0.0.11 for more rdetails.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
