### PR TITLE
[stable/curator] - configure pod security context

### DIFF
--- a/stable/elasticsearch-curator/Chart.yaml
+++ b/stable/elasticsearch-curator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "5.5.4"
 description: A Helm chart for Elasticsearch Curator
 name: elasticsearch-curator
-version: 1.3.1
+version: 1.3.2
 home: https://github.com/elastic/curator
 keywords:
 - curator

--- a/stable/elasticsearch-curator/README.md
+++ b/stable/elasticsearch-curator/README.md
@@ -52,6 +52,6 @@ their default values.
 | `priorityClassName`                  | priorityClassName                                           | `nil`                                        |
 | `extraVolumeMounts`                  | Mount extra volume(s),                                      |                                              |
 | `extraVolumes`                       | Extra volumes                                               |                                              |
-
+| `securityContext`                    | Configure PodSecurityContext                          |
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.

--- a/stable/elasticsearch-curator/templates/cronjob.yaml
+++ b/stable/elasticsearch-curator/templates/cronjob.yaml
@@ -102,3 +102,7 @@ spec:
           tolerations:
 {{ toYaml . | indent 12 }}
     {{- end }}
+    {{- with .Values.securityContext }}
+          securityContext:
+{{ toYaml . | indent 12 }}
+    {{- end }}

--- a/stable/elasticsearch-curator/values.yaml
+++ b/stable/elasticsearch-curator/values.yaml
@@ -100,3 +100,6 @@ priorityClassName: ""
 #   - name: es-certs
 #     mountPath: /certs
 #     readOnly: true
+
+securityContext:
+  runAsUser: 16  # run as cron user instead of root


### PR DESCRIPTION
#### What this PR does / why we need it:

It allows us to configure pod security context for the curator cronjob.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
