### PR TITLE
[incubator/patroni] Fix Patroni Kubernetes DCS labels

### DIFF
--- a/incubator/patroni/Chart.yaml
+++ b/incubator/patroni/Chart.yaml
@@ -1,6 +1,6 @@
 name: patroni
 description: 'Highly available elephant herd: HA PostgreSQL cluster.'
-version: 0.11.0
+version: 0.11.1
 appVersion: 1.4-p16
 home: https://github.com/zalando/patroni
 sources:

--- a/incubator/patroni/templates/statefulset-patroni.yaml
+++ b/incubator/patroni/templates/statefulset-patroni.yaml
@@ -72,7 +72,7 @@ spec:
         {{- end }}
         {{- end }}
         - name: SCOPE
-          value: {{ template "patroni.fullname" . }}
+          value: {{ template "patroni.name" . }}
         {{- if .Values.walE.enable }}
         - name: USE_WALE
           value: {{ .Values.walE.enable | quote }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently the Kubernetes DCS feature of Patroni will not work if `patroni.fullnameOverride` and `patroni.nameOverride` are not exactly equal. 

This is resolved by setting the `SCOPE` envvar of the statefule set to `patroni.name` instead of `patroni.fullname`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
