### PR TITLE
[stable/wordpress] fix customHTAccessCM value

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 5.2.3
+version: 5.2.4
 appVersion: 5.1.0
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/templates/deployment.yaml
+++ b/stable/wordpress/templates/deployment.yaml
@@ -207,8 +207,8 @@ spec:
       {{- if and .Values.allowOverrideNone .Values.customHTAccessCM}}
       - name: custom-htaccess
         configMap:
-          name: {{ template "wordpress.customHTAccessCM" . }}
-      {{- end }} 
+          name: {{ .Values.customHTAccessCM | quote }}
+      {{- end }}
       - name: wordpress-data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:


### PR DESCRIPTION
Signed-off-by: Todd Brown <mrbrownt@me.com>

#### What this PR does / why we need it:
wordpress has a render error when using the value customHTAccessCM

#### Which issue this PR fixes
  - fixes #11713

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
