### PR TITLE
[stable/kong] fix config var for loadBalancerSourceRanges

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.9.5
+version: 0.9.6
 appVersion: 1.0.2

--- a/stable/kong/templates/service-kong-proxy.yaml
+++ b/stable/kong/templates/service-kong-proxy.yaml
@@ -19,7 +19,7 @@ spec:
   {{- end }}
   {{- if .Values.proxy.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
-  {{- range $cidr := .Values.admin.loadBalancerSourceRanges }}
+  {{- range $cidr := .Values.proxy.loadBalancerSourceRanges }}
   - {{ $cidr }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
Signed-off-by: Nima Jalali <nima@jalali.net>

#### What this PR does / why we need it:
Fixes a bug with the configuration. `service-kong-proxy.yaml` was using `admin.loadBalancerSourceRanges` instead of `proxy.loadBalancerSourceRanges`

@hbagdi @shashiranjan84 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
