### PR TITLE
[stable/consul] Use ui.enabled instead of uiService.enabled

### DIFF
--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,6 +1,6 @@
 name: consul
 home: https://github.com/hashicorp/consul
-version: 3.5.3
+version: 3.5.4
 appVersion: 1.0.0
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,6 +1,6 @@
 name: consul
 home: https://github.com/hashicorp/consul
-version: 3.5.4
+version: 3.6.0
 appVersion: 1.0.0
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/stable/consul/templates/consul-statefulset.yaml
+++ b/stable/consul/templates/consul-statefulset.yaml
@@ -139,7 +139,7 @@ spec:
             {{- range .Values.ConsulConfig }}
               -config-dir /etc/consul/userconfig/{{ .name }} \
             {{- end}}
-            {{- if .Values.uiService.enabled }}
+            {{- if .Values.ui.enabled }}
               -ui \
             {{- end }}
             {{- if .Values.DisableHostNodeId }}


### PR DESCRIPTION
Signed-off-by: Robert James Hernandez <rob@sarcasticadmin.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
In the [consul chart readme](https://github.com/helm/charts/tree/master/stable/consul#configuration) it calls out to the following option `ui.enabled` for toggling on and off the UI. The UI is currently being toggled via `uiService.enabled`. However, there could be times where a user would like to set `uiService.enabled: false` but keep `ui.enabled: true` and leverage `kubectl port-forward` to get to consul's web ui. This fix makes `ui.enabled` actually toggle the UI on and off as intended.

Setting the following in `values.yaml`:
```
ui:
  enabled: true

uiService:
  enabled: false
```

Testing by change on `localhost`:
```
~ $ kubectl port-forward --namespace default my-release-consul-0 8500:8500
```

Curl works as intended and can reach UI:
```
$ curl http://127.0.0.1:8500/ui -L -o /dev/null -s -w "%{http_code}\n"
200
```

#### Special notes for your reviewer:

Running this chart with `helm` on `minikube` with the following configuration:

```
~ $ minikube version
minikube version
minikube version: v0.33.1

~ $ kubectl version
Client Version: version.Info{Major:"1", Minor:"13", GitVersion:"v1.13.2", GitCommit:"cff46ab41ff0bb44d8584413b598ad8360ec1def", GitTreeState:"clean", BuildDate:"2019-01-13T23:16:58Z", GoVersion:"go1.11.4", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"13", GitVersion:"v1.13.2", GitCommit:"cff46ab41ff0bb44d8584413b598ad8360ec1def", GitTreeState:"clean", BuildDate:"2019-01-10T23:28:14Z", GoVersion:"go1.11.4", Compiler:"gc", Platform:"linux/amd64"}

~ $ helm version
Client: &version.Version{SemVer:"v2.12.2", GitCommit:"7d2b0c73d734f6586ed222a567c5d103fed435be", GitTreeState:"clean"}
Server: &version.Version{SemVer:"v2.12.2", GitCommit:"7d2b0c73d734f6586ed222a567c5d103fed435be", GitTreeState:"clean"}
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
