### PR TITLE
[stable/prometheus-operator] Support multi service ports to use and expose prom…

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 4.1.1
+version: 4.2.0
 appVersion: 0.29.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -144,6 +144,7 @@ The following tables lists the configurable parameters of the prometheus-operato
 | `prometheus.enabled` | Deploy prometheus | `true` |
 | `prometheus.serviceMonitor.selfMonitor` | Create a `serviceMonitor` to automatically monitor the prometheus instance | `true` |
 | `prometheus.serviceAccount.create` | Create a default serviceaccount for prometheus to use | `true` |
+| `prometheus.authProxyEnabled`    | enables authproxy. Create container in extracontainers  | `false` |
 | `prometheus.serviceAccount.name` | Name for prometheus serviceaccount | `""` |
 | `prometheus.rbac.roleNamespaces` | Create role bindings in the specified namespaces, to allow Prometheus monitoring a role binding in the release namespace will always be created. | `["kube-system"]` |
 | `prometheus.podDisruptionBudget.enabled` | If true, create a pod disruption budget for prometheus pods. The created resource cannot be modified once created - it must be deleted to perform a change | `true` |
@@ -157,6 +158,7 @@ The following tables lists the configurable parameters of the prometheus-operato
 | `prometheus.service.type` |  Prometheus Service type | `ClusterIP` |
 | `prometheus.service.clusterIP` | Prometheus service clusterIP IP | `""` |
 | `prometheus.service.targetPort` |  Prometheus Service internal port | `9090` |
+| `prometheus.service.authProxyPort` | port to use when using sidecar authProxy | None: |
 | `prometheus.service.nodePort` |  Prometheus Service port for NodePort service type | `39090` |
 | `prometheus.service.annotations` |  Prometheus Service Annotations | `{}` |
 | `prometheus.service.labels` |  Prometheus Service Labels | `{}` |

--- a/stable/prometheus-operator/ci/test-values.yaml
+++ b/stable/prometheus-operator/ci/test-values.yaml
@@ -700,16 +700,18 @@ prometheus:
     create: true
     name: ""
 
+  # Enable an authproxy. Specify container in extraContainers
+  authProxyEnabled: false
+
   ## Configuration for Prometheus service
   ##
   service:
     annotations: {}
     labels: {}
     clusterIP: ""
-
-
-    ## To be used with a proxy extraContainer port
+    ## internal prometheus service port
     targetPort: 9090
+    # authProxyPort: 4181 To be used with authProxyEnabled and a proxy extraContainer
 
     ## List of IP addresses at which the Prometheus server service is available
     ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips

--- a/stable/prometheus-operator/templates/prometheus/ingress.yaml
+++ b/stable/prometheus-operator/templates/prometheus/ingress.yaml
@@ -24,7 +24,7 @@ spec:
           - path: "{{ $routePrefix }}"
             backend:
               serviceName: {{ $serviceName }}
-              servicePort: 9090
+              servicePort: 80
     {{- end }}
 {{- if .Values.prometheus.ingress.tls }}
   tls:

--- a/stable/prometheus-operator/templates/prometheus/service.yaml
+++ b/stable/prometheus-operator/templates/prometheus/service.yaml
@@ -34,6 +34,13 @@ spec:
     {{- end }}
     port: 9090
     targetPort: {{ .Values.prometheus.service.targetPort }}
+  - name: webexpose
+    port: 80
+    {{- if not .Values.prometheus.authProxyEnabled }}
+    targetPort: {{ .Values.prometheus.service.targetPort }}
+    {{- else }}
+    targetPort: {{ .Values.prometheus.service.authProxyPort }}
+    {{- end }}
   selector:
     app: prometheus
     prometheus: {{ template "prometheus-operator.fullname" . }}-prometheus

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -700,16 +700,18 @@ prometheus:
     create: true
     name: ""
 
+  # Enable an authproxy. Specify container in extraContainers
+  authProxyEnabled: false
+
   ## Configuration for Prometheus service
   ##
   service:
     annotations: {}
     labels: {}
     clusterIP: ""
-
-
-    ## To be used with a proxy extraContainer port
+    ## internal prometheus service port
     targetPort: 9090
+    # authProxyPort: 4181 ##To be used with authProxyEnabled and a proxy extraContainer
 
     ## List of IP addresses at which the Prometheus server service is available
     ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
@@ -1051,7 +1053,7 @@ prometheus:
     thanos: {}
 
     ## Containers allows injecting additional containers. This is meant to allow adding an authentication proxy to a Prometheus pod.
-    ##  if using proxy extraContainer  update targetPort with proxy container port
+    ##  if using proxy extraContainer update authproxyPort with proxy container port
     containers: []
 
     ## Enable additional scrape configs that are managed externally to this chart. Note that the prometheus


### PR DESCRIPTION
**What this PR does / why we need it**:
It adds multi target ports to prometheus service  . 
This enables adding a openid-connect proxy port to expose prometheus service **WITHOUT** affect on internal services like grafana 
**Problem**:
after adding `targetPort` with **proxy-auth port** , **Grafana dashboard unauthorized** to scrape
 **Because** it is in this case call prometheus service through proxy   

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
