### PR TITLE
[stable/elasticsearch-exporter] Added PrometheusRule CRD

### DIFF
--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 1.1.2
+version: 1.2.0
 appVersion: 1.0.2
 home: https://github.com/justwatchcom/elasticsearch_exporter
 sources:

--- a/stable/elasticsearch-exporter/README.md
+++ b/stable/elasticsearch-exporter/README.md
@@ -71,7 +71,7 @@ Parameter | Description | Default
 `prometheusRule.enabled` | If true, a PrometheusRule CRD is created for a prometheus operator | `false`
 `prometheusRule.prometheusNamespace` | Namespace for prometheusRule | `monitoring`
 `prometheusRule.elasticsearchNodes` | Number of all nodes in Elasticsearch cluster (all roles) | `7`
-`prometheusRule.elasticsearchDateNodes` | Number of Data nodes in Elasticsearch cluster | `2`
+`prometheusRule.elasticsearchDataNodes` | Number of Data nodes in Elasticsearch cluster | `2`
 
 `prometheusRule.labels` | PrometheusRule labels for prometheus operator | `{}`
 

--- a/stable/elasticsearch-exporter/README.md
+++ b/stable/elasticsearch-exporter/README.md
@@ -67,7 +67,11 @@ Parameter | Description | Default
 `es.ssl.client.key` | Private key for client auth when connecting to Elasticsearch |
 `web.path` | path under which to expose metrics | `/metrics`
 `serviceMonitor.enabled` | If true, a ServiceMonitor CRD is created for a prometheus operator | `false`
-`serviceMonitor.labels` | Labels for prometheus operator | `{}`
+`serviceMonitor.labels` | ServiceMonitor labels for prometheus operator | `{}`
+`prometheusRule.enabled` | If true, a PrometheusRule CRD is created for a prometheus operator | `false`
+`prometheusRule.prometheusNamespace` | Namespace for prometheusRule | `monitoring`
+`prometheusRule.labels` | PrometheusRule labels for prometheus operator | `{}`
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/elasticsearch-exporter/README.md
+++ b/stable/elasticsearch-exporter/README.md
@@ -70,6 +70,9 @@ Parameter | Description | Default
 `serviceMonitor.labels` | ServiceMonitor labels for prometheus operator | `{}`
 `prometheusRule.enabled` | If true, a PrometheusRule CRD is created for a prometheus operator | `false`
 `prometheusRule.prometheusNamespace` | Namespace for prometheusRule | `monitoring`
+`prometheusRule.elasticsearchNodes` | Number of all nodes in Elasticsearch cluster (all roles) | `7`
+`prometheusRule.elasticsearchDateNodes` | Number of Data nodes in Elasticsearch cluster | `2`
+
 `prometheusRule.labels` | PrometheusRule labels for prometheus operator | `{}`
 
 

--- a/stable/elasticsearch-exporter/templates/prometheusrule.yaml
+++ b/stable/elasticsearch-exporter/templates/prometheusrule.yaml
@@ -15,23 +15,31 @@ metadata:
   namespace: {{ .Values.prometheusRule.prometheusNamespace }}
 spec:
   groups:
-  - name: elasticsearch
+  - name: elasticsearch_{{ .Release.Name }}
     rules:
     - record: elasticsearch_filesystem_data_used_percent
-      expr: 100 * (elasticsearch_filesystem_data_size_bytes - elasticsearch_filesystem_data_free_bytes)
-        / elasticsearch_filesystem_data_size_bytes
+      expr: 100 * (elasticsearch_filesystem_data_size_bytes{job="{{ .Release.Name }}"} - elasticsearch_filesystem_data_free_bytes{job="{{ .Release.Name }}"})
+        / elasticsearch_filesystem_data_size_bytes{job="{{ .Release.Name }}"}
     - record: elasticsearch_filesystem_data_free_percent
-      expr: 100 - elasticsearch_filesystem_data_used_percent
+      expr: 100 - elasticsearch_filesystem_data_used_percent{job="{{ .Release.Name }}"}
     - alert: ElasticsearchTooFewNodesRunning
-      expr: elasticsearch_cluster_health_number_of_nodes < {{ .Values.prometheusRule.elasticsearchNodes }}
+      expr: elasticsearch_cluster_health_number_of_nodes{job="{{ .Release.Name }}"} < {{ .Values.prometheusRule.elasticsearchNodes }}
       for: 5m
       labels:
         severity: critical
       annotations:
         description: There are only {{ "{{$value}}" }} < {{ .Values.prometheusRule.elasticsearchNodes }} ElasticSearch nodes running
         summary: ElasticSearch running on less than {{ .Values.prometheusRule.elasticsearchNodes }} nodes
+    - alert: ElasticsearchTooFewDataNodesRunning
+      expr: elasticsearch_cluster_health_number_of_data_nodes{job="{{ .Release.Name }}"} < {{ .Values.prometheusRule.elasticsearchDataNodes }}
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        description: There are only {{ "{{$value}}" }} < {{ .Values.prometheusRule.elasticsearchDataNodes }} ElasticSearch Data nodes running
+        summary: ElasticSearch running on less than {{ .Values.prometheusRule.elasticsearchDataNodes }} Data nodes
     - alert: ElasticsearchHeapTooHigh
-      expr: elasticsearch_jvm_memory_used_bytes{area="heap"} / elasticsearch_jvm_memory_max_bytes{area="heap"}
+      expr: elasticsearch_jvm_memory_used_bytes{job="{{ .Release.Name }}", area="heap"} / elasticsearch_jvm_memory_max_bytes{job="{{ .Release.Name }}", area="heap"}
         > 0.9
       for: 15m
       labels:

--- a/stable/elasticsearch-exporter/templates/prometheusrule.yaml
+++ b/stable/elasticsearch-exporter/templates/prometheusrule.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.prometheusRule.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "elasticsearch-exporter.fullname" . }}
+  labels:
+    chart: {{ template "elasticsearch-exporter.chart" . }}
+    app: {{ template "elasticsearch-exporter.name" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    {{- if .Values.prometheusRule.labels }}
+    {{- toYaml .Values.prometheusRule.labels | nindent 4 }}
+    {{- end }}
+  namespace: {{ .Values.prometheusRule.prometheusNamespace }}
+spec:
+  groups:
+  - name: elasticsearch
+    rules:
+    - record: elasticsearch_filesystem_data_used_percent
+      expr: 100 * (elasticsearch_filesystem_data_size_bytes - elasticsearch_filesystem_data_free_bytes)
+        / elasticsearch_filesystem_data_size_bytes
+    - record: elasticsearch_filesystem_data_free_percent
+      expr: 100 - elasticsearch_filesystem_data_used_percent
+    - alert: ElasticsearchTooFewNodesRunning
+      expr: elasticsearch_cluster_health_number_of_nodes < {{ .Values.prometheusRule.elasticsearchNodes }}
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        description: There are only {{ "{{$value}}" }} < {{ .Values.prometheusRule.elasticsearchNodes }} ElasticSearch nodes running
+        summary: ElasticSearch running on less than {{ .Values.prometheusRule.elasticsearchNodes }} nodes
+    - alert: ElasticsearchHeapTooHigh
+      expr: elasticsearch_jvm_memory_used_bytes{area="heap"} / elasticsearch_jvm_memory_max_bytes{area="heap"}
+        > 0.9
+      for: 15m
+      labels:
+        severity: critical
+      annotations:
+        description: The heap usage is over 90% for 15m
+        summary: ElasticSearch node {{ "{{$labels.node}}" }} heap usage is high
+{{- end }}

--- a/stable/elasticsearch-exporter/values.yaml
+++ b/stable/elasticsearch-exporter/values.yaml
@@ -85,3 +85,12 @@ serviceMonitor:
   ##
   enabled: false
   labels: {}
+
+prometheusRule:
+  ## If true, a PrometheusRule CRD is created for a prometheus operator
+  ## https://github.com/coreos/prometheus-operator
+  ##
+  enabled: false
+  prometheusNamespace: monitoring
+  labels: {}
+    # role: alert-rules

--- a/stable/elasticsearch-exporter/values.yaml
+++ b/stable/elasticsearch-exporter/values.yaml
@@ -92,5 +92,9 @@ prometheusRule:
   ##
   enabled: false
   prometheusNamespace: monitoring
+  # Nuber of all nodes in Elasticsearch Cluster (all roles)
+  elasticsearchNodes: 7
+  # Nuber of Data nodes in Elasticsearch Cluster
+  elasticsearchDataNodes: 2
   labels: {}
     # role: alert-rules


### PR DESCRIPTION
Signed-off-by: Pavel Zilke <zidex@altlinux.org>

#### What this PR does / why we need it:
Added template for PrometheusRule to stable/elasticsearch-exporter chart

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
