### PR TITLE
[stable/wordpress] Fixed metrics resources templating. (#11733)

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 5.2.4
+version: 5.2.5
 appVersion: 5.1.0
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/templates/deployment.yaml
+++ b/stable/wordpress/templates/deployment.yaml
@@ -201,7 +201,7 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 1
         resources:
-  {{ toYaml .Values.metrics.resources | indent 10 }}
+{{ toYaml .Values.metrics.resources | indent 10 }}
 {{- end }}
       volumes:
       {{- if and .Values.allowOverrideNone .Values.customHTAccessCM}}


### PR DESCRIPTION
* Fixed wrong indenting when using limits and requests on metrics.resources

* Bumped chart version

Signed-off-by: JoostC <jcoelingh@gmail.com>


#### What this PR does / why we need it:
When using both resources.requests and resources.limits for the metrics it renders wrong. i.e.:
```
        resources:
            limits:
            cpu: 70m
            memory: 150Mi
          requests:
            cpu: 50m
            memory: 100Mi
```
When this should be:
```
        resources:
          limits:
            cpu: 70m
            memory: 150Mi
          requests:
            cpu: 50m
            memory: 100Mi
```

#### Which issue this PR fixes
  - fixes #11733

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
