### PR TITLE
[stable/dex] Add support for defining custom initContainers

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,5 +1,5 @@
 name: dex
-version: 0.8.0
+version: 0.9.0
 appVersion: 2.14.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/templates/deployment.yaml
+++ b/stable/dex/templates/deployment.yaml
@@ -61,6 +61,10 @@ spec:
 {{- if ne (len .Values.extraVolumeMounts) 0 }}
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
 {{- end }}
+{{- if ne (len .Values.extraInitContainers) 0 }}
+      initContainers:
+{{ toYaml .Values.extraInitContainers | indent 8 }}
+{{- end }}
       volumes:
       - secret:
           defaultMode: 420

--- a/stable/dex/values.yaml
+++ b/stable/dex/values.yaml
@@ -49,6 +49,10 @@ ingress:
 
 extraVolumes: []
 extraVolumeMounts: []
+extraInitContainers: []
+  # - name: init-dex
+  #   image: bash:4.4
+  #   command: ['bash', '-c', 'for i in {1..5}; do echo "sleeping $i"; sleep $i; done']
 
 certs:
   image: gcr.io/google_containers/kubernetes-dashboard-init-amd64


### PR DESCRIPTION
#### What this PR does / why we need it:

When Dex is using a SQL backend for storage (in my case Postgres), it immediately attempts to connect to the database. In the event that the Postgres server isn't ready to accept connections, Dex will block until eventually failing and restarting.

This tends to be a problem when Dex is a dependency in an umbrella chart, which may also start up a Postgres database for the Dex storage at the same time.

This PR introduces the ability for consumers of the chart to specify `extraInitContainers` which can (for example) wait until the Postgres database is ready before the Dex pod starts.

#### Which issue this PR fixes

N/A

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md _(N/a - there is no README.md)_
