### PR TITLE
fix indent and clean up parser config

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 1.7.0
+version: 1.8.0
 appVersion: 1.0.4
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -11,7 +11,7 @@ metadata:
 data:
   fluent-bit-service.conf: |-
     [SERVICE]
-        Flush        {{ .Values.service.flush }} 
+        Flush        {{ .Values.service.flush }}
         Daemon       Off
         Log_Level    {{ .Values.service.logLevel }}
         Parsers_File parsers.conf
@@ -47,7 +47,7 @@ data:
         Max_Entries     {{ .Values.input.systemd.maxEntries }}
         Read_From_Tail  {{ .Values.input.systemd.readFromTail }}
 {{- end }}
-{{ .Values.extraEntries.input | indent 8 }}
+{{ .Values.extraEntries.input | indent 4 }}
 
   fluent-bit-filter.conf: |-
     [FILTER]
@@ -65,7 +65,7 @@ data:
 {{- if .Values.filter.enableExclude }}
         K8S-Logging.Exclude On
 {{- end }}
-{{ .Values.extraEntries.filter | indent 8 }}
+{{ .Values.extraEntries.filter | indent 4 }}
 
   fluent-bit-output.conf: |-
 {{ if eq .Values.backend.type "test" }}
@@ -146,7 +146,7 @@ data:
 {{- end }}
         Format {{ .Values.backend.http.format }}
 {{- end }}
-{{ .Values.extraEntries.output | indent 8 }}
+{{ .Values.extraEntries.output | indent 4 }}
 
 
   fluent-bit.conf: |-
@@ -181,6 +181,9 @@ data:
 {{- if .timeFormat }}
         Time_Format {{ .timeFormat }}
 {{- end }}
+{{- if .decodeField  }}
+        Decode_Field json {{ .decodeField }}
+{{- end}}
 {{- if .decodeFieldAs  }}
         Decode_Field_As {{ .decodeFieldAs }} {{ .decodeField | default "log" }}
 {{- end}}


### PR DESCRIPTION
Signed-off-by: Lutz Behnke <lutz.behnke@figo.io>

#### What this PR does / why we need it:

* It fixes the indentation set by the template, so that the values.yml as well as the resultant config.yml are valid YAML files and work as input to fluent-bit
* adds the capability to use `Decode_Field`Attribute in parser config without the need for `extraEntries` 


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
