### PR TITLE
[stable/mysql] add deployment labels

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.15.0
+version: 0.16.0
 appVersion: 5.7.14
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.

--- a/stable/mysql/README.md
+++ b/stable/mysql/README.md
@@ -104,6 +104,7 @@ The following table lists the configurable parameters of the MySQL chart and the
 | `podAnnotations`                             | Map of annotations to add to the pods                                                        | `{}`                                                 |
 | `podLabels`                                  | Map of labels to add to the pods                                                        | `{}`                                                 |
 | `priorityClassName`                          | Set pod priorityClassName                                                                    | `{}`                                                 |
+| `deploymentLabels`                           | Map of labels to add to the deployment                                                       | `{}`                                                 |
 
 Some of the parameters above map to the env variables defined in the [MySQL DockerHub image](https://hub.docker.com/_/mysql/).
 

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -3,10 +3,15 @@ kind: Deployment
 metadata:
   name: {{ template "mysql.fullname" . }}
   labels:
-    app: {{ template "mysql.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    {{- if not .Values.deploymentLabels.app }}
+    app: {{ template "mysql.fullname" . }}
+    {{- end }}
+    {{- range $key, $val := .Values.deploymentLabels }}
+    {{ $key }}: {{ $val }}
+    {{- end}}
 spec:
   template:
     metadata:

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -9,9 +9,9 @@ metadata:
     {{- if not .Values.deploymentLabels.app }}
     app: {{ template "mysql.fullname" . }}
     {{- end }}
-    {{- range $key, $val := .Values.deploymentLabels }}
-    {{ $key }}: {{ $val }}
-    {{- end}}
+{{- with .Values.deploymentLabels }}
+{{ toYaml . | indent 4 }}
+{{- end}}
 spec:
   template:
     metadata:

--- a/stable/mysql/values.yaml
+++ b/stable/mysql/values.yaml
@@ -170,6 +170,9 @@ ssl:
 ## Example: 'Australia/Sydney'
 # timezone:
 
+# To be added to the deployment
+deploymentLabels: {}
+
 # To be added to the database server pod(s)
 podAnnotations: {}
 


### PR DESCRIPTION
Signed-off-by: Daniel Karnutsch <d.karnutsch@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
In order to have custom labels on the deployment like #11634 or change the app label to correctly group the application in OpenShift I've added support for custom labels on the deployment like #11510 does.
Backwards compatibility is ensured by setting the app name to its previous value if not overwritten by `values.deploymentLabels`.  

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
