### PR TITLE
[stable/cockroachdb] Additional parameters for cockroachdb

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 2.0.11
+version: 2.1.0
 appVersion: 2.1.5
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -102,6 +102,8 @@ The following table lists the configurable parameters of the CockroachDB chart a
 | `Secure.ServiceAccount.Name`   | Name of RBAC service account to use              | `""`                                      |
 | `JoinExisting`                 | List of already-existing cockroach instances     | `[]`                                      |
 | `Locality`                     | Locality attribute for this deployment           | `""`                                      |
+| `ExtraArgs`                    | Additional command-line arguments                | `[]`                                      |
+| `ExtraSecretMounts`            | Additional secrets to mount at cluster members   | `[]`                                      |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
+++ b/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
@@ -290,12 +290,17 @@ spec:
         - name: certs
           mountPath: /cockroach/cockroach-certs
 {{- end }}
+{{- range .Values.ExtraSecretMounts }}
+        - name: extra-secret-{{ . }}
+          mountPath: /etc/cockroach/secrets/{{ . }}
+          readOnly: true
+{{- end }}
         command:
           - "/bin/bash"
           - "-ecx"
             # The use of qualified `hostname -f` is crucial:
             # Other nodes aren't able to look up the unqualified hostname.
-          - "exec /cockroach/cockroach start --logtostderr {{ if .Values.Secure.Enabled }}--certs-dir /cockroach/cockroach-certs{{ else }}--insecure{{ end }} --advertise-host $(hostname).${STATEFULSET_FQDN} --http-host 0.0.0.0 --http-port {{ .Values.InternalHttpPort }} --port {{ .Values.InternalGrpcPort }} --cache {{ .Values.CacheSize }} --max-sql-memory {{ .Values.MaxSQLMemory }} {{ if .Values.Locality }}--locality={{.Values.Locality }}{{ end }} --join {{ if .Values.JoinExisting }}{{ join "," .Values.JoinExisting }}{{ else }}${STATEFULSET_NAME}-0.${STATEFULSET_FQDN}:{{ .Values.InternalGrpcPort }},${STATEFULSET_NAME}-1.${STATEFULSET_FQDN}:{{ .Values.InternalGrpcPort }},${STATEFULSET_NAME}-2.${STATEFULSET_FQDN}:{{ .Values.InternalGrpcPort }}{{ end }}"
+          - "exec /cockroach/cockroach start --logtostderr {{ if .Values.Secure.Enabled }}--certs-dir /cockroach/cockroach-certs{{ else }}--insecure{{ end }} --advertise-host $(hostname).${STATEFULSET_FQDN} --http-host 0.0.0.0 --http-port {{ .Values.InternalHttpPort }} --port {{ .Values.InternalGrpcPort }} --cache {{ .Values.CacheSize }} --max-sql-memory {{ .Values.MaxSQLMemory }} {{ if .Values.Locality }}--locality={{.Values.Locality }}{{ end }} --join {{ if .Values.JoinExisting }}{{ join "," .Values.JoinExisting }}{{ else }}${STATEFULSET_NAME}-0.${STATEFULSET_FQDN}:{{ .Values.InternalGrpcPort }},${STATEFULSET_NAME}-1.${STATEFULSET_FQDN}:{{ .Values.InternalGrpcPort }},${STATEFULSET_NAME}-2.${STATEFULSET_FQDN}:{{ .Values.InternalGrpcPort }}{{ end }}{{ range .Values.ExtraArgs }} {{ . }}{{ end }}"
       # No pre-stop hook is required, a SIGTERM plus some time is all that's
       # needed for graceful shutdown of a node.
       terminationGracePeriodSeconds: 60
@@ -306,6 +311,11 @@ spec:
 {{- if .Values.Secure.Enabled }}
       - name: certs
         emptyDir: {}
+{{- end }}
+{{- range .Values.ExtraSecretMounts }}
+      - name: extra-secret-{{ . }}
+        secret:
+          secretName: {{ . }}
 {{- end }}
   podManagementPolicy: {{ .Values.PodManagementPolicy }}
   updateStrategy:

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -72,4 +72,3 @@ Locality: ""
 ExtraArgs: []
 # ExtraSecretMounts is a list of names from secrets in the same namespace as the cockroachdb cluster, which shall be mounted into /etc/cockroach/secrets/ for every cluster member.
 ExtraSecretMounts: []
-

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -68,3 +68,8 @@ Secure:
 JoinExisting: []
 # Set a locality (e.g. "region=us-central1,datacenter=us-centra1-a") if you're doing multi-cluster so data is distributed properly
 Locality: ""
+# Additional command-line arguments you want to pass to the `cockroach start` commands
+ExtraArgs: []
+# ExtraSecretMounts is a list of names from secrets in the same namespace as the cockroachdb cluster, which shall be mounted into /etc/cockroach/secrets/ for every cluster member.
+ExtraSecretMounts: []
+


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently it is not possible to provide advanded command line arguments for cockroachdb or to provide additional secrets for the cluster members.

This PR introduces two variables:
* `ExtraArgs` to provide additional command-line arguments
* `ExtraSecretMounts` to mount arbitrary secrets

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
