### PR TITLE
[stable/grafana]: Specify namespace explicity to generate template with correct namespace

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 2.2.0
+version: 2.3.0
 appVersion: 6.0.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/clusterrole.yaml
+++ b/stable/grafana/templates/clusterrole.yaml
@@ -12,6 +12,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
   name: {{ template "grafana.fullname" . }}-clusterrole
+  namespace: {{ .Release.Namespace }}
 {{- if or .Values.sidecar.dashboards.enabled .Values.sidecar.datasources.enabled }}
 rules:
 - apiGroups: [""] # "" indicates the core API group

--- a/stable/grafana/templates/clusterrolebinding.yaml
+++ b/stable/grafana/templates/clusterrolebinding.yaml
@@ -3,6 +3,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "grafana.fullname" . }}-clusterrolebinding
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}

--- a/stable/grafana/templates/configmap-dashboard-provider.yaml
+++ b/stable/grafana/templates/configmap-dashboard-provider.yaml
@@ -12,6 +12,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
   name: {{ template "grafana.fullname" . }}-config-dashboards
+  namespace: {{ .Release.Namespace }}
 data:
   provider.yaml: |-
     apiVersion: 1

--- a/stable/grafana/templates/configmap.yaml
+++ b/stable/grafana/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "grafana.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}

--- a/stable/grafana/templates/dashboards-json-configmap.yaml
+++ b/stable/grafana/templates/dashboards-json-configmap.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "grafana.fullname" $ }}-dashboards-{{ $provider }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "grafana.name" $ }}
     chart: {{ template "grafana.chart" $ }}

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: {{ template "grafana.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}

--- a/stable/grafana/templates/ingress.yaml
+++ b/stable/grafana/templates/ingress.yaml
@@ -6,6 +6,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}

--- a/stable/grafana/templates/podsecuritypolicy.yaml
+++ b/stable/grafana/templates/podsecuritypolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: extensions/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "grafana.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/stable/grafana/templates/pvc.yaml
+++ b/stable/grafana/templates/pvc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ template "grafana.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}

--- a/stable/grafana/templates/role.yaml
+++ b/stable/grafana/templates/role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: {{ template "grafana.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/stable/grafana/templates/rolebinding.yaml
+++ b/stable/grafana/templates/rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: {{ template "grafana.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/stable/grafana/templates/secret.yaml
+++ b/stable/grafana/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "grafana.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}

--- a/stable/grafana/templates/service.yaml
+++ b/stable/grafana/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "grafana.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}

--- a/stable/grafana/templates/serviceaccount.yaml
+++ b/stable/grafana/templates/serviceaccount.yaml
@@ -8,4 +8,5 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "grafana.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
For usage with helm template it generates a one big file with all
resources. It is not possible to specify multiple namespaces, when you
do apply, without changing context.

How it is in master:

```shell
$ helm template stable/grafana grafana
metadata:
  name: release-name-grafana
  labels:
```

With current changes it would not brake stuf:

```shell
$ helm template stable/grafana grafana
kind: PodSecurityPolicy
metadata:
  name: release-name-grafana
  namespace: kube-system
```

where `kube-sysem` is the namespace of current context.

```shell
$ helm template stable/grafana --namespace mon grafana 
kind: PodSecurityPolicy
metadata:
  name: release-name-grafana
  namespace: mon
```
So my goal to build template for `prometheus-operator` with explicit
namespaces. Should I do all changes in one PR?

```shell
$ helm template stable/grafana --namespace mon grafana > grafana.yaml
$ kubectl apply -f grafana.yaml
# Should create all resoures in `mon` namespace
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
**BROKEN LINK!!!** - [ ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md