### PR TITLE
Set readOnly on consuming containers for authz/n

### DIFF
--- a/stable/opa/Chart.yaml
+++ b/stable/opa/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - opa
 - admission control
 - policy
-version: 0.4.0
+version: 0.5.0
 home: https://www.openpolicyagent.org
 icon: https://raw.githubusercontent.com/open-policy-agent/opa/master/logo/logo.png
 sources:

--- a/stable/opa/templates/deployment.yaml
+++ b/stable/opa/templates/deployment.yaml
@@ -66,6 +66,7 @@ spec:
               mountPath: /config
 {{- if .Values.authz.enabled }}
             - name: authz
+              readOnly: true
               mountPath: /authz
 {{- end }}
 {{- if .Values.mgmt.enabled }}
@@ -92,6 +93,7 @@ spec:
 {{- if .Values.authz.enabled }}
           volumeMounts:
             - name: authz
+              readOnly: true
               mountPath: /authz
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Jeff Bachtel <jeff.bachtel@gmail.com>

#### What this PR does / why we need it:
Makes volumeMounts for authz/n consuming containers readOnly

#### Which issue this PR fixes
No open issue

#### Special notes for your reviewer:

#### Checklist
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
