### PR TITLE
Airflow role fix

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,6 +1,6 @@
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 2.0.1
+version: 2.0.2
 appVersion: 1.10.0
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/templates/role.yaml
+++ b/stable/airflow/templates/role.yaml
@@ -17,4 +17,8 @@ rules:
   resources:
   - "pods/log"
   verbs: ["get", "list"]
+- apiGroups: [""]
+  resources:
+  - "pods/exec"
+  verbs: ["create", "get"]
 {{ end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Without these permissions, airflow running with RBAC does not have permission to run kubernetes stream to extract the xcom return.json file.

Without these permissions, you get a `Handshake status 403 Forbidden` error when setting `xcom_push=True`.  With these permissions, xcom_push is working correctly.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped

@gsemet @maver1ck 