### PR TITLE
fix DCO link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,6 +35,6 @@ even continue reviewing your changes.
 
 #### Checklist
 [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
-- [ ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
+- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
 - [ ] Chart Version bumped
 - [ ] Variables are documented in the README.md


### PR DESCRIPTION
Reported on Slack that this link 404s. I switched it to link to CONTRIBUTING.md instead of the blog post on https://helm.sh/blog as CONTRIBUTING.md contains more information on how to sign off on the DCO. The DCO process could also change over time, so keeping up to date with the docs in master seemed more fitting.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>
