### PR TITLE
[stable/jenkins] Add agent raw pod yaml option

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.33.0
+version: 0.33.1
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -123,6 +123,9 @@ data:
               <imagePullSecrets/>
 {{- end }}
               <nodeProperties/>
+{{- if .Values.Agent.YamlTemplate }}
+              <yaml>{{ .Values.Agent.YamlTemplate | replace "\"" "&quot;" }}</yaml>
+{{- end }}
               <podRetention class="org.csanchez.jenkins.plugins.kubernetes.pod.retention.Default"/>
             </org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
 {{- end -}}

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -124,7 +124,9 @@ data:
 {{- end }}
               <nodeProperties/>
 {{- if .Values.Agent.YamlTemplate }}
-              <yaml>{{ .Values.Agent.YamlTemplate | replace "\"" "&quot;" }}</yaml>
+              <yaml>
+              {{ .Values.Agent.YamlTemplate | replace "\"" "&quot;" | indent 4 }}
+              </yaml>
 {{- end }}
               <podRetention class="org.csanchez.jenkins.plugins.kubernetes.pod.retention.Default"/>
             </org.csanchez.jenkins.plugins.kubernetes.PodTemplate>

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -318,14 +318,14 @@ Agent:
   # Raw yaml template for the Pod. For example this allows usage of toleration for agent pods.
   # https://github.com/jenkinsci/kubernetes-plugin#using-yaml-to-define-pod-templates
   # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-  # YamlTemplate: |-
-  #   apiVersion: v1
-  #   kind: Pod
-  #   spec:
-  #     tolerations:
-  #     - key: "key"
-  #       operator: "Equal"
-  #       value: "value"
+  YamlTemplate: |-
+    apiVersion: v1
+    kind: Pod
+    spec:
+      tolerations:
+      - key: "key"
+        operator: "Equal"
+        value: "value"
 
 Persistence:
   Enabled: true

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -315,6 +315,17 @@ Agent:
   ContainerCap: 10
   # Pod name
   PodName: default
+  # Raw yaml template for the Pod. For example this allows usage of toleration for agent pods.
+  # https://github.com/jenkinsci/kubernetes-plugin#using-yaml-to-define-pod-templates
+  # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  # YamlTemplate: |-
+  #   apiVersion: v1
+  #   kind: Pod
+  #   spec:
+  #     tolerations:
+  #     - key: "key"
+  #       operator: "Equal"
+  #       value: "value"
 
 Persistence:
   Enabled: true


### PR DESCRIPTION

#### What this PR does / why we need it:
Use yaml to define pod templates as defined here : https://github.com/jenkinsci/kubernetes-plugin#using-yaml-to-define-pod-templates

The main purpose in my case is to add tolerations.
