### PR TITLE
[stable/memcached] default to 1 replica

### DIFF
--- a/stable/memcached/Chart.yaml
+++ b/stable/memcached/Chart.yaml
@@ -1,5 +1,5 @@
 name: memcached
-version: 2.7.0
+version: 2.8.0
 appVersion: 1.5.12
 description: Free & open source, high-performance, distributed memory object caching
   system.

--- a/stable/memcached/README.md
+++ b/stable/memcached/README.md
@@ -44,6 +44,7 @@ The following table lists the configurable parameters of the Memcached chart and
 |---------------------------|---------------------------------|---------------------------------------------------------|
 | `image`                   | The image to pull and run       | A recent official memcached tag                         |
 | `imagePullPolicy`         | Image pull policy               | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
+| `replicaCount`            | Number of replicas to use       | 1 (see note below)                                      |
 | `memcached.verbosity`     | Verbosity level (v, vv, or vvv) | Un-set.                                                 |
 | `memcached.maxItemMemory` | Max memory for items (in MB)    | `64`                                                    |
 | `metrics.enabled`         | Expose metrics in prometheus format | false                                               |
@@ -78,3 +79,12 @@ $ helm install --name my-release -f values.yaml stable/memcached
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+### Replicas
+
+Setting more than 1 replica is valid, but data will not be shared
+between replicas, so any replicas are really just separate memcached
+instances. When you send data to the service endpoint, the DNS will
+resolve to one of the replica pods, and data will only be stored in
+that pod. When you retrieve data later, you may not be retrieving from
+the same pod, so the data may appear missing.

--- a/stable/memcached/values.yaml
+++ b/stable/memcached/values.yaml
@@ -11,7 +11,7 @@ image: memcached:1.5.12-alpine
 #
 
 ## Replica count
-replicaCount: 3
+replicaCount: 1
 
 ## Pod disruption budget minAvailable count
 ## Ensure this value is lower than replicaCount in order to allow a worker

--- a/stable/memcached/values.yaml
+++ b/stable/memcached/values.yaml
@@ -16,7 +16,7 @@ replicaCount: 1
 ## Pod disruption budget minAvailable count
 ## Ensure this value is lower than replicaCount in order to allow a worker
 ## node to drain successfully
-pdbMinAvailable: 2
+pdbMinAvailable: 0
 
 ## Select AntiAffinity as either hard or soft, default is hard
 AntiAffinity: "hard"


### PR DESCRIPTION
Signed-off-by: Andrew Plummer <plummer574@gmail.com>

#### What this PR does / why we need it:

Makes the memcached chart use 1 replica, not 3. This results in less surprising behaviour as no data is replicated between any replicas.

#### Which issue this PR fixes

#11773 (contains some debugging and more explanation)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
