### PR TITLE
[stable/chaoskube] Utilize the podAnnotations for Prometheus scraping

### DIFF
--- a/stable/chaoskube/Chart.yaml
+++ b/stable/chaoskube/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: chaoskube
-version: 0.14.0
+version: 0.14.1
 appVersion: 0.12.1
 description: Chaoskube periodically kills random pods in your Kubernetes cluster.
 icon: https://raw.githubusercontent.com/linki/chaoskube/master/chaoskube.png

--- a/stable/chaoskube/Chart.yaml
+++ b/stable/chaoskube/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: chaoskube
-version: 0.14.1
+version: 1.0.0
 appVersion: 0.12.1
 description: Chaoskube periodically kills random pods in your Kubernetes cluster.
 icon: https://raw.githubusercontent.com/linki/chaoskube/master/chaoskube.png

--- a/stable/chaoskube/README.md
+++ b/stable/chaoskube/README.md
@@ -63,6 +63,7 @@ $ helm install stable/chaoskube --set dryRun=false
 | `minimumAge`              | Set minimum pod age to filter pod by                | `0s`                             |
 | `podAnnotations`          | Annotations for the chaoskube pod                   | `{}`                             |
 | `gracePeriod`             | grace period to give pods when terminating them     | `-1s` (pod decides)              |
+| `metricsAddress`          | Listening address for metrics handler               | `:8080`                          |
 
 Setting label and namespaces selectors from the shell can be tricky but is possible (example with zsh):
 

--- a/stable/chaoskube/templates/deployment.yaml
+++ b/stable/chaoskube/templates/deployment.yaml
@@ -43,9 +43,7 @@ spec:
             {{- end }}
             - --minimum-age={{ .Values.minimumAge }}
             - --grace-period={{ .Values.gracePeriod }}
-          ports:
-            - containerPort: 8080
-              name: http
+            - --metrics-address={{ .Values.metricsAddress }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           securityContext:

--- a/stable/chaoskube/templates/deployment.yaml
+++ b/stable/chaoskube/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
     metadata:
       labels:
 {{ include "labels.standard" . | indent 8 }}
+    {{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+    {{- end }}
     spec:
       containers:
         - name: {{ .Values.name }}
@@ -39,6 +43,9 @@ spec:
             {{- end }}
             - --minimum-age={{ .Values.minimumAge }}
             - --grace-period={{ .Values.gracePeriod }}
+          ports:
+            - containerPort: 8080
+              name: http
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           securityContext:

--- a/stable/chaoskube/values.yaml
+++ b/stable/chaoskube/values.yaml
@@ -46,6 +46,9 @@ minimumAge: 0s
 # grace period to give pods when terminating them (negative: pod decides)
 gracePeriod: -1s
 
+# Listening address for metrics handler
+metricsAddress: :8080
+
 priorityClassName: ""
 
 # create service account with permission to list and kill pods


### PR DESCRIPTION
Signed-off-by: Marc Sensenich <sensenichm91@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Utilizes the Chaoskube chart's `podAnnotations` field to set the annotations on the Chaoskube pods for Prometheus configuration

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
