### PR TITLE
[stable/owncloud] Add apiVersion in Chart.yaml and add test info to README.md

### DIFF
--- a/stable/owncloud/Chart.yaml
+++ b/stable/owncloud/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: owncloud
-version: 4.0.3
+version: 4.0.4
 appVersion: 10.1.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/owncloud/README.md
+++ b/stable/owncloud/README.md
@@ -14,7 +14,7 @@ This chart bootstraps an [ownCloud](https://github.com/bitnami/bitnami-docker-ow
 
 It also packages the [Bitnami MariaDB chart](https://github.com/kubernetes/charts/tree/master/stable/mariadb) which is required for bootstrapping a MariaDB deployment for the database requirements of the ownCloud application.
 
-Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters.
+Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters. This chart has been tested to work with NGINX Ingress, cert-manager, fluentd and Prometheus on top of the [BKPR](https://kubeprod.io/).
 
 ## Prerequisites
 


### PR DESCRIPTION
According to https://github.com/helm/helm/blob/master/docs/charts.md#the-chartyaml-file:

> The `Chart.yaml` file is required for a chart. It contains the following fields:
> ```yaml
> apiVersion: The chart API version, always "v1" (required)
> name: The name of the chart (required)
> version: A SemVer 2 version (required)
> ...
> ```

We're not using the `apiVersion` field. In the same way, added some information about how we are testing this chart.