### PR TITLE
[stable/wordpress] Add apiVersion in Chart.yaml and add test info to README.md

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: wordpress
-version: 5.2.5
+version: 5.2.6
 appVersion: 5.1.0
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -14,7 +14,7 @@ This chart bootstraps a [WordPress](https://github.com/bitnami/bitnami-docker-wo
 
 It also packages the [Bitnami MariaDB chart](https://github.com/kubernetes/charts/tree/master/stable/mariadb) which is required for bootstrapping a MariaDB deployment for the database requirements of the WordPress application.
 
-Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters.
+Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters. This chart has been tested to work with NGINX Ingress, cert-manager, fluentd and Prometheus on top of the [BKPR](https://kubeprod.io/).
 
 ## Prerequisites
 


### PR DESCRIPTION
According to https://github.com/helm/helm/blob/master/docs/charts.md#the-chartyaml-file:

> The `Chart.yaml` file is required for a chart. It contains the following fields:
> ```yaml
> apiVersion: The chart API version, always "v1" (required)
> name: The name of the chart (required)
> version: A SemVer 2 version (required)
> ...
> ```

We're not using the `apiVersion` field. In the same way, added some information about how we are testing this chart.