### PR TITLE
[stable/parse] Add apiVersion in Chart.yaml and add test info to README.md

### DIFF
--- a/stable/parse/Chart.yaml
+++ b/stable/parse/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: parse
-version: 6.0.2
+version: 6.0.3
 appVersion: 3.1.3
 description: Parse is a platform that enables users to add a scalable and powerful backend to launch a full-featured app for iOS, Android, JavaScript, Windows, Unity, and more.
 keywords:

--- a/stable/parse/README.md
+++ b/stable/parse/README.md
@@ -12,7 +12,7 @@ $ helm install stable/parse
 
 This chart bootstraps a [Parse](https://github.com/bitnami/bitnami-docker-parse) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
-Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters.
+Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters. This chart has been tested to work with NGINX Ingress, cert-manager, fluentd and Prometheus on top of the [BKPR](https://kubeprod.io/).
 
 ## Prerequisites
 


### PR DESCRIPTION
According to https://github.com/helm/helm/blob/master/docs/charts.md#the-chartyaml-file:

> The `Chart.yaml` file is required for a chart. It contains the following fields:
> ```yaml
> apiVersion: The chart API version, always "v1" (required)
> name: The name of the chart (required)
> version: A SemVer 2 version (required)
> ...
> ```

We're not using the `apiVersion` field. In the same way, added some information about how we are testing this chart.