### PR TITLE
[stable/kubewatch] Add apiVersion in Chart.yaml and add test info to README.md

### DIFF
--- a/stable/kubewatch/Chart.yaml
+++ b/stable/kubewatch/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: kubewatch
-version: 0.6.1
+version: 0.6.2
 apiVersion: v1
 appVersion: 0.0.4
 home: https://github.com/bitnami-labs/kubewatch


### PR DESCRIPTION
According to https://github.com/helm/helm/blob/master/docs/charts.md#the-chartyaml-file:

> The `Chart.yaml` file is required for a chart. It contains the following fields:
> ```yaml
> apiVersion: The chart API version, always "v1" (required)
> name: The name of the chart (required)
> version: A SemVer 2 version (required)
> ...
> ```

We're not using the `apiVersion` field. In the same way, added some information about how we are testing this chart.