### PR TITLE
[stable/airflow] Fixing a scoping issue within the secret definition

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 2.8.3
+version: 2.8.4
 appVersion: 1.10.0
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
 version: 2.8.3
-appVersion: 1.10.2
+appVersion: 1.10.0
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/
 maintainers:

--- a/stable/airflow/templates/_helpers.tpl
+++ b/stable/airflow/templates/_helpers.tpl
@@ -84,14 +84,9 @@ Create the name for the airflow secret.
 Map environment vars to secrets
 */}}
 {{- define "airflow.mapenvsecrets" -}}
-    {{- $secretName := printf "%s-env" (include "airflow.fullname" .) }}
-    {{- $mapping := .Values.airflow.defaultSecretsMapping }}
-    {{- if .Values.existingAirflowSecret }}
-      {{- $secretName := .Values.existingAirflowSecret }}
-      {{- if .Values.airflow.secretsMapping }}
-        {{- $mapping := .Values.airflow.secretsMapping }}
-      {{- end }}
-    {{- end }}
+    {{- $defaultSecretName := .Release.Name | trunc 63 | trimSuffix "-" }}
+    {{- $secretName := (eq .Values.existingAirflowSecret "") | ternary $defaultSecretName .Values.existingAirflowSecret }}
+    {{- $mapping := or (eq .Values.existingAirflowSecret "") (empty .Values.airflow.secretsMapping) | ternary .Values.airflow.defaultSecretsMapping .Values.airflow.secretsMapping }}
     {{- range $val := $mapping }}
       {{- if $val }}
   - name: {{ $val.envVar }}


### PR DESCRIPTION
#### What this PR does / why we need it:

There's a scoping error that prevents secrets from being set properly through `airflow.secretsMapping`.

#### Which issue this PR fixes

None that I'm aware of, but it seems to be a [common problem](https://stackoverflow.com/a/49604964/2708667).

#### Special notes for your reviewer:

First timer! Please let me know if something is wrong.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
