### PR TITLE
[stable/prometheus-operator] Update deps for grafana v6

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 4.1.1
+version: 4.2.0
 appVersion: 0.29.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/requirements.lock
+++ b/stable/prometheus-operator/requirements.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 1.3.0
 - name: grafana
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 2.0.2
-digest: sha256:c3746232f84904ce907eaf0f886e2a076e75d766e81a7c12140c41890d9985f5
-generated: 2019-02-21T22:20:40.7283+03:00
+  version: 2.2.0
+digest: sha256:6e9375439679814f0e01aa0eb840f7e332f2ba22c468539689bd462f356d6e50
+generated: 2019-02-27T22:56:03.708807073-07:00

--- a/stable/prometheus-operator/requirements.yaml
+++ b/stable/prometheus-operator/requirements.yaml
@@ -11,6 +11,6 @@ dependencies:
     condition: nodeExporter.enabled
 
   - name: grafana
-    version: 2.0.*
+    version: 2.2.*
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: grafana.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:
This patch bumps the Grafana subchart version to `v2.2.* (appVersion v6.0.*)`.
Grafana v6 includes support for Loki which is a simple, scalable logging solution :)
There's also a new Explore panel which allows you to work on your queries.

https://github.com/grafana/grafana/releases/tag/v6.0.0

#### Special notes for your reviewers:
@gianrubio @vsliouniaev
There are a few chart features that have been added in the past few commits on stable/grafana.
  https://github.com/helm/charts/commits/master/stable/grafana
I've reviewed them, and they look non-consequential.
( Even the chart major version bump just updated the image tag. )

I've deployed this setup to an existing GKE cluster, and it's working well.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md