### PR TITLE
[stable/mongodb] Allow MongoDB to be configured with directoryPerDB option

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 5.6.2
+version: 5.7.0
 appVersion: 4.0.6
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/README.md
+++ b/stable/mongodb/README.md
@@ -61,6 +61,7 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `mongodbPassword`                                  | MongoDB custom user password                                                                 | `random alphanumeric string (10)`                       |
 | `mongodbDatabase`                                  | Database to create                                                                           | `nil`                                                   |
 | `mongodbEnableIPv6`                                | Switch to enable/disable IPv6 on MongoDB                                                     | `true`                                                  |
+| `mongodbDirectoryPerDB`                            | Switch to enable/disable DirectoryPerDB on MongoDB                                           | `false`                                                 |
 | `mongodbSystemLogVerbosity`                        | MongoDB systen log verbosity level                                                           | `0`                                                     |
 | `mongodbDisableSystemLog`                          | Whether to disable MongoDB system log or not                                                 | `false`                                                 |
 | `mongodbExtraFlags`                                | MongoDB additional command line flags                                                        | []                                                      |

--- a/stable/mongodb/templates/deployment-standalone.yaml
+++ b/stable/mongodb/templates/deployment-standalone.yaml
@@ -107,6 +107,12 @@ spec:
         {{- else }}
           value: "no"
         {{- end }}
+        - name: MONGODB_ENABLE_DIRECTORY_PER_DB
+        {{- if .Values.mongodbDirectoryPerDB }}
+          value: "yes"
+        {{- else }}
+          value: "no"
+        {{- end }}
         {{- if .Values.mongodbExtraFlags }}
         - name: MONGODB_EXTRA_FLAGS
           value: {{ .Values.mongodbExtraFlags | join " " }}

--- a/stable/mongodb/templates/statefulset-arbiter-rs.yaml
+++ b/stable/mongodb/templates/statefulset-arbiter-rs.yaml
@@ -113,6 +113,12 @@ spec:
           {{- else }}
             value: "no"
           {{- end }}
+          - name: MONGODB_ENABLE_DIRECTORY_PER_DB
+          {{- if .Values.mongodbDirectoryPerDB }}
+            value: "yes"
+          {{- else }}
+            value: "no"
+          {{- end }}
           {{- if .Values.mongodbExtraFlags }}
           - name: MONGODB_EXTRA_FLAGS
             value: {{ .Values.mongodbExtraFlags | join " " }}

--- a/stable/mongodb/templates/statefulset-primary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-primary-rs.yaml
@@ -131,6 +131,12 @@ spec:
           {{- else }}
             value: "no"
           {{- end }}
+          - name: MONGODB_ENABLE_DIRECTORY_PER_DB
+          {{- if .Values.mongodbDirectoryPerDB }}
+            value: "yes"
+          {{- else }}
+            value: "no"
+          {{- end }}
           {{- if .Values.mongodbExtraFlags }}
           - name: MONGODB_EXTRA_FLAGS
             value: {{ .Values.mongodbExtraFlags | join " " }}

--- a/stable/mongodb/templates/statefulset-secondary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-secondary-rs.yaml
@@ -119,6 +119,12 @@ spec:
           {{- else }}
             value: "no"
           {{- end }}
+          - name: MONGODB_ENABLE_DIRECTORY_PER_DB
+          {{- if .Values.mongodbDirectoryPerDB }}
+            value: "yes"
+          {{- else }}
+            value: "no"
+          {{- end }}
           {{- if .Values.mongodbExtraFlags }}
           - name: MONGODB_EXTRA_FLAGS
             value: {{ .Values.mongodbExtraFlags | join " " }}

--- a/stable/mongodb/values-production.yaml
+++ b/stable/mongodb/values-production.yaml
@@ -55,6 +55,11 @@ usePassword: true
 ##
 mongodbEnableIPv6: true
 
+## Whether enable/disable DirectoryPerDB on MongoDB
+## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#enabling/disabling-directoryperdb
+##
+mongodbDirectoryPerDB: false
+
 ## MongoDB System Log configuration
 ## ref: https://github.com/bitnami/bitnami-docker-mongodb#configuring-system-log-verbosity-level
 ##

--- a/stable/mongodb/values.yaml
+++ b/stable/mongodb/values.yaml
@@ -50,11 +50,15 @@ usePassword: true
 # mongodbPassword: password
 # mongodbDatabase: database
 
-
 ## Whether enable/disable IPv6 on MongoDB
 ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#enabling/disabling-ipv6
 ##
 mongodbEnableIPv6: true
+
+## Whether enable/disable DirectoryPerDB on MongoDB
+## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#enabling/disabling-directoryperdb
+##
+mongodbDirectoryPerDB: false
 
 ## MongoDB System Log configuration
 ## ref: https://github.com/bitnami/bitnami-docker-mongodb#configuring-system-log-verbosity-level


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR allows the user to add the configuration option `directoryPerDB` so the databases are created on different directories.

#### Which issue this PR fixes

- fixes #https://github.com/bitnami/bitnami-docker-mongodb/issues/134

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
