### PR TITLE
expose container port so it can be scraped

### DIFF
--- a/stable/kuberhealthy/Chart.yaml
+++ b/stable/kuberhealthy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.0.2"
 home: https://comcast.github.io/kuberhealthy/
 description: The official Helm chart for Kuberhealthy.
 name: kuberhealthy
-version: 1.2.1
+version: 1.2.2
 maintainers:
   - name: integrii
     email: eric.greer@comcast.com

--- a/stable/kuberhealthy/templates/deployment.yaml
+++ b/stable/kuberhealthy/templates/deployment.yaml
@@ -41,6 +41,9 @@ spec:
         args:
 {{ toYaml .Values.deployment.args | nindent 8 }}
         {{- end }}
+        ports:
+        - containerPort: 8080
+          name: http
         securityContext:
         {{- toYaml .Values.securityContext | nindent 10 -}}
         imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}

--- a/stable/kuberhealthy/templates/service.yaml
+++ b/stable/kuberhealthy/templates/service.yaml
@@ -8,7 +8,6 @@ metadata:
   {{ if .Values.prometheus.enableScraping -}}
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: {{ .Values.service.externalPort | quote }}
     prometheus.io/path: "/metrics"
   {{ end -}}
   {{ end -}}
@@ -18,7 +17,7 @@ spec:
   ports:
   - port: {{ .Values.service.externalPort }}
     name: http
-    targetPort: 8080
+    targetPort: http
   selector:
     app: {{ template "kuberhealthy.name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
Signed-off-by: David J. M. Karlsen <david@davidkarlsen.com>


#### What this PR does / why we need it:
https://github.com/Comcast/kuberhealthy/issues/119

Exposes the container ports so that the service works properly and the containers can be scraped by prometheus. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
