### PR TITLE
Add quotes to cluster name in kurberos

### DIFF
--- a/stable/kuberos/templates/configmap.yaml
+++ b/stable/kuberos/templates/configmap.yaml
@@ -10,7 +10,7 @@ data:
     current-context: {{ (index .Values.kuberos.clusters 0).name  }}
     clusters:
     {{ range .Values.kuberos.clusters }}
-    - name: {{ .name }}
+    - name: {{ .name | quote }}
       cluster:
         certificate-authority-data: {{ .caCrt | b64enc | quote }}
         server: {{ .apiServer }}


### PR DESCRIPTION
In our environment clusters have number names. 10, 110 etc.
If i put it to kuberos configuration it will be converted to name: 10 , without quotes. Such yaml will conver to json with 10 as number, not a string.
When kuberos will try to load this configuration, json decoding will fail because it expects string there.

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
