### PR TITLE
[stable/ark] Fix handling of extraEnvVars when useSecret is false

### DIFF
--- a/stable/ark/Chart.yaml
+++ b/stable/ark/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.10.1
+appVersion: 0.10.2
 description: A Helm chart for ark
 name: ark
 version: 4.0.0

--- a/stable/ark/templates/deployment.yaml
+++ b/stable/ark/templates/deployment.yaml
@@ -74,18 +74,20 @@ spec:
         {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp")) }}
             - name: cloud-credentials
               mountPath: /credentials
+        {{- end }}
           env:
+        {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp")) }}
           {{- if eq $provider "aws" }}
             - name: AWS_SHARED_CREDENTIALS_FILE
           {{- else }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
           {{- end }}
               value: /credentials/cloud
-          {{ if .Values.configuration.extraEnvVars }}
+        {{- end }}
+        {{ if .Values.configuration.extraEnvVars }}
           {{- range $key, $value := .Values.configuration.extraEnvVars }}
             - name: {{ default "none" $key }}
               value: {{ default "none" $value }}
-          {{- end }}
           {{- end }}
         {{- end }}
       volumes:


### PR DESCRIPTION
This change ensures that extraEnvVars are set when useSecret
is set to false.

#### Checklist

- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped

Signed-off-by: Steffen Pingel <steffen.pingel@tasktop.com>

