### PR TITLE
Add Piwigo chart to incubator

### DIFF
--- a/incubator/piwigo/.helmignore
+++ b/incubator/piwigo/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+# OWNERS file for Kubernetes
+OWNERS

--- a/incubator/piwigo/Chart.yaml
+++ b/incubator/piwigo/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+appVersion: 2.9.4
+description: Piwigo is open source photo gallery software for the web.
+name: piwigo
+version: 0.0.1
+keywords:
+  - piwigo
+  - photos
+  - gallery
+home: https://piwigo.org/
+sources:
+  - https://github.com/Piwigo/Piwigo
+  - https://github.com/mathieuruellan/docker-piwigo
+  - https://github.com/helm/charts/tree/master/incubator/piwigo
+maintainers:
+  - name: mcronce
+    email: mike@quadra-tec.net

--- a/incubator/piwigo/OWNERS
+++ b/incubator/piwigo/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- mcronce
+reviewers:
+- mcronce

--- a/incubator/piwigo/README.md
+++ b/incubator/piwigo/README.md
@@ -1,0 +1,96 @@
+# Piwigo
+This is a helm chart for [Piwigo][piwigo]
+
+## TL;DR;
+```console
+helm install --set server_name=matrix.example.org incubator/piwigo
+```
+
+## Installing the Chart
+To install the chart with the release name `my-release`:
+
+```console
+helm install --name my-release incubator/piwigo
+```
+
+## Uninstalling the Chart
+To uninstall/delete the `my-release` deployment:
+
+```console
+helm delete my-release --purge
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+The following tables lists the configurable parameters of the Piwigo chart and their default values.
+
+Note that the database user and password options _only_ apply directly to the user that MariaDB creates automatically.  Piwigo has an install procedure it goes through the first time it's visited in a web browser.
+
+| Parameter                          | Description                                                                                                      | Default                           |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `image.repository`                 | Image repository                                                                                                 | `mathieuruellan/piwigo`           |
+| `image.tag`                        | Image tag. Possible values listed [here][docker].                                                                | `release-2.9.4`                   |
+| `image.pullPolicy`                 | Image pull policy                                                                                                | `IfNotPresent`                    |
+| `replicaCount`                     | Number of replicas to deploy                                                                                     | `1`                               |
+| `extraLabels`                      | Additional labels to apply to all created resources                                                              | `{}`                              |
+| `mariadb.deploy`                   | Whether or not to deploy `stable/mariadb` as a subchart                                                          | `false`                           |
+| `mariadb.nameOverride`             | Override for MariaDB subchart artifacts' names                                                                   | `db`                              |
+| `mariadb.existingSecret`           | Name of secret to pass to MariaDB for user creation; this is deployed as part of this chart                      | `piwigo-db`                       |
+| `mariadb.replication.enabled`      | Whether or not to deploy a MariaDB cluster                                                                       | `false`                           |
+| `mariadb.db.user`                  | Name of user to automatically create in MariaDB                                                                  | `piwigo`                          |
+| `mariadb.db.password`              | Password for automatically-created user in MariaDB                                                               | 16 random alphanumeric characters |
+| `mariadb`                          | There are many other options for [the Mariadb subchart][mariadb-chart]                                           |                                   |
+| `database.storage_engine`          | Which storage engine to use for creating the database tables.  Only applies during the installation procedure.   | `MyISAM`                          |
+| `service.annotations`              | Annotations for Service resource                                                                                 | `{}`                              |
+| `service.type`                     | Type of service to deploy                                                                                        | `ClusterIP`                       |
+| `service.clusterIP`                | ClusterIP of service; if blank, it will be selected at random from the cluster CIDR range                        | `""`                              |
+| `service.port`                     | Port to expose service                                                                                           | `80`                              |
+| `service.externalIPs`              | External IPs for service                                                                                         | `[]`                              |
+| `service.loadBalancerIP`           | Load balancer IP                                                                                                 | `""`                              |
+| `service.loadBalancerSourceRanges` | List of IP CIDRs allowed to access the load balancer (if supported)                                              | `[]`                              |
+| `ingress.enabled`                  | Whether or not to deploy the Ingress resource                                                                    | `false`                           |
+| `ingress.class`                    | Ingress class (included in annotations)                                                                          | ``                                |
+| `ingress.annotations`              | Ingress annotations                                                                                              | `{}`                              |
+| `ingress.path`                     | Ingress path                                                                                                     | `/`                               |
+| `ingress.hosts`                    | Ingress accepted hostnames                                                                                       | `[piwigo]`                        |
+| `ingress.tls`                      | Ingress TLS configuration                                                                                        | `[]`                              |
+| `persistence.galleries`            | Optional VolumeSpec to inject; if not specified, will simply be deployed as a subdirectory in `persistence.data` | `{}`                              |
+| `persistence.data.enabled`         | Use persistent volume to store data                                                                              | `true`                            |
+| `persistence.data.size`            | Size of persistent volume claim                                                                                  | `256Gi`                           |
+| `persistence.data.existingClaim`   | Use an existing PVC to persist data                                                                              | ``                                |
+| `persistence.data.storageClass`    | Type of persistent volume claim                                                                                  | ``                                |
+| `persistence.data.accessMode`      | PVC access mode                                                                                                  | `ReadWriteMany`                   |
+| `persistence.config.enabled`       | Use persistent volume to store config                                                                            | `true`                            |
+| `persistence.config.size`          | Size of persistent volume claim                                                                                  | `4Gi`                             |
+| `persistence.config.existingClaim` | Use an existing PVC to persist config                                                                            | ``                                |
+| `persistence.config.storageClass`  | Type of persistent volume claim                                                                                  | ``                                |
+| `persistence.config.accessMode`    | PVC access mode                                                                                                  | `ReadWriteMany`                   |
+| `resources`                        | CPU/Memory resource requests/limits                                                                              | `{}`                              |
+| `nodeSelector`                     | Node labels for pod assignment                                                                                   | `{}`                              |
+| `tolerations`                      | Toleration labels for pod assignment                                                                             | `[]`                              |
+| `affinity`                         | Affinity settings for pod assignment                                                                             | `{}`                              |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+helm install --name my-release \
+	--set server_name="matrix.example.com" \
+	--set ingress.enabled=true \
+	incubator/piwigo
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+helm install --name my-release -f values.yaml incubator/piwigo
+```
+
+Read through the [values.yaml](values.yaml) file.
+
+[docker]: https://hub.docker.com/r/mathieuruellan/piwigo
+[github]: https://github.com/Piwigo/Piwigo
+[piwigo]: https://piwigo.org/
+[mariadb-docker]: https://hub.docker.com/r/bitnami/mariadb
+[mariadb-chart]: https://github.com/helm/charts/tree/master/stable/mariadb
+

--- a/incubator/piwigo/requirements.lock
+++ b/incubator/piwigo/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: mariadb
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 5.5.3
+digest: sha256:515c85bf6a4fbfb72b2ce7e248b01390d47dd2c4f42155f4dd85cda94dbe6256
+generated: 2019-02-27T13:57:38.308118-05:00

--- a/incubator/piwigo/requirements.yaml
+++ b/incubator/piwigo/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+  - name: mariadb
+    version: 5.x.x
+    repository: https://kubernetes-charts.storage.googleapis.com/
+    condition: mariadb.deploy

--- a/incubator/piwigo/templates/NOTES.txt
+++ b/incubator/piwigo/templates/NOTES.txt
@@ -1,0 +1,10 @@
+Piwigo has been installed. You can access the server from within the k8s cluster using:
+
+  {{ template "piwigo.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+Please visit it in your browser to run the installation procedure.  You will need the username and password from secret {{ default (printf "%s-%s" (include "piwigo.fullname" .) "db") .Values.mariadb.existingSecret }}
+
+{{- if .Values.mariadb.deploy }}
+The hostname for your MariaDB service is {{ template "mariadb.fullname" }}.{{ .Release.Namespace }}.svc.cluster.local - you will need this for the installation procedure
+{{- end }}
+

--- a/incubator/piwigo/templates/_helpers.tpl
+++ b/incubator/piwigo/templates/_helpers.tpl
@@ -1,0 +1,69 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "piwigo.name" -}}
+  {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "piwigo.fullname" -}}
+  {{- if .Values.fullnameOverride -}}
+    {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+  {{- else -}}
+    {{- $name := default .Chart.Name .Values.nameOverride -}}
+    {{- if contains $name .Release.Name -}}
+      {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+      {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "piwigo.chart" -}}
+  {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Generate chart secret name
+*/}}
+{{- define "piwigo.secretName" -}}
+  {{- default (include "piwigo.fullname" .) .Values.secret.nameOverride -}}
+{{- end -}}
+
+{{/*
+Generate all the labels for chart-deployed resources
+*/}}
+{{- define "piwigo.labels" -}}
+app.kubernetes.io/name: {{ template "piwigo.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ template "piwigo.chart" . }}
+{{- if .Values.extraLabels -}}
+{{- toYaml .Values.extraLabels -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Include this here since we can't call subcharts' templates
+*/}}
+{{- define "mariadb.fullname" -}}
+  {{- if .Values.fullnameOverride -}}
+    {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+  {{- else -}}
+    {{- $name := default .Chart.Name .Values.nameOverride -}}
+    {{- if contains $name .Release.Name -}}
+      {{- printf .Release.Name | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+      {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+

--- a/incubator/piwigo/templates/deployment.yaml
+++ b/incubator/piwigo/templates/deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name:  {{ template "piwigo.fullname" . }}
+  labels:
+    {{- include "piwigo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "piwigo.labels" . | nindent 6 }}
+      app.kubernetes.io/component: server
+  template:
+    metadata:
+      labels:
+        {{- include "piwigo.labels" . | nindent 8 }}
+        app.kubernetes.io/component: server
+    spec:
+      containers:
+        - name: piwigo
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+          env:
+            - name: PIWIGO_MYSQL_ENGINE
+              value: {{ .Values.database.storage_engine | quote }}
+          volumeMounts:
+            - mountPath: /var/www/galleries
+              {{- if .Values.persistence.galleries }}
+              name: galleries
+              {{- else }}
+              name: data
+              subPath: galleries
+              {{- end }}
+            - mountPath: /var/www/upload
+              name: data
+              subPath: upload
+            - mountPath: /var/www/_data/i
+              name: data
+              subPath: cache
+            - mountPath: /var/www/_data/combined
+              name: data
+              subPath: combined
+            - mountPath: /config
+              name: config
+              subPath: config
+            - mountPath: /var/www/local
+              name: config
+              subPath: app-config
+            - mountPath: /var/www/plugins
+              name: config
+              subPath: plugins
+            - mountPath: /var/www/themes
+              name: config
+              subPath: themes
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 2
+            failureThreshold: 5
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      volumes:
+        {{- if .Values.persistence.galleries }}
+        - name: galleries
+          {{- toYaml .Values.persistence.galleries | nindent 10 }}
+        {{- end }}
+        - name: data
+          {{- if .Values.persistence.data.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.data.existingClaim | default (printf "%s-%s" (include "piwigo.fullname" .) "data") }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: config
+          {{- if .Values.persistence.config.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.config.existingClaim | default (printf "%s-%s" (include "piwigo.fullname" .) "config") }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+

--- a/incubator/piwigo/templates/ingress.yaml
+++ b/incubator/piwigo/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "piwigo.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "piwigo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+  annotations:
+    kubernetes.io/ingress.class: {{ required "If ingress.enabled is set to true, ingress.class is required" .Values.ingress.class | quote }}
+    {{- if .Values.ingress.annotations }}
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $servicePort }}
+    {{- end }}
+{{- end }}
+

--- a/incubator/piwigo/templates/pvc-config.yaml
+++ b/incubator/piwigo/templates/pvc-config.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.persistence.config.enabled (not .Values.persistence.config.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "piwigo.fullname" . }}-config
+  labels:
+    {{- include "piwigo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  accessModes:
+    - {{ .Values.persistence.config.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.config.size | quote }}
+  {{- if .Values.persistence.config.storageClass }}
+  {{- if not .Values.persistence.config.storageClass }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.persistence.config.storageClass | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+

--- a/incubator/piwigo/templates/pvc-data.yaml
+++ b/incubator/piwigo/templates/pvc-data.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.persistence.data.enabled (not .Values.persistence.data.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "piwigo.fullname" . }}-data
+  labels:
+    {{- include "piwigo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  accessModes:
+    - {{ .Values.persistence.data.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.data.size | quote }}
+  {{- if .Values.persistence.data.storageClass }}
+  {{- if not .Values.persistence.data.storageClass }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.persistence.data.storageClass | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+

--- a/incubator/piwigo/templates/secret-database.yaml
+++ b/incubator/piwigo/templates/secret-database.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.mariadb.deploy }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ default (printf "%s-%s" (include "piwigo.fullname" .) "db") .Values.mariadb.existingSecret | quote }}
+  labels:
+    {{- include "piwigo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: initdb
+type: Opaque
+data:
+  mariadb-password: {{ (default .Values.mariadb.db.password (randAlphaNum 16)) | b64enc | quote }}
+{{- end }}
+

--- a/incubator/piwigo/templates/service.yaml
+++ b/incubator/piwigo/templates/service.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Service
+metadata:
+  {{- if .Values.service.annotations }}
+  annotations:
+  {{- toYaml .Values.service.annotations | nindent 4 }}
+  {{- end }}
+  name: {{ template "piwigo.fullname" . }}
+  labels:
+    {{- include "piwigo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  clusterIP: {{ .Values.service.clusterIP | quote }}
+  {{- if .Values.service.externalIPs }}
+  externalIPs:
+  {{- toYaml .Values.service.externalIPs | nindent 4 }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP | quote }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.service.port }}
+      targetPort: http
+  selector:
+    {{- include "piwigo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+  type: {{ .Values.service.type }}
+

--- a/incubator/piwigo/values.yaml
+++ b/incubator/piwigo/values.yaml
@@ -1,0 +1,91 @@
+# Default values for piwigo.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  # From repository https://github.com/Piwigo/Piwigo
+  repository: mathieuruellan/piwigo
+  tag: release-2.9.4
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+## Add additional labels to all resources
+extraLabels: {}
+
+mariadb:
+  deploy: false
+  nameOverride: db
+  existingSecret: piwigo-db
+  replication:
+    enabled: false
+  db:
+    user: piwigo
+    password:
+
+database:
+  storage_engine: MyISAM
+
+service:
+  annotations: {}
+  type: ClusterIP
+  clusterIP: ""
+
+  port: 80
+  ## List of IP addresses at which the service is available
+  ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+  ##
+  externalIPs: []
+
+  loadBalancerIP: ""
+  loadBalancerSourceRanges: []
+
+ingress:
+  enabled: false
+  class:
+  annotations: {}
+  path: /
+  hosts:
+    - piwigo
+  tls: []
+    # - secretName: piwigo-tls
+    #    hosts:
+    #      - piwigo
+
+## Persist configuration to a persistent volume
+persistence:
+  ## Data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If unset, storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  data:
+    enabled: true
+    existingClaim:
+    storageClass:
+    accessMode: ReadWriteMany
+    size: 256Gi
+  config:
+    enabled: true
+    existingClaim:
+    storageClass:
+    accessMode: ReadWriteMany
+    size: 4Gi
+  ## Set this to mount a custom VolumeSpec in for galleries, in cases of e.g. shared storage; leaving it empty will put it in the data volume under "galleries"
+  galleries: {}
+
+resources:
+  requests:
+    cpu: "1"
+    memory: "256Mi"
+  limits:
+    cpu: "2"
+    memory: "512Mi"
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds a chart for Piwigo, self-hosted photo gallery software, to incubator

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
The install procedure for Piwigo isn't real modern - it's a little weird for people who are used to a Kubernetes world where everything is configured by environment variables.  I think I covered it pretty well in the README but I'm open to suggestions.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
