### PR TITLE
[stable/stolon] Provision to create standby stolon cluster

### DIFF
--- a/stable/stolon/Chart.yaml
+++ b/stable/stolon/Chart.yaml
@@ -1,5 +1,5 @@
 name: stolon
-version: 1.1.0
+version: 1.2.0
 appVersion: 0.13.0
 description: Stolon - PostgreSQL cloud native High Availability.
 home: https://github.com/sorintlab/stolon

--- a/stable/stolon/README.md
+++ b/stable/stolon/README.md
@@ -57,6 +57,9 @@ Kubernetes is the default store backend. `consul`, `etcdv2` or `etcdv3` can also
 | `job.autoCreateCluster`                 | Set to `false` to force-disable auto-cluster-creation which may clear pre-existing postgres db data | `true`  |
 | `job.autoUpdateClusterSpec`             | Set to `false` to force-disable auto-cluster-spec-update | `true`                                             |
 | `clusterSpec`                           | Stolon cluster spec [reference](https://github.com/sorintlab/stolon/blob/master/doc/cluster_spec.md) | `{}`   |
+| `standby.enabled`                       | If true, create stolon cluster in standby mode | `false`
+| `standby.primarySlotName`               | Slot to be used for streaming replication      | (Required field if `standby.enabled` is true)
+| `standby.remoteHost`                    | Address of the master postgres/stolon          | (Required field if `standby.enabled` is true)
 | `keeper.replicaCount`                   | Number of keeper nodes                         | `2`                                                          |
 | `keeper.resources`                      | Keeper resource requests/limit                 | `{}`                                                         |
 | `keeper.priorityClassName`              | Keeper priorityClassName                       | `nil`                                                        |

--- a/stable/stolon/templates/_helpers.tpl
+++ b/stable/stolon/templates/_helpers.tpl
@@ -40,3 +40,56 @@ Create chart name and version as used by the chart label.
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+pg_basebackup password file location
+*/}}
+{{- define "standby.passwordfile.path" -}}
+{{- printf "/home/stolon/standbypassword" -}}
+{{- end -}}
+
+{{/*
+pg_basebackup password file content
+*/}}
+{{- define "standby.passwordfile.content" -}}
+{{- printf "%s:%d:*:%s:%s" .Values.standby.remoteHost 5432 .Values.replicationUsername .Values.replicationPassword | b64enc -}}
+{{- end -}}
+
+
+{{/*
+Get cluster specification
+*/}}
+{{- define "cluster.specification.json" -}}
+{{- $clusterSpecification := .Values.clusterSpec -}}
+{{- if .Values.standby.enabled -}}
+    {{- $remoteHost := required "Provide remote host address" .Values.standby.remoteHost -}}
+    {{- $primarySlotName := required "Provide primary replication slot name" .Values.standby.primarySlotName -}}
+    {{- $remoteReplUser := required "Provide remote replication username" .Values.replicationUsername -}}
+    {{- $remoteReplPassword := required "Provide remote replication password" .Values.replicationPassword -}}
+    {{- $passwordFilePath := include "standby.passwordfile.path" . -}}
+    {{- $standBySpecAsJson := printf "{\"initMode\":\"pitr\",\"pitrConfig\":{\"dataRestoreCommand\":\"PGPASSFILE=%s pg_basebackup -D %s -h  %s -p 5432 -U %s\"},\"role\":\"standby\",\"standbyConfig\":{\"standbySettings\":{\"primaryConnInfo\":\"host=%s port=5432 user=%s password=%s sslmode=disable\", \"primarySlotName\":\"%s\" }}}" $passwordFilePath "%d" $remoteHost $remoteReplUser $remoteHost $remoteReplUser $remoteReplPassword $primarySlotName -}}
+    {{- if $clusterSpecification -}}
+        {{- $extraSpecAsMap := $clusterSpecification | toJson | fromJson -}}
+        {{- $standBySpecAsMap := fromJson $standBySpecAsJson -}}
+        {{- merge $standBySpecAsMap $extraSpecAsMap | toJson -}}
+    {{- else -}}
+        {{- $standBySpecAsJson -}}
+    {{- end -}}
+{{- else if $clusterSpecification -}}
+    {{- toJson $clusterSpecification -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get cluster specification on initializations
+*/}}
+{{- define "cluster.init-specification.json" -}}
+    {{- $initModeSpecMap := fromJson "{\"initMode\":\"new\"}" -}}
+    {{- $clusterSpecification := include "cluster.specification.json" . -}}
+    {{- if $clusterSpecification -}}
+        {{- $clusterSpecificationMap := fromJson $clusterSpecification -}}
+        {{- merge $clusterSpecificationMap $initModeSpecMap | toJson -}}
+    {{- else -}}
+        {{- toJson $initModeSpecMap -}}
+    {{- end -}}
+{{- end -}}

--- a/stable/stolon/templates/hooks/create-cluster-job.yaml
+++ b/stable/stolon/templates/hooks/create-cluster-job.yaml
@@ -42,5 +42,5 @@ spec:
             - --store-endpoints={{ .Values.store.endpoints }}
             {{- end }}
             - --yes
-            - '{ "initMode": "new", {{- range $key, $value := .Values.clusterSpec }} {{ $key | quote }}: {{ if typeIs "string" $value }} {{ $value | quote }} {{ else }} {{ $value }} {{ end }}, {{- end }} "pgParameters": {{ toJson .Values.pgParameters }} }'
+            - '{{template "cluster.init-specification.json" .}}'
 {{ end }}

--- a/stable/stolon/templates/keeper-statefulset.yaml
+++ b/stable/stolon/templates/keeper-statefulset.yaml
@@ -46,6 +46,13 @@ spec:
               export POD_IP=$(hostname -i)
               export STKEEPER_PG_LISTEN_ADDRESS=$POD_IP
               export STOLON_DATA=/stolon-data
+
+              {{- if .Values.standby.enabled -}}
+              cp /etc/secrets/stolon/standbypassword {{ template "standby.passwordfile.path" . }}
+              chmod 600 {{ template "standby.passwordfile.path" . }}
+              chown stolon:stolon {{ template "standby.passwordfile.path" . }}
+              {{- end }}
+
               chown stolon:stolon $STOLON_DATA
               exec gosu stolon stolon-keeper --data-dir $STOLON_DATA
           env:

--- a/stable/stolon/templates/secret.yaml
+++ b/stable/stolon/templates/secret.yaml
@@ -16,4 +16,7 @@ data:
 {{ if empty .Values.replicationSecret.name }}
   pg_repl_password: {{ required "A valid .Values.replicationPassword entry is required!" .Values.replicationPassword | b64enc | quote }}
 {{ end }}
+{{- if .Values.standby.enabled }}
+  standbypassword: {{ template "standby.passwordfile.content" . }}
+  {{- end }}
 {{ end }}

--- a/stable/stolon/values.yaml
+++ b/stable/stolon/values.yaml
@@ -59,6 +59,11 @@ store:
 pgParameters: {}
   # maxConnections: 1000
 
+standby:
+  enabled: false
+# primarySlotName: "stolon_readonly_cluster"
+# remoteHost: master-stolon-proxy.default.svc.cluster.local.
+
 ports:
   stolon:
     containerPort: 5432
@@ -69,7 +74,9 @@ job:
   autoCreateCluster: true
   autoUpdateClusterSpec: true
 
-clusterSpec: {}
+clusterSpec:
+  # additionalMasterReplicationSlots:
+  # - "readonly_cluster"
   # sleepInterval: 1s
   # maxStandbys: 5
 


### PR DESCRIPTION
This is to run `stolon` cluster in `standby mode` refer https://github.com/helm/charts/issues/11582

It is controlled by `standby.enabled` which is **false** by default.

I have tested it by installing a `stolon` cluster in non-standby(master/primary) mode and then ran an another `stolon` cluster in standby mode which replicates the content from the master cluster.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
