### PR TITLE
[stable/grafana] Allow to define GF admin user and admin password in …

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 2.2.0
+version: 2.2.1
 appVersion: 6.0.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -206,16 +206,20 @@ spec:
               containerPort: 3000
               protocol: TCP
           env:
+            {{- if not .Values.env.GF_SECURITY_ADMIN_USER }}
             - name: GF_SECURITY_ADMIN_USER
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.admin.existingSecret | default (include "grafana.fullname" .) }}
                   key: {{ .Values.admin.userKey | default "admin-user" }}
+            {{- end }}
+            {{- if not .Values.env.GF_SECURITY_ADMIN_PASSWORD }}
             - name: GF_SECURITY_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.admin.existingSecret | default (include "grafana.fullname" .) }}
                   key: {{ .Values.admin.passwordKey | default "admin-password" }}
+            {{- end }}
             {{- if .Values.plugins }}
             - name: GF_INSTALL_PLUGINS
               valueFrom:


### PR DESCRIPTION
…value file as env

Signed-off-by: Cyrille DE CIANCIO <cyrille@omise.co>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
It allows to define GF admin user and GF admin password in value file as env using GF_SECURITY_ADMIN_USER and GF_SECURITY_ADMIN_PASSWORD.
Env format is required by some third party tools like HashiCorp Vault to be able to retrieve value from their vault.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed