### PR TITLE
[filebeat] fix filebeat exporter container port

### DIFF
--- a/stable/filebeat/Chart.yaml
+++ b/stable/filebeat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart to collect Kubernetes logs with filebeat
 icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.svg
 name: filebeat
-version: 1.4.2
+version: 1.4.3
 appVersion: 6.6.1
 home: https://www.elastic.co/products/beats/filebeat
 sources:

--- a/stable/filebeat/templates/daemonset.yaml
+++ b/stable/filebeat/templates/daemonset.yaml
@@ -122,6 +122,8 @@ spec:
 {{ toYaml .Values.monitoring.resources | indent 10 }}
 {{- end }}
 {{- end }}
+        ports:
+          - containerPort: {{ .Values.monitoring.exporterPort}}
       volumes:
       - name: varlog
         hostPath:


### PR DESCRIPTION
#### What this PR does / why we need it:
Bring by #11408 , the prometheus exporter for filebeat does not expose the exporter port.

This PR add `containerPort` field to prometheus exporter container.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
