### PR TITLE
Add stable/prometheus-es-explorer

### DIFF
--- a/stable/prometheus-es-exporter/.helmignore
+++ b/stable/prometheus-es-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+# Unittests
+templates/tests/unittest-*

--- a/stable/prometheus-es-exporter/Chart.yaml
+++ b/stable/prometheus-es-exporter/Chart.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+description: Launch queries to elasticsearch and renderize them as prometheus metrics.
+name: prometheus-es-exporter
+version: 0.0.1

--- a/stable/prometheus-es-exporter/Chart.yaml
+++ b/stable/prometheus-es-exporter/Chart.yaml
@@ -5,3 +5,6 @@ name: prometheus-es-exporter
 version: 0.0.1
 appVersion: "1.0"
 home: https://github.com/braedon/prometheus-es-exporter
+maintainers:
+  - name: Àlex Pérez-Pujol
+    email: alexperezpujol@disroot.org

--- a/stable/prometheus-es-exporter/Chart.yaml
+++ b/stable/prometheus-es-exporter/Chart.yaml
@@ -5,6 +5,3 @@ name: prometheus-es-exporter
 version: 0.0.1
 appVersion: "1.0"
 home: https://github.com/braedon/prometheus-es-exporter
-maintainers:
-  - name: Àlex Pérez-Pujol
-    email: alexperezpujol@disroot.org

--- a/stable/prometheus-es-exporter/Chart.yaml
+++ b/stable/prometheus-es-exporter/Chart.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 description: Launch queries to elasticsearch and renderize them as prometheus metrics.
 name: prometheus-es-exporter
 version: 0.0.1
+appVersion: "1.0"
+home: https://github.com/braedon/prometheus-es-exporter

--- a/stable/prometheus-es-exporter/Chart.yaml
+++ b/stable/prometheus-es-exporter/Chart.yaml
@@ -5,3 +5,6 @@ name: prometheus-es-exporter
 version: 0.0.1
 appVersion: "1.0"
 home: https://github.com/braedon/prometheus-es-exporter
+maintainers:
+  - name: Alex Perez-Pujol
+    email: alexperezpujol@disroot.org

--- a/stable/prometheus-es-exporter/README.md
+++ b/stable/prometheus-es-exporter/README.md
@@ -83,7 +83,7 @@ helm install stable/prometheus-es-exporter --name my-release -f values.yaml
 ### Integration tests
 Two tests will be run. One will test that the service is really pointing to the
 pod and the other will only be run if `prometheus.serviceMonitor` is enabled,
-and will test if there's metrics in prometheus. You may execute them like this:
+and will test if there are metrics in prometheus. You may execute them like this:
 
 ```bash
 helm test my-release --cleanup

--- a/stable/prometheus-es-exporter/README.md
+++ b/stable/prometheus-es-exporter/README.md
@@ -25,7 +25,7 @@ package manager.
 To install the chart with the release name `my-release`:
 
 ```bash
-helm install --name my-release stable/prometheus-es-explorer --set elasticsearch.url="http://elasticsearch:9200"
+helm install --name my-release stable/prometheus-es-exporter --set elasticsearch.url="http://elasticsearch:9200"
 ```
 
 The command deploys nginx-ingress on the Kubernetes cluster in the default
@@ -66,7 +66,7 @@ Parameter | Description | Default
 `service.port` | port in which the service will be listening | `9206`
 
 ```bash
-helm install stable/prometheus-es-explorer --name my-release \
+helm install stable/prometheus-es-exporter --name my-release \
     --set elasticsearch.url="http://elasticsearch:9200"
 ```
 
@@ -74,7 +74,7 @@ Alternatively, a YAML file that specifies the values for the parameters can be
 provided while installing the chart. For example:
 
 ```bash
-helm install stable/prometheus-es-explorer --name my-release -f values.yaml
+helm install stable/prometheus-es-exporter --name my-release -f values.yaml
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/prometheus-es-exporter/README.md
+++ b/stable/prometheus-es-exporter/README.md
@@ -1,0 +1,120 @@
+# prometheus-es-exporter
+
+[prometheus-es-exporter](https://github.com/braedon/prometheus-es-exporter) is a
+prometheus exporter that collects metrics from queries run on an Elasticsearch
+cluster's data, and metrics about the cluster itself.
+
+## TL;DR;
+
+```bash
+helm install stable/prometheus-es-explorer --set elasticsearch.url="http://elasticsearch:9200"
+```
+
+## Introduction
+
+This chart bootstraps a prometheus elasticsearch queries exporter deployment on a
+[Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh)
+package manager.
+
+## Prerequisites
+  - Kubernetes 1.9+
+  - Prometheus operator (if you want to use the ServiceMonitor)
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+helm install --name my-release stable/prometheus-es-explorer --set elasticsearch.url="http://elasticsearch:9200"
+```
+
+The command deploys nginx-ingress on the Kubernetes cluster in the default
+configuration. The [configuration](#configuration) section lists the parameters
+that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and
+deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the nginx-ingress chart and their default values.
+
+Parameter | Description | Default
+--- | --- | ---
+`elasticsearch.url` | elasticsearch endpoint, with the port included | none
+`elasticsearch.queries` | elasticsearch queries to make | none
+`prometheus.serviceMonitor` | if set to `true`, will create a ServiceMonitor | `false`
+`prometheus.name` | label name of the prometheus instance used | none
+`image.repository` | prometheus-es-exporter container image repository | `braedon/prometheus-es-exporter`
+`image.tag` | prometheus-es-exporter container image tag | `0.5.1`
+`image.pullPolicy` | prometheus-es-exporter container image pull policy | `IfNotPresent`
+`tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
+`affinity` | node/pod affinities (requires Kubernetes >=1.6) | `{}`
+`nodeSelector` | node labels for pod assignment | `{}`
+`resources` | controller pod resource requests & limits | `{}`
+`service.type` | type of controller service to create | `ClusterIp`
+`service.port` | port in which the service will be listening | `9206`
+
+```bash
+helm install stable/prometheus-es-explorer --name my-release \
+    --set elasticsearch.url="http://elasticsearch:9200"
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be
+provided while installing the chart. For example:
+
+```bash
+helm install stable/prometheus-es-explorer --name my-release -f values.yaml
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Tests
+### Integration tests
+Two tests will be run. One will test that the service is really pointing to the
+pod and the other will only be run if `prometheus.serviceMonitor` is enabled,
+and will test if there's metrics in prometheus. You may execute them like this:
+
+```bash
+helm test my-release --cleanup
+```
+
+```console
+RUNNING: my-release-servicemonitor-test
+PASSED: my-release-servicemonitor-test
+RUNNING: my-release-service-test
+PASSED: my-release-service-test
+```
+
+### Unittests
+There's some unittests done with the
+![helm-unittests](https://github.com/lrills/helm-unittest) plugin. You may check
+it's page to install the plugin. You may execute them like this:
+
+```bash
+helm unittest -f templates/tests/unittest-deployment.yaml -f \
+    `templates/tests/unittest-servicemonitor.yaml .
+```
+
+```console
+### Chart [ prometheus-es-exporter ] .
+
+ PASS  test deployment	templates/tests/unittest-deployment.yaml
+ PASS  test servicemonitor	templates/tests/unittest-servicemonitor.yaml
+
+Charts:      1 passed, 1 total
+Test Suites: 2 passed, 2 total
+Tests:       11 passed, 11 total
+Snapshot:    0 passed, 0 total
+Time:        14.940903ms
+```

--- a/stable/prometheus-es-exporter/templates/NOTES.txt
+++ b/stable/prometheus-es-exporter/templates/NOTES.txt
@@ -1,0 +1,12 @@
+{{- if eq (printf "%s" .Values.elasticsearch.url ) "" }}
+########################################################
+####   ERROR: You did not set an elasticsearch url. ####
+########################################################
+
+This deployment will be incomplete until you set the elasticsearch url:
+
+    helm upgrade {{ .Release.Name }} \
+        --set elasticsearch.url="http://elasticsearch:9200" stable/prometheus-es-exporter
+{{- else -}}
+If you created a ServiceMonitor, it may take a while for prometheus to ingest the metrics.
+{{end}}

--- a/stable/prometheus-es-exporter/templates/_helpers.tpl
+++ b/stable/prometheus-es-exporter/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prometheus-es-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "prometheus-es-exporter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prometheus-es-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/prometheus-es-exporter/templates/configmap.yaml
+++ b/stable/prometheus-es-exporter/templates/configmap.yaml
@@ -1,0 +1,15 @@
+{{ if .Values.elasticsearch.queries }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "prometheus-es-exporter.fullname" . }}
+  labels:
+    app: {{ include "prometheus-es-exporter.name" . }}
+    chart: {{ include "prometheus-es-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  exporter.cfg: |
+{{ .Values.elasticsearch.queries | indent 4 }}
+{{- end }}

--- a/stable/prometheus-es-exporter/templates/deployment.yaml
+++ b/stable/prometheus-es-exporter/templates/deployment.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ include "prometheus-es-exporter.fullname" . }}
+  labels:
+    app: {{ include "prometheus-es-exporter.name" . }}
+    chart: {{ include "prometheus-es-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "prometheus-es-exporter.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "-p"
+            - "{{ .Values.service.port }}"
+            - "-e"
+            - "{{ required "A valid .Values.elasticsearch.url entry required!" .Values.elasticsearch.url }}"
+           {{- if not .Values.elasticsearch.queries }}
+            - "--query-disable"
+           {{- end }}
+           {{- if .Values.containerExtraArgs }}
+           {{- range .Values.containerExtraArgs }}
+            - {{ . }}
+           {{- end }}
+           {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          volumeMounts:
+            - mountPath: /usr/src/app/exporter.cfg
+              subPath: "exporter.cfg"
+              name: {{ include "prometheus-es-exporter.fullname" . }}
+{{ if .Values.resources }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+{{ end }}
+      volumes:
+        - name: {{ include "prometheus-es-exporter.fullname" . }}
+          configMap:
+            name: {{ include "prometheus-es-exporter.fullname" . }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/stable/prometheus-es-exporter/templates/service.yaml
+++ b/stable/prometheus-es-exporter/templates/service.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "prometheus-es-exporter.fullname" . }}
+  labels:
+    app: {{ include "prometheus-es-exporter.name" . }}
+    chart: {{ include "prometheus-es-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ include "prometheus-es-exporter.name" . }}
+    release: {{ .Release.Name }}

--- a/stable/prometheus-es-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-es-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,21 @@
+{{ if .Values.prometheus.serviceMonitor }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "prometheus-es-exporter.fullname" . }}
+  labels:
+    prometheus: {{ required "A valid .Values.prometheus.name entry required!" .Values.prometheus.name }}
+    app: {{ include "prometheus-es-exporter.name" . }}
+    chart: {{ include "prometheus-es-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "prometheus-es-exporter.name" . }}
+  endpoints:
+  - port: http
+    interval: 60s
+  jobLabel: {{ include "prometheus-es-exporter.fullname" . }}
+{{ end }}

--- a/stable/prometheus-es-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-es-exporter/templates/servicemonitor.yaml
@@ -16,6 +16,6 @@ spec:
       app: {{ include "prometheus-es-exporter.name" . }}
   endpoints:
   - port: http
-    interval: 60s
+    interval: {{ .Values.prometheus.serviceMonitorInterval }}
   jobLabel: {{ include "prometheus-es-exporter.fullname" . }}
 {{ end }}

--- a/stable/prometheus-es-exporter/templates/tests/test-service.yaml
+++ b/stable/prometheus-es-exporter/templates/tests/test-service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-service-test"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+  - name: "{{ .Release.Name }}-service-test"
+    image: alpine:3.7
+    command:
+      - "sh"
+      - "-c"
+      - "apk add -U curl && curl --silent {{ .Values.elasticsearch.url }}"
+  restartPolicy: Never

--- a/stable/prometheus-es-exporter/templates/tests/test-servicemonitor.yaml
+++ b/stable/prometheus-es-exporter/templates/tests/test-servicemonitor.yaml
@@ -1,0 +1,19 @@
+---
+{{ if .Values.prometheus.serviceMonitor }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-servicemonitor-test"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+  - name: "{{ .Release.Name }}-servicemonitor-test"
+    image: alpine:3.7
+    command:
+      - "sh"
+      - "-c"
+      # TODO use the api instead of using an awful if
+      - "apk add -U curl && curl --silent {{ .Values.elasticsearch.url }} && if [ -n \"`curl --silent http://{{ .Values.prometheus.name }}:9090/targets | grep {{ include "prometheus-es-exporter.fullname" . }}`\" ]; then return 0; else return 1; fi"
+  restartPolicy: Never
+{{ end }}

--- a/stable/prometheus-es-exporter/templates/tests/unittest-deployment.yaml
+++ b/stable/prometheus-es-exporter/templates/tests/unittest-deployment.yaml
@@ -1,0 +1,117 @@
+---
+suite: test deployment
+templates:
+  - deployment.yaml
+tests:
+  - it: should render default args if containerExtraArgs and elasticsearch.queries are not set
+    set:
+      elasticsearch.url: "localhost:9200"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - "-p"
+            - "9206"
+            - "-e"
+            - "localhost:9200"
+            - "--query-disable"
+
+  - it: should not disable queries if elasticsearch.queries is set
+    set:
+      elasticsearch.url: "localhost:9200"
+      elasticsearch.queries: |
+        QueryIntervalSecs = 15
+        QueryTimeoutSecs = 10
+        QueryIndices = _all
+        [query_all]
+        QueryJson = {
+            "size": 0,
+            "query": {
+              "match_all": {}
+              }
+            }
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - "-p"
+            - "9206"
+            - "-e"
+            - "localhost:9200"
+
+  - it: should render extra arg if containerExtraArgs is set
+    set:
+      elasticsearch.url: "localhost:9200"
+      containerExtraArgs:
+        - '"--nodes-stats-disable"'
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content:
+            "--nodes-stats-disable"
+
+  - it: should render nothing if resources are not set
+    set:
+      elasticsearch.url: "localhost:9200"
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].resources
+
+  - it: should render resources if resources are set
+    set:
+      elasticsearch.url: "localhost:9200"
+      resources:
+        limits:
+          cpu: 100m
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+
+  - it: should render nothing if nodeSelector is not set
+    set:
+      elasticsearch.url: "localhost:9200"
+    asserts:
+      - isNull:
+          path: spec.template.spec.nodeSelector
+
+  - it: should render nodeSelector if nodeSelector is set
+    set:
+      elasticsearch.url: "localhost:9200"
+      nodeSelector:
+        kops.k8s.io/instancegroup: prometheus
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            kops.k8s.io/instancegroup: prometheus
+
+  - it: should render nothing if tolerations is not set
+    set:
+      elasticsearch.url: "localhost:9200"
+    asserts:
+      - isNull:
+          path: spec.template.spec.tolerations
+
+  - it: should render tolerations if tolerations is set
+    set:
+      elasticsearch.url: "localhost:9200"
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+            - key: "node-role.kubernetes.io/master"
+              effect: NoSchedule

--- a/stable/prometheus-es-exporter/templates/tests/unittest-servicemonitor.yaml
+++ b/stable/prometheus-es-exporter/templates/tests/unittest-servicemonitor.yaml
@@ -1,0 +1,17 @@
+---
+suite: test servicemonitor
+templates:
+  - servicemonitor.yaml
+tests:
+  - it: should render nothing if not enabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render something if enabled
+    set:
+      prometheus.serviceMonitor: true
+      prometheus.name: kube-prometheus
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/stable/prometheus-es-exporter/values.yaml
+++ b/stable/prometheus-es-exporter/values.yaml
@@ -1,0 +1,56 @@
+---
+# Default values for prometheus-es-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+elasticsearch:
+  url: ""
+  queries: ""
+#     Example:
+#     [DEFAULT]
+#     QueryIntervalSecs = 15
+#     QueryTimeoutSecs = 10
+#     QueryIndices = _all
+
+#     [query_all]
+#     QueryJson = {
+#     "size": 0,
+#     "query": {
+#       "match_all": {}
+#       }
+#     }
+
+containerExtraArgs: ""
+
+prometheus:
+  serviceMonitor: false
+  name: ""
+
+replicaCount: 1
+
+image:
+  repository: braedon/prometheus-es-exporter
+  tag: 0.5.1
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 9206
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/stable/prometheus-es-exporter/values.yaml
+++ b/stable/prometheus-es-exporter/values.yaml
@@ -24,6 +24,7 @@ containerExtraArgs: ""
 
 prometheus:
   serviceMonitor: false
+  serviceMonitorInterval: 60s
   name: ""
 
 replicaCount: 1


### PR DESCRIPTION
Signed-off-by: Àlex Pérez-Pujol <alexperezpujol@disroot.org>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
It adds the [prometheus-es-exporter](https://github.com/braedon/prometheus-es-exporter) to the stable chart repository.

#### Special notes for your reviewer:
None.

#### Checklist
- [x ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x ] Variables are documented in the README.md
