### PR TITLE
use object for rollingUpdate

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.33.0
+version: 0.33.1
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -18,7 +18,8 @@ spec:
   replicas: 1
   strategy:
     type: {{ if .Values.Persistence.Enabled }}Recreate{{ else }}RollingUpdate{{ end }}
-    rollingUpdate: {{ if .Values.Persistence.Enabled }}{{ else }}true{{ end }}
+    rollingUpdate:
+{{ toYaml .Values.Master.RollingUpdate | indent 6 }}
   selector:
     matchLabels:
       component: "{{ .Release.Name }}-{{ .Values.Master.Component }}"

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -39,6 +39,10 @@ Master:
   # If you choose to use your own, you must upload your decrypted RSA private key (not the public key above) to a Kubernetes secret using the following command:
   # kubectl -n <namespace> create secret generic <helm_release_name> --dry-run --from-file=jenkins-admin-private-key=~/.ssh/id_rsa -o yaml |kubectl -n <namespace> apply -f -
   # Replace ~/.ssh/id_rsa in the above command with the path to your private key file and the <helm_release_name> and <namespace> placeholders to suit.
+  RollingUpdate: {}
+  # Ignored if Persistence is enabled
+  # maxSurge: 1
+  # maxUnavailable: 25%
   resources:
     requests:
       cpu: "50m"


### PR DESCRIPTION
#### What this PR does / why we need it:
When `Persistence: false` the jenkins chart is using a boolean for the `rollingUpdate` deployment attribute, which causes the build to fail
#### Which issue this PR fixes
  - fixes  #11865 
#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
