### PR TITLE
[stable/concourse] Upgrade to 5.0.0

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,6 @@
 name: concourse
-version: 3.8.0
-appVersion: 4.2.2
+version: 4.0.0
+appVersion: 5.0.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479
 keywords:

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -2,20 +2,24 @@
 
 [Concourse](https://concourse-ci.org/) is a simple and scalable CI system.
 
+
 ## TL;DR;
 
 ```console
 $ helm install stable/concourse
 ```
 
+
 ## Introduction
 
 This chart bootstraps a [Concourse](https://concourse-ci.org/) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
+
 ## Prerequisites Details
 
-* Kubernetes 1.6 (for `pod affinity` support)
-* PV support on underlying infrastructure (if persistence is required)
+* Kubernetes 1.6 (for [`pod affinity`](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) support)
+* [`PersistentVolume`](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) support on underlying infrastructure (if persistence is required)
+
 
 ## Installing the Chart
 
@@ -24,6 +28,7 @@ To install the chart with the release name `my-release`:
 ```console
 $ helm install --name my-release stable/concourse
 ```
+
 
 ## Uninstalling the Chart
 
@@ -35,9 +40,13 @@ $ helm delete my-release
 
 The command removes nearly all the Kubernetes components associated with the chart and deletes the release.
 
+> ps: By default, a [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) is created for the `main` team named after `${RELEASE}-main` and is kept untouched after a `helm delete`.
+> See the [Configuration section](#configuration) for how to control the behavior.
+
+
 ### Cleanup orphaned Persistent Volumes
 
-This chart uses `StatefulSets` for Concourse Workers. Deleting a `StatefulSet` does not delete associated Persistent Volumes.
+This chart uses [`StatefulSets`](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) for Concourse Workers. Deleting a `StatefulSet` does not delete associated `PersistentVolume`s.
 
 Do the following after deleting the chart release to clean up orphaned Persistent Volumes.
 
@@ -45,21 +54,24 @@ Do the following after deleting the chart release to clean up orphaned Persisten
 $ kubectl delete pvc -l app=${RELEASE-NAME}-worker
 ```
 
-## Scaling the Chart
-
-Scaling should typically be managed via the `helm upgrade` command, but `StatefulSets` don't yet work with `helm upgrade`. In the meantime, until `helm upgrade` works, if you want to change the number of replicas, you can use the `kubectl scale` command as shown below:
-
-```console
-$ kubectl scale statefulset my-release-worker --replicas=3
-```
 
 ### Restarting workers
 
-If a worker isn't taking on work, you can restart the worker with `kubectl delete pod`. This initiates a graceful shutdown by "retiring" the worker, to ensure Concourse doesn't try looking for old volumes on the new worker. The value`worker.terminationGracePeriodSeconds` can be used to provide an upper limit on graceful shutdown time before forcefully terminating the container. Check the output of `fly workers`, and if a worker is `stalled`, you'll also need to run `fly prune-worker` to allow the new incarnation of the worker to start.
+If a [Worker](https://concourse-ci.org/architecture.html#architecture-worker) isn't taking on work, you can recreate it with `kubectl delete pod`. This initiates a graceful shutdown by ["retiring"](https://concourse-ci.org/worker-internals.html#RETIRING-table) the worker, to ensure Concourse doesn't try looking for old volumes on the new worker.
+
+The value`worker.terminationGracePeriodSeconds` can be used to provide an upper limit on graceful shutdown time before forcefully terminating the container.
+
+Check the output of `fly workers`, and if a worker is [`stalled`](https://concourse-ci.org/worker-internals.html#STALLED-table), you'll also need to run [`fly prune-worker`](https://concourse-ci.org/administration.html#fly-prune-worker) to allow the new incarnation of the worker to start.
+
+> **TIP**: you can download `fly` either from https://concourse-ci.org/download.html or the home page of your Concourse installation.
+
 
 ### Worker Liveness Probe
 
-The worker's Liveness Probe will trigger a restart of the worker if it detects unrecoverable errors, by looking at the worker's logs. The set of strings used to identify such errors could change in the future, but can be tuned with `worker.fatalErrors`. See [values.yaml](values.yaml) for the defaults.
+By default, the worker's [`LivenessProbe`](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) will trigger a restart of the worker container if it detects errors when trying to reach the worker's healthcheck endpoint which takes care of making sure that the [workers' components](https://concourse-ci.org/architecture.html#architecture) can properly serve their purpose.
+
+See [Configuration](#configuration) and [`values.yaml`](./values.yaml) for the configuration of both the `livenessProbe` (`worker.livenessProbe`) and the default healthchecking timeout (`concourse.worker.healthcheckTimeout`).
+
 
 ## Configuration
 
@@ -67,78 +79,41 @@ The following table lists the configurable parameters of the Concourse chart and
 
 | Parameter               | Description                           | Default                                                    |
 | ----------------------- | ----------------------------------    | ---------------------------------------------------------- |
-| `image` | Concourse image | `concourse/concourse` |
-| `imageTag` | Concourse image version | `4.2.2` |
+| `fullnameOverride` | Provide a name to substitute for the full names of resources | `nil` |
+| `imageDigest` | Specific image digest to use in place of a tag. | `nil` |
 | `imagePullPolicy` | Concourse image pull policy | `IfNotPresent` |
 | `imagePullSecrets` | Array of imagePullSecrets in the namespace for pulling images | `[]` |
-| `web.additionalAffinities` | Additional affinities to apply to web pods. E.g: node affinity | `{}` |
-| `web.additionalVolumeMounts` | VolumeMounts to be added to the web pods | `nil` |
-| `web.additionalVolumes` | Volumes to be added to the web pods | `nil` |
-| `web.annotations`| Concourse Web deployment annotations | `nil` |
-| `web.authSecretsPath` | Specify the mount directory of the web auth secrets | `/concourse-auth` |
-| `web.env` | Configure additional environment variables for the web containers | `[]` |
-| `web.ingress.annotations` | Concourse Web Ingress annotations | `{}` |
-| `web.ingress.enabled` | Enable Concourse Web Ingress | `false` |
-| `web.ingress.hosts` | Concourse Web Ingress Hostnames | `[]` |
-| `web.ingress.tls` | Concourse Web Ingress TLS configuration | `[]` |
-| `web.keysSecretsPath` | Specify the mount directory of the web keys secrets | `/concourse-keys` |
-| `web.livenessProbe` | Liveness Probe settings | `{"failureThreshold":5,"httpGet":{"path":"/api/v1/info","port":"atc"},"initialDelaySeconds":10,"periodSeconds":15,"timeoutSeconds":3}` |
-| `web.nameOverride` | Override the Concourse Web components name | `nil` |
-| `web.nodeSelector` | Node selector for web nodes | `{}` |
-| `web.postgresqlSecrtsPath` | Specify the mount directory of the web postgresql secrets | `/concourse-postgresql` |
-| `web.readinessProbe` | Readiness Probe settings | `{"httpGet":{"path":"/api/v1/info","port":"atc"}}` |
-| `web.replicas` | Number of Concourse Web replicas | `1` |
-| `web.resources` | Concourse Web resource requests and limits | `{requests: {cpu: "100m", memory: "128Mi"}}` |
-| `web.service.annotations` | Concourse Web Service annotations | `nil` |
-| `web.service.atcNodePort` | Sets the nodePort for atc when using `NodePort` | `nil` |
-| `web.service.atcTlsNodePort` | Sets the nodePort for atc tls when using `NodePort` | `nil` |
-| `web.service.labels` | Additional concourse web service labels | `nil` |
-| `web.service.loadBalancerIP` | The IP to use when web.service.type is LoadBalancer | `nil` |
-| `web.service.loadBalancerSourceRanges` | Concourse Web Service Load Balancer Source IP ranges | `nil` |
-| `web.service.tsaNodePort` | Sets the nodePort for tsa when using `NodePort` | `nil` |
-| `web.service.type` | Concourse Web service type | `ClusterIP` |
-| `web.sidecarContainers` | Array of extra containers to run alongside the Concourse web container | `nil` |
-| `web.syslogSecretsPath` | Specify the mount directory of the web syslog secrets | `/concourse-syslog` |
-| `web.tolerations` | Tolerations for the web nodes | `[]` |
-| `web.vaultSecretsPath` | Specify the mount directory of the web vault secrets | `/concourse-vault` |
-| `worker.nameOverride` | Override the Concourse Worker components name | `nil` |
-| `worker.replicas` | Number of Concourse Worker replicas | `2` |
-| `worker.minAvailable` | Minimum number of workers available after an eviction | `1` |
-| `worker.resources` | Concourse Worker resource requests and limits | `{requests: {cpu: "100m", memory: "512Mi"}}` |
-| `worker.env` | Configure additional environment variables for the worker container(s) | `[]` |
-| `worker.annotations` | Annotations to be added to the worker pods | `{}` |
-| `worker.keysSecretsPath` | Specify the mount directory of the worker keys secrets | `/concourse-keys` |
-| `worker.additionalVolumeMounts` | VolumeMounts to be added to the worker pods | `nil` |
-| `worker.additionalVolumes` | Volumes to be added to the worker pods | `nil` |
-| `worker.additionalAffinities` | Additional affinities to apply to worker pods. E.g: node affinity | `{}` |
-| `worker.tolerations` | Tolerations for the worker nodes | `[]` |
-| `worker.terminationGracePeriodSeconds` | Upper bound for graceful shutdown to allow the worker to drain its tasks | `60` |
-| `worker.fatalErrors` | Newline delimited strings which, when logged, should trigger a restart of the worker | *See [values.yaml](values.yaml)* |
-| `worker.updateStrategy` | `OnDelete` or `RollingUpdate` (requires Kubernetes >= 1.7) | `RollingUpdate` |
-| `worker.podManagementPolicy` | `OrderedReady` or `Parallel` (requires Kubernetes >= 1.7) | `Parallel` |
-| `worker.sidecarContainers` | Array of extra containers to run alongside the Concourse worker container | `nil` |
-| `worker.hardAntiAffinity` | Should the workers be forced (as opposed to preferred) to be on different nodes? | `false` |
-| `worker.emptyDirSize` | When persistance is disabled this value will be used to limit the emptyDir volume size | `nil` |
+| `imageTag` | Concourse image version | `5.0.0` |
+| `image` | Concourse image | `concourse/concourse` |
+| `nameOverride` | Provide a name in place of `concourse` for `app:` labels | `nil` |
 | `persistence.enabled` | Enable Concourse persistence using Persistent Volume Claims | `true` |
-| `persistence.worker.storageClass` | Concourse Worker Persistent Volume Storage Class | `generic` |
 | `persistence.worker.accessMode` | Concourse Worker Persistent Volume Access Mode | `ReadWriteOnce` |
 | `persistence.worker.size` | Concourse Worker Persistent Volume Storage Size | `20Gi` |
+| `persistence.worker.storageClass` | Concourse Worker Persistent Volume Storage Class | `generic` |
 | `postgresql.enabled` | Enable PostgreSQL as a chart dependency | `true` |
-| `postgresql.postgresUser` | PostgreSQL User to create | `concourse` |
-| `postgresql.postgresPassword` | PostgreSQL Password for the new user | `concourse` |
-| `postgresql.postgresDatabase` | PostgreSQL Database to create | `concourse` |
+| `postgresql.persistence.accessMode` | Persistent Volume Access Mode | `ReadWriteOnce` |
 | `postgresql.persistence.enabled` | Enable PostgreSQL persistence using Persistent Volume Claims | `true` |
-| `rbac.create` | Enables creation of RBAC resources | `true` |
+| `postgresql.persistence.size` | Persistent Volume Storage Size | `8Gi` |
+| `postgresql.persistence.storageClass` | Concourse data Persistent Volume Storage Class | `nil` |
+| `postgresql.postgresDatabase` | PostgreSQL Database to create | `concourse` |
+| `postgresql.postgresPassword` | PostgreSQL Password for the new user | `concourse` |
+| `postgresql.postgresUser` | PostgreSQL User to create | `concourse` |
 | `rbac.apiVersion` | RBAC version | `v1beta1` |
+| `rbac.create` | Enables creation of RBAC resources | `true` |
 | `rbac.webServiceAccountName` | Name of the service account to use for web pods if `rbac.create` is `false` | `default` |
 | `rbac.workerServiceAccountName` | Name of the service account to use for workers if `rbac.create` is `false` | `default` |
-| `secrets.create` | Create the secret resource from the following values. *See [Secrets](#secrets)* | `true` |
+| `secrets.awsSecretsmanagerAccessKey` | AWS Access Key ID for Secrets Manager access | `nil` |
+| `secrets.awsSecretsmanagerSecretKey` | AWS Secret Access Key ID for Secrets Manager access | `nil` |
+| `secrets.awsSecretsmanagerSessionToken` | AWS Session Token for Secrets Manager access | `nil` |
 | `secrets.awsSsmAccessKey` | AWS Access Key ID for SSM access | `nil` |
 | `secrets.awsSsmSecretKey` | AWS Secret Access Key ID for SSM access | `nil` |
 | `secrets.awsSsmSessionToken` | AWS Session Token for SSM access | `nil` |
+| `secrets.bitbucketCloudClientId` | Client ID for the BitbucketCloud OAuth | `nil` |
+| `secrets.bitbucketCloudClientSecret` | Client Secret for the BitbucketCloud OAuth | `nil` |
 | `secrets.cfCaCert` | CA certificate for cf auth provider | `nil` |
 | `secrets.cfClientId` | Client ID for cf auth provider | `nil` |
 | `secrets.cfClientSecret` | Client secret for cf auth provider | `nil` |
+| `secrets.create` | Create the secret resource from the following values. *See [Secrets](#secrets)* | `true` |
 | `secrets.encryptionKey` | current encryption key | `nil` |
 | `secrets.githubCaCert` | CA certificate for Enterprise Github OAuth | `nil` |
 | `secrets.githubClientId` | Application client ID for GitHub OAuth | `nil` |
@@ -148,6 +123,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `secrets.hostKeyPub` | Concourse Host Public Key | *See [values.yaml](values.yaml)* |
 | `secrets.hostKey` | Concourse Host Private Key | *See [values.yaml](values.yaml)* |
 | `secrets.influxdbPassword` | Password used to authenticate with influxdb | `nil` |
+| `secrets.ldapCaCert` | CA Certificate for LDAP | `nil` |
 | `secrets.localUsers` | Create concourse local users. Default username and password are `test:test` *See [values.yaml](values.yaml)* |
 | `secrets.oauthCaCert` | CA certificate for Generic OAuth | `nil` |
 | `secrets.oauthClientId` | Application client ID for Generic OAuth | `nil` |
@@ -156,11 +132,11 @@ The following table lists the configurable parameters of the Concourse chart and
 | `secrets.oidcClientId` | Application client ID for OIDI OAuth | `nil` |
 | `secrets.oidcClientSecret` | Application client secret for OIDC OAuth | `nil` |
 | `secrets.oldEncryptionKey` | old encryption key, used for key rotation | `nil` |
-| `secrets.postgresqlCaCert` | PostgreSQL CA certificate | `nil` |
-| `secrets.postgresqlClientCert` | PostgreSQL Client certificate | `nil` |
-| `secrets.postgresqlClientKey` | PostgreSQL Client key | `nil` |
-| `secrets.postgresqlPassword` | PostgreSQL User Password | `nil` |
-| `secrets.postgresqlUser` | PostgreSQL User Name | `nil` |
+| `secrets.postgresCaCert` | PostgreSQL CA certificate | `nil` |
+| `secrets.postgresClientCert` | PostgreSQL Client certificate | `nil` |
+| `secrets.postgresClientKey` | PostgreSQL Client key | `nil` |
+| `secrets.postgresPassword` | PostgreSQL User Password | `nil` |
+| `secrets.postgresUser` | PostgreSQL User Name | `nil` |
 | `secrets.sessionSigningKey` | Concourse Session Signing Private Key | *See [values.yaml](values.yaml)* |
 | `secrets.syslogCaCert` | SSL certificate to verify Syslog server | `nil` |
 | `secrets.vaultAuthParam` | Paramter to pass when logging in via the backend | `nil` |
@@ -172,8 +148,77 @@ The following table lists the configurable parameters of the Concourse chart and
 | `secrets.webTlsKey` | An RSA private key, used to encrypt HTTPS traffic  | `nil` |
 | `secrets.workerKeyPub` | Concourse Worker Public Key | *See [values.yaml](values.yaml)* |
 | `secrets.workerKey` | Concourse Worker Private Key | *See [values.yaml](values.yaml)* |
+| `web.additionalAffinities` | Additional affinities to apply to web pods. E.g: node affinity | `{}` |
+| `web.additionalVolumeMounts` | VolumeMounts to be added to the web pods | `nil` |
+| `web.additionalVolumes` | Volumes to be added to the web pods | `nil` |
+| `web.annotations`| Concourse Web deployment annotations | `nil` |
+| `web.authSecretsPath` | Specify the mount directory of the web auth secrets | `/concourse-auth` |
+| `web.env` | Configure additional environment variables for the web containers | `[]` |
+| `web.ingress.annotations` | Concourse Web Ingress annotations | `{}` |
+| `web.ingress.enabled` | Enable Concourse Web Ingress | `false` |
+| `web.ingress.hosts` | Concourse Web Ingress Hostnames | `[]` |
+| `web.ingress.tls` | Concourse Web Ingress TLS configuration | `[]` |
+| `web.keySecretsPath` | Specify the mount directory of the web keys secrets | `/concourse-keys` |
+| `web.livenessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded | `5` |
+| `web.livenessProbe.httpGet.path` | Path to access on the HTTP server when performing the healthcheck | `/api/v1/info` |
+| `web.livenessProbe.httpGet.port` | Name or number of the port to access on the container | `atc` |
+| `web.livenessProbe.initialDelaySeconds` | Number of seconds after the container has started before liveness probes are initiated | `10` |
+| `web.livenessProbe.periodSeconds` | How often (in seconds) to perform the probe | `15` |
+| `web.livenessProbe.timeoutSeconds` | Number of seconds after which the probe times out | `3` |
+| `web.nameOverride` | Override the Concourse Web components name | `nil` |
+| `web.nodeSelector` | Node selector for web nodes | `{}` |
+| `web.postgresqlSecretsPath` | Specify the mount directory of the web postgresql secrets | `/concourse-postgresql` |
+| `web.readinessProbe.httpGet.path` | Path to access on the HTTP server when performing the healthcheck | `/api/v1/info` |
+| `web.readinessProbe.httpGet.port` | Name or number of the port to access on the container | `atc` |
+| `web.replicas` | Number of Concourse Web replicas | `1` |
+| `web.resources.requests.cpu` | Minimum amount of cpu resources requested | `100m` |
+| `web.resources.requests.memory` | Minimum amount of memory resources requested | `128Mi` |
+| `web.service.annotations` | Concourse Web Service annotations | `nil` |
+| `web.service.atcNodePort` | Sets the nodePort for atc when using `NodePort` | `nil` |
+| `web.service.atcTlsNodePort` | Sets the nodePort for atc tls when using `NodePort` | `nil` |
+| `web.service.labels` | Additional concourse web service labels | `nil` |
+| `web.service.loadBalancerIP` | The IP to use when web.service.type is LoadBalancer | `nil` |
+| `web.service.loadBalancerSourceRanges` | Concourse Web Service Load Balancer Source IP ranges | `nil` |
+| `web.service.tsaNodePort` | Sets the nodePort for tsa when using `NodePort` | `nil` |
+| `web.service.type` | Concourse Web service type | `ClusterIP` |
+| `web.sidecarContainers` | Array of extra containers to run alongside the Concourse web container | `nil` |
+| `web.syslogSecretsPath` | Specify the mount directory of the web syslog secrets | `/concourse-syslog` |
+| `web.tlsSecretsPath` | Where in the container the web TLS secrets should be mounted | `/concourse-web-tls` |
+| `web.tolerations` | Tolerations for the web nodes | `[]` |
+| `web.vaultSecretsPath` | Specify the mount directory of the web vault secrets | `/concourse-vault` |
+| `worker.additionalAffinities` | Additional affinities to apply to worker pods. E.g: node affinity | `{}` |
+| `worker.additionalVolumeMounts` | VolumeMounts to be added to the worker pods | `nil` |
+| `worker.additionalVolumes` | Volumes to be added to the worker pods | `nil` |
+| `worker.annotations` | Annotations to be added to the worker pods | `{}` |
+| `worker.cleanUpWorkDirOnStart` | Removes any previous state created in `concourse.worker.workDir` | `true` |
+| `worker.emptyDirSize` | When persistance is disabled this value will be used to limit the emptyDir volume size | `nil` |
+| `worker.env` | Configure additional environment variables for the worker container(s) | `[]` |
+| `worker.hardAntiAffinity` | Should the workers be forced (as opposed to preferred) to be on different nodes? | `false` |
+| `worker.keySecretsPath` | Specify the mount directory of the worker keys secrets | `/concourse-keys` |
+| `worker.livenessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded | `5` |
+| `worker.livenessProbe.httpGet.path` | Path to access on the HTTP server when performing the healthcheck | `/` |
+| `worker.livenessProbe.httpGet.port` | Name or number of the port to access on the container | `worker-hc` |
+| `worker.livenessProbe.initialDelaySeconds` | Number of seconds after the container has started before liveness probes are initiated | `10` |
+| `worker.livenessProbe.periodSeconds` | How often (in seconds) to perform the probe | `15` |
+| `worker.livenessProbe.timeoutSeconds` | Number of seconds after which the probe times out | `3` |
+| `worker.minAvailable` | Minimum number of workers available after an eviction | `1` |
+| `worker.nameOverride` | Override the Concourse Worker components name | `nil` |
+| `worker.nodeSelector` | Node selector for worker nodes | `{}` |
+| `worker.podManagementPolicy` | `OrderedReady` or `Parallel` (requires Kubernetes >= 1.7) | `Parallel` |
+| `worker.readinessProbe` | Periodic probe of container service readiness | `{}` |
+| `worker.replicas` | Number of Concourse Worker replicas | `2` |
+| `worker.resources.requests.cpu` | Minimum amount of cpu resources requested | `100m` |
+| `worker.resources.requests.memory` | Minimum amount of memory resources requested | `512Mi` |
+| `worker.sidecarContainers` | Array of extra containers to run alongside the Concourse worker container | `nil` |
+| `worker.terminationGracePeriodSeconds` | Upper bound for graceful shutdown to allow the worker to drain its tasks | `60` |
+| `worker.tolerations` | Tolerations for the worker nodes | `[]` |
+| `worker.updateStrategy` | `OnDelete` or `RollingUpdate` (requires Kubernetes >= 1.7) | `RollingUpdate` |
 
-For configurable concourse parameters, refer to [values.yaml](values.yaml) `concourse` section. All parameters under this section are strictly mapped from concourse binary commands. For example if one needs to configure the concourse external URL, the param `concourse` -> `web` -> `externalUrl` should be set, which is equivalent to running concourse binary as `concourse web --external-url`. For those sub-sections that have `enabled`, one needs to set `enabled` to be `true` to use the following params within the section.
+For configurable Concourse parameters, refer to [`values.yaml`](values.yaml)' `concourse` section. All parameters under this section are strictly mapped from the `concourse` binary commands.
+
+For example if one needs to configure the Concourse external URL, the param `concourse` -> `web` -> `externalUrl` should be set, which is equivalent to running the `concourse` binary as `concourse web --external-url`.
+
+For those sub-sections that have `enabled`, one needs to set `enabled` to be `true` to use the following params within the section.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
@@ -185,13 +230,28 @@ $ helm install --name my-release -f values.yaml stable/concourse
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
+
 ### Secrets
 
-For your convenience, this chart provides some default values for secrets, but it is recommended that you generate and manage these secrets outside the Helm chart. To do this, set `secrets.create` to `false`, create files for each secret value, and turn it all into a k8s secret. Be careful with introducing trailing newline characters; following the steps below ensures none end up in your secrets. First, perform the following to create the mandatory secret values:
+For your convenience, this chart provides some default values for secrets, but it is recommended that you generate and manage these secrets outside the Helm chart.
 
-```console
+To do that, set `secrets.create` to `false`, create files for each secret value, and turn it all into a Kubernetes [Secret](https://kubernetes.io/docs/concepts/configuration/secret/).
+
+Be careful with introducing trailing newline characters; following the steps below ensures none end up in your secrets. First, perform the following to create the mandatory secret values:
+
+```sh
+# Create a directory to host the set of secrets that are
+# required for a working Concourse installation and get
+# into it.
+#
 mkdir concourse-secrets
 cd concourse-secrets
+
+# Generate the files for the secrets that are required:
+# - web key pair,
+# - worker key pair, and
+# - the session signing token.
+#
 ssh-keygen -t rsa -f host-key  -N ''
 mv host-key.pub host-key-pub
 ssh-keygen -t rsa -f worker-key  -N ''
@@ -201,19 +261,27 @@ rm session-signing-key.pub
 printf "%s:%s" "concourse" "$(openssl rand -base64 24)" > local-users
 ```
 
-You'll also need to create/copy secret values for optional features. See [templates/secrets.yaml](templates/secrets.yaml) for possible values. In the example below, we are not using the [PostgreSQL](#postgresql) chart dependency, and so we must set `postgresql-user` and `postgresql-password` secrets.
+You'll also need to create/copy secret values for optional features. See [templates/secrets.yaml](templates/secrets.yaml) for possible values.
 
-```console
-# copy a posgres user to clipboard and paste it to file
+In the example below, we are not using the [PostgreSQL](#postgresql) chart dependency, and so we must set `postgresql-user` and `postgresql-password` secrets.
+
+```sh
+# Still within the directory where our secrets exist,
+# copy a postgres user to clipboard and paste it to file.
+#
 printf "%s" "$(pbpaste)" > postgresql-user
-# copy a posgres password to clipboard and paste it to file
+
+# Copy a postgres password to clipboard and paste it to file
+#
 printf "%s" "$(pbpaste)" > postgresql-password
 
-# copy Github client id and secrets to clipboard and paste to files
+# Copy Github client id and secrets to clipboard and paste to files
+#
 printf "%s" "$(pbpaste)" > github-client-id
 printf "%s" "$(pbpaste)" > github-client-secret
 
-# set an encryption key for DB encryption at rest
+# Set an encryption key for DB encryption at rest
+#
 printf "%s" "$(openssl rand -base64 24)" > encryption-key
 ```
 
@@ -225,9 +293,14 @@ kubectl create secret generic my-release-concourse --from-file=.
 
 Make sure you clean up after yourself.
 
+
 ### Persistence
 
-This chart mounts a Persistent Volume for each Concourse Worker. The volume is created using dynamic volume provisioning. If you want to disable it or change the persistence properties, update the `persistence` section of your custom `values.yaml` file:
+This chart mounts a Persistent Volume for each Concourse Worker.
+
+The volume is created using dynamic volume provisioning.
+
+If you want to disable it or change the persistence properties, update the `persistence` section of your custom `values.yaml` file:
 
 ```yaml
 ## Persistent Volume Storage configuration.
@@ -254,7 +327,8 @@ persistence:
     size: "20Gi"
 ```
 
-It is highly recommended to use Persistent Volumes for Concourse Workers; otherwise, the container images managed by the Worker are stored in an `emptyDir` volume on the node's disk. This will interfere with k8s ImageGC and the node's disk will fill up as a result. This will be fixed in a future release of k8s: https://github.com/kubernetes/kubernetes/pull/57020
+It is highly recommended to use Persistent Volumes for Concourse Workers; otherwise, the Concourse volumes managed by the Worker are stored in an [`emptyDir`](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) volume on the Kubernetes node's disk. This will interfere with Kubernete's [ImageGC](https://kubernetes.io/docs/concepts/cluster-administration/kubelet-garbage-collection/#image-collection) and the node's disk will fill up as a result.
+
 
 ### Ingress TLS
 
@@ -310,7 +384,7 @@ Pipelines usually need credentials to do things. Concourse supports the use of a
 
 #### Kubernetes Secrets
 
-By default, this chart uses Kubernetes Secrets as a credential manager. 
+By default, this chart uses Kubernetes Secrets as a credential manager.
 
 For a given Concourse *team*, a pipeline looks for secrets in a namespace named `[namespacePrefix][teamName]`. The namespace prefix is the release name followed by a hyphen by default, and can be overridden with the value `concourse.web.kubernetes.namespacePrefix`. Each team listed under `concourse.web.kubernetes.teams` will have a namespace created for it, and the namespace remains after deletion of the release unless you set `concourse.web.kubernetes.keepNamespace` to `false`. By default, a namespace will be created for the `main` team.
 

--- a/stable/concourse/templates/_helpers.tpl
+++ b/stable/concourse/templates/_helpers.tpl
@@ -45,3 +45,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "concourse.namespacePrefix" -}}
 {{- default (printf "%s-" .Release.Name ) .Values.concourse.web.kubernetes.namespacePrefix -}}
 {{- end -}}
+
+{{- define "concourse.are-there-additional-volumes.with-the-name.concourse-work-dir" }}
+  {{- range .Values.worker.additionalVolumes }}
+    {{- if .name | eq "concourse-work-dir" }}
+      {{- .name }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/stable/concourse/templates/secrets.yaml
+++ b/stable/concourse/templates/secrets.yaml
@@ -34,6 +34,10 @@ data:
   cf-client-secret: {{ template "concourse.secret.required" dict "key" "cfClientSecret" "is" "concourse.web.auth.cf.enabled" "root" . }}
   cf-ca-cert: {{ default "" .Values.secrets.cfCaCert | b64enc | quote }}
   {{- end }}
+  {{- if .Values.concourse.web.auth.bitbucketCloud.enabled }}
+  bitbucket-cloud-client-id: {{ template "concourse.secret.required" dict "key" "bitbucketCloudClientId" "is" "concourse.web.auth.bitbucketCloud.enabled" "root" . }}
+  bitbucket-cloud-client-secret: {{ template "concourse.secret.required" dict "key" "bitbucketCloudClientSecret" "is" "concourse.web.auth.bitbucketCloud.enabled" "root" . }}
+  {{- end }}
   {{- if .Values.concourse.web.auth.github.enabled }}
   github-client-id: {{ template "concourse.secret.required" dict "key" "githubClientId" "is" "concourse.web.auth.github.enabled" "root" . }}
   github-client-secret: {{ template "concourse.secret.required" dict "key" "githubClientSecret" "is" "concourse.web.auth.github.enabled" "root" . }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -19,9 +19,9 @@ spec:
 {{ toYaml .Values.web.annotations | indent 8 }}
       {{- end }}
     spec:
-    {{- with .Values.web.nodeSelector }}
+    {{- if .Values.web.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
+{{ toYaml .Values.web.nodeSelector | indent 8 }}
     {{- end }}
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "concourse.web.fullname" . }}{{ else }}{{ .Values.rbac.webServiceAccountName }}{{ end }}
       {{- if .Values.web.tolerations }}
@@ -46,14 +46,60 @@ spec:
           {{- end }}
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
           args:
-            - "web"
-            {{- if and (.Values.concourse.web.awsSecretsManager.enabled) (.Values.concourse.web.awsSecretsManager.region) }}
-            - '--aws-secretsmanager-region={{ .Values.concourse.web.awsSecretsManager.region | quote }}'
-            {{- end }}
-            {{- if and (.Values.concourse.web.awsSsm.enabled) (.Values.concourse.web.awsSsm.region) }}
-            - '--aws-ssm-region={{ .Values.concourse.web.awsSsm.region | quote }}'
-            {{- end }}
+            - web
           env:
+            {{- if .Values.concourse.web.enableGlobalResources }}
+            - name: CONCOURSE_ENABLE_GLOBAL_RESOURCES
+              value: {{ .Values.concourse.web.enableGlobalResources | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.secretRetryAttempts }}
+            - name: CONCOURSE_SECRET_RETRY_ATTEMPTS
+              value: {{ .Values.concourse.web.secretRetryAttempts | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.secretRetryInterval }}
+            - name: CONCOURSE_SECRET_RETRY_INTERVAL
+              value: {{ .Values.concourse.web.secretRetryInterval | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.awsSecretsManager.region }}
+            - name: CONCOURSE_AWS_SECRETSMANAGER_REGION
+              value: {{ .Values.concourse.web.awsSecretsManager.region | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.awsSsm.region }}
+            - name: CONCOURSE_AWS_SSM_REGION
+              value: {{ .Values.concourse.web.awsSsm.region | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.metrics.captureErrorMetrics }}
+            - name: CONCOURSE_CAPTURE_ERROR_METRICS
+              value: {{ .Values.concourse.web.metrics.captureErrorMetrics | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.gc.missingGracePeriod }}
+            - name: CONCOURSE_GC_MISSING_GRACE_PERIOD
+              value: {{ .Values.concourse.web.gc.missingGracePeriod | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.auth.mainTeam.config }}
+            - name: CONCOURSE_MAIN_TEAM_CONFIG
+              value: {{ .Values.concourse.web.auth.mainTeam.config | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.auth.mainTeam.bitbucketCloud.user }}
+            - name: CONCOURSE_MAIN_TEAM_BITBUCKET_CLOUD_USER
+              value: {{ .Values.concourse.web.auth.mainTeam.bitbucketCloud.user | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.auth.mainTeam.bitbucketCloud.team }}
+            - name: CONCOURSE_MAIN_TEAM_BITBUCKET_CLOUD_TEAM
+              value: {{ .Values.concourse.web.auth.mainTeam.bitbucketCloud.team | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.auth.bitbucketCloud.enabled }}
+            - name: CONCOURSE_BITBUCKET_CLOUD_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: bitbucket-cloud-client-id
+            - name: CONCOURSE_BITBUCKET_CLOUD_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: bitbucket-cloud-client-secret
+            {{- end }}
             {{- if .Values.concourse.web.logLevel }}
             - name: CONCOURSE_LOG_LEVEL
               value: {{ .Values.concourse.web.logLevel | quote }}
@@ -75,7 +121,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.tls.enabled }}
             - name: CONCOURSE_TLS_BIND_PORT
-              value: {{ .Values.concourse.web.tls.bindPort | default "443" | quote }}
+              value: {{ .Values.concourse.web.tls.bindPort | quote }}
             - name: CONCOURSE_TLS_CERT
               value: "{{ .Values.web.tlsSecretsPath }}/client.cert"
             - name: CONCOURSE_TLS_KEY
@@ -173,7 +219,6 @@ spec:
             - name: CONCOURSE_DEFAULT_TASK_MEMORY_LIMIT
               value: {{ .Values.concourse.web.defaultTaskMemoryLimit | quote }}
             {{- end }}
-
             {{- if .Values.postgresql.enabled }}
             - name: CONCOURSE_POSTGRES_HOST
               value: {{ template "concourse.postgresql.fullname" . }}
@@ -234,7 +279,6 @@ spec:
               value: {{ .Values.concourse.web.postgres.database | quote }}
             {{- end }}
             {{- end }}
-
             {{- if .Values.concourse.web.kubernetes.enabled }}
             - name: CONCOURSE_KUBERNETES_IN_CLUSTER
               value: "true"
@@ -250,7 +294,6 @@ spec:
               value: {{ .Values.concourse.web.kubernetes.namespacePrefix | quote }}
             {{- end }}
             {{- end }}
-
             {{- if .Values.concourse.web.awsSecretsManager.enabled }}
             - name: CONCOURSE_AWS_SECRETSMANAGER_ACCESS_KEY
               valueFrom:
@@ -278,7 +321,6 @@ spec:
               value: {{ .Values.concourse.web.awsSecretsManager.teamSecretTemplate | quote }}
             {{- end }}
             {{- end }}
-
             {{- if .Values.concourse.web.awsSsm.enabled }}
             - name: CONCOURSE_AWS_SSM_ACCESS_KEY
               valueFrom:
@@ -306,7 +348,6 @@ spec:
               value: {{ .Values.concourse.web.awsSsm.teamSecretTemplate | quote }}
             {{- end }}
             {{- end }}
-
             {{- if .Values.concourse.web.vault.enabled }}
             - name: CONCOURSE_VAULT_URL
               value: {{ .Values.concourse.web.vault.url | quote }}
@@ -318,20 +359,20 @@ spec:
             - name: CONCOURSE_VAULT_CA_CERT
               value: "{{ .Values.web.vaultSecretsPath }}/ca.cert"
             {{- end }}
-            {{- if eq (default "" .Values.concourse.web.vault.authBackend) "token" }}
+            {{- if eq .Values.concourse.web.vault.authBackend "token" }}
             - name: CONCOURSE_VAULT_CLIENT_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-client-token
             {{- end }}
-            {{- if eq (default "" .Values.concourse.web.vault.authBackend) "cert" }}
+            {{- if eq .Values.concourse.web.vault.authBackend "cert" }}
             - name: CONCOURSE_VAULT_CLIENT_CERT
               value: "{{ .Values.web.vaultSecretsPath }}/client.cert"
             - name: CONCOURSE_VAULT_CLIENT_KEY
               value: "{{ .Values.web.vaultSecretsPath }}/client.key"
             {{- end }}
-            {{- if eq (default "" .Values.concourse.web.vault.authBackend) "approle" }}
+            {{- if eq .Values.concourse.web.vault.authBackend "approle" }}
             - name: CONCOURSE_VAULT_AUTH_PARAM
               valueFrom:
                 secretKeyRef:
@@ -371,12 +412,10 @@ spec:
               value: {{ .Values.concourse.web.vault.serverName | quote }}
             {{- end }}
             {{- end }}
-
             {{- if .Values.concourse.web.noop }}
             - name: CONCOURSE_NOOP
               value: {{ .Values.concourse.web.noop | quote }}
             {{- end }}
-
             {{- if .Values.concourse.web.staticWorker.enabled }}
             {{- if .Values.concourse.web.staticWorker.gardenUrl }}
             - name: CONCOURSE_WORKER_GARDEN_URL
@@ -391,7 +430,6 @@ spec:
               value: {{ .Values.concourse.web.staticWorker.resource | quote }}
             {{- end }}
             {{- end }}
-
             {{- if .Values.concourse.web.metrics.hostName }}
             - name: CONCOURSE_METRICS_HOST_NAME
               value: {{ .Values.concourse.web.metrics.hostName | quote }}
@@ -400,7 +438,6 @@ spec:
             - name: CONCOURSE_METRICS_ATTRIBUTE
               value: {{ .Values.concourse.web.metrics.attribute | quote }}
             {{- end }}
-
             {{- if .Values.concourse.web.datadog.enabled }}
             - name: CONCOURSE_DATADOG_AGENT_HOST
             {{- if .Values.concourse.web.datadog.agentHostUseHostIP }}
@@ -417,7 +454,6 @@ spec:
               value: {{ .Values.concourse.web.datadog.prefix | quote }}
             {{- end }}
             {{- end }}
-
             {{- if .Values.concourse.web.influxdb.enabled }}
             - name: CONCOURSE_INFLUXDB_URL
               value: {{ .Values.concourse.web.influxdb.url | quote }}
@@ -433,12 +469,10 @@ spec:
             - name: CONCOURSE_INFLUXDB_INSECURE_SKIP_VERIFY
               value: {{ .Values.concourse.web.influxdb.insecureSkipVerify | quote}}
             {{- end }}
-
             {{- if .Values.concourse.web.emitToLogs }}
             - name: CONCOURSE_EMIT_TO_LOGS
               value: {{ .Values.concourse.web.emitToLogs | quote }}
             {{- end }}
-
             {{- if .Values.concourse.web.newrelic.enabled }}
             {{- if .Values.concourse.web.newrelic.accountId }}
             - name: CONCOURSE_NEWRELIC_ACCOUNT_ID
@@ -453,14 +487,12 @@ spec:
               value: {{ .Values.concourse.web.newrelic.servicePrefix | quote }}
             {{- end }}
             {{- end }}
-
             {{- if .Values.concourse.web.prometheus.enabled }}
             - name: CONCOURSE_PROMETHEUS_BIND_IP
               value: {{ .Values.concourse.web.prometheus.bindIp | quote }}
             - name: CONCOURSE_PROMETHEUS_BIND_PORT
               value: {{ .Values.concourse.web.prometheus.bindPort | quote }}
             {{- end }}
-
             {{- if .Values.concourse.web.riemann.enabled }}
             {{- if .Values.concourse.web.riemann.host }}
             - name: CONCOURSE_RIEMANN_HOST
@@ -479,12 +511,10 @@ spec:
               value: {{ .Values.concourse.web.riemann.tag | quote }}
             {{- end }}
             {{- end }}
-
             {{- if .Values.concourse.web.xFrameOptions }}
             - name: CONCOURSE_X_FRAME_OPTIONS
               value: {{ .Values.concourse.web.xFrameOptions | quote }}
             {{- end }}
-
             {{- if .Values.concourse.web.gc.overrideDefaults }}
             {{- if .Values.concourse.web.gc.interval }}
             - name: CONCOURSE_GC_INTERVAL
@@ -495,7 +525,6 @@ spec:
               value: {{ .Values.concourse.web.gc.oneOffGracePeriod | quote }}
             {{- end }}
             {{- end }}
-
             {{- if .Values.concourse.web.syslog.enabled }}
             {{- if .Values.concourse.web.syslog.hostname }}
             - name: CONCOURSE_SYSLOG_HOSTNAME
@@ -518,7 +547,6 @@ spec:
               value: "{{ .Values.web.syslogSecretsPath }}/ca.cert"
             {{- end }}
             {{- end }}
-
             {{- if .Values.concourse.web.auth.cookieSecure }}
             - name: CONCOURSE_COOKIE_SECURE
               value: {{ .Values.concourse.web.auth.cookieSecure | quote }}
@@ -529,16 +557,10 @@ spec:
             {{- end }}
             - name: CONCOURSE_SESSION_SIGNING_KEY
               value: "{{ .Values.web.keySecretsPath }}/session_signing_key"
-
             {{- if .Values.concourse.web.auth.mainTeam.localUser }}
             - name: CONCOURSE_MAIN_TEAM_LOCAL_USER
               value: {{ .Values.concourse.web.auth.mainTeam.localUser | quote }}
             {{- end }}
-            {{- if .Values.concourse.web.auth.mainTeam.allowAllUsers }}
-            - name: CONCOURSE_MAIN_TEAM_ALLOW_ALL_USERS
-              value: {{ .Values.concourse.web.auth.mainTeam.allowAllUsers | quote }}
-            {{- end }}
-
             {{- if .Values.concourse.web.auth.mainTeam.cf.org }}
             - name: CONCOURSE_MAIN_TEAM_CF_ORG
               value: {{ .Values.concourse.web.auth.mainTeam.cf.org | quote }}
@@ -555,7 +577,6 @@ spec:
             - name: CONCOURSE_MAIN_TEAM_CF_USER
               value: {{ .Values.concourse.web.auth.mainTeam.cf.user | quote }}
             {{- end }}
-
             {{- if .Values.concourse.web.auth.mainTeam.github.user }}
             - name: CONCOURSE_MAIN_TEAM_GITHUB_USER
               value: {{ .Values.concourse.web.auth.mainTeam.github.user | quote }}
@@ -568,7 +589,6 @@ spec:
             - name: CONCOURSE_MAIN_TEAM_GITHUB_TEAM
               value: {{ .Values.concourse.web.auth.mainTeam.github.team | quote }}
             {{- end }}
-
             {{- if .Values.concourse.web.auth.mainTeam.gitlab.user }}
             - name: CONCOURSE_MAIN_TEAM_GITLAB_USER
               value: {{ .Values.concourse.web.auth.mainTeam.gitlab.user | quote }}
@@ -577,7 +597,6 @@ spec:
             - name: CONCOURSE_MAIN_TEAM_GITLAB_GROUP
               value: {{ .Values.concourse.web.auth.mainTeam.gitlab.group | quote }}
             {{- end }}
-
             {{- if .Values.concourse.web.auth.mainTeam.ldap.user }}
             - name: CONCOURSE_MAIN_TEAM_LDAP_USER
               value: {{ .Values.concourse.web.auth.mainTeam.ldap.user | quote }}
@@ -586,7 +605,6 @@ spec:
             - name: CONCOURSE_MAIN_TEAM_LDAP_GROUP
               value: {{ .Values.concourse.web.auth.mainTeam.ldap.group | quote }}
             {{- end }}
-
             {{- if .Values.concourse.web.auth.mainTeam.oauth.user }}
             - name: CONCOURSE_MAIN_TEAM_OAUTH_USER
               value: {{ .Values.concourse.web.auth.mainTeam.oauth.user | quote }}
@@ -595,7 +613,6 @@ spec:
             - name: CONCOURSE_MAIN_TEAM_OAUTH_GROUP
               value: {{ .Values.concourse.web.auth.mainTeam.oauth.group | quote }}
             {{- end }}
-
             {{- if .Values.concourse.web.auth.mainTeam.oidc.group }}
             - name: CONCOURSE_MAIN_TEAM_OIDC_GROUP
               value: {{ .Values.concourse.web.auth.mainTeam.oidc.group | quote }}
@@ -604,7 +621,6 @@ spec:
             - name: CONCOURSE_MAIN_TEAM_OIDC_USER
               value: {{ .Values.concourse.web.auth.mainTeam.oidc.user | quote }}
             {{- end }}
-
             {{- if .Values.concourse.web.auth.cf.enabled }}
             - name: CONCOURSE_CF_CLIENT_ID
               valueFrom:
@@ -629,7 +645,6 @@ spec:
               value: {{ .Values.concourse.web.auth.cf.skipSslValidation | quote }}
             {{- end }}
             {{- end }}
-
             {{- if .Values.concourse.web.auth.github.enabled }}
             - name: CONCOURSE_GITHUB_CLIENT_ID
               valueFrom:
@@ -650,7 +665,6 @@ spec:
               value: "{{ .Values.web.authSecretsPath }}/github_ca.cert"
             {{- end }}
             {{- end }}
-
             {{- if .Values.concourse.web.auth.gitlab.enabled }}
             - name: CONCOURSE_GITLAB_CLIENT_ID
               valueFrom:
@@ -667,7 +681,6 @@ spec:
               value: {{ .Values.concourse.web.auth.gitlab.host | quote }}
             {{- end }}
             {{- end }}
-
             {{- if .Values.concourse.web.auth.ldap.enabled }}
             {{- if .Values.concourse.web.auth.ldap.bindDn }}
             - name: CONCOURSE_LDAP_BIND_DN
@@ -754,7 +767,6 @@ spec:
               value: {{ .Values.concourse.web.auth.ldap.userSearchUsername | quote }}
             {{- end }}
             {{- end }}
-
             {{- if .Values.concourse.web.auth.oauth.enabled }}
             {{- if .Values.concourse.web.auth.oauth.displayName }}
             - name: CONCOURSE_OAUTH_DISPLAY_NAME
@@ -799,7 +811,6 @@ spec:
               value: {{ .Values.concourse.web.auth.oauth.skipSslValidation | quote }}
             {{- end }}
             {{- end }}
-
             {{- if .Values.concourse.web.auth.oidc.enabled }}
             {{- if .Values.concourse.web.auth.oidc.displayName }}
             - name: CONCOURSE_OIDC_DISPLAY_NAME
@@ -840,7 +851,6 @@ spec:
               value: {{ .Values.concourse.web.auth.oidc.skipSslValidation | quote }}
             {{- end }}
             {{- end }}
-
             {{- if .Values.concourse.web.tsa.logLevel }}
             - name: CONCOURSE_TSA_LOG_LEVEL
               value: {{ .Values.concourse.web.tsa.logLevel | quote }}
@@ -851,9 +861,13 @@ spec:
             {{- end }}
             - name: CONCOURSE_TSA_BIND_PORT
               value: {{ .Values.concourse.web.tsa.bindPort | quote }}
-            {{- if .Values.concourse.web.tsa.bindDebugPort }}
-            - name: CONCOURSE_TSA_BIND_DEBUG_PORT
-              value: {{ .Values.concourse.web.tsa.bindDebugPort | quote }}
+            {{- if .Values.concourse.web.tsa.debugBindIp }}
+            - name: CONCOURSE_TSA_DEBUG_BIND_IP
+              value: {{ .Values.concourse.web.tsa.debugBindIp | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.tsa.debugBindPort }}
+            - name: CONCOURSE_TSA_DEBUG_BIND_PORT
+              value: {{ .Values.concourse.web.tsa.debugBindPort | quote }}
             {{- end }}
             {{- if .Values.concourse.web.tsa.peerIp }}
             - name: CONCOURSE_TSA_PEER_IP
@@ -903,13 +917,22 @@ spec:
             - name: prometheus
               containerPort: {{ .Values.concourse.web.prometheus.bindPort }}
             {{- end }}
+{{- if .Values.web.livenessProbe }}
           livenessProbe:
 {{ toYaml .Values.web.livenessProbe | indent 12 }}
+{{- end }}
+{{- if .Values.web.readinessProbe }}
           readinessProbe:
 {{ toYaml .Values.web.readinessProbe | indent 12 }}
+{{- end }}
+{{- if .Values.web.resources }}
           resources:
 {{ toYaml .Values.web.resources | indent 12 }}
+{{- end }}
           volumeMounts:
+{{- if .Values.web.additionalVolumeMounts }}
+{{ toYaml .Values.web.additionalVolumeMounts | indent 12 }}
+{{- end }}
             - name: concourse-keys
               mountPath: {{ .Values.web.keySecretsPath | quote }}
               readOnly: true
@@ -923,7 +946,7 @@ spec:
               mountPath: {{ .Values.web.vaultSecretsPath | quote }}
               readOnly: true
             {{- end }}
-            {{- if not (eq (default "disable" .Values.concourse.web.postgres.sslmode) "disable") }}
+            {{- if not (eq .Values.concourse.web.postgres.sslmode "disable") }}
             - name: postgresql-keys
               mountPath: {{ .Values.web.postgresqlSecretsPath | quote }}
               readOnly: true
@@ -936,15 +959,10 @@ spec:
             - name: auth-keys
               mountPath: {{ .Values.web.authSecretsPath | quote }}
               readOnly: true
-{{- if .Values.web.additionalVolumeMounts }}
-{{ toYaml .Values.web.additionalVolumeMounts | indent 12 }}
-{{- end }}
-      {{- if .Values.web.additionalAffinities }}
-      affinity:
 {{- if .Values.web.additionalAffinities }}
+      affinity:
 {{ toYaml .Values.web.additionalAffinities | indent 8 }}
 {{- end }}
-      {{- end }}
       volumes:
 {{- if .Values.web.additionalVolumes }}
 {{ toYaml .Values.web.additionalVolumes | indent 8 }}
@@ -981,14 +999,14 @@ spec:
               - key: vault-ca-cert
                 path: ca.cert
             {{- end }}
-            {{- if eq (default "" .Values.concourse.web.vault.authBackend) "cert" }}
+            {{- if (eq .Values.concourse.web.vault.authBackend "cert") }}
               - key: vault-client-cert
                 path: client.cert
               - key: vault-client-key
                 path: client.key
             {{- end }}
         {{- end }}
-        {{- if not (eq (default "disable" .Values.concourse.web.postgres.sslmode) "disable") }}
+        {{- if not (eq .Values.concourse.web.postgres.sslmode "disable") }}
         - name: postgresql-keys
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -7,7 +7,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-
 spec:
   serviceName: {{ template "concourse.worker.fullname" . }}
   replicas: {{ .Values.worker.replicas }}
@@ -18,14 +17,12 @@ spec:
         release: "{{ .Release.Name }}"
       {{- if .Values.worker.annotations }}
       annotations:
-      {{- range $key, $value := .Values.worker.annotations }}
-        {{ $key }}: {{ $value | quote }}
-      {{- end }}
+{{ toYaml .Values.worker.annotations | indent 8 }}
       {{- end }}
     spec:
-    {{- with .Values.worker.nodeSelector }}
+    {{- if .Values.worker.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
+{{ toYaml .Values.worker.nodeSelector | indent 8 }}
     {{- end }}
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "concourse.worker.fullname" . }}{{ else }}{{ .Values.rbac.workerServiceAccountName }}{{ end }}
       {{- if .Values.worker.tolerations }}
@@ -38,7 +35,28 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if .Values.worker.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds }}
+      {{- end }}
+      {{- if .Values.worker.cleanUpWorkDirOnStart }}
+      initContainers:
+        - name: {{ template "concourse.worker.fullname" . }}-init-rm
+          {{- if .Values.imageDigest }}
+          image: "{{ .Values.image }}@{{ .Values.imageDigest }}"
+          {{- else }}
+          image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+          command:
+            - /bin/sh
+          args:
+            - -ce
+            - |-
+              rm -rf {{ .Values.concourse.worker.workDir }}/*
+          volumeMounts:
+            - name: concourse-work-dir
+              mountPath: {{ .Values.concourse.worker.workDir | quote }}
+      {{- end }}
       containers:
       {{- if .Values.worker.sidecarContainers }}
       {{- toYaml .Values.worker.sidecarContainers | nindent 8 }}
@@ -50,50 +68,53 @@ spec:
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
           {{- end }}
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
-          command:
-            - /bin/sh
           args:
-            - -c
-            - |-
-              cp /dev/null /tmp/.liveness_probe
-              rm -rf ${CONCOURSE_WORK_DIR:-/concourse-work-dir}/*
-              while ! concourse retire-worker --name=${HOSTNAME} | grep -q worker-not-found; do
-                touch /tmp/.pre_start_cleanup
-                sleep 5
-              done
-              rm -f /tmp/.pre_start_cleanup
-              concourse worker --name=${HOSTNAME} | tee -a /tmp/.liveness_probe
+            - worker
+{{- if .Values.worker.livenessProbe }}
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - |-
-                  FATAL_ERRORS=$( echo "${LIVENESS_PROBE_FATAL_ERRORS}" | grep -q '\S' && \
-                      grep -F "${LIVENESS_PROBE_FATAL_ERRORS}" /tmp/.liveness_probe )
-                  cp /dev/null /tmp/.liveness_probe
-                  if [ ! -z "${FATAL_ERRORS}" ]; then
-                    >&2 echo "Fatal error detected: ${FATAL_ERRORS}"
-                    exit 1
-                  fi
-                  if [ -f /tmp/.pre_start_cleanup ]; then
-                    >&2 echo "Still trying to clean up before starting concourse. 'fly prune-worker -w ${HOSTNAME}' might need to be called to force cleanup."
-                    exit 1
-                  fi
-            failureThreshold: 1
-            initialDelaySeconds: 10
-            periodSeconds: 10
+{{ toYaml .Values.worker.livenessProbe | indent 12 }}
+{{- end }}
+{{- if .Values.worker.readinessProbe }}
+          readinessProbe:
+{{ toYaml .Values.worker.readinessProbe | indent 12 }}
+{{- end }}
           lifecycle:
             preStop:
               exec:
                 command:
-                  - /bin/sh
-                  - -c
-                  - |-
-                    while ! concourse retire-worker --name=${HOSTNAME} | grep -q worker-not-found; do
-                      sleep 5
-                    done
+                  - "kill"
+                  - "-s"
+                  - {{ .Values.concourse.worker.shutdownSignal | quote }}
+                  - "1"
           env:
+            {{- if .Values.concourse.worker.rebalanceInterval }}
+            - name: CONCOURSE_REBALANCE_INTERVAL
+              value: {{ .Values.concourse.worker.rebalanceInterval | quote }}
+            {{- end }}
+            {{- if .Values.concourse.worker.sweepInterval }}
+            - name: CONCOURSE_SWEEP_INTERVAL
+              value: {{ .Values.concourse.worker.sweepInterval | quote }}
+            {{- end }}
+            {{- if .Values.concourse.worker.resourceTypes }}
+            - name: CONCOURSE_RESOURCE_TYPES
+              value: {{ .Values.concourse.worker.resourceTypes | quote }}
+            {{- end }}
+            {{- if .Values.concourse.worker.connectionDrainTimeout }}
+            - name: CONCOURSE_CONNECTION_DRAIN_TIMEOUT
+              value: {{ .Values.concourse.worker.connectionDrainTimeout | quote }}
+            {{- end }}
+            {{- if .Values.concourse.worker.healthcheckBindIp }}
+            - name: CONCOURSE_HEALTHCHECK_BIND_IP
+              value: {{ .Values.concourse.worker.healthcheckBindIp | quote }}
+            {{- end }}
+            {{- if .Values.concourse.worker.healthcheckBindPort }}
+            - name: CONCOURSE_HEALTHCHECK_BIND_PORT
+              value: {{ .Values.concourse.worker.healthcheckBindPort | quote }}
+            {{- end }}
+            {{- if .Values.concourse.worker.healthcheckTimeout }}
+            - name: CONCOURSE_HEALTHCHECK_TIMEOUT
+              value: {{ .Values.concourse.worker.healthcheckTimeout | quote }}
+            {{- end }}
             {{- if .Values.concourse.worker.name }}
             - name: CONCOURSE_NAME
               value: {{ .Values.concourse.worker.name | quote }}
@@ -122,9 +143,13 @@ spec:
             - name: CONCOURSE_EPHEMERAL
               value: {{ .Values.concourse.worker.ephemeral | quote }}
             {{- end }}
-            {{- if .Values.concourse.worker.bindDebugPort }}
-            - name: CONCOURSE_BIND_DEBUG_PORT
-              value: {{ .Values.concourse.worker.bindDebugPort | quote }}
+            {{- if .Values.concourse.worker.debugBindIp }}
+            - name: CONCOURSE_DEBUG_BIND_IP
+              value: {{ .Values.concourse.worker.debugBindIp | quote }}
+            {{- end }}
+            {{- if .Values.concourse.worker.debugBindPort }}
+            - name: CONCOURSE_DEBUG_BIND_PORT
+              value: {{ .Values.concourse.worker.debugBindPort | quote }}
             {{- end }}
             {{- if .Values.concourse.worker.certsDir }}
             - name: CONCOURSE_CERTS_DIR
@@ -142,275 +167,32 @@ spec:
             - name: CONCOURSE_BIND_PORT
               value: {{ .Values.concourse.worker.bindPort | quote }}
             {{- end }}
-            {{- if .Values.concourse.worker.peerIp }}
-            - name: CONCOURSE_PEER_IP
-              value: {{ .Values.concourse.worker.peerIp | quote }}
-            {{- end }}
             {{- if .Values.concourse.worker.logLevel }}
             - name: CONCOURSE_LOG_LEVEL
               value: {{ .Values.concourse.worker.logLevel | quote }}
             {{- end }}
-
             - name: CONCOURSE_TSA_HOST
               value: "{{ template "concourse.web.fullname" . }}:{{ .Values.concourse.web.tsa.bindPort}}"
             - name: CONCOURSE_TSA_PUBLIC_KEY
               value: "{{ .Values.worker.keySecretsPath }}/host_key.pub"
             - name: CONCOURSE_TSA_WORKER_PRIVATE_KEY
               value: "{{ .Values.worker.keySecretsPath }}/worker_key"
-
-            {{- if .Values.concourse.worker.garden.logLevel }}
-            - name: CONCOURSE_GARDEN_LOG_LEVEL
-              value: {{ .Values.concourse.worker.garden.logLevel | quote }}
+            {{- if .Values.concourse.worker.garden.useHoudini }}
+              - name: CONCOURSE_GARDEN_USE_HOUDINI
+              value: {{ .Values.concourse.worker.garden.useHoudini | quote }}
             {{- end }}
-            {{- if .Values.concourse.worker.garden.timeFormat }}
-            - name: CONCOURSE_GARDEN_TIME_FORMAT
-              value: {{ .Values.concourse.worker.garden.timeFormat | quote }}
+            {{- if .Values.concourse.worker.garden.bin }}
+            - name: CONCOURSE_GARDEN_BIN
+              value: {{ .Values.concourse.worker.garden.bin | quote }}
             {{- end }}
-            {{- if .Values.concourse.worker.garden.bindIp }}
-            - name: CONCOURSE_GARDEN_BIND_IP
-              value: {{ .Values.concourse.worker.garden.bindIp | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.bindPort }}
-            - name: CONCOURSE_GARDEN_BIND_PORT
-              value: {{ .Values.concourse.worker.garden.bindPort | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.bindSocket }}
-            - name: CONCOURSE_GARDEN_BIND_SOCKET
-              value: {{ .Values.concourse.worker.garden.bindSocket | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.debugBindIp }}
-            - name: CONCOURSE_GARDEN_DEBUG_BIND_IP
-              value: {{ .Values.concourse.worker.garden.debugBindIp | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.debugBindPort }}
-            - name: CONCOURSE_GARDEN_DEBUG_BIND_PORT
-              value: {{ .Values.concourse.worker.garden.debugBindPort | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.skipSetup }}
-            - name: CONCOURSE_GARDEN_SKIP_SETUP
-              value: {{ .Values.concourse.worker.garden.skipSetup | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.depot }}
-            - name: CONCOURSE_GARDEN_DEPOT
-              value: {{ .Values.concourse.worker.garden.depot | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.propertiesPath }}
-            - name: CONCOURSE_GARDEN_PROPERTIES_PATH
-              value: {{ .Values.concourse.worker.garden.propertiesPath | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.consoleSocketsPath }}
-            - name: CONCOURSE_GARDEN_CONSOLE_SOCKETS_PATH
-              value: {{ .Values.concourse.worker.garden.consoleSocketsPath | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.cleanupProcessDirsOnWait }}
-            - name: CONCOURSE_GARDEN_CLEANUP_PROCESS_DIRS_ON_WAIT
-              value: {{ .Values.concourse.worker.garden.cleanupProcessDirsOnWait | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.disablePrivilegedContainers }}
-            - name: CONCOURSE_GARDEN_DISABLE_PRIVILEGED_CONTAINERS
-              value: {{ .Values.concourse.worker.garden.disablePrivilegedContainers | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.uidMapStart }}
-            - name: CONCOURSE_GARDEN_UID_MAP_START
-              value: {{ .Values.concourse.worker.garden.uidMapStart | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.uidMapLength }}
-            - name: CONCOURSE_GARDEN_UID_MAP_LENGTH
-              value: {{ .Values.concourse.worker.garden.uidMapLength | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.gidMapStart }}
-            - name: CONCOURSE_GARDEN_GID_MAP_START
-              value: {{ .Values.concourse.worker.garden.gidMapStart | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.gidMapLength }}
-            - name: CONCOURSE_GARDEN_GID_MAP_LENGTH
-              value: {{ .Values.concourse.worker.garden.gidMapLength | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.defaultRootfs }}
-            - name: CONCOURSE_GARDEN_DEFAULT_ROOTFS
-              value: {{ .Values.concourse.worker.garden.defaultRootfs | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.defaultGraceTime }}
-            - name: CONCOURSE_GARDEN_DEFAULT_GRACE_TIME
-              value: {{ .Values.concourse.worker.garden.defaultGraceTime | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.destroyContainersOnStartup }}
-            - name: CONCOURSE_GARDEN_DESTROY_CONTAINERS_ON_STARTUP
-              value: {{ .Values.concourse.worker.garden.destroyContainersOnStartup | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.apparmor }}
-            - name: CONCOURSE_GARDEN_APPARMOR
-              value: {{ .Values.concourse.worker.garden.apparmor | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.assetsDir }}
-            - name: CONCOURSE_GARDEN_ASSETS_DIR
-              value: {{ .Values.concourse.worker.garden.assetsDir | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.dadooBin }}
-            - name: CONCOURSE_GARDEN_DADOO_BIN
-              value: {{ .Values.concourse.worker.garden.dadooBin | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.nstarBin }}
-            - name: CONCOURSE_GARDEN_NSTAR_BIN
-              value: {{ .Values.concourse.worker.garden.nstarBin | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.tarBin }}
-            - name: CONCOURSE_GARDEN_TAR_BIN
-              value: {{ .Values.concourse.worker.garden.tarBin | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.iptablesBin }}
-            - name: CONCOURSE_GARDEN_IPTABLES_BIN
-              value: {{ .Values.concourse.worker.garden.iptablesBin | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.iptablesRestoreBin }}
-            - name: CONCOURSE_GARDEN_IPTABLES_RESTORE_BIN
-              value: {{ .Values.concourse.worker.garden.iptablesRestoreBin | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.initBin }}
-            - name: CONCOURSE_GARDEN_INIT_BIN
-              value: {{ .Values.concourse.worker.garden.initBin | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.runtimePlugin }}
-            - name: CONCOURSE_GARDEN_RUNTIME_PLUGIN
-              value: {{ .Values.concourse.worker.garden.runtimePlugin | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.runtimePluginExtraArg }}
-            - name: CONCOURSE_GARDEN_RUNTIME_PLUGIN_EXTRA_ARG
-              value: {{ .Values.concourse.worker.garden.runtimePluginExtraArg | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.graph }}
-            - name: CONCOURSE_GARDEN_GRAPH
-              value: {{ .Values.concourse.worker.garden.graph | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.graphCleanupThresholdInMegabytes }}
-            - name: CONCOURSE_GARDEN_GRAPH_CLEANUP_THRESHOLD_IN_MEGABYTES
-              value: {{ .Values.concourse.worker.garden.graphCleanupThresholdInMegabytes | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.persistentImage }}
-            - name: CONCOURSE_GARDEN_PERSISTENT_IMAGE
-              value: {{ .Values.concourse.worker.garden.persistentImage | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.imagePlugin }}
-            - name: CONCOURSE_GARDEN_IMAGE_PLUGIN
-              value: {{ .Values.concourse.worker.garden.imagePlugin | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.imagePluginExtraArg }}
-            - name: CONCOURSE_GARDEN_IMAGE_PLUGIN_EXTRA_ARG
-              value: {{ .Values.concourse.worker.garden.imagePluginExtraArg | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.privilegedImagePlugin }}
-            - name: CONCOURSE_GARDEN_PRIVILEGED_IMAGE_PLUGIN
-              value: {{ .Values.concourse.worker.garden.privilegedImagePlugin | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.privilegedImagePluginExtraArg }}
-            - name: CONCOURSE_GARDEN_PRIVILEGED_IMAGE_PLUGIN_EXTRA_ARG
-              value: {{ .Values.concourse.worker.garden.privilegedImagePluginExtraArg | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.dockerRegistry }}
-            - name: CONCOURSE_GARDEN_DOCKER_REGISTRY
-              value: {{ .Values.concourse.worker.garden.dockerRegistry | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.insecureDockerRegistry }}
-            - name: CONCOURSE_GARDEN_INSECURE_DOCKER_REGISTRY
-              value: {{ .Values.concourse.worker.garden.insecureDockerRegistry | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.networkPool }}
-            - name: CONCOURSE_GARDEN_NETWORK_POOL
-              value: {{ .Values.concourse.worker.garden.networkPool | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.allowHostAccess }}
-            - name: CONCOURSE_GARDEN_ALLOW_HOST_ACCESS
-              value: {{ .Values.concourse.worker.garden.allowHostAccess | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.denyNetwork }}
-            - name: CONCOURSE_GARDEN_DENY_NETWORK
-              value: {{ .Values.concourse.worker.garden.denyNetwork | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.dnsServer }}
-            - name: CONCOURSE_GARDEN_DNS_SERVER
-              value: {{ .Values.concourse.worker.garden.dnsServer | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.additionalDnsServer }}
-            - name: CONCOURSE_GARDEN_ADDITIONAL_DNS_SERVER
-              value: {{ .Values.concourse.worker.garden.additionalDnsServer | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.additionalHostEntry }}
-            - name: CONCOURSE_GARDEN_ADDITIONAL_HOST_ENTRY
-              value: {{ .Values.concourse.worker.garden.additionalHostEntry | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.externalIp }}
-            - name: CONCOURSE_GARDEN_EXTERNAL_IP
-              value: {{ .Values.concourse.worker.garden.externalIp | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.portPoolStart }}
-            - name: CONCOURSE_GARDEN_PORT_POOL_START
-              value: {{ .Values.concourse.worker.garden.portPoolStart | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.portPoolSize }}
-            - name: CONCOURSE_GARDEN_PORT_POOL_SIZE
-              value: {{ .Values.concourse.worker.garden.portPoolSize | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.portPoolPropertiesPath }}
-            - name: CONCOURSE_GARDEN_PORT_POOL_PROPERTIES_PATH
-              value: {{ .Values.concourse.worker.garden.portPoolPropertiesPath | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.mtu }}
-            - name: CONCOURSE_GARDEN_MTU
-              value: {{ .Values.concourse.worker.garden.mtu | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.networkPlugin }}
-            - name: CONCOURSE_GARDEN_NETWORK_PLUGIN
-              value: {{ .Values.concourse.worker.garden.networkPlugin | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.networkPluginExtraArg }}
-            - name: CONCOURSE_GARDEN_NETWORK_PLUGIN_EXTRA_ARG
-              value: {{ .Values.concourse.worker.garden.networkPluginExtraArg | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.cpuQuotaPerShare }}
-            - name: CONCOURSE_GARDEN_CPU_QUOTA_PER_SHARE
-              value: {{ .Values.concourse.worker.garden.cpuQuotaPerShare | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.tcpMemoryLimit }}
-            - name: CONCOURSE_GARDEN_TCP_MEMORY_LIMIT
-              value: {{ .Values.concourse.worker.garden.tcpMemoryLimit | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.defaultContainerBlockioWeight }}
-            - name: CONCOURSE_GARDEN_DEFAULT_CONTAINER_BLOCKIO_WEIGHT
-              value: {{ .Values.concourse.worker.garden.defaultContainerBlockioWeight | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.maxContainers }}
-            - name: CONCOURSE_GARDEN_MAX_CONTAINERS
-              value: {{ .Values.concourse.worker.garden.maxContainers | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.disableSwapLimit }}
-            - name: CONCOURSE_GARDEN_DISABLE_SWAP_LIMIT
-              value: {{ .Values.concourse.worker.garden.disableSwapLimit | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.metricsEmissionInterval }}
-            - name: CONCOURSE_GARDEN_METRICS_EMISSION_INTERVAL
-              value: {{ .Values.concourse.worker.garden.metricsEmissionInterval | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.dropsondeOrigin }}
-            - name: CONCOURSE_GARDEN_DROPSONDE_ORIGIN
-              value: {{ .Values.concourse.worker.garden.dropsondeOrigin | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.dropsondeDestination }}
-            - name: CONCOURSE_GARDEN_DROPSONDE_DESTINATION
-              value: {{ .Values.concourse.worker.garden.dropsondeDestination | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.containerdSocket }}
-            - name: CONCOURSE_GARDEN_CONTAINERD_SOCKET
-              value: {{ .Values.concourse.worker.garden.containerdSocket | quote }}
-            {{- end }}
-            {{- if .Values.concourse.worker.garden.useContainerdForProcesses }}
-            - name: CONCOURSE_GARDEN_USE_CONTAINERD_FOR_PROCESSES
-              value: {{ .Values.concourse.worker.garden.useContainerdForProcesses | quote }}
+            {{- if .Values.concourse.worker.garden.config }}
+            - name: CONCOURSE_GARDEN_CONFIG
+              value: {{ .Values.concourse.worker.garden.config | quote }}
             {{- end }}
             {{- if .Values.concourse.worker.garden.dnsProxyEnable }}
             - name: CONCOURSE_GARDEN_DNS_PROXY_ENABLE
               value: {{ .Values.concourse.worker.garden.dnsProxyEnable | quote }}
             {{- end }}
-
             {{- if .Values.concourse.worker.baggageclaim.logLevel }}
             - name: CONCOURSE_BAGGAGECLAIM_LOG_LEVEL
               value: {{ .Values.concourse.worker.baggageclaim.logLevel | quote }}
@@ -423,9 +205,13 @@ spec:
             - name: CONCOURSE_BAGGAGECLAIM_BIND_PORT
               value: {{ .Values.concourse.worker.baggageclaim.bindPort | quote }}
             {{- end }}
-            {{- if .Values.concourse.worker.baggageclaim.bindDebugPort }}
-            - name: CONCOURSE_BAGGAGECLAIM_BIND_DEBUG_PORT
-              value: {{ .Values.concourse.worker.baggageclaim.bindDebugPort | quote }}
+            {{- if .Values.concourse.worker.baggageclaim.debugBindIp }}
+            - name: CONCOURSE_BAGGAGECLAIM_DEBUG_BIND_IP
+              value: {{ .Values.concourse.worker.baggageclaim.debugBindIp | quote }}
+            {{- end }}
+            {{- if .Values.concourse.worker.baggageclaim.debugBindPort }}
+            - name: CONCOURSE_BAGGAGECLAIM_DEBUG_BIND_PORT
+              value: {{ .Values.concourse.worker.baggageclaim.debugBindPort | quote }}
             {{- end }}
             {{- if .Values.concourse.worker.baggageclaim.volumes }}
             - name: CONCOURSE_BAGGAGECLAIM_VOLUMES
@@ -451,14 +237,20 @@ spec:
             - name: CONCOURSE_BAGGAGECLAIM_REAP_INTERVAL
               value: {{ .Values.concourse.worker.baggageclaim.reapInterval | quote }}
             {{- end }}
-            - name: LIVENESS_PROBE_FATAL_ERRORS
-              value: {{ .Values.worker.fatalErrors | quote }}
-
+            {{- if .Values.concourse.worker.baggageclaim.disableUserNamespaces }}
+            - name: CONCOURSE_BAGGAGECLAIM_DISABLE_USER_NAMESPACES
+              value: {{ .Values.concourse.worker.baggageclaim.disableUserNamespaces | quote }}
+            {{- end }}
 {{- if .Values.worker.env }}
 {{ toYaml .Values.worker.env | indent 12 }}
 {{- end }}
+          ports:
+            - name: worker-hc
+              containerPort: {{ .Values.concourse.worker.healthcheckBindPort }}
+{{- if .Values.worker.resources }}
           resources:
 {{ toYaml .Values.worker.resources | indent 12 }}
+{{- end }}
           securityContext:
             privileged: true
           volumeMounts:
@@ -466,7 +258,7 @@ spec:
               mountPath: {{ .Values.worker.keySecretsPath | quote }}
               readOnly: true
             - name: concourse-work-dir
-              mountPath: {{ .Values.concourse.workingDirectory | default "/concourse-work-dir" | quote }}
+              mountPath: {{ .Values.concourse.worker.workDir | quote }}
 {{- if .Values.worker.additionalVolumeMounts }}
 {{ toYaml .Values.worker.additionalVolumeMounts | indent 12 }}
 {{- end }}
@@ -507,13 +299,6 @@ spec:
                 path: worker_key
               - key: worker-key-pub
                 path: worker_key.pub
-{{- define "concourse.are-there-additional-volumes.with-the-name.concourse-work-dir" }}
-  {{- range .Values.worker.additionalVolumes }}
-    {{- if .name | eq "concourse-work-dir" }}
-      {{- .name }}
-    {{- end }}
-  {{- end }}
-{{- end }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
@@ -540,8 +325,10 @@ spec:
             {{- end }}
       {{- end }}
   {{- end }}
-{{- if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion }}
+  {{- if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion }}
   updateStrategy:
     type: {{ .Values.worker.updateStrategy }}
-{{- end }}
+  {{- end }}
+  {{- if .Values.worker.podManagementPolicy }}
   podManagementPolicy: {{ .Values.worker.podManagementPolicy }}
+  {{- end }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -19,7 +19,7 @@ image: concourse/concourse
 ##      of `concourse/concourse`.
 ## Ref: https://hub.docker.com/r/concourse/concourse/tags/
 ##
-imageTag: "4.2.2"
+imageTag: "5.0.0"
 
 ## Specific image digest to use in place of a tag.
 ## Ref: https://kubernetes.io/docs/concepts/configuration/overview/#container-images
@@ -40,7 +40,7 @@ imagePullPolicy: IfNotPresent
 ##   imagePullSecrets:
 ##    - myRegistryKeySecretName
 ##
-imagePullSecrets:
+imagePullSecrets: []
 
 
 ## Configuration values for the Concourse application (worker and web components).
@@ -52,6 +52,19 @@ concourse:
   ## through the `concourse web` command.
   ##
   web:
+    ## Enable equivalent resources across pipelines and teams to share a single version history.
+    ## Ref: https://concourse-ci.org/global-resources.html
+    ##
+    enableGlobalResources: true
+
+    ## The number of attempts secret will be retried to be fetched,
+    ## in case a retryable error happens.
+    ##
+    secretRetryAttempts:
+
+    ## The interval between secret retry retieval attempts.
+    ##
+    secretRetryInterval:
 
     ## Minimum level of logs to see. Possible options: debug, info, error.
     ##
@@ -120,7 +133,7 @@ concourse:
 
     ## Port on which to listen for the pprof debugger endpoints.
     ##
-    debugBindPort:
+    debugBindPort: 8079
 
     ## Length of time for a intercepted session to be idle before terminating.
     ##
@@ -139,7 +152,7 @@ concourse:
     resourceTypeCheckingInterval:
 
     ## Method by which a worker is selected during container placement.
-    ## Possible values: volume-locality | random
+    ## Possible values: volume-locality | random | fewest-build-containers
     containerPlacementStrategy:
 
     ## How long to wait for Baggageclaim to send the response header.
@@ -194,7 +207,7 @@ concourse:
 
       ## Whether or not to use SSL.
       ##
-      sslmode:
+      sslmode: disable
 
       ## Dialing timeout. (0 means wait indefinitely)
       ##
@@ -236,6 +249,9 @@ concourse:
       ##
       configPath:
 
+    ## Configuration for using AWS SSM as a credential manager.
+    ## Ref: https://concourse-ci.org/creds.html#asm
+    ##
     awsSecretsManager:
       ## Enable the use of AWS Secrets Manager for credential management.
       ##
@@ -253,6 +269,9 @@ concourse:
       ##
       teamSecretTemplate:
 
+    ## Configuration for using AWS SSM as a credential manager.
+    ## Ref: https://concourse-ci.org/creds.html#ssm
+    ##
     awsSsm:
       ## Enable the use of AWS SSM.
       ##
@@ -271,7 +290,7 @@ concourse:
       teamSecretTemplate:
 
 
-    ## Configuring for using Vault as a credential manager.
+    ## Configuration for using Vault as a credential manager.
     ## Ref: https://concourse-ci.org/creds.html#vault
     ##
     vault:
@@ -295,7 +314,7 @@ concourse:
       ## Vault authentication backend, leave this blank if using an initial periodic token.
       ## Currently supported backends: token, approle, cert.
       ##
-      authBackend:
+      authBackend: ""
 
       ## Cache returned secrets for their lease duration in memory
       ##
@@ -363,6 +382,10 @@ concourse:
       ## A key-value attribute to attach to emitted metrics.
       ##
       attribute:
+
+      ## Enable capturing of error log metrics.
+      ##
+      captureErrorMetrics: false
 
     datadog:
       enabled: false
@@ -472,6 +495,11 @@ concourse:
       ##
       oneOffGracePeriod: 5m
 
+      ## Period after which to reap containers and volumes that were created but
+      ## went missing from the worker.
+      ##
+      missingGracePeriod:
+
     syslog:
       ## Enables the emission of build logs to external log ingesters through
       ## using the syslog protocol.
@@ -509,16 +537,16 @@ concourse:
       duration:
 
       mainTeam:
+        ## Configuration file for specifying team params.
+        ## Ref: https://concourse-ci.org/managing-teams.html#setting-roles
+        ##
+        config:
+
         ## List of local Concourse users to be included as members of the `main` team.
         ## Make sure you have local users support enabled (`concourse.web.localAuth.enabled`) and
         ## that the users were added (`local-users` secret).
         ##
         localUser: "test"
-
-        ## Setting this flag will whitelist all logged in users in the system. ALL OF THEM.
-        ## If, for example, you've configured GitHub, any user with a GitHub account will have access to your team.
-        ##
-        allowAllUsers: false
 
         ## Authentication (Main Team) (CloudFoundry)
         ##
@@ -538,6 +566,18 @@ concourse:
           ## (Deprecated) List of whitelisted CloudFoundry space guids
           ##
           spaceGuid:
+
+        ## Authentication (Main Team) (Bitbucket Cloud)
+        ##
+        bitbucketCloud:
+
+          ## List of whitelisted Bitbucket Cloud users
+          ##
+          user:
+
+          ## List of whitelisted Bitbucket Cloud teams
+          ##
+          team:
 
         ## Authentication (Main Team) (GitHub)
         ##
@@ -632,6 +672,11 @@ concourse:
         ## CA certificate of GitHub Enterprise deployment
         ##
         useCaCert: false
+
+      ## Authentication (BitbucketCloud)
+      ##
+      bitbucketCloud:
+        enabled: false
 
       ## Authentication (GitLab)
       gitlab:
@@ -809,9 +854,13 @@ concourse:
       ##
       bindPort: 2222
 
+      ## IP address on which to listen for the pprof debugger endpoints (default: 127.0.0.1)
+      ##
+      debugBindIp:
+
       ## Port on which to listen for TSA pprof server.
       ##
-      bindDebugPort:
+      debugBindPort: 2221
 
       ## IP address of this TSA, reachable by the ATCs. Used for forwarded worker addresses.
       ##
@@ -842,6 +891,38 @@ concourse:
       heartbeatInterval:
 
   worker:
+    ## Signal to send to the worker container when shutting down.
+    ## Possible values:
+    ##
+    ## - SIGUSR1: land the worker, and
+    ## - SIGUSR2: retire the worker.
+    ##
+    ## Note.: using SIGUSR2 with persistence enabled implies the use of an
+    ## initContainer that removes any data the existed previously under
+    ## `concourse.worker.workDir` as the action of `retire`ing a worker implies
+    ## that no state comes back with it when re-registering.
+    ##
+    ## Ref: https://concourse-ci.org/concourse-worker.html
+    ## Ref: https://concourse-ci.org/worker-internals.html
+    ##
+    shutdownSignal: SIGUSR2
+
+    ## Duration after which the registration should be swapped to another random SSH gateway.
+    ##
+    rebalanceInterval:
+
+    ## IP address on which to listen for health checking requests.
+    ##
+    healthcheckBindIp:
+
+    ## Port on which to listen for health checking requests.
+    ##
+    healthcheckBindPort: 8888
+
+    ## HTTP timeout for the full duration of health checking.
+    ##
+    healthcheckTimeout:
+
     ## The name to set for the worker during registration. If not specified, the hostname will be used.
     ##
     name:
@@ -870,9 +951,13 @@ concourse:
     ##
     ephemeral:
 
+    ## IP address on which to listen for the pprof debugger endpoints.
+    ##
+    debugBindIp:
+
     ## Port on which to listen for beacon pprof server.
     ##
-    bindDebugPort: 9099
+    debugBindPort: 7776
 
     ## Version of the worker. This is normally baked in to the binary, so this flag is hidden.
     ##
@@ -884,7 +969,7 @@ concourse:
 
     ## IP address on which to listen for the Garden server.
     ##
-    bindIp: 127.0.0.1
+    bindIp:
 
     ## Port on which to listen for the Garden server.
     ##
@@ -894,14 +979,14 @@ concourse:
     ##
     peerIp:
 
-    ## Minimum level of logs to see.
+    ## Minimum level of logs to see. Possible options: debug, info, error.
     ##
-    logLevel: info
+    logLevel:
 
     tsa:
       ## TSA host to forward the worker through. Can be specified multiple times.
       ##
-      host: 127.0.0.1:2222
+      host:
 
       ## File containing a public key to expect from the TSA.
       ##
@@ -912,132 +997,29 @@ concourse:
       workerPrivateKey:
 
     garden:
-      ## Minimum level of logs to see.
-      # logLevel: info
-      ## format of log timestamps
-      # timeFormat: unix-epoch
-      ## Bind with TCP on the given IP.
-      # bindIp:
-      ## Bind with TCP on the given port.
-      bindPort: 7777
-      ## Bind with Unix on the given socket path.
-      # bindSocket: /tmp/garden.sock
-      ## Bind the debug server on the given IP.
-      # debugBindIp:
-      ## Bind the debug server to the given port.
-      # debugBindPort: 17013
-      ## Skip the preparation part of the host that requires root privileges
-      # skipSetup:
-      ## Directory in which to store container data.
-      # depot: /var/run/gdn/depot
-      ## Path in which to store properties.
-      # propertiesPath:
-      ## Path in which to store temporary sockets
-      # consoleSocketsPath:
-      ## Clean up proccess dirs on first invocation of wait
-      # cleanupProcessDirsOnWait:
-      ## Disable creation of privileged containers
-      # disablePrivilegedContainers:
-      ## The lowest numerical subordinate user ID the user is allowed to map
-      # uidMapStart: 1
-      ## The number of numerical subordinate user IDs the user is allowed to map
-      # uidMapLength:
-      ## The lowest numerical subordinate group ID the user is allowed to map
-      # gidMapStart: 1
-      ## The number of numerical subordinate group IDs the user is allowed to map
-      # gidMapLength:
-      ## Default rootfs to use when not specified on container creation.
-      # defaultRootfs:
-      ## Default time after which idle containers should expire.
-      # defaultGraceTime:
-      ## Clean up all the existing containers on startup.
-      # destroyContainersOnStartup:
-      ## Apparmor profile to use for unprivileged container processes
-      # apparmor:
-      ## Directory in which to extract packaged assets
-      # assetsDir: /var/gdn/assets
-      ## Path to the 'dadoo' binary.
-      # dadooBin:
-      ## Path to the 'nstar' binary.
-      # nstarBin:
-      ## Path to the 'tar' binary.
-      # tarBin:
-      ## path to the iptables binary
-      # iptablesBin: /sbin/iptables
-      ## path to the iptables-restore binary
-      # iptablesRestoreBin: /sbin/iptables-restore
-      ## Path execute as pid 1 inside each container.
-      # initBin:
-      ## Path to the runtime plugin binary.
-      # runtimePlugin: runc
-      ## Extra argument to pass to the runtime plugin. Can be specified multiple times.
-      # runtimePluginExtraArg:
-      ## Directory on which to store imported rootfs graph data.
-      # graph:
-      ## Disk usage of the graph dir at which cleanup should trigger, or -1 to disable graph cleanup.
-      # graphCleanupThresholdInMegabytes: -1
-      ## Image that should never be garbage collected. Can be specified multiple times.
-      # persistentImage:
-      ## Path to image plugin binary.
-      # imagePlugin:
-      ## Extra argument to pass to the image plugin to create unprivileged images. Can be specified multiple times.
-      # imagePluginExtraArg:
-      ## Path to privileged image plugin binary.
-      # privilegedImagePlugin:
-      ## Extra argument to pass to the image plugin to create privileged images. Can be specified multiple times.
-      # privilegedImagePluginExtraArg:
-      ## Docker registry API endpoint.
-      # dockerRegistry: registry-1.docker.io
-      ## Docker registry to allow connecting to even if not secure. Can be specified multiple times.
-      # insecureDockerRegistry:
-      ## Network range to use for dynamically allocated container subnets.
-      # networkPool: 10.254.0.0/22
-      ## Allow network access to the host machine.
-      # allowHostAccess:
-      ## Network ranges to which traffic from containers will be denied. Can be specified multiple times.
-      # denyNetwork:
-      ## DNS server IP address to use instead of automatically determined servers. Can be specified multiple times.
-      # dnsServer:
-      ## DNS server IP address to append to the automatically determined servers. Can be specified multiple times.
-      # additionalDnsServer:
-      ## Per line hosts entries. Can be specified multiple times and will be appended verbatim in order to /etc/hosts
-      # additionalHostEntry:
-      ## IP address to use to reach container's mapped ports. Autodetected if not specified.
-      # externalIp:
-      ## Start of the ephemeral port range used for mapped container ports.
-      # portPoolStart: 61001
-      ## Size of the port pool used for mapped container ports.
-      # portPoolSize: 4534
-      ## Path in which to store port pool properties.
-      # portPoolPropertiesPath:
-      ## MTU size for container network interfaces. Defaults to the MTU of the interface used for outbound access by the host. Max allowed value is 1500.
-      # mtu:
-      ## Path to network plugin binary.
-      # networkPlugin:
-      ## Extra argument to pass to the network plugin. Can be specified multiple times.
-      # networkPluginExtraArg:
-      ## Maximum number of microseconds each cpu share assigned to a container allows per quota period
-      # cpuQuotaPerShare: 0
-      ## Set hard limit for the tcp buf memory, value in bytes
-      # tcpMemoryLimit: 0
-      ## Default block IO weight assigned to a container
-      # defaultContainerBlockioWeight: 0
-      ## Maximum number of containers that can be created.
-      # maxContainers: 0
-      ## Disable swap memory limit
-      # disableSwapLimit:
-      ## Interval on which to emit metrics.
-      # metricsEmissionInterval: 1m
-      ## Origin identifier for Dropsonde-emitted metrics.
-      # dropsondeOrigin: garden-linux
-      ## Destination for Dropsonde-emitted metrics.
-      # dropsondeDestination: 127.0.0.1:3457
-      ## Path to a containerd socket.
-      # containerdSocket:
-      ## Use containerd to run processes in containers.
-      # useContainerdForProcesses:
-      ## Enable proxy DNS server.
-      # dnsProxyEnable:
+      ## Path to the 'gdn' executable (or leave as 'gdn' to find it in $PATH)
+      ##
+      bin:
+
+      ## Path to a config file to use for Garden in INI format.
+      ##
+      ## For example, in a ConfigMap:
+      ##
+      ##   [server]
+      ##     max-containers = 100
+      ##
+      ## For information about the possible values:
+      ## Ref: https://bosh.io/jobs/garden?source=github.com/cloudfoundry/garden-runc-release
+      ##
+      config:
+
+      ## Enable a proxy DNS server for Garden
+      ##
+      dnsProxyEnable:
+
+      ## Use the insecure Houdini Garden backend.
+      ##
+      useHoudini:
 
     baggageclaim:
       ## Minimum level of logs to see. Possible values: debug, info, error
@@ -1050,11 +1032,19 @@ concourse:
 
       ## Port on which to listen for API traffic.
       ##
-      bindPort:
+      bindPort: 7788
+
+      ## IP address on which to listen for the pprof debugger endpoints.
+      ##
+      debugBindIp:
+
+      ## Disable remapping of user/group IDs in unprivileged volumes.
+      ##
+      disableUserNamespaces:
 
       ## Port on which to listen for baggageclaim pprof server.
       ##
-      bindDebugPort:
+      debugBindPort: 7787
 
       ## Directory in which to place volume data.
       ##
@@ -1082,6 +1072,8 @@ concourse:
       reapInterval:
 
 ## Configuration values for Concourse Web components.
+## For more information regarding the characteristics of
+## Concourse Web nodes, see https://concourse-ci.org/concourse-web.html.
 ##
 web:
 
@@ -1101,7 +1093,7 @@ web:
   ##   image: busybox
   ##   command: ['sh', '-c', 'echo Hello && sleep 3600']
   ##
-  sidecarContainers:
+  sidecarContainers: []
 
   ## Configures the liveness probe used to determine if the Web component is up.
   ## ps.: if you're upgrading Concourse from one version  to another, the probe will
@@ -1136,12 +1128,14 @@ web:
 
   ## Configure additional environment variables for the
   ## web containers.
+  ## Example:
+  ##
+  ##   - name: CONCOURSE_LOG_LEVEL
+  ##     value: "debug"
+  ##   - name: CONCOURSE_TSA_LOG_LEVEL
+  ##     value: "debug"
   ##
   env:
-  #   - name: CONCOURSE_LOG_LEVEL
-  #     value: "debug"
-  #   - name: CONCOURSE_TSA_LOG_LEVEL
-  #     value: "debug"
 
   ## Where secrets should be mounted for the web container.
   ##
@@ -1153,57 +1147,73 @@ web:
   tlsSecretsPath: "/concourse-web-tls"
 
   ## Configure additional volumes for the
-  ## web container(s)
+  ## web container(s).
+  ##
+  ## Example:
+  ##
+  ##   - name: my-team-authorized-keys
+  ##     configMap:
+  ##       name: my-team-authorized-keys-config
+  ##
   ## Ref: https://kubernetes.io/docs/concepts/storage/volumes/
   ##
-  additionalVolumes:
-  #   - name: my-team-authorized-keys
-  #     configMap:
-  #       name: my-team-authorized-keys-config
+  additionalVolumes: []
 
   ## Configure additional volumeMounts for the
   ## web container(s)
+  ##
+  ## Example:
+  ##
+  ##  - name: my-team-authorized-keys
+  ##    mountPath: /my-team-authorized-keys
+  ##
   ## Ref: https://kubernetes.io/docs/concepts/storage/volumes/
   ##
   additionalVolumeMounts:
-  #   - name: my-team-authorized-keys
-  #     mountPath: /my-team-authorized-keys
 
   ## Additional affinities to add to the web pods.
+  ##
+  ## Example:
+  ##   nodeAffinity:
+  ##     preferredDuringSchedulingIgnoredDuringExecution:
+  ##       - weight: 50
+  ##         preference:
+  ##           matchExpressions:
+  ##             - key: spot
+  ##               operator: NotIn
+  ##               values:
+  ##                 - "true"
+  ##
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ##
   additionalAffinities:
-  #   nodeAffinity:
-  #     preferredDuringSchedulingIgnoredDuringExecution:
-  #       - weight: 50
-  #         preference:
-  #           matchExpressions:
-  #             - key: spot
-  #               operator: NotIn
-  #               values:
-  #                 - "true"
 
   ## Annotations for the web nodes.
+  ##
+  ## Example:
+  ##   key1: "value1"
+  ##   key2: "value2"
+  ##
   ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
   annotations:
-  #   key1: "value1"
-  #   key2: "value2"
 
   ## Node selector for web nodes.
   ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   ##
-  nodeSelector:
+  nodeSelector: {}
 
   ## Tolerations for the web nodes.
+  ##
+  ## Example:
+  ##   - key: "toleration=key"
+  ##     operator: "Equal"
+  ##     value: "value"
+  ##     effect: "NoSchedule"
+  ##
   ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
-  tolerations:
-  # tolerations:
-  #  - key: "toleration=key"
-  #    operator: "Equal"
-  #    value: "value"
-  #    effect: "NoSchedule"
+  tolerations: []
 
   ## Service configuration.
   ## Ref: https://kubernetes.io/docs/user-guide/services/
@@ -1225,20 +1235,25 @@ web:
 
     ## Annotations to be added to the web service.
     ##
+    ## Example:
+    ##
+    ##   prometheus.io/probe: "true"
+    ##   prometheus.io/probe_path: "/"
+    ##
+    ## When using `web.service.type: LoadBalancer` in AWS, enable HTTPS with an ACM cert:
+    ##
+    ##   service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "arn:aws:acm:eu-west-1:123456789:certificate/abc123-abc123-abc123-abc123"
+    ##   service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
+    ##   service.beta.kubernetes.io/aws-load-balancer-backend-port: "atc"
+    ##   service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+    ##
     annotations:
-    #   prometheus.io/probe: "true"
-    #   prometheus.io/probe_path: "/"
-    #
-    #   ## When using web.service.type: LoadBalancer, enable HTTPS with an ACM cert
-    #   service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "arn:aws:acm:eu-west-1:123456789:certificate/abc123-abc123-abc123-abc123"
-    #   service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
-    #   service.beta.kubernetes.io/aws-load-balancer-backend-port: "atc"
-    #   service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
 
     ## When using `web.service.type: LoadBalancer`, whitelist the load balancer to particular IPs
+    ## Example:
+    ##   - 192.168.1.10/32
     ##
     loadBalancerSourceRanges:
-    #   - 192.168.1.10/32
 
     ## When using `web.service.type: NodePort`, sets the nodePort for atc
     ##
@@ -1261,31 +1276,40 @@ web:
     enabled: false
 
     ## Annotations to be added to the web ingress.
+    ## Example:
+    ##   kubernetes.io/ingress.class: nginx
+    ##   kubernetes.io/tls-acme: 'true'
     ##
     annotations:
-    #   kubernetes.io/ingress.class: nginx
-    #   kubernetes.io/tls-acme: 'true'
 
     ## Hostnames.
     ## Must be provided if Ingress is enabled.
+    ## Example:
+    ##   - concourse.domain.com
     ##
     hosts:
-    #   - concourse.domain.com
 
     ## TLS configuration.
     ## Secrets must be manually created in the namespace.
+    ## Example:
+    ##   - secretName: concourse-web-tls
+    ##     hosts:
+    ##       - concourse.domain.com
     ##
     tls:
-    #   - secretName: concourse-web-tls
-    #     hosts:
-    #       - concourse.domain.com
 
 ## Configuration values for Concourse Worker components.
+## For more information regarding the characteristics of
+## Concourse Workers, see https://concourse-ci.org/concourse-worker.html
 ##
 worker:
   ## Override the components name (defaults to worker).
   ##
   nameOverride:
+
+  ## Removes any previous state created in `concourse.worker.workDir`.
+  ##
+  cleanUpWorkDirOnStart: true
 
   ## Number of replicas.
   ##
@@ -1295,16 +1319,34 @@ worker:
   ## container.
   ##
   ## Example:
+  ##
   ## - name: myapp-container
   ##   image: busybox
   ##   command: ['sh', '-c', 'echo Hello && sleep 3600']
   ##
-  sidecarContainers:
+  sidecarContainers: []
 
   ## Minimum number of workers available after an eviction
   ## Ref: https://kubernetes.io/docs/admin/disruptions/
   ##
   minAvailable: 1
+
+  ## Configures the liveness probe used to determine if the Worker component is up.
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+  ##
+  livenessProbe:
+    failureThreshold: 5
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    timeoutSeconds: 3
+    httpGet:
+      path: /
+      port: worker-hc
+
+  ## Configures the readiness probes.
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+  ##
+  readinessProbe: {}
 
   ## Configure resource requests and limits.
   ## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
@@ -1317,19 +1359,12 @@ worker:
   ## Configure additional environment variables for the
   ## worker container(s)
   ##
-  env:
-  #   - name: http_proxy
-  #     value: "http://proxy.your-domain.com:3128"
-  #   - name: https_proxy
-  #     value: "http://proxy.your-domain.com:3128"
-  #   - name: no_proxy
-  #     value: "your-domain.com"
-  #   - name: CONCOURSE_GARDEN_DNS_SERVER
-  #     value: "8.8.8.8"
-  #   - name: CONCOURSE_GARDEN_DNS_PROXY_ENABLE
-  #     value: "true"
-  #   - name: CONCOURSE_GARDEN_ALLOW_HOST_ACCESS
-  #     value: "true"
+  ## Example:
+  ##
+  ##   - name: CONCOURSE_NAME
+  ##     value: "anything"
+  ##
+  env: []
 
   ## For managing where secrets should be mounted for worker agents
   ##
@@ -1338,53 +1373,62 @@ worker:
   ## Configure additional volumeMounts for the
   ## worker container(s)
   ##
-  additionalVolumeMounts:
-  #   - name: concourse-baggageclaim
-  #     mountPath: /baggageclaim
+  ## Example:
+  ##   - name: concourse-baggageclaim
+  ##     mountPath: /baggageclaim
+  ##
+  additionalVolumeMounts: []
 
   ## Annotations to be added to the worker pods.
   ##
-  annotations:
-  #   iam.amazonaws.com/role: arn:aws:iam::123456789012:role/concourse
-  #
+  ## Example:
+  ##
+  ##   iam.amazonaws.com/role: arn:aws:iam::123456789012:role/concourse
+  ##
+  annotations: {}
 
   ## Node selector for the worker nodes.
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
   ##
-  nodeSelector:
-  # type: concourse
+  nodeSelector: {}
 
   ## Additional affinities to add to the worker pods.
-  ## Useful if you prefer to run workers on non-spot instances, for example
+  ## Useful if you prefer to run workers on non-spot instances, for example.
   ##
-  additionalAffinities:
-  #   nodeAffinity:
-  #     preferredDuringSchedulingIgnoredDuringExecution:
-  #       - weight: 50
-  #         preference:
-  #           matchExpressions:
-  #             - key: spot
-  #               operator: NotIn
-  #               values:
-  #                 - "true"
+  ## Example:
+  ##
+  ##   nodeAffinity:
+  ##     preferredDuringSchedulingIgnoredDuringExecution:
+  ##       - weight: 50
+  ##         preference:
+  ##           matchExpressions:
+  ##             - key: spot
+  ##               operator: NotIn
+  ##               values:
+  ##                 - "true"
+  ##
+  additionalAffinities: {}
 
   ## Configure additional volumes for the
   ## worker container(s).
+  ## Example:
   ##
-  additionalVolumes:
-  #   - name: concourse-baggageclaim
-  #     hostPath:
-  #       path: /dev/nvme0n1
-  #       type: BlockDevice
-  #
-  # As a special exception, this allows taking over the `concourse-work-dir`
-  # volume (from the default emptyDir) if `persistence.enabled` is false:
-  #
-  # additionalVolumes:
-  #   - name: concourse-work-dir
-  #     hostPath:
-  #       path: /mnt/locally-mounted-fast-disk/concourse
-  #       type: DirectoryOrCreate
+  ##  - name: concourse-baggageclaim
+  ##    hostPath:
+  ##      path: /dev/nvme0n1
+  ##      type: BlockDevice
+  ##
+  ##
+  ## As a special exception, this allows taking over the `concourse-work-dir`
+  ## volume (from the default emptyDir) if `persistence.enabled` is false:
+  ##
+  ##   additionalVolumes:
+  ##     - name: concourse-work-dir
+  ##       hostPath:
+  ##         path: /mnt/locally-mounted-fast-disk/concourse
+  ##         type: DirectoryOrCreate
+  ##
+  additionalVolumes: []
 
   ## Whether the workers should be forced to run on separate nodes.
   ## This is accomplished by setting their AntiAffinity with requiredDuringSchedulingIgnoredDuringExecution as opposed to preferred
@@ -1395,24 +1439,20 @@ worker:
   ## Tolerations for the worker nodes.
   ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
-  tolerations:
-  #  - key: "toleration=key"
-  #    operator: "Equal"
-  #    value: "value"
-  #    effect: "NoSchedule"
+  ## For example:
+  ##
+  ##   - key: "toleration=key"
+  ##     operator: "Equal"
+  ##     value: "value"
+  ##     effect: "NoSchedule"
+  ##
+  tolerations: []
 
   ## Time to allow the pod to terminate before being forcefully terminated. This should provide time for
   ## the worker to retire, i.e. drain its tasks. See https://concourse-ci.org/worker-internals.html for worker
   ## lifecycle semantics.
   ##
   terminationGracePeriodSeconds: 60
-
-  ## If any of the strings are found in logs, the worker's livenessProbe will fail and trigger a pod restart.
-  ## Specify one string per line, exact matching is used.
-  ##
-  fatalErrors: |-
-    guardian.api.garden-server.create.failed
-    baggageclaim.api.volume-server.create-volume-async.failed-to-create
 
   ## Strategy for StatefulSet updates (requires Kubernetes 1.6+)
   ## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset
@@ -1679,6 +1719,11 @@ secrets:
   cfClientId:
   cfClientSecret:
   cfCaCert:
+
+  ## Secrets for BitbucketCloud OAuth.
+  ##
+  bitbucketCloudClientId:
+  bitbucketCloudClientSecret:
 
   ## Secrets for GitHub OAuth.
   ##

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1196,7 +1196,7 @@ web:
   ##
   ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
-  annotations:
+  annotations: {}
 
   ## Node selector for web nodes.
   ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -1533,7 +1533,8 @@ postgresql:
     ##
     enabled: true
 
-    ## Concourse data Persistent Volume Storage Class
+    ## Concourse data Persistent Volume Storage Class.
+    ##
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning
     ## If undefined (the default) or set to null, no storageClassName spec is


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR is all about bringing the necessary changes for accomodating the 5.0 release of Concourse. Here you can find the release notes: https://concourse-ci.org/download.html#v500

From the commit message, here's a breakdown of the changes, sorted by three categories: breaking, deprecations, and enhancements.


*BREAKING*:
- `concourse.web.auth.mainTeam.allowAllUsers`, which was previously used
  to allow any logged user to be part of `main`, has now been removed;

- `concourse.worker.bindDebugPort` is now
  `concourse.worker.debugBindPort`;

- `concourse.worker.baggageclaim.bindDebugPort` is now
  `concourse.worker.baggageclaim.debugBindPort`;

- `concourse.worker.garden.*` variables that would previously turn into
  environment variables that got translated to `gdn`-specfic tunings are
  not values that can be set through `concourse.worker.garden` anymore.
  These can still be provided through environment variables though -
  `CONCOURSE_GARDEN_...` works as before.

- the new image is packaged in a slightly different way (see release notes or the `docs` repo directly: [new binary distribution](https://github.com/concourse/docs/blob/888c4175ae80717015cb5975e26afc3afe4e121b/lit/release-notes/v5.0.0.lit#L79-L100)), meaning that the `concourse` binary *does not* live in the same place as before (now it's under `/usr/local/concourse/bin/concourse`) - see https://concourse-ci.org/install.html.


*DEPRECATIONS*:
- `concourse.worker.peerIp` is not used anymore;
- `worker.fatalErrors` are not used anymore in favor of worker
   healthchecks through a specific port (`worker-hc`) in the worker
   container.


*ENHANCEMENTS*:
- reduced complexity in the liveness probe for the worker, removing the
  need for custom scripts to verify its health;
- bitbucket cloud is now supported through
  `secrets.bitbucket-cloud-client*` and other `concourse.web.*`
  configurations;
- AWS region settings can now be configured at environment-var level
  instead of arguments;
- garden configuration can be specified through `ini` files that can be
  passed through `configmap`s;
- RBAC configuration for local users can be specified through
  `configmap`s
- ability to opt-out of the automatic removal of
  `concourse.worker.workDir` contents
- ability to specify whether `land`ing or `retire`ing should be
  performed when terminating the worker pod (through the configuration
  of `worker.shutdownSignal`);
- ability to specify custom readinessProbe for the worker;
- more consistent `values.yaml` examples and documentation.


By the way, `README` might need some updates as well - I'll review that soon 😁 

#### Special notes for your reviewer:

To test it, make sure you properly set `image` and `imageTag`:

```sh
helm upgrade \
  --install \
  --set=image=concourse/concourse-rc \
  --set=imageTag=latest \
  dev .
```

That's needed because `concourse/concourse:5.0.0` is not released yet, and we've not been pushing tags for `concourse/concourse-rc` (5.0 sits in `latest` at this moment - https://github.com/concourse/concourse/issues/3332)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md  (not sure yet)
