### PR TITLE
[stable/ambassador] add option to use old label names

### DIFF
--- a/stable/ambassador/Chart.yaml
+++ b/stable/ambassador/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.50.3
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 1.1.5
+version: 1.2.0
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/stable/ambassador/README.md
+++ b/stable/ambassador/README.md
@@ -55,6 +55,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `image.repository`                 | Image                                                                           | `quay.io/datawire/ambassador` |
 | `image.tag`                        | Image tag                                                                       | `0.50.3`                      |
 | `imagePullSecrets`                 | Image pull secrets                                                              | `[]`                          |
+| `legacyLabels`                     | Set this to use same labels and selectors as datawire/ambassador chart used     | `false`                       |
 | `namespace.name`                   | Set the `AMBASSADOR_NAMESPACE` environment variable                             | `metadata.namespace`          |
 | `podAnnotations`                   | Additional annotations for ambassador pods                                      | `{}`                          |
 | `prometheusExporter.enabled`       | Prometheus exporter side-car enabled                                            | `false`                       |
@@ -130,7 +131,7 @@ $ helm upgrade --install --wait my-release -f values.yaml stable/ambassador
 
 ## Migrating from `datawire/ambassador` chart (chart version 0.40.0 or 0.50.0)
 
-Chart now runs ambassador as non-root by default, so you might need to update your ambassador module config to match this.
+Chart now runs ambassador as non-root by default, so you might need to update your ambassador module config to match this. The chart has changed labels and selectors to match best practices, to ease migration you can set `legacyLabels` to `true` and the chart will template with the old label names.
 
 ### Timings
 

--- a/stable/ambassador/ci/old-labels-values.yaml
+++ b/stable/ambassador/ci/old-labels-values.yaml
@@ -1,0 +1,11 @@
+legacyLabels: true
+
+env:
+  AMBASSADOR_NO_KUBEWATCH: no_kubewatch
+
+ambassadorConfig: |
+  apiVersion: ambassador/v1
+  kind: Module
+  name: ambassador
+  config:
+    service_port: 8080

--- a/stable/ambassador/templates/admin-service.yaml
+++ b/stable/ambassador/templates/admin-service.yaml
@@ -4,10 +4,17 @@ kind: Service
 metadata:
   name: {{ include "ambassador.fullname" . }}-admins
   labels:
+    {{- if .Values.legacyLabels }}
+    app: {{ include "ambassador.name" . }}
+    chart: {{ include "ambassador.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- else }}
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- end }}
 spec:
   type: {{ .Values.adminService.type }}
   ports:
@@ -19,6 +26,11 @@ spec:
       nodePort: {{ .Values.adminService.nodePort }}
       {{- end }}
   selector:
+    {{- if .Values.legacyLabels }}
+    app: {{ include "ambassador.name" . }}
+    release: {{ .Release.Name }}
+    {{- else }}
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- end }}
 {{- end -}}

--- a/stable/ambassador/templates/admin-service.yaml
+++ b/stable/ambassador/templates/admin-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "ambassador.fullname" . }}-admins
+  name: {{ include "ambassador.fullname" . }}-admin
   labels:
     {{- if .Values.legacyLabels }}
     app: {{ include "ambassador.name" . }}

--- a/stable/ambassador/templates/config.yaml
+++ b/stable/ambassador/templates/config.yaml
@@ -4,10 +4,17 @@ kind: ConfigMap
 metadata:
   name: '{{ include "ambassador.fullname" . }}-file-config'
   labels:
+    {{- if .Values.legacyLabels }}
+    app: {{ include "ambassador.name" . }}
+    chart: {{ include "ambassador.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- else }}
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- end }}
 data:
   ambassadorConfig: |-
     {{- .Values.ambassadorConfig | nindent 4 }}

--- a/stable/ambassador/templates/deployment.yaml
+++ b/stable/ambassador/templates/deployment.yaml
@@ -7,23 +7,40 @@ kind: Deployment
 metadata:
   name: {{ include "ambassador.fullname" . }}
   labels:
+    {{- if .Values.legacyLabels }}
+    app: {{ include "ambassador.name" . }}
+    chart: {{ include "ambassador.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- else }}
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- end }}
 spec:
 {{- if not .Values.daemonSet }}
   replicas: {{ .Values.replicaCount }}
 {{- end }}
   selector:
     matchLabels:
+      {{- if .Values.legacyLabels }}
+      app: {{ include "ambassador.name" . }}
+      release: {{ .Release.Name }}
+      {{- else }}
       app.kubernetes.io/name: {{ include "ambassador.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- end }}
   template:
     metadata:
       labels:
+        {{- if .Values.legacyLabels }}
+        app: {{ include "ambassador.name" . }}
+        release: {{ .Release.Name }}
+        {{- else }}
         app.kubernetes.io/name: {{ include "ambassador.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
       {{- if .Values.podAnnotations }}

--- a/stable/ambassador/templates/exporter-config.yaml
+++ b/stable/ambassador/templates/exporter-config.yaml
@@ -4,10 +4,17 @@ kind: ConfigMap
 metadata:
   name: '{{ include "ambassador.fullname" . }}-exporter-config'
   labels:
+    {{- if .Values.legacyLabels }}
+    app: {{ include "ambassador.name" . }}
+    chart: {{ include "ambassador.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- else }}
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- end }}
 data:
   exporterConfiguration:
 {{- if .Values.prometheusExporter.configuration }} |

--- a/stable/ambassador/templates/rbac.yaml
+++ b/stable/ambassador/templates/rbac.yaml
@@ -8,10 +8,17 @@ kind: ClusterRole
 metadata:
   name: {{ include "ambassador.fullname" . }}
   labels:
+    {{- if .Values.legacyLabels }}
+    app: {{ include "ambassador.name" . }}
+    chart: {{ include "ambassador.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- else }}
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- end }}
 rules:
   - apiGroups: [""]
     resources:
@@ -33,10 +40,17 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "ambassador.fullname" . }}
   labels:
+    {{- if .Values.legacyLabels }}
+    app: {{ include "ambassador.name" . }}
+    chart: {{ include "ambassador.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- else }}
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   {{- if .Values.rbac.namespaced }}

--- a/stable/ambassador/templates/service.yaml
+++ b/stable/ambassador/templates/service.yaml
@@ -3,10 +3,17 @@ kind: Service
 metadata:
   name: {{ include "ambassador.fullname" . }}
   labels:
+    {{- if .Values.legacyLabels }}
+    app: {{ include "ambassador.name" . }}
+    chart: {{ include "ambassador.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- else }}
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- end }}
   {{- with .Values.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -40,8 +47,13 @@ spec:
       {{- end }}
     {{- end }}
   selector:
+    {{- if .Values.legacyLabels }}
+    app: {{ include "ambassador.name" . }}
+    release: {{ .Release.Name }}
+    {{- else }}
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- end }}
   {{- with .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- toYaml . | nindent 4 }}

--- a/stable/ambassador/templates/serviceaccount.yaml
+++ b/stable/ambassador/templates/serviceaccount.yaml
@@ -4,8 +4,15 @@ kind: ServiceAccount
 metadata:
   name: {{ include "ambassador.serviceAccountName" . }}
   labels:
+    {{- if .Values.legacyLabels }}
+    app: {{ include "ambassador.name" . }}
+    chart: {{ include "ambassador.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- else }}
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- end }}
 {{- end -}}

--- a/stable/ambassador/values.yaml
+++ b/stable/ambassador/values.yaml
@@ -5,6 +5,9 @@
 replicaCount: 3
 daemonSet: false
 
+# Set to true to use same labels and selectors as datawire/ambassador chart used
+legacyLabels: false
+
 ambassador:
   id: default
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

When moving the ambassador chart to helm/charts we made a few breaking changes including changing labels which make migration from the old chart a bit of a headache.

#### Which issue this PR fixes

  - fixes datawire/ambassador#1268

#### Special notes for your reviewer:

Adds a bit of a mess to the templates but suppose thats worth it to make migration easier :) 
Also removes the `s` in admin service name which was accidentally added. Not sure if we should leave it be or remove it to match the old chart again :) 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
