### PR TITLE
docker-registry: added new ingress annotation for body size

### DIFF
--- a/stable/docker-registry/Chart.yaml
+++ b/stable/docker-registry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Docker Registry
 name: docker-registry
-version: 1.7.0
+version: 1.7.1
 appVersion: 2.6.2
 home: https://hub.docker.com/_/registry/
 icon: https://hub.docker.com/public/images/logos/mini-logo.svg

--- a/stable/docker-registry/values.yaml
+++ b/stable/docker-registry/values.yaml
@@ -33,6 +33,7 @@ ingress:
     - chart-example.local
   annotations:
     # kubernetes.io/ingress.class: nginx
+    # nginx.ingress.kubernetes.io/proxy-body-size: "0"
     # kubernetes.io/tls-acme: "true"
   labels: {}
   tls:


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix the problem when I push docker image to the docker-registry and nginx throw exception "413 Request Entity Too Large"

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist