### PR TITLE
hoard mount yaml configuration

### DIFF
--- a/stable/hoard/Chart.yaml
+++ b/stable/hoard/Chart.yaml
@@ -1,6 +1,6 @@
 name: hoard
-version: 0.6.6
-appVersion: 3.0.0
+version: 0.6.7
+appVersion: 3.0.1
 description: Hoard is a stateless, deterministically encrypted, content-addressed object store
 home: https://github.com/monax/hoard
 icon: https://pbs.twimg.com/profile_images/781959787856687105/76s1CJER_400x400.jpg

--- a/stable/hoard/README.md
+++ b/stable/hoard/README.md
@@ -32,14 +32,23 @@ The following table lists the configurable parameters of the Hoard chart and its
 | --------- | ----------- | ------- |
 | `replicaCount` | number of daemons | `1` |
 | `image.repository` | docker image | `"quay.io/monax/hoard"` |
-| `image.tag` | version | `"3.0.0"` |
+| `image.tag` | version | `"3.0.1"` |
 | `image.pullPolicy` | pull policy | `"IfNotPresent"` |
-| `storage.type` | backend object store (aws, azure, filesystem, gcp, ipfs)| `"filesystem"` |
-| `storage.remote` | remote api location (ipfs only) | `""` |
-| `storage.region` | object store location (cloud only) | `""` |
-| `storage.bucket` | object storage container (cloud only) | `""` |
-| `storage.prefix` | bucket folder (cloud only) | `""` |
-| `storage.secret` | required secret for cloud providers | `""` |
+| `config.listenaddress` | address to listen on | `tcp://:53431` |
+| `config.storage.storagetype` | backend object store (aws, azure, filesystem, gcp, ipfs) | `filesystem` |
+| `config.storage.addressencoding` | object address encoding | `base64` |
+| `config.storage.filesystemconfig.rootdirectory` | object address encoding | `"/data"` |
+| `config.storage.cloudconfig.bucket` | object storage container (cloud only) | `""` |
+| `config.storage.cloudconfig.prefix` | bucket folder (cloud only) | `""` |
+| `config.storage.cloudconfig.region` | object store location (cloud only) | `""` |
+| `config.storage.ipfsconfig.remoteapi` | remote api location (ipfs only) | `""` |
+| `config.logging.loggingtype` | format for logging output | `"json"` |
+| `config.logging.channels` | logging types | `[]` |
+| `config.secrets.symmetric` | symmetric secrets (publicid, passphrase) | `[]` |
+| `config.secrets.openpgp.privateid` | id of private key to sign with | `""` |
+| `config.secrets.openpgp.file` | name of the file mounted from secret | `"/secrets/keyring"` |
+| `secrets.creds` | required secret for cloud providers | `"cloud-credentials"` |
+| `secrets.keyring` | required secret for openpgp grants | `"private-keyring"` |
 | `persistence.size` | size of local store | `"10Gi"` |
 | `persistence.storageClass` | pvc type | `"standard"` |
 | `persistence.accessMode` | pvc access | `"ReadWriteOnce"` |

--- a/stable/hoard/templates/configmap.yaml
+++ b/stable/hoard/templates/configmap.yaml
@@ -8,36 +8,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "hoard.chart" . }}
 data:
-  hoard.toml: |
-    ListenAddress = "tcp://0.0.0.0:{{ .Values.service.port }}"
-
-    [Storage]
-      StorageType = "{{ .Values.storage.type }}"
-      AddressEncoding = "{{ .Values.storage.encoding }}"
-      RootDirectory = "/data"
-      RemoteAPI = "{{ .Values.storage.remote }}"
-      Bucket = "{{ .Values.storage.bucket }}"
-      Prefix = "{{ .Values.storage.prefix }}"
-      Region = "{{ .Values.storage.region }}"
-
-    [Logging]
-      LoggingType = "{{ .Values.logging.type }}"
-      Channels = [{{- range .Values.logging.channels }}{{ . | quote }},{{- end }}]
-
-{{- if .Values.openpgp }}
-
-    [Secrets.OpenPGP]
-      PrivateID = "{{ .Values.openpgp.id }}"
-      File = "/secrets/keyring"
-
-{{- end }}
-
-{{- range $key, $val := .Values.secrets }}
-
-    [[Secrets.Symmetric]] 
-      PublicID = {{ $key | quote }}
-      Passphrase = {{ $val | quote }} 
-
-{{- end }}
-
+  hoard.conf: |
+{{ toYaml .Values.config | indent 4 }}
     

--- a/stable/hoard/templates/deployment.yaml
+++ b/stable/hoard/templates/deployment.yaml
@@ -23,52 +23,52 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command: ["hoard", "--config", "/conf/hoard.toml"]
+        command: ["hoard", "--config", "/conf/hoard.conf"]
         volumeMounts:
-        - name: config-toml
+        - name: config-file
           mountPath: /conf
-{{- if eq .Values.storage.type "filesystem" }}
-        - mountPath: /data
+{{- if eq .Values.config.storage.storagetype "filesystem" }}
+        - mountPath: {{ required "A valid directory is required." .Values.config.storage.filesystemconfig.rootdirectory }}
           name: data-dir
 {{- end }}
-{{- if .Values.openpgp }}
+{{- if ne .Values.config.secrets.openpgp.privateid "" }}
         - mountPath: /secrets
-          subPath: keyring
+          subPath: {{ required "A valid file name is required." .Values.config.secrets.openpgp.file }}
           name: key-ring
 {{- end }}
         ports:
           - containerPort: {{ .Values.service.port }}
             name: http
         env:
-{{- if eq .Values.storage.type "aws" }}
+{{- if eq .Values.config.storage.storagetype "aws" }}
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
-              name: {{ required "A valid storage credential is required." .Values.storage.secret }}
+              name: {{ required "A valid storage credential is required." .Values.secrets.creds }}
               key: access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ required "A valid storage credential is required." .Values.storage.secret }}
+              name: {{ required "A valid storage credential is required." .Values.secrets.creds }}
               key: secret-access-key
 {{- end }}
-{{- if eq .Values.storage.type "azure" }}
+{{- if eq .Values.config.storage.storagetype "azure" }}
         - name: AZURE_STORAGE_ACCOUNT_NAME
           valueFrom:
             secretKeyRef:
-              name: {{ required "A valid storage credential is required." .Values.storage.secret }}
+              name: {{ required "A valid storage credential is required." .Values.secrets.creds }}
               key: storage-account-name
         - name: AZURE_STORAGE_ACCOUNT_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ required "A valid storage credential is required." .Values.storage.secret }}
+              name: {{ required "A valid storage credential is required." .Values.secrets.creds }}
               key: storage-account-key
 {{- end }}
-{{- if eq .Values.storage.type "gcp" }}
+{{- if eq .Values.config.storage.storagetype "gcp" }}
         - name: GCLOUD_SERVICE_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ required "A valid storage credential is required." .Values.storage.secret }}
+              name: {{ required "A valid storage credential is required." .Values.secrets.creds }}
               key: service-key
 {{- end }}
         livenessProbe:
@@ -82,18 +82,18 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:
-      - name: config-toml
+      - name: config-file
         configMap:
           name: {{ template "hoard.fullname" . }}
-{{- if eq .Values.storage.type "filesystem" }}
+{{- if eq .Values.config.storage.storagetype "filesystem" }}
       - name: data-dir
         persistentVolumeClaim:
           claimName: {{ template "hoard.fullname" $ }}
 {{- end }}
-{{- if .Values.openpgp }}
+{{- if ne .Values.config.secrets.openpgp.privateid "" }}
       - name: key-ring
         secret:
-          secretName: {{ required "A valid keyring is required." .Values.openpgp.secret }}
+          secretName: {{ required "A valid keyring is required." .Values.secrets.keyring }}
 {{- end }}
 {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/stable/hoard/templates/pvc.yaml
+++ b/stable/hoard/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.storage.type "filesystem" }}
+{{- if eq .Values.config.storage.storagetype "filesystem" }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/stable/hoard/values.yaml
+++ b/stable/hoard/values.yaml
@@ -2,24 +2,37 @@ replicaCount: 1
 
 image:
   repository: quay.io/monax/hoard
-  tag: 3.0.0
+  tag: 3.0.1
   pullPolicy: IfNotPresent
 
-storage:
-  # aws | azure | filesystem | gcp | ipfs
-  type: filesystem
-  remote: ""
-  bucket: ""
-  prefix: ""
-  region: ""
-  secret: ""
-  encoding: base64
+config:
+  listenaddress: tcp://:53431
+  storage:
+    # aws | azure | filesystem | gcp | ipfs
+    storagetype: filesystem
+    addressencoding: base64
+    filesystemconfig:
+      rootdirectory: "/data"
+    cloudconfig:
+      bucket: ""
+      prefix: ""
+      region: ""
+    ipfsconfig:
+      remoteapi: ""
+  logging:
+    loggingtype: json
+    channels:
+    - info
+    - trace
+  secrets:
+    symmetric: []
+    openpgp:
+      privateid: ""
+      file: "keyring"
 
-logging:
-  type: json
-  channels:
-  - info
-  - trace
+secrets:
+  creds: "cloud-credentials"
+  keyring: "private-keyring"
 
 # only filesystem
 persistence:
@@ -29,13 +42,6 @@ persistence:
   persistentVolumeReclaimPolicy: "Retain"
   annotations:
     "helm.sh/resource-policy": keep
-
-# openpgp:
-#   id: "10449759736975846181"
-#   secret: "private-keyring"
-# secrets:
-#   key1: passphrase1
-#   key2: passphrase2
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Signed-off-by: Gregory Hill <greg.hill@monax.io>

To simplify configuration, we've integrated yaml support into hoard s.t. we can simply call `toYaml` when building the configmap.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
