### PR TITLE
[stable/wordpress] Allow setting custom sidecar containers

### DIFF
--- a/stable/nats/README.md
+++ b/stable/nats/README.md
@@ -163,6 +163,17 @@ sidecars:
    containerPort: 1234
 ```
 
+If these sidecars export extra ports, you can add extra port definitions using the `service.extraPorts` value:
+
+```yaml
+service:
+...
+  extraPorts:
+  - name: extraPort
+    port: 11311
+    targetPort: 11311
+```
+
 ## Production settings and horizontal scaling
 
 The [values-production.yaml](values-production.yaml) file consists a configuration to deploy a scalable and high-available NATS deployment for production environments. We recommend that you base your production configuration on this template and adjust the parameters appropriately.

--- a/stable/nats/README.md
+++ b/stable/nats/README.md
@@ -163,17 +163,6 @@ sidecars:
    containerPort: 1234
 ```
 
-If these sidecars export extra ports, you can add extra port definitions using the `service.extraPorts` value:
-
-```yaml
-service:
-...
-  extraPorts:
-  - name: extraPort
-    port: 11311
-    targetPort: 11311
-```
-
 ## Production settings and horizontal scaling
 
 The [values-production.yaml](values-production.yaml) file consists a configuration to deploy a scalable and high-available NATS deployment for production environments. We recommend that you base your production configuration on this template and adjust the parameters appropriately.

--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 5.2.6
+version: 5.3.0
 appVersion: 5.1.0
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 5.3.0
+version: 5.4.0
 appVersion: 5.1.0
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -119,6 +119,7 @@ The following table lists the configurable parameters of the WordPress chart and
 | `metrics.image.pullSecrets`      | Specify docker-registry secret names as an array        | `[]` (does not add image pull secrets to deployed pods)        |
 | `metrics.podAnnotations`         | Additional annotations for Metrics exporter pod         | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}`   |
 | `metrics.resources`              | Exporter resource requests/limit           | {}                                                      |
+| `sidecars`                           | Attach additional containers to the pod                                                      | `nil`                                                         |
 
 The above parameters map to the env variables defined in [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress). For more information please refer to the [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress) image documentation.
 
@@ -156,6 +157,19 @@ Note that [values-production.yaml](values-production.yaml) includes a replicaCou
 $ helm install stable/nfs-server-provisioner --set persistence.enabled=true,persistence.size=10Gi
 $ helm install --name my-release -f values-production.yaml --set persistence.storageClass=nfs stable/wordpress --set mariadb.master.persistence.storageClass=nfs
 ```
+
+## Sidecars
+
+If you have a need for additional containers to run within the same pod as WordPress (e.g. an additional metrics or logging exporter), you can do so via the `sidecars` config parameter. Simply define your container according to the Kubernetes container spec.
+
+```yaml
+sidecars:
+- name: your-image-name
+  image: your-image
+  imagePullPolicy: Always
+  ports:
+  - name: portname
+   containerPort: 1234
 
 ## Persistence
 

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -89,6 +89,7 @@ The following table lists the configurable parameters of the WordPress chart and
 | `service.externalTrafficPolicy`  | Enable client source IP preservation       | `Cluster`                                               |
 | `service.nodePorts.http`         | Kubernetes http node port                  | `""`                                                    |
 | `service.nodePorts.https`        | Kubernetes https node port                 | `""`                                                    |
+| `service.extraPorts`            | Extra ports to expose in the service (normally used with the `sidecar` value)                        | `nil`                                                    |
 | `healthcheckHttps`               | Use https for liveliness and readiness     | `false`                                                 |
 | `livenessProbeHeaders`           | Headers to use for livenessProbe           | `nil`                                                   |
 | `readinessProbeHeaders`          | Headers to use for readinessProbe          | `nil`                                                   |

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -172,6 +172,17 @@ sidecars:
   - name: portname
    containerPort: 1234
 
+If these sidecars export extra ports, you can add extra port definitions using the `service.extraPorts` value:
+
+```yaml
+service:
+...
+  extraPorts:
+  - name: extraPort
+    port: 11311
+    targetPort: 11311
+```
+
 ## Persistence
 
 The [Bitnami WordPress](https://github.com/bitnami/bitnami-docker-wordpress) image stores the WordPress data and configurations at the `/bitnami` path of the container.

--- a/stable/wordpress/templates/deployment.yaml
+++ b/stable/wordpress/templates/deployment.yaml
@@ -203,6 +203,9 @@ spec:
         resources:
 {{ toYaml .Values.metrics.resources | indent 10 }}
 {{- end }}
+{{- if .Values.sidecars }}
+{{ toYaml .Values.sidecars | indent 6 }}
+{{- end }}
       volumes:
       {{- if and .Values.allowOverrideNone .Values.customHTAccessCM}}
       - name: custom-htaccess

--- a/stable/wordpress/templates/svc.yaml
+++ b/stable/wordpress/templates/svc.yaml
@@ -29,5 +29,8 @@ spec:
       {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePorts.https)))}}
       nodePort: {{ .Values.service.nodePorts.https }}
       {{- end }}
+{{- if .Values.service.extraPorts }}
+{{ toYaml .Values.service.extraPorts | indent 6 }}
+{{- end }}      
   selector:
     app: "{{ template "wordpress.fullname" . }}"

--- a/stable/wordpress/values-production.yaml
+++ b/stable/wordpress/values-production.yaml
@@ -306,3 +306,13 @@ metrics:
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
   # resources: {}
+
+sidecars:
+## Add sidecars to the pod.
+## e.g.
+# - name: your-image-name
+  # image: your-image
+  # imagePullPolicy: Always
+  # ports:
+  # - name: portname
+  #   containerPort: 1234

--- a/stable/wordpress/values-production.yaml
+++ b/stable/wordpress/values-production.yaml
@@ -159,6 +159,8 @@ service:
   ##
   externalTrafficPolicy: Local
   annotations: {}
+  ## Extra ports to expose (normally used with the `sidecar` value)
+  # extraPorts:
 
 ## Allow health checks to be pointed at the https port
 healthcheckHttps: false

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -164,6 +164,8 @@ service:
   ##
   externalTrafficPolicy: Cluster
   annotations: {}
+  ## Extra ports to expose (normally used with the `sidecar` value)
+  # extraPorts:
 
 ## Allow health checks to be pointed at the https port
 healthcheckHttps: false

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -309,3 +309,13 @@ metrics:
     ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
     ##
   # resources: {}
+
+sidecars:
+## Add sidecars to the pod.
+## e.g.
+# - name: your-image-name
+  # image: your-image
+  # imagePullPolicy: Always
+  # ports:
+  # - name: portname
+  #   containerPort: 1234


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
There are workflows where using extra sidecar containers is required (for example, setting a SFTP server). This PR allows setting extra sidecar containers and expose extra ports in the service, in case it is required.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes https://github.com/helm/charts/issues/11882

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
