### PR TITLE
fix: double quotes issue in stable/mariadb

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb
-version: 5.7.0
+version: 5.7.1
 appVersion: 10.1.38
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/templates/role.yaml
+++ b/stable/mariadb/templates/role.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     app: "{{ template "mariadb.name" . }}"
     chart: "{{ template "mariadb.chart" . }}"
-    release: "{{ .Release.Name | quote }}"
-    heritage: "{{ .Release.Service | quote }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 rules:
 - apiGroups:
     - ""

--- a/stable/mariadb/templates/rolebinding.yaml
+++ b/stable/mariadb/templates/rolebinding.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     app: "{{ template "mariadb.name" . }}"
     chart: "{{ template "mariadb.chart" . }}"
-    release: "{{ .Release.Name | quote }}"
-    heritage: "{{ .Release.Service | quote }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "mariadb.serviceAccountName" . }}

--- a/stable/mariadb/templates/serviceaccount.yaml
+++ b/stable/mariadb/templates/serviceaccount.yaml
@@ -6,6 +6,6 @@ metadata:
   labels:
     app: "{{ template "mariadb.name" . }}"
     chart: "{{ template "mariadb.chart" . }}"
-    release: "{{ .Release.Name | quote }}"
-    heritage: "{{ .Release.Service | quote }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 {{- end }}


### PR DESCRIPTION
#### Which issue this PR fixes
fix double quotes issue during the installation with `serviceAccount.create=true  rbac.create=true`
```sh
helm install stable/mariadb --set serviceAccount.create=true --set rbac.create=true
Error: YAML parse error on mariadb/templates/serviceaccount.yaml: error converting YAML to JSON: yaml: line 7: did not find expected key
```
#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
