### PR TITLE
[incubator/sparkoperator] add ConfigMap update to sparkoperator clusterrole

### DIFF
--- a/incubator/sparkoperator/Chart.yaml
+++ b/incubator/sparkoperator/Chart.yaml
@@ -1,6 +1,6 @@
 name: sparkoperator
 description: A Helm chart for Spark on Kubernetes operator
-version: 0.1.10
+version: 0.1.11
 appVersion: v1beta1-0.7-2.4.0
 kubeVersion: ">=1.8.0-0"
 keywords:

--- a/incubator/sparkoperator/templates/spark-operator-rbac.yaml
+++ b/incubator/sparkoperator/templates/spark-operator-rbac.yaml
@@ -14,7 +14,7 @@ rules:
   verbs: ["*"]
 - apiGroups: [""]
   resources: ["services", "configmaps", "secrets"]
-  verbs: ["create", "get", "delete"]
+  verbs: ["create", "get", "delete", "update"]
 - apiGroups: ["extensions"]
   resources: ["ingresses"]
   verbs: ["create", "get", "delete"]


### PR DESCRIPTION
Signed-off-by: Grzegorz Lyczba <grzegorz.lyczba@gmail.com>
@yuchaoran2011 

#### Which issue this PR fixes
Spark operator want to update prometheus ConfigMap while resubmitting application what ends with an error right now:
```
E0304 22:32:09.310899      12 controller.go:553] failed to apply app-prom-conf in namespace appns: configmaps "app-prom-conf" is forbidden: User "system:serviceaccount:spark:spark-operator-sparkoperator" cannot update configmaps in the namespace "appns"
```


#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
