### PR TITLE
Adds PodDisruptionBudget to OPA

### DIFF
--- a/stable/opa/Chart.yaml
+++ b/stable/opa/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - opa
 - admission control
 - policy
-version: 1.2.0
+version: 1.3.0
 home: https://www.openpolicyagent.org
 icon: https://raw.githubusercontent.com/open-policy-agent/opa/master/logo/logo.png
 sources:

--- a/stable/opa/README.md
+++ b/stable/opa/README.md
@@ -64,8 +64,8 @@ Reference](https://www.openpolicyagent.org/docs/configuration.html).
 | `admissionControllerCert` | Manually set admission controller certificate. | Unset |
 | `admissionControllerKey` | Manually set admission controller key. | Unset |
 | `podDisruptionBudget.enabled` | Enables creation of a PodDisruptionBudget for OPA. | `false` |
-| `podDisruptionBudget.minAvailable` | Sets the minimum number of pods to be available. Cannot be set at the same time as maxUnavailable. | `false` |
-| `podDisruptionBudget.maxUnavailable` | Sets the maximum number of pods to be unavailable. Cannot be set at the same time as minAvailable. | `false` |
+| `podDisruptionBudget.minAvailable` | Sets the minimum number of pods to be available. Cannot be set at the same time as maxUnavailable. | `1` |
+| `podDisruptionBudget.maxUnavailable` | Sets the maximum number of pods to be unavailable. Cannot be set at the same time as minAvailable. | Unset |
 | `image` | OPA image to deploy. | `openpolicyagent/opa` |
 | `imageTag` | OPA image tag to deploy. | See [values.yaml](values.yaml) |
 | `logLevel` | Log level that OPA outputs at, (`debug`, `info` or `error`) | `info` |

--- a/stable/opa/README.md
+++ b/stable/opa/README.md
@@ -63,6 +63,9 @@ Reference](https://www.openpolicyagent.org/docs/configuration.html).
 | `admissionControllerCA` | Manually set admission controller certificate CA. | Unset |
 | `admissionControllerCert` | Manually set admission controller certificate. | Unset |
 | `admissionControllerKey` | Manually set admission controller key. | Unset |
+| `podDisruptionBudget.enabled` | Enables creation of a PodDisruptionBudget for OPA. | `false` |
+| `podDisruptionBudget.minAvailable` | Sets the minimum number of pods to be available. Cannot be set at the same time as maxUnavailable. | `false` |
+| `podDisruptionBudget.maxUnavailable` | Sets the maximum number of pods to be unavailable. Cannot be set at the same time as minAvailable. | `false` |
 | `image` | OPA image to deploy. | `openpolicyagent/opa` |
 | `imageTag` | OPA image tag to deploy. | See [values.yaml](values.yaml) |
 | `logLevel` | Log level that OPA outputs at, (`debug`, `info` or `error`) | `info` |

--- a/stable/opa/templates/poddisruptionbudget.yaml
+++ b/stable/opa/templates/poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "opa.fullname" . }}
+  labels:
+{{ include "opa.labels.standard" . | indent 4 }}
+spec:
+{{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "opa.fullname" . }}
+{{- end }}

--- a/stable/opa/values.yaml
+++ b/stable/opa/values.yaml
@@ -28,6 +28,13 @@ admissionControllerRules:
     apiVersions: ["*"]
     resources: ["*"]
 
+# Controls a PodDisruptionBudget for the OPA pod. Suggested use if having opa
+# always running for admission control is important
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  #maxUnavailable: 1
+
 # The helm Chart will automatically generate a CA and server certificate for
 # the OPA. If you want to supply your own certificates, set the field below to
 # false and add the PEM encoded CA certificate and server key pair below.

--- a/stable/opa/values.yaml
+++ b/stable/opa/values.yaml
@@ -33,7 +33,7 @@ admissionControllerRules:
 podDisruptionBudget:
   enabled: false
   minAvailable: 1
-  #maxUnavailable: 1
+# maxUnavailable: 1
 
 # The helm Chart will automatically generate a CA and server certificate for
 # the OPA. If you want to supply your own certificates, set the field below to


### PR DESCRIPTION
#### What this PR does / why we need it:
Sets a PDB for the OPA pod. Important for cases where OPA is an admission controller and all requests must go through OPA but `Ignore` may be set or downtime/errors are not wanted.

#### Which issue this PR fixes
No current issue for this

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
