### PR TITLE
[cockroachdb] Document that windows hostpath provisioner is not suppo…

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 2.1.0
+version: 2.1.1
 appVersion: 2.1.5
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites Details
 * Kubernetes 1.8
-* PV support on the underlying infrastructure
+* PV support on the underlying infrastructure. [Docker for windows hostpath provisioner is not supported](https://github.com/cockroachdb/docs/issues/3184).
 * If you want to secure your cluster to use TLS certificates for all network
   communication, [Helm must be installed with RBAC
   privileges](https://github.com/kubernetes/helm/blob/master/docs/rbac.md)


### PR DESCRIPTION
…rted

Signed-off-by: Jonas Eckerström <jonaseck@gmail.com>

#### What this PR does / why we need it:

You can't run cockroachdb in docker for windows kubernetes due to file system issues when using the hostpath provisioner. Works great for linux and MacOs though and the suggested solution for windows is not to use windows... https://github.com/cockroachdb/docs/issues/3184#issuecomment-461506063

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x ] Chart Version bumped
- [x] Variables are documented in the README.md
