### PR TITLE
[stable/elasticsearch-exporter] fix non working servicemonitor

### DIFF
--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 1.1.2
+version: 1.1.3
 appVersion: 1.0.2
 home: https://github.com/justwatchcom/elasticsearch_exporter
 sources:

--- a/stable/elasticsearch-exporter/templates/servicemonitor.yaml
+++ b/stable/elasticsearch-exporter/templates/servicemonitor.yaml
@@ -16,7 +16,7 @@ spec:
   endpoints:
   - interval: 10s
     honorLabels: true
-    port: "{{ .Values.service.httpPort }}"
+    port: http
     path: {{ .Values.web.path }}
     scheme: http
   jobLabel: "{{ .Release.Name }}"


### PR DESCRIPTION
#### Which issue this PR fixes
  - fixes wrong usage of `port` for servicemonitor. `port` only allows the name of the port. `targetPort` would allow the port number. Without this change, the servicemonitor never gets scraped.
