### PR TITLE
[stable/mariadb] Fix naming of StatefulSets

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb
-version: 5.7.1
+version: 5.7.2
 appVersion: 10.1.38
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/templates/_helpers.tpl
+++ b/stable/mariadb/templates/_helpers.tpl
@@ -26,14 +26,14 @@ If release name contains chart name it will be used as a full name.
 
 {{- define "master.fullname" -}}
 {{- if .Values.replication.enabled -}}
-{{- printf "%s-%s" .Release.Name "mariadb-master" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" (include "mariadb.fullname" .) "master" | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
+{{- include "mariadb.fullname" . -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "slave.fullname" -}}
-{{- printf "%s-%s" .Release.Name "mariadb-slave" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" (include "mariadb.fullname" .) "slave" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "mariadb.chart" -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

All the resources created by MariaDB charts are using `mariadb.fullname` for naming, therefore making it possible to deploy multiple instances of MariaDB charts in a single release (and use `nameOverrider`/`fullnameOverride`). However both of the `StatefulSet` resources are using hardcoded names (`mariadb-master` and `mariadb-slaves`) making chart's naming and behaviour inconsistent.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped