### PR TITLE
add support for monitoring-service

### DIFF
--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,5 +1,5 @@
 name: hazelcast
-version: 1.2.0
+version: 1.3.0
 appVersion: "3.11"
 description: Hazelcast IMDG is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.
 keywords:

--- a/stable/hazelcast/templates/monitoring-service.yaml
+++ b/stable/hazelcast/templates/monitoring-service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.monitoringService.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "hazelcast.fullname" . }}-monitoring
+  labels:
+    app: {{ template "hazelcast.name" . }}
+    chart: {{ template "hazelcast.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+{{ toYaml .Values.monitoringService.annotations | indent 4 }}
+spec:
+  type: {{ .Values.monitoringService.type }}
+  selector:
+    app: {{ template "hazelcast.name" . }}
+    release: "{{ .Release.Name }}"
+  ports:
+  - protocol: TCP
+    port: {{ .Values.monitoringService.port }}
+    targetPort: monitoring
+    name: monitoring
+{{- end }}

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -45,6 +45,10 @@ spec:
         ports:
         - name: hazelcast
           containerPort: 5701
+        {{- if .Values.monitoringService.enabled }}
+        - name: monitoring
+          containerPort: {{ .Values.monitoringService.port }}
+        {{- end }}
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -132,3 +132,12 @@ securityContext:
   readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   defaultAllowPrivilegeEscalation: false
+
+# Allows to enable a Prometheus service to scrape pods, if using a custom image like https://hub.docker.com/r/evryfs/hazelcast-prometheus
+monitoringService:
+  enabled: false
+  type: ClusterIP
+  port: 8080
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: "/metrics"


### PR DESCRIPTION
Signed-off-by: David J. M. Karlsen <david@davidkarlsen.com>

#### What this PR does / why we need it:
Supports adding a monitoring service port for prometheus.
This requires a customized image, and thus is configured as opt-in.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
