### PR TITLE
[incubator/vault] allow usage of config in existing configmap

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.14.10
+version: 0.14.11
 appVersion: 1.0.1
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.14.9
+version: 0.14.10
 appVersion: 1.0.1
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -57,6 +57,7 @@ The following table lists the configurable parameters of the Vault chart and the
 | `vault.extraContainers`           | Sidecar containers to add to the vault pod | `{}`                              |
 | `vault.extraVolumes`              | Additional volumes to the controller pod | `{}`                                |
 | `vault.customSecrets`             | Custom secrets available to Vault        | `[]`                                |
+| `vault.existingConfigName`        | Location of existing Vault configuration | nil                                 |
 | `vault.config`                    | Vault configuration                      | No default backend                  |
 | `replicaCount`                    | k8s replicas                             | `3`                                 |
 | `resources.limits.cpu`            | Container requested CPU                  | `nil`                               |

--- a/incubator/vault/templates/configmap.yaml
+++ b/incubator/vault/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.vault.existingConfigName }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,3 +11,4 @@ metadata:
 data:
   config.json: |
     {{ .Values.vault.config | toJson }}
+{{ end }}

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -128,7 +128,7 @@ spec:
       volumes:
         - name: vault-config
           configMap:
-            name: "{{ template "vault.fullname" . }}-config"
+            name: {{ if .Values.vault.existingConfigName }}{{ .Values.vault.existingConfigName }}{{- else }}"{{ template "vault.fullname" . }}-config"{{- end }}
         - name: vault-root
           emptyDir: {}
         {{- range .Values.vault.customSecrets }}

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -139,6 +139,8 @@ vault:
     readyIfSealed: false
     readyIfStandby: true
     readyIfUninitialized: true
+  # Use an existing config in a named ConfigMap
+  #existingConfigName: vault-cm
   config:
     # A YAML representation of a final vault config.json file.
     # See https://www.vaultproject.io/docs/configuration/ for more information.

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -139,8 +139,8 @@ vault:
     readyIfSealed: false
     readyIfStandby: true
     readyIfUninitialized: true
-  # Use an existing config in a named ConfigMap
-  #existingConfigName: vault-cm
+  ## Use an existing config in a named ConfigMap
+  # existingConfigName: vault-cm
   config:
     # A YAML representation of a final vault config.json file.
     # See https://www.vaultproject.io/docs/configuration/ for more information.


### PR DESCRIPTION
Signed-off-by: Louise Champ <louise@livewyer.com>

#### What this PR does / why we need it:

This PR is intended to support production environments which may want to define the configuration outside of the values file (eg, credentials provided for storage backends and sealing)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
