### PR TITLE
[stable/jaeger-operator] Update Jaeger operator permissions

### DIFF
--- a/stable/jaeger-operator/Chart.yaml
+++ b/stable/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.3.0
+version: 2.3.1
 appVersion: 1.10.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/stable/jaeger-operator/templates/role.yaml
+++ b/stable/jaeger-operator/templates/role.yaml
@@ -26,6 +26,7 @@ rules:
   - events
   - configmaps
   - secrets
+  - serviceaccounts
   verbs:
   - "*"
 - apiGroups:
@@ -49,4 +50,42 @@ rules:
   - jobs
   - cronjobs
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - "*"
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - '*'
+- apiGroups:
+  - elasticsearch.jaegertracing.io
+  resources:
+  - jaeger
+  verbs:
+  - 'get'
+- apiGroups:
+  - logging.openshift.io
+  resources:
+  - elasticsearches
+  verbs:
+  - '*'
+- apiGroups:
+  - jaegertracing.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

jaeger-operator v1.10.0 requires some additional permissions.  Without them you get
errors like:

Failed to list *v1.Role: roles.rbac.authorization.k8s.io is forbidden: User "system:serviceaccount:default:jaeger-operator" cannot list roles.rbac.authorization.k8s.io in the namespace "default"

Copied and pasted the latest list of permissions from upstream

https://github.com/jaegertracing/jaeger-operator/blob/v1.10.0/deploy/role.yaml

@cpanato 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped