### PR TITLE
[stable/elasticsearch-exporter] Use port name instead of number in service monitor

### DIFF
--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 1.1.2
+version: 1.1.3
 appVersion: 1.0.2
 home: https://github.com/justwatchcom/elasticsearch_exporter
 sources:

--- a/stable/elasticsearch-exporter/templates/servicemonitor.yaml
+++ b/stable/elasticsearch-exporter/templates/servicemonitor.yaml
@@ -16,7 +16,7 @@ spec:
   endpoints:
   - interval: 10s
     honorLabels: true
-    port: "{{ .Values.service.httpPort }}"
+    port: http
     path: {{ .Values.web.path }}
     scheme: http
   jobLabel: "{{ .Release.Name }}"


### PR DESCRIPTION

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Prometheus discovery cannot find the exporter's service because it has an incorrect port name.

```
  - source_labels: [__meta_kubernetes_endpoint_port_name]
    separator: ;
    regex: "9108"
    replacement: $1
    action: keep
```

To fix this issue, it is necessary to use the same port name as in the service: `http`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
