### PR TITLE
[stable/prometheus-operator] Update prometheus-operator CLI flags to not manage CRDs

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 4.3.1
+version: 4.3.2
 appVersion: 0.29.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
@@ -43,6 +43,7 @@ spec:
             - --localhost=127.0.0.1
             - --prometheus-config-reloader={{ .Values.prometheusOperator.prometheusConfigReloaderImage.repository }}:{{ .Values.prometheusOperator.prometheusConfigReloaderImage.tag }}
             - --config-reloader-image={{ .Values.prometheusOperator.configmapReloadImage.repository }}:{{ .Values.prometheusOperator.configmapReloadImage.tag }}
+            - --manage-crds=false
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
#### What this PR does / why we need it:

The prometheus-operator helm chart has a flag which decides whether or not to create the CRDs: `prometheusOperator.createCustomResource`.

However, even when a user sets this flag to false, the prometheus operator itself will go ahead and create/update the existing CRDs during controller startup via this logic:

https://github.com/coreos/prometheus-operator/blob/1f2cf36582ced42e0c3bcb45a6f269d563d70eb3/pkg/prometheus/operator.go#L1445

The above logic creates or updates the existing prometheus CRDs which is not expected when setting prometheusOperator.createCustomResource=false.

This change adds the `--manage-crds=false` to the command line options to prometheus-operator so that when a user sets `prometheusOperator.createCustomResource=false`, no CRDs will be created (either by helm or by the operator). The decision to create CRDs or not is now fully controlled by the chart and not the operator. 


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
