### PR TITLE
[stable/mongodb] Add custom config map for init scripts

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 5.10.0
+version: 5.11.0
 appVersion: 4.0.6
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/README.md
+++ b/stable/mongodb/README.md
@@ -186,6 +186,7 @@ Some characteristics of this chart are:
 ## Initialize a fresh instance
 
 The [Bitnami MongoDB](https://github.com/bitnami/bitnami-docker-mongodb) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder `files/docker-entrypoint-initdb.d` so they can be consumed as a ConfigMap.
+Also you can create a custom config map and give it via `initConfigMap`(check options for more details).
 
 The allowed extensions are `.sh`, and `.js`.
 

--- a/stable/mongodb/README.md
+++ b/stable/mongodb/README.md
@@ -110,6 +110,7 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `readinessProbe.timeoutSeconds`                    | When the probe times out                                                                     | `5`                                                     |
 | `readinessProbe.failureThreshold`                  | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | `6`                                                     |
 | `readinessProbe.successThreshold`                  | Minimum consecutive successes for the probe to be considered successful after having failed. | `1`                                                     |
+| `initConfigMap.name`                               | Custom config map with init scripts                                                          | `nil`                                                   |
 | `configmap`                                        | MongoDB configuration file to be used                                                        | `nil`                                                   |
 | `metrics.enabled`                                  | Start a side-car prometheus exporter                                                         | `false`                                                 |
 | `metrics.image.registry`                           | MongoDB exporter image registry                                                              | `docker.io`                                             |

--- a/stable/mongodb/templates/deployment-standalone.yaml
+++ b/stable/mongodb/templates/deployment-standalone.yaml
@@ -193,7 +193,7 @@ spec:
 {{ toYaml .Values.metrics.resources | indent 10 }}
 {{- end }}
       volumes:
-      {{- if  (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") }}
+      {{- if (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") }}
       - name: custom-init-scripts
         configMap:
           name: {{ template "mongodb.fullname" . }}-init-scripts

--- a/stable/mongodb/templates/deployment-standalone.yaml
+++ b/stable/mongodb/templates/deployment-standalone.yaml
@@ -198,6 +198,11 @@ spec:
         configMap:
           name: {{ template "mongodb.fullname" . }}-init-scripts
       {{- end }}
+      {{- if (.Values.initConfigMap) }}
+      - name: custom-init-scripts
+        configMap:
+          name: {{ .Values.initConfigMap.name }}
+      {{- end }}
       - name: data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:

--- a/stable/mongodb/templates/initialization-configmap.yaml
+++ b/stable/mongodb/templates/initialization-configmap.yaml
@@ -9,5 +9,5 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 data:
-{{ (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]").AsConfig | indent 2 }}
+{{ tpl (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]").AsConfig . | indent 2 }}
 {{ end }}

--- a/stable/mongodb/templates/statefulset-primary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-primary-rs.yaml
@@ -222,7 +222,7 @@ spec:
         {{- if (.Values.initConfigMap) }}
         - name: custom-init-scripts
           configMap:
-            name: {{ Values.initConfigMap.name }}
+            name: {{ .Values.initConfigMap.name }}
         {{- end }}
         {{- if .Values.configmap }}
         - name: config

--- a/stable/mongodb/templates/statefulset-primary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-primary-rs.yaml
@@ -169,7 +169,7 @@ spec:
           volumeMounts:
             - name: datadir
               mountPath: /bitnami/mongodb
-            {{- if  (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") }}
+            {{- if  or (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") (.Values.initConfigMap) }}
             - name: custom-init-scripts
               mountPath: /docker-entrypoint-initdb.d
             {{- end }}
@@ -214,10 +214,15 @@ spec:
 {{ toYaml .Values.metrics.resources | indent 12 }}
 {{- end }}
       volumes:
-        {{- if  (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") }}
+        {{- if (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") }}
         - name: custom-init-scripts
           configMap:
             name: {{ template "mongodb.fullname" . }}-init-scripts
+        {{- end }}
+        {{- if (.Values.initConfigMap) }}
+        - name: custom-init-scripts
+          configMap:
+            name: {{ Values.initConfigMap.name }}
         {{- end }}
         {{- if .Values.configmap }}
         - name: config

--- a/stable/mongodb/values-production.yaml
+++ b/stable/mongodb/values-production.yaml
@@ -217,6 +217,10 @@ readinessProbe:
   failureThreshold: 6
   successThreshold: 1
 
+# Define custom config map with init scripts
+initConfigMap: {}
+#  name: "init-config-map"
+
 # Entries for the MongoDB config file
 configmap:
 #  # Where and how to store data.

--- a/stable/mongodb/values.yaml
+++ b/stable/mongodb/values.yaml
@@ -216,6 +216,10 @@ readinessProbe:
   failureThreshold: 6
   successThreshold: 1
 
+# Define custom config map with init scripts
+initConfigMap: {}
+#  name: "init-config-map"
+
 # Entries for the MongoDB config file
 configmap:
 #  # Where and how to store data.


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently, we can't add custom init script without copy the chart locally and set init files in `files/docker-entrypoint-initdb.d`. 

#### Special notes for your reviewer:

Please review it and let me know if this is OK. Not having much experience with helm charts. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
