### PR TITLE
[stable/percona-xtradb-cluster] Add prometheus-operator support

### DIFF
--- a/stable/percona-xtradb-cluster/Chart.yaml
+++ b/stable/percona-xtradb-cluster/Chart.yaml
@@ -1,5 +1,5 @@
 name: percona-xtradb-cluster
-version: 0.6.6
+version: 0.7.0
 appVersion: 5.7.19
 description: free, fully compatible, enhanced, open source drop-in replacement for
   MySQL with Galera Replication (xtradb)

--- a/stable/percona-xtradb-cluster/README.md
+++ b/stable/percona-xtradb-cluster/README.md
@@ -82,6 +82,14 @@ The following table lists the configurable parameters of the Percona chart and t
 | `metricsExporter.enabled` | if set to true runs a [mysql metrics exporter](https://github.com/prometheus/mysqld_exporter) container in the pod | false |
 | `metricsExporter.commandOverrides` | Overrides default docker command for metrics exporter | `[]` |
 | `metricsExporter.argsOverrides`   | Overrides default docker args for metrics exporter     | `[]` |
+| `prometheus.operator.enabled`                  | Setting to true will create Prometheus-Operator specific resources | `false` |
+| `prometheus.operator.prometheusRule.enabled`   | Create default alerting rules                                      | `true`  |
+| `prometheus.operator.prometheusRule.labels`    | Labels to add to alerts                                            | `{}`    |
+| `prometheus.operator.prometheusRule.namespace` | Namespace which Prometheus is installed in                         | `nil`   |
+| `prometheus.operator.prometheusRule.selector`  | Label Selector for Prometheus to find ServiceMonitors              | `nil`   |
+| `prometheus.operator.serviceMonitor.interval`  | Interval at which Prometheus will scrape metrics exporter          | `10s`   |
+| `prometheus.operator.serviceMonitor.namespace` | Namespace which Prometheus is installed in                         | `nil`   |
+| `prometheus.operator.serviceMonitor.selector`  | Label Selector for Prometheus to find ServiceMonitors              | `nil`   |
 | `podDisruptionBudget` | Pod disruption budget | `{enabled: false, maxUnavailable: 1}` |
 | `service.percona.headless` | if set to true makes the percona service [headless](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services) | false |
 

--- a/stable/percona-xtradb-cluster/templates/prometheusrule.yaml
+++ b/stable/percona-xtradb-cluster/templates/prometheusrule.yaml
@@ -1,0 +1,61 @@
+{{ if and .Values.metricsExporter.enabled .Values.prometheus.operator.enabled .Values.prometheus.operator.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "percona-xtradb-cluster.fullname" . }}
+{{- if .Values.prometheus.operator.prometheusRule.namespace }}
+  namespace: {{ .Values.prometheus.operator.prometheusRule.namespace }}
+{{- end }}
+  labels:
+    app: {{ template "percona-xtradb-cluster.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+{{- if .Values.prometheus.operator.prometheusRule.selector }}
+{{ toYaml .Values.prometheus.operator.prometheusRule.selector | indent 4 }}
+{{- end }}
+spec:
+  groups:
+  - name: {{ template "percona-xtradb-cluster.fullname" . }}-alerts
+    rules:
+    - alert: MySQLGaleraNotReady
+      annotations:
+        message: Galera cluster node not ready
+      expr: mysql_global_status_wsrep_ready{service="{{ template "percona-xtradb-cluster.fullname" . }}-metrics"} != 1
+      for: 5m
+      labels:
+        severity: critical
+{{- if .Values.prometheus.operator.prometheusRule.labels }}
+{{ toYaml .Values.prometheus.operator.prometheusRule.labels | indent 8 }}
+{{- end }}
+    - alert: MySQLGaleraOutOfSync
+      annotations:
+        message: Galera cluster node out of sync
+      expr: (mysql_global_status_wsrep_local_state{service="{{ template "percona-xtradb-cluster.fullname" . }}-metrics"} != 4 and mysql_global_variables_wsrep_desync{service="{{ template "percona-xtradb-cluster.fullname" . }}-metrics"} == 0)
+      for: 5m
+      labels:
+        severity: critical
+{{- if .Values.prometheus.operator.prometheusRule.labels }}
+{{ toYaml .Values.prometheus.operator.prometheusRule.labels | indent 8 }}
+{{- end }}
+    - alert: MySQLGaleraDonorFallingBehind
+      annotations:
+        message: xtradb cluster donor node falling behind
+      expr: (mysql_global_status_wsrep_local_state{service="{{ template "percona-xtradb-cluster.fullname" . }}-metrics"} == 2 and mysql_global_status_wsrep_local_recv_queue{service="{{ template "percona-xtradb-cluster.fullname" . }}-metrics"} > 100)
+      for: 5m
+      labels:
+        severity: warning
+{{- if .Values.prometheus.operator.prometheusRule.labels }}
+{{ toYaml .Values.prometheus.operator.prometheusRule.labels | indent 8 }}
+{{- end }}
+    - alert: MySQLInnoDBLogWaits
+      annotations:
+        message: MySQL innodb log writes stalling
+      expr: rate(mysql_global_status_innodb_log_waits{service="{{ template "percona-xtradb-cluster.fullname" . }}-metrics"}[15m]) > 10
+      for: 5m
+      labels:
+        severity: warning
+{{- if .Values.prometheus.operator.prometheusRule.labels }}
+{{ toYaml .Values.prometheus.operator.prometheusRule.labels | indent 8 }}
+{{- end }}
+{{ end }}

--- a/stable/percona-xtradb-cluster/templates/service-metrics.yaml
+++ b/stable/percona-xtradb-cluster/templates/service-metrics.yaml
@@ -12,7 +12,8 @@ metadata:
 spec:
   clusterIP: None
   ports:
-  - port: 9104
+  - name: metrics
+    port: 9104
   selector:
     app: {{ template "percona-xtradb-cluster.fullname" . }}
     release: "{{ .Release.Name }}"

--- a/stable/percona-xtradb-cluster/templates/servicemonitor.yaml
+++ b/stable/percona-xtradb-cluster/templates/servicemonitor.yaml
@@ -1,0 +1,27 @@
+{{ if and .Values.metricsExporter.enabled .Values.prometheus.operator.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "percona-xtradb-cluster.fullname" . }}
+{{- if .Values.prometheus.operator.serviceMonitor.namespace }}
+  namespace: {{ .Values.prometheus.operator.serviceMonitor.namespace }}
+{{- end }}
+  labels:
+    app: {{ template "percona-xtradb-cluster.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+{{- if .Values.prometheus.operator.serviceMonitor.selector }}
+{{ toYaml .Values.prometheus.operator.serviceMonitor.selector | indent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "percona-xtradb-cluster.fullname" . }}
+      release: {{ .Release.Name }}
+  endpoints:
+  - port: metrics
+    interval: {{ .Values.prometheus.operator.serviceMonitor.interval }}
+  namespaceSelector:
+    any: true
+{{ end }}

--- a/stable/percona-xtradb-cluster/values.yaml
+++ b/stable/percona-xtradb-cluster/values.yaml
@@ -101,6 +101,38 @@ metricsExporter:
   commandOverrides: []
   argsOverrides: []
 
+prometheus:
+  ## Are you using [Prometheus Operator](https://coreos.com/operators/prometheus/docs/latest/user-guides/getting-started.html)?
+  operator:
+    ## Setting to true will create Prometheus-Operator specific resources like ServiceMonitors
+    enabled: false
+
+    ## Configures alerts for Prometheus to pick up
+    prometheusRule:
+      enabled: true
+
+      ## Labels to add to alerts
+      labels: {}
+
+      ## Namespace which Prometheus is installed in
+      # namespace: monitoring
+
+      ## Label Selector for Prometheus to find alert rules
+      # selector:
+      #   prometheus: kube-prometheus
+
+    ## Configures targets for Prometheus to pick up
+    serviceMonitor:
+      ## Interval at which Prometheus will scrape metrics exporter
+      interval: 10s
+
+      ## Namespace which Prometheus is installed in
+      # namespace: monitoring
+
+      ## Label Selector for Prometheus to find ServiceMonitors
+      # selector:
+      #   prometheus: kube-prometheus
+
 ## When set to true will create sidecar to tail mysql log
 logTail: true
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows users to create PrometheusRule and ServiceMonitor objects used for defining alerts and targets in Prometheus using Prometheus Operator.

### Special notes for your reviewer:
What metrics should be measured and alerted upon by default could probably be better.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md