### PR TITLE
[stable/grafana] add missing multiline indicator

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 2.2.2
+version: 2.2.3
 appVersion: 6.0.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/dashboards-json-configmap.yaml
+++ b/stable/grafana/templates/dashboards-json-configmap.yaml
@@ -15,7 +15,7 @@ metadata:
 data:
 {{- range $key, $value := $dashboards }}
 {{- if (or (hasKey $value "json") (hasKey $value "file")) }}
-{{ print $key | indent 2 }}.json:
+{{ print $key | indent 2 }}.json: |-
 {{- if hasKey $value "json" }}
 {{ $value.json | indent 4 }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Jannis Oeltjen <oss@jcoeltjen.de>

#### What this PR does / why we need it:
Fixes a bug that occurs when using the `dashboards` value to preload some dashboards using a JSON string.
One multiline indicator was missing from the template. Without it the templated configmap was invalid.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
