### PR TITLE
[stable/kong] Adding option to configure the proxy cipher suite value

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.9.5
+version: 0.9.6
 appVersion: 1.0.2

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -78,6 +78,7 @@ and their default values.
 | proxy.tls.servicePort          | Service port to use for TLS                                                      | 8443                |
 | proxy.tls.nodePort             | Node port to use for TLS                                                         | 32443               |
 | proxy.tls.hostPort             | Host port to use for TLS                                                         |                     |
+| proxy.tls.ssl_cipher_suite     | Set the cipher suite to use                                                      | modern              |
 | proxy.type                     | k8s service type. Options: NodePort, ClusterIP, LoadBalancer                     | `NodePort`          |
 | proxy.loadBalancerSourceRanges | Limit proxy access to CIDRs if set and service type is `LoadBalancer`            | `[]`                |
 | proxy.loadBalancerIP           | To reuse an existing ingress static IP for the admin service                     |                     |
@@ -103,12 +104,12 @@ the value provided by you as opposed to constructing a listen variable
 from fields like `proxy.http.containerPort` and `proxy.http.enabled`. This allows
 you to be more prescriptive when defining listen directives.
 
-**Note:** Overriding `env.proxy_listen` and `env.admin_listen` will potentially cause 
-`admin.containerPort`, `proxy.http.containerPort` and `proxy.tls.containerPort` to become out of sync, 
+**Note:** Overriding `env.proxy_listen` and `env.admin_listen` will potentially cause
+`admin.containerPort`, `proxy.http.containerPort` and `proxy.tls.containerPort` to become out of sync,
 and therefore must be updated accordingly.
 
-I.E. updatating to `env.proxy_listen: 0.0.0.0:4444, 0.0.0.0:4443 ssl` will need 
-`proxy.http.containerPort: 4444` and `proxy.tls.containerPort: 4443` to be set in order 
+I.E. updatating to `env.proxy_listen: 0.0.0.0:4444, 0.0.0.0:4443 ssl` will need
+`proxy.http.containerPort: 4444` and `proxy.tls.containerPort: 4443` to be set in order
 for the service definition to work properly.
 
 ### Kong-specific parameters
@@ -155,7 +156,7 @@ kong:
             key: kong
             name: postgres
 ```
- 
+
 
 For complete list of Kong configurations please check https://getkong.org/docs/1.0.x/configuration/.
 

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -89,6 +89,10 @@ spec:
           value: "/dev/stderr"
         - name: KONG_ADMIN_ERROR_LOG
           value: "/dev/stderr"
+        {{- if .Values.proxy.tls.ssl_cipher_suite }}
+        - name: KONG_SSL_CIPHER_SUITE
+          value: {{ .Values.proxy.tls.ssl_cipher_suite }}
+        {{- end }}
         {{- include "kong.env" .  | indent 8 }}
         {{- if .Values.postgresql.enabled }}
         - name: KONG_PG_HOST

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -65,6 +65,7 @@ proxy:
     containerPort: 8443
     # Set a nodePort which is available if service type is NodePort
     # nodePort: 32443
+    ssl_cipher_suite: modern
 
   type: NodePort
 


### PR DESCRIPTION
Signed-off-by: garland <garlandk@gmail.com>

#### What this PR does / why we need it:
This PR is here to be able to configure the `KONG_SSL_CIPHER_SUITE` setting in the proxy.

https://github.com/helm/charts/issues/11013

When trying to use an AWS ELB to offload SSL, when the ELB tries to create the connection to Kong, the connection hangs.  It was hard to tell why it was hanging but in the ticket above it describes changing the `ssl_cipher_suite` and that fixed the problem.

The topology:
```
Internet---port https-->(*.example.com)443:ELB:https-->(kong self signed cert)443:kong
```

#### Which issue this PR fixes
https://github.com/helm/charts/issues/11013

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
