### PR TITLE
[stable/concourse] Easier way to add team external workers

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 4.1.0
+version: 5.0.0
 appVersion: 5.0.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 4.0.0
+version: 4.1.0
 appVersion: 5.0.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -139,7 +139,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `secrets.postgresUser` | PostgreSQL User Name | `nil` |
 | `secrets.sessionSigningKey` | Concourse Session Signing Private Key | *See [values.yaml](values.yaml)* |
 | `secrets.syslogCaCert` | SSL certificate to verify Syslog server | `nil` |
-| `secrets.teamKeys` | Array of team names and worker public keys for external workers | `nil` |
+| `secrets.teamAuthorizedKeys` | Array of team names and worker public keys for external workers | `nil` |
 | `secrets.vaultAuthParam` | Paramter to pass when logging in via the backend | `nil` |
 | `secrets.vaultCaCert` | CA certificate use to verify the vault server SSL cert | `nil` |
 | `secrets.vaultClientCert` | Vault Client Certificate | `nil` |

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -103,6 +103,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `rbac.webServiceAccountName` | Name of the service account to use for web pods if `rbac.create` is `false` | `default` |
 | `rbac.workerServiceAccountName` | Name of the service account to use for workers if `rbac.create` is `false` | `default` |
 | `secrets.awsSecretsmanagerAccessKey` | AWS Access Key ID for Secrets Manager access | `nil` |
+| `secrets.teamKeys` | Array of team names and worker public keys for external workers | `nil` |
 | `secrets.awsSecretsmanagerSecretKey` | AWS Secret Access Key ID for Secrets Manager access | `nil` |
 | `secrets.awsSecretsmanagerSessionToken` | AWS Session Token for Secrets Manager access | `nil` |
 | `secrets.awsSsmAccessKey` | AWS Access Key ID for SSM access | `nil` |

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -103,7 +103,6 @@ The following table lists the configurable parameters of the Concourse chart and
 | `rbac.webServiceAccountName` | Name of the service account to use for web pods if `rbac.create` is `false` | `default` |
 | `rbac.workerServiceAccountName` | Name of the service account to use for workers if `rbac.create` is `false` | `default` |
 | `secrets.awsSecretsmanagerAccessKey` | AWS Access Key ID for Secrets Manager access | `nil` |
-| `secrets.teamKeys` | Array of team names and worker public keys for external workers | `nil` |
 | `secrets.awsSecretsmanagerSecretKey` | AWS Secret Access Key ID for Secrets Manager access | `nil` |
 | `secrets.awsSecretsmanagerSessionToken` | AWS Session Token for Secrets Manager access | `nil` |
 | `secrets.awsSsmAccessKey` | AWS Access Key ID for SSM access | `nil` |
@@ -140,6 +139,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `secrets.postgresUser` | PostgreSQL User Name | `nil` |
 | `secrets.sessionSigningKey` | Concourse Session Signing Private Key | *See [values.yaml](values.yaml)* |
 | `secrets.syslogCaCert` | SSL certificate to verify Syslog server | `nil` |
+| `secrets.teamKeys` | Array of team names and worker public keys for external workers | `nil` |
 | `secrets.vaultAuthParam` | Paramter to pass when logging in via the backend | `nil` |
 | `secrets.vaultCaCert` | CA certificate use to verify the vault server SSL cert | `nil` |
 | `secrets.vaultClientCert` | Vault Client Certificate | `nil` |

--- a/stable/concourse/templates/secrets.yaml
+++ b/stable/concourse/templates/secrets.yaml
@@ -91,7 +91,7 @@ data:
   {{- if .Values.concourse.web.syslog.enabled }}
   syslog-ca-cert: {{ default "" .Values.secrets.syslogCaCert | b64enc | quote }}
   {{- end }}
-  {{- range .Values.secrets.teamKeys}}
+  {{- range .Values.secrets.teamAuthorizedKeys}}
   {{ .team }}-team-authorized-key: {{ .key | b64enc | quote }}
   {{- end}}
 {{- end }}

--- a/stable/concourse/templates/secrets.yaml
+++ b/stable/concourse/templates/secrets.yaml
@@ -91,4 +91,7 @@ data:
   {{- if .Values.concourse.web.syslog.enabled }}
   syslog-ca-cert: {{ default "" .Values.secrets.syslogCaCert | b64enc | quote }}
   {{- end }}
+  {{- range .Values.secrets.teamKeys}}
+  {{ .team }}-team-authorized-key: {{ .key | b64enc | quote }}
+  {{- end}}
 {{- end }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -877,9 +877,9 @@ spec:
               value: "{{ .Values.web.keySecretsPath }}/host_key"
             - name: CONCOURSE_TSA_AUTHORIZED_KEYS
               value: "{{ .Values.web.keySecretsPath }}/worker_key.pub"
-            {{- if .Values.secrets.teamKeys }}
+            {{- if .Values.secrets.teamAuthorizedKeys }}
             - name: CONCOURSE_TSA_TEAM_AUTHORIZED_KEYS
-              value: "{{- $root := . -}}{{- range $i, $v := .Values.secrets.teamKeys }}{{- if $i}},{{- end}}{{ $v.team }}:{{ $root.Values.web.teamSecretsPath }}/{{ $v.team }}-authorized-key.pub{{- end }}"
+              value: "{{- $root := . -}}{{- range $i, $v := .Values.secrets.teamAuthorizedKeys }}{{- if $i}},{{- end}}{{ $v.team }}:{{ $root.Values.web.teamSecretsPath }}/{{ $v.team }}-authorized-key.pub{{- end }}"
             {{- end }}
             {{- if .Values.concourse.web.tsa.atcUrl }}
             - name: CONCOURSE_TSA_ATC_URL
@@ -936,7 +936,7 @@ spec:
             - name: concourse-keys
               mountPath: {{ .Values.web.keySecretsPath | quote }}
               readOnly: true
-            {{- if .Values.secrets.teamKeys }}
+            {{- if .Values.secrets.teamAuthorizedKeys }}
             - name: team-authorized-keys
               mountPath: {{ .Values.web.teamSecretsPath | quote }}
               readOnly: true
@@ -983,13 +983,13 @@ spec:
                 path: session_signing_key
               - key: worker-key-pub
                 path: worker_key.pub
-        {{- if .Values.secrets.teamKeys }}
+        {{- if .Values.secrets.teamAuthorizedKeys }}
         - name: team-authorized-keys
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}
             defaultMode: 0400
             items:
-            {{- range .Values.secrets.teamKeys }}
+            {{- range .Values.secrets.teamAuthorizedKeys }}
             - key: {{ .team }}-team-authorized-key
               path: {{ .team }}-authorized-key.pub
             {{- end }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -877,9 +877,9 @@ spec:
               value: "{{ .Values.web.keySecretsPath }}/host_key"
             - name: CONCOURSE_TSA_AUTHORIZED_KEYS
               value: "{{ .Values.web.keySecretsPath }}/worker_key.pub"
-            {{- if .Values.concourse.web.tsa.teamAuthorizedKeys }}
+            {{- if .Values.secrets.teamKeys }}
             - name: CONCOURSE_TSA_TEAM_AUTHORIZED_KEYS
-              value: {{ .Values.concourse.web.tsa.teamAuthorizedKeys | quote }}
+              value: "{{- $root := . -}}{{- range $i, $v := .Values.secrets.teamKeys }}{{- if $i}},{{- end}}{{ $v.team }}:{{ $root.Values.web.teamSecretsPath }}/{{ $v.team }}-authorized-key.pub{{- end }}"
             {{- end }}
             {{- if .Values.concourse.web.tsa.atcUrl }}
             - name: CONCOURSE_TSA_ATC_URL
@@ -936,6 +936,11 @@ spec:
             - name: concourse-keys
               mountPath: {{ .Values.web.keySecretsPath | quote }}
               readOnly: true
+            {{- if .Values.secrets.teamKeys }}
+            - name: team-authorized-keys
+              mountPath: {{ .Values.web.teamSecretsPath | quote }}
+              readOnly: true
+            {{- end }}
             {{- if .Values.concourse.web.tls.enabled }}
             - name: web-tls
               mountPath: {{ .Values.web.tlsSecretsPath | quote }}
@@ -978,6 +983,17 @@ spec:
                 path: session_signing_key
               - key: worker-key-pub
                 path: worker_key.pub
+        {{- if .Values.secrets.teamKeys }}
+        - name: team-authorized-keys
+          secret:
+            secretName: {{ template "concourse.concourse.fullname" . }}
+            defaultMode: 0400
+            items:
+            {{- range .Values.secrets.teamKeys }}
+            - key: {{ .team }}-team-authorized-key
+              path: {{ .team }}-authorized-key.pub
+            {{- end }}
+        {{- end }}
         {{- if .Values.concourse.web.tls.enabled }}
         - name: web-tls
           secret:

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1576,7 +1576,8 @@ secrets:
   create: true
 
   ## Array of team names and public keys for team external workers.
-  ## Ref: 
+  ##
+  ## Example:
   ## - team: main
   ##   key: |-
   ##     ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYBQ9fG6IML+qsFaMh1Pl+81wyUwRilHdfhItAiAsLVQsOwI5+V4pn5aLhHPBuRQqIqYmbkZ7I1VUIN1+90PVJ3X7l9qqanb85AHMtLujw1j9u0zDyH2XHgpUloknUQzUSLIZjjU3Hn3Uo/XikF+vT8104isO7Ym8Xp7sIcRuvOQ3nuRsFVCRogxpLTVHD/k57rwYVqWWLaKLwvx01ZVXOq4GHk/BVaKa9ODC/dNgbZMfwvVVXuf7/NFGmSMyXb49Si4aoP4Gn7jAX6GngBbm/bgKqO0skQy/ggQm/YVF+s5q4EhleMBLVJKD1VpM5LeLDFpiu/y4bVd8wUcgK+QQ9 Concourse

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -874,10 +874,6 @@ concourse:
       ##
       authorizedKeys:
 
-      ## Path to file containing keys to authorize, in SSH authorized_keys format (one public key per line).
-      ##
-      teamAuthorizedKeys:
-
       ## ATC API endpoints to which workers will be registered.
       ##
       atcUrl:
@@ -1140,6 +1136,7 @@ web:
   ## Where secrets should be mounted for the web container.
   ##
   keySecretsPath: "/concourse-keys"
+  teamSecretsPath: "/team-authorized-keys"
   authSecretsPath: "/concourse-auth"
   vaultSecretsPath: "/concourse-vault"
   postgresqlSecretsPath: "/concourse-postgresql"
@@ -1577,6 +1574,13 @@ secrets:
   ## false to manage these secrets outside Helm.
   ##
   create: true
+
+  ## array of team names and public keys for team external workers
+  ##
+  teamKeys:
+    ## - team: main
+    ##   key: |-
+    ##     ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYBQ9fG6IML+qsFaMh1Pl+81wyUwRilHdfhItAiAsLVQsOwI5+V4pn5aLhHPBuRQqIqYmbkZ7I1VUIN1+90PVJ3X7l9qqanb85AHMtLujw1j9u0zDyH2XHgpUloknUQzUSLIZjjU3Hn3Uo/XikF+vT8104isO7Ym8Xp7sIcRuvOQ3nuRsFVCRogxpLTVHD/k57rwYVqWWLaKLwvx01ZVXOq4GHk/BVaKa9ODC/dNgbZMfwvVVXuf7/NFGmSMyXb49Si4aoP4Gn7jAX6GngBbm/bgKqO0skQy/ggQm/YVF+s5q4EhleMBLVJKD1VpM5LeLDFpiu/y4bVd8wUcgK+QQ9 Concourse
 
   ## List of `username:password` or `username:bcrypted_password` combinations for all your local concourse users.
   ##

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1582,6 +1582,10 @@ secrets:
   ##   key: |-
   ##     ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYBQ9fG6IML+qsFaMh1Pl+81wyUwRilHdfhItAiAsLVQsOwI5+V4pn5aLhHPBuRQqIqYmbkZ7I1VUIN1+90PVJ3X7l9qqanb85AHMtLujw1j9u0zDyH2XHgpUloknUQzUSLIZjjU3Hn3Uo/XikF+vT8104isO7Ym8Xp7sIcRuvOQ3nuRsFVCRogxpLTVHD/k57rwYVqWWLaKLwvx01ZVXOq4GHk/BVaKa9ODC/dNgbZMfwvVVXuf7/NFGmSMyXb49Si4aoP4Gn7jAX6GngBbm/bgKqO0skQy/ggQm/YVF+s5q4EhleMBLVJKD1VpM5LeLDFpiu/y4bVd8wUcgK+QQ9 Concourse
   ##
+  ## Make sure to chack the security caveats here: https://concourse-ci.org/teams-caveats.html
+  ## Extra Reads: https://github.com/concourse/concourse/issues/1865#issuecomment-464166994
+  ## https://concourse-ci.org/global-resources.html#complications-with-reusing-containers
+  ##
   teamKeys:
 
   ## List of `username:password` or `username:bcrypted_password` combinations for all your local concourse users.

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1586,7 +1586,7 @@ secrets:
   ## Extra Reads: https://github.com/concourse/concourse/issues/1865#issuecomment-464166994
   ## https://concourse-ci.org/global-resources.html#complications-with-reusing-containers
   ##
-  teamKeys:
+  teamAuthorizedKeys:
 
   ## List of `username:password` or `username:bcrypted_password` combinations for all your local concourse users.
   ##

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1575,12 +1575,13 @@ secrets:
   ##
   create: true
 
-  ## array of team names and public keys for team external workers
+  ## Array of team names and public keys for team external workers.
+  ## Ref: 
+  ## - team: main
+  ##   key: |-
+  ##     ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYBQ9fG6IML+qsFaMh1Pl+81wyUwRilHdfhItAiAsLVQsOwI5+V4pn5aLhHPBuRQqIqYmbkZ7I1VUIN1+90PVJ3X7l9qqanb85AHMtLujw1j9u0zDyH2XHgpUloknUQzUSLIZjjU3Hn3Uo/XikF+vT8104isO7Ym8Xp7sIcRuvOQ3nuRsFVCRogxpLTVHD/k57rwYVqWWLaKLwvx01ZVXOq4GHk/BVaKa9ODC/dNgbZMfwvVVXuf7/NFGmSMyXb49Si4aoP4Gn7jAX6GngBbm/bgKqO0skQy/ggQm/YVF+s5q4EhleMBLVJKD1VpM5LeLDFpiu/y4bVd8wUcgK+QQ9 Concourse
   ##
   teamKeys:
-    ## - team: main
-    ##   key: |-
-    ##     ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYBQ9fG6IML+qsFaMh1Pl+81wyUwRilHdfhItAiAsLVQsOwI5+V4pn5aLhHPBuRQqIqYmbkZ7I1VUIN1+90PVJ3X7l9qqanb85AHMtLujw1j9u0zDyH2XHgpUloknUQzUSLIZjjU3Hn3Uo/XikF+vT8104isO7Ym8Xp7sIcRuvOQ3nuRsFVCRogxpLTVHD/k57rwYVqWWLaKLwvx01ZVXOq4GHk/BVaKa9ODC/dNgbZMfwvVVXuf7/NFGmSMyXb49Si4aoP4Gn7jAX6GngBbm/bgKqO0skQy/ggQm/YVF+s5q4EhleMBLVJKD1VpM5LeLDFpiu/y4bVd8wUcgK+QQ9 Concourse
 
   ## List of `username:password` or `username:bcrypted_password` combinations for all your local concourse users.
   ##


### PR DESCRIPTION
#### What this PR does / why we need it:
- Previously, in order to add an external worker to web deployment,
worker keys were to be added as a separate secret or a config map and
then mounted as an additional volume to the web pod.

- With this feature, only team names and public keys are to be added to
the secrets as an array and the creation of secrets and mounting the
volumes is done automatically.

- Also, removed `.Values.concourse.Web.teamAuthorizedKeys` as it won't
be used anymore.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
