### PR TITLE
[incubator/sentry-kubernetes] Make LOG_LEVEL env configurable

### DIFF
--- a/incubator/sentry-kubernetes/Chart.yaml
+++ b/incubator/sentry-kubernetes/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for sentry-kubernetes (https://github.com/getsentry/sentry-kubernetes)
 name: sentry-kubernetes
-version: 0.1.7
+version: 0.2.0
 appVersion: latest
 icon: https://sentry-brand.storage.googleapis.com/sentry-glyph-white.png
 home: https://github.com/getsentry/sentry-kubernetes

--- a/incubator/sentry-kubernetes/README.md
+++ b/incubator/sentry-kubernetes/README.md
@@ -17,6 +17,7 @@ The following table lists the configurable parameters of the sentry-kubernetes c
 | `sentry.dsn`            | Sentry dsn                                                                                                                  | Empty                         |
 | `sentry.environment`    | Sentry environment                                                                                                          | Empty                         |
 | `sentry.release`        | Sentry release                                                                                                              | Empty                         |
+| `sentry.logLevel`       | Sentry log level                                                                                                            | Empty                         |
 | `image.repository`      | Container image name                                                                                                        | `getsentry/sentry-kubernetes` |
 | `image.tag`             | Container image tag                                                                                                         | `latest`                      |
 | `rbac.create`           | If `true`, create and use RBAC resources                                                                                    | `true`                        |

--- a/incubator/sentry-kubernetes/templates/deployment.yaml
+++ b/incubator/sentry-kubernetes/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
           - name: RELEASE 
             value: {{ .Values.sentry.release }}
           {{ end }}
+          {{ if .Values.sentry.logLevel }}
+          - name: LOG_LEVEL
+            value: {{ .Values.sentry.logLevel }}
+          {{ end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
     {{- if .Values.nodeSelector }}

--- a/incubator/sentry-kubernetes/values.yaml
+++ b/incubator/sentry-kubernetes/values.yaml
@@ -2,6 +2,7 @@
 
 sentry:
   dsn: <change-me>
+  logLevel: ~
 image:
   repository: getsentry/sentry-kubernetes
   tag: latest


### PR DESCRIPTION
#### What this PR does / why we need it:

Make the `LOG_LEVEL` environment configurable through the `sentry.logLevel` value.

#### Special notes for your reviewer:

This feature is already exposed in the underlying docker image:
https://github.com/getsentry/sentry-kubernetes/blob/108ae63cc7f0343bdb84fe7e9ff62e0d540dc0cb/sentry-kubernetes.py#L32-L36

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [X] Variables are documented in the README.md
