### PR TITLE
[stable/magic-namespace] Add TLS capabilities to Tiller deployment

### DIFF
--- a/stable/magic-namespace/Chart.yaml
+++ b/stable/magic-namespace/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: magic-namespace
-version: 0.3.0
+version: 0.4.0
 appVersion: 2.8.1
 home: https://github.com/kubernetes/charts/tree/master/stable/magic-namespace
 description: Elegantly enables a Tiller per namespace in RBAC-enabled clusters

--- a/stable/magic-namespace/README.md
+++ b/stable/magic-namespace/README.md
@@ -140,6 +140,13 @@ reference the default `values.yaml` to understand further options.
 | `tiller.role.type` | Identify the name of the `Role` or `ClusterRole` that will be referenced in the role binding for Tiller's service account. There is seldom any reason to override this. | `admin` |
 | `tiller.includeService` | This deploys a service resource for Tiller. This is not generally needed. Please understand the security implications of this before overriding the default. | `false` |
 | `tiller.onlyListenOnLocalhost` | This prevents Tiller from binding to `0.0.0.0`. This is generally advisable to close known Tiller-based attack vectors. Please understand the security implications of this before overriding the default. | `true` |
+| `tls.enabled` | Whether to enable TLS encryption between Helm and Tiller. | `false` |
+| `tls.verify` | Whether to verify a remote certificate. | `true` |
+| `tls.certPath` | Path to mount certificates into the container. | `/etc/certs` |
+| `tls.secretName` | Provide TLS certs via an existing secret with Path to mount certificates into the container. Must include ca.crt, tls.crt and tls.key files| `nil` |
+| `tls.ca` | a Base64 encoded string to mount ca.crt into the container.  | `nil` |
+| `tls.cert` | a Base64 encoded string to mount tls.cert into the container.  | `nil` |
+| `tls.key` | a Base64 encoded string to mount tls.key into the container.  | `nil` |
 | `serviceAccounts` | An optional array of names of additional service account to create | `nil` |
 | `roleBindings` | An optional array of objects that define role bindings | `nil` |
 | `roleBindings[n].role.kind` | Identify the kind of role (`Role` or `ClusterRole`) to be used in the role binding | |

--- a/stable/magic-namespace/README.md
+++ b/stable/magic-namespace/README.md
@@ -140,13 +140,13 @@ reference the default `values.yaml` to understand further options.
 | `tiller.role.type` | Identify the name of the `Role` or `ClusterRole` that will be referenced in the role binding for Tiller's service account. There is seldom any reason to override this. | `admin` |
 | `tiller.includeService` | This deploys a service resource for Tiller. This is not generally needed. Please understand the security implications of this before overriding the default. | `false` |
 | `tiller.onlyListenOnLocalhost` | This prevents Tiller from binding to `0.0.0.0`. This is generally advisable to close known Tiller-based attack vectors. Please understand the security implications of this before overriding the default. | `true` |
-| `tls.enabled` | Whether to enable TLS encryption between Helm and Tiller. | `false` |
-| `tls.verify` | Whether to verify a remote certificate. | `true` |
-| `tls.certPath` | Path to mount certificates into the container. | `/etc/certs` |
-| `tls.secretName` | Provide TLS certs via an existing secret with Path to mount certificates into the container. Must include ca.crt, tls.crt and tls.key files| `nil` |
-| `tls.ca` | a Base64 encoded string to mount ca.crt into the container.  | `nil` |
-| `tls.cert` | a Base64 encoded string to mount tls.cert into the container.  | `nil` |
-| `tls.key` | a Base64 encoded string to mount tls.key into the container.  | `nil` |
+| `tiller.tls.enabled` | Whether to enable TLS encryption between Helm and Tiller. Specify either `tiller.tls.secretName` to mount an existing secret, or `tiller.tls.ca`, `tiller.tls.cert` and `tiller.tls.key` to create a secret from Base64 provided values | `false` |
+| `tiller.tls.verify` | Whether to verify a remote Tiller certificate. | `true` |
+| `tiller.tls.certPath` | Path to mount certificates into the Tiller container. | `/etc/certs` |
+| `tiller.tls.secretName` | Mount an existing TLS secret into the Tiller container at `tls.certPath`. The secret must include data keys: `ca.crt`, `tls.crt` and `tls.key` | `nil` |
+| `tiller.tls.ca` | Base64 encoded string to mount ca.crt into the Tiller container. This value requires `tiller.tls.cert` and `tiller.tls.key` to also be set. | `nil` |
+| `tiller.tls.cert` | Base64 encoded string to mount tls.cert into the Tiller container. This value requires `tiller.tls.ca and `tiller.tls.key` to also be set. | `nil` |
+| `tiller.tls.key` | Base64 encoded string to mount tls.key into the Tiller container. This value requires `tiller.tls.ca` and `tiller.tls.cert` to also be set. | `nil` |
 | `serviceAccounts` | An optional array of names of additional service account to create | `nil` |
 | `roleBindings` | An optional array of objects that define role bindings | `nil` |
 | `roleBindings[n].role.kind` | Identify the kind of role (`Role` or `ClusterRole`) to be used in the role binding | |

--- a/stable/magic-namespace/README.md
+++ b/stable/magic-namespace/README.md
@@ -142,8 +142,7 @@ reference the default `values.yaml` to understand further options.
 | `tiller.onlyListenOnLocalhost` | This prevents Tiller from binding to `0.0.0.0`. This is generally advisable to close known Tiller-based attack vectors. Please understand the security implications of this before overriding the default. | `true` |
 | `tiller.tls.enabled` | Whether to enable TLS encryption between Helm and Tiller. Specify either `tiller.tls.secretName` to mount an existing secret, or `tiller.tls.ca`, `tiller.tls.cert` and `tiller.tls.key` to create a secret from Base64 provided values | `false` |
 | `tiller.tls.verify` | Whether to verify a remote Tiller certificate. | `true` |
-| `tiller.tls.certPath` | Path to mount certificates into the Tiller container. | `/etc/certs` |
-| `tiller.tls.secretName` | Mount an existing TLS secret into the Tiller container at `tls.certPath`. The secret must include data keys: `ca.crt`, `tls.crt` and `tls.key` | `nil` |
+| `tiller.tls.secretName` | Mount an existing TLS secret into the Tiller container. The secret must include data keys: `ca.crt`, `tls.crt` and `tls.key` | `nil` |
 | `tiller.tls.ca` | Base64 encoded string to mount ca.crt into the Tiller container. This value requires `tiller.tls.cert` and `tiller.tls.key` to also be set. | `nil` |
 | `tiller.tls.cert` | Base64 encoded string to mount tls.cert into the Tiller container. This value requires `tiller.tls.ca and `tiller.tls.key` to also be set. | `nil` |
 | `tiller.tls.key` | Base64 encoded string to mount tls.key into the Tiller container. This value requires `tiller.tls.ca` and `tiller.tls.cert` to also be set. | `nil` |

--- a/stable/magic-namespace/templates/_helpers.tpl
+++ b/stable/magic-namespace/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "magic-namespace.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Allow a custom secretName to be defined
+*/}}
+{{- define "magic-namespace.tillerTlsSecret" -}}
+{{- if .Values.tiller.tls.secretName -}}
+{{- .Values.tiller.tls.secretName }}
+{{- else -}}
+{{- template "magic-namespace.chart" . }}-tiller-secret
+{{- end -}}
+{{- end -}}

--- a/stable/magic-namespace/templates/secret.yaml
+++ b/stable/magic-namespace/templates/secret.yaml
@@ -3,7 +3,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "magic-namespace.tillerTlsSecret" . }}
+  {{- if hasKey .Values "namespace" }}
   namespace: {{ .Values.namespace }}
+  {{- end }}
   labels:
     app: {{ template "magic-namespace.chart" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/stable/magic-namespace/templates/secret.yaml
+++ b/stable/magic-namespace/templates/secret.yaml
@@ -1,0 +1,17 @@
+{{- if (and (.Values.tiller.tls.enabled) (not .Values.tiller.tls.secretName)) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "magic-namespace.tillerTlsSecret" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "magic-namespace.chart" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  ca.crt: {{ required "You need to populate .Values.tiller.tls.ca with a Base64 encoded CA" .Values.tiller.tls.ca }}
+  tls.crt: {{ required "You need to populate .Values.tiller.tls.cert with a Base64 encoded cert" .Values.tiller.tls.cert }}
+  tls.key: {{ required "You need to populate .Values.tiller.tls.key with a Base64 encoded key" .Values.tiller.tls.key}}
+{{- end }}

--- a/stable/magic-namespace/templates/tiller-deployment.yaml
+++ b/stable/magic-namespace/templates/tiller-deployment.yaml
@@ -50,7 +50,7 @@ spec:
             value: "1"
           {{- end }}
           - name: TILLER_TLS_CERTS
-            value: {{ quote .Values.tiller.tls.certPath }}
+            value: /etc/certs
           {{- end }}
           {{- if .Values.tiller.onlyListenOnLocalhost }}
           command: ["/tiller"]
@@ -86,7 +86,7 @@ spec:
             timeoutSeconds: 1
           volumeMounts:
           {{- if .Values.tiller.tls.enabled }}
-          - mountPath: {{ quote .Values.tiller.tls.certPath }}
+          - mountPath: /etc/certs
             name: tiller-certs
             readOnly: true
           {{- end }}

--- a/stable/magic-namespace/templates/tiller-deployment.yaml
+++ b/stable/magic-namespace/templates/tiller-deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       serviceAccountName: tiller
       containers:
-        - name: tiller
+        - name: {{ .Chart.Name }}
           image: "{{ .Values.tiller.image.repository }}:{{ .Values.tiller.image.tag }}"
           imagePullPolicy: {{ .Values.tiller.image.pullPolicy }}
           env:

--- a/stable/magic-namespace/templates/tiller-deployment.yaml
+++ b/stable/magic-namespace/templates/tiller-deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       serviceAccountName: tiller
       containers:
-        - name: {{ .Chart.Name }}
+        - name: tiller
           image: "{{ .Values.tiller.image.repository }}:{{ .Values.tiller.image.tag }}"
           imagePullPolicy: {{ .Values.tiller.image.pullPolicy }}
           env:
@@ -42,6 +42,16 @@ spec:
             {{- end }}
           - name: TILLER_HISTORY_MAX
             value: {{ quote .Values.tiller.maxHistory }}
+          {{- if .Values.tiller.tls.enabled }}
+          - name: TILLER_TLS_ENABLE
+            value: "1"
+          {{- if .Values.tiller.tls.verify }}
+          - name: TILLER_TLS_VERIFY
+            value: "1"
+          {{- end }}
+          - name: TILLER_TLS_CERTS
+            value: {{ quote .Values.tiller.tls.certPath }}
+          {{- end }}
           {{- if .Values.tiller.onlyListenOnLocalhost }}
           command: ["/tiller"]
           args: ["--listen=127.0.0.1:44134"]
@@ -74,8 +84,21 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
+          volumeMounts:
+          {{- if .Values.tiller.tls.enabled }}
+          - mountPath: {{ quote .Values.tiller.tls.certPath }}
+            name: tiller-certs
+            readOnly: true
+          {{- end }}
           resources:
 {{ toYaml .Values.tiller.resources | indent 12 }}
+      volumes:
+      {{- if .Values.tiller.tls.enabled }}
+      - name: tiller-certs
+        secret:
+          defaultMode: 420
+          secretName: {{ template "magic-namespace.tillerTlsSecret" . }}
+      {{- end }}
     {{- with .Values.tiller.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/stable/magic-namespace/values.yaml
+++ b/stable/magic-namespace/values.yaml
@@ -23,6 +23,28 @@ tiller:
 
   maxHistory: 0
 
+  tls:
+    ## Enable TLS encryption between Helm and Tiller
+    enabled: false
+
+    ## Verify remote certificate
+    verify: true
+
+    ## The directory where Tiller's TLS certificates are located
+    certPath: /etc/certs
+
+    ## A custom secret to mount instead of specifying Base64 Values below
+    secretName: ""
+
+    ## Specify a Base64 encoded CA
+    # ca: "Zm9vCg=="
+
+    ## Specify a Base64 encoded cert
+    # cert: "Zm9vCg=="
+
+    ## Specify a Base64 encoded private key
+    # key: "Zm9vCg=="
+
   ## The following options specify the Role or ClusterRole to assign to the
   ## tiller service account. The ClusterRole "admin" is usually pre-defined in
   ## RBAC-enabled clusters and will allow administration of a namespace by
@@ -67,8 +89,8 @@ tiller:
 
 ## Optional additional ServiceAccounts
 serviceAccounts:
-- some-service-account
-- another-service-account
+# - some-service-account
+# - another-service-account
 
 ## Optional additional RoleBindings. It is a good idea to specify at least one
 ## to grant administrative permissions to a user or group.

--- a/stable/magic-namespace/values.yaml
+++ b/stable/magic-namespace/values.yaml
@@ -30,9 +30,6 @@ tiller:
     ## Verify remote certificate
     verify: true
 
-    ## The directory where Tiller's TLS certificates are located
-    certPath: /etc/certs
-
     ## A custom secret to mount instead of specifying Base64 Values below
     secretName: ""
 

--- a/stable/magic-namespace/values.yaml
+++ b/stable/magic-namespace/values.yaml
@@ -89,8 +89,8 @@ tiller:
 
 ## Optional additional ServiceAccounts
 serviceAccounts:
-# - some-service-account
-# - another-service-account
+- some-service-account
+- another-service-account
 
 ## Optional additional RoleBindings. It is a good idea to specify at least one
 ## to grant administrative permissions to a user or group.


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds TLS capabilities to the magic namespace installed Tiller, also:
* Fix Tiller container name
* Make additional service accounts optional

#### Special notes for your reviewer:
@lachie83 - Please review :)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
