### PR TITLE
[stable/weave-scope] Add readOnly flag

### DIFF
--- a/stable/weave-scope/Chart.yaml
+++ b/stable/weave-scope/Chart.yaml
@@ -1,5 +1,5 @@
 name: weave-scope
-version: 0.11.0
+version: 0.11.1
 appVersion: 1.10.1
 description: A Helm chart for the Weave Scope cluster visualizer.
 keywords:

--- a/stable/weave-scope/README.md
+++ b/stable/weave-scope/README.md
@@ -81,7 +81,8 @@ The **agent** section controls how the Weave Scope node agent pods are installed
 | **scopeFrontendAddr** | the host:port of a Scope frontend to send data to -- this is only needed in cases where the frontend is deployed separately from the agent (e.g. an install outside the cluster or a pre-existing install inside it) | |
 | **probeToken** | the token used to connect to Weave Cloud -- this is not needed for connecting to non-cloud Scope frontends | |
 | **rbac.*** | controls RBAC resource creation/use | |
-| **rbac.create** | whether RBAC resources should be created (required) -- this **must** be set to false if RBAC is not enabled in the cluster; it *may* be set to false in an RBAC-enabled cluster to allow for external management of RBAC | true |
+| **rbac.create** | whether RBAC resources should be created (required) -- this **must** be set to false if RBAC is not enabled in the cluster; it *may* be set to false in an RBAC-enabled cluster to allow for external management of RBAC | `true` |
+| **readOnly** | disables all controls (e.g. start/stop, terminal, logs, etc.) | `false` |
 | **serviceAccount.create** | whether a new service account name that the agent will use should be created. | `true` |
 | **serviceAccount.name** | service account to be used.  If not set and serviceAccount.create is `true` a name is generated using the fullname template. |  |
 | **resources.*** | controls requests/limits for the agent (these values are all optional) | |

--- a/stable/weave-scope/charts/weave-scope-agent/templates/daemonset.yaml
+++ b/stable/weave-scope/charts/weave-scope-agent/templates/daemonset.yaml
@@ -34,6 +34,9 @@ spec:
             - '--probe.docker.bridge={{ .Values.dockerBridge }}'
             - '--probe.docker=true'
             - '--probe.kubernetes=true'
+            {{if .Values.readOnly}}
+            - "--probe.no-controls"
+            {{end}}
             {{- if .Values.global.probeToken }}
             - '--probe-token={{ .Values.global.probeToken }}'
             {{- else if .Values.global.scopeFrontendAddr }}

--- a/stable/weave-scope/values.yaml
+++ b/stable/weave-scope/values.yaml
@@ -54,6 +54,8 @@ weave-scope-agent:
     # weave-scope-agent.rbac.create *must* be set to false if RBAC is not enabled in the cluster
     # weave-scope-agent.rbac.create *may* be set to false in an RBAC-enabled cluster to allow for external management of RBAC
     create: true
+  # Enabling readOnly adds --probe.no-controls to args list.
+  readOnly: false
   serviceAccount:
     # Specifies whether a ServiceAccount should be created
     create: true


### PR DESCRIPTION
#### What this PR does / why we need it:

This new flag allows to disable the controls completely. Once readOnly is set to true, it will add --probe.no-controls to the list of args for weave-scope-agent.

#### Which issue this PR fixes
No Issue.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
