### PR TITLE
[stable/envoy] Add prometheus-operator ServiceMonitor support

### DIFF
--- a/stable/envoy/Chart.yaml
+++ b/stable/envoy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Envoy is an open source edge and service proxy, designed for cloud-native applications.
 name: envoy
-version: 1.4.1
+version: 1.5.0
 appVersion: 1.9.0
 keywords:
 - envoy

--- a/stable/envoy/README.md
+++ b/stable/envoy/README.md
@@ -30,5 +30,12 @@ Parameter | Description | Default
 --- | --- | ---
 `files.envoy\.yaml` | content of a full envoy configuration file as documented in https://www.envoyproxy.io/docs/envoy/latest/configuration/configuration | See [values.yaml](values.yaml)
 `templates.envoy\.yaml` | golang template of a full configuration file. Use the `{{ .Values.foo.bar }}` syntax to embed chart values | See [values.yaml](values.yaml)
+`serviceMonitor.enabled` | if `true`, creates a Prometheus Operator ServiceMonitor | `false`
+`serviceMonitor.interval` | Interval that Prometheus scrapes Envoy metrics | `15s`
+`serviceMonitor.namespace` | Namespace which the operated Prometheus is running in | ``
+`serviceMonitor.additionalLabels` | Labels used by Prometheus Operator to discover your Service Monitor. Set according to your Prometheus setup | `{}`
+| `prometheusRule.enabled` | If `true`, creates a Prometheus Operator PrometheusRule | `false``
+| `prometheusRule.groups` | Prometheus alerting rules | `{}`
+| `prometheusRule.additionalLabels` | Labels used by Prometheus Operator to discover your Prometheus Rule | `{}`
 
 All other user-configurable settings, default values and some commentary about them can be found in [values.yaml](values.yaml).

--- a/stable/envoy/templates/servicemonitor.yaml
+++ b/stable/envoy/templates/servicemonitor.yaml
@@ -1,0 +1,30 @@
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.serviceMonitor.enabled )  }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: {{ template "envoy.name" . }}
+    chart: {{ template "envoy.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- if .Values.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.serviceMonitor.additionalLabels | indent 4}}
+{{- end }}
+  name: {{ template "envoy.fullname" . }}
+{{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+{{- end }}
+spec:
+  endpoints:
+  - targetPort: {{ .Values.ports.admin.containerPort }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    path: "/stats/prometheus"
+  jobLabel: {{ template "envoy.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "envoy.name" . }}
+      release: {{ .Release.Name }}
+{{- end }} 

--- a/stable/envoy/values.yaml
+++ b/stable/envoy/values.yaml
@@ -238,3 +238,40 @@ files:
 #               port_value: 443
 #         tls_context:
 #           sni: www.google.com
+
+## ServiceMonitor consumed by prometheus-operator
+serviceMonitor:
+  ## If the operator is installed in your cluster, set to true to create a Service Monitor Entry
+  enabled: false
+  interval: "15s"
+  ## Namespace in which the service monitor is created
+  # namespace: monitoring
+  # Added to the ServiceMonitor object so that prometheus-operator is able to discover it
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+  additionalLabels: {}
+
+## PrometheusRule consumed by prometheus-operator
+prometheusRule:
+  enabled: false
+  ## Namespace in which the prometheus rule is created
+  # namespace: monitoring
+  ## Define individual alerting rules as required
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#rulegroup
+  ##      https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+  groups:
+    upstream-rules:
+      enabled: true
+      rules:
+        high4xxRate:
+          enabled: true
+          alert: High4xxRate
+          expr: sum(rate(envoy_cluster_upstream_rq_xx{response_code_class="4"}[1m])) / sum(rate(envoy_cluster_upstream_rq_xx[1m])) * 100 > 1
+          for: 1m
+          labels:
+            severity: page
+          annotations:
+            summary: "4xx response rate above 1%"
+            description: "The 4xx error response rate for envoy cluster {{ $labels.envoy_cluster_name }} reported a service replication success rate of {{ $value }}% for more than 1 minute."
+  ## Added to the PrometheusRule object so that prometheus-operator is able to discover it
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+  additionalLabels: {}


### PR DESCRIPTION
Also bumps the chart minor version number because this results in a feature release

Signed-off-by: Yusuke Kuoka <ykuoka@gmail.com>