### PR TITLE
[stable/phabricator] Add global 'imagePullSecrets' to overwrite any other existing one

### DIFF
--- a/stable/phabricator/Chart.yaml
+++ b/stable/phabricator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: phabricator
-version: 4.0.15
+version: 4.1.0
 appVersion: 2019.10.0
 description: Collection of open source web applications that help software companies build better software.
 keywords:

--- a/stable/phabricator/README.md
+++ b/stable/phabricator/README.md
@@ -50,6 +50,7 @@ The following table lists the configurable parameters of the Phabricator chart a
 |               Parameter                |                 Description                  |                         Default                          |
 |----------------------------------------|----------------------------------------------|----------------------------------------------------------|
 | `global.imageRegistry`                 | Global Docker image registry                 | `nil`                                                    |
+| `global.imagePullSecrets`              | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
 | `image.registry`                       | Phabricator image registry                   | `docker.io`                                              |
 | `image.repository`                     | Phabricator image name                       | `bitnami/phabricator`                                    |
 | `image.tag`                            | Phabricator image tag                        | `{VERSION}`                                              |

--- a/stable/phabricator/templates/_helpers.tpl
+++ b/stable/phabricator/templates/_helpers.tpl
@@ -89,8 +89,7 @@ Also, we can not use a single if because lazy evaluation is not an option
 {{- if .Values.global }}
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
-{{- range
-.Values.global.imagePullSecrets }}
+{{- range .Values.global.imagePullSecrets }}
   - name: {{ . }}
 {{- end }}
 {{- else if or .Values.image.pullSecrets .Values.metrics.image.pullSecrets }}

--- a/stable/phabricator/templates/_helpers.tpl
+++ b/stable/phabricator/templates/_helpers.tpl
@@ -76,3 +76,39 @@ Return the proper image name (for the metrics image)
 {{- $tag := .Values.metrics.image.tag | toString -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "phabricator.imagePullSecrets" -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
+Also, we can not use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range
+.Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- else if or .Values.image.pullSecrets .Values.metrics.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.metrics.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- else if or .Values.image.pullSecrets .Values.metrics.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.metrics.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/stable/phabricator/templates/deployment.yaml
+++ b/stable/phabricator/templates/deployment.yaml
@@ -29,12 +29,7 @@ spec:
   {{- end }}
 {{- end }}
     spec:
-      {{- if .Values.image.pullSecrets }}
-      imagePullSecrets:
-      {{- range .Values.image.pullSecrets }}
-        - name: {{ . }}
-      {{- end}}
-      {{- end }}
+{{- include "phabricator.imagePullSecrets" . | indent 6 }}
       hostAliases:
       - ip: "127.0.0.1"
         hostnames:

--- a/stable/phabricator/values.yaml
+++ b/stable/phabricator/values.yaml
@@ -1,6 +1,6 @@
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
-## Current available global Docker image parameters: imageRegistry and imagepullSecrets
+## Current available global Docker image parameters: imageRegistry and imagePullSecrets
 ##
 # global:
 #   imageRegistry: myRegistryName

--- a/stable/phabricator/values.yaml
+++ b/stable/phabricator/values.yaml
@@ -1,8 +1,11 @@
-## Global Docker image registry
-## Please, note that this will override the image registry for all the images, including dependencies, configured to use the global value
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imageRegistry and imagepullSecrets
 ##
 # global:
-#   imageRegistry:
+#   imageRegistry: myRegistryName
+#   imagePullSecrets:
+#     - myRegistryKeySecretName
 
 ## Bitnami Phabricator image version
 ## ref: https://hub.docker.com/r/bitnami/phabricator/tags/
@@ -21,7 +24,7 @@ image:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   ##
   # pullSecrets:
-  #   - myRegistrKeySecretName
+  #   - myRegistryKeySecretName
 
 ## Phabricator host to create application URLs
 ## ref: https://github.com/bitnami/bitnami-docker-phabricator#configuration
@@ -225,7 +228,7 @@ metrics:
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
     ##
     # pullSecrets:
-    #   - myRegistrKeySecretName
+    #   - myRegistryKeySecretName
      ## Metrics exporter pod Annotation and Labels
   podAnnotations:
     prometheus.io/scrape: "true"


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR allows using a global parameter to indicate the array of secret names to use as Image Registry Secret.

Use:
```
$ kubectl create secret XXXX ...
$ helm install bitnami/apache --name apache --set global.imagePullSecrets=XXXX ...
```

Specify a secret globally for a specific registry, in this way, we are able to modify the registry and the secret for pulling images for all Charts globally without having to specify this per image

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
