### PR TITLE
bump Spinnaker & Halyard versions for Spinnaker chart

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.7.2
-appVersion: 1.11.6
+version: 1.8.0
+appVersion: 1.12.5
 home: http://spinnaker.io/
 sources:
 - https://github.com/spinnaker

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -1,8 +1,8 @@
 halyard:
-  spinnakerVersion: 1.11.6
+  spinnakerVersion: 1.12.5
   image:
     repository: gcr.io/spinnaker-marketplace/halyard
-    tag: 1.13.1
+    tag: 1.16.0
   # Provide a config map with Hal commands that will be run the core config (storage)
   # The config map should contain a script in the config.sh key
   additionalScripts:


### PR DESCRIPTION
Bump Spinnaker & Halyard versions. Review @viglesiasce ? Plz k thx :)

#### What this PR does / why we need it:

Bumps the default version of Spinnaker & Halyard to be the latest.

#### Special notes for your reviewer:

Latest versions of Spinnaker & Halyard have lots of fixes & improvements, so let the latest version of the Helm chart use them.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
