### PR TITLE
fix(stable/vault-operator): image.pullPolicy set to "Always"

### DIFF
--- a/stable/vault-operator/Chart.yaml
+++ b/stable/vault-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: CoreOS vault-operator Helm chart for Kubernetes
 name: vault-operator
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.1.9
 home: https://github.com/coreos/vault-operator
 icon: https://s3.amazonaws.com/hashicorp-marketing-web-assets/brand/Vault_VerticalLogo_FullColor.B1xPC0pSax.svg

--- a/stable/vault-operator/values.yaml
+++ b/stable/vault-operator/values.yaml
@@ -4,7 +4,7 @@ replicaCount: 1
 image:
   repository: quay.io/coreos/vault-operator
   tag: 0.1.9
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 ## Install Default RBAC roles and bindings
 rbac:


### PR DESCRIPTION
#### What this PR does / why we need it:
Variable image.pullPolicy was supposed to be set to "Always" according to [README.md](https://github.com/helm/charts/blob/master/stable/vault-operator/README.md#configuration) but is set to "IfNotPresent" in the [values.yaml](https://github.com/helm/charts/blob/master/stable/vault-operator/values.yaml#L7). Fixed it by changing value to "Always" in values.yaml.

#### Special notes for your reviewer: @mlaccetti 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped

Signed-off-by: Saad Rana <saadrana219@gmail.com>