### PR TITLE
Correct jenkins master ingress attribute

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.34.0
+version: 0.34.1
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/jenkins-master-ingress.yaml
+++ b/stable/jenkins/templates/jenkins-master-ingress.yaml
@@ -21,8 +21,8 @@ spec:
 {{- if .Values.Master.ingress.path }}
         path: {{ .Values.Master.ingress.path }}
 {{- end -}}
-{{- if .Values.Master.hostName }}
-    host: {{ .Values.Master.hostName | quote }}
+{{- if .Values.Master.ingress.hostName }}
+    host: {{ .Values.Master.ingress.hostName | quote }}
 {{- end }}
 {{- if .Values.Master.ingress.tls }}
   tls:


### PR DESCRIPTION
#### What this PR does / why we need it:
This chart's ingress does not work as is. In #11960, the attribute used to set the ingress hostname was modified, but does not match the path specified in `values.yaml`, and does not fit with the rest of the ingress attribute paths.

This PR makes the chart match the documentation