### PR TITLE
[stable/metrics-server] Add priorityClassName and podAnnotations to metrics server deployment

### DIFF
--- a/stable/metrics-server/Chart.yaml
+++ b/stable/metrics-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.3.1
 description: Metrics Server is a cluster-wide aggregator of resource usage data.
 name: metrics-server
-version: 2.4.0
+version: 2.5.0
 keywords:
 - metrics-server
 home: https://github.com/kubernetes-incubator/metrics-server

--- a/stable/metrics-server/README.md
+++ b/stable/metrics-server/README.md
@@ -1,6 +1,6 @@
 # metrics-server
 
-Metrics Server is a cluster-wide aggregator of resource usage data.
+[Metrics Server](https://github.com/kubernetes-incubator/metrics-server) is a cluster-wide aggregator of resource usage data.
 
 ## Configuration
 
@@ -23,3 +23,5 @@ Parameter | Description | Default
 `replicas` | Number of replicas | `1`
 `extraVolumeMounts` | Ability to provide volume mounts to the pod | `[]`
 `extraVolumes` | Ability to provide volumes to the pod | `[]`
+`podAnnotations` | annotations to be added to pods | `{}`
+`priorityClassName` | priorityClassName to be added to pods | `""`

--- a/stable/metrics-server/templates/metrics-server-deployment.yaml
+++ b/stable/metrics-server/templates/metrics-server-deployment.yaml
@@ -18,9 +18,9 @@ spec:
       labels:
         app: {{ template "metrics-server.name" . }}
         release: {{ .Release.Name }}
-      {{- if .Values.podAnnotations }}
+      {{- with .Values.podAnnotations }}
       annotations:
-      {{- range $key, $value := .Values.podAnnotations }}
+      {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- end }}

--- a/stable/metrics-server/templates/metrics-server-deployment.yaml
+++ b/stable/metrics-server/templates/metrics-server-deployment.yaml
@@ -18,11 +18,20 @@ spec:
       labels:
         app: {{ template "metrics-server.name" . }}
         release: {{ .Release.Name }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+      {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
     spec:
+{{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+{{- end }}
       serviceAccountName: {{ template "metrics-server.serviceAccountName" . }}
-{{ if .Values.hostNetwork.enabled }}
+{{- if .Values.hostNetwork.enabled }}
       hostNetwork: true
-{{ end }}
+{{- end }}
       containers:
         - name: metrics-server
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/metrics-server/templates/metrics-server-deployment.yaml
+++ b/stable/metrics-server/templates/metrics-server-deployment.yaml
@@ -35,7 +35,7 @@ spec:
 {{- if .Values.extraVolumeMounts }}
           volumeMounts:
 {{ toYaml .Values.extraVolumeMounts | indent 12}}
-  {{- end }}
+{{- end }}
         {{- with .Values.resources }}
           resources:
 {{ toYaml . | indent 12 }}
@@ -52,7 +52,7 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-  {{- if .Values.extraVolumes }}
+{{- if .Values.extraVolumes }}
       volumes:
-  {{ toYaml .Values.extraVolumes | indent 8}}
-  {{- end }}
+{{ toYaml .Values.extraVolumes | indent 8}}
+{{- end }}

--- a/stable/metrics-server/values.yaml
+++ b/stable/metrics-server/values.yaml
@@ -46,6 +46,11 @@ affinity: {}
 
 replicas: 1
 
+podAnnotations: {}
+#  scheduler.alpha.kubernetes.io/critical-pod: ''
+
+#priorityClassName: system-node-critical
+
 extraVolumeMounts: []
 #  - name: secrets
 #    mountPath: /etc/kubernetes/secrets

--- a/stable/metrics-server/values.yaml
+++ b/stable/metrics-server/values.yaml
@@ -49,7 +49,7 @@ replicas: 1
 podAnnotations: {}
 #  scheduler.alpha.kubernetes.io/critical-pod: ''
 
-#priorityClassName: system-node-critical
+# priorityClassName: system-node-critical
 
 extraVolumeMounts: []
 #  - name: secrets


### PR DESCRIPTION
#### What this PR does / why we need it:
- Since metrics-server pod is important, so I add priorityClass for deployment
- In the cluster which ```priorityClass``` can not be used, it is possible to specify ```scheduler.alpha.kubernetes.io/critical-pod``` by podAnnotations.
- In addition I fixed https://github.com/helm/charts/commit/544699151ad871f5fce1b239ee08ce5833ff5bf0

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
