### PR TITLE
Adds PSP for speaker daemon set to metallb

### DIFF
--- a/stable/metallb/Chart.yaml
+++ b/stable/metallb/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.8.4
+version: 0.9.0
 
 name: metallb
 appVersion: 0.7.3

--- a/stable/metallb/templates/podsecuritypolicy.yaml
+++ b/stable/metallb/templates/podsecuritypolicy.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.podSecurityPolicy.enabled }}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "metallb.fullname" . }}-speaker
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
+spec:
+  allowPrivilegeEscalation: false
+  allowedCapabilities:
+  - NET_ADMIN
+  - NET_RAW
+  - SYS_ADMIN
+  fsGroup:
+    rule: RunAsAny
+  hostNetwork: true
+  hostPorts:
+  - max: 7472
+    min: 7472
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+{{- end}}

--- a/stable/metallb/templates/rbac.yaml
+++ b/stable/metallb/templates/rbac.yaml
@@ -34,6 +34,12 @@ rules:
 - apiGroups: [""]
   resources: ["services", "endpoints", "nodes"]
   verbs: ["get", "list", "watch"]
+{{- if .Values.podSecurityPolicy.enabled }}
+- apiGroups: ["extensions"]
+  resourceNames: ["{{ template "metallb.fullname" . }}-speaker"]
+  resources: ["podsecuritypolicies"]
+  verbs: ["use"]
+{{- end}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/stable/metallb/values.yaml
+++ b/stable/metallb/values.yaml
@@ -40,6 +40,10 @@ rbac:
   # create specifies whether to install and use RBAC rules.
   create: true
 
+# Enable the creation of PodSecurityPolicy for speaker DaemonSet
+podSecurityPolicy:
+  enabled: false
+
 prometheus:
   # scrape annotations specifies whether to add Prometheus metric
   # auto-collection annotations to pods. See


### PR DESCRIPTION
#### What this PR does / why we need it:
Clusters with pod security enabled can't run the speaker DaemonSet without a PSP attached. This addition lets the chart bootstrap a PSP for speaker.

#### Which issue this PR fixes
No issues as of writing this

#### Special notes for your reviewer:
I hope I got the PSP correct but it may be to permissive.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
