### PR TITLE
[stable/socat-tunneller] Add chart

### DIFF
--- a/stable/socat-tunneller/.helmignore
+++ b/stable/socat-tunneller/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/socat-tunneller/Chart.yaml
+++ b/stable/socat-tunneller/Chart.yaml
@@ -3,3 +3,4 @@ appVersion: "1.0"
 description: A Helm chart for socat-tunneller
 name: socat-tunneller
 version: 0.1.0
+home: http://www.dest-unreach.org/socat/

--- a/stable/socat-tunneller/Chart.yaml
+++ b/stable/socat-tunneller/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for socat-tunneller
+name: socat-tunneller
+version: 0.1.0

--- a/stable/socat-tunneller/Chart.yaml
+++ b/stable/socat-tunneller/Chart.yaml
@@ -4,3 +4,6 @@ description: A Helm chart for socat-tunneller
 name: socat-tunneller
 version: 0.1.0
 home: http://www.dest-unreach.org/socat/
+maintainers:
+  - name: plumdog
+    email: plummer574@gmail.com

--- a/stable/socat-tunneller/README.md
+++ b/stable/socat-tunneller/README.md
@@ -1,0 +1,46 @@
+# socat-tunneller
+
+A `port-forward` proxy. Allows an onward connection from the cluster
+to some other host in your cluster's network, eg your hosted
+database/cache/other service.
+
+In practice, this means that a hosted service can be made available
+only to the cluster, then cluster users can be granted access by
+giving them permission to run `port-forward` on the tunneller.
+
+## Basic usage
+
+```
+helm install stable/socat-tunneller --name db-tunneller --set tunnel.host=mydbhost.cloud --set tunnel.port=3306 --set nameOverride=db-tunneller
+```
+then
+```
+kubectl port-forward svc/db-tunneller 13306:3306
+```
+then, for eg
+```
+mysql -u myuser -h 127.0.0.1 --port 13306 -p
+```
+
+## Configuration values
+
+### Important configuration
+
+| Parameter     | Description                                              | Default    |
+| ---------     | -----------                                              | -------    |
+| `tunnel.host` | The host to target, this should be resolvable by the pod | (required) |
+| `tunnel.port` | The port to target on the host                           | (required) |
+
+### Other configuration
+
+| Parameter          | Description                    | Default        |
+| ---------          | -----------                    | -------        |
+| `replicaCount`     | Deployment replicas            | 1              |
+| `image.repository` | Image repository               | `alpine/socat` |
+| `image.tag`        | Image tag                      | `1.0.3`        |
+| `image.pullPolicy` | Image pull policy              | `IfNotPresent` |
+| `resources`        | Container resources            | `{}`           |
+| `nodeSelector`     | Pod node selector              | `{}`           |
+| `tolerations`      | Pod tolerations                | `[]`           |
+| `affinity`         | Pod affinity                   | `{}`           |
+| `podAnnotations`   | Pod annotations                | `{}`           |

--- a/stable/socat-tunneller/templates/NOTES.txt
+++ b/stable/socat-tunneller/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Connect to the target by using kubectl port-forward to forward one of your local ports to a tunneller pod's port {{ .Values.tunnel.port }}, or to the service using svc/{{ include "tunneller.fullname" . }}.

--- a/stable/socat-tunneller/templates/_helpers.tpl
+++ b/stable/socat-tunneller/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tunneller.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tunneller.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tunneller.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/socat-tunneller/templates/deployment.yaml
+++ b/stable/socat-tunneller/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "tunneller.fullname" . }}

--- a/stable/socat-tunneller/templates/deployment.yaml
+++ b/stable/socat-tunneller/templates/deployment.yaml
@@ -3,21 +3,21 @@ kind: Deployment
 metadata:
   name: {{ include "tunneller.fullname" . }}
   labels:
-    app: {{ include "tunneller.name" . }}
-    chart: {{ include "tunneller.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "tunneller.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "tunneller.chart" . }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ include "tunneller.name" . }}
-      release: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ include "tunneller.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ include "tunneller.name" . }}
-        release: {{ .Release.Name }}
+        app.kubernetes.io/name: {{ include "tunneller.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
 {{- with .Values.podAnnotations }}
       annotations:
 {{ toYaml . | indent 8 }}

--- a/stable/socat-tunneller/templates/deployment.yaml
+++ b/stable/socat-tunneller/templates/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ include "tunneller.fullname" . }}
+  labels:
+    app: {{ include "tunneller.name" . }}
+    chart: {{ include "tunneller.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "tunneller.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "tunneller.name" . }}
+        release: {{ .Release.Name }}
+{{- with .Values.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - socat
+          args:
+            - "TCP-LISTEN:$(TUNNEL_PORT),fork"
+            - "TCP:$(TUNNEL_HOST):$(TUNNEL_PORT)"
+          env:
+            - name: TUNNEL_HOST
+              value: {{ required "Must specify a target host for the tunnel." .Values.tunnel.host | quote }}
+            - name: TUNNEL_PORT
+              value: {{ required "Must specify a target port for the tunnel." .Values.tunnel.port | quote }}
+          ports:
+            - name: tunnel-port
+              containerPort: {{ (int64 .Values.tunnel.port) }}
+              protocol: TCP
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/stable/socat-tunneller/templates/service.yaml
+++ b/stable/socat-tunneller/templates/service.yaml
@@ -3,10 +3,10 @@ kind: Service
 metadata:
   name: {{ include "tunneller.fullname" . }}
   labels:
-    app: {{ include "tunneller.name" . }}
-    chart: {{ include "tunneller.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "tunneller.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "tunneller.chart" . }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -15,5 +15,5 @@ spec:
       protocol: TCP
       name: tunnel-port
   selector:
-    app: {{ include "tunneller.name" . }}
-    release: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ include "tunneller.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/socat-tunneller/templates/service.yaml
+++ b/stable/socat-tunneller/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tunneller.fullname" . }}
+  labels:
+    app: {{ include "tunneller.name" . }}
+    chart: {{ include "tunneller.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.tunnel.port }}
+      targetPort: tunnel-port
+      protocol: TCP
+      name: tunnel-port
+  selector:
+    app: {{ include "tunneller.name" . }}
+    release: {{ .Release.Name }}

--- a/stable/socat-tunneller/values.yaml
+++ b/stable/socat-tunneller/values.yaml
@@ -1,0 +1,26 @@
+replicaCount: 1
+
+image:
+  repository: alpine/socat
+  tag: 1.0.3
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+podAnnotations: {}
+
+tunnel:
+  host:
+  port:

--- a/stable/socat-tunneller/values.yaml
+++ b/stable/socat-tunneller/values.yaml
@@ -22,5 +22,5 @@ affinity: {}
 podAnnotations: {}
 
 tunnel:
-  host:
-  port:
+  host: myhost
+  port: 9999


### PR DESCRIPTION
Signed-off-by: Andrew Plummer <plummer574@gmail.com>

#### What this PR does / why we need it:

This adds a little chart to run a pod running `socat`, to proxy `kubectl port-forward` on to some other host accessible to the cluster (eg, a hosted database).

I think this will have wider usage as I have had to add it to basically every cluster I've stood up.

It might be that a better/cleverer solution to this problem already exists that I don't know about.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Variables are documented in the README.md