### PR TITLE
 [stable/nats] Add global options to values-production

### DIFF
--- a/stable/nats/Chart.yaml
+++ b/stable/nats/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nats
-version: 2.1.0
+version: 2.2.0
 appVersion: 1.4.1
 description: An open-source, cloud-native messaging system
 keywords:

--- a/stable/nats/values-production.yaml
+++ b/stable/nats/values-production.yaml
@@ -1,8 +1,9 @@
-## Global Docker image registry
-## Please, note that this will override the image registry for all the images, including dependencies, configured to use the global value
-##
-# global:
-#   imageRegistry:
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistryKeySecretName
 
 ## Bitnami NATS image version
 ## ref: https://hub.docker.com/r/bitnami/nats/tags/
@@ -17,7 +18,7 @@ image:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   ##
   # pullSecrets:
-  #   - name: myRegistrKeySecretName
+  #   - name: myRegistryKeySecretName
 
 ## NATS replicas
 replicaCount: 3
@@ -267,7 +268,7 @@ metrics:
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
     ##
     # pullSecrets:
-    #   - myRegistrKeySecretName
+    #   - myRegistryKeySecretName
   ## Metrics exporter resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##

--- a/stable/nats/values-production.yaml
+++ b/stable/nats/values-production.yaml
@@ -1,9 +1,11 @@
-  ## Optionally specify an array of imagePullSecrets.
-  ## Secrets must be manually created in the namespace.
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-  ##
-  # pullSecrets:
-  #   - myRegistryKeySecretName
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imageRegistry and imagePullSecrets
+##
+# global:
+#   imageRegistry: myRegistryName
+#   imagePullSecrets:
+#     - myRegistryKeySecretName
 
 ## Bitnami NATS image version
 ## ref: https://hub.docker.com/r/bitnami/nats/tags/


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR allows using a global parameter in the production yaml to indicate the array of secret names to use as Image Registry Secret.

Use:
```
$ kubectl create secret XXXX ...
$ helm install bitnami/apache --name apache --set global.imagePullSecrets=XXXX ...
```

Specify a secret globally for a specific registry, in this way, we are able to modify the registry and the secret for pulling images for all Charts globally without having to specify this per image

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md