### PR TITLE
[stable/grafana] Upgrade sidecar to v0.0.13

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 2.2.4
+version: 2.2.5
 appVersion: 6.0.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -78,7 +78,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ldap.config  `                           | Grafana's LDAP configuration                  | `""`                                                    |
 | `annotations`                             | Deployment annotations                        | `{}`                                                    |
 | `podAnnotations`                          | Pod annotations                               | `{}`                                                    |
-| `sidecar.image`              | Sidecar image | `kiwigrid/k8s-sidecar:0.0.11`       |
+| `sidecar.image`              | Sidecar image | `kiwigrid/k8s-sidecar:0.0.13`       |
 | `sidecar.imagePullPolicy`              | Sidecar image pull policy | `IfNotPresent`       |
 | `sidecar.resources`              | Sidecar resources | `{}`       |
 | `sidecar.dashboards.enabled`              | Enabled the cluster wide search for dashboards and adds/updates/deletes them in grafana | `false`       |

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -321,7 +321,7 @@ smtp:
 ## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
 ## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards
 sidecar:
-  image: kiwigrid/k8s-sidecar:0.0.11
+  image: kiwigrid/k8s-sidecar:0.0.13
   imagePullPolicy: IfNotPresent
   resources: {}
 #   limits:


### PR DESCRIPTION
#### What this PR does / why we need it:

Upgrade `kiwigrid/k8s-sidecar` to `v0.0.13`.
Despite upgrading to `v0.0.10` (in #11409), the error still occurs and the pod is restarted (as the application crashes). And the problem is still present in `v0.0.11`.
This is now "patched" in `v0.0.12` with a `try/catch` (see kiwigrid/k8s-sidecar/pull/15).

#### Which issue this PR fixes
  - fixes #9136

#### Special notes for your reviewer:

Thanks @zanhsieh @rtluckie @maorfr

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
