### PR TITLE
Adding resource metric support

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus-adapter
-version: v0.4.1
+version: v0.4.2
 appVersion: v0.4.1
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/README.md
+++ b/stable/prometheus-adapter/README.md
@@ -49,6 +49,7 @@ The following table lists the configurable parameters of the Prometheus Adapter 
 | `rbac.create`                   | If true, create & use RBAC resources                                            | `true`                                      |
 | `resources`                     | CPU/Memory resource requests/limits                                             | `{}`                                        |
 | `rules.default`                 | If `true`, enable a set of default rules in the configmap                       | `true`                                      |
+| `rules.resources`               | If `true`, enable resource metric collection in the configmap                   | `false`                                     |
 | `rules.custom`                  | A list of custom configmap rules                                                | `[]`                                        |
 | `rules.existing`                | The name of an existing configMap with rules. Overrides default and custom.     | ``                                          |                                                                                                        
 | `service.annotations`           | Annotations to add to the service                                               | `{}`                                        |

--- a/stable/prometheus-adapter/templates/custom-metrics-configmap.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-configmap.yaml
@@ -82,4 +82,32 @@ data:
 {{- if .Values.rules.custom }}
 {{ toYaml .Values.rules.custom | indent 4 }}
 {{- end -}}
+{{- if .Values.rules.resources }}
+    resourceRules:
+      cpu:
+        containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>)
+        nodeQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, id='/'}[1m])) by (<<.GroupBy>>)
+        resources:
+          overrides:
+            instance:
+              resource: node
+            namespace:
+              resource: namespace
+            pod_name:
+              resource: pod
+        containerLabel: container_name
+      memory:
+        containerQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+        nodeQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>,id='/'}) by (<<.GroupBy>>)
+        resources:
+          overrides:
+            instance:
+              resource: node
+            namespace:
+              resource: namespace
+            pod_name:
+              resource: pod
+        containerLabel: container_name
+      window: 1m
+{{- end -}}
 {{- end -}}

--- a/stable/prometheus-adapter/templates/custom-metrics-resource-reader-cluster-role.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-resource-reader-cluster-role.yaml
@@ -16,7 +16,13 @@ rules:
   - pods
   - services
   - configmaps
+  {{- if .Values.rules.resources }}
+  - nodes
+  {{- end }}
   verbs:
   - get
   - list
+  {{- if .Values.rules.resources }}
+  - watch
+  {{- end }}
 {{- end -}}

--- a/stable/prometheus-adapter/templates/metrics-apiservice.yaml
+++ b/stable/prometheus-adapter/templates/metrics-apiservice.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.rules.resources -}}
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  labels:
+    app: {{ template "k8s-prometheus-adapter.name" . }}
+    chart: {{ template "k8s-prometheus-adapter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: v1beta1.metrics.k8s.io
+spec:
+  service:
+    name: {{ template "k8s-prometheus-adapter.fullname" . }}
+    namespace: {{ .Release.Namespace | quote }}
+  {{ if .Values.tls.enable -}}
+  caBundle: {{ b64enc .Values.tls.ca }}
+  {{- end }}
+  group: metrics.k8s.io
+  version: v1beta1
+  insecureSkipTLSVerify: {{ if .Values.tls.enable }}false{{ else }}true{{ end }}
+  groupPriorityMinimum: 100
+  versionPriority: 100
+{{- end -}}

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -40,6 +40,7 @@ resources: {}
 
 rules:
   default: true
+  resources: false
   custom: []
 # - seriesQuery: '{__name__=~"^some_metric_count$"}'
 #   resources:


### PR DESCRIPTION
This PR provides the ability for the prometheus adapter to provide resource level metrics for pods and nodes if the metric-server is not available. The functionality was introduced v.0.3.0 