### PR TITLE
Remove quotes around _SYSTEMD_UNIT value

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 1.9.1
+version: 1.9.2
 appVersion: 1.0.6
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -42,7 +42,7 @@ data:
         Name            systemd
         Tag             {{ .Values.input.systemd.tag }}
 {{- range $value := .Values.input.systemd.filters.systemdUnit }}
-        Systemd_Filter  _SYSTEMD_UNIT="{{ $value }}"
+        Systemd_Filter  _SYSTEMD_UNIT={{ $value }}
 {{- end }}
         Max_Entries     {{ .Values.input.systemd.maxEntries }}
         Read_From_Tail  {{ .Values.input.systemd.readFromTail }}


### PR DESCRIPTION
#### What this PR does / why we need it:

If the _SYSTEMD_UNIT value is quoted then fluent-bit will fail to pick
up the value desired. Removing the quotes fixes the issue.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes # 12161

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped

Signed-off-by: Steve Flanders <steve@sflanders.net>