### PR TITLE
[stable/external-dns] Add support for Dyn

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: external-dns
-version: 2.0.2
-appVersion: 0.5.15
+version: 2.0.3
+appVersion: 0.5.16
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:
 - external-dns

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -73,6 +73,9 @@ The following table lists the configurable parameters of the external-dns chart 
 | `designate.customCA.mountPath`     | When using the Designate provider, set the mountPath in which to mount the custom CA configuration       | "/config/designate"                                      |
 | `designate.customCA.filename`      | When using the Designate provider, set the custom CA configuration filename                              | "designate-ca.pem"                                       |
 | `digitalocean.apiToken`            | When using the DigitalOcean provider, `DO_TOKEN` to set (optional)                                       | `""`                                                     |
+| `dyn.customerName`                | When using Dyn provider, specify the Dyn Customer Name.                                                                     | `""`                                               |
+| `dyn.username`                     | When using Dyn provider, specify the Dyn Username.                                                                         | `""`                                               |
+| `dyn.password`                     | When using Dyn provider, specify the Dyn Password.                                                                         | `""`   
 | `google.project`                   | When using the Google provider, specify the Google project (required when provider=google)               | `""`                                                     |
 | `google.serviceAccountSecret`      | When using the Google provider, specify the existing secret which contains credentials.json (optional)   | `""`                                                     |
 | `google.serviceAccountKey`         | When using the Google provider, specify the service account key JSON file. (required when `google.serviceAccountSecret` is not provided. In this case a new secret will be created holding this service account | `""` |

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -203,6 +203,28 @@ spec:
               name: {{ template "external-dns.fullname" . }}
               key: digitalocean_api_token
         {{- end }}
+        # Dyn environment variables
+        {{- if .Values.dyn.customerName }}
+          - name: EXTERNAL_DNS_DYN_CUSTOMER_NAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "external-dns.fullname" . }}
+                key: dyn_customer_name
+        {{- end }}
+        {{- if .Values.dyn.username }}
+          - name: EXTERNAL_DNS_DYN_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "external-dns.fullname" . }}
+                key: dyn_username
+        {{- end }}
+        {{- if .Values.dyn.password }}
+          - name: EXTERNAL_DNS_DYN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "external-dns.fullname" . }}
+                key: dyn_password
+        {{- end }}
         # Google environment variables
         {{- if eq .Values.provider "google" }}
         - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/stable/external-dns/templates/secret.yaml
+++ b/stable/external-dns/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.aws.assumeRoleArn (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey) .Values.cloudflare.apiKey .Values.digitalocean.apiToken .Values.google.serviceAccountKey (and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword) .Values.rfc2136.tsigSecret .Values.extraEnv }}
+{{- if or .Values.aws.assumeRoleArn (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey) .Values.cloudflare.apiKey .Values.digitalocean.apiToken (and .Values.dyn.customerName .Values.dyn.username .Values.dyn.password) .Values.google.serviceAccountKey (and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword) .Values.rfc2136.tsigSecret .Values.extraEnv }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -22,6 +22,15 @@ data:
   {{- end }}
   {{- if .Values.digitalocean.apiToken }}
   digitalocean_api_token: {{ .Values.digitalocean.apiToken | b64enc | quote }}
+  {{- end }}
+  {{ if .Values.dyn.customerName }}
+  dyn_customer_name: {{ .Values.dyn.customerName | b64enc | quote }}
+  {{- end }}
+  {{ if .Values.dyn.username }}
+  dyn_username: {{ .Values.dyn.username | b64enc | quote }}
+  {{- end }}
+  {{ if .Values.dyn.password }}
+  dyn_password: {{ .Values.dyn.password | b64enc | quote }}
   {{- end }}
   {{- if and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword }}
   infoblox_wapi_username: {{ .Values.infoblox.wapiUsername | b64enc | quote }}

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -40,7 +40,7 @@ sources:
 # - crd
 
 ## DNS provider where the DNS records will be created. Available providers are:
-## - aws, azure, cloudflare, designate, digitalocoean, google, infoblox, rfc2136
+## - aws, azure, cloudflare, designate, digitalocoean, dyn, google, infoblox, rfc2136
 ##
 provider: aws
 
@@ -119,6 +119,12 @@ digitalocean:
   ## `DO_TOKEN` to set in the environment
   ##
   apiToken: ""
+
+# Configuration for Dyn provider.
+dyn:
+  customer_name: ""
+  username: ""
+  password: ""
 
 ## Google configuration to be set via arguments/env. variables
 ##


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds support for Dyn to external-dns chart.

#### Special notes for your reviewer:

Tested against Kubernetes 1.11.5 and Helm 2.13.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
