### PR TITLE
[stable/openvpn] Updated notes to use logs command instead of deprecated log command

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 3.12.0
+version: 3.12.1
 appVersion: 1.1.0
 maintainers:
 - name: jfelten

--- a/stable/openvpn/README.md
+++ b/stable/openvpn/README.md
@@ -18,7 +18,7 @@ Check pod status, replacing `$HELM_RELEASE` with the name of your release, via:
 
 ```bash
 POD_NAME=$(kubectl get pods -l "app=openvpn,release=$HELM_RELEASE" -o jsonpath='{.items[0].metadata.name}') \
-&& kubectl log "$POD_NAME" --follow
+&& kubectl logs "$POD_NAME" --follow
 ```
 
 When all components of the openvpn chart have started use the following script to generate a client key:

--- a/stable/openvpn/templates/NOTES.txt
+++ b/stable/openvpn/templates/NOTES.txt
@@ -4,7 +4,7 @@ Please be aware that certificate generation is variable and may take some time (
 
 Check pod status with the command:
 
-  POD_NAME=$(kubectl get pods --namespace "{{ .Release.Namespace }}" -l app=openvpn -o jsonpath='{ .items[0].metadata.name }') && kubectl log $POD_NAME --follow
+  POD_NAME=$(kubectl get pods --namespace "{{ .Release.Namespace }}" -l app=openvpn -o jsonpath='{ .items[0].metadata.name }') && kubectl logs $POD_NAME --follow
 
 LoadBalancer ingress creation can take some time as well. Check service status with the command:
 


### PR DESCRIPTION
#### What this PR does / why we need it:
The kubectl log command referenced in the chart notes is deprecated.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
