### PR TITLE
Fixed invalid empty annotations in kube-state-metrics chart template

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - metric
 - monitoring
 - prometheus
-version: 0.14.1
+version: 0.14.2
 appVersion: 1.5.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/templates/podsecuritypolicy.yaml
+++ b/stable/kube-state-metrics/templates/podsecuritypolicy.yaml
@@ -8,8 +8,8 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  annotations:
 {{- if .Values.podSecurityPolicy.annotations }}
+  annotations:
 {{ toYaml .Values.podSecurityPolicy.annotations | indent 4 }}
 {{- end }}
 spec:

--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 6.3.0
+version: 6.3.1
 appVersion: 4.0.13
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/redis-master-svc.yaml
+++ b/stable/redis/templates/redis-master-svc.yaml
@@ -7,9 +7,9 @@ metadata:
     chart: {{ template "redis.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-{{- with .Values.master.service.annotations }}
+{{- if .Values.master.service.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
+{{ toYaml .Values.master.service.annotations | indent 4 }}
 {{- end }}
 spec:
   type: {{ .Values.master.service.type }}


### PR DESCRIPTION
Signed-off-by: Guillermo Guirao Aguilar <contact@guillermoguiraoaguilar.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

The kube-state-metrics chart template renders an empty annotations field. This PR ensures that the annotations field is only included if it contains values.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
