### PR TITLE
[stable/elasticsearch] Add options for pre-stop and post-start hooks 

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.29.1
+version: 1.30.0
 appVersion: 6.7.0
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/stable/elasticsearch/README.md
+++ b/stable/elasticsearch/README.md
@@ -135,6 +135,8 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `master.nodeAffinity`                | Master node affinity policy                                         | `{}`                                                |
 | `master.podManagementPolicy`         | Master pod creation strategy                                        | `OrderedReady`                                      |
 | `master.updateStrategy`              | Master node update strategy policy                                  | `{type: "onDelete"}`                                |
+| `master.hooks.preStop`               | Master nodes: Lifecycle hook script to execute prior the pod stops  | `nil`                                               |
+| `master.hooks.preStart`              | Master nodes: Lifecycle hook script to execute after the pod starts | `nil`                                               |
 | `data.initResources`                 | Data initContainer resources requests & limits                      | `{}`                                                |
 | `data.additionalJavaOpts`            | Parameters to be added to `ES_JAVA_OPTS` environment variable for data | `""`                                             |
 | `data.exposeHttp`                    | Expose http port 9200 on data Pods for monitoring, etc              | `false`                                             |

--- a/stable/elasticsearch/README.md
+++ b/stable/elasticsearch/README.md
@@ -95,6 +95,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `client.podAnnotations`              | Client Deployment annotations                                       | `{}`                                                |
 | `client.nodeSelector`                | Node labels for client pod assignment                               | `{}`                                                |
 | `client.tolerations`                 | Client tolerations                                                  | `[]`                                                |
+| `client.terminationGracePeriodSeconds` | Client nodes: Termination grace period (seconds)                  | `nil`                                               |
 | `client.serviceAnnotations`          | Client Service annotations                                          | `{}`                                                |
 | `client.serviceType`                 | Client service type                                                 | `ClusterIP`                                         |
 | `client.httpNodePort`                | Client service HTTP NodePort port number. Has no effect if client.serviceType is not `NodePort`.   | `nil`                                         |
@@ -123,6 +124,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `master.podAnnotations`              | Master Deployment annotations                                       | `{}`                                                |
 | `master.nodeSelector`                | Node labels for master pod assignment                               | `{}`                                                |
 | `master.tolerations`                 | Master tolerations                                                  | `[]`                                                |
+| `master.terminationGracePeriodSeconds` | Master nodes: Termination grace period (seconds)                  | `nil`                                               |
 | `master.heapSize`                    | Master node heap size                                               | `512m`                                              |
 | `master.name`                        | Master component name                                               | `master`                                            |
 | `master.persistence.enabled`         | Master persistent enabled/disabled                                  | `true`                                              |

--- a/stable/elasticsearch/README.md
+++ b/stable/elasticsearch/README.md
@@ -141,6 +141,8 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `data.priorityClassName`             | Data priorityClass                                                  | `nil`                                               |
 | `data.heapSize`                      | Data node heap size                                                 | `1536m`                                             |
 | `data.hooks.drain.enabled`           | Data nodes: Enable drain pre-stop and post-start hook               | `true`                                              |
+| `data.hooks.preStop`                 | Data nodes: Lifecycle hook script to execute prior the pod stops. Ignored if `data.hooks.drain.enabled` is `true` | `nil` |
+| `data.hooks.preStart`                | Data nodes: Lifecycle hook script to execute after the pod starts. Ignored if `data.hooks.drain.enabled` is `true` | `nil`|
 | `data.persistence.enabled`           | Data persistent enabled/disabled                                    | `true`                                              |
 | `data.persistence.name`              | Data statefulset PVC template name                                  | `data`                                              |
 | `data.persistence.size`              | Data persistent volume size                                         | `30Gi`                                              |

--- a/stable/elasticsearch/README.md
+++ b/stable/elasticsearch/README.md
@@ -103,6 +103,8 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `client.antiAffinity`                | Client anti-affinity policy                                         | `soft`                                              |
 | `client.nodeAffinity`                | Client node affinity policy                                         | `{}`                                                |
 | `client.initResources`               | Client initContainer resources requests & limits                    | `{}`                                                |
+| `client.hooks.preStop`               | Client nodes: Lifecycle hook script to execute prior the pod stops  | `nil`                                               |
+| `client.hooks.preStart`              | Client nodes: Lifecycle hook script to execute after the pod starts | `nil`                                               |
 | `client.additionalJavaOpts`          | Parameters to be added to `ES_JAVA_OPTS` environment variable for client | `""`                                           |
 | `client.ingress.enabled`             | Enable Client Ingress                                               | `false`                                             |
 | `client.ingress.user`                | If this & password are set, enable basic-auth on ingress            | `nil`                                               |

--- a/stable/elasticsearch/ci/hooks-values.yaml
+++ b/stable/elasticsearch/ci/hooks-values.yaml
@@ -1,0 +1,31 @@
+---
+# Enable custom lifecycle hooks for client, data and master pods
+
+client:
+  hooks:
+    preStop: |-
+      #!/bin/bash
+      echo "Node {{ template "elasticsearch.client.fullname" . }} is shutting down"
+    postStart: |-
+      #!/bin/bash
+      echo "Node {{ template "elasticsearch.client.fullname" . }} is ready to be used"
+
+data:
+  hooks:
+    drain:
+      enabled: false
+    preStop: |-
+      #!/bin/bash
+      echo "Node {{ template "elasticsearch.data.fullname" . }} is shutting down"
+    postStart: |-
+      #!/bin/bash
+      echo "Node {{ template "elasticsearch.data.fullname" . }} is ready to be used"
+
+master:
+  hooks:
+    preStop: |-
+      #!/bin/bash
+      echo "Node {{ template "elasticsearch.master.fullname" . }} is shutting down"
+    postStart: |-
+      #!/bin/bash
+      echo "Node {{ template "elasticsearch.master.fullname" . }} is ready to be used"

--- a/stable/elasticsearch/templates/client-deployment.yaml
+++ b/stable/elasticsearch/templates/client-deployment.yaml
@@ -64,6 +64,9 @@ spec:
       tolerations:
 {{ toYaml .Values.client.tolerations | indent 8 }}
 {{- end }}
+{{- if .Values.client.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.client.terminationGracePeriodSeconds }}
+{{- end }}
 {{- if or .Values.extraInitContainers .Values.sysctlInitContainer.enabled .Values.cluster.plugins }}
       initContainers:
 {{- if .Values.sysctlInitContainer.enabled }}

--- a/stable/elasticsearch/templates/client-deployment.yaml
+++ b/stable/elasticsearch/templates/client-deployment.yaml
@@ -155,6 +155,29 @@ spec:
           subPath: elasticsearch.keystore
           readOnly: true
 {{- end }}
+{{- if .Values.client.hooks.preStop }}
+        - name: config
+          mountPath: /client-pre-stop-hook.sh
+          subPath: client-pre-stop-hook.sh
+{{- end }}
+{{- if .Values.client.hooks.postStart }}
+        - name: config
+          mountPath: /client-post-start-hook.sh
+          subPath: client-post-start-hook.sh
+{{- end }}
+{{- if or .Values.client.hooks.preStop .Values.client.hooks.postStart }}
+        lifecycle:
+  {{- if .Values.client.hooks.preStop }}
+          preStop:
+            exec:
+              command: ["/bin/bash","/client-pre-stop-hook.sh"]
+  {{- end }}
+  {{- if .Values.client.hooks.postStart }}
+          postStart:
+            exec:
+              command: ["/bin/bash","/client-post-start-hook.sh"]
+  {{- end }}
+{{- end }}
 {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range $pullSecret := .Values.image.pullSecrets }}

--- a/stable/elasticsearch/templates/configmap.yaml
+++ b/stable/elasticsearch/templates/configmap.yaml
@@ -98,7 +98,7 @@ data:
 {{ tpl .Values.cluster.log4j2Properties . | indent 4 }}
 {{- end }}
 {{- if .Values.data.hooks.drain.enabled }}
-  pre-stop-hook.sh: |-
+  data-pre-stop-hook.sh: |-
     #!/bin/bash
     exec &> >(tee -a "/var/log/elasticsearch-hooks.log")
     NODE_NAME=${HOSTNAME}
@@ -120,7 +120,7 @@ data:
       sleep 1
     done
     echo "Node ${NODE_NAME} is ready to shutdown"
-  post-start-hook.sh: |-
+  data-post-start-hook.sh: |-
     #!/bin/bash
     exec &> >(tee -a "/var/log/elasticsearch-hooks.log")
     NODE_NAME=${HOSTNAME}
@@ -134,4 +134,13 @@ data:
       }"
     fi
     echo "Node ${NODE_NAME} is ready to be used"
+{{- else }}
+  {{- if .Values.data.hooks.preStop }}
+  data-pre-stop-hook.sh: |-
+{{ tpl .Values.data.hooks.preStop . | indent 4 }}
+  {{- end }}
+  {{- if .Values.data.hooks.postStart }}
+  data-post-start-hook.sh: |-
+{{ tpl .Values.data.hooks.postStart . | indent 4 }}
+  {{- end }}
 {{- end }}

--- a/stable/elasticsearch/templates/configmap.yaml
+++ b/stable/elasticsearch/templates/configmap.yaml
@@ -153,3 +153,12 @@ data:
   client-post-start-hook.sh: |-
 {{ tpl .Values.client.hooks.postStart . | indent 4 }}
 {{- end }}
+
+{{- if .Values.master.hooks.preStop }}
+  master-pre-stop-hook.sh: |-
+{{ tpl .Values.master.hooks.preStop . | indent 4 }}
+{{- end }}
+{{- if .Values.master.hooks.postStart }}
+  master-post-start-hook.sh: |-
+{{ tpl .Values.master.hooks.postStart . | indent 4 }}
+{{- end }}

--- a/stable/elasticsearch/templates/configmap.yaml
+++ b/stable/elasticsearch/templates/configmap.yaml
@@ -144,3 +144,12 @@ data:
 {{ tpl .Values.data.hooks.postStart . | indent 4 }}
   {{- end }}
 {{- end }}
+
+{{- if .Values.client.hooks.preStop }}
+  client-pre-stop-hook.sh: |-
+{{ tpl .Values.client.hooks.preStop . | indent 4 }}
+{{- end }}
+{{- if .Values.client.hooks.postStart }}
+  client-post-start-hook.sh: |-
+{{ tpl .Values.client.hooks.postStart . | indent 4 }}
+{{- end }}

--- a/stable/elasticsearch/templates/data-statefulset.yaml
+++ b/stable/elasticsearch/templates/data-statefulset.yaml
@@ -180,20 +180,28 @@ spec:
           subPath: elasticsearch.keystore
           readOnly: true
 {{- end }}
-{{- if .Values.data.hooks.drain.enabled }}
+{{- if or .Values.data.hooks.preStop .Values.data.hooks.drain.enabled }}
         - name: config
-          mountPath: /pre-stop-hook.sh
-          subPath: pre-stop-hook.sh
+          mountPath: /data-pre-stop-hook.sh
+          subPath: data-pre-stop-hook.sh
+{{- end }}
+{{- if or .Values.data.hooks.postStart .Values.data.hooks.drain.enabled }}
         - name: config
-          mountPath: /post-start-hook.sh
-          subPath: post-start-hook.sh
+          mountPath: /data-post-start-hook.sh
+          subPath: data-post-start-hook.sh
+{{- end }}
+{{- if or .Values.data.hooks.preStop .Values.data.hooks.postStart .Values.data.hooks.drain.enabled }}
         lifecycle:
+  {{- if or .Values.data.hooks.preStop .Values.data.hooks.drain.enabled }}
           preStop:
             exec:
-              command: ["/bin/bash","/pre-stop-hook.sh"]
+              command: ["/bin/bash","/data-pre-stop-hook.sh"]
+  {{- end }}
+  {{- if or .Values.data.hooks.postStart .Values.data.hooks.drain.enabled }}
           postStart:
             exec:
-              command: ["/bin/bash","/post-start-hook.sh"]
+              command: ["/bin/bash","/data-post-start-hook.sh"]
+  {{- end }}
 {{- end }}
       terminationGracePeriodSeconds: {{ .Values.data.terminationGracePeriodSeconds }}
 {{- if .Values.image.pullSecrets }}

--- a/stable/elasticsearch/templates/master-statefulset.yaml
+++ b/stable/elasticsearch/templates/master-statefulset.yaml
@@ -184,6 +184,29 @@ spec:
           subPath: elasticsearch.keystore
           readOnly: true
 {{- end }}
+{{- if .Values.master.hooks.preStop }}
+        - name: config
+          mountPath: /master-pre-stop-hook.sh
+          subPath: master-pre-stop-hook.sh
+{{- end }}
+{{- if .Values.master.hooks.postStart }}
+        - name: config
+          mountPath: /master-post-start-hook.sh
+          subPath: master-post-start-hook.sh
+{{- end }}
+{{- if or .Values.master.hooks.preStop .Values.master.hooks.postStart }}
+        lifecycle:
+  {{- if .Values.master.hooks.preStop }}
+          preStop:
+            exec:
+              command: ["/bin/bash","/master-pre-stop-hook.sh"]
+  {{- end }}
+  {{- if .Values.master.hooks.postStart }}
+          postStart:
+            exec:
+              command: ["/bin/bash","/master-post-start-hook.sh"]
+  {{- end }}
+{{- end }}
 {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range $pullSecret := .Values.image.pullSecrets }}

--- a/stable/elasticsearch/templates/master-statefulset.yaml
+++ b/stable/elasticsearch/templates/master-statefulset.yaml
@@ -73,6 +73,9 @@ spec:
       tolerations:
 {{ toYaml .Values.master.tolerations | indent 8 }}
 {{- end }}
+{{- if .Values.master.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.master.terminationGracePeriodSeconds }}
+{{- end }}
 {{- if or .Values.extraInitContainers .Values.sysctlInitContainer.enabled .Values.chownInitContainer.enabled .Values.cluster.plugins }}
       initContainers:
 {{- end }}

--- a/stable/elasticsearch/values.yaml
+++ b/stable/elasticsearch/values.yaml
@@ -124,6 +124,7 @@ client:
   nodeAffinity: {}
   nodeSelector: {}
   tolerations: []
+  # terminationGracePeriodSeconds: 60
   initResources: {}
     # limits:
     #   cpu: "25m"
@@ -188,6 +189,7 @@ master:
   nodeAffinity: {}
   nodeSelector: {}
   tolerations: []
+  # terminationGracePeriodSeconds: 60
   initResources: {}
     # limits:
     #   cpu: "25m"

--- a/stable/elasticsearch/values.yaml
+++ b/stable/elasticsearch/values.yaml
@@ -213,6 +213,12 @@ master:
     # maxUnavailable: 1
   updateStrategy:
     type: OnDelete
+  hooks: {}
+    ## (string) Script to execute prior the master pod stops.
+    # preStop: |-
+
+    ## (string) Script to execute after the master pod starts.
+    # postStart: |-
 
 data:
   name: data

--- a/stable/elasticsearch/values.yaml
+++ b/stable/elasticsearch/values.yaml
@@ -255,9 +255,39 @@ data:
   podManagementPolicy: OrderedReady
   updateStrategy:
     type: OnDelete
-  hooks:  # post-start and pre-stop hooks
-    drain:  # drain the node before stopping it and re-integrate it into the cluster after start
+  hooks:
+    ## Drain the node before stopping it and re-integrate it into the cluster after start.
+    ## When enabled, it supersedes `data.hooks.preStop` and `data.hooks.postStart` defined below.
+    drain:
       enabled: true
+
+    ## (string) Script to execute prior the data pod stops. Ignored if `data.hooks.drain.enabled` is true (default)
+    # preStop: |-
+    #   #!/bin/bash
+    #   exec &> >(tee -a "/var/log/elasticsearch-hooks.log")
+    #   NODE_NAME=${HOSTNAME}
+    #   curl -s -XPUT -H 'Content-Type: application/json' '{{ template "elasticsearch.client.fullname" . }}:9200/_cluster/settings' -d "{
+    #     \"transient\" :{
+    #         \"cluster.routing.allocation.exclude._name\" : \"${NODE_NAME}\"
+    #     }
+    #   }"
+    #   echo "Node ${NODE_NAME} is exluded from the allocation"
+
+    ## (string) Script to execute after the data pod starts. Ignored if `data.hooks.drain.enabled` is true (default)
+    # postStart: |-
+    #   #!/bin/bash
+    #   exec &> >(tee -a "/var/log/elasticsearch-hooks.log")
+    #   NODE_NAME=${HOSTNAME}
+    #   CLUSTER_SETTINGS=$(curl -s -XGET "http://{{ template "elasticsearch.client.fullname" . }}:9200/_cluster/settings")
+    #   if echo "${CLUSTER_SETTINGS}" | grep -E "${NODE_NAME}"; then
+    #     echo "Activate node ${NODE_NAME}"
+    #     curl -s -XPUT -H 'Content-Type: application/json' "http://{{ template "elasticsearch.client.fullname" . }}:9200/_cluster/settings" -d "{
+    #       \"transient\" :{
+    #           \"cluster.routing.allocation.exclude._name\" : null
+    #       }
+    #     }"
+    #   fi
+    #   echo "Node ${NODE_NAME} is ready to be used"
 
 ## Sysctl init container to setup vm.max_map_count
 # see https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html

--- a/stable/elasticsearch/values.yaml
+++ b/stable/elasticsearch/values.yaml
@@ -146,6 +146,12 @@ client:
     enabled: false
     minAvailable: 1
     # maxUnavailable: 1
+  hooks: {}
+    ## (string) Script to execute prior the client pod stops.
+    # preStop: |-
+
+    ## (string) Script to execute after the client pod starts.
+    # postStart: |-
   ingress:
     enabled: false
     # user: NAME


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR is the reworked version of https://github.com/helm/charts/pull/11494

It adds the following optional values:
- `data.hooks.preStop`, `data.hooks.postStart`
- `client.hooks.preStop`, `client.hooks.postStart`
- `master.hooks.preStop`, `master.hooks.postStart`

That allows to specify custom scripts which could be executed as post-start and pre-stop hooks on master, client or data ElasticSearch nodes (pods).

_Note:_ In order for `data.hooks.preStop` and `data.hooks.postStart` to take an effect, `data.hooks.drain.enabled` should be explicitly set to `false`. That's done this way for the backward compatibility with previous versions of the chart.

It also adds optional values `master.terminationGracePeriodSeconds` and `client.terminationGracePeriodSeconds`, so users can tweak termination grace periods according to pre-stop hooks they use.

#### Which issue this PR fixes

  - closes #11494 (the parent PR)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
