### PR TITLE
[stable/prometheus-couchdb-exporter] Various fixes

### DIFF
--- a/stable/prometheus-couchdb-exporter/Chart.yaml
+++ b/stable/prometheus-couchdb-exporter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart to export the metrics from couchdb in Prometheus format.
 name: prometheus-couchdb-exporter
 home: https://github.com/gesellix/couchdb-prometheus-exporter
-version: 0.1.0
+version: 0.1.1
 keywords:
 - couchdb-exporter
 sources:

--- a/stable/prometheus-couchdb-exporter/Chart.yaml
+++ b/stable/prometheus-couchdb-exporter/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "22"
 description: A Helm chart to export the metrics from couchdb in Prometheus format.
 name: prometheus-couchdb-exporter
 home: https://github.com/gesellix/couchdb-prometheus-exporter
-version: 0.1.1
+version: 0.2.0
 keywords:
 - couchdb-exporter
 sources:

--- a/stable/prometheus-couchdb-exporter/README.md
+++ b/stable/prometheus-couchdb-exporter/README.md
@@ -44,7 +44,7 @@ The following table lists the configurable parameters and their default values.
 | ---------------------- | --------------------------------------------------- | --------------------------------------- |
 | `replicaCount`         | desired number of prometheus-couchdb-exporter pods  | `1`                                     |
 | `image.repository`     | prometheus-couchdb-exporter image repository        | `gesellix/couchdb-prometheus-exporter`  |
-| `image.tag`            | prometheus-couchdb-exporter image tag               | `16`                                    |
+| `image.tag`            | prometheus-couchdb-exporter image tag               | `22`                                    |
 | `image.pullPolicy`     | image pull policy                                   | `IfNotPresent`                          |
 | `service.type`         | desired service type                                | `ClusterIP`                             |
 | `service.port`         | service external port                               | `9984`                                  |

--- a/stable/prometheus-couchdb-exporter/README.md
+++ b/stable/prometheus-couchdb-exporter/README.md
@@ -57,6 +57,7 @@ The following table lists the configurable parameters and their default values.
 | `nodeSelector`         | node labels for pod assignment                      | {}                                      |
 | `tolerations`          | tolerations for pod assignment                      | {}                                      |
 | `affinity`             | affinity settings for proxy pod assignments         | {}                                      |
+| `podAnnotations`       | annotations to add to each pod                      | {}                                      |
 | `couchdb.uri`          | address of the couchdb                              | `http://couchdb.default.svc:5984`       |
 | `couchdb.databases`    | comma separated databases to monitor                | `_all_dbs`                              |
 

--- a/stable/prometheus-couchdb-exporter/templates/deployment.yaml
+++ b/stable/prometheus-couchdb-exporter/templates/deployment.yaml
@@ -36,14 +36,12 @@ spec:
               containerPort: 9984
           livenessProbe:
             httpGet:
-              path: /
+              path: /status
               port: http
-              initialDelaySeconds: 60
           readinessProbe:
             httpGet:
-              path: /
+              path: /status
               port: http
-              initialDelaySeconds: 60
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/stable/prometheus-couchdb-exporter/templates/deployment.yaml
+++ b/stable/prometheus-couchdb-exporter/templates/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       labels:
         app: {{ template "prometheus-couchdb-exporter.name" . }}
         release: {{ .Release.Name }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
       serviceAccountName: {{ template "prometheus-couchdb-exporter.serviceAccountName" . }}
       containers:

--- a/stable/prometheus-couchdb-exporter/values.yaml
+++ b/stable/prometheus-couchdb-exporter/values.yaml
@@ -56,6 +56,8 @@ tolerations: []
 
 affinity: {}
 
+podAnnotations: {}
+
 ## CouchDB exporter configuratons
 couchdb:
   ## URI ofthe couchdb instance

--- a/stable/prometheus-couchdb-exporter/values.yaml
+++ b/stable/prometheus-couchdb-exporter/values.yaml
@@ -18,7 +18,7 @@ replicaCount: 1
 
 image:
   repository: gesellix/couchdb-prometheus-exporter
-  tag: 16
+  tag: 22
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
* Added podAnnotations so metrics an actually be exported
* Upgrade to version 22
* Fixed probe endpoint

Signed-off-by: Jonathan Davies <jpds@protonmail.com>

#### What this PR does / why we need it:

There's no way to actually export the metrics to Prometheus from this helm chart.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
