### PR TITLE
[stable/redis] Use global registry in secondary and/or metrics images

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 6.3.1
+version: 6.4.0
 appVersion: 4.0.13
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/_helpers.tpl
+++ b/stable/redis/templates/_helpers.tpl
@@ -68,21 +68,47 @@ Also, we can't use a single if because lazy evaluation is not an option
 {{/*
 Return the proper image name (for the metrics image)
 */}}
-{{- define "metrics.image" -}}
-{{- $registryName :=  .Values.metrics.image.registry -}}
+{{- define "redis.metrics.image" -}}
+{{- $registryName := .Values.metrics.image.registry -}}
 {{- $repositoryName := .Values.metrics.image.repository -}}
 {{- $tag := .Values.metrics.image.tag | toString -}}
-{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
 Return the proper image name (for the init container volume-permissions image)
 */}}
-{{- define "volumePermissions.image" -}}
-{{- $registryName :=  .Values.volumePermissions.image.registry -}}
+{{- define "redis.volumePermissions.image" -}}
+{{- $registryName := .Values.volumePermissions.image.registry -}}
 {{- $repositoryName := .Values.volumePermissions.image.repository -}}
 {{- $tag := .Values.volumePermissions.image.tag | toString -}}
-{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -170,8 +196,22 @@ Return sysctl image
 */}}
 {{- define "redis.sysctl.image" -}}
 {{- $registryName :=  default "docker.io" .Values.sysctlImage.registry -}}
+{{- $repositoryName := .Values.sysctlImage.image.repository -}}
 {{- $tag := default "latest" .Values.sysctlImage.tag | toString -}}
-{{- printf "%s/%s:%s" $registryName .Values.sysctlImage.repository $tag -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/redis/templates/_helpers.tpl
+++ b/stable/redis/templates/_helpers.tpl
@@ -196,7 +196,7 @@ Return sysctl image
 */}}
 {{- define "redis.sysctl.image" -}}
 {{- $registryName :=  default "docker.io" .Values.sysctlImage.registry -}}
-{{- $repositoryName := .Values.sysctlImage.image.repository -}}
+{{- $repositoryName := .Values.sysctlImage.repository -}}
 {{- $tag := default "latest" .Values.sysctlImage.tag | toString -}}
 {{/*
 Helm 2.11 supports the assignment of a value to a variable defined in a different scope,

--- a/stable/redis/templates/metrics-deployment.yaml
+++ b/stable/redis/templates/metrics-deployment.yaml
@@ -45,7 +45,7 @@ spec:
       {{- end }}
       containers:
       - name: metrics
-        image: {{ template "metrics.image" . }}
+        image: {{ template "redis.metrics.image" . }}
         imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
         args:
         {{- range $key, $value := .Values.metrics.extraArgs }}

--- a/stable/redis/templates/redis-master-statefulset.yaml
+++ b/stable/redis/templates/redis-master-statefulset.yaml
@@ -155,7 +155,7 @@ spec:
       initContainers:
       {{- if $needsVolumePermissions }}
       - name: volume-permissions
-        image: "{{ template "volumePermissions.image" . }}"
+        image: "{{ template "redis.volumePermissions.image" . }}"
         imagePullPolicy: {{ default "" .Values.volumePermissions.image.pullPolicy | quote }}
         command: ["/bin/chown", "-R", "{{ .Values.master.securityContext.runAsUser }}:{{ .Values.master.securityContext.fsGroup }}", "{{ .Values.master.persistence.path }}"]
         securityContext:


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

Allow using `global.imageRegistry` (already implemented for the main images) in the metrics container and/or other secondary containers.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
