### PR TITLE
[stable/orangehrm] Use global registry in secondary and/or metrics images

### DIFF
--- a/stable/orangehrm/Chart.yaml
+++ b/stable/orangehrm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: orangehrm
-version: 4.1.0
+version: 4.2.0
 appVersion: 4.3.0-0
 description: OrangeHRM is a free HR management system that offers a wealth of modules
   to suit the needs of your business.

--- a/stable/orangehrm/templates/_helpers.tpl
+++ b/stable/orangehrm/templates/_helpers.tpl
@@ -49,11 +49,24 @@ Also, we can't use a single if because lazy evaluation is not an option
 {{/*
 Return the proper image name (for the metrics image)
 */}}
-{{- define "metrics.image" -}}
-{{- $registryName :=  .Values.metrics.image.registry -}}
+{{- define "orangehrm.metrics.image" -}}
+{{- $registryName := .Values.metrics.image.registry -}}
 {{- $repositoryName := .Values.metrics.image.repository -}}
 {{- $tag := .Values.metrics.image.tag | toString -}}
-{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/orangehrm/templates/deployment.yaml
+++ b/stable/orangehrm/templates/deployment.yaml
@@ -113,7 +113,7 @@ spec:
           mountPath: /bitnami/apache
 {{- if .Values.metrics.enabled }}
       - name: metrics
-        image: {{ template "metrics.image" . }}
+        image: {{ template "orangehrm.metrics.image" . }}
         imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
         command: [ '/bin/apache_exporter', '-scrape_uri', 'http://status.localhost:80/server-status/?auto']
         ports:


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

Allow using `global.imageRegistry` (already implemented for the main images) in the metrics container and/or other secondary containers.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
