### PR TITLE
[stable/keycloak] Use KUBE_PING for discovery

### DIFF
--- a/stable/keycloak/Chart.yaml
+++ b/stable/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 4.6.1
+version: 4.7.0
 appVersion: 4.8.3.Final
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/stable/keycloak/README.md
+++ b/stable/keycloak/README.md
@@ -306,7 +306,7 @@ Everything is in `values.yaml` and can be overridden. Additional CLI commands ma
 
 For high availability, Keycloak should be run with multiple replicas (`keycloak.replicas > 1`).
 WildFly uses Infinispan for caching. These caches can be replicated across all instances forming a cluster.
-If `keycloak.replicas > 1`, JGroups' DNS_PING is configured for cluster discovery and Keycloak is started with `--server-config standalone-ha.xml`.
+If `keycloak.replicas > 1`, JGroups' KUBE_PING is configured for cluster discovery and Keycloak is started with `--server-config standalone-ha.xml`.
 
 ## Why StatefulSet?
 
@@ -316,4 +316,3 @@ This can be problematic because pod names are quite long.
 We would have to truncate the chart's fullname to six characters because pods get a 17-character suffix (e. g. `-697f8b7655-mf5ht`).
 Using a StatefulSet allows us to truncate to 20 characters leaving room for up to 99 replicas, which is much better.
 Additionally, we get stable values for `jboss.node.name` which can be advantageous for cluster discovery.
-The headless service that governs the StatefulSet is used for DNS discovery.

--- a/stable/keycloak/templates/configmap.yaml
+++ b/stable/keycloak/templates/configmap.yaml
@@ -58,3 +58,21 @@ data:
 
     run-batch
     stop-embedded-server
+
+{{- if $highAvailability }}
+  kubernetes.cli: |
+    embed-server --server-config=standalone-ha.xml --std-out=echo
+    batch
+    /subsystem=jgroups/stack=udp/protocol=PING:remove()
+    /subsystem=jgroups/stack=udp/protocol=kubernetes.KUBE_PING:add(add-index=0, properties={"namespace"=>"{{ .Release.Namespace }}","labels"=>"app={{ template "keycloak.name" . }}"})
+
+    /subsystem=jgroups/stack=tcp/protocol=MPING:remove()
+    /subsystem=jgroups/stack=tcp/protocol=kubernetes.KUBE_PING:add(add-index=0, properties={"namespace"=>"{{ .Release.Namespace }}","labels"=>"app={{ template "keycloak.name" . }}"})
+    run-batch
+    stop-embedded-server
+
+  jgroups.sh: |
+    #!/bin/bash
+    set -e
+    /opt/jboss/keycloak/bin/jboss-cli.sh --file="/opt/jboss/tools/cli/jgroups/discovery/kubernetes.cli"
+{{- end }}

--- a/stable/keycloak/templates/headless-service.yaml
+++ b/stable/keycloak/templates/headless-service.yaml
@@ -16,12 +16,6 @@ spec:
       port: {{ .Values.keycloak.service.port }}
       targetPort: http
       protocol: TCP
-  {{- if $highAvailability }}
-    - name: jgroups
-      port: {{ .Values.keycloak.service.jgroupsPort }}
-      targetPort: jgroups
-      protocol: TCP
-  {{- end }}
   selector:
     app: {{ template "keycloak.name" . }}
     release: "{{ .Release.Name }}"

--- a/stable/keycloak/templates/serviceaccount.yaml
+++ b/stable/keycloak/templates/serviceaccount.yaml
@@ -1,0 +1,33 @@
+{{- $highAvailability := gt (int .Values.keycloak.replicas) 1 -}}
+{{- if $highAvailability }}
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{ template "keycloak.fullname" . }}-service-account
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "keycloak.fullname" . }}-pod-reader
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "keycloak.fullname" . }}-api-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "keycloak.fullname" . }}-pod-reader
+subjects:
+- kind: ServiceAccount
+  name: {{ template "keycloak.fullname" . }}-service-account
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/stable/keycloak/templates/statefulset.yaml
+++ b/stable/keycloak/templates/statefulset.yaml
@@ -65,6 +65,9 @@ spec:
 {{ tpl .Values.keycloak.extraInitContainers . | indent 8 }}
       {{- end }}
     {{- end }}
+{{- if $highAvailability }}
+      serviceAccountName: {{ template "keycloak.fullname" . }}-service-account
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.keycloak.image.repository }}:{{ .Values.keycloak.image.tag }}"
@@ -81,12 +84,6 @@ spec:
                   name: {{ template "keycloak.fullname" . }}-http
                   key: password
           {{- end }}
-          {{- if $highAvailability }}
-            - name: JGROUPS_DISCOVERY_PROTOCOL
-              value: "dns.DNS_PING"
-            - name: JGROUPS_DISCOVERY_PROPERTIES
-              value: "dns_query={{ template "keycloak.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
-          {{- end }}
 {{ include "keycloak.dbEnvVars" . | indent 12 }}
 {{- with .Values.keycloak.extraEnv }}
 {{ tpl . $ | indent 12 }}
@@ -94,6 +91,16 @@ spec:
           volumeMounts:
             - name: scripts
               mountPath: /scripts
+{{- if $highAvailability }}
+            - name: scripts
+              mountPath: /opt/jboss/tools/cli/jgroups/discovery/kubernetes.cli
+              subPath: kubernetes.cli
+              mode: 0444
+            - name: scripts
+              mountPath: /opt/jboss/tools/jgroups.sh
+              subPath: jgroups.sh
+              mode: 0555
+{{- end }}
 {{- with .Values.keycloak.extraVolumeMounts }}
 {{ tpl . $ | indent 12 }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Thomas Recloux <thomas@recloux.fr>

#### What this PR does / why we need it:
This PR changes the jgroups autodiscovery used by Keycloak in multi node mode (highavailability) to use Kubernetes discovery.

The Chart was using DNS_PING discovery which was based on the headless service to list endpoints.
This PR switches to KUBE_PING, using a the jgroups-kubernetes discovery already bundled in Keycloak image. Discovery is more kubernetes native and is not linked to node readiness.

#### Special notes for your reviewer:

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md

Ping @thomasdarimont 
