### PR TITLE
[stable/cloudserver] bump docker image

### DIFF
--- a/stable/cloudserver/Chart.yaml
+++ b/stable/cloudserver/Chart.yaml
@@ -1,6 +1,6 @@
 name: cloudserver
-version: 1.0.0
-appVersion: 8.1.1
+version: 1.0.1
+appVersion: 8.1.5
 kubeVersion: "^1.8.0-0"
 description: An open-source Node.js implementation of the Amazon S3 protocol on the front-end and backend storage capabilities to multiple clouds, including Azure and Google.
 home: https://www.zenko.io/cloudserver/

--- a/stable/cloudserver/OWNERS
+++ b/stable/cloudserver/OWNERS
@@ -1,4 +1,6 @@
 approvers:
 - giacomoguiulfo
+- ssalaues
 reviewers:
 - giacomoguiulfo
+- ssalaues

--- a/stable/cloudserver/README.md
+++ b/stable/cloudserver/README.md
@@ -45,7 +45,7 @@ Parameter | Description | Default
 `serviceAccounts.localdata.create` | If true, create the cloudserver localdata service account | `true`
 `serviceAccounts.localdata.name` | name of the cloudserver localdata service account to use or create | `{{ cloudserver.localdata.fullname }}`
 `image.repository` | cloudserver image repository | `zenko/cloudserver`
-`image.tag` | cloudserver image tag | `8.1.1`
+`image.tag` | cloudserver image tag | `8.1.5`
 `image.pullPolicy` | cloudserver image pullPolicy | `IfNotPresent`
 `api.replicaCount` | number of api replicas | `1`
 `api.locationConstraints` | cloudserver location constraint configuration | `{}`

--- a/stable/cloudserver/values.yaml
+++ b/stable/cloudserver/values.yaml
@@ -17,7 +17,7 @@ serviceAccounts:
 ##
 image:
   repository: zenko/cloudserver
-  tag: 8.1.1
+  tag: 8.1.5
   pullPolicy: IfNotPresent
 
 ## Configuration for the cloudserver api component


### PR DESCRIPTION
#### What this PR does / why we need it:
Bumps the Cloudserver docker image to 8.1.5 which contains bug fixes and minor capability tweaks

#### Special notes for your reviewer:
Added myself to the OWNERS file as well since I am already listed as a maintainer.

cc @giacomoguiulfo 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md