### PR TITLE
Allow servicename and serviceport to be specified in an ingress host rule

### DIFF
--- a/stable/chartmuseum/Chart.yaml
+++ b/stable/chartmuseum/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Host your own Helm Chart Repository
 name: chartmuseum
 version: 2.0.0
-appVersion: 0.8.1
+appVersion: 0.8.2
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/helm/chartmuseum/master/logo2.png
 keywords:

--- a/stable/chartmuseum/Chart.yaml
+++ b/stable/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 2.0.1
+version: 2.1.0
 appVersion: 0.8.2
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/helm/chartmuseum/master/logo2.png

--- a/stable/chartmuseum/README.md
+++ b/stable/chartmuseum/README.md
@@ -10,27 +10,29 @@ Please also see https://github.com/kubernetes-helm/chartmuseum
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 
-- [Prerequisites](#prerequisites)
-- [Configuration](#configuration)
-- [Installation](#installation)
-  - [Using with Amazon S3](#using-with-amazon-s3)
-    - [permissions grant with access keys](#permissions-grant-with-access-keys)
-    - [permissions grant with IAM instance profile](#permissions-grant-with-iam-instance-profile)
-    - [permissions grant with IAM assumed role](#permissions-grant-with-iam-assumed-role)
-  - [Using with Google Cloud Storage](#using-with-google-cloud-storage)
-  - [Using with Google Cloud Storage and a Google Service Account](#using-with-google-cloud-storage-and-a-google-service-account)
-  - [Using with Microsoft Azure Blob Storage](#using-with-microsoft-azure-blob-storage)
-  - [Using with Alibaba Cloud OSS Storage](#using-with-alibaba-cloud-oss-storage)
-  - [Using with Openstack Object Storage](#using-with-openstack-object-storage)
-  - [Using with Oracle Object Storage](#using-with-oracle-object-storage)
-  - [Using an existing secret](#using-an-existing-secret)
-  - [Using with local filesystem storage](#using-with-local-filesystem-storage)
-    - [Example storage class](#example-storage-class)
-  - [Ingress](#ingress)
-    - [Hosts](#hosts)
-    - [Annotations](#annotations)
-    - [Example Ingress configuration](#example-ingress-configuration)
-- [Uninstall](#uninstall)
+- [ChartMuseum Helm Chart](#chartmuseum-helm-chart)
+  - [Table of Content](#table-of-content)
+  - [Prerequisites](#prerequisites)
+  - [Configuration](#configuration)
+  - [Installation](#installation)
+    - [Using with Amazon S3](#using-with-amazon-s3)
+      - [permissions grant with access keys](#permissions-grant-with-access-keys)
+      - [permissions grant with IAM instance profile](#permissions-grant-with-iam-instance-profile)
+      - [permissions grant with IAM assumed role](#permissions-grant-with-iam-assumed-role)
+    - [Using with Google Cloud Storage](#using-with-google-cloud-storage)
+    - [Using with Google Cloud Storage and a Google Service Account](#using-with-google-cloud-storage-and-a-google-service-account)
+    - [Using with Microsoft Azure Blob Storage](#using-with-microsoft-azure-blob-storage)
+    - [Using with Alibaba Cloud OSS Storage](#using-with-alibaba-cloud-oss-storage)
+    - [Using with Openstack Object Storage](#using-with-openstack-object-storage)
+    - [Using with Oracle Object Storage](#using-with-oracle-object-storage)
+    - [Using an existing secret](#using-an-existing-secret)
+    - [Using with local filesystem storage](#using-with-local-filesystem-storage)
+      - [Example storage class](#example-storage-class)
+    - [Ingress](#ingress)
+      - [Hosts](#hosts)
+      - [Annotations](#annotations)
+      - [Example Ingress configuration](#example-ingress-configuration)
+  - [Uninstall](#uninstall)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -155,6 +157,8 @@ their default values. See values.yaml for all available options.
 | `ingress.hosts[0].path`                | Path within the url structure               | ``                                                  |
 | `ingress.hosts[0].tls `                | Enable TLS on the ingress host              | `false`                                             |
 | `ingress.hosts[0].tlsSecret`           | TLS secret to use (must be manually created)| ``                                                  |
+| `ingress.hosts[0].serviceName`         | The name of the service to route traffic to. | `{{ .Values.service.externalPort }}`               |
+| `ingress.hosts[0].servicePort`         | The port of the service to route traffic to. | `{{ .chartmuseum. }}`                              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.
@@ -570,6 +574,8 @@ To enable ingress integration, please set `ingress.enabled` to `true`
 #### Hosts
 
 Most likely you will only want to have one hostname that maps to this Chartmuseum installation, however, it is possible to have more than one host. To facilitate this, the `ingress.hosts` object is an array.  TLS secrets referenced in the ingress host configuration must be manually created in the namespace.
+
+In most cases, you should not specify values for `ingress.hosts[0].serviceName` and `ingress.hosts[0].servicePort`. However, some ingress controllers support advanced scenarios requiring you to specify these values. For example, [setting up an SSL redirect using the AWS ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/tasks/ssl_redirect/).
 
 #### Annotations
 

--- a/stable/chartmuseum/templates/ingress.yaml
+++ b/stable/chartmuseum/templates/ingress.yaml
@@ -21,8 +21,8 @@ spec:
       paths:
       - path: {{ default "/" .path }}
         backend:
-          serviceName: {{ $serviceName }}
-          servicePort: {{ $servicePort }}
+          serviceName: {{ default $serviceName .serviceName }}
+          servicePort: {{ default $servicePort .servicePort }}
   {{- end }}
   tls:
   {{- range .Values.ingress.hosts }}

--- a/stable/chartmuseum/values.yaml
+++ b/stable/chartmuseum/values.yaml
@@ -5,7 +5,7 @@ strategy:
     maxUnavailable: 0
 image:
   repository: chartmuseum/chartmuseum
-  tag: v0.8.1
+  tag: v0.8.2
   pullPolicy: IfNotPresent
 env:
   open:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Chartmuseum doesn't allow the user to specify their own serviceName and servicePort values when defining an ingress host rule. This PR enables the user to do so.

This is required to support setting up custom actions using the AWS ALB Ingress Controller. One such frequent use-case is [Setting Up an SSL Redirect](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/tasks/ssl_redirect/).

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #12261

#### Special notes for your reviewer:
I have tested this chart against my own EKS cluster and it creates the required ingress host rules, and the AWS ALB Ingress Controller creates the custom actions as expected. 

Use the following yaml for testing, if you wish:

```yaml
ingress:
  enabled: true
  labels:
    dns: "route53"

  annotations:
    # If you wish to test the entire ssl-redirect scenario using the AWS ALB Ingress Controller,  set these annotations
    kubernetes.io/ingress.class: alb
    alb.ingress.kubernetes.io/scheme: internet-facing
    alb.ingress.kubernetes.io/target-type: instance
    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80,"HTTPS":443}]'
    alb.ingress.kubernetes.io/certificate-arn: 'YOUR_CERTIFICATE_ARN'
    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'

  # At a minimum, you can provide two rules to see they both work as expected.
  hosts:
    - name: example.com
      path: /*
      serviceName: ssl-redirect
      servicePort: use-annotation
    - name: example.com
      path: /*
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
