### PR TITLE
fix ingress can't work.

### DIFF
--- a/stable/spark-history-server/templates/ingress.yaml
+++ b/stable/spark-history-server/templates/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: {{ include "spark-history-server.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    annotations:
+  annotations:
 {{- range $key, $value := .Values.ingress.annotations }}
       {{ $key }}: {{ $value | quote }}
 {{- end }}


### PR DESCRIPTION
What this PR does / why we need it:
It fixes spark history server helm chart can't execute when ingress is enabled.
Also resources are now supported on the pod.

Which issue this PR fixes
(optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged)


