### PR TITLE
[stable/kibana] Added alternative method to import saved objects

### DIFF
--- a/stable/kibana/Chart.yaml
+++ b/stable/kibana/Chart.yaml
@@ -1,5 +1,5 @@
 name: kibana
-version: 2.0.0
+version: 2.1.0
 appVersion: 6.6.1
 description: Kibana is an open source data visualization plugin for Elasticsearch
 icon: https://raw.githubusercontent.com/elastic/kibana/master/src/ui/public/icons/kibana-color.svg

--- a/stable/kibana/README.md
+++ b/stable/kibana/README.md
@@ -89,6 +89,12 @@ The following table lists the configurable parameters of the kibana chart and th
 | `dashboardImport.xpackauth.username`       | Optional Xpack username                                                | `myuser`                              |
 | `dashboardImport.xpackauth.password`       | Optional Xpack password                                                | `mypass`                              |
 | `dashboardImport.dashboards`               | Dashboards                                                             | `{}`                                  |
+| `objectsImport.enabled`                    | Enable objects import                                                  | `false`                               |
+| `objectsImport.timeout`                    | Time in seconds waiting for Kibana to be in green overall state        | `60`                                  |
+| `objectsImport.xpackauth.enabled`          | Enable Xpack auth                                                      | `false`                               |
+| `objectsImport.xpackauth.username`         | Optional Xpack username                                                | `myuser`                              |
+| `objectsImport.xpackauth.password`         | Optional Xpack password                                                | `mypass`                              |
+| `objectsImport.objects   `                 | Saved objects (visualization, dashboard, search, index-pattern, ...)   | `{}`                                  |
 | `plugins.enabled`                          | Enable installation of plugins.                                        | `false`                               |
 | `plugins.reset`                            | Optional : Remove all installed plugins before installing all new ones | `false`                               |
 | `plugins.values`                           | List of plugins to install. Format                                     | None:                                 |

--- a/stable/kibana/templates/configmap-objectsimport.yaml
+++ b/stable/kibana/templates/configmap-objectsimport.yaml
@@ -1,0 +1,67 @@
+{{- if .Values.objectsImport.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "kibana.fullname" . }}-objects-importscript
+  labels:
+    app: {{ template "kibana.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  objectsImport.sh: |
+    #!/usr/bin/env bash
+    #
+    # kibana objects import script
+    #
+
+    cd /kibanaobjects
+
+    echo "Starting Kibana..."
+
+    /usr/local/bin/kibana-docker $@ &
+
+    echo "Waiting up to {{ .Values.objectsImport.timeout }} seconds for Kibana to get in green overall state..."
+
+    for i in {1..{{ .Values.objectsImport.timeout }}}; do
+      curl -s localhost:5601/api/status | python -c 'import sys, json; print json.load(sys.stdin)["status"]["overall"]["state"]' 2> /dev/null | grep green > /dev/null && break || sleep 1
+    done
+
+    for OBJECT_FILE in *; do
+      echo -e "Importing ${OBJECT_FILE} objects..."
+
+      if ! python -c 'import sys, json; print json.load(sys.stdin)' < "${OBJECT_FILE}" &> /dev/null ; then
+        echo "${OBJECT_FILE} is not valid JSON, assuming it's an URL..."
+        TMP_FILE="$(mktemp)"
+        curl -s $(cat ${OBJECT_FILE}) > ${TMP_FILE}
+        curl -v {{ if .Values.objectsImport.xpackauth.enabled }}--user {{ .Values.objectsImport.xpackauth.username }}:{{ .Values.objectsImport.xpackauth.password }}{{ end }} -s --connect-timeout 60 --max-time 60 -XPOST localhost:5601/api/saved_objects/_bulk_create?overwrite=true -H 'kbn-xsrf:true' -H 'Content-type:application/json' -d @${TMP_FILE}
+        rm ${TMP_FILE}
+      else
+        echo "Valid JSON found in ${OBJECT_FILE}, importing..."
+        curl -v {{ if .Values.objectsImport.xpackauth.enabled }}--user {{ .Values.objectsImport.xpackauth.username }}:{{ .Values.objectsImport.xpackauth.password }}{{ end }} -s --connect-timeout 60 --max-time 60 -XPOST localhost:5601/api/saved_objects/_bulk_create?overwrite=true -H 'kbn-xsrf:true' -H 'Content-type:application/json' -d @./${OBJECT_FILE}
+      fi
+
+      if [ "$?" != "0" ]; then
+        echo -e "\nImport of ${OBJECT_FILE} objects failed... Exiting..."
+        exit 1
+      else
+        echo -e "\nImport of ${OBJECT_FILE} objects finished :-)"
+      fi
+
+    done
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "kibana.fullname" . }}-objects
+  labels:
+    app: {{ template "kibana.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+{{- range $key, $value := .Values.objectsImport.objects }}
+  {{ $key }}: |-
+{{ $value | indent 4 }}
+{{- end -}}
+{{- end -}}

--- a/stable/kibana/templates/deployment.yaml
+++ b/stable/kibana/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
-{{- if or (.Values.initContainers) (.Values.dashboardImport.enabled) (.Values.plugins.enabled) }}
+{{- if or (.Values.initContainers) (.Values.dashboardImport.enabled) (.Values.objectsImport.enabled) (.Values.plugins.enabled) }}
       initContainers:
 {{- if .Values.initContainers }}
 {{- range $key, $value := .Values.initContainers }}
@@ -67,6 +67,34 @@ spec:
           mountPath: "/usr/share/kibana/config/{{ $configFile }}"
           subPath: {{ $configFile }}
         {{- end }}
+{{- end }}
+{{- if .Values.objectsImport.enabled }}
+      - name: {{ .Chart.Name }}-objectsimport
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/bin/bash"]
+        args:
+          - "-c"
+          - "/tmp/objectsImport.sh"
+{{- if .Values.commandline.args }}
+{{ toYaml .Values.commandline.args | indent 10 }}
+{{- end }}
+        env:
+{{- range $key, $value := .Values.env }}
+        - name: "{{ $key }}"
+          value: "{{ $value }}"
+{{- end }}
+        volumeMounts:
+        - name: {{ template "kibana.fullname" . }}-objects
+          mountPath: "/kibanaobjects"
+        - name: {{ template "kibana.fullname" . }}-objects-importscript
+          mountPath: "/tmp/objectsImport.sh"
+          subPath: objectsImport.sh
+{{- range $configFile := (keys .Values.files) }}
+        - name: {{ template "kibana.name" $ }}
+          mountPath: "/usr/share/kibana/config/{{ $configFile }}"
+          subPath: {{ $configFile }}
+{{- end }}
 {{- end }}
 {{- if .Values.plugins.enabled}}
       - name: {{ .Chart.Name }}-plugins-install
@@ -226,6 +254,15 @@ spec:
         - name: {{ template "kibana.fullname" . }}-importscript
           configMap:
             name: {{ template "kibana.fullname" . }}-importscript
+            defaultMode: 0777
+{{- end }}
+{{- if .Values.objectsImport.enabled }}
+        - name: {{ template "kibana.fullname" . }}-objects
+          configMap:
+            name: {{ template "kibana.fullname" . }}-objects
+        - name: {{ template "kibana.fullname" . }}-objects-importscript
+          configMap:
+            name: {{ template "kibana.fullname" . }}-objects-importscript
             defaultMode: 0777
 {{- end }}
 {{- range .Values.extraConfigMapMounts }}

--- a/stable/kibana/values.yaml
+++ b/stable/kibana/values.yaml
@@ -155,6 +155,25 @@ dashboardImport:
   dashboards: {}
     # k8s: https://raw.githubusercontent.com/monotek/kibana-dashboards/master/k8s-fluentd-elasticsearch.json
 
+objectsImport:
+  enabled: false
+#  timeout: 60
+#  xpackauth:
+#    enabled: false
+#    username: myuser
+#    password: mypass
+  objects: {}
+#    my_index_patterns: |-
+#      [
+#        {
+#          "type": "index-pattern",
+#          "id": "my-pattern",
+#          "attributes": {
+#            "title": "my-pattern-*"
+#          }
+#        }
+#      ]
+
 # List of plugins to install using initContainer
 # NOTE : We notice that lower resource constraints given to the chart + plugins are likely not going to work well.
 plugins:


### PR DESCRIPTION
Added alternative method to import saved objects like: visualization, dashboard, search, index-pattern, config, and timelion-sheet.

Right now the Bulk Create Object API is used to create the objects on startup (analog to the dashboards).

@compleatang
I'm not sure if we need both functions or if we just should merge them to one using saved_objects api.

Pro: Single objects could be imported
Con: More configuration to import a dashboard together with all saved objects.

Whats your opinion?
