### PR TITLE
Signed-off-by: von1994 yihang1994.feng@gmail.com

### DIFF
--- a/stable/spark-history-server/Chart.yaml
+++ b/stable/spark-history-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: spark-history-server
-version: 0.4.0
+version: 0.4.1
 appVersion: 2.4.0
 description: A Helm chart for Spark History Server
 home: https://spark.apache.org

--- a/stable/spark-history-server/templates/ingress.yaml
+++ b/stable/spark-history-server/templates/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: {{ include "spark-history-server.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    annotations:
+  annotations:
 {{- range $key, $value := .Values.ingress.annotations }}
       {{ $key }}: {{ $value | quote }}
 {{- end }}


### PR DESCRIPTION
fixes spark history server helm chart can't execute when ingress is enabled.

#### What this PR does / why we need it:
fixes spark history server helm chart can't execute when ingress is enabled.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
