### PR TITLE
[stable/mariadb] Master Pod fails starting if initdbScripts is set

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb
-version: 5.10.0
+version: 5.10.1
 appVersion: 10.1.38
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/templates/_helpers.tpl
+++ b/stable/mariadb/templates/_helpers.tpl
@@ -94,7 +94,7 @@ Get the initialization scripts ConfigMap name.
 {{- if .Values.initdbScriptsConfigMap -}}
 {{- printf "%s" .Values.initdbScriptsConfigMap -}}
 {{- else -}}
-{{- printf "%s-init-scripts" (include "mariadb.fullname" .) -}}
+{{- printf "%s-init-scripts" (include "master.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
When `.Values.initdbScripts` is set, the master Pod by now fails starting with the error

    MountVolume.SetUp failed for volume "custom-init-scripts" : configmap "RELEASE-NAME-mariadb-init-scripts" not found

because the name of the init ConfigMap and the name used in code don't match. This PR fixes this.

The two code parts:
_stable/mariadb/templates/initialization-configmap.yaml_ line 5

    metadata:
      name: {{ template "master.fullname" . }}-init-scripts

and
_stable/mariadb/templates/_helpers.tpl_ line 97

    {{- define "mariadb.initdbScriptsCM" -}}
    {{- if .Values.initdbScriptsConfigMap -}}
    {{- printf "%s" .Values.initdbScriptsConfigMap -}}
    {{- else -}}
    {{- printf "%s-init-scripts" (include "mariadb.fullname" .) -}}
    {{- end -}}
    {{- end -}}

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
