### PR TITLE
[stable/logstash] Simplify port specification

### DIFF
--- a/stable/logstash/Chart.yaml
+++ b/stable/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 1.6.0
+version: 2.0.0
 appVersion: 6.7.0
 sources:
 - https://www.docker.elastic.co

--- a/stable/logstash/README.md
+++ b/stable/logstash/README.md
@@ -79,12 +79,11 @@ The following table lists the configurable parameters of the chart and its defau
 | `image.pullPolicy`              | Container image pull policy                        | `IfNotPresent`                                   |
 | `service.type`                  | Service type (ClusterIP, NodePort or LoadBalancer) | `ClusterIP`                                      |
 | `service.annotations`           | Service annotations                                | `{}`                                             |
-| `service.ports`                 | Ports exposed by service                           | beats                                            |
 | `service.loadBalancerIP`        | The load balancer IP for the service               | unset                                            |
 | `service.clusterIP`             | The cluster IP for the service                     | unset                                            |
 | `service.nodePort`              | The nodePort for the service                       | unset                                            |
 | `service.externalTrafficPolicy` | Set externalTrafficPolicy                          | unset                                            |
-| `ports`                         | Ports exposed by logstash container                | beats                                            |
+| `exposePorts`                   | Ports exposed by the Logstash container and service | `[{name: monitor, port: 9600}]`                  |
 | `ingress.enabled`               | Enables Ingress                                    | `false`                                          |
 | `ingress.annotations`           | Ingress annotations                                | `{}`                                             |
 | `ingress.path`                  | Ingress path                                       | `/`                                              |

--- a/stable/logstash/templates/NOTES.txt
+++ b/stable/logstash/templates/NOTES.txt
@@ -1,21 +1,12 @@
-{{- if .Values.service.ports.http }}
-Get the Logstash HTTP Input URL by running these commands:
-  {{- if .Values.ingress.enabled }}
-    {{- range .Values.ingress.hosts }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+Logstash has been installed.
+
+The following service has been created:
+
+    {{ template "logstash.fullname" . }}.{{ .Release.Namespace }}.svc
+
+The following ports have been exposed for it:
+    {{ range .Values.exposePorts }}
+    {{- if gt (int .servicePort) -1 }}
+    - {{ .servicePort | default .port }}/{{ .protocol | default "tcp" | upper }}
     {{- end }}
-  {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "logstash.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
-  {{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get svc -w {{ template "logstash.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "logstash.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.service.ports.http.port }}
-  {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "logstash.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:{{ .Values.service.ports.http.port }}
-  {{- end }}
-{{- end }}
+    {{- end }}

--- a/stable/logstash/templates/service.yaml
+++ b/stable/logstash/templates/service.yaml
@@ -23,6 +23,9 @@ spec:
     - name: {{ .name | default (printf "%v-%v" $protocol .port) }}
       port: {{ .servicePort | default .port }}
       targetPort: {{ .port }}
+      {{- with .nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
       protocol: {{ $protocol | upper }}
   {{- end }}
   {{- end }}
@@ -34,7 +37,4 @@ spec:
 {{- end }}
 {{- if .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP }}
-{{- end }}
-{{ if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
-  nodePort: {{ .Values.service.nodePort }}
 {{- end }}

--- a/stable/logstash/templates/service.yaml
+++ b/stable/logstash/templates/service.yaml
@@ -17,9 +17,14 @@ spec:
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
 {{- end }}
   ports:
-  {{- range $key, $value := .Values.service.ports }}
-    - name: {{ $key }}
-{{ toYaml $value | indent 6 }}
+  {{- range .Values.exposePorts }}
+  {{- if gt (int .servicePort) -1 }}
+  {{- $protocol := .protocol | default "tcp" | lower }}
+    - name: {{ .name | default (printf "%v-%v" $protocol .port) }}
+      port: {{ .servicePort | default .port }}
+      targetPort: {{ .port }}
+      protocol: {{ $protocol | upper }}
+  {{- end }}
   {{- end }}
   selector:
     app: {{ template "logstash.name" . }}

--- a/stable/logstash/templates/statefulset.yaml
+++ b/stable/logstash/templates/statefulset.yaml
@@ -52,10 +52,12 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - name: monitor
-              containerPort: {{ .Values.exporter.logstash.target.port }}
-              protocol: TCP
-{{ toYaml .Values.ports | indent 12 }}
+          {{- range .Values.exposePorts }}
+          {{- $protocol := .protocol | default "tcp" | lower }}
+            - name: {{ .name | default (printf "%v-%v" $protocol .port) }}
+              containerPort: {{ .port }}
+              protocol: {{ $protocol | upper }}
+          {{- end }}
           livenessProbe:
 {{ toYaml .Values.livenessProbe | indent 12 }}
           readinessProbe:

--- a/stable/logstash/values.yaml
+++ b/stable/logstash/values.yaml
@@ -27,37 +27,25 @@ service:
     # external-dns.alpha.kubernetes.io/hostname: logstash.cluster.local
     # service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
     # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
-  ports:
-    # syslog-udp:
-    #   port: 1514
-    #   targetPort: syslog-udp
-    #   protocol: UDP
-    # syslog-tcp:
-    #   port: 1514
-    #   targetPort: syslog-tcp
-    #   protocol: TCP
-    beats:
-      port: 5044
-      targetPort: beats
-      protocol: TCP
-    # http:
-    #  port: 8080
-    #  targetPort: http
-    #  protocol: TCP
-    # loadBalancerIP: 10.0.0.1
-ports:
-  # - name: syslog-udp
-  #   containerPort: 1514
-  #   protocol: UDP
-  # - name: syslog-tcp
-  #   containerPort: 1514
-  #   protocol: TCP
-  - name: beats
-    containerPort: 5044
-    protocol: TCP
-  # - name: http
-  #   containerPort: 8080
-  #   protocol: TCP
+
+exposePorts:
+  - name: monitor
+    port: 9600
+# - name: syslog-udp
+#   port: 1514
+#   protocol: udp
+# - name: syslog-tcp
+#   port: 1514
+#   protocol: tcp
+# - port: 5044
+#   # By default, the protocol is TCP.
+#   # By default, the name of the port is '<protocol>-<port>'.
+# - port: 8080
+#   servicePort: 80
+#   # By default, the exposed service port is the exposed container port, but can be overridden.
+# - port: 9999
+#   servicePort: -1
+#   # A negative value for 'servicePort' will not expose a service port.
 
 ingress:
   enabled: false

--- a/stable/logstash/values.yaml
+++ b/stable/logstash/values.yaml
@@ -42,7 +42,9 @@ exposePorts:
 #   # By default, the name of the port is '<protocol>-<port>'.
 # - port: 8080
 #   servicePort: 80
+#   nodePort: 32323
 #   # By default, the exposed service port is the exposed container port, but can be overridden.
+#   # If our service is of type NodePort, set the exposed nodePort for the service
 # - port: 9999
 #   servicePort: -1
 #   # A negative value for 'servicePort' will not expose a service port.


### PR DESCRIPTION
This fixes https://github.com/helm/charts/issues/12291. It allows for cleaner port specification.

I bumped chart's version to 2.0.0. Unfortunately since `service.ports` was a map, the range on it traversed the entries in sorted key order, so there's no guarantee the array formed from `exposePorts` (an array) for the service's ports will be the same, so existing releases might not be able to upgrade.

Lemme know your thoughts!

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
