### PR TITLE
[stable/mattermost-team-edition] bump mm-te to 5.9.0

### DIFF
--- a/stable/mattermost-team-edition/Chart.yaml
+++ b/stable/mattermost-team-edition/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Mattermost Team Edition server.
 name: mattermost-team-edition
-version: 3.0.0
-appVersion: 5.8.0
+version: 3.1.0
+appVersion: 5.9.0
 keywords:
 - mattermost
 - communication

--- a/stable/mattermost-team-edition/README.md
+++ b/stable/mattermost-team-edition/README.md
@@ -55,7 +55,7 @@ Parameter                             | Description                             
 ---                                   | ---                                                                                             | ---
 `configJSON`                          | The `config.json` configuration to be used by the mattermost server. The values you provide will by using Helm's merging behavior override individual default values only. See the [example configuration](#example-configuration) and the [Mattermost documentation](https://docs.mattermost.com/administration/config-settings.html) for details. |  See `configJSON` in [values.yaml](https://github.com/helm/charts/blob/master/stable/mattermost-team-edition/values.yaml)
 `image.repository`                    | Container image repository                                                                      | `mattermost/mattermost-team-edition`
-`image.tag`                           | Container image tag                                                                             | `5.8.0`
+`image.tag`                           | Container image tag                                                                             | `5.9.0`
 `image.imagePullPolicy`               | Container image pull policy                                                                     | `IfNotPresent`
 `initContainerImage.repository`       | Init container image repository                                                                 | `appropriate/curl`
 `initContainerImage.tag`              | Init container image tag                                                                        | `latest`

--- a/stable/mattermost-team-edition/values.yaml
+++ b/stable/mattermost-team-edition/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: mattermost/mattermost-team-edition
-  tag: 5.8.0
+  tag: 5.9.0
   imagePullPolicy: IfNotPresent
 
 initContainerImage:


### PR DESCRIPTION
#### What this PR does / why we need it:
Bump mm-te to 5.9.0

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
