### PR TITLE
[incubator/keycloak-proxy] allow generic constraints

### DIFF
--- a/incubator/keycloak-proxy/Chart.yaml
+++ b/incubator/keycloak-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "3.4.2.Final"
 description: Keycloak Proxy supports Single Sign-On with Keycloak
 name: keycloak-proxy
-version: 0.0.1
+version: 0.0.2
 keywords:
 - authentication
 - sso

--- a/incubator/keycloak-proxy/README.md
+++ b/incubator/keycloak-proxy/README.md
@@ -63,8 +63,7 @@ Parameter | Description | Default
 `configmap.authServerUrl` | The base URL of the Keycloak server. All other Keycloak pages and REST service endpoints are derived from this. It is usually of the form https://host:port/auth | `http://url-to-keycloak.example.com/auth`
 `configmap.resource` | The client-id of the application. Each application has a client-id that is used to identify the application | `CLIENT_ID`
 `configmap.secret` | Specify the credentials of the application. This is an object notation where the key is the credential type and the value is the value of the credential type. Currently password and jwt is supported. This is REQUIRED only for clients with 'Confidential' access type | `CLIENT_SECRET`
-`configmap.pattern` | URL pattern to match relative to the base-path of the application. Must start with '/' REQUIRED. You may only have one wildcard and it must come at the end of the pattern | `/admin`
-`configmap.rolesAllowed` | Array of strings of roles allowed to access this url pattern | `admin`
+`configmap.constraints`| List of constraints to apply while proxying. Refer to the [Keycloak manual](https://www.keycloak.org/docs/latest/server_installation/index.html#constraint-config) for options. At least one constraint is REQUIRED. | `[ { 'pattern': '/admin', 'roles': ['admin'] } ]`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/incubator/keycloak-proxy/templates/configmap.yaml
+++ b/incubator/keycloak-proxy/templates/configmap.yaml
@@ -28,14 +28,8 @@ data:
                   "secret": "{{ .Values.configmap.secret }}"
                 }
              },
-             "constraints":[
-               {
-                  "pattern":"{{ .Values.configmap.pattern }}",
-                  "roles-allowed":[
-                    "{{ .Values.configmap.rolesAllowed }}"
-                  ]
-               }
-             ],
+             "constraints":
+{{ toPrettyJson .Values.configmap.constraints | indent 14 }},
              "proxy-address-forwarding": true
           }
        ]

--- a/incubator/keycloak-proxy/values.yaml
+++ b/incubator/keycloak-proxy/values.yaml
@@ -55,5 +55,11 @@ configmap:
   authServerUrl: http://url-to-keycloak.example.com/auth
   resource: CLIENT_ID
   secret: CLIENT_SECRET
-  pattern: /admin
-  rolesAllowed: admin
+  # See keycloak documentation for constraints configuration. At least one constraint must
+  # be given, which might as well just contain a pattern without further qualification.
+  # Pattern can have a single wildcard at the end.
+  # https://www.keycloak.org/docs/latest/server_installation/index.html#constraint-config
+  constraints:
+    pattern: /admin
+    roles-allowed:
+      - admin


### PR DESCRIPTION
Signed-off-by: Jens Erat <email@jenserat.de>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Keycloak Proxy is much more flexible regarding constraints. Currently, the chart does not allow configuring anything but a single constraint enforcing one specific role. This PR makes the chart flexible to support all constraints offered by Keycloak Proxy by simply passing them through.

#### Which issue this PR fixes

No issue opened.

#### Special notes for your reviewer:

This PR (somewhat) breaks with the camalcase convention: [Keycloak Proxy configuration is given in a hyphenated syntax](https://www.keycloak.org/docs/latest/server_installation/index.html#constraint-config), eg.

```yaml
  constraints:
    pattern: /admin
    roles-allowed:
      - admin
```

translating to configmap snippet

```json
             "constraints":
              {
                "pattern": "/admin",
                "roles-allowed": [
                  "admin"
                ]
              },
```

My opinion is keeping the template simple is preferable to the camelcase best practice. Putting together constraint templating would get horribly complicated and error-prone, otherwise.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
