### PR TITLE
[stable/openldap][WIP] Add support for passing TLS keys from secret

### DIFF
--- a/stable/openldap/Chart.yaml
+++ b/stable/openldap/Chart.yaml
@@ -1,6 +1,6 @@
 name: openldap
 home: https://www.openldap.org
-version: 0.3.0
+version: 0.4.0
 appVersion: 2.4.44
 description: Community developed LDAP software
 icon: http://www.openldap.org/images/headers/LDAPworm.gif

--- a/stable/openldap/README.md
+++ b/stable/openldap/README.md
@@ -38,8 +38,10 @@ The following table lists the configurable parameters of the openldap chart and 
 | `service.ldapPort`                 | External service port for LDAP                                            | `389`             |
 | `service.loadBalancerIP`           | IP address to assign to load balancer (if supported)                      | `""`              |
 | `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)           | `[]`              |
-| `service.sslLdapPort`              | External service port for SSL+LDAP                                        | `636`             |
+| `service.sslLdapPort`              | External service port for SSL+LDAP, only used if `tls.enabled` is set     | `636`             |
 | `service.type`                     | Service type                                                              | `ClusterIP`       |
+| `tls.enabled`                      | Set to enable TLS/LDAPS - should also set `tls.secret`                    | `false`           |
+| `tls.secret`                       | Secret containing TLS cert and key (eg, generated via cert-manager)       | `""`              |
 | `env`                              | List of key value pairs as env variables to be sent to the docker image. See https://github.com/osixia/docker-openldap for available ones | `[see values.yaml]`  |
 | `adminPassword`                    | Password for admin user. Unset to auto-generate the password              | None              |
 | `configPassword`                   | Password for config user. Unset to auto-generate the password             | None              |

--- a/stable/openldap/templates/deployment.yaml
+++ b/stable/openldap/templates/deployment.yaml
@@ -43,6 +43,16 @@ spec:
           mountPath: /ldifworkingdir
       {{- end }}
       containers:
+        {{- if .Values.tls.enabled }}
+        - name: {{ .Chart.Name }}-tls
+          image: busybox
+          command: ['sh', '-c', 'cp /tls/* /certs; while true; do sleep 10000; done']
+          volumeMounts:
+            - name: tls
+              mountPath: /tls
+            - name: certs
+              mountPath: /certs
+        {{- end }}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -54,6 +64,13 @@ spec:
               containerPort: 389
             - name: ssl-ldap-port
               containerPort: 636
+          {{- if .Values.tls.enabled }}
+          env:
+            - name: LDAP_TLS_CRT_FILENAME
+              value: tls.crt
+            - name: LDAP_TLS_KEY_FILENAME
+              value: tls.key
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ template "openldap.fullname" . }}-env
@@ -69,6 +86,10 @@ spec:
             {{- if .Values.customLdifFiles }}
             - name: ldifworkingdir
               mountPath: /container/service/slapd/assets/config/bootstrap/ldif/custom
+            {{- end }}
+            {{- if .Values.tls.enabled }}
+            - name: certs
+              mountPath: /container/service/slapd/assets/certs
             {{- end }}
           livenessProbe:
             tcpSocket:
@@ -103,6 +124,14 @@ spec:
             name: {{ template "openldap.fullname" . }}-customldif
         - name: ldifworkingdir
           emptyDir: {}
+        {{- end }}
+        {{- if .Values.tls.enabled }}
+        - name: tls
+          secret:
+            secretName: {{ .Values.tls.secret }}
+        - name: certs
+          emptyDir:
+            medium: Memory
         {{- end }}
         - name: data
         {{- if .Values.persistence.enabled }}

--- a/stable/openldap/templates/service.yaml
+++ b/stable/openldap/templates/service.yaml
@@ -32,10 +32,12 @@ spec:
       protocol: TCP
       port: {{ .Values.service.ldapPort }}
       targetPort: ldap-port
+{{- if .Values.tls.enabled }}
     - name: ssl-ldap-port
       protocol: TCP
       port: {{ .Values.service.sslLdapPort }}
       targetPort: ssl-ldap-port
+{{- end }}
   selector:
     app: {{ template "openldap.name" . }}
     release: {{ .Release.Name }}

--- a/stable/openldap/values.yaml
+++ b/stable/openldap/values.yaml
@@ -25,6 +25,11 @@ image:
 # Spcifies an existing secret to be used for admin and config user passwords
 existingSecret: ""
 
+# settings for enabling TLS
+tls:
+  enabled: false
+  secret: ""  # The name of a kubernetes.io/tls type secret to use for TLS
+
 ## Add additional labels to all resources
 extraLabels: {}
 
@@ -33,7 +38,7 @@ service:
   clusterIP: ""
 
   ldapPort: 389
-  sslLdapPort: 636
+  sslLdapPort: 636  # Only used if tls.enabled is true
   ## List of IP addresses at which the service is available
   ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
   ##


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**After further testing I've run into issues using LetsEncrypt certificates with this - please consider this a WIP**

#### What this PR does / why we need it:
Adds an easy way to secure OpenLDAP connections using TLS certificates. In particular, this makes it possible to use certificates generated by cert-manager.

#### Which issue this PR fixes
 - fixes #11719

#### Special notes for your reviewer:
The change to the service to not publish the LDAPS port unless `tls.enabled` might not be appropriate, happy to back that out if people want me to

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
