### PR TITLE
[stable/redis] Set rollingUpdate to null when updateStrategy is Recreate

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 6.5.1
+version: 6.4.1
 appVersion: 4.0.13
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 6.4.0
+version: 6.5.1
 appVersion: 4.0.13
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/redis-master-statefulset.yaml
+++ b/stable/redis/templates/redis-master-statefulset.yaml
@@ -242,6 +242,9 @@ spec:
   updateStrategy:
     type: {{ .Values.master.statefulset.updateStrategy }}
     {{- if .Values.master.statefulset.rollingUpdatePartition }}
+    {{- if (eq "Recreate" .Values.master.statefulset.updateStrategy) }}
+    rollingUpdate: null
+    {{- else }}
     rollingUpdate:
       partition: {{ .Values.master.statefulset.rollingUpdatePartition }}
     {{- end }}

--- a/stable/redis/templates/redis-master-statefulset.yaml
+++ b/stable/redis/templates/redis-master-statefulset.yaml
@@ -248,3 +248,4 @@ spec:
     rollingUpdate:
       partition: {{ .Values.master.statefulset.rollingUpdatePartition }}
     {{- end }}
+    {{- end }}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR sets the updateStrategy.rollingUpdate to 'null' when updateStrategy.type is 'Recreate' to avoid the issue:

```
Error: StatefulSet.apps "redis" is invalid: spec.updateStrategy: Invalid value: apps.StatefulSetUpdateStrategy{Type:"Recreate", RollingUpdate:(*apps.RollingUpdateStatefulSetStrategy)(nil)}: must be 'RollingUpdate' or 'OnDelete' && StatefulSet.apps "redis" is invalid: spec.updateStrategy: Invalid value: apps.StatefulSetUpdateStrategy{Type:"Recreate", RollingUpdate:(*apps.RollingUpdateStatefulSetStrategy)(nil)}: must be 'RollingUpdate' or 'OnDelete'
```

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
