### PR TITLE
[stable/nats] Set rollingUpdate to null when updateStrategy is Recreate

### DIFF
--- a/stable/nats/Chart.yaml
+++ b/stable/nats/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nats
-version: 2.3.0
+version: 2.3.1
 appVersion: 1.4.1
 description: An open-source, cloud-native messaging system
 keywords:

--- a/stable/nats/templates/statefulset.yaml
+++ b/stable/nats/templates/statefulset.yaml
@@ -12,9 +12,13 @@ spec:
   replicas: {{ .Values.replicaCount }}
   updateStrategy:
     type: {{ .Values.statefulset.updateStrategy }}
+    {{- if (eq "Recreate" .Values.statefulset.updateStrategy) }}
+    rollingUpdate: null
+    {{- else }}
     {{- if .Values.statefulset.rollingUpdatePartition }}
     rollingUpdate:
       partition: {{ .Values.statefulset.rollingUpdatePartition }}
+    {{- end }}
     {{- end }}
   selector:
     matchLabels:


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR sets the updateStrategy.rollingUpdate to 'null' when updateStrategy.type is 'Recreate' to avoid the issue:

```
Error: StatefulSet.apps "nats" is invalid: spec.updateStrategy: Invalid value: apps.StatefulSetUpdateStrategy{Type:"Recreate", RollingUpdate:(*apps.RollingUpdateStatefulSetStrategy)(nil)}: must be 'RollingUpdate' or 'OnDelete' && StatefulSet.apps "nats" is invalid: spec.updateStrategy: Invalid value: apps.StatefulSetUpdateStrategy{Type:"Recreate", RollingUpdate:(*apps.RollingUpdateStatefulSetStrategy)(nil)}: must be 'RollingUpdate' or 'OnDelete'
```

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped