### PR TITLE
[stable/grafana] Enable extra init containers and extra emptyDir mounts

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 2.3.1
+version: 2.3.2
 appVersion: 6.0.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 2.3.2
+version: 2.3.3
 appVersion: 6.0.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -69,6 +69,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `extraSecretMounts`                       | Additional grafana server secret mounts       | `[]`                                                    |
 | `extraVolumeMounts`                       | Additional grafana server volume mounts       | `[]`                                                    |
 | `extraConfigmapMounts`                    | Additional grafana server configMap volume mounts  | `[]`                                               |
+| `extraEmptyDirMounts`                     | Additional grafana server emptyDir volume mounts   | `[]`                                               |
 | `plugins`                                 | Plugins to be loaded along with Grafana       | `[]`                                                    |
 | `datasources`                             | Configure grafana datasources (passed through tpl) | `{}`                                                    |
 | `notifiers`                               | Configure grafana notifiers | `{}`                                                                      |

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -54,6 +54,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `nodeSelector`                            | Node labels for pod assignment                | `{}`                                                    |
 | `tolerations`                             | Toleration labels for pod assignment          | `[]`                                                    |
 | `affinity`                                | Affinity settings for pod assignment          | `{}`                                                    |
+| `extraInitContainers`                     | Init containers to add to the grafana pod     | `{}` |
 | `extraContainers`                         | Sidecar containers to add to the grafana pod  | `{}` |
 | `persistence.enabled`                     | Use persistent volume to store data           | `false`                                                 |
 | `persistence.initChownData`               | Change ownership of persistent volume on initialization | `true`                                                  |

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -212,6 +212,10 @@ spec:
               subPath: {{ .subPath | default "" }}
               readOnly: {{ .readOnly }}
           {{- end }}
+          {{- range .Values.extraEmptyDirMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+          {{- end }}
           ports:
             - name: service
               containerPort: {{ .Values.service.port }}
@@ -347,4 +351,8 @@ spec:
         - name: {{ .name }}
           persistentVolumeClaim:
             claimName: {{ .existingClaim }}
+      {{- end }}
+      {{- range .Values.extraEmptyDirMounts }}
+        - name: {{ .name }}
+          emptyDir: {}
       {{- end }}

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
 {{- end }}
-{{- if ( or .Values.persistence.enabled .Values.dashboards .Values.sidecar.datasources.enabled) }}
+{{- if ( or .Values.persistence.enabled .Values.dashboards .Values.sidecar.datasources.enabled .Values.extraInitContainers) }}
       initContainers:
 {{- end }}
 {{- if ( and .Values.persistence.enabled .Values.persistence.initChownData ) }}
@@ -101,6 +101,9 @@ spec:
             - name: sc-datasources-volume
               mountPath: "/etc/grafana/provisioning/datasources"
 {{- end}}
+{{- if .Values.extraInitContainers }}
+{{ toYaml .Values.extraInitContainers | indent 8 }}
+{{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -48,6 +48,11 @@ extraConfigmapMounts: []
   #   readOnly: true
 
 
+extraEmptyDirMounts: []
+  # - name: provisioning-notifiers
+  #   mountPath: /etc/grafana/provisioning/notifiers
+
+
 ## Assign a PriorityClassName to pods if set
 # priorityClassName:
 

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -116,6 +116,8 @@ tolerations: []
 ##
 affinity: {}
 
+extraInitContainers: []
+
 ## Enable an Specify container in extraContainers. This is meant to allow adding an authentication proxy to a grafana pod
 extraContainers: |
 # - name: proxy


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR introduces two new parameters for the Grafana chart, *extraInitContainers* and *extraEmptyDirMounts*.

Since Grafana v6.0.0, it is possible to provision [notification channels](http://docs.grafana.org/administration/provisioning/#alert-notification-channels). These channels might have some sensitive parts (i.e. tokens) and therefore I would like to be able to have an init container which initializes somehow the necessary yaml files. The values can then be shared with the actual Grafana container via emptyDir volumes.

cc @zanhsieh @rtluckie @maorfr 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
