### PR TITLE
[incubator/cassandra] rename backup.image.repository, update default …

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,5 +1,5 @@
 name: cassandra
-version: 0.10.6
+version: 0.11.0
 appVersion: 3.11.3
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,5 +1,5 @@
 name: cassandra
-version: 0.10.5
+version: 0.10.6
 appVersion: 3.11.3
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/README.md
+++ b/incubator/cassandra/README.md
@@ -80,7 +80,7 @@ The following table lists the configurable parameters of the Cassandra chart and
 
 | Parameter                  | Description                                     | Default                                                    |
 | -----------------------    | ---------------------------------------------   | ---------------------------------------------------------- |
-| `image.repository`                         | `cassandra` image repository                    | `cassandra`                                                |
+| `image.repo`                         | `cassandra` image repository                    | `cassandra`                                                |
 | `image.tag`                          | `cassandra` image tag                           | `3.11.3`                                                   |
 | `image.pullPolicy`                   | Image pull policy                               | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
 | `image.pullSecrets`                  | Image pull secrets                              | `nil`                                                      |
@@ -129,8 +129,8 @@ The following table lists the configurable parameters of the Cassandra chart and
 | `backup.enabled`                     | Enable backup on chart installation             | `false`                                                    |
 | `backup.schedule`                    | Keyspaces to backup, each with cron time        |                                                            |
 | `backup.annotations`                 | Backup pod annotations                          | iam.amazonaws.com/role: `cain`                             |
-| `backup.image.repo`                  | Backup image repository                         | `nuvo/cain`                                                |
-| `backup.image.tag`                   | Backup image tag                                | `0.4.1`                                                    |
+| `backup.image.repository`            | Backup image repository                         | `maorfr/cain`                                              |
+| `backup.image.tag`                   | Backup image tag                                | `0.6.0`                                                    |
 | `backup.extraArgs`                   | Additional arguments for cain                   | `[]`                                                       |
 | `backup.env`                         | Backup environment variables                    | AWS_REGION: `us-east-1`                                    |
 | `backup.resources`                   | Backup CPU/Memory resource requests/limits      | Memory: `1Gi`, CPU: `1`                                    |

--- a/incubator/cassandra/README.md
+++ b/incubator/cassandra/README.md
@@ -80,7 +80,7 @@ The following table lists the configurable parameters of the Cassandra chart and
 
 | Parameter                  | Description                                     | Default                                                    |
 | -----------------------    | ---------------------------------------------   | ---------------------------------------------------------- |
-| `image.repo`                         | `cassandra` image repository                    | `cassandra`                                                |
+| `image.repository`                         | `cassandra` image repository                    | `cassandra`                                                |
 | `image.tag`                          | `cassandra` image tag                           | `3.11.3`                                                   |
 | `image.pullPolicy`                   | Image pull policy                               | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
 | `image.pullSecrets`                  | Image pull secrets                              | `nil`                                                      |
@@ -135,6 +135,7 @@ The following table lists the configurable parameters of the Cassandra chart and
 | `backup.env`                         | Backup environment variables                    | AWS_REGION: `us-east-1`                                    |
 | `backup.resources`                   | Backup CPU/Memory resource requests/limits      | Memory: `1Gi`, CPU: `1`                                    |
 | `backup.destination`                 | Destination to store backup artifacts           | `s3://bucket/cassandra`                                    |
+| `backup.google.serviceAccountSecret` | Secret containing credentials if GCS is used as destination |                                                |
 | `exporter.enabled`                   | Enable Cassandra exporter                       | `false`                                                    |
 | `exporter.image.repo`                | Exporter image repository                       | `criteord/cassandra_exporter`                              |
 | `exporter.image.tag`                 | Exporter image tag                              | `2.0.2`                                                    |

--- a/incubator/cassandra/templates/backup/cronjob.yaml
+++ b/incubator/cassandra/templates/backup/cronjob.yaml
@@ -28,7 +28,7 @@ spec:
           serviceAccountName: {{ template "cassandra.serviceAccountName" $ }}
           containers:
           - name: cassandra-backup
-            image: "{{ $backup.image.repos }}:{{ $backup.image.tag }}"
+            image: "{{ $backup.image.repository }}:{{ $backup.image.tag }}"
             command: ["cain"]
             args:
             - backup
@@ -42,15 +42,30 @@ spec:
             - {{ $backup.destination }}
             {{- with $backup.extraArgs }}
 {{ toYaml . | indent 12 }}
-          {{- end }}
-          {{- with $backup.env }}
+            {{- end }}
             env:
+{{- if $backup.google.serviceAccountSecret }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/etc/secrets/google/credentials.json"
+{{- end }}
+          {{- with $backup.env }}
 {{ toYaml . | indent 12 }}
           {{- end }}
           {{- with $backup.resources }}
             resources:
 {{ toYaml . | indent 14 }}
           {{- end }}
+{{- if $backup.google.serviceAccountSecret }}
+            volumeMounts:
+            - name: google-service-account
+              mountPath: /etc/secrets/google/
+{{- end }}
+{{- if $backup.google.serviceAccountSecret }}
+          volumes:
+          - name: google-service-account
+            secret:
+              secretName: {{ $backup.google.serviceAccountSecret | quote }}
+{{- end }}
         affinity:
           podAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -171,8 +171,8 @@ backup:
     iam.amazonaws.com/role: cain
 
   image:
-    repos: nuvo/cain
-    tag: 0.4.1
+    repository: maorfr/cain
+    tag: 0.6.0
 
   # Additional arguments for cain
   # Ref: https://github.com/nuvo/cain#usage
@@ -191,6 +191,10 @@ backup:
     limits:
       memory: 1Gi
       cpu: 1
+
+  # Name of the secret containing the credentials of the service account used by GOOGLE_APPLICATION_CREDENTIALS, as a credentials.json file
+  # google:
+    # serviceAccountSecret:
 
   # Destination to store the backup artifacts
   # Supported cloud storage services: AWS S3, Minio S3, Azure Blob Storage

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -197,7 +197,7 @@ backup:
     # serviceAccountSecret:
 
   # Destination to store the backup artifacts
-  # Supported cloud storage services: AWS S3, Minio S3, Azure Blob Storage
+  # Supported cloud storage services: AWS S3, Minio S3, Azure Blob Storage, Google Cloud Storage
   # Additional support can added. Visit this repository for details
   # Ref: https://github.com/maorfr/skbn
   destination: s3://bucket/cassandra

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -153,7 +153,7 @@ serviceAccount:
 hostNetwork: false
 
 ## Backup cronjob configuration
-## Ref: https://github.com/nuvo/cain
+## Ref: https://github.com/maorfr/cain
 backup:
   enabled: false
 
@@ -175,7 +175,7 @@ backup:
     tag: 0.6.0
 
   # Additional arguments for cain
-  # Ref: https://github.com/nuvo/cain#usage
+  # Ref: https://github.com/maorfr/cain#usage
   extraArgs: []
 
   # Add additional environment variables
@@ -199,7 +199,7 @@ backup:
   # Destination to store the backup artifacts
   # Supported cloud storage services: AWS S3, Minio S3, Azure Blob Storage
   # Additional support can added. Visit this repository for details
-  # Ref: https://github.com/nuvo/skbn
+  # Ref: https://github.com/maorfr/skbn
   destination: s3://bucket/cassandra
 
 ## Cassandra exported configuration


### PR DESCRIPTION
…value, add support for google credentials as a secret

Signed-off-by: Simon Hardy <simonhardy8@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Adds support for GCS as destination of Cassandra backups. 
I also renamed the backup.image.repository attribute because it was not standard and wrongly documented ("repo" in the doc but "repos" in reality, while "repository" seems the standard in other helm charts). 

#### Special notes for your reviewer:
I had to allow the user to mount a secret containing the Google credentials because the standard way of providing credentials is to provide the GOOGLE_APPLICATION_CREDENTIALS environment variable that contains the path to the key file, unlike e.g. AZURE_STORAGE_ACCESS_KEY that asks for the key directly. 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
