### PR TITLE
[stable/grafana] Notification channel provisioning (Resolves issue #12334)

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 2.2.6
+version: 2.3.0
 appVersion: 6.0.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 2.2.5
+version: 2.2.6
 appVersion: 6.0.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -70,6 +70,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `extraConfigmapMounts`                    | Additional grafana server configMap volume mounts  | `[]`                                               |
 | `plugins`                                 | Plugins to be loaded along with Grafana       | `[]`                                                    |
 | `datasources`                             | Configure grafana datasources (passed through tpl) | `{}`                                                    |
+| `notifiers`                               | Configure grafana notifiers | `{}`                                                                      |
 | `dashboardProviders`                      | Configure grafana dashboard providers         | `{}`                                                    |
 | `dashboards`                              | Dashboards to import                          | `{}`                                                    |
 | `dashboardsConfigMaps`                    | ConfigMaps reference that contains dashboards | `{}`                                                    |

--- a/stable/grafana/templates/configmap.yaml
+++ b/stable/grafana/templates/configmap.yaml
@@ -27,6 +27,13 @@ data:
   {{- end -}}
 {{- end -}}
 
+{{- if .Values.notifiers }}
+  {{- range $key, $value := .Values.notifiers }}
+  {{ $key }}: |
+{{ toYaml $value | indent 4 }}
+  {{- end -}}
+{{- end -}}
+
 {{- if .Values.dashboardProviders }}
   {{- range $key, $value := .Values.dashboardProviders }}
   {{ $key }}: |

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -177,6 +177,11 @@ spec:
               mountPath: "/etc/grafana/provisioning/datasources/datasources.yaml"
               subPath: datasources.yaml
 {{- end }}
+{{- if .Values.notifiers }}
+            - name: config
+              mountPath: "/etc/grafana/provisioning/notifiers/notifiers.yaml"
+              subPath: notifiers.yaml
+{{- end }}
 {{- if .Values.dashboardProviders }}
             - name: config
               mountPath: "/etc/grafana/provisioning/dashboards/dashboardproviders.yaml"

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -211,6 +211,24 @@ datasources: {}
 #      access: proxy
 #      isDefault: true
 
+## Configure notifiers
+## ref: http://docs.grafana.org/administration/provisioning/#alert-notification-channels
+##
+notifiers: {}
+#  notifiers.yaml:
+#    notifiers:
+#    - name: email-notifier
+#      type: email
+#      uid: email1
+#      # either:
+#      org_id: 1
+#      # or
+#      org_name: Main Org.
+#      is_default: true
+#      settings:
+#        addresses: an_email_address@example.com
+#    delete_notifiers:
+
 ## Configure grafana dashboard providers
 ## ref: http://docs.grafana.org/administration/provisioning/#dashboards
 ##


### PR DESCRIPTION
Addresses issue [#12334](https://github.com/helm/charts/issues/12334).

To do in a separate issue\PR: add on-the-fly notification channel management via a sidecar.