### PR TITLE
[stable/ghost] Adds support for custom TLS hosts in ingress

### DIFF
--- a/stable/ghost/Chart.yaml
+++ b/stable/ghost/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ghost
-version: 6.5.3
+version: 6.6.0
 appVersion: 2.18.1
 description: A simple, powerful publishing platform that allows you to share your stories with the world
 keywords:

--- a/stable/ghost/README.md
+++ b/stable/ghost/README.md
@@ -89,6 +89,7 @@ The following table lists the configurable parameters of the Ghost chart and the
 | `ingress.hosts[0].name`             | Hostname to your Ghost installation                           | `ghost.local`                                            |
 | `ingress.hosts[0].path`             | Path within the url structure                                 | `/`                                                      |
 | `ingress.hosts[0].tls`              | Utilize TLS backend in ingress                                | `false`                                                  |
+| `ingress.hosts[0].tlsHosts`         | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`)                               | `nil`                                                  |
 | `ingress.hosts[0].tlsSecret`        | TLS Secret (certificates)                                     | `ghost.local-tls-secret`                                 |
 | `ingress.secrets[0].name`           | TLS Secret Name                                               | `nil`                                                    |
 | `ingress.secrets[0].certificate`    | TLS Secret Certificate                                        | `nil`                                                    |

--- a/stable/ghost/templates/ingress.yaml
+++ b/stable/ghost/templates/ingress.yaml
@@ -30,7 +30,13 @@ spec:
   {{- range .Values.ingress.hosts }}
   {{- if .tls }}
   - hosts:
+  {{- if .tlsHosts }}
+  {{- range $host := .tlsHosts }}
+    - {{ $host }}
+  {{- end }}
+  {{- else }}
     - {{ .name }}
+  {{- end }}
     secretName: {{ .tlsSecret }}
   {{- end }}
   {{- end }}

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -231,6 +231,13 @@ ingress:
     ## Set this to true in order to enable TLS on the ingress record
     tls: false
 
+    ## Optionally specify the TLS hosts for the ingress record
+    ## Useful when the Ingress controller supports www-redirection
+    ## If not specified, the above host name will be used
+    # tlsHosts:
+    # - www.ghost.local
+    # - ghost.local
+
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
     tlsSecret: ghost.local-tls
 


### PR DESCRIPTION
Signed-off-by: Greg Richardson <greg.nmr@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Currently when the Ingress is enabled and TLS is enabled on a host record, the chart will create a TLS host that matches the host rule 1-to-1.

In some situations it's useful to specify more TLS hosts, such as when using `nginx-ingress` controller's `nginx.ingress.kubernetes.io/from-to-www-redirect` option, which automatically redirects `example.com` to `www.example.com`. In this situation a second TLS host is required on the certificate:

```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: example-app
  labels:
    app: "example-app"
  annotations:
    kubernetes.io/ingress.class: "nginx"
    kubernetes.io/tls-acme: "true"
    nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
spec:
  rules:
  - host: www.example.com
    http:
      paths:
      - path: /
        backend:
          serviceName: example-app
          servicePort: http
  tls:
  - hosts:
    - example.com
    - www.example.com
    secretName: example-com-tls
```

This PR allows you to specify a `tlsHosts` ingress option to override the default host name with a list of TLS hosts:

*values.yaml*:
```yaml
ingress:
  enabled: true
  annotations:
    kubernetes.io/ingress.class: nginx
    kubernetes.io/tls-acme: "true"
    nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
  hosts:
    - name: www.example.com
      path: /
      tls: true
      tlsHosts:
        - example.com
        - www.example.com
      tlsSecret: example-com-tls
```

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
