### PR TITLE
[stable/redis-ha] remove chart ref from sentinel ID generation

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.3.1
+version: 3.3.2
 appVersion: 5.0.3
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/stable/redis-ha/templates/redis-ha-statefulset.yaml
@@ -77,7 +77,7 @@ spec:
 {{- $replicas := int .Values.replicas -}}
 {{- range $i := until $replicas }}
         - name: SENTINEL_ID_{{ $i }}
-          value: {{ printf "%s\nindex: %d" (include "labels.standard" $) $i | sha1sum }}
+          value: {{ printf "%s\n%s\nindex: %d" (include "redis-ha.name" $) ($.Release.Name) $i | sha1sum }}
 {{ end -}}
 {{- if .Values.auth }}
         - name: AUTH


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes a bug where new chart version upgrades cause a new sentinel IDs to be generated.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
