### PR TITLE
[stable/cluster-overprovisioner] enabled option for default priority class

### DIFF
--- a/stable/cluster-overprovisioner/Chart.yaml
+++ b/stable/cluster-overprovisioner/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: Installs the a deployment that overprovisions the cluster
 name: cluster-overprovisioner
 home: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler
-version: 0.1.0
+version: 0.2.0
 maintainers:
 - name: max-rocket-internet
   email: max.williams@deliveryhero.com

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -37,6 +37,7 @@ The following table lists the configurable parameters for this chart and their d
 | -----------------------------------|---------------------------------------------------|-------------------|
 | `priorityClassOverprovision.name`  | Name of the overprovision priorityClass           | `overprovision`   |
 | `priorityClassOverprovision.value` | Priority value of the overprovision priorityClass | `-1`              |
+| `priorityClassDefault.enabled`     | If true, enable default priorityClass             | `true`            |
 | `priorityClassDefault.name`        | Name of the default priorityClass                 | `default`         |
 | `priorityClassDefault.value`       | Priority value of the default priorityClass       | `0`               |
 | `replicaCount`                     | Number of replicas                                | `1`               |

--- a/stable/cluster-overprovisioner/templates/priorityclass-default.yaml
+++ b/stable/cluster-overprovisioner/templates/priorityclass-default.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.priorityClassDefault.enabled }}
 apiVersion: scheduling.k8s.io/{{ template "PriorityClass.apiVersion" . }}
 kind: PriorityClass
 metadata:
@@ -10,3 +11,4 @@ metadata:
 value: {{ .Values.priorityClassDefault.value }}
 globalDefault: true
 description: "Default priority class for all pods"
+{{- end }}

--- a/stable/cluster-overprovisioner/values.yaml
+++ b/stable/cluster-overprovisioner/values.yaml
@@ -3,6 +3,7 @@ priorityClassOverprovision:
   value: -1
 
 priorityClassDefault:
+  enabled: true
   name: default
   value: 0
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR makes default priority class optional with enabled option for clusters that have own default class

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
