### PR TITLE
[stable/keycloak] Don't auto-generate passwords for CI

### DIFF
--- a/stable/keycloak/Chart.yaml
+++ b/stable/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 4.7.0
+version: 4.6.2
 appVersion: 4.8.3.Final
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/stable/keycloak/Chart.yaml
+++ b/stable/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 4.6.1
+version: 4.7.0
 appVersion: 4.8.3.Final
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/stable/keycloak/ci/h2-values.yaml
+++ b/stable/keycloak/ci/h2-values.yaml
@@ -1,1 +1,2 @@
-# No config change. Just use defaults.
+keycloak:
+  password: keycloak

--- a/stable/keycloak/ci/postgres-ha-values.yaml
+++ b/stable/keycloak/ci/postgres-ha-values.yaml
@@ -1,5 +1,6 @@
 keycloak:
   replicas: 3
+  password: keycloak
   persistence:
     deployPostgres: true
     dbVendor: postgres


### PR DESCRIPTION
We should no longer use auto-generated passwords in tests because they break upgrade tests with the upcoming chart-testing release.