### PR TITLE
[stable/ghost] Adds ghostPort for application URLs

### DIFF
--- a/stable/ghost/Chart.yaml
+++ b/stable/ghost/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ghost
-version: 6.6.0
+version: 6.7.0
 appVersion: 2.18.1
 description: A simple, powerful publishing platform that allows you to share your stories with the world
 keywords:

--- a/stable/ghost/README.md
+++ b/stable/ghost/README.md
@@ -61,6 +61,7 @@ The following table lists the configurable parameters of the Ghost chart and the
 | `volumePermissions.image.tag`       | Init container volume-permissions image tag                   | `latest`                                                 |
 | `volumePermissions.image.pullPolicy`| Init container volume-permissions image pull policy           | `Always`                                                 |
 | `ghostHost`                         | Ghost host to create application URLs                         | `nil`                                                    |
+| `ghostPort`                         | Ghost port to use in application URLs (defaults to `service.port` if `nil`) | `nil`                                                    |
 | `ghostProtocol`                     | Protocol (http or https) to use in the application URLs       | `http`                                                   |
 | `ghostPath`                         | Ghost path to create application URLs                         | `nil`                                                    |
 | `ghostUsername`                     | User of the application                                       | `user@example.com`                                       |

--- a/stable/ghost/templates/deployment.yaml
+++ b/stable/ghost/templates/deployment.yaml
@@ -85,7 +85,11 @@ spec:
         - name: GHOST_PROTOCOL
           value: {{  .Values.ghostProtocol | quote }}
         - name: GHOST_PORT_NUMBER
+        {{- if .Values.ghostPort }}
+          value: {{ .Values.ghostPort | quote }}
+        {{- else }}
           value: {{ .Values.service.port | quote }}
+        {{- end }}
         - name: GHOST_USERNAME
           value: {{ .Values.ghostUsername | quote }}
         - name: GHOST_PASSWORD

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -42,11 +42,12 @@ volumePermissions:
     # pullSecrets:
     #   - myRegistryKeySecretName
 
-## Ghost protocol, host and path to create application URLs
+## Ghost protocol, host, port and path to create application URLs
 ## ref: https://github.com/bitnami/bitnami-docker-ghost#configuration
 ##
 ghostProtocol: http
 # ghostHost:
+# ghostPort:
 ghostPath: /
 
 


### PR DESCRIPTION
Signed-off-by: Greg Richardson <greg.nmr@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Currently a `GHOST_PORT_NUMBER` environment variable is passed into the ghost container to set the port in the application URL, but it's value is always based on the `service.port`:

*deployment.yaml*:
```yaml
env:
- name: GHOST_PORT_NUMBER
  value: {{ .Values.service.port | quote }}
```

If the application is behind an Ingress, using the service port can be incorrect (eg. Service is on port 80, but Ingress is on 443). This PR adds a `ghostPort` option to manually set this port. If not set, it will fall back to the service port.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
