### PR TITLE
Feature grafana/add resourcequotas persistence initcontainer

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 2.3.5
+version: 3.0.0
 appVersion: 6.0.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -63,7 +63,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `persistence.storageClassName`            | Type of persistent volume claim               | `nil`                                                   |
 | `persistence.accessModes`                 | Persistence access modes                      | `[ReadWriteOnce]`                                       |
 | `persistence.subPath`                     | Mount a sub dir of the persistent volume      | `nil`                                                   |
-| `persistence.resources`                   | Persistence initContainer resources           | `{}`                                                    |
 | `initChownData.enabled`                   | If false, don't reset data ownership at startup | true                                                  |
 | `initChownData.name`                      | init-chown-data container name                | `init-chown-data`                                       |
 | `initChownData.image.repository`          | init-chown-data container image repository    | `busybox`                                               |

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -58,13 +58,18 @@ The command removes all the Kubernetes components associated with the chart and 
 | `extraInitContainers`                     | Init containers to add to the grafana pod     | `{}` |
 | `extraContainers`                         | Sidecar containers to add to the grafana pod  | `{}` |
 | `persistence.enabled`                     | Use persistent volume to store data           | `false`                                                 |
-| `persistence.initChownData`               | Change ownership of persistent volume on initialization | `true`                                                  |
 | `persistence.size`                        | Size of persistent volume claim               | `10Gi`                                                  |
 | `persistence.existingClaim`               | Use an existing PVC to persist data           | `nil`                                                   |
 | `persistence.storageClassName`            | Type of persistent volume claim               | `nil`                                                   |
 | `persistence.accessModes`                 | Persistence access modes                      | `[ReadWriteOnce]`                                       |
 | `persistence.subPath`                     | Mount a sub dir of the persistent volume      | `nil`                                                   |
 | `persistence.resources`                   | Persistence initContainer resources           | `{}`                                                    |
+| `initChownData.enabled`                   | If false, don't reset data ownership at startup | true                                                  |
+| `initChownData.name`                      | init-chown-data container name                | `init-chown-data`                                       |
+| `initChownData.image.repository`          | init-chown-data container image repository    | `busybox`                                               |
+| `initChownData.image.tag`                 | init-chown-data container image tag           | `latest`                                                |
+| `initChownData.image.pullPolicy`          | init-chown-data container image pull policy   | `IfNotPresent`                                          |
+| `initChownData.resources`                 | init-chown-data pod resource requests & limits | `{}`                                                   |
 | `schedulerName`                           | Alternate scheduler name                      | `nil`                                                   |
 | `env`                                     | Extra environment variables passed to pods    | `{}`                                                    |
 | `envFromSecret`                           | Name of a Kubenretes secret (must be manually created in the same namespace) containing values to be added to the environment | `""` |

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -64,6 +64,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `persistence.storageClassName`            | Type of persistent volume claim               | `nil`                                                   |
 | `persistence.accessModes`                 | Persistence access modes                      | `[ReadWriteOnce]`                                       |
 | `persistence.subPath`                     | Mount a sub dir of the persistent volume      | `nil`                                                   |
+| `persistence.resources`                   | Persistence initContainer resources           | `{}`                                                    |
 | `schedulerName`                           | Alternate scheduler name                      | `nil`                                                   |
 | `env`                                     | Extra environment variables passed to pods    | `{}`                                                    |
 | `envFromSecret`                           | Name of a Kubenretes secret (must be manually created in the same namespace) containing values to be added to the environment | `""` |

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -64,7 +64,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `persistence.accessModes`                 | Persistence access modes                      | `[ReadWriteOnce]`                                       |
 | `persistence.subPath`                     | Mount a sub dir of the persistent volume      | `nil`                                                   |
 | `initChownData.enabled`                   | If false, don't reset data ownership at startup | true                                                  |
-| `initChownData.name`                      | init-chown-data container name                | `init-chown-data`                                       |
 | `initChownData.image.repository`          | init-chown-data container image repository    | `busybox`                                               |
 | `initChownData.image.tag`                 | init-chown-data container image tag           | `latest`                                                |
 | `initChownData.image.pullPolicy`          | init-chown-data container image pull policy   | `IfNotPresent`                                          |

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
       initContainers:
 {{- end }}
 {{- if ( and .Values.persistence.enabled .Values.initChownData.enabled ) }}
-        - name: "{{ .Values.initChownData.name }}"
+        - name: init-chown-data
           image: "{{ .Values.initChownData.image.repository }}:{{ .Values.initChownData.image.tag }}"
           imagePullPolicy: {{ .Values.initChownData.image.pullPolicy }}
           securityContext:

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -53,6 +53,8 @@ spec:
           securityContext:
             runAsUser: 0
           command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsUser }}", "/var/lib/grafana"]
+          resources:
+{{ toYaml .Values.persistence.resources | indent 12 }}
           volumeMounts:
             - name: storage
               mountPath: "/var/lib/grafana"

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -46,15 +46,15 @@ spec:
 {{- if ( or .Values.persistence.enabled .Values.dashboards .Values.sidecar.datasources.enabled .Values.extraInitContainers) }}
       initContainers:
 {{- end }}
-{{- if ( and .Values.persistence.enabled .Values.persistence.initChownData ) }}
-        - name: init-chown-data
-          image: "{{ .Values.chownDataImage.repository }}:{{ .Values.chownDataImage.tag }}"
-          imagePullPolicy: {{ .Values.chownDataImage.pullPolicy }}
+{{- if ( and .Values.persistence.enabled .Values.initChownData.enabled ) }}
+        - name: "{{ .Values.initChownData.name }}"
+          image: "{{ .Values.initChownData.image.repository }}:{{ .Values.initChownData.image.tag }}"
+          imagePullPolicy: {{ .Values.initChownData.image.pullPolicy }}
           securityContext:
             runAsUser: 0
           command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsUser }}", "/var/lib/grafana"]
           resources:
-{{ toYaml .Values.persistence.resources | indent 12 }}
+{{ toYaml .Values.initChownData.resources | indent 12 }}
           volumeMounts:
             - name: storage
               mountPath: "/var/lib/grafana"

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -147,12 +147,12 @@ persistence:
   enabled: false
   initChownData: true
   resources: {}
-   #limits:
-   #  cpu: 100m
-   #  memory: 100Mi
-   #requests:
-   #  cpu: 50m
-   #  memory: 50Mi
+#   limits:
+#     cpu: 100m
+#     memory: 100Mi
+#   requests:
+#     cpu: 50m
+#     memory: 50Mi
   # storageClassName: default
   accessModes:
     - ReadWriteOnce

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -154,25 +154,25 @@ persistence:
   # existingClaim:
 
 initChownData:
-  ## If false, data ownership will not be reset at startup
-  ## This allows the prometheus-server to be run with an arbitrary user
-  ##
+## If false, data ownership will not be reset at startup
+## This allows the prometheus-server to be run with an arbitrary user
+##
   enabled: true
 
-  ## initChownData container name
-  ##
+## initChownData container name
+##
   name: init-chown-data
 
-  ## initChownData container image
-  ##
+## initChownData container image
+##
   image:
     repository: busybox
     tag: latest
     pullPolicy: IfNotPresent
 
-  ## initChownData resource requests and limits
-  ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
-  ##
+## initChownData resource requests and limits
+## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
   resources: 
     limits:
       cpu: 100m

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -154,32 +154,32 @@ persistence:
   # existingClaim:
 
 initChownData:
-## If false, data ownership will not be reset at startup
-## This allows the prometheus-server to be run with an arbitrary user
-##
+  ## If false, data ownership will not be reset at startup
+  ## This allows the prometheus-server to be run with an arbitrary user
+  ##
   enabled: true
 
-## initChownData container name
-##
+  ## initChownData container name
+  ##
   name: init-chown-data
 
-## initChownData container image
-##
+  ## initChownData container image
+  ##
   image:
     repository: busybox
     tag: latest
     pullPolicy: IfNotPresent
 
-## initChownData resource requests and limits
-## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
-##
-  resources: 
-    limits:
-      cpu: 100m
-      memory: 128Mi
-    requests:
-      cpu: 100m
-      memory: 128Mi
+  ## initChownData resource requests and limits
+  ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+  #  limits:
+  #    cpu: 100m
+  #    memory: 128Mi
+  #  requests:
+  #    cpu: 100m
+  #    memory: 128Mi
 
 
 # Administrator credentials when not using an existing secret (see below)

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -145,14 +145,6 @@ extraContainers: |
 ##
 persistence:
   enabled: false
-  initChownData: true
-  resources: {}
-#   limits:
-#     cpu: 100m
-#     memory: 100Mi
-#   requests:
-#     cpu: 50m
-#     memory: 50Mi
   # storageClassName: default
   accessModes:
     - ReadWriteOnce
@@ -160,6 +152,35 @@ persistence:
   # annotations: {}
   # subPath: ""
   # existingClaim:
+
+initChownData:
+  ## If false, data ownership will not be reset at startup
+  ## This allows the prometheus-server to be run with an arbitrary user
+  ##
+  enabled: true
+
+  ## initChownData container name
+  ##
+  name: init-chown-data
+
+  ## initChownData container image
+  ##
+  image:
+    repository: busybox
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  ## initChownData resource requests and limits
+  ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: 
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
 
 # Administrator credentials when not using an existing secret (see below)
 adminUser: admin

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -146,6 +146,13 @@ extraContainers: |
 persistence:
   enabled: false
   initChownData: true
+  resources: {}
+   #limits:
+   #  cpu: 100m
+   #  memory: 100Mi
+   #requests:
+   #  cpu: 50m
+   #  memory: 50Mi
   # storageClassName: default
   accessModes:
     - ReadWriteOnce

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -61,11 +61,6 @@ downloadDashboardsImage:
   tag: latest
   pullPolicy: IfNotPresent
 
-chownDataImage:
-  repository: busybox
-  tag: 1.30.0
-  pullPolicy: IfNotPresent
-
 ## Pod Annotations
 # podAnnotations: {}
 
@@ -159,15 +154,11 @@ initChownData:
   ##
   enabled: true
 
-  ## initChownData container name
-  ##
-  name: init-chown-data
-
   ## initChownData container image
   ##
   image:
     repository: busybox
-    tag: latest
+    tag: 1.30
     pullPolicy: IfNotPresent
 
   ## initChownData resource requests and limits


### PR DESCRIPTION
@rtluckie

#### What this PR does / why we need it:
This PR add the feature to config the resourcesquotas in the initcontainer when you enable the option persistence and initChownData

#### Which issue this PR fixes
#12395 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [X] Variables are documented in the README.md
