### PR TITLE
[prometheus-cloudwatch-exporter] Added securityContext configuration

### DIFF
--- a/stable/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/stable/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.4.7
+version: 0.4.8
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -85,6 +85,7 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | `ingress.labels`                  | Custom labels                                                           | `{}`                        |
 | `ingress.hosts`                   | Ingress accepted hostnames                                              | `[]`                        |
 | `ingress.tls`                     | Ingress TLS configuration                                               | `[]`                        |
+| `securityContext`                 | Security Context for the pod                                            | `{}`                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -102,6 +102,10 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+    {{- end }}
       volumes:
       - configMap:
           defaultMode: 420

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -148,3 +148,6 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+
+securityContext:
+  runAsUser: 65534  # run as nobody user instead of root


### PR DESCRIPTION
#### What this PR does / why we need it:

Allow user to specify securityContext configuration onto the pods

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
