### PR TITLE
Add get /metrics to nonResourceURLs rbac

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.29.0
+version: 1.30.0
 appVersion: 6.10.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/clusterrole.yaml
+++ b/stable/datadog/templates/clusterrole.yaml
@@ -63,6 +63,10 @@ rules:
   verbs:
   - get
 {{- end }}
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get
 - apiGroups:  # Kubelet connectivity
   - ""
   resources:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Add `/metrics` to the bare endpoints the agent can access.

This is required to support querying endpoints protected by RBAC, by [kube-rbac-proxy](https://github.com/brancz/kube-rbac-proxy/) for instance.

(mirrors https://github.com/DataDog/datadog-agent/pull/3178)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
