### PR TITLE
[stable/jenkins] Add flag to overwrite jobs definition from values.yaml

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.36.0
+version: 0.36.1
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -89,6 +89,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Master.CredentialsXmlSecret`     | Kubernetes secret that contains a 'credentials.xml' file | Not set                                                  |
 | `Master.SecretsFilesSecret`       | Kubernetes secret that contains 'secrets' files | Not set                                                           |
 | `Master.Jobs`                     | Jenkins XML job configs              | Not set                                                                      |
+| `Master.OverwriteJobs`          | Replace jobs w/ ConfigMap on boot  | `false`                                                                      |
 | `Master.InstallPlugins`           | List of Jenkins plugins to install   | `kubernetes:1.14.0 workflow-aggregator:2.6 credentials-binding:1.17 git:3.9.1 workflow-job:2.31` |
 | `Master.OverwritePlugins`         | Overwrite installed plugins on start.| `false`                                                                      |
 | `Master.EnableRawHtmlMarkupFormatter` | Enable HTML parsing using (see below) | Not set                                                                 |

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -89,7 +89,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Master.CredentialsXmlSecret`     | Kubernetes secret that contains a 'credentials.xml' file | Not set                                                  |
 | `Master.SecretsFilesSecret`       | Kubernetes secret that contains 'secrets' files | Not set                                                           |
 | `Master.Jobs`                     | Jenkins XML job configs              | Not set                                                                      |
-| `Master.OverwriteJobs`          | Replace jobs w/ ConfigMap on boot  | `false`                                                                      |
+| `Master.overwriteJobs`          | Replace jobs w/ ConfigMap on boot  | `false`                                                                      |
 | `Master.InstallPlugins`           | List of Jenkins plugins to install   | `kubernetes:1.14.0 workflow-aggregator:2.6 credentials-binding:1.17 git:3.9.1 workflow-job:2.31` |
 | `Master.OverwritePlugins`         | Overwrite installed plugins on start.| `false`                                                                      |
 | `Master.EnableRawHtmlMarkupFormatter` | Enable HTML parsing using (see below) | Not set                                                                 |

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -281,7 +281,7 @@ data:
 {{- if .Values.Master.Jobs }}
     for job in $(ls /var/jenkins_jobs); do
       mkdir -p /var/jenkins_home/jobs/$job
-      yes {{- if not .Values.Master.OverwriteJobs }}n{{- end }} | cp -i /var/jenkins_jobs/$job /var/jenkins_home/jobs/$job/config.xml
+      yes {{- if not .Values.Master.overwriteJobs }}n{{- end }} | cp -i /var/jenkins_jobs/$job /var/jenkins_home/jobs/$job/config.xml
     done
 {{- end }}
 {{- range $key, $val := .Values.Master.InitScripts }}

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -281,7 +281,7 @@ data:
 {{- if .Values.Master.Jobs }}
     for job in $(ls /var/jenkins_jobs); do
       mkdir -p /var/jenkins_home/jobs/$job
-      yes n | cp -i /var/jenkins_jobs/$job /var/jenkins_home/jobs/$job/config.xml
+      yes {{- if not .Values.Master.OverwriteJobs }}n{{- end }} | cp -i /var/jenkins_jobs/$job /var/jenkins_home/jobs/$job/config.xml
     done
 {{- end }}
 {{- range $key, $val := .Values.Master.InitScripts }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -247,6 +247,11 @@ Master:
   # This will also overwrite all init scripts
   OverwriteConfig: false
 
+  # By default, the Jobs Map is only used to set the initial jobs the first time
+  # that the chart is installed.  Setting `OverwriteJobs` to `true` will overwrite
+  # the jenkins jobs configuration with the contents of Jobs every time the pod starts.
+  OverwriteJobs: false
+
   ingress:
     enabled: false
     labels: {}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -248,9 +248,9 @@ Master:
   OverwriteConfig: false
 
   # By default, the Jobs Map is only used to set the initial jobs the first time
-  # that the chart is installed.  Setting `OverwriteJobs` to `true` will overwrite
+  # that the chart is installed.  Setting `overwriteJobs` to `true` will overwrite
   # the jenkins jobs configuration with the contents of Jobs every time the pod starts.
-  OverwriteJobs: false
+  overwriteJobs: false
 
   ingress:
     enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds a flag to overwrite the job configuration using the values.yaml definition when restarting Jenkins.
Per default, this is set to `false` to not break existing behaviour.

#### Which issue this PR fixes
  - fixes #7880

#### Reviewer mentions:
@lachie83 
@viglesiasce 
@maorfr 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
