### PR TITLE
Add daemonsets.apps to clusterrole

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 0.12.1
+version: 0.12.2
 appVersion: 1.13.1
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/templates/clusterrole.yaml
+++ b/stable/cluster-autoscaler/templates/clusterrole.yaml
@@ -87,6 +87,7 @@ rules:
   - apiGroups:
     - apps
     resources:
+    - daemonsets
     - replicasets
     - statefulsets
     verbs:


### PR DESCRIPTION
#### What this PR does / why we need it:

[cluster-autoscaler](https://github.com/kubernetes/autoscaler) introduced a [change](https://github.com/kubernetes/autoscaler/commit/60babe7158386ab466833793a7d0eeffc2c20f8e#diff-ba8cd51a55555d26fb799c31d7c0bb79) that switched from using `extensions/v1beta1` to `apps/v1.DaemonSet`, changing the permissions necessary to operate.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
