### PR TITLE
[stable/nginx-ingress] Add variable for allowPrivilegeEscalation

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.11.0
+version: 1.11.1
 appVersion: 0.25.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -95,6 +95,7 @@ spec:
                 add:
                 - NET_BIND_SERVICE
             runAsUser: {{ .Values.controller.image.runAsUser }}
+            allowPrivilegeEscalation: {{ .Values.controller.image.allowPrivilegeEscalation }}
           {{- end }}
           env:
             - name: POD_NAME

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -95,6 +95,7 @@ spec:
                 add:
                 - NET_BIND_SERVICE
             runAsUser: {{ .Values.controller.image.runAsUser }}
+            allowPrivilegeEscalation: {{ .Values.controller.image.allowPrivilegeEscalation }}
           {{- end }}
           env:
             - name: POD_NAME

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -9,7 +9,7 @@ controller:
     pullPolicy: IfNotPresent
     # www-data -> uid 33
     runAsUser: 33
-    allowPrivilegeEscalation: false
+    allowPrivilegeEscalation: true
 
   # Configures the ports the nginx-controller listens on
   containerPort:

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -9,6 +9,7 @@ controller:
     pullPolicy: IfNotPresent
     # www-data -> uid 33
     runAsUser: 33
+    allowPrivilegeEscalation: false
 
   # Configures the ports the nginx-controller listens on
   containerPort:


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows port 80 and 443 using NET_BIND_SERVICE as a non-root container this also needs privilegeEscalation to be enabled. The default value of `allowPrivilegeEscalation` can be `false` due to a `PodSecurityPolicy` so this value should be changed to true.

Otherweise the service cannot open port 80 and 443 due to a permission denied.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped

@mgoodness  @jackzampolin 