### PR TITLE
[stable/concourse] #12431 concourse 5.1 params

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 5.1.2
+version: 5.2.2
 appVersion: 5.0.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -860,6 +860,17 @@ spec:
               value: {{ .Values.concourse.web.auth.oidc.userNameKey | quote }}
             {{- end }}
             {{- end }}
+            {{- if .Values.concourse.web.peerAddress }}
+            - name: CONCOURSE_PEER_ADDRESS
+              value: {{ .Values.concourse.web.peerAddress | quote }}
+            {{- else }}
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: CONCOURSE_PEER_ADDRESS
+              value: "$(POD_IP)"
+            {{- end }}
             {{- if .Values.concourse.web.tsa.logLevel }}
             - name: CONCOURSE_TSA_LOG_LEVEL
               value: {{ .Values.concourse.web.tsa.logLevel | quote }}
@@ -877,17 +888,6 @@ spec:
             {{- if .Values.concourse.web.tsa.debugBindPort }}
             - name: CONCOURSE_TSA_DEBUG_BIND_PORT
               value: {{ .Values.concourse.web.tsa.debugBindPort | quote }}
-            {{- end }}
-            {{- if .Values.concourse.web.tsa.peerAddress }}
-            - name: CONCOURSE_TSA_PEER_ADDRESS
-              value: {{ .Values.concourse.web.tsa.peerAddress | quote }}
-            {{- else }}
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: CONCOURSE_TSA_PEER_ADDRESS
-              value: "$(POD_IP)"
             {{- end }}
             - name: CONCOURSE_TSA_HOST_KEY
               value: "{{ .Values.web.keySecretsPath }}/host_key"

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -807,6 +807,14 @@ spec:
             - name: CONCOURSE_OAUTH_SKIP_SSL_VALIDATION
               value: {{ .Values.concourse.web.auth.oauth.skipSslValidation | quote }}
             {{- end }}
+            {{- if .Values.concourse.web.auth.oauth.userNameKey }}
+            - name: CONCOURSE_OAUTH_USER_NAME_KEY
+              value: {{ .Values.concourse.web.auth.oauth.userNameKey | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.auth.oauth.userIdKey }}
+            - name: CONCOURSE_OAUTH_USER_ID_KEY
+              value: {{ .Values.concourse.web.auth.oauth.userIdKey | quote }}
+            {{- end }}
             {{- end }}
             {{- if .Values.concourse.web.auth.oidc.enabled }}
             {{- if .Values.concourse.web.auth.oidc.displayName }}
@@ -846,6 +854,10 @@ spec:
             {{- if .Values.concourse.web.auth.oidc.skipSslValidation }}
             - name: CONCOURSE_OIDC_SKIP_SSL_VALIDATION
               value: {{ .Values.concourse.web.auth.oidc.skipSslValidation | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.auth.oidc.userNameKey }}
+            - name: CONCOURSE_OIDC_USER_NAME_KEY
+              value: {{ .Values.concourse.web.auth.oidc.userNameKey | quote }}
             {{- end }}
             {{- end }}
             {{- if .Values.concourse.web.tsa.logLevel }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -346,6 +346,10 @@ spec:
               value: {{ .Values.concourse.web.vault.url | quote }}
             - name: CONCOURSE_VAULT_PATH_PREFIX
               value: {{ .Values.concourse.web.vault.pathPrefix | quote }}
+            {{- if.Values.concourse.web.vault.sharedPath }}
+            - name: CONCOURSE_VAULT_SHARED_PATH
+              value: {{ .Values.concourse.web.vault.sharedPath | quote }}
+            {{- end }}
             - name: CONCOURSE_VAULT_AUTH_BACKEND
               value: {{ .Values.concourse.web.vault.authBackend | quote }}
             {{- if .Values.concourse.web.vault.useCaCert }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -136,17 +136,6 @@ spec:
               value: {{ .Values.concourse.web.externalUrl | quote }}
             {{- end }}
             {{- end }}
-            {{- if .Values.concourse.web.peerUrl }}
-            - name: CONCOURSE_PEER_URL
-              value: {{ .Values.concourse.web.peerUrl | quote }}
-            {{- else }}
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: CONCOURSE_PEER_URL
-              value: "http://$(POD_IP):$(CONCOURSE_BIND_PORT)"
-            {{- end }}
             {{- if .Values.concourse.web.encryption.enabled }}
             - name: CONCOURSE_ENCRYPTION_KEY
               valueFrom:
@@ -873,9 +862,16 @@ spec:
             - name: CONCOURSE_TSA_DEBUG_BIND_PORT
               value: {{ .Values.concourse.web.tsa.debugBindPort | quote }}
             {{- end }}
-            {{- if .Values.concourse.web.tsa.peerIp }}
-            - name: CONCOURSE_TSA_PEER_IP
-              value: {{ .Values.concourse.web.tsa.peerIp | quote }}
+            {{- if .Values.concourse.web.tsa.peerAddress }}
+            - name: CONCOURSE_TSA_PEER_ADDRESS
+              value: {{ .Values.concourse.web.tsa.peerAddress | quote }}
+            {{- else }}
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: CONCOURSE_TSA_PEER_ADDRESS
+              value: "$(POD_IP)"
             {{- end }}
             - name: CONCOURSE_TSA_HOST_KEY
               value: "{{ .Values.web.keySecretsPath }}/host_key"

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -235,6 +235,14 @@ spec:
             - name: CONCOURSE_BAGGAGECLAIM_DISABLE_USER_NAMESPACES
               value: {{ .Values.concourse.worker.baggageclaim.disableUserNamespaces | quote }}
             {{- end }}
+            {{- if .Values.concourse.worker.volumeSweeperMaxInFlight }}
+            - name: CONCOURSE_VOLUME_SWEEPER_MAX_IN_FLIGHT
+              value: {{ .Values.concourse.worker.volumeSweeperMaxInFlight }}
+            {{- end }}
+            {{- if .Values.concourse.worker.containerSweeperMaxInFlight }}
+            - name: CONCOURSE_CONTAINER_SWEEPER_MAX_IN_FLIGHT
+              value: {{ .Values.concourse.worker.containerSweeperMaxInFlight }}
+            {{- end }}
 {{- if .Values.worker.env }}
 {{ toYaml .Values.worker.env | indent 12 }}
 {{- end }}

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -237,11 +237,11 @@ spec:
             {{- end }}
             {{- if .Values.concourse.worker.volumeSweeperMaxInFlight }}
             - name: CONCOURSE_VOLUME_SWEEPER_MAX_IN_FLIGHT
-              value: {{ .Values.concourse.worker.volumeSweeperMaxInFlight }}
+              value: {{ .Values.concourse.worker.volumeSweeperMaxInFlight | quote }}
             {{- end }}
             {{- if .Values.concourse.worker.containerSweeperMaxInFlight }}
             - name: CONCOURSE_CONTAINER_SWEEPER_MAX_IN_FLIGHT
-              value: {{ .Values.concourse.worker.containerSweeperMaxInFlight }}
+              value: {{ .Values.concourse.worker.containerSweeperMaxInFlight | quote }}
             {{- end }}
 {{- if .Values.worker.env }}
 {{ toYaml .Values.worker.env | indent 12 }}

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -231,10 +231,6 @@ spec:
             - name: CONCOURSE_BAGGAGECLAIM_OVERLAYS_DIR
               value: {{ .Values.concourse.worker.baggageclaim.overlaysDir | quote }}
             {{- end }}
-            {{- if .Values.concourse.worker.baggageclaim.reapInterval }}
-            - name: CONCOURSE_BAGGAGECLAIM_REAP_INTERVAL
-              value: {{ .Values.concourse.worker.baggageclaim.reapInterval | quote }}
-            {{- end }}
             {{- if .Values.concourse.worker.baggageclaim.disableUserNamespaces }}
             - name: CONCOURSE_BAGGAGECLAIM_DISABLE_USER_NAMESPACES
               value: {{ .Values.concourse.worker.baggageclaim.disableUserNamespaces | quote }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -999,11 +999,11 @@ concourse:
     ##
     logLevel:
 
-    ## Maximum number of containers which can be swept in parallel. (default: 5)
+    ## Maximum number of containers which can be swept in parallel.
     ##
     containerSweeperMaxInFlight: 5
 
-    ## Maximum number of volumes which can be swept in parallel. (default: 5)
+    ## Maximum number of volumes which can be swept in parallel.
     ##
     volumeSweeperMaxInFlight: 5
 

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -100,13 +100,6 @@ concourse:
     ##
     externalUrl:
 
-    ## URL used to reach this ATC from other ATCs in the cluster.
-    ## By default, this corresponds to `$(POD_IP):$(CONCOURSE_BIND_PORT)`.
-    ##
-    ## Example: http://127.0.0.1:8080
-    ##
-    peerUrl:
-
     encryption:
       ## Enable encryption of pipeline configuration. Encryption keys can be set via secrets
       ## (`encryption-key` and `old-encryption-key` fields).
@@ -874,10 +867,6 @@ concourse:
       ##
       debugBindPort: 2221
 
-      ## IP address of this TSA, reachable by the ATCs. Used for forwarded worker addresses.
-      ##
-      peerIp:
-
       ## Path to private key to use for the SSH server.
       ##
       hostKey:
@@ -897,6 +886,10 @@ concourse:
       ## Interval on which to heartbeat workers to the ATC.
       ##
       heartbeatInterval:
+
+      ## Network address of this TSA node, reachable by other web nodes. Used for forwarded worker addresses. (default: $POD_IP)
+      ##
+      peerAddress:
 
   worker:
     ## Signal to send to the worker container when shutting down.
@@ -1074,10 +1067,6 @@ concourse:
       ## Path to directory in which to store overlay data
       ##
       overlaysDir:
-
-      ## Interval on which to reap expired volumes.
-      ##
-      reapInterval:
 
 ## Configuration values for Concourse Web components.
 ## For more information regarding the characteristics of

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -182,6 +182,10 @@ concourse:
     ##
     defaultTaskMemoryLimit:
 
+    ## Network address of this web node, reachable by other web nodes. Used for forwarded worker addresses. (default: $POD_IP)
+    ##
+    peerAddress:
+
     ## Configurations regarding how the web component is able to connect to a postgres
     ## instance.
     ##
@@ -905,10 +909,6 @@ concourse:
       ## Interval on which to heartbeat workers to the ATC.
       ##
       heartbeatInterval:
-
-      ## Network address of this TSA node, reachable by other web nodes. Used for forwarded worker addresses. (default: $POD_IP)
-      ##
-      peerAddress:
 
   worker:
     ## Signal to send to the worker container when shutting down.

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -311,6 +311,10 @@ concourse:
       ##
       pathPrefix:
 
+      ## Path under which to lookup shared credentials.
+      ##
+      sharedPath:
+
       ## if the Vault server is using a self-signed certificate, set this to true,
       ## and provide a value for the cert in secrets (field `vault-ca-cert`).
       ##

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -822,6 +822,16 @@ concourse:
         ##
         skipSslValidation:
 
+        ## The user id key indicates which claim to use to map an external user id to a
+        ## Concourse user id.
+        ##
+        userIdKey: user_id
+
+        ## The user name key indicates which claim to use to map an external user name to a
+        ## Concourse user name.
+        ##
+        userNameKey: user_name
+
       ## Authentication (OIDC)
       oidc:
         enabled: false
@@ -849,6 +859,11 @@ concourse:
         ## Skip SSL validation
         ##
         skipSslValidation:
+
+        ## The user name key indicates which claim to use to map an external user name to a
+        ## Concourse user name.
+        ##
+        userNameKey: username
 
     tsa:
       ## Minimum level of logs to see. Possible values: debug, info, error.

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -976,10 +976,6 @@ concourse:
     ##
     bindPort: 7777
 
-    ## IP used to reach this worker from the ATC nodes.
-    ##
-    peerIp:
-
     ## Minimum level of logs to see. Possible options: debug, info, error.
     ##
     logLevel:

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -980,6 +980,14 @@ concourse:
     ##
     logLevel:
 
+    ## Maximum number of containers which can be swept in parallel. (default: 5)
+    ##
+    containerSweeperMaxInFlight: 5
+
+    ## Maximum number of volumes which can be swept in parallel. (default: 5)
+    ##
+    volumeSweeperMaxInFlight: 5
+
     tsa:
       ## TSA host to forward the worker through. Can be specified multiple times.
       ##


### PR DESCRIPTION
#### What this PR does / why we need it:

- removed `baggageclaim-reap-interval`, `peer-ip`, `peer-url` flags that have been recently removed.
- added `peer-address` flag.

#### Which issue this PR fixes
  - fixes #12431 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
    ^
    +---- will do that whenever we are ready to merge 
- [ ] Variables are documented in the README.md
    ^
    +---- will do that whenever we are ready to merge (or whenever we add concourse specific params documentation)