### PR TITLE
[prometheus-operator]: enable overriding of ingress path

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 5.0.7
+version: 5.1.0
 appVersion: 0.29.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -183,7 +183,12 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheus.ingress.annotations` | Prometheus Ingress annotations | `{}` |
 | `prometheus.ingress.labels` | Prometheus Ingress additional labels | `{}` |
 | `prometheus.ingress.hosts` | Prometheus Ingress hostnames | `[]` |
+<<<<<<< HEAD
 | `prometheus.ingress.paths` | Prometheus Ingress paths | `[]` |
+||||||| merged common ancestors
+=======
+| `prometheus.ingress.path` | Prometheus Ingress path | default to `prometheus.prometheusSpec.routePrefix` |
+>>>>>>> [prometheus-operator]: enable overriding of ingress path
 | `prometheus.ingress.tls` | Prometheus Ingress TLS configuration (YAML) | `[]` |
 | `prometheus.service.type` |  Prometheus Service type | `ClusterIP` |
 | `prometheus.service.clusterIP` | Prometheus service clusterIP IP | `""` |
@@ -252,7 +257,12 @@ The following tables list the configurable parameters of the prometheus-operator
 | `alertmanager.ingress.annotations` | Alertmanager Ingress annotations | `{}` |
 | `alertmanager.ingress.labels` | Alertmanager Ingress additional labels | `{}` |
 | `alertmanager.ingress.hosts` | Alertmanager Ingress hostnames | `[]` |
+<<<<<<< HEAD
 | `alertmanager.ingress.paths` | Alertmanager Ingress paths | `[]` |
+||||||| merged common ancestors
+=======
+| `alertmanager.ingress.path` | Alertmanager Ingress path | default to `alertmanager.alertmanagerSpec.routePrefix` |
+>>>>>>> [prometheus-operator]: enable overriding of ingress path
 | `alertmanager.ingress.tls` | Alertmanager Ingress TLS configuration (YAML) | `[]` |
 | `alertmanager.service.type` | Alertmanager Service type | `ClusterIP` |
 | `alertmanager.service.clusterIP` | Alertmanager service clusterIP IP | `""` |
@@ -297,7 +307,8 @@ The following tables list the configurable parameters of the prometheus-operator
 | `grafana.ingress.enabled` | Enables Ingress for Grafana | `false` |
 | `grafana.ingress.annotations` | Ingress annotations for Grafana | `{}` |
 | `grafana.ingress.labels` | Custom labels for Grafana Ingress | `{}` |
-| `grafana.ingress.hosts` | Ingress accepted hostnames for Grafana| `[]` |
+| `grafana.ingress.path` | Ingress accepted path for Grafana | `"/"` |
+| `grafana.ingress.hosts` | Ingress accepted hostnames for Grafana | `[]` |
 | `grafana.ingress.tls` | Ingress TLS configuration for Grafana | `[]` |
 | `grafana.sidecar.dashboards.enabled` | Enable the Grafana sidecar to automatically load dashboards with a label `{{ grafana.sidecar.dashboards.label }}=1` | `true` |
 | `grafana.sidecar.dashboards.label` | If the sidecar is enabled, configmaps with this label will be loaded into Grafana as dashboards | `grafana_dashboard` |

--- a/stable/prometheus-operator/templates/alertmanager/ingress.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/ingress.yaml
@@ -1,4 +1,11 @@
 {{- if and .Values.alertmanager.enabled .Values.alertmanager.ingress.enabled }}
+<<<<<<< HEAD
+||||||| merged common ancestors
+{{- $routePrefix := .Values.alertmanager.alertmanagerSpec.routePrefix }}
+=======
+{{- $routePrefix := .Values.alertmanager.alertmanagerSpec.routePrefix }}
+{{- $ingressPath := .Values.alertmanager.ingress.path }}
+>>>>>>> [prometheus-operator]: enable overriding of ingress path
 {{- $serviceName := printf "%s-%s" (include "prometheus-operator.fullname" .) "alertmanager" }}
 {{- $servicePort := 9093 -}}
 {{- $routePrefix := list .Values.alertmanager.alertmanagerSpec.routePrefix }}
@@ -24,8 +31,14 @@ spec:
     - host: {{ tpl $host $ }}
       http:
         paths:
+<<<<<<< HEAD
   {{- range $p := $paths }}
           - path: {{ tpl $p $ }}
+||||||| merged common ancestors
+          - path: "{{ $routePrefix }}"
+=======
+          - path: "{{ default $routePrefix $ingressPath }}"
+>>>>>>> [prometheus-operator]: enable overriding of ingress path
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}

--- a/stable/prometheus-operator/templates/prometheus/ingress.yaml
+++ b/stable/prometheus-operator/templates/prometheus/ingress.yaml
@@ -1,4 +1,11 @@
 {{- if and .Values.prometheus.enabled .Values.prometheus.ingress.enabled }}
+<<<<<<< HEAD
+||||||| merged common ancestors
+{{- $routePrefix := .Values.prometheus.prometheusSpec.routePrefix }}
+=======
+{{- $routePrefix := .Values.prometheus.prometheusSpec.routePrefix }}
+{{- $ingressPath := .Values.prometheus.ingress.path }}
+>>>>>>> [prometheus-operator]: enable overriding of ingress path
 {{- $serviceName := printf "%s-%s" (include "prometheus-operator.fullname" .) "prometheus" }}
 {{- $servicePort := 9090 -}}
 {{- $routePrefix := list .Values.prometheus.prometheusSpec.routePrefix }}
@@ -24,8 +31,14 @@ spec:
     - host: {{ tpl $host $ }}
       http:
         paths:
+<<<<<<< HEAD
   {{- range $p := $paths }}
           - path: {{ tpl $p $ }}
+||||||| merged common ancestors
+          - path: "{{ $routePrefix }}"
+=======
+          - path: "{{ default $routePrefix $ingressPath }}"
+>>>>>>> [prometheus-operator]: enable overriding of ingress path
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -144,11 +144,18 @@ alertmanager:
     hosts: []
       # - alertmanager.domain.com
 
+<<<<<<< HEAD
     ## Paths to use for ingress rules - one path should match the alertmanagerSpec.routePrefix
     ##
     paths: []
     # - /
 
+||||||| merged common ancestors
+=======
+    ## Ingress path, defaults to routePrefix if unset
+    # path: "/"
+
+>>>>>>> [prometheus-operator]: enable overriding of ingress path
     ## TLS configuration for Alertmanager Ingress
     ## Secret must be manually created in the namespace
     ##
@@ -343,10 +350,19 @@ grafana:
     #   - grafana.domain.com
     hosts: []
 
+<<<<<<< HEAD
     ## Path for grafana ingress
     path: /
 
     ## TLS configuration for grafana Ingress
+||||||| merged common ancestors
+    ## TLS configuration for prometheus Ingress
+=======
+    ## Ingress path
+    path: "/"
+
+    ## TLS configuration for prometheus Ingress
+>>>>>>> [prometheus-operator]: enable overriding of ingress path
     ## Secret must be manually created in the namespace
     ##
     tls: []
@@ -871,11 +887,18 @@ prometheus:
     #   - prometheus.domain.com
     hosts: []
 
+<<<<<<< HEAD
     ## Paths to use for ingress rules - one path should match the prometheusSpec.routePrefix
     ##
     paths: []
     # - /
 
+||||||| merged common ancestors
+=======
+    ## Ingress path, defaults to routePrefix if unset
+    # path: "/"
+
+>>>>>>> [prometheus-operator]: enable overriding of ingress path
     ## TLS configuration for Prometheus Ingress
     ## Secret must be manually created in the namespace
     ##


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Some ingress controllers (like the one on Google Cloud) need a ingress path with a wildcard `*` at the end in order to route all traffic to the pod and not only what is on `/` which is currently what is happening.

```yaml
…
prometheus:
  ingress:
    enabled: true

    hosts:
    - prometheus.my.domain

    path: /*
```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
