### PR TITLE
[stable/mongodb] - ensure that custom init script config maps are mounted when supplied 

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 5.14.0
+version: 5.14.1
 appVersion: 4.0.7
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/templates/deployment-standalone.yaml
+++ b/stable/mongodb/templates/deployment-standalone.yaml
@@ -148,7 +148,7 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /bitnami/mongodb
-        {{- if  (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") }}
+        {{- if  or (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js|json]") (.Values.initConfigMap) }}
         - name: custom-init-scripts
           mountPath: /docker-entrypoint-initdb.d
         {{- end }}
@@ -193,7 +193,7 @@ spec:
 {{ toYaml .Values.metrics.resources | indent 10 }}
 {{- end }}
       volumes:
-      {{- if (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") }}
+      {{- if (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js|json]") }}
       - name: custom-init-scripts
         configMap:
           name: {{ template "mongodb.fullname" . }}-init-scripts

--- a/stable/mongodb/templates/initialization-configmap.yaml
+++ b/stable/mongodb/templates/initialization-configmap.yaml
@@ -1,4 +1,4 @@
-{{ if  (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") }}
+{{ if  (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js|json]") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,5 +9,5 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 data:
-{{ tpl (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]").AsConfig . | indent 2 }}
+{{ tpl (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js|json]").AsConfig . | indent 2 }}
 {{ end }}

--- a/stable/mongodb/templates/statefulset-primary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-primary-rs.yaml
@@ -174,7 +174,7 @@ spec:
           volumeMounts:
             - name: datadir
               mountPath: /bitnami/mongodb
-            {{- if  or (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") (.Values.initConfigMap) }}
+            {{- if  or (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js|json]") (.Values.initConfigMap) }}
             - name: custom-init-scripts
               mountPath: /docker-entrypoint-initdb.d
             {{- end }}
@@ -219,7 +219,7 @@ spec:
 {{ toYaml .Values.metrics.resources | indent 12 }}
 {{- end }}
       volumes:
-        {{- if (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") }}
+        {{- if (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js|json]") }}
         - name: custom-init-scripts
           configMap:
             name: {{ template "mongodb.fullname" . }}-init-scripts


### PR DESCRIPTION
Ensure that custom init script config maps are mounted when supplied and add *.json files to the list of files that are importable as init scripts

Signed-off-by: Michael McCord <michael.lee.mccord@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This chart currently has a bug in the `deployment-standalone.yaml` template. If a custom config map containing init scripts is supplied, it is not mounted. This is important because the `.Files.Glob` function is relative to the chart in which it's used. If this chart is used as a dependency in another chart then the only means of adding init scripts is by providing a custom config map.

#### Which issue this PR fixes
I am unaware of any issues previously filed for this.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
