### PR TITLE
Add optional ServiceMonitor and values stub with it disabled by default

### DIFF
--- a/stable/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/stable/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.4.2
+version: 0.4.3
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -73,6 +73,11 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | `affinity`                  | node/pod affinities                                    | `{}`                       |
 | `livenessProbe`             | Liveness probe settings                                |                            |
 | `readinessProbe`            | Readiness probe settings                               |                            |
+| `servicemonitor.enabled`    | Use servicemonitor from prometheus operator            | `false`                    |
+| `servicemonitor.namespace`  | Namespace thes Servicemonitor  is installed in         |                            |
+| `servicemonitor.interval`   | How frequently Prometheus should scrape                |                            |
+| `servicemonitor.telemetryPath` |  path to cloudwatch-exporter telemtery-path         |                            |
+| `servicemonitor.labels`     |   labels for the ServiceMonitor passed to Prometheus Operator      |  `{}`          |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,30 @@
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.serviceMonitor.enabled ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+{{- if .Values.serviceMonitor.labels }}
+  labels:
+{{ toYaml .Values.serviceMonitor.labels | indent 4}}
+{{- end }}
+  name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
+{{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+{{- end }}
+spec:
+  endpoints:
+  - targetPort: {{ .Values.service.port }}
+{{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}
+{{- if .Values.serviceMonitor.telemetryPath }}
+    path: {{ .Values.serviceMonitor.telemetryPath }}
+{{- end }}
+  jobLabel: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "prometheus-cloudwatch-exporter.name" . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -106,3 +106,15 @@ readinessProbe:
   timeoutSeconds: 5
   successThreshold: 1
   failureThreshold: 3
+
+serviceMonitor:
+  # When set true then use a ServiceMonitor to configure scraping
+  enabled: false 
+  # Set the namespace the ServiceMonitor should be deployed
+  # namespace: monitoring
+  # Set how frequently Prometheus should scrape
+  # interval: 30s
+  # Set path to cloudwatch-exporter telemtery-path
+  # telemetryPath: /metrics
+  # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
+  # labels:

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -109,7 +109,7 @@ readinessProbe:
 
 serviceMonitor:
   # When set true then use a ServiceMonitor to configure scraping
-  enabled: false 
+  enabled: false
   # Set the namespace the ServiceMonitor should be deployed
   # namespace: monitoring
   # Set how frequently Prometheus should scrape


### PR DESCRIPTION
Signed-off-by: Brian Gibbins <brian.eroteme@gmail.com>

#### What this PR does / why we need it:
This PR adds an optional servicemonitor to allow scraping of metrics by prometheus via service monitors

#### Which issue this PR fixes
  - fixes #12500 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
