### PR TITLE
[stable/redis-ha] Allow for custom key in secret

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.4.0
+version: 3.4.1
 appVersion: 5.0.3
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/README.md
+++ b/stable/redis-ha/README.md
@@ -72,7 +72,8 @@ The following table lists the configurable parameters of the Redis chart and the
 | `init.resources`         | CPU/Memory for init Container node resource requests/limits                                                                                                                                              | `{}`                                                                                       |
 | `auth`                   | Enables or disables redis AUTH (Requires `redisPassword` to be set)                                                                                                                                      | `false`                                                                                    |
 | `redisPassword`          | A password that configures a `requirepass` and `masterauth` in the conf parameters (Requires `auth: enabled`)                                                                                            | ``                                                                                         |
-| `existingSecret`         | An existing secret containing an `auth` key that configures `requirepass` and `masterauth` in the conf parameters (Requires `auth: enabled`, cannot be used in conjunction with `.Values.redisPassword`) | ``                                                                                         |
+| `authKey`                | The key holding the redis password in an existing secret.                                                                                                                                                | `auth`                                                                                     |
+| `existingSecret`         | An existing secret containing a key defined by `authKey` that configures `requirepass` and `masterauth` in the conf parameters (Requires `auth: enabled`, cannot be used in conjunction with `.Values.redisPassword`) | ``                                                                                         |
 | `nodeSelector`           | Node labels for pod assignment                                                                                                                                                                           | `{}`                                                                                       |
 | `tolerations`            | Toleration labels for pod assignment                                                                                                                                                                     | `[]`                                                                                       |
 | `podAntiAffinity.server` | Antiaffinity for pod assignment of servers, `hard` or `soft`                                                                                                                                             | `Hard node and soft zone anti-affinity`                                                    |
@@ -101,7 +102,7 @@ $ helm install \
     stable/redis-ha
 ```
 
-The above command sets the Redis server within  `default` namespace.
+The above command sets the Redis server within `default` namespace.
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 

--- a/stable/redis-ha/templates/redis-auth-secret.yaml
+++ b/stable/redis-ha/templates/redis-auth-secret.yaml
@@ -7,5 +7,5 @@ metadata:
 {{ include "labels.standard" . | indent 4 }}
 type: Opaque
 data:
-  auth: {{ .Values.redisPassword | b64enc | quote }}
+  {{ .Values.authKey }}: {{ .Values.redisPassword | b64enc | quote }}
 {{- end -}}

--- a/stable/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/stable/redis-ha/templates/redis-ha-statefulset.yaml
@@ -103,7 +103,7 @@ spec:
             {{- else }}
               name: {{ template "redis-ha.fullname" . }}
             {{- end }}
-              key: auth
+              key: {{ .Values.authKey }}
 {{- end }}
         volumeMounts:
         - name: config
@@ -129,7 +129,7 @@ spec:
             {{- else }}
               name: {{ template "redis-ha.fullname" . }}
             {{- end }}
-              key: auth
+              key: {{ .Values.authKey }}
 {{- end }}
         livenessProbe:
           exec:
@@ -168,7 +168,7 @@ spec:
             {{- else }}
               name: {{ template "redis-ha.fullname" . }}
             {{- end }}
-              key: auth
+              key: {{ .Values.authKey }}
 {{- end }}
         livenessProbe:
           exec:
@@ -210,7 +210,7 @@ spec:
               {{- else }}
                 name: {{ template "redis-ha.fullname" . }}
               {{- end }}
-                key: auth
+                key: {{ .Values.authKey }}
         {{- end }}
         livenessProbe:
           httpGet:

--- a/stable/redis-ha/values.yaml
+++ b/stable/redis-ha/values.yaml
@@ -146,8 +146,11 @@ podDisruptionBudget: {}
 auth: false
 # redisPassword:
 
-## Use existing secret containing "auth" key (ignores redisPassword)
+## Use existing secret containing key `authKey` (ignores redisPassword)
 # existingSecret:
+
+## Defines the key holding the redis password in existing secret.
+authKey: auth
 
 persistentVolume:
   enabled: true


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
When using an existing secret to provide the redis password, the key in the secret is hardcoded to `auth`. This is so generic, it could easily conflict with other charts looking for `auth` in the secret. It's also not exclusively tied to redis, so secret generation would require extra documentation to explain what `auth` is being used for.

By making the key customizable to something like `redis-password` these issues get solved.

The old hardcoded key is left as a default value.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
