### PR TITLE
Node-RED: Implemented the option to add a subPath when enabling persistence

### DIFF
--- a/stable/node-red/Chart.yaml
+++ b/stable/node-red/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.19.4
 description: Node-RED is flow-based programming for the Internet of Things
 name: node-red
-version: 1.0.2
+version: 1.1.0
 keywords:
   - nodered
   - node-red

--- a/stable/node-red/README.md
+++ b/stable/node-red/README.md
@@ -62,6 +62,7 @@ The following tables lists the configurable parameters of the Sentry chart and t
 | `persistence.existingClaim`          | Use an existing PVC to persist data        | `nil` |
 | `persistence.storageClass`           | Type of persistent volume claim            | `-` |
 | `persistence.accessModes`            | Persistence access modes                   | `ReadWriteOnce` |
+| `persistence.subPath`                | Mount a sub dir of the persistent volume   | `nil` |
 | `resources`                          | CPU/Memory resource requests/limits        | `{}` |
 | `nodeSelector`                       | Node labels for pod assignment             | `{}` |
 | `tolerations`                        | Toleration labels for pod assignment       | `[]` |

--- a/stable/node-red/templates/deployment.yaml
+++ b/stable/node-red/templates/deployment.yaml
@@ -45,6 +45,9 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
+{{- if .Values.persistence.subPath }}
+              subPath: {{ .Values.persistence.subPath }}
+{{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:

--- a/stable/node-red/values.yaml
+++ b/stable/node-red/values.yaml
@@ -66,6 +66,8 @@ persistence:
   # existingClaim: your-claim
   accessMode: ReadWriteOnce
   size: 5Gi
+  ## When mounting the data volume you may specify a subPath
+  # subPath: /configs/node-red
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
#### What this PR does / why we need it:

I implemented the option to specify a subPath when enabling persistence.

#### Special notes for your reviewer:

@billimek Could you take a look please?

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md