### PR TITLE
Add POD_IP variable and update values.yaml comment

### DIFF
--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -162,6 +162,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/incubator/kafka/values.yaml
+++ b/incubator/kafka/values.yaml
@@ -170,7 +170,7 @@ configurationOverrides:
   ## - http://kafka.apache.org/documentation/#security_configbroker
   ## - https://cwiki.apache.org/confluence/display/KAFKA/KIP-103%3A+Separation+of+Internal+and+External+traffic
   ##
-  ## Setting "advertised.listeners" here appends to "PLAINTEXT://${POD_IP}:9092,"
+  ## Setting "advertised.listeners" here appends to "PLAINTEXT://${POD_NAME}:9092,"
   # "advertised.listeners": |-
   #   EXTERNAL://kafka.cluster.local:$((31090 + ${KAFKA_BROKER_ID}))
   # "listener.security.protocol.map": |-


### PR DESCRIPTION
#### What this PR does / why we need it:
- Add POD_IP for use cases like EKS that each POD get routable ip, we can add listener like:
`EXTERNAL://${POD_IP}:$((31090 + ${KAFKA_BROKER_ID}))`

- Update comment in `values.yaml` with wrong variable name.
