### PR TITLE
Fix self-introduced whitespace bug

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.36.1
+version: 0.36.2
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -281,7 +281,7 @@ data:
 {{- if .Values.Master.Jobs }}
     for job in $(ls /var/jenkins_jobs); do
       mkdir -p /var/jenkins_home/jobs/$job
-      yes {{- if not .Values.Master.overwriteJobs }}n{{- end }} | cp -i /var/jenkins_jobs/$job /var/jenkins_home/jobs/$job/config.xml
+      yes {{ if not .Values.Master.overwriteJobs }}n{{ end }} | cp -i /var/jenkins_jobs/$job /var/jenkins_home/jobs/$job/config.xml
     done
 {{- end }}
 {{- range $key, $val := .Values.Master.InitScripts }}


### PR DESCRIPTION
#### What this PR does / why we need it:

With https://github.com/helm/charts/pull/12427 I introduced a bug. This PR fixes it.
Without this fix, it would write `yesn` instead of `yes n` into the configmap.

#### Which issue this PR fixes
* https://github.com/helm/charts/pull/12427

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
