### PR TITLE
[stable/elasticsearch] Add podManagementStrategy

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.22.0
+version: 1.23.0
 appVersion: 6.7.0
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/stable/elasticsearch/README.md
+++ b/stable/elasticsearch/README.md
@@ -118,6 +118,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `master.readinessProbe`              | Master container readiness probes                                   | see `values.yaml` for defaults                      |
 | `master.antiAffinity`                | Master anti-affinity policy                                         | `soft`                                              |
 | `master.nodeAffinity`                | Master node affinity policy                                         | `{}`                                                |
+| `master.podManagementPolicy`         | Master pod creation strategy                                        | `OrderedReady`                                      |
 | `master.updateStrategy`              | Master node update strategy policy                                  | `{type: "onDelete"}`                                |
 | `data.initResources`                 | Data initContainer resources requests & limits                      | `{}`                                                |
 | `data.additionalJavaOpts`            | Parameters to be added to `ES_JAVA_OPTS` environment variable for data | `""`                                             |
@@ -139,6 +140,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `data.terminationGracePeriodSeconds` | Data termination grace period (seconds)                             | `3600`                                              |
 | `data.antiAffinity`                  | Data anti-affinity policy                                           | `soft`                                              |
 | `data.nodeAffinity`                  | Data node affinity policy                                           | `{}`                                                |
+| `data.podManagementPolicy`           | Data pod creation strategy                                          | `OrderedReady`                                      |
 | `data.updateStrategy`                | Data node update strategy policy                                    | `{type: "onDelete"}`                                |
 | `sysctlInitContainer.enabled`        | If true, the sysctl init container is enabled (does not stop extraInitContainers from running) | `true`                                              |
 | `extraInitContainers`                | Additional init container passed through the tpl                    | ``                                                  |

--- a/stable/elasticsearch/templates/data-statefulset.yaml
+++ b/stable/elasticsearch/templates/data-statefulset.yaml
@@ -203,6 +203,7 @@ spec:
       - name: data
         emptyDir: {}
   {{- end }}
+  podManagementPolicy: {{ .Values.data.podManagementPolicy }}
   updateStrategy:
     type: {{ .Values.data.updateStrategy.type }}
   {{- if .Values.data.persistence.enabled }}

--- a/stable/elasticsearch/templates/master-statefulset.yaml
+++ b/stable/elasticsearch/templates/master-statefulset.yaml
@@ -191,6 +191,7 @@ spec:
       - name: data
         emptyDir: {}
   {{- end }}
+  podManagementPolicy: {{ .Values.master.podManagementPolicy }}
   updateStrategy:
     type: {{ .Values.master.updateStrategy.type }}
   {{- if .Values.master.persistence.enabled }}

--- a/stable/elasticsearch/values.yaml
+++ b/stable/elasticsearch/values.yaml
@@ -158,6 +158,7 @@ master:
   ## (dict) If specified, apply these annotations to each master Pod
   # podAnnotations:
   #   example: master-foo
+  podManagementPolicy: OrderedReady
   podDisruptionBudget:
     enabled: false
     minAvailable: 2  # Same as `cluster.env.MINIMUM_MASTER_NODES`
@@ -209,6 +210,7 @@ data:
     enabled: false
     # minAvailable: 1
     maxUnavailable: 1
+  podManagementPolicy: OrderedReady
   updateStrategy:
     type: OnDelete
   hooks:  # post-start and pre-stop hooks


### PR DESCRIPTION
Default is OrderedReady as is default for all statefulsets

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Adds the option to set podManagementPolicy for elasticsearch master/data statefulsets. This enables the option to set `Parallel` mode, which is faster, but sometimes not desirable. The default deploy is unchanged.
#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
