### PR TITLE
[stable/mysql] New configuration securityContext for the chart mysql

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.17.0
+version: 0.18.0
 appVersion: 5.7.14
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.

--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.18.0
+version: 0.19.0
 appVersion: 5.7.14
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.

--- a/stable/mysql/README.md
+++ b/stable/mysql/README.md
@@ -92,6 +92,9 @@ The following table lists the configurable parameters of the MySQL chart and the
 | `metrics.readinessProbe.timeoutSeconds`      | When the probe times out                                                                     | 1                                                    |
 | `resources`                                  | CPU/Memory resource requests/limits                                                          | Memory: `256Mi`, CPU: `100m`                         |
 | `configurationFiles`                         | List of mysql configuration files                                                            | `nil`                                                |
+| `securityContext.enabled`                    | Enable security context (mysql pod)                                                          | `false`                                              |
+| `securityContext.fsGroup`                    | Group ID for the container (mysql pod)                                                       | 999                                               |
+| `securityContext.runAsUser`                  | User ID for the container (mysql pod)                                                        | 999                                                |
 | `service.annotations`                        | Kubernetes annotations for mysql                                                             | {}                                                   |
 | `ssl.enabled`                                | Setup and use SSL for MySQL connections                                                      | `false`                                              |
 | `ssl.secret`                                 | Name of the secret containing the SSL certificates                                           | mysql-ssl-certs                                      |

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -27,6 +27,11 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+      {{- end }}
       initContainers:
       - name: "remove-lost-found"
         image: "{{ .Values.busybox.image}}:{{ .Values.busybox.tag }}"

--- a/stable/mysql/values.yaml
+++ b/stable/mysql/values.yaml
@@ -95,6 +95,12 @@ persistence:
   size: 8Gi
   annotations: {}
 
+## Security context
+securityContext:
+  enabled: false
+  runAsUser: 999
+  fsGroup: 999
+
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

It doesn't provide security context for mysql pod when using current chart. It causes the process `mysqld` runs under user `root`, which is not preferred in production k8s cluster with security policy like that from [Runc and CVE-2019-5736](https://kubernetes.io/blog/2019/02/11/runc-and-cve-2019-5736/)

#### Which issue this PR fixes

  - fixes #12537

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
