### PR TITLE
haproxy ingress tcp template enhancements

### DIFF
--- a/incubator/haproxy-ingress/Chart.yaml
+++ b/incubator/haproxy-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: haproxy-ingress
-version: 0.0.9
+version: 0.0.10
 appVersion: 0.7.0
 home: https://github.com/jcmoraisjr/haproxy-ingress
 description: Ingress controller implementation for haproxy loadbalancer.

--- a/incubator/haproxy-ingress/README.md
+++ b/incubator/haproxy-ingress/README.md
@@ -74,6 +74,7 @@ Parameter | Description | Default
 `controller.dnsPolicy` | Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true' | `ClusterFirst`
 `controller.kind` | Type of deployment, DaemonSet or Deployment | `Deployment`
 `controller.tcp` | TCP [service ConfigMap](https://github.com/jcmoraisjr/haproxy-ingress/blob/v0.6/README.md#tcp-services-configmap): `<port>: <namespace>/<servicename>:<portnumber>[:[<in-proxy>][:<out-proxy>]]` | `{}`
+`controller.enableStaticPorts` | Set to `false` to only rely on ports from `controller.tcp` | `true`
 `controller.daemonset.useHostPort` | Set to true to use host ports 80 and 443 | `false`
 `controller.daemonset.hostPorts.http` | If `controller.daemonset.useHostPort` is `true` and this is non-empty sets the hostPort for http | `"80"`
 `controller.daemonset.hostPorts.https` | If `controller.daemonset.useHostPort` is `true` and this is non-empty sets the hostPort for https | `"443"`

--- a/incubator/haproxy-ingress/templates/controller-deployment.yaml
+++ b/incubator/haproxy-ingress/templates/controller-deployment.yaml
@@ -77,8 +77,8 @@ spec:
             - name: healthz
               containerPort: {{ .Values.controller.healthzPort }}
           {{- range $key, $value := .Values.controller.tcp }}
-            - name: "{{ $key }}-tcp"
-              containerPort: {{ $key }}
+            - name: "{{ tpl $key $ }}-tcp"
+              containerPort: {{ tpl $key $ }}
               protocol: TCP
           {{- end }}
           livenessProbe:

--- a/incubator/haproxy-ingress/templates/controller-deployment.yaml
+++ b/incubator/haproxy-ingress/templates/controller-deployment.yaml
@@ -65,10 +65,12 @@ spec:
             {{- end }}
           {{- end }}
           ports:
+          {{- if .Values.controller.enableStaticPorts }}
             - name: http
               containerPort: 80
             - name: https
               containerPort: 443
+          {{- end }}
           {{- if .Values.controller.stats.enabled }}
             - name: stats
               containerPort: {{ .Values.controller.stats.port }}

--- a/incubator/haproxy-ingress/templates/controller-service.yaml
+++ b/incubator/haproxy-ingress/templates/controller-service.yaml
@@ -57,10 +57,10 @@ spec:
       {{- end }}
   {{- end }}
   {{- range $key, $value := .Values.controller.tcp }}
-    - name: "{{ $key }}-tcp"
-      port: {{ $key }}
+    - name: "{{ tpl $key $ }}-tcp"
+      port: {{ tpl $key $ }}
       protocol: TCP
-      targetPort: "{{ $key }}-tcp"
+      targetPort: "{{ tpl $key $ }}-tcp"
   {{- end }}
   selector:
     app: {{ template "haproxy-ingress.name" . }}

--- a/incubator/haproxy-ingress/templates/controller-service.yaml
+++ b/incubator/haproxy-ingress/templates/controller-service.yaml
@@ -38,6 +38,7 @@ spec:
   healthCheckNodePort: {{ .Values.controller.service.healthCheckNodePort }}
 {{- end }}
   ports:
+  {{- if .Values.controller.enableStaticPorts }}
   {{- range .Values.controller.service.httpPorts }}
     - name: "{{ .port }}-http"
       port: {{ .port }}
@@ -55,6 +56,7 @@ spec:
       {{- if (not (empty .nodePort)) }}
       nodePort: {{ .nodePort }}
       {{- end }}
+  {{- end }}
   {{- end }}
   {{- range $key, $value := .Values.controller.tcp }}
     - name: "{{ tpl $key $ }}-tcp"

--- a/incubator/haproxy-ingress/templates/tcp-configmap.yaml
+++ b/incubator/haproxy-ingress/templates/tcp-configmap.yaml
@@ -1,3 +1,4 @@
+---
 {{- if .Values.controller.tcp }}
 apiVersion: v1
 kind: ConfigMap
@@ -10,5 +11,7 @@ metadata:
     heritage: {{ .Release.Service }}
   name: {{ template "haproxy-ingress.controller.fullname" . }}-tcp
 data:
-{{ toYaml .Values.controller.tcp | indent 2 }}
+{{- range $key, $value := .Values.controller.tcp }}
+  {{ tpl $key $ | quote }}: {{ tpl $value $ | quote }}
+{{- end }}
 {{- end }}

--- a/incubator/haproxy-ingress/values.yaml
+++ b/incubator/haproxy-ingress/values.yaml
@@ -118,6 +118,9 @@ controller:
   tcp: {}
   #  8080: "default/example-tcp-svc:9000"
 
+  # optionally disable static ports, including the default 80 and 443
+  enableStaticPorts: true
+
   ## Use host ports 80 and 443
   daemonset:
     useHostPort: false


### PR DESCRIPTION
#### What this PR does / why we need it:
This enhances the TCP service configurations by:
* allowing templating of `controllers.tcp` values, so that parent charts can configure TCP services in subcharts
* allows a user to disable the default `80/tcp` and `443/tcp` listeners in cases where those ports aren't used

#### Which issue this PR fixes
None

#### Special notes for your reviewer:
None

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
