### PR TITLE
[stable/fluent-bit] add test

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 1.8.2
+version: 1.9.0
 appVersion: 1.0.5
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -125,6 +125,9 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `metrics.service.port`             | Port on where metrics should be exposed    | `2020`                                            |
 | `metrics.service.type`             | Service type for metrics                   | `ClusterIP`                                       |
 | `trackOffsets`                     | Specify whether to track the file offsets for tailing docker logs. This allows fluent-bit to pick up where it left after pod restarts but requires access to a `hostPath` | `false` |
+| `testFramework.image`              | `test-framework` image repository.         | `dduportal/bats`                                  |
+| `testFramework.tag`                | `test-framework` image tag.                | `0.4.0`                                           |
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/fluent-bit/templates/tests/test-configmap.yaml
+++ b/stable/fluent-bit/templates/tests/test-configmap.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fluent-bit.fullname" . }}-test
+  labels:
+    app: {{ template "fluent-bit.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+data:
+  run.sh: |-
+    {{- if eq .Values.backend.type "forward"}}
+    {{- if eq .Values.backend.forward.tls "on"}}
+    fluent-gem install fluent-plugin-secure-forward
+    {{- end }}
+    @test "Test Access" {
+      fluentd -c /tests/fluentd.conf --dry-run
+    }
+    {{- end }}
+
+  fluentd.conf: |-
+    <source>
+      {{- if eq .Values.backend.forward.tls "off" }}
+      @type forward
+      bind 0.0.0.0
+      port {{ .Values.backend.forward.port }}
+      {{- else }}
+      @type secure_forward
+      self_hostname myserver.local
+      secure no
+      {{- end }}
+      shared_key {{ .Values.backend.forward.shared_key }}
+    </source>
+
+    <match **>
+      @type stdout
+    </match>

--- a/stable/fluent-bit/templates/tests/test-configmap.yaml
+++ b/stable/fluent-bit/templates/tests/test-configmap.yaml
@@ -16,6 +16,12 @@ data:
     @test "Test Access" {
       fluentd -c /tests/fluentd.conf --dry-run
     }
+    {{- else if eq .Values.backend.type "es"}}
+    @test "Test Elasticssearch Indices" {
+      url="http://{{ .Values.backend.es.host }}:{{ .Values.backend.es.port }}/_cat/indices?format=json"
+      result=$(curl url | jq -cr '.[] | select((.index | contains("kubernetes_cluster")) and (.health != "green"))')
+      [ "$result" == "" ]
+    }
     {{- end }}
 
   fluentd.conf: |-

--- a/stable/fluent-bit/templates/tests/test.yaml
+++ b/stable/fluent-bit/templates/tests/test.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.backend.type "forward") (and (eq .Values.backend.type "es") (eq .Values.backend.es.tls "off")) }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -28,7 +29,7 @@ spec:
       {{- if eq .Values.backend.type "forward"}}
       image: "fluent/fluentd:v1.4-debian-1"
       {{- else }}
-      image: "{{ .Values.testFramework.image}}:{{ .Values.testFramework.tag }}"
+      image: "dwdraju/alpine-curl-jq"
       {{- end }}
       command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
       {{- if eq .Values.backend.forward.tls "on"}}
@@ -49,3 +50,4 @@ spec:
   - name: tools
     emptyDir: {}
   restartPolicy: Never
+{{- end }}

--- a/stable/fluent-bit/templates/tests/test.yaml
+++ b/stable/fluent-bit/templates/tests/test.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ template "fluent-bit.fullname" . }}-test
+  labels:
+    app: {{ template "fluent-bit.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  initContainers:
+    - name: test-framework
+      image: "{{ .Values.testFramework.image}}:{{ .Values.testFramework.tag }}"
+      command:
+      - "bash"
+      - "-c"
+      - |
+        set -ex
+        # copy bats to tools dir
+        cp -R /usr/local/libexec/ /tools/bats/
+      volumeMounts:
+      - mountPath: /tools
+        name: tools
+  containers:
+    - name: {{ .Release.Name }}-test
+      {{- if eq .Values.backend.type "forward"}}
+      image: "fluent/fluentd:v1.4-debian-1"
+      {{- else }}
+      image: "{{ .Values.testFramework.image}}:{{ .Values.testFramework.tag }}"
+      {{- end }}
+      command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
+      {{- if eq .Values.backend.forward.tls "on"}}
+      securityContext:
+        # run as root to install fluent gems
+        runAsUser: 0
+      {{- end }}
+      volumeMounts:
+        - mountPath: /tests
+          name: tests
+          readOnly: true
+        - mountPath: /tools
+          name: tools
+  volumes:
+  - name: tests
+    configMap:
+      name: {{ template "fluent-bit.fullname" . }}-test
+  - name: tools
+    emptyDir: {}
+  restartPolicy: Never

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -8,6 +8,10 @@ image:
     tag: 1.0.5
   pullPolicy: IfNotPresent
 
+testFramework:
+  image: "dduportal/bats"
+  tag: "0.4.0"
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Add basic tests to stable/fluent-bit.

#### Which issue this PR fixes
No issue, adds new test.

#### Special notes for your reviewer:
- used `dwdraju/alpine-curl-jq` to test `es` because I need curl, jq, and bash to accurately test, let me know if there's a better idea to test the `es` output. I couldn't find a more popular docker hub image that works.
- testing `forward` with/without tls and `es` without tls for now, I might come back and add more, especially `es` with tls

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md