### PR TITLE
[stable/jenkins] Use same JENKINS_URL no matter if slaves use different namespace

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 1.1.5
+version: 1.1.6
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -91,11 +91,7 @@ data:
                   <envVars>
                     <org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar>
                       <key>JENKINS_URL</key>
-{{- if .Values.master.slaveKubernetesNamespace }}
-                      <value>http://{{ template "jenkins.fullname" . }}.{{.Release.Namespace}}:{{.Values.master.servicePort}}{{ default "" .Values.master.jenkinsUriPrefix }}</value>
-{{- else }}
-                      <value>http://{{ template "jenkins.fullname" . }}:{{.Values.master.servicePort}}{{ default "" .Values.master.jenkinsUriPrefix }}</value>
-{{- end }}
+                      <value>http://{{ template "jenkins.fullname" . }}.{{.Release.Namespace}}.svc.cluster.local:{{.Values.master.servicePort}}{{ default "" .Values.master.jenkinsUriPrefix }}</value>
                     </org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar>
                   </envVars>
                 </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>


### PR DESCRIPTION
#### What this PR does / why we need it:
JENKINS_URL is used by [kubernetes plugin](https://github.com/jenkinsci/kubernetes-plugin)
to tell build agents how they can connect to the Jenkins master.

So far there have been different URLs depending if `Master.SlaveKubernetesNamespace`
has been set.

- `http://{{ template "jenkins.fullname" . }}.{{.Release.Namespace}}:...`
- `http://{{ template "jenkins.fullname" . }}:...`

Looking up the Jenkins namespace can be done using the first setting in both cases.

I also added the `svc.cluster.local` suffix to make it a fully qualified entry.
See https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/

This helps in case you configure a proxy via environment variables in you pod template
as `.svc.cluster.local` is typically part of `no_proxy` settings. So the same `no_proxy`
setting can be used no matter in which namespace Jenkins is deployed.
Otherwise the `{{.Release.Namespace}}` must be configured in `no_proxy` variable.

Signed-off-by: Torsten Walter <mail@torstenwalter.de>


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
