### PR TITLE
allow custom cacerts for spinnaker

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.13.4
+version: 1.14.0
 appVersion: 1.12.5
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/README.md
+++ b/stable/spinnaker/README.md
@@ -106,7 +106,7 @@ In environments with air-gapped setup, especially with internal tooling (repos) 
    apiVersion: v1
    kind: Secret
    metadata:
-     name: my-cacerts
+     name: custom-cacerts
    data:
      cacerts: |
        xxxxxxxxxxxxxxxxxxxxxxx
@@ -124,7 +124,7 @@ In environments with air-gapped setup, especially with internal tooling (repos) 
    customCerts:
       ## Enable to override the default cacerts with your own one
       enabled: false
-      secretName: my-cacerts
+      secretName: custom-cacerts
    ```
 
 ## Customizing your installation

--- a/stable/spinnaker/README.md
+++ b/stable/spinnaker/README.md
@@ -96,6 +96,37 @@ Spinnaker supports [many](https://www.spinnaker.io/setup/install/storage/) persi
 * Redis
 * AWS S3
 
+## Use custom `cacerts`
+
+In environments with air-gapped setup, especially with internal tooling (repos) and self-signed certificates it is required to provide an adequate `cacerts` which overrides the default one:
+
+1. Create a yaml file `cacerts.yaml` with a secret that contanins the `cacerts`
+
+   ```yaml
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: my-cacerts
+   data:
+     cacerts: |
+       xxxxxxxxxxxxxxxxxxxxxxx
+   ```
+
+2. Upload your `cacerts.yaml` to a secret with the key you specify in `secretName` in the cluster you are installing Spinnaker to.
+
+   ```shell
+   $ kubectl apply -f cacerts.yaml
+   ```
+
+3. Set the following values of the chart:
+
+   ```yaml
+   customCerts:
+      ## Enable to override the default cacerts with your own one
+      enabled: false
+      secretName: my-cacerts
+   ```
+
 ## Customizing your installation
 
 ### Manual

--- a/stable/spinnaker/templates/statefulsets/halyard.yaml
+++ b/stable/spinnaker/templates/statefulsets/halyard.yaml
@@ -46,6 +46,11 @@ spec:
           mountPath: /tmp/additionalProfileConfigMaps
         - name: halyard-initscript
           mountPath: /tmp/initscript
+        {{- if .Values.halyard.customCerts.enabled }}
+        - mountPath: /etc/ssl/certs/java/cacerts
+          subPath: cacerts
+          name: cacerts
+        {{- end -}}
       volumes:
       {{- if .Values.kubeConfig.enabled }}
       - name: kube-config
@@ -102,6 +107,14 @@ spec:
       - name: halyard-initscript
         configMap:
           name: {{ template "spinnaker.fullname" . }}-halyard-init-script
+      {{- if .Values.halyard.customCerts.enabled }}
+      - name: cacerts
+        secret:
+          secretName: {{ .Values.halyard.customCerts.secretName }}
+          items:
+          - key: cacerts
+            path: cacerts
+      {{- end -}}
       containers:
       - name: halyard
         image: {{ .Values.halyard.image.repository }}:{{ .Values.halyard.image.tag }}
@@ -143,6 +156,11 @@ spec:
         env:
 {{ toYaml .Values.halyard.env | indent 8 }}
         {{- end }}
+        {{- if .Values.halyard.customCerts.enabled }}
+        - mountPath: /etc/ssl/certs/java/cacerts
+          subPath: cacerts
+          name: cacerts
+        {{- end -}}
   volumeClaimTemplates:
   - metadata:
       name: halyard-home

--- a/stable/spinnaker/templates/statefulsets/halyard.yaml
+++ b/stable/spinnaker/templates/statefulsets/halyard.yaml
@@ -50,7 +50,7 @@ spec:
         - mountPath: /etc/ssl/certs/java/cacerts
           subPath: cacerts
           name: cacerts
-        {{- end -}}
+        {{- end }}
       volumes:
       {{- if .Values.kubeConfig.enabled }}
       - name: kube-config
@@ -71,7 +71,7 @@ spec:
           {{- if .Values.dockerRegistryAccountSecret }}
           secretName: {{ .Values.dockerRegistryAccountSecret }}
           {{- else }}
-          secretName: {{ template "spinnaker.fullname" .}}-registry
+          secretName: {{ template "spinnaker.fullname" . }}-registry
           {{- end }}
       {{- if and .Values.s3.enabled .Values.s3.accessKey .Values.s3.secretKey }}
       - name: s3-secrets
@@ -114,7 +114,7 @@ spec:
           items:
           - key: cacerts
             path: cacerts
-      {{- end -}}
+      {{- end }}
       containers:
       - name: halyard
         image: {{ .Values.halyard.image.repository }}:{{ .Values.halyard.image.tag }}
@@ -160,7 +160,7 @@ spec:
         - mountPath: /etc/ssl/certs/java/cacerts
           subPath: cacerts
           name: cacerts
-        {{- end -}}
+        {{- end }}
   volumeClaimTemplates:
   - metadata:
       name: halyard-home

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -75,6 +75,10 @@ halyard:
   # env:
   #   - name: DEFAULT_JVM_OPTS
   #     value: -Dhttp.proxyHost=proxy.example.com
+  customCerts:
+    ## Enable to override the default cacerts with your own one
+    enabled: false
+    secretName: my-cacerts
 
 # Define which registries and repositories you want available in your
 # Spinnaker pipeline definitions

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -78,7 +78,7 @@ halyard:
   customCerts:
     ## Enable to override the default cacerts with your own one
     enabled: false
-    secretName: my-cacerts
+    secretName: custom-cacerts
 
 # Define which registries and repositories you want available in your
 # Spinnaker pipeline definitions


### PR DESCRIPTION
#### What this PR does / why we need it:

In environments with air-gapped setup, especially with internal tooling (repos) and self-signed certificates it is required to provide an adequate `cacerts` which overrides the default one:

#### Which issue this PR fixes
none

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
