### PR TITLE
cluster-autoscaler: support managed identity extension in Azure

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 0.12.3
+version: 0.12.4
 appVersion: 1.13.1
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/README.md
+++ b/stable/cluster-autoscaler/README.md
@@ -168,6 +168,7 @@ Parameter | Description | Default
 `azureResourceGroup` | Azure resource group that the cluster is located | none
 `azureVMType: "AKS"` | Azure VM type | `AKS`
 `azureNodeResourceGroup` | azure resource group where the clusters Nodes are located, typically set as `MC_<cluster-resource-group-name>_<cluster-name>_<location>` | none
+`azureUseManagedIdentityExtension` | Whether to use Azure's managed identity extension for credentials | false
 
 Specify each parameter you'd like to override using a YAML file as described above in the [installation](#installing-the-chart) section or by using the `--set key=value[,key=value]` argument to `helm install`. For example, to change the region and [expander](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders):
 

--- a/stable/cluster-autoscaler/templates/deployment.yaml
+++ b/stable/cluster-autoscaler/templates/deployment.yaml
@@ -84,6 +84,15 @@ spec:
                 secretKeyRef:
                   key: ResourceGroup
                   name: {{ template "cluster-autoscaler.fullname" . }}
+            - name: ARM_VM_TYPE
+              valueFrom:
+                secretKeyRef:
+                  key: VMType
+                  name: {{ template "cluster-autoscaler.fullname" . }}
+            {{- if .Values.azureUseManagedIdentityExtension }}
+            - name: ARM_USE_MANAGED_IDENTITY_EXTENSION
+              value: "true"
+            {{- else }}
             - name: ARM_TENANT_ID
               valueFrom:
                 secretKeyRef:
@@ -99,11 +108,6 @@ spec:
                 secretKeyRef:
                   key: ClientSecret
                   name: {{ template "cluster-autoscaler.fullname" . }}
-            - name: ARM_VM_TYPE
-              valueFrom:
-                secretKeyRef:
-                  key: VMType
-                  name: {{ template "cluster-autoscaler.fullname" . }}
             - name: AZURE_CLUSTER_NAME
               valueFrom:
                 secretKeyRef:
@@ -114,6 +118,7 @@ spec:
                 secretKeyRef:
                   key: NodeResourceGroup
                   name: {{ template "cluster-autoscaler.fullname" . }}
+            {{- end }}
           {{- end }}
           {{- range $key, $value := .Values.extraEnv }}
             - name: {{ $key }}
@@ -156,4 +161,4 @@ spec:
           hostPath:
             path: {{ .Values.cloudConfigPath }}
         {{- end }}
-{{- end}}
+{{- end }}

--- a/stable/cluster-autoscaler/values.yaml
+++ b/stable/cluster-autoscaler/values.yaml
@@ -36,6 +36,8 @@ azureTenantID: ""
 azureVMType: "AKS"
 azureClusterName: ""
 azureNodeResourceGroup: ""
+# if using MSI, ensure subscription ID and resource group are set
+azureUseManagedIdentityExtension: false
 
 # Currently only `gce`, `aws`, `azure` & `spotinst` are supported
 cloudProvider: aws


### PR DESCRIPTION
#### What this PR does / why we need it:

cluster-autoscaler supports the `ARM_USE_MANAGED_IDENTITY_EXTENSION` flag in Azure. The only other [requirements are the subscription ID and resource group](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/azure/examples/cluster-autoscaler-vmss-msi.yaml).

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
