### PR TITLE
[stable/external-dns] Update helper functions to follow best practice

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -3,7 +3,7 @@ description: |
   Configure external DNS servers (AWS Route53, Google CloudDNS and others)
   for Kubernetes Ingresses and Services
 name: external-dns
-version: 1.7.0
+version: 1.7.1
 appVersion: 0.5.9
 home: https://github.com/kubernetes-incubator/external-dns
 sources:

--- a/stable/external-dns/templates/_helpers.tpl
+++ b/stable/external-dns/templates/_helpers.tpl
@@ -9,13 +9,18 @@ Expand the name of the chart.
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "external-dns.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if ne $name .Release.Name -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

The recommended helper function created by `helm create` now avoids the double naming situation
when the release name contains chart name. It also adds `fullnameOverride` value, so the fullname
could be overridden.
This commit updates `external-dns` chart to work the same way.

P.s. These changes should be backward compatible, so I bumped the patchset version. Please let me know if I should bump the minor one instead.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] ~Variables are documented in the README.md~ (_AFAIK, usually `fullnameOverride` and `nameOverride ` are not mentioned in `README.md` and `values.yaml`_)
