### PR TITLE
Upgrade fluentd to 1.5.1

### DIFF
--- a/stable/elastic-stack/Chart.yaml
+++ b/stable/elastic-stack/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart for ELK
 home: https://www.elastic.co/products
 icon: https://www.elastic.co/assets/bltb35193323e8f1770/logo-elastic-stack-lt.svg
 name: elastic-stack
-version: 1.5.0
+version: 1.5.1
 appVersion: 6.0
 maintainers:
 - name: rendhalver

--- a/stable/elastic-stack/requirements.yaml
+++ b/stable/elastic-stack/requirements.yaml
@@ -16,7 +16,7 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: logstash.enabled
 - name: fluentd
-  version: ^1.3.0
+  version: ^1.5.1
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: fluentd.enabled
 - name: fluent-bit


### PR DESCRIPTION
#### What this PR does / why we need it:
This upgrades fluentd chart to 1.5.1 to support static node port assignments.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
