### PR TITLE
Removed CRDs upon helm delete

### DIFF
--- a/incubator/sparkoperator/Chart.yaml
+++ b/incubator/sparkoperator/Chart.yaml
@@ -1,6 +1,6 @@
 name: sparkoperator
 description: A Helm chart for Spark on Kubernetes operator
-version: 0.1.13
+version: 0.2.0
 appVersion: v1beta1-0.8.1-2.4.0
 kubeVersion: ">=1.8.0-0"
 keywords:

--- a/incubator/sparkoperator/README.md
+++ b/incubator/sparkoperator/README.md
@@ -1,6 +1,6 @@
 ### Helm Chart for Spark Operator
 
-This is the Helm chart for the [Spark-on-Kubernetes Operator](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator).
+This is the Helm chart for the [Kubernetes Operator for Apache Spark](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator).
 
 #### Prerequisites
 
@@ -12,7 +12,7 @@ The chart can be installed by running:
 
 ```bash
 $ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
-$ helm install incubator/sparkoperator --namespace spark-operator
+$ helm install incubator/sparkoperator --namespace spark-operator --set sparkJobNamespace=default
 ```
 
 Note that you need to use the `--namespace` flag during `helm install` to specify in which namespace you want to install the operator. The namespace can be existing or not. When it's not available, Helm would take care of creating the namespace. Note that this namespace has no relation to the namespace where you would like to deploy Spark jobs (i.e. the setting `sparkJobNamespace` shown in the table below). They can be the same namespace or different ones. 
@@ -24,13 +24,14 @@ The following table lists the configurable parameters of the Spark operator char
 | Parameter                 | Description                                                  | Default                                |
 | ------------------------- | ------------------------------------------------------------ | -------------------------------------- |
 | `operatorImageName`       | The name of the operator image                               | `gcr.io/spark-operator/spark-operator` |
-| `operatorVersion`         | The version of the operator to install                       | `v2.4.0-v1beta1-latest`               |
+| `operatorVersion`         | The version of the operator to install                       | `v2.4.0-v1beta1-0.8.1`                |
 | `imagePullPolicy`         | Docker image pull policy                                     | `IfNotPresent`                         |
-| `sparkJobNamespace`       | K8s namespace where Spark jobs are to be deployed            | `default`                              |
-| `enableWebhook`           | Whether to enable mutating admission webhook                 | false                                   |
+| `sparkJobNamespace`       | K8s namespace where Spark jobs are to be deployed            | ``                                     |
+| `enableWebhook`           | Whether to enable mutating admission webhook                 | false                                  |
 | `enableMetrics`           | Whether to expose metrics to be scraped by Premetheus        | true                                   |
-| `controllerThreads`       | Number of worker threads used by the SparkApplication controller | 10                                     |
-| `ingressUrlFormat` | Ingress URL format | "" |
+| `controllerThreads`       | Number of worker threads used by the SparkApplication controller | 10                                 |
+| `ingressUrlFormat`        | Ingress URL format                                           | ""                                     |
+| `logLevel`                | Logging verbosity level                                      | 2                                      |
 | `installCrds`             | Whether to install CRDs                                      | true                                   |
 | `metricsPort`             | Port for the metrics endpoint                                | 10254                                  |
 | `metricsEndpoint`         | Metrics endpoint                                             | "/metrics"                             |

--- a/incubator/sparkoperator/templates/crd-cleanup-job.yaml
+++ b/incubator/sparkoperator/templates/crd-cleanup-job.yaml
@@ -1,0 +1,44 @@
+{{ if .Values.installCrds }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "sparkoperator.fullname" . }}-crd-cleanup
+  annotations:
+    "helm.sh/hook": pre-delete, pre-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded
+  labels:
+    app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
+    helm.sh/chart: {{ include "sparkoperator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ include "sparkoperator.serviceAccountName" . }}
+      restartPolicy: OnFailure
+      containers:
+        - name: delete-sparkapp-crd
+          image: {{ .Values.operatorImageName }}:{{ .Values.operatorVersion }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          command:
+            - "/bin/sh"
+            - "-c"
+            - "curl -ik \
+          -X DELETE \
+          -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" \
+          -H \"Accept: application/json\" \
+          -H \"Content-Type: application/json\" \
+          https://kubernetes.default.svc/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/sparkapplications.sparkoperator.k8s.io"
+        - name: delete-scheduledsparkapp-crd
+          image: {{ .Values.operatorImageName }}:{{ .Values.operatorVersion }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          command:
+            - "/bin/sh"
+            - "-c"
+            - "curl -ik \
+          -X DELETE \
+          -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" \
+          -H \"Accept: application/json\" \
+          -H \"Content-Type: application/json\" \
+          https://kubernetes.default.svc/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/scheduledsparkapplications.sparkoperator.k8s.io"
+{{ end }}

--- a/incubator/sparkoperator/templates/crd-cleanup-job.yaml
+++ b/incubator/sparkoperator/templates/crd-cleanup-job.yaml
@@ -4,7 +4,7 @@ kind: Job
 metadata:
   name: {{ include "sparkoperator.fullname" . }}-crd-cleanup
   annotations:
-    "helm.sh/hook": pre-delete, pre-upgrade
+    "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     app.kubernetes.io/name: {{ include "sparkoperator.name" . }}

--- a/incubator/sparkoperator/templates/spark-operator-deployment.yaml
+++ b/incubator/sparkoperator/templates/spark-operator-deployment.yaml
@@ -56,7 +56,7 @@ spec:
           - containerPort: {{ .Values.metricsPort }}
         {{ end }}
         args:
-        - -v=2
+        - -v={{ .Values.logLevel }}
         - -namespace={{ .Values.sparkJobNamespace }}
         - -ingress-url-format={{ .Values.ingressUrlFormat }}
         - -install-crds={{ .Values.installCrds }}

--- a/incubator/sparkoperator/templates/webhook-cleanup-job.yaml
+++ b/incubator/sparkoperator/templates/webhook-cleanup-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "sparkoperator.fullname" . }}-cleanup
+  name: {{ include "sparkoperator.fullname" . }}-webhook-cleanup
   annotations:
     "helm.sh/hook": pre-delete, pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/incubator/sparkoperator/values.yaml
+++ b/incubator/sparkoperator/values.yaml
@@ -31,3 +31,5 @@ webhookPort: 8080
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
 nodeSelector: {}
+
+logLevel: 2


### PR DESCRIPTION
1. Because the CRDs are not directly created by Helm (they are created by the operator Go code), Helm is not responsible for deleting them during helm upgrade or helm delete. Now the chart deletes them upon a helm upgrade or delete to avoid having outdated definitions left in the cluster.

2. Made logging level configurable.