### PR TITLE
Upgraded appVersion from 0.15.1 to 0.17.1 because of CVE-2018-17144

### DIFF
--- a/stable/bitcoind/Chart.yaml
+++ b/stable/bitcoind/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: bitcoind
-version: 0.1.5
-appVersion: 0.15.1
+version: 0.1.6
+appVersion: 0.17.1
 description: Bitcoin is an innovative payment network and a new kind of money.
 keywords:
   - bitcoind

--- a/stable/bitcoind/README.md
+++ b/stable/bitcoind/README.md
@@ -43,7 +43,7 @@ The following table lists the configurable parameters of the bitcoind chart and 
 Parameter                  | Description                        | Default
 -----------------------    | ---------------------------------- | ----------------------------------------------------------
 `image.repository`         | Image source repository name       | `arilot/docker-bitcoind`
-`image.tag`                | `bitcoind` release tag.            | `0.15.1`
+`image.tag`                | `bitcoind` release tag.            | `0.17.1`
 `image.pullPolicy`         | Image pull policy                  | `IfNotPresent`
 `service.rpcPort`          | RPC port                           | `8332`
 `service.p2pPort`          | P2P port                           | `8333`


### PR DESCRIPTION
Signed-off-by: Harsha Goli <harshagoli@gmail.com>

#### What this PR does / why we need it:

Changes the bitcoind version from 0.15.1, which is susceptible to CVE-2018-17144, to 0.17.1 the next stable release with no known vulnerabilities at this time. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped