### PR TITLE
WIP: [stable/cert-manager] add security context on webhook

### DIFF
--- a/stable/cert-manager/README.md
+++ b/stable/cert-manager/README.md
@@ -102,6 +102,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `https_proxy` | Value of the `HTTPS_PROXY` environment variable in the cert-manager pod | |
 | `no_proxy` | Value of the `NO_PROXY` environment variable in the cert-manager pod | |
 | `webhook.enabled` | Toggles whether the validating webhook component should be installed | `true` |
+| `webhook.securityContext` | Give the opportunity to set a security context | `{}` |
 | `webhook.replicaCount` | Number of cert-manager webhook replicas | `1` |
 | `webhook.podAnnotations` | Annotations to add to the webhook pods | `{}` |
 | `webhook.extraArgs` | Optional flags for cert-manager webhook component | `[]` |

--- a/stable/cert-manager/requirements.lock
+++ b/stable/cert-manager/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: webhook
   repository: file://webhook
-  version: v0.6.4
-digest: sha256:a0af88ca014f7195e521457f22c31d8bf28c7c90b0c9a088bfc5cb8ab188b769
-generated: 2019-02-19T11:13:47.831977937Z
+  version: v0.6.6
+digest: sha256:6d5c27f10ad36f571d301ff5d911d0f04cf4e4a80e08020c73b8e40d9474bdb9
+generated: 2019-03-28T21:10:39.730072451Z

--- a/stable/cert-manager/requirements.yaml
+++ b/stable/cert-manager/requirements.yaml
@@ -1,6 +1,6 @@
 # requirements.yaml
 dependencies:
 - name: webhook
-  version: "v0.6.4"
+  version: "v0.6.6"
   repository: "file://webhook"
   condition: webhook.enabled

--- a/stable/cert-manager/webhook/Chart.yaml
+++ b/stable/cert-manager/webhook/Chart.yaml
@@ -1,6 +1,6 @@
 name: webhook
 apiVersion: v1
-version: "v0.6.5"
+version: "v0.6.6"
 appVersion: "v0.6.2"
 description: A Helm chart for deploying the cert-manager webhook component
 home: https://github.com/jetstack/cert-manager

--- a/stable/cert-manager/webhook/Chart.yaml
+++ b/stable/cert-manager/webhook/Chart.yaml
@@ -1,6 +1,6 @@
 name: webhook
 apiVersion: v1
-version: "v0.6.4"
+version: "v0.6.5"
 appVersion: "v0.6.2"
 description: A Helm chart for deploying the cert-manager webhook component
 home: https://github.com/jetstack/cert-manager

--- a/stable/cert-manager/webhook/templates/ca-sync.yaml
+++ b/stable/cert-manager/webhook/templates/ca-sync.yaml
@@ -64,7 +64,11 @@ spec:
     spec:
       serviceAccountName: {{ include "webhook.fullname" . }}-ca-sync
       restartPolicy: OnFailure
-      securityContext: {{ .Values.securityContext }}
+      {{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+
       containers:
       - name: ca-helper
         image: {{ .Values.caSyncImage.repository }}:{{ .Values.caSyncImage.tag }}

--- a/stable/cert-manager/webhook/templates/ca-sync.yaml
+++ b/stable/cert-manager/webhook/templates/ca-sync.yaml
@@ -64,9 +64,10 @@ spec:
     spec:
       serviceAccountName: {{ include "webhook.fullname" . }}-ca-sync
       restartPolicy: OnFailure
-
+      {{- with .Values.securityContext }}
       securityContext:
-        runAsUser: 1001
+{{ toYaml . | indent 8 }}
+      {{- end }}
 
       containers:
       - name: ca-helper

--- a/stable/cert-manager/webhook/templates/ca-sync.yaml
+++ b/stable/cert-manager/webhook/templates/ca-sync.yaml
@@ -64,10 +64,9 @@ spec:
     spec:
       serviceAccountName: {{ include "webhook.fullname" . }}-ca-sync
       restartPolicy: OnFailure
-      {{- with .Values.securityContext }}
+
       securityContext:
-{{ toYaml . | indent 8 }}
-      {{- end }}
+        runAsUser: 1001
 
       containers:
       - name: ca-helper

--- a/stable/cert-manager/webhook/templates/ca-sync.yaml
+++ b/stable/cert-manager/webhook/templates/ca-sync.yaml
@@ -64,6 +64,7 @@ spec:
     spec:
       serviceAccountName: {{ include "webhook.fullname" . }}-ca-sync
       restartPolicy: OnFailure
+      securityContext: {{ .Values.securityContext }}
       containers:
       - name: ca-helper
         image: {{ .Values.caSyncImage.repository }}:{{ .Values.caSyncImage.tag }}

--- a/stable/cert-manager/webhook/templates/deployment.yaml
+++ b/stable/cert-manager/webhook/templates/deployment.yaml
@@ -28,6 +28,11 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+
       serviceAccountName: {{ include "webhook.fullname" . }}
       {{- if .Values.global.priorityClassName }}
       priorityClassName: {{ .Values.global.priorityClassName | quote }}

--- a/stable/cert-manager/webhook/values.yaml
+++ b/stable/cert-manager/webhook/values.yaml
@@ -35,3 +35,8 @@ caSyncImage:
   repository: quay.io/munnerz/apiextensions-ca-helper
   tag: v0.1.0
   pullPolicy: IfNotPresent
+
+
+# Give the opportunity to set a security Context
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+securityContext: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
It allow user to set a securitycontext also on webhook and his job to be able to run in a K8S with PodSecurityPolicy set runAsNonRoot
#### Which issue this PR fixes

  - fixes https://github.com/helm/charts/issues/11951

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
