### PR TITLE
[WIP][incubator/resource-quotas] Add resource-quotas chart to bootstrap K8s

### DIFF
--- a/incubator/resource-quotas/.helmignore
+++ b/incubator/resource-quotas/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/incubator/resource-quotas/Chart.yaml
+++ b/incubator/resource-quotas/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+appVersion: "1.0"
+description: The chart helps Kubernetes administrators to configure resource limits and defaults.
+name: resource-quotas
+version: 0.1.0
+keywords:
+  - kubernetes
+  - quotas
+  - resources
+  - cpu
+  - memory
+  - storage
+maintainers:
+  - email: kivagant@gmail.com
+    name: kivagant
+home: https://github.com/kivagant/charts
+icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.svg

--- a/incubator/resource-quotas/README.md
+++ b/incubator/resource-quotas/README.md
@@ -1,0 +1,125 @@
+# kubernetes-dashboard
+
+## TL;DR
+
+```console
+helm install incubator/resource-quotas -f myvalues.yaml
+```
+
+## Introduction
+
+This chart bootstraps resource quotas for a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+The chart helps Kubernetes administrators to configure resource limits and defaults.
+
+## Warnings
+
+1. Do NOT install the chart until you read the following documentation:
+
+- https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
+- https://kubernetes.io/docs/concepts/policy/resource-quotas/
+- https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/ and all other topics in the category
+- https://kubernetes.io/docs/tasks/administer-cluster/limit-storage-consumption/
+- https://docs.openshift.com/container-platform/3.11/dev_guide/compute_resources.html
+
+2. Do NOT install the chart with default values.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+Unlike many other charts this one should be installed without passing the `namespace` argument because it works
+with several namespaces at once.
+
+```console
+helm install incubator/resource-quotas --name my-release
+```
+
+The command deploys ResourceQuota and LimitRange objects on the Kubernetes cluster in the default configuration.
+The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+Depending on the values you have passed to helm, you will get an output with the list of installed resources:
+
+```console
+RESOURCES:
+==> v1/ResourceQuota
+NAME
+default-general
+kube-system-general
+your-namespace-general
+
+==> v1/LimitRange
+NAME
+default-container
+default-pod
+default-pvc
+kube-system-container
+kube-system-pod
+kube-system-pvc
+your-namespace-container
+your-namespace-pod
+your-namespace-pvc
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+helm delete my-release --purge
+```
+
+Unfortunately, Helm does not guarantee that all resources created by this chart will be removed together with the chart.
+Delete artifacts manually using the commands:
+
+```console
+kubectl get limitranges --all-namespaces
+kubectl delete limitranges -n default default-container default-pod default-pvc
+kubectl delete limitranges -n kube-system kube-system-container kube-system-pod kube-system-pvc
+kubectl delete limitranges -n your-namespace your-namespace-container your-namespace-pod your-namespace-pvc
+
+kubectl get resourcequotas -n default
+kubectl get resourcequotas -n kube-system
+kubectl get resourcequotas -n your-namespace
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the kubernetes-dashboard chart and their default values.
+
+| Parameter                           | Description                                                                                                                       | Default                                                                    |
+|-------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------|
+| `namespaces.*`                      | List of namespaces to generate Kubernetes resources.                                                                              | default, kube-system                                                       |
+| `namespaces.*.limitrange-container` | Settings for a LimitRange with the type "Container".                                                                              | request, limit, min, max                                                   |
+| `namespaces.*.limitrange-pod`       | Settings for a LimitRange with the type "Pod".                                                                                    | min, max                                                                   |
+| `namespaces.*.limitrange-pvc`       | Settings for a LimitRange with the type "PersistentVolumeClaim".                                                                  | min, max                                                                   |
+| `namespaces.*.general`              | Settings for the default ResourceQuota which doesn't have scope selectors and will be applied for all resources in the namespace. | see `values.yaml` to get the full predefined list                          |
+| `namespaces.*.high`                 | Settings for a ResourceQuota which will be applied to all pods with PriorityClass="high".                                         | see `values.yaml` to get the full predefined list                          |
+| `namespaces.*.medium`               | Settings for a ResourceQuota which will be applied to all pods with PriorityClass="medium".                                       | see `values.yaml` to get the full predefined list                          |
+| `namespaces.*.low`                  | Settings for a ResourceQuota which will be applied to all pods with PriorityClass="low".                                          | see `values.yaml` to get the full predefined list                          |
+
+Make sure that your cluster supports necessary extentions. For example, to use `ResourceQuota`s for `PriorityClasses`
+make sure you have enabled `ResourceQuotaScopeSelectors`:
+
+https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+
+You can add your own values to the each specific list if your cluster supports them.
+
+> **Warning**: Do NOT install the chart using the default [values.yaml](values.yaml).
+
+Create a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+        
+```console
+helm install incubator/resource-quotas --name my-release -f values.yaml
+```
+
+Alternatively, you can specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+helm install incubator/resource-quotas --name my-release \
+  --set=namespaces.default.limitrange-container.request.cpu="100m",namespaces.default.general.pods=100
+```
+
+## Getting installed quotas
+
+```console
+kubectl describe quota compute-resources --namespace kube-system
+```

--- a/incubator/resource-quotas/templates/_helpers.tpl
+++ b/incubator/resource-quotas/templates/_helpers.tpl
@@ -1,0 +1,1 @@
+{{/* vim: set filetype=mustache: */}}

--- a/incubator/resource-quotas/templates/limitrange-container.yaml
+++ b/incubator/resource-quotas/templates/limitrange-container.yaml
@@ -1,0 +1,33 @@
+{{- range $namespace, $quotas := .Values.namespaces }}
+{{- if $limitrange := index $quotas "limitrange-container" -}}
+{{- $request := index $limitrange "request" -}}
+{{- $limit := index $limitrange "limit" }}
+{{- $min := index $limitrange "min" -}}
+{{- $max := index $limitrange "max" }}
+---
+apiVersion: v1
+kind: LimitRange
+namespace: {{ $namespace | quote }}
+metadata:
+  name: "{{ $namespace }}-container"
+spec:
+  limits:
+    - type: Container
+      defaultRequest:
+      {{- range $k, $v := $request }}
+        {{ $k }}: {{ $v | quote }}
+      {{- end }}
+      default:
+      {{- range $k, $v := $limit }}
+        {{ $k }}: {{ $v | quote }}
+      {{- end }}
+      min:
+      {{- range $k, $v := $min }}
+        {{ $k }}: {{ $v | quote }}
+      {{- end }}
+      max:
+      {{- range $k, $v := $max }}
+        {{ $k }}: {{ $v | quote }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/incubator/resource-quotas/templates/limitrange-persistentvolumeclaim.yaml
+++ b/incubator/resource-quotas/templates/limitrange-persistentvolumeclaim.yaml
@@ -1,0 +1,24 @@
+{{- range $namespace, $quotas := .Values.namespaces }}
+{{- if $limitrange := index $quotas "limitrange-pvc" -}}
+{{- $min := index $limitrange "min" -}}
+{{- $max := index $limitrange "max" }}
+---
+apiVersion: v1
+kind: LimitRange
+namespace: {{ $namespace | quote }}
+metadata:
+  name: "{{ $namespace }}-pvc"
+spec:
+  limits:
+    - type: PersistentVolumeClaim
+      min:
+      {{- range $k, $v := $min }}
+        {{ $k }}: {{ $v | quote }}
+      {{- end }}
+      max:
+      {{- range $k, $v := $max }}
+        {{ $k }}: {{ $v | quote }}
+      {{- end }}
+
+{{- end }}
+{{- end }}

--- a/incubator/resource-quotas/templates/limitrange-pod.yaml
+++ b/incubator/resource-quotas/templates/limitrange-pod.yaml
@@ -1,0 +1,25 @@
+{{- range $namespace, $quotas := .Values.namespaces }}
+{{- if $limitrange := index $quotas "limitrange-pod" -}}
+{{- $request := index $limitrange "request" -}}
+{{- $limit := index $limitrange "limit" }}
+{{- $min := index $limitrange "min" -}}
+{{- $max := index $limitrange "max" }}
+---
+apiVersion: v1
+kind: LimitRange
+namespace: {{ $namespace | quote }}
+metadata:
+  name: "{{ $namespace }}-pod"
+spec:
+  limits:
+    - type: Pod
+      min:
+      {{- range $k, $v := $min }}
+        {{ $k }}: {{ $v | quote }}
+      {{- end }}
+      max:
+      {{- range $k, $v := $max }}
+        {{ $k }}: {{ $v | quote }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/incubator/resource-quotas/templates/resourcequota-general.yaml
+++ b/incubator/resource-quotas/templates/resourcequota-general.yaml
@@ -1,0 +1,15 @@
+{{- range $namespace, $quotas := .Values.namespaces }}
+{{- if $general := index $quotas "general" }}
+---
+apiVersion: v1
+kind: ResourceQuota
+namespace: {{ $namespace | quote }}
+metadata:
+  name: "{{ $namespace }}-general"
+spec:
+  hard:
+  {{- range $k, $v := $general}}
+    {{ $k }}: {{ $v | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/incubator/resource-quotas/templates/resourcequota-high.yaml
+++ b/incubator/resource-quotas/templates/resourcequota-high.yaml
@@ -1,0 +1,20 @@
+{{- range $namespace, $quotas := .Values.namespaces }}
+{{- if $high := index $quotas "high" }}
+---
+apiVersion: v1
+kind: ResourceQuota
+namespace: {{ $namespace | quote }}
+metadata:
+  name: "{{ $namespace }}-high"
+spec:
+  hard:
+  {{- range $k, $v := $high}}
+    {{ $k }}: {{ $v | quote }}
+  {{- end }}
+  scopeSelector:
+    matchExpressions:
+      - operator : In
+        scopeName: PriorityClass
+        values: ["high"]
+{{- end }}
+{{- end }}

--- a/incubator/resource-quotas/templates/resourcequota-low.yaml
+++ b/incubator/resource-quotas/templates/resourcequota-low.yaml
@@ -1,0 +1,20 @@
+{{- range $namespace, $quotas := .Values.namespaces }}
+{{- if $low := index $quotas "low" }}
+---
+apiVersion: v1
+kind: ResourceQuota
+namespace: {{ $namespace | quote }}
+metadata:
+  name: "{{ $namespace }}-low"
+spec:
+  hard:
+  {{- range $k, $v := $low}}
+    {{ $k }}: {{ $v | quote }}
+  {{- end }}
+  scopeSelector:
+    matchExpressions:
+      - operator : In
+        scopeName: PriorityClass
+        values: ["low"]
+{{- end }}
+{{- end }}

--- a/incubator/resource-quotas/templates/resourcequota-medium.yaml
+++ b/incubator/resource-quotas/templates/resourcequota-medium.yaml
@@ -1,0 +1,20 @@
+{{- range $namespace, $v := .Values.namespaces }}
+{{- if $medium := index $v "medium" }}
+---
+apiVersion: v1
+kind: ResourceQuota
+namespace: {{ $namespace | quote }}
+metadata:
+  name: "{{ $namespace }}-medium"
+spec:
+  hard:
+  {{- range $k, $v := $medium}}
+    {{ $k }}: {{ $v | quote }}
+  {{- end }}
+  scopeSelector:
+    matchExpressions:
+      - operator : In
+        scopeName: PriorityClass
+        values: ["medium"]
+{{- end }}
+{{- end }}

--- a/incubator/resource-quotas/values.yaml
+++ b/incubator/resource-quotas/values.yaml
@@ -1,0 +1,260 @@
+namespaces:
+
+  # ---- NS ----
+  default:                                # Namespace name. The settings below forbid default namespace usage even when it is existing
+
+    limitrange-container:                 # ranges and quotas set by default for each CONTAINER that has not configured their own requests and limits
+      request:                            # default requests for one container
+        cpu: "0"
+        memory: "0"
+        ephemeral-storage: "0"
+      limit:                              # default limits for one container
+        cpu: "0"
+        memory: "0"
+        ephemeral-storage: "0"
+      min:                                # a container can't request less than the values
+        cpu: "0"
+        memory: "0"
+        ephemeral-storage: "0"
+      max:                                # a container can't request more than the values
+        cpu: "0"
+        memory: "0"
+        ephemeral-storage: "0"
+
+    limitrange-pod:                       # PODs can't request resources beyond the limits
+      min:                                # a pod can't request less than the values
+        cpu: "0"
+        memory: "0"
+        ephemeral-storage: "0"
+      max:                                # a pod can't request more than the values
+        cpu: "0"
+        memory: "0"
+        ephemeral-storage: "0"
+
+    limitrange-pvc:                       # one PersistentVolumeClaim can't request resources beyond the limits
+      min:                                # a PVC can't request less than the values
+        storage: "0"
+      max:                                # a PVC can't request more than the values
+        storage: "0"
+
+    general:                              # default quotas for the entire namespace for all pods without priority classes
+      pods: "0"
+      requests.cpu: "0"
+      requests.memory: "0"
+      requests.ephemeral-storage: "0"
+      requests.storage: "0"
+      limits.cpu: "0"
+      limits.memory: "0"
+      limits.ephemeral-storage: "0"
+      count/persistentvolumeclaims: "0"
+      count/services: "0"
+      services.loadbalancers: "0"
+      services.nodeports: "0"
+      count/secrets: "0"
+      count/configmaps: "0"
+      count/replicationcontrollers: "0"
+      count/deployments.apps: "0"
+      count/replicasets.apps: "0"
+      count/statefulsets.apps: "0"
+      count/jobs.batch: "0"
+      count/cronjobs.batch: "0"
+      count/ingresses.extensions: "0"
+
+    # To use the following settings for PriorityClasses make sure you have enabled ResourceQuotaScopeSelectors
+    # https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+    high: ~                                 # total quotas for the entire namespace for all pods with PriorityClass: "high"
+    medium: ~                               # total quotas for the entire namespace for all pods with PriorityClass: "medium"
+    low: ~                                  # total quotas for the entire namespace for all pods with PriorityClass: "low"
+
+  # ---- NS ----
+  kube-system:
+
+    limitrange-container:
+      request:
+        cpu: "10m"
+        memory: "32Mi"
+        ephemeral-storage: "100Mi"
+      limit:
+        cpu: "300m"
+        memory: "1Gi"
+        ephemeral-storage: "1Gi"
+      min:
+        cpu: "10m"
+        memory: "32Mi"
+        ephemeral-storage: "100Mi"
+      max:
+        cpu: "500m"
+        memory: "1Gi"
+        ephemeral-storage: "1Gi"
+
+    limitrange-pod:
+      min:
+        cpu: "10m"
+        memory: "32Mi"
+        ephemeral-storage: "100Mi"
+      max:                                  # limitrange-container.* x 5 to allow 5 containers per pod
+        cpu: "500m"
+        memory: "5Gi"
+        ephemeral-storage: "5Gi"
+
+    limitrange-pvc:
+      min:
+        storage: "0"
+      max:
+        storage: "0"
+
+    general:
+      pods: "200"
+      requests.cpu: "1"
+      requests.memory: "4Gi"
+      requests.ephemeral-storage: "4Gi"
+      requests.storage: "0"
+      limits.cpu: "1"
+      limits.memory: "4Gi"
+      limits.ephemeral-storage: "4Gi"
+      count/persistentvolumeclaims: "0"
+      count/services: "10"
+      services.loadbalancers: "5"
+      services.nodeports: "0"
+      count/secrets: "1000"
+      count/configmaps: "1000"
+      count/replicationcontrollers: "0"
+      count/deployments.apps: "20"
+      count/replicasets.apps: "60"
+      count/statefulsets.apps: "0"
+      count/jobs.batch: "20"
+      count/cronjobs.batch: "5"
+      count/ingresses.extensions: "0"
+
+    high: ~
+    medium: ~
+    low: ~
+
+  # ---- NS ----
+#  your-namespace:
+#
+#    limitrange-container:
+#      request:
+#        cpu: "10m"
+#        memory: "32Mi"
+#        ephemeral-storage: "100Mi"
+#      limit:
+#        cpu: "300m"
+#        memory: "512Mi"
+#        ephemeral-storage: "1Gi"
+#      min:
+#        cpu: "10m"
+#        memory: "32Mi"
+#        ephemeral-storage: "100Mi"
+#      max:
+#        cpu: "1600m"
+#        memory: "7Gi"
+#        ephemeral-storage: "10Gi"
+#
+#    limitrange-pod:
+#      min:
+#        cpu: "10m"
+#        memory: "32Mi"
+#        ephemeral-storage: "100Mi"
+#      max:
+#        cpu: "1600m"
+#        memory: "7Gi"
+#        ephemeral-storage: "20Gi"
+#
+#    limitrange-pvc:
+#      min:
+#        storage: "0"
+#      max:
+#        storage: "0"
+#
+#    general:
+#      pods: "200"
+#      requests.cpu: "4"
+#      requests.memory: "32Gi"
+#      requests.ephemeral-storage: "64Gi"
+#      requests.storage: "0"
+#      limits.cpu: "8"
+#      limits.memory: "64Gi"
+#      limits.ephemeral-storage: "128Gi"
+#      count/persistentvolumeclaims: "0"
+#      count/services: "30"
+#      services.loadbalancers: "15"
+#      services.nodeports: "0"
+#      count/secrets: "1000"
+#      count/configmaps: "1000"
+#      count/replicationcontrollers: "0"
+#      count/deployments.apps: "30"
+#      count/replicasets.apps: "90"
+#      count/statefulsets.apps: "0"
+#      count/jobs.batch: "30"
+#      count/cronjobs.batch: "10"
+#      count/ingresses.extensions: "10"
+#
+#    high:
+#      pods: "200"
+#      requests.cpu: "4"
+#      requests.memory: "32Gi"
+#      requests.ephemeral-storage: "64Gi"
+#      requests.storage: "0"
+#      limits.cpu: "8"
+#      limits.memory: "64Gi"
+#      limits.ephemeral-storage: "128Gi"
+#      count/persistentvolumeclaims: "0"
+#      count/services: "30"
+#      services.loadbalancers: "15"
+#      services.nodeports: "0"
+#      count/secrets: "1000"
+#      count/configmaps: "1000"
+#      count/replicationcontrollers: "0"
+#      count/deployments.apps: "30"
+#      count/replicasets.apps: "90"
+#      count/statefulsets.apps: "0"
+#      count/jobs.batch: "30"
+#      count/cronjobs.batch: "10"
+#      count/ingresses.extensions: "10"
+#
+#    medium:
+#      pods: "200"
+#      requests.cpu: "4"
+#      requests.memory: "32Gi"
+#      requests.ephemeral-storage: "64Gi"
+#      requests.storage: "0"
+#      limits.cpu: "8"
+#      limits.memory: "64Gi"
+#      limits.ephemeral-storage: "128Gi"
+#      count/persistentvolumeclaims: "0"
+#      count/services: "30"
+#      services.loadbalancers: "15"
+#      services.nodeports: "0"
+#      count/secrets: "1000"
+#      count/configmaps: "1000"
+#      count/replicationcontrollers: "0"
+#      count/deployments.apps: "30"
+#      count/replicasets.apps: "90"
+#      count/statefulsets.apps: "0"
+#      count/jobs.batch: "30"
+#      count/cronjobs.batch: "10"
+#      count/ingresses.extensions: "10"
+#
+#    low:
+#      pods: "200"
+#      requests.cpu: "4"
+#      requests.memory: "32Gi"
+#      requests.ephemeral-storage: "64Gi"
+#      requests.storage: "0"
+#      limits.cpu: "8"
+#      limits.memory: "64Gi"
+#      limits.ephemeral-storage: "128Gi"
+#      count/persistentvolumeclaims: "0"
+#      count/services: "30"
+#      services.loadbalancers: "15"
+#      services.nodeports: "0"
+#      count/secrets: "1000"
+#      count/configmaps: "1000"
+#      count/replicationcontrollers: "0"
+#      count/deployments.apps: "30"
+#      count/replicasets.apps: "90"
+#      count/statefulsets.apps: "0"
+#      count/jobs.batch: "30"
+#      count/cronjobs.batch: "10"
+#      count/ingresses.extensions: "10"


### PR DESCRIPTION
(!) Replaced with https://github.com/helm/charts/pull/12664

Signed-off-by: Eugene Glotov <kivagant@gmail.com>

#### What this PR does / why we need it:

The chart helps Kubernetes administrators to configure resource limits and defaults. It can install the following resources to a Kubernetes cluster depending on the passed values:

```console
RESOURCES:
==> v1/ResourceQuota
NAME
default-general
kube-system-general
your-namespace-general

==> v1/LimitRange
NAME
default-container
default-pod
default-pvc
kube-system-container
kube-system-pod
kube-system-pvc
your-namespace-container
your-namespace-pod
your-namespace-pvc
```

#### Special notes for your reviewer:

Unlike many other charts this one should be installed without passing the `namespace` argument because it works with several namespaces at once.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
