### PR TITLE
Update Elastic Stack chart dependencies

### DIFF
--- a/stable/elastic-stack/Chart.yaml
+++ b/stable/elastic-stack/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart for ELK
 home: https://www.elastic.co/products
 icon: https://www.elastic.co/assets/bltb35193323e8f1770/logo-elastic-stack-lt.svg
 name: elastic-stack
-version: 1.5.0
+version: 1.5.1
 appVersion: 6.0
 maintainers:
 - name: rendhalver

--- a/stable/elastic-stack/requirements.lock
+++ b/stable/elastic-stack/requirements.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.22.0
 - name: kibana
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.6.0
+  version: 2.0.0
 - name: filebeat
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 1.5.0
@@ -19,7 +19,7 @@ dependencies:
   version: 1.9.1
 - name: fluentd-elasticsearch
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.5.0
+  version: 2.0.7
 - name: nginx-ldapauth-proxy
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.1.2
@@ -28,6 +28,6 @@ dependencies:
   version: 1.2.1
 - name: elasticsearch-exporter
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.4.1
-digest: sha256:bfe45d33ce37ca75438638314b480535edab5dffc957fc351bd94d0babf641fd
-generated: 2019-03-28T15:24:21.69260004-04:00
+  version: 1.1.3
+digest: sha256:864b4833a330aa2a6c2331c3565241edb1b12f09ed6ebaefad849f1d3d208804
+generated: 2019-03-28T15:49:30.778303879-04:00

--- a/stable/elastic-stack/requirements.lock
+++ b/stable/elastic-stack/requirements.lock
@@ -1,22 +1,22 @@
 dependencies:
 - name: elasticsearch
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.18.1
+  version: 1.22.0
 - name: kibana
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.4.1
+  version: 1.6.0
 - name: filebeat
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.2.0
+  version: 1.5.0
 - name: logstash
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.5.0
+  version: 1.6.0
 - name: fluentd
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.4.0
+  version: 1.5.1
 - name: fluent-bit
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.5.2
+  version: 1.9.1
 - name: fluentd-elasticsearch
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 1.5.0
@@ -25,9 +25,9 @@ dependencies:
   version: 0.1.2
 - name: elasticsearch-curator
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.1.0
+  version: 1.2.1
 - name: elasticsearch-exporter
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.4.1
-digest: sha256:8455d84f9a92b252ce877037f85082eba25a7d5828a5f73dbfba19179232f3f1
-generated: 2019-02-04T12:54:51.901881528+01:00
+digest: sha256:bfe45d33ce37ca75438638314b480535edab5dffc957fc351bd94d0babf641fd
+generated: 2019-03-28T15:24:21.69260004-04:00

--- a/stable/elastic-stack/requirements.yaml
+++ b/stable/elastic-stack/requirements.yaml
@@ -1,30 +1,30 @@
 dependencies:
 - name: elasticsearch
-  version: ^1.17.0
+  version: ^1.22.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: elasticsearch.enabled
 - name: kibana
-  version: ^1.1.0
+  version: ^2.0.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: kibana.enabled
 - name: filebeat
-  version: ^1.0.0
+  version: ^1.5.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: filebeat.enabled
 - name: logstash
-  version: ^1.2.1
+  version: ^1.6.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: logstash.enabled
 - name: fluentd
-  version: ^1.5.1
+  version: ^1.5.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: fluentd.enabled
 - name: fluent-bit
-  version: ^1.3.0
+  version: ^1.9.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: fluent-bit.enabled
 - name: fluentd-elasticsearch
-  version: ^1.0.0
+  version: ^2.0.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: fluentd-elasticsearch.enabled
 - name: nginx-ldapauth-proxy
@@ -32,10 +32,10 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: nginx-ldapauth-proxy.enabled
 - name: elasticsearch-curator
-  version: ^1.0.0
+  version: ^1.2.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: elasticsearch-curator.enabled
 - name: elasticsearch-exporter
-  version: ^0.4.0
+  version: ^1.1.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: elasticsearch-exporter.enabled

--- a/stable/elastic-stack/requirements.yaml
+++ b/stable/elastic-stack/requirements.yaml
@@ -16,7 +16,7 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: logstash.enabled
 - name: fluentd
-  version: ^1.3.0
+  version: ^1.5.1
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: fluentd.enabled
 - name: fluent-bit


### PR DESCRIPTION
Signed-off-by: David Taylor <djtaylor13@gmail.com>

@rendhalver @jar361 This should address the lack of static node port assignment. I have also signed my commit as according to the DCO. This also updates all dependencies for this chart.

#### What this PR does / why we need it:
This updates the fluentd dependency to 1.5.1 to allow static node port assignment. This also updates dependencies for each sub-chart to the latest version.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
