### PR TITLE
Update the bitbucket cloud clientSecretKey in stable/drone

### DIFF
--- a/stable/drone/values.yaml
+++ b/stable/drone/values.yaml
@@ -96,7 +96,7 @@ sourceControl:
     server:
   bitbucketCloud:
     clientID:
-    clientSecret: clientSecret
+    clientSecretKey: clientSecret
   bitbucketServer:
     server:
     consumerKey: consumerKey


### PR DESCRIPTION
#### What this PR does / why we need it:
Update the bitbucket cloud clientSecretKey in the stable/drone values.yaml

The templates/_provider-envs.yaml file is referencing the .Values.sourceControl.bitbucketCloud.clientSecretKey instead of .Values.sourceControl.bitbucketCloud.clientSecret
