### PR TITLE
[stable/node-problem-detector] Add priority class

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,5 +1,5 @@
 name: node-problem-detector
-version: "1.3.1"
+version: "1.4.0"
 appVersion: v0.6.1
 home: https://github.com/kubernetes/node-problem-detector
 description: Installs the node-problem-detector daemonset for monitoring extra attributes on nodes

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -45,6 +45,7 @@ The following table lists the configurable parameters for this chart and their d
 | `nameOverride`                        | Override the name of the chart             | `nil`                                                        |
 | `rbac.create`                         | RBAC                                       | `true`                                                       |
 | `hostNetwork`                         | Run pod on host network                    | `false`                                                      |
+| `priorityClassName`                   | Priority class name                        | `""`                                                      |
 | `resources`                           | Pod resource requests and limits           | `{}`                                                         |
 | `settings.custom_monitor_definitions` | User-specified custom monitor definitions  | `{}`                                                         |
 | `settings.log_monitors`               | System log monitor config files            | `/config/kernel-monitor.json`, `/config/docker-monitor.json` |

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -27,6 +27,9 @@ spec:
       serviceAccountName: {{ template "node-problem-detector.serviceAccountName" . }}
       hostNetwork: {{ .Values.hostNetwork }}
       terminationGracePeriodSeconds: 30
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image:  "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -51,6 +51,8 @@ rbac:
 # not recommended, but may be useful for certain use cases.
 hostNetwork: false
 
+priorityClassName: ""
+
 resources: {}
 
 annotations: {}


### PR DESCRIPTION
Signed-off-by: Robert Sheehy <gameboy1092@gmail.com>

#### What this PR does / why we need it:
We run node-problem-detector as a part of our infrastructure and we'd like to give its pods priority when being scheduled onto nodes.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
