### PR TITLE
[stable/home-assistant] configurator-ingress was trying to use api v1 instead of v1beta1

### DIFF
--- a/stable/home-assistant/Chart.yaml
+++ b/stable/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.89.1
 description: Home Assistant
 name: home-assistant
-version: 0.6.0
+version: 0.6.1
 keywords:
 - home-assistant
 - hass

--- a/stable/home-assistant/templates/configurator-ingress.yaml
+++ b/stable/home-assistant/templates/configurator-ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "home-assistant.fullname" . -}}
 {{- $servicePort := .Values.configurator.service.port -}}
 {{- $ingressPath := .Values.configurator.ingress.path -}}
-apiVersion: extensions/v1
+apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-configurator


### PR DESCRIPTION
#### What this PR does / why we need it: the `configurator-ingress.yaml` was erroneously attempting to use the API v1 for Ingress, which fails.
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
