### PR TITLE
[stable/airflow]: Configurable initialDelay for starting Webserver

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,6 +1,6 @@
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 2.3.0
+version: 2.4.0
 appVersion: 1.10.0
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -300,6 +300,8 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `airflow.extraVolumes`                   | additional volumes for the scheduler, worker & web pods | `[]`                      |
 | `flower.resources`                       | custom resource configuration for flower pod            | `{}`                      |
 | `web.resources`                          | custom resource configuration for web pod               | `{}`                      |
+| `web.initialStartupDelay`                | amount of time webserver pod should sleep before initializing webserver             | `60`  |
+| `web.initialDelaySeconds`                | initial delay on livenessprobe before checking if webserver is available    | `360` |
 | `scheduler.resources`                    | custom resource configuration for scheduler pod         | `{}`                      |
 | `workers.enabled`                        | enable workers                                          | `true`                    |
 | `workers.replicas`                       | number of workers pods to launch                        | `1`                       |

--- a/stable/airflow/templates/deployments-web.yaml
+++ b/stable/airflow/templates/deployments-web.yaml
@@ -103,8 +103,8 @@ spec:
             - "-c"
           {{- if and ( .Values.dags.initContainer.enabled ) ( .Values.dags.initContainer.installRequirements ) }}
             - >
-              echo 'waiting 60s...' &&
-              sleep 60 &&
+              echo 'waiting {{ .Values.web.initialStartupDelay }}s...' &&
+              sleep {{ .Values.web.initialStartupDelay }} &&
               echo 'installing requirements...' &&
               mkdir -p /usr/local/airflow/.local/bin &&
               export PATH=/usr/local/airflow/.local/bin:$PATH &&
@@ -113,8 +113,8 @@ spec:
               airflow webserver
           {{- else }}
             - >
-              echo 'waiting 60s...' &&
-              sleep 60 &&
+              echo 'waiting {{ .Values.web.initialStartupDelay }}s...' &&
+              sleep {{ .Values.web.initialStartupDelay }} &&
               mkdir -p /usr/local/airflow/.local/bin &&
               export PATH=/usr/local/airflow/.local/bin:$PATH &&
               echo 'executing webserver...' &&
@@ -125,7 +125,7 @@ spec:
               path: "{{ .Values.ingress.web.path }}/health"
               port: web
             ## Keep 6 minutes the delay to allow clean wait of postgres and redis containers
-            initialDelaySeconds: 360
+            initialDelaySeconds: {{ .Values.web.initialDelaySeconds }}
             periodSeconds: 60
             timeoutSeconds: 1
             successThreshold: 1

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -188,6 +188,8 @@ web:
     # requests:
     #   cpu: "100m"
     #   memory: "512Mi"
+  initialStartupDelay: "60"
+  initialDelaySeconds: "360"
 ##
 ## Workers configuration
 workers:


### PR DESCRIPTION

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
When running locally, it is nice to have a delay initially to make sure postgres and redis are available. However, in the case you are interacting with an external redis or postgres, it is expected that they're already available, so the wait time isn't necessary.

This change makes the intial sleep delay before starting airflow configurable and the initialDelay before a healthcheck configurable so it possible to start up the webserver faster.

Signed-off-by: Brian Nutt <brian@slice.com>

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
