### PR TITLE
[stable/home-assistant] fixing label-name migration and bumping image version

### DIFF
--- a/stable/home-assistant/Chart.yaml
+++ b/stable/home-assistant/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.89.1
+appVersion: 0.90.2
 description: Home Assistant
 name: home-assistant
-version: 0.6.1
+version: 0.6.2
 keywords:
 - home-assistant
 - hass

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -13,13 +13,13 @@ spec:
     type: {{ .Values.strategyType }}
   selector:
     matchLabels:
-      app: {{ template "home-assistant.name" . }}
-      release: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ include "home-assistant.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ template "home-assistant.name" . }}
-        release: {{ .Release.Name }}
+        app.kubernetes.io/name: {{ include "home-assistant.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/stable/home-assistant/templates/pvc.yaml
+++ b/stable/home-assistant/templates/pvc.yaml
@@ -5,10 +5,10 @@ apiVersion: v1
 metadata:
   name: {{ template "home-assistant.fullname" . }}
   labels:
-    app: {{ template "home-assistant.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ include "home-assistant.name" . }}
+    helm.sh/chart: {{ include "home-assistant.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: homeassistant/home-assistant
-  tag: 0.89.1
+  tag: 0.90.2
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
#### What this PR does / why we need it:

* A previous change to bring the label-name usage up-to-standards resulted in some missed references to the new naming style. This PR fixes that miss
* Bump the application image tag to version 0.90.2

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
