### PR TITLE
[elasticsearch-curator] Enabling the use of secrets in environment

### DIFF
--- a/stable/elasticsearch-curator/Chart.yaml
+++ b/stable/elasticsearch-curator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "5.5.4"
 description: A Helm chart for Elasticsearch Curator
 name: elasticsearch-curator
-version: 1.2.1
+version: 1.3.0
 home: https://github.com/elastic/curator
 keywords:
 - curator

--- a/stable/elasticsearch-curator/Chart.yaml
+++ b/stable/elasticsearch-curator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "5.5.4"
 description: A Helm chart for Elasticsearch Curator
 name: elasticsearch-curator
-version: 1.3.0
+version: 1.3.1
 home: https://github.com/elastic/curator
 keywords:
 - curator

--- a/stable/elasticsearch-curator/README.md
+++ b/stable/elasticsearch-curator/README.md
@@ -28,27 +28,30 @@ $ helm install stable/elasticsearch-curator
 The following table lists the configurable parameters of the docker-registry chart and
 their default values.
 
-|          Parameter                   |                      Description                      |                   Default                    |
-| :----------------------------------- | :---------------------------------------------------- | :------------------------------------------- |
-| `image.pullPolicy`                   | Container pull policy                                 | `IfNotPresent`                               |
-| `image.repository`                   | Container image to use                                | `quay.io/pires/docker-elasticsearch-curator` |
-| `image.tag`                          | Container image tag to deploy                         | `5.5.4`                                      |
-| `hooks`                              | Whether to run job on selected hooks                  | `{ "install": false, "upgrade": false }`     |
-| `cronjob.schedule`                   | Schedule for the CronJob                              | `0 1 * * *`                                  |
-| `cronjob.annotations`                | Annotations to add to the cronjob                     | {}                                           |
-| `cronjob.concurrencyPolicy`          | `Allow|Forbid|Replace` concurrent jobs                | `nil`                                        |
-| `cronjob.failedJobsHistoryLimit`     | Specify the number of failed Jobs to keep             | `nil`                                        |
-| `cronjob.successfulJobsHistoryLimit` | Specify the number of completed Jobs to keep          | `nil`                                        |
-| `pod.annotations`                    | Annotations to add to the pod                         | {}                                           |
-| `dryrun`                             | Run Curator in dry-run mode                           | `false`                                     |
-| `env`                                | Environment variables to add to the cronjob container | {}                                           |
-| `command`                            | Command to execute                                    | ["curator"]                                  |
-| `configMaps.action_file_yml`         | Contents of the Curator action_file.yml               | See values.yaml                              |
-| `configMaps.config_yml`              | Contents of the Curator config.yml (overrides config) | See values.yaml                              |
-| `resources`                          | Resource requests and limits                          | {}                                           |
-| `priorityClassName`                  | priorityClassName                                     | `nil`                                        |
-| `extraVolumeMounts`                  | Mount extra volume(s),                                |                                              |
-| `extraVolumes`                       | Extra volumes                                         |                                              |
+|          Parameter                   |                         Description                         |                   Default                    |
+| :----------------------------------- | :---------------------------------------------------------- | :------------------------------------------- |
+| `image.pullPolicy`                   | Container pull policy                                       | `IfNotPresent`                               |
+| `image.repository`                   | Container image to use                                      | `quay.io/pires/docker-elasticsearch-curator` |
+| `image.tag`                          | Container image tag to deploy                               | `5.5.4`                                      |
+| `hooks`                              | Whether to run job on selected hooks                        | `{ "install": false, "upgrade": false }`     |
+| `cronjob.schedule`                   | Schedule for the CronJob                                    | `0 1 * * *`                                  |
+| `cronjob.annotations`                | Annotations to add to the cronjob                           | {}                                           |
+| `cronjob.concurrencyPolicy`          | `Allow|Forbid|Replace` concurrent jobs                      | `nil`                                        |
+| `cronjob.failedJobsHistoryLimit`     | Specify the number of failed Jobs to keep                   | `nil`                                        |
+| `cronjob.successfulJobsHistoryLimit` | Specify the number of completed Jobs to keep                | `nil`                                        |
+| `pod.annotations`                    | Annotations to add to the pod                               | {}                                           |
+| `dryrun`                             | Run Curator in dry-run mode                                 | `false`                                      |
+| `env`                                | Environment variables to add to the cronjob container       | {}                                           |
+| `envFromSecrets`                     | Environment variables from secrets to the cronjob container | {}                                           |
+| `envFromSecrets.*.from.secret`       | - `secretKeyRef.name` used for environment variable         |                                              |              
+| `envFromSecrets.*.from.key`          | - `secretKeyRef.key` used for environment variable          |                                              |              
+| `command`                            | Command to execute                                          | ["curator"]                                  |
+| `configMaps.action_file_yml`         | Contents of the Curator action_file.yml                     | See values.yaml                              |
+| `configMaps.config_yml`              | Contents of the Curator config.yml (overrides config)       | See values.yaml                              |
+| `resources`                          | Resource requests and limits                                | {}                                           |
+| `priorityClassName`                  | priorityClassName                                           | `nil`                                        |
+| `extraVolumeMounts`                  | Mount extra volume(s),                                      |                                              |
+| `extraVolumes`                       | Extra volumes                                               |                                              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.

--- a/stable/elasticsearch-curator/templates/cronjob.yaml
+++ b/stable/elasticsearch-curator/templates/cronjob.yaml
@@ -49,6 +49,10 @@ spec:
 {{- if .Values.priorityClassName }}
           priorityClassName: "{{ .Values.priorityClassName }}"
 {{- end }}
+{{- if .Values.image.pullSecret }}
+          imagePullSecrets:
+            - name: {{ .Values.image.pullSecret }}
+{{- end }}
           containers:
             - name: {{ .Chart.Name }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/elasticsearch-curator/templates/cronjob.yaml
+++ b/stable/elasticsearch-curator/templates/cronjob.yaml
@@ -75,6 +75,15 @@ spec:
                 value: {{ $value | quote}}
 {{- end }}
 {{- end }}
+{{- if .Values.envFromSecrets }}
+{{- range $key,$value := .Values.envFromSecrets }}
+              - name: {{ $key | upper | quote}}
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $value.from.secret | quote}}
+                    key: {{ $value.from.key | quote}}
+{{- end }}
+{{- end }}
               resources:
 {{ toYaml .Values.resources | indent 16 }}
     {{- with .Values.nodeSelector }}


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR enables the possibility to inject environment variables to the cronjob container from kubernetes secrets (authentication credentials, for example).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

Signed-off-by: Endre Czirbesz <endre.czirbesz@rungway.com>