### PR TITLE
Improves ClusterRole management in Datadog chart

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.26.1
+version: 1.27.0
 appVersion: 6.10.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -291,11 +291,13 @@ helm install --name <RELEASE_NAME> \
 | `clusterAgent.livenessProbe`             | Overrides the default liveness probe                                                      | http port 443 if external metrics enabled   |
 | `clusterAgent.readinessProbe`            | Overrides the default readiness probe                                                     | http port 443 if external metrics enabled   |
 | `clusterchecksDeployment.enabled`        | Enable Datadog agent deployment dedicated for running Cluster Checks. It allows having different resources (Request/Limit) for Cluster Checks agent pods.  | `false` |
-| `clusterchecksDeployment.env`                            | Additional Datadog environment variables for Cluster Checks Deployment    | `nil`                                       |
-| `clusterchecksDeployment.resources.requests.cpu`         | CPU resource requests                                                     | `200m`                                      |
-| `clusterchecksDeployment.resources.limits.cpu`           | CPU resource limits                                                       | `200m`                                      |
-| `clusterchecksDeployment.resources.requests.memory`      | Memory resource requests                                                  | `256Mi`                                     |
-| `clusterchecksDeployment.resources.limits.memory`        | Memory resource limits                                                    | `256Mi`                                     |
-| `clusterchecksDeployment.nodeSelector`                   | Node selectors                                                            | `nil`                                       |
-| `clusterchecksDeployment.affinity`                       | Node affinities                                                           | avoid running pods on the same node         |
-| `clusterchecksDeployment.livenessProbe`                  | Overrides the default liveness probe                                      | http port 5555                              |
+| `clusterchecksDeployment.env`                            | Additional Datadog environment variables for Cluster Checks Deployment                        | `nil`                                       |
+| `clusterchecksDeployment.resources.requests.cpu`         | CPU resource requests                                                                         | `200m`                                      |
+| `clusterchecksDeployment.resources.limits.cpu`           | CPU resource limits                                                                           | `200m`                                      |
+| `clusterchecksDeployment.resources.requests.memory`      | Memory resource requests                                                                      | `256Mi`                                     |
+| `clusterchecksDeployment.resources.limits.memory`        | Memory resource limits                                                                        | `256Mi`                                     |
+| `clusterchecksDeployment.nodeSelector`                   | Node selectors                                                                                | `nil`                                       |
+| `clusterchecksDeployment.affinity`                       | Node affinities                                                                               | avoid running pods on the same node         |
+| `clusterchecksDeployment.livenessProbe`                  | Overrides the default liveness probe                                                          | http port 5555                              |
+| `clusterchecksDeployment.rbac.dedicated`                  | If true, use dedicated RBAC resources for clusterchecks agent's pods                          | `false`                                     |
+| `clusterchecksDeployment.rbac.serviceAccount`            | existing ServiceAccount to use (ignored if rbac.create=true) for clusterchecks                | `default`                                   |

--- a/stable/datadog/templates/agent-clusterchecks-clusterrolebinding.yaml
+++ b/stable/datadog/templates/agent-clusterchecks-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create (not .Values.clusterchecksDeployment.rbac.dedicated) -}}
+{{- if and .Values.rbac.create .Values.clusterAgent.enabled .Values.clusterAgent.clusterChecks.enabled .Values.clusterchecksDeployment.enabled -}}
 apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
@@ -7,13 +7,13 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-  name: {{ template "datadog.fullname" . }}
+  name: {{ template "datadog.fullname" . }}-cluster-checks
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ template "datadog.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "datadog.fullname" . }}
+    name: {{ template "datadog.fullname" . }}-cluster-checks
     namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/stable/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/stable/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clusterAgent.clusterChecks.enabled .Values.clusterchecksDeployment.enabled }}
+{{- if and .Values.clusterAgent.enabled .Values.clusterAgent.clusterChecks.enabled .Values.clusterchecksDeployment.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -16,7 +16,11 @@ spec:
         app: {{ template "datadog.fullname" . }}-clusterchecks
       name: {{ template "datadog.fullname" . }}-clusterchecks
     spec:
+      {{- if .Values.clusterchecksDeployment.rbac.dedicated }}
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "datadog.fullname" . }}-cluster-checks{{ else }}"{{ .Values.clusterchecksDeployment.rbac.serviceAccountName }}"{{ end }}
+      {{- else }}
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "datadog.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      {{- end }}
       containers:
       - name: {{ default .Chart.Name .Values.datadog.name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/datadog/templates/agent-clusterchecks-serviceaccount.yaml
+++ b/stable/datadog/templates/agent-clusterchecks-serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.rbac.create .Values.clusterAgent.enabled .Values.clusterAgent.clusterChecks.enabled .Values.clusterchecksDeployment.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: "{{ template "datadog.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+  name: {{ template "datadog.fullname" . }}-cluster-checks
+{{- end -}}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -508,6 +508,16 @@ clusterchecksDeployment:
   #
   enabled: false
 
+  rbac:
+    ## @param dedicated - boolean - required
+    ## If true, use a dedicated RBAC resource for the cluster checks agent(s)
+    #
+    dedicated: false
+    ## @param serviceAccountName - string - required
+    ## Ignored if rbac.create is true
+    #
+    serviceAccountName: default
+
   ## @param replicas - integer - required
   ## If you want to deploy the cluckerchecks agent in HA, keep at least clusterchecksDeployment.replicas set to 2.
   ## And increase the clusterchecksDeployment.replicas according to the number of Cluster Checks.


### PR DESCRIPTION
#### What this PR does / why we need it:

If a user choose to deploy a dedicated agent deployment for running
the cluster checks, the agent RBAC is updated in order to give only
ClusterRole permission to the Agent that need it.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
