### PR TITLE
[incubator/pypiserver] Introduce PyPI server chart

### DIFF
--- a/incubator/pypiserver/.helmignore
+++ b/incubator/pypiserver/.helmignore
@@ -1,0 +1,2 @@
+.git
+OWNERS

--- a/incubator/pypiserver/Chart.yaml
+++ b/incubator/pypiserver/Chart.yaml
@@ -8,5 +8,5 @@ sources:
   - https://github.com/pypiserver/pypiserver
   - https://pypi.org/project/pypiserver/
 maintainers:
-  - name: Clement Gautier
+  - name: ClementGautier
     email: clement@gautier.im

--- a/incubator/pypiserver/Chart.yaml
+++ b/incubator/pypiserver/Chart.yaml
@@ -1,0 +1,12 @@
+name: pypiserver
+home: https://github.com/pypiserver/pypiserver
+version: 0.0.1
+appVersion: 1.2.7
+description: PyPI compatible server for pip or easy_install.
+icon: https://raw.githubusercontent.com/pypiserver/pypiserver/master/pypiserver_logo.png
+sources:
+  - https://github.com/pypiserver/pypiserver
+  - https://pypi.org/project/pypiserver/
+maintainers:
+  - name: Clement Gautier
+    email: clement@gautier.im

--- a/incubator/pypiserver/OWNERS
+++ b/incubator/pypiserver/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- ClementGautier
+reviewers:
+- ClementGautier

--- a/incubator/pypiserver/README.md
+++ b/incubator/pypiserver/README.md
@@ -1,0 +1,68 @@
+# PyPi Sever Helm Chart
+
+This chart installs a PyPI server
+
+## Prerequisites Details
+
+* Kubernetes 1.6+
+* PV dynamic provisioning support on the underlying infrastructure
+
+## Todo
+
+* Document a setup using a `ReadWriteMany` storage that is resilient and scallable.
+* Maybe use part of pypicloud in order to use S3 or GCS backend storage.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release incubator/pypisever
+```
+
+## Upgrading the Charts
+
+Updating the chart is as straightforward as updating the helm release
+
+```bash
+$ helm upgrade my-release incubator/pypisever
+```
+
+## Configuration
+
+The following tables lists the configurable parameters of the PyPI server chart and their default values.
+
+| Parameter                          | Description                                                    | Default                 |
+| ---------------------------------- | -------------------------------------------------------------- | ----------------------- |
+| `replicaCount`                     | Deployment replica count                                       | `1`                     |
+| `image.repository`                 | Container image repository                                     | `pypiserver/pypiserver` |
+| `image.tag`                        | Container image name                                           | `v1.2.7`                |
+| `image.pullPolicy`                 | Container pull policy                                          | `IfNotPresent`          |
+| `image.pullSecrets`                | Container pull secrets                                         | `[]`                    |
+| `auth.actions`                     | Actions requiring authentication (comma separated list)        | `update`                |
+| `auth.credentials`                 | Map of username / encoded password to write in a htpasswd file | `{}`                    |
+| `ingress.enabled`                  | Ingress configuration flag                                     | `false`                 |
+| `ingress.labels`                   | Ingress labels                                                 | `{}`                    |
+| `ingress.annotations`              | Ingress annotations                                            | `{}`                    |
+| `ingress.path`                     | Ingress path                                                   | `nil`                   |
+| `ingress.tls`                      | Ingress TLS configuration                                      | `[]`                    |
+| `service.type`                     | Service type                                                   | `ClusterIP`             |
+| `service.port`                     | Service port                                                   | `8080`                  |
+| `service.annotations`              | Service annotations                                            | `{}`                    |
+| `service.labels`                   | Service labels                                                 | `{}`                    |
+| `service.clusterIP`                | Service cluster IP                                             | `""`                    |
+| `service.externalIPs`              | Service external IPs                                           | `[]`                    |
+| `service.loadBalancerIP`           | Service load balancer IP                                       | `""`                    |
+| `service.loadBalancerSourceRanges` | Service load balancer CIDR ranges                              | `[]`                    |
+| `service.nodePort`                 | Service node port                                              | `nil`                   |
+| `persistence.enabled`              | Persistence configuration flag                                 | `false`                 |
+| `persistence.storageClass`         | Persistence storage class                                      | `nil`                   |
+| `persistence.existingClaim`        | Persistent volume claim static name                            | `nil`                   |
+| `persistence.accessMode`           | Persistence access mode                                        | `ReadWriteOnce`         |
+| `persistence.size`                 | Persistence volume size                                        | `5Gi`                   |
+| `resources`                        | Resources configuration bloc                                   | `{}`                    |
+| `nodeSelector`                     | Node selector of the deployment                                | `{}`                    |
+| `tolerations`                      | Tolerations configuration for the deployment                   | `[]`                    |
+| `affinity`                         | Affinity of the deployment                                     | `{}`                    |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/incubator/pypiserver/templates/NOTES.txt
+++ b/incubator/pypiserver/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "pypiserver.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "pypiserver.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "pypiserver.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "pypiserver.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.port }}
+{{- end }}

--- a/incubator/pypiserver/templates/_helpers.tpl
+++ b/incubator/pypiserver/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "pypiserver.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "pypiserver.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/pypiserver/templates/deployment.yaml
+++ b/incubator/pypiserver/templates/deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "pypiserver.fullname" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ template "pypiserver.name" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+        app.kubernetes.io/name: {{ template "pypiserver.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "pypiserver.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      containers:
+        - name: {{ template "pypiserver.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["pypi-server"]
+          args: ["-P", "/config/.htpasswd", "-a", "{{ .Values.auth.actions }}", "-p", "8080", "/data/packages"]
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /data/packages
+              name: packages
+            - mountPath: /config
+              name: secrets
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            timeoutSeconds: 3
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: secrets
+          secret:
+            secretName: {{ template "pypiserver.fullname" . }}
+        - name: packages
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "pypiserver.fullname" . }}{{- end }}
+        {{- else }}
+          emptyDir: {}
+        {{ end }}
+
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/incubator/pypiserver/templates/ingress.yaml
+++ b/incubator/pypiserver/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "pypiserver.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ template "pypiserver.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $servicePort }}
+  {{- end }}
+{{- end }}

--- a/incubator/pypiserver/templates/pvc.yaml
+++ b/incubator/pypiserver/templates/pvc.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.persistence.enabled -}}
+{{- if not .Values.persistence.existingClaim -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "pypiserver.fullname" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ template "pypiserver.name" . }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/incubator/pypiserver/templates/secret.yaml
+++ b/incubator/pypiserver/templates/secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+stringData:
+  .htpasswd: |-
+  {{- range $key, $value := .Values.auth.credentials }}
+    {{ $key }}:{{ $value }}
+  {{- end }}
+metadata:
+  name: {{ template "pypiserver.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "pypiserver.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/incubator/pypiserver/templates/service.yaml
+++ b/incubator/pypiserver/templates/service.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "pypiserver.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "pypiserver.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Values.service.labels }}
+    {{- toYaml .Values.service.labels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.service.annotations }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+  {{- end }}
+spec:
+{{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}
+  type: ClusterIP
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{end}}
+{{- else if eq .Values.service.type "LoadBalancer" }}
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.service.type }}
+{{- end }}
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      protocol: TCP
+      targetPort: 8080
+{{ if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+      nodePort: {{.Values.service.nodePort}}
+{{ end }}
+  selector:
+    app.kubernetes.io/name: {{ template "pypiserver.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/incubator/pypiserver/values.yaml
+++ b/incubator/pypiserver/values.yaml
@@ -1,0 +1,80 @@
+## If you want more than 1 replica you will have to use a ReadWriteMany volume
+replicaCount: 1
+
+image:
+  repository: pypiserver/pypiserver
+  tag: v1.2.7
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+auth:
+  ## comma-separated list of (case-insensitive) actions to authenticate
+  ## Use '.' or '' for empty. Requires to have set the password (option below).
+  ## Available actions are update, download and list
+  actions: update
+  ## List of username / encoded passwords that will be put to the htpasswd file
+  ## use `htpasswd -n -b username password` to generate them
+  credentials: {}
+
+ingress:
+  enabled: false
+  labels: {}
+  annotations: {}
+  # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
+  # path: "/pypiserver"
+  tls: []
+  # - secretName: pypiserver.cluster.local
+  #   hosts:
+  #     - pypiserver.cluster.local
+
+service:
+  type: ClusterIP
+  port: 8080
+  annotations: {}
+  labels: {}
+  clusterIP: ""
+  ## List of IP addresses at which the pypiserver service is available
+  ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+  externalIPs: []
+  loadBalancerIP: ""
+  loadBalancerSourceRanges: []
+  # nodePort: 30000
+
+persistence:
+  enabled: false
+  ## PyPi server packages Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  ##
+  ## If you want to reuse an existing claim, you can pass the name of the PVC
+  ## using the existingClaim variable
+  # existingClaim: your-claim
+  ##
+  ## The Access mode should be ReadWriteMany if you decide to scale up to more
+  ## than one replica
+  accessMode: ReadWriteOnce
+  size: 5Gi
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
This pull request introduce a new chart that deploy a PyPI server (https://pypi.org/project/pypiserver/ / https://github.com/pypiserver/pypiserver). Pypi server is a private registry for python packages well known in the cimmunity.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
From what I understand PyPI server basically act as a very simple simple webserver, listing packages (tar.gz) to the end user so the `pip` or `easy_install` command line interface can use this registry instead of using pypi.org.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
