### PR TITLE
[stable/elasticsearch-exporter] Extending ServiceMonitor configuration

### DIFF
--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 1.1.3
+version: 1.2.0
 appVersion: 1.0.2
 home: https://github.com/justwatchcom/elasticsearch_exporter
 sources:

--- a/stable/elasticsearch-exporter/README.md
+++ b/stable/elasticsearch-exporter/README.md
@@ -67,7 +67,11 @@ Parameter | Description | Default
 `es.ssl.client.key` | Private key for client auth when connecting to Elasticsearch |
 `web.path` | path under which to expose metrics | `/metrics`
 `serviceMonitor.enabled` | If true, a ServiceMonitor CRD is created for a prometheus operator | `false`
+`serviceMonitor.namespace` | If set, the ServiceMonitor will be installed in a different namespace  | `""`
 `serviceMonitor.labels` | Labels for prometheus operator | `{}`
+`serviceMonitor.interval` | Interval at which metrics should be scraped | `10s`
+`serviceMonitor.scrapeTimeout` | Timeout after which the scrape is ended | `10s`
+`serviceMonitor.scheme` | Scheme to use for scraping | `http`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/elasticsearch-exporter/templates/servicemonitor.yaml
+++ b/stable/elasticsearch-exporter/templates/servicemonitor.yaml
@@ -4,6 +4,9 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "elasticsearch-exporter.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
   labels:
     chart: {{ template "elasticsearch-exporter.chart" . }}
     app: {{ template "elasticsearch-exporter.name" . }}
@@ -14,11 +17,14 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-  - interval: 10s
+  - interval: {{ .Values.serviceMonitor.interval }}
+    {{- if .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- end }}
     honorLabels: true
     port: http
     path: {{ .Values.web.path }}
-    scheme: http
+    scheme: {{ .Values.serviceMonitor.scheme }}
   jobLabel: "{{ .Release.Name }}"
   selector:
     matchLabels:

--- a/stable/elasticsearch-exporter/values.yaml
+++ b/stable/elasticsearch-exporter/values.yaml
@@ -84,4 +84,8 @@ serviceMonitor:
   ## https://github.com/coreos/prometheus-operator
   ##
   enabled: false
+  #  namespace: monitoring
   labels: {}
+  interval: 10s
+  scrapeTimeout: 10s
+  scheme: http


### PR DESCRIPTION
#### What this PR does / why we need it:
Extending the Prometheus ServiceMonitor configuration for following properties:
- namespace
- interval
- scrapeTimeout
- scheme

#### Which issue this PR fixes
--

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md