### PR TITLE
[stable][chartmuseum] Allow use of Bearer Auth

### DIFF
--- a/stable/chartmuseum/Chart.yaml
+++ b/stable/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 2.1.0
+version: 2.2.0
 appVersion: 0.8.2
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/helm/chartmuseum/master/logo2.png

--- a/stable/chartmuseum/templates/deployment.yaml
+++ b/stable/chartmuseum/templates/deployment.yaml
@@ -77,6 +77,10 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
+{{- if .Values.bearerAuth.secret.enabled }}
+        -  name: AUTH_CERT_PATH
+           value: /var/keys/public-key.pem
+{{ end }}
         args:
         - --port=8080
 {{- if eq .Values.env.open.STORAGE "local" }}
@@ -95,20 +99,23 @@ spec:
             path: {{ .Values.env.open.CONTEXT_PATH }}/health
             port: http
 {{ toYaml .Values.probes.readiness | indent 10 }}
-{{- if eq .Values.env.open.STORAGE "local" }}
         volumeMounts:
+{{- if eq .Values.env.open.STORAGE "local" }}
         - mountPath: /storage
           name: storage-volume
 {{- end }}
 {{- if  .Values.gcp.secret.enabled }}
-        volumeMounts:
         - mountPath: /etc/secrets/google
           name: {{ include "chartmuseum.fullname" . }}-gcp
 {{- end }}
 {{- if  .Values.oracle.secret.enabled }}
-        volumeMounts:
         - mountPath: /home/chartmuseum/.oci
           name: {{ include "chartmuseum.fullname" . }}-oracle
+{{- end }}
+{{- if .Values.bearerAuth.secret.enabled }}
+        - name: public-key
+          mountPath: /var/keys
+          readOnly: true
 {{- end }}
       {{- with .Values.resources }}
         resources:
@@ -168,3 +175,8 @@ spec:
           - key: {{ .Values.oracle.secret.key_file }}
             path: oci.key
       {{ end }}
+{{- if .Values.bearerAuth.secret.enabled }}
+      - name: public-key
+        secret:
+          secretName: {{ .Values.bearerAuth.secret.publicKeySecret }}
+{{- end }}

--- a/stable/chartmuseum/values.yaml
+++ b/stable/chartmuseum/values.yaml
@@ -84,6 +84,12 @@ env:
     CACHE_REDIS_ADDR:
     # Redis database to be selected after connect
     CACHE_REDIS_DB: 0
+    # enable bearer auth
+    BEARER_AUTH: false
+    # auth realm used for bearer auth
+    AUTH_REALM:
+    # auth service used for bearer auth
+    AUTH_SERVICE:
   field:
     # POD_IP: status.podIP
   secret:
@@ -249,3 +255,7 @@ oracle:
     config: config
     # Secret key that holds the oci private key
     key_file: key_file
+bearerAuth:
+  secret:
+    enabled: false
+    publicKeySecret: chartmuseum-public-key


### PR DESCRIPTION
Signed-off-by: Gerald Barker <gerald.barker@gmail.com>

#### What this PR does / why we need it:
* Allows the public key needed for bearer/token auth to be mounted from a secret
* Added the relevant bearer/token parameters to the values file 
* Added an authentication section to the README along with examples

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
