### PR TITLE
[incubator/sentry-kubernetes] Add optional PodDisruptionBudget

### DIFF
--- a/incubator/sentry-kubernetes/Chart.yaml
+++ b/incubator/sentry-kubernetes/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for sentry-kubernetes (https://github.com/getsentry/sentry-kubernetes)
 name: sentry-kubernetes
-version: 0.1.6
+version: 0.1.7
 appVersion: latest
 home: https://github.com/getsentry/sentry-kubernetes
 sources:

--- a/incubator/sentry-kubernetes/README.md
+++ b/incubator/sentry-kubernetes/README.md
@@ -22,3 +22,4 @@ The following table lists the configurable parameters of the sentry-kubernetes c
 | `rbac.create`           | If `true`, create and use RBAC resources                                                                                    | `true`                        |
 | `serviceAccount.name`   | Service account to be used. If not set and serviceAccount.create is `true`, a name is generated using the fullname template | ``                            |
 | `serviceAccount.create` | If true, create a new service account                                                                                       | `true`                        |
+| `podDisruptionBudget`   | If set, create a PodDisruptionBudget with the items in this map set in the spec                                             | ``                            |

--- a/incubator/sentry-kubernetes/templates/pdb.yaml
+++ b/incubator/sentry-kubernetes/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels: {{ include "sentry-kubernetes.labels" . | indent 4 }}
+  name: {{ template "sentry-kubernetes.fullname" . }}
+
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "sentry-kubernetes.name" . }}
+{{ toYaml .Values.podDisruptionBudget | indent 2 }}
+{{- end -}}

--- a/incubator/sentry-kubernetes/values.yaml
+++ b/incubator/sentry-kubernetes/values.yaml
@@ -24,3 +24,7 @@ serviceAccount:
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
+
+# The values to set in the PodDisruptionBudget spec (minAvailable/maxUnavailable)
+# If not set then a PodDisruptionBudget will not be created
+podDisruptionBudget:


### PR DESCRIPTION
@gianrubio 

#### What this PR does / why we need it: Adds an optional PodDisruptionBudget

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
