### PR TITLE
[stable/prometheus-blackbox-exporter] add option to store config as a Secret

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 0.2.1
+version: 0.3.0
 appVersion: 0.14.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/README.md
+++ b/stable/prometheus-blackbox-exporter/README.md
@@ -44,7 +44,7 @@ The following table lists the configurable parameters of the Blackbox-Exporter c
 |               Parameter                |                    Description                    |            Default            |
 | -------------------------------------- | ------------------------------------------------- | ----------------------------- |
 | `config`                               | Prometheus blackbox configuration                 | {}                            |
-| `secretConfig`                         | Whether to treat blackbox configuration as secret | false                         |
+| `secretConfig`                         | Whether to treat blackbox configuration as secret | `false`                       |
 | `configmapReload.name`                 | configmap-reload container name                   | `configmap-reload`            |
 | `configmapReload.image.repository`     | configmap-reload container image repository       | `jimmidyson/configmap-reload` |
 | `configmapReload.image.tag`            | configmap-reload container image tag              | `v0.2.2`                      |

--- a/stable/prometheus-blackbox-exporter/README.md
+++ b/stable/prometheus-blackbox-exporter/README.md
@@ -41,35 +41,36 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Blackbox-Exporter chart and their default values.
 
-|               Parameter                |                   Description                   |            Default            |
-| -------------------------------------- | ----------------------------------------------- | ----------------------------- |
-| `config`                               | Prometheus blackbox configuration               | {}                            |
-| `configmapReload.name`                 | configmap-reload container name                 | `configmap-reload`            |
-| `configmapReload.image.repository`     | configmap-reload container image repository     | `jimmidyson/configmap-reload` |
-| `configmapReload.image.tag`            | configmap-reload container image tag            | `v0.2.2`                      |
-| `configmapReload.image.pullPolicy`     | configmap-reload container image pull policy    | `IfNotPresent`                |
-| `configmapReload.extraArgs`            | Additional configmap-reload container arguments | `{}`                          |
-| `configmapReload.extraConfigmapMounts` | Additional configmap-reload configMap mounts    | `[]`                          |
-| `configmapReload.resources`            | configmap-reload pod resource requests & limits | `{}`                          |
-| `extraArgs`                            | Optional flags for blackbox                     | `[]`                          |
-| `image.repository`                     | container image repository                      | `prom/blackbox-exporter`      |
-| `image.tag`                            | container image tag                             | `v0.14.0`                     |
-| `image.pullPolicy`                     | container image pull policy                     | `IfNotPresent`                |
-| `ingress.annotations`                  | Ingress annotations                             | None                          |
-| `ingress.enabled`                      | Enables Ingress                                 | `false`                       |
-| `ingress.hosts`                        | Ingress accepted hostnames                      | None                          |
-| `ingress.tls`                          | Ingress TLS configuration                       | None                          |
-| `nodeSelector`                         | node labels for pod assignment                  | `{}`                          |
-| `tolerations`                          | node tolerations for pod assignment             | `[]`                          |
-| `affinity`                             | node affinity for pod assignment                | `{}`                          |
-| `podAnnotations`                       | annotations to add to each pod                  | `{}`                          |
-| `resources`                            | pod resource requests & limits                  | `{}`                          |
-| `restartPolicy`                        | container restart policy                        | `Always`                      |
-| `service.annotations`                  | annotations for the service                     | `{}`                          |
-| `service.labels`                       | additional labels for the service               | None                          |
-| `service.type`                         | type of service to create                       | `ClusterIP`                   |
-| `service.port`                         | port for the blackbox http service              | `9115`                        |
-| `service.externalIPs`                  | list of external ips                            | []                            |
+|               Parameter                |                    Description                    |            Default            |
+| -------------------------------------- | ------------------------------------------------- | ----------------------------- |
+| `config`                               | Prometheus blackbox configuration                 | {}                            |
+| `secretConfig`                         | Whether to treat blackbox configuration as secret | false                         |
+| `configmapReload.name`                 | configmap-reload container name                   | `configmap-reload`            |
+| `configmapReload.image.repository`     | configmap-reload container image repository       | `jimmidyson/configmap-reload` |
+| `configmapReload.image.tag`            | configmap-reload container image tag              | `v0.2.2`                      |
+| `configmapReload.image.pullPolicy`     | configmap-reload container image pull policy      | `IfNotPresent`                |
+| `configmapReload.extraArgs`            | Additional configmap-reload container arguments   | `{}`                          |
+| `configmapReload.extraConfigmapMounts` | Additional configmap-reload configMap mounts      | `[]`                          |
+| `configmapReload.resources`            | configmap-reload pod resource requests & limits   | `{}`                          |
+| `extraArgs`                            | Optional flags for blackbox                       | `[]`                          |
+| `image.repository`                     | container image repository                        | `prom/blackbox-exporter`      |
+| `image.tag`                            | container image tag                               | `v0.14.0`                     |
+| `image.pullPolicy`                     | container image pull policy                       | `IfNotPresent`                |
+| `ingress.annotations`                  | Ingress annotations                               | None                          |
+| `ingress.enabled`                      | Enables Ingress                                   | `false`                       |
+| `ingress.hosts`                        | Ingress accepted hostnames                        | None                          |
+| `ingress.tls`                          | Ingress TLS configuration                         | None                          |
+| `nodeSelector`                         | node labels for pod assignment                    | `{}`                          |
+| `tolerations`                          | node tolerations for pod assignment               | `[]`                          |
+| `affinity`                             | node affinity for pod assignment                  | `{}`                          |
+| `podAnnotations`                       | annotations to add to each pod                    | `{}`                          |
+| `resources`                            | pod resource requests & limits                    | `{}`                          |
+| `restartPolicy`                        | container restart policy                          | `Always`                      |
+| `service.annotations`                  | annotations for the service                       | `{}`                          |
+| `service.labels`                       | additional labels for the service                 | None                          |
+| `service.type`                         | type of service to create                         | `ClusterIP`                   |
+| `service.port`                         | port for the blackbox http service                | `9115`                        |
+| `service.externalIPs`                  | list of external ips                              | []                            |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-blackbox-exporter/ci/secret-values.yaml
+++ b/stable/prometheus-blackbox-exporter/ci/secret-values.yaml
@@ -1,0 +1,1 @@
+secretConfig: true

--- a/stable/prometheus-blackbox-exporter/templates/configmap.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/configmap.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.config }}
 apiVersion: v1
-kind: ConfigMap
+kind: {{ if .Values.secretConfig -}} Secret {{- else -}} ConfigMap {{- end }}
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}
   labels:
@@ -8,7 +8,7 @@ metadata:
     app: {{ template "prometheus-blackbox-exporter.name" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-data:
+{{ if .Values.secretConfig -}} stringData: {{- else -}} data: {{- end }}
   blackbox.yaml: |
 {{ toYaml .Values.config | indent 4 }}
 {{- end }}

--- a/stable/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -87,12 +87,11 @@ spec:
               name: config
               readOnly: true
       volumes:
-{{- if .Values.secretConfig }}
         - name: config
+{{- if .Values.secretConfig }}
           secret:
             secretName: {{ template "prometheus-blackbox-exporter.fullname" . }}
 {{- else }}
-        - name: config
           configMap:
             name: {{ template "prometheus-blackbox-exporter.fullname" . }}
 {{- end }}

--- a/stable/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -87,7 +87,12 @@ spec:
               name: config
               readOnly: true
       volumes:
+{{- if .Values.secretConfig }}
+        - name: config
+          secret:
+            secretName: {{ template "prometheus-blackbox-exporter.fullname" . }}
+{{- else }}
         - name: config
           configMap:
             name: {{ template "prometheus-blackbox-exporter.fullname" . }}
-
+{{- end }}

--- a/stable/prometheus-blackbox-exporter/values.yaml
+++ b/stable/prometheus-blackbox-exporter/values.yaml
@@ -9,6 +9,7 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
+secretConfig: false
 config:
   modules:
     http_2xx:


### PR DESCRIPTION
#### What this PR does / why we need it:

This adds the ability to store blackbox config as a Secret, which is a more appropriate place if the blackbox config includes http credentials.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
