### PR TITLE
Prometheus retention time: This flag has been deprecated in favour of…

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 8.9.1
+version: 8.9.2
 appVersion: 2.8.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -87,7 +87,7 @@ spec:
           {{- end }}
           args:
           {{- if .Values.server.retention }}
-            - --storage.tsdb.retention={{ .Values.server.retention }}
+            - --storage.tsdb.retention.time={{ .Values.server.retention }}
           {{- end }}
             - --config.file={{ .Values.server.configPath }}
             - --storage.tsdb.path={{ .Values.server.persistentVolume.mountPath }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This flag is deprecated.

--storage.tsdb.retention: This flag has been deprecated in favour of storage.tsdb.retention.time.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
