### PR TITLE
[bookstack] Fix persistance path for storage files to match paths mentioned in bookstack docs

### DIFF
--- a/stable/bookstack/Chart.yaml
+++ b/stable/bookstack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.25.2
 description: BookStack is a simple, self-hosted, easy-to-use platform for organising and storing information.
 name: bookstack
-version: 1.1.3
+version: 1.1.0
 home: https://www.bookstackapp.com/
 icon: https://github.com/BookStackApp/website/blob/master/static/images/logo.png
 sources:

--- a/stable/bookstack/Chart.yaml
+++ b/stable/bookstack/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.26.2
+appVersion: 0.25.2
 description: BookStack is a simple, self-hosted, easy-to-use platform for organising and storing information.
 name: bookstack
-version: 1.0.3
+version: 1.1.3
 home: https://www.bookstackapp.com/
 icon: https://github.com/BookStackApp/website/blob/master/static/images/logo.png
 sources:

--- a/stable/bookstack/Chart.yaml
+++ b/stable/bookstack/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.25.2
+appVersion: 0.26.2
 description: BookStack is a simple, self-hosted, easy-to-use platform for organising and storing information.
 name: bookstack
 version: 1.0.3

--- a/stable/bookstack/templates/deployment.yaml
+++ b/stable/bookstack/templates/deployment.yaml
@@ -89,7 +89,7 @@ spec:
           - name: uploads
             mountPath: /var/www/bookstack/public/uploads
           - name: storage
-            mountPath: /var/www/bookstack/public/storage
+            mountPath: /var/www/bookstack/storage/uploads
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:


### PR DESCRIPTION
#### What this PR does / why we need it:
As per https://www.bookstackapp.com/docs/admin/backup-restore/, the paths that should be backed up are `storage/uploads` and `public/uploads`. Otherwise, attachments are not persisted which causes data loss on restart. 
The current version does not persist `storage/uploads`, instead, it persists `public/storage` which is not mentioned in the docs above anywhere.

#### Which issue this PR fixes
  - fixes #12539 

#### Special notes for your reviewer:
Changed minor as this might be breaking change for anyone who uses it.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

Signed-off-by: Rafal Gembalik <rafal.gembalik@codewave.pl>
