### PR TITLE
Update elastic-stack to use correct Kibana chart

### DIFF
--- a/stable/elastic-stack/Chart.yaml
+++ b/stable/elastic-stack/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart for ELK
 home: https://www.elastic.co/products
 icon: https://www.elastic.co/assets/bltb35193323e8f1770/logo-elastic-stack-lt.svg
 name: elastic-stack
-version: 1.5.1
+version: 1.6.0
 appVersion: 6.0
 maintainers:
 - name: rendhalver

--- a/stable/elastic-stack/requirements.lock
+++ b/stable/elastic-stack/requirements.lock
@@ -4,10 +4,10 @@ dependencies:
   version: 1.22.0
 - name: kibana
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 2.0.0
+  version: 2.2.0
 - name: filebeat
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.5.0
+  version: 1.5.1
 - name: logstash
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 1.6.0
@@ -25,9 +25,9 @@ dependencies:
   version: 0.1.2
 - name: elasticsearch-curator
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.2.1
+  version: 1.3.2
 - name: elasticsearch-exporter
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 1.1.3
-digest: sha256:864b4833a330aa2a6c2331c3565241edb1b12f09ed6ebaefad849f1d3d208804
-generated: 2019-03-28T15:49:30.778303879-04:00
+digest: sha256:c64f0ce3be369001b814ba8fd0d04fa38c09657b327ba6fa21fcf73e1e57e2e7
+generated: 2019-04-02T18:40:18.875184031+04:00

--- a/stable/elastic-stack/requirements.yaml
+++ b/stable/elastic-stack/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: elasticsearch.enabled
 - name: kibana
-  version: ^2.0.0
+  version: ^2.2.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: kibana.enabled
 - name: filebeat


### PR DESCRIPTION
Signed-off-by: Bagrat Lazaryan <bagratte@live.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
@rendhalver @jar361 @christian-roggia 
This PR updates Kibana chart dependency from version 2.0.0 to version 2.2.0. In chart version 2.0.0, Kibana app version 6.6.1 is installed which is behind and incompatible with the rest of the components of Elastic Stack, all versioned 6.7.0.

#### Which issue this PR fixes
  - none

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
