### PR TITLE
[incubator/kafka] Fixed typo in notes

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.14.0
+version: 0.14.1
 appVersion: 5.0.1
 keywords:
 - kafka

--- a/incubator/kafka/templates/NOTES.txt
+++ b/incubator/kafka/templates/NOTES.txt
@@ -20,7 +20,7 @@ Once you have the testclient pod above running, you can list all kafka
 topics with:
 
   kubectl -n {{ .Release.Namespace }} exec testclient -- /opt/kafka/bin/kafka-topics.sh --zookeeper {{ .Release.Name }}-zookeeper:2181 --list
-n
+
 To create a new topic:
 
   kubectl -n {{ .Release.Namespace }} exec testclient -- /opt/kafka/bin/kafka-topics.sh --zookeeper {{ .Release.Name }}-zookeeper:2181 --topic test1 --create --partitions 1 --replication-factor 1


### PR DESCRIPTION
Signed-off-by: David Jannotta <djannotta@gmail.com>

#### What this PR does / why we need it:
Removes an extra 'n' in the Kafka notes. Pretty minor.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
