### PR TITLE
[stable/filebeat] Move beat-exporter containerPort into context block

### DIFF
--- a/stable/filebeat/Chart.yaml
+++ b/stable/filebeat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart to collect Kubernetes logs with filebeat
 icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.svg
 name: filebeat
-version: 1.5.1
+version: 1.5.2
 appVersion: 6.7.0
 home: https://www.elastic.co/products/beats/filebeat
 sources:

--- a/stable/filebeat/templates/daemonset.yaml
+++ b/stable/filebeat/templates/daemonset.yaml
@@ -124,9 +124,9 @@ spec:
         resources:
 {{ toYaml .Values.monitoring.resources | indent 10 }}
 {{- end }}
-{{- end }}
         ports:
           - containerPort: {{ .Values.monitoring.exporterPort}}
+{{- end }}
       volumes:
       - name: varlog
         hostPath:


### PR DESCRIPTION
#### What this PR does / why we need it:

Invalid template where beat-exporter containerPort remains in
daemonset template when beat-exporter service is disabled.

#### Which issue this PR fixes

- fixes #12768
