### PR TITLE
[stable/elasticsearch-curator] Add support for init containers

### DIFF
--- a/stable/elasticsearch-curator/Chart.yaml
+++ b/stable/elasticsearch-curator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "5.5.4"
 description: A Helm chart for Elasticsearch Curator
 name: elasticsearch-curator
-version: 1.3.2
+version: 1.4.0
 home: https://github.com/elastic/curator
 keywords:
 - curator

--- a/stable/elasticsearch-curator/README.md
+++ b/stable/elasticsearch-curator/README.md
@@ -52,6 +52,8 @@ their default values.
 | `priorityClassName`                  | priorityClassName                                           | `nil`                                        |
 | `extraVolumeMounts`                  | Mount extra volume(s),                                      |                                              |
 | `extraVolumes`                       | Extra volumes                                               |                                              |
-| `securityContext`                    | Configure PodSecurityContext                          |
+| `securityContext`                    | Configure PodSecurityContext                                |                                              |
+| `initContainers`                     | Init containers to add to the cronjob container             | {}                                           |
+
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.

--- a/stable/elasticsearch-curator/README.md
+++ b/stable/elasticsearch-curator/README.md
@@ -52,8 +52,8 @@ their default values.
 | `priorityClassName`                  | priorityClassName                                           | `nil`                                        |
 | `extraVolumeMounts`                  | Mount extra volume(s),                                      |                                              |
 | `extraVolumes`                       | Extra volumes                                               |                                              |
+| `extraInitContainers`                | Init containers to add to the cronjob container             | {}                                           |
 | `securityContext`                    | Configure PodSecurityContext                                |                                              |
-| `initContainers`                     | Init containers to add to the cronjob container             | {}                                           |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.

--- a/stable/elasticsearch-curator/ci/initcontainer-values.yaml
+++ b/stable/elasticsearch-curator/ci/initcontainer-values.yaml
@@ -1,0 +1,9 @@
+extraInitContainers:
+  test:
+    image: alpine:latest
+    command:
+    - "/bin/sh"
+    - "-c"
+    args:
+    - |
+      true

--- a/stable/elasticsearch-curator/templates/cronjob.yaml
+++ b/stable/elasticsearch-curator/templates/cronjob.yaml
@@ -53,9 +53,9 @@ spec:
           imagePullSecrets:
             - name: {{ .Values.image.pullSecret }}
 {{- end }}
-{{- if .Values.initContainers }}
+{{- if .Values.extraInitContainers }}
           initContainers:
-{{- range $key, $value := .Values.initContainers }}
+{{- range $key, $value := .Values.extraInitContainers }}
           - name: "{{ $key }}"
 {{ toYaml $value | indent 12 }}
 {{- end }}

--- a/stable/elasticsearch-curator/templates/cronjob.yaml
+++ b/stable/elasticsearch-curator/templates/cronjob.yaml
@@ -53,6 +53,13 @@ spec:
           imagePullSecrets:
             - name: {{ .Values.image.pullSecret }}
 {{- end }}
+{{- if .Values.initContainers }}
+          initContainers:
+{{- range $key, $value := .Values.initContainers }}
+          - name: "{{ $key }}"
+{{ toYaml $value | indent 12 }}
+{{- end }}
+{{- end }}
           containers:
             - name: {{ .Chart.Name }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/elasticsearch-curator/values.yaml
+++ b/stable/elasticsearch-curator/values.yaml
@@ -103,3 +103,38 @@ priorityClassName: ""
 
 securityContext:
   runAsUser: 16  # run as cron user instead of root
+
+# Add your own init container or uncomment and modify the given example.
+initContainers: {}
+  ## Don't configure S3 repository till Elasticsearch is reachable.
+  ## Ensure that it is available at http://elasticsearch:9200
+  ##
+  # elasticsearch-s3-repository:
+  #   image: jwilder/dockerize:latest
+  #   imagePullPolicy: "IfNotPresent"
+  #   command:
+  #   - "/bin/sh"
+  #   - "-c"
+  #   args:
+  #   - |
+  #     ES_HOST=elasticsearch
+  #     ES_PORT=9200
+  #     ES_REPOSITORY=backup
+  #     S3_REGION=us-east-1
+  #     S3_BUCKET=bucket
+  #     S3_BASE_PATH=backup
+  #     S3_COMPRESS=true
+  #     S3_STORAGE_CLASS=standard
+  #     apk add curl --no-cache && \
+  #     dockerize -wait http://${ES_HOST}:${ES_PORT} --timeout 120s && \
+  #     cat <<EOF | curl -sS -XPUT -H "Content-Type: application/json" -d @- http://${ES_HOST}:${ES_PORT}/_snapshot/${ES_REPOSITORY} \
+  #     {
+  #       "type": "s3",
+  #       "settings": {
+  #         "bucket": "${S3_BUCKET}",
+  #         "base_path": "${S3_BASE_PATH}",
+  #         "region": "${S3_REGION}",
+  #         "compress": "${S3_COMPRESS}",
+  #         "storage_class": "${S3_STORAGE_CLASS}"
+  #       }
+  #     }

--- a/stable/elasticsearch-curator/values.yaml
+++ b/stable/elasticsearch-curator/values.yaml
@@ -101,11 +101,8 @@ priorityClassName: ""
 #     mountPath: /certs
 #     readOnly: true
 
-securityContext:
-  runAsUser: 16  # run as cron user instead of root
-
 # Add your own init container or uncomment and modify the given example.
-initContainers: {}
+extraInitContainers: {}
   ## Don't configure S3 repository till Elasticsearch is reachable.
   ## Ensure that it is available at http://elasticsearch:9200
   ##
@@ -138,3 +135,6 @@ initContainers: {}
   #         "storage_class": "${S3_STORAGE_CLASS}"
   #       }
   #     }
+
+securityContext:
+  runAsUser: 16  # run as cron user instead of root


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Add support for init containers to be run before the Elasticsearch Curator task. This is useful for checking if the Elasticsearch cluster is available or configuring settings before running a Curator action. A common use case would be to configure an AWS S3 bucket to be used as an Elasticsearch backup repository.

#### Special notes for your reviewer:

This uses the same pattern as the Kibana chart.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
