### PR TITLE
Provide a prometheus exporter for Vault metrics

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.16.1
+version: 0.16.2
 appVersion: 1.0.1
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -11,7 +11,7 @@ This directory contains a Kubernetes chart to deploy a Vault server.
 This chart will do the following:
 
 * Implement a Vault deployment
-* Optionally, deploy a consul agent in the pod
+* Optionally, deploy a consul agent in the pod and a Prometheus exporter for metrics
 
 Please note that a backend service for Vault (for example, Consul) must
 be deployed beforehand and configured with the `vault.config` option. YAML
@@ -60,6 +60,7 @@ The following table lists the configurable parameters of the Vault chart and the
 | `vault.customSecrets`             | Custom secrets available to Vault        | `[]`                                |
 | `vault.existingConfigName`        | Location of existing Vault configuration | nil                                 |
 | `vault.config`                    | Vault configuration                      | No default backend                  |
+| `metrics.enabled`                 | Enable Vault metrics exporter            | false                               |
 | `replicaCount`                    | k8s replicas                             | `3`                                 |
 | `resources.limits.cpu`            | Container requested CPU                  | `nil`                               |
 | `resources.limits.memory`         | Container requested memory               | `nil`                               |
@@ -107,6 +108,24 @@ If you are using the `stable/consul` helm chart, consul communications
 are encrypted with a gossip key.  You can configure a secret with the
 same format as that chart and specify it in the
 `consulAgent.gossipKeySecretName` parameter.
+
+## Optional Vault Metrics
+
+If you enable Vault metrics, uncomment the telemetry options in Vault's config.
+
+```yaml
+vault:
+  config:
+    telemetry:
+      statsite_address: "127.0.0.1:9125"
+```
+
+Once the Vault pod is ready, it can be accessed metrics using `kubectl port-forward`:
+
+```console
+$ kubectl port-forward vault-pod 9102
+$ curl localhost:9102/metrics
+```
 
 ## Using Vault
 

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -34,6 +34,18 @@ spec:
 {{ tpl .Values.vault.extraInitContainers . | indent 6 }}
       {{- end }}
       containers:
+      {{- if .Values.metrics.enabled }}
+      - name: {{ .Chart.Name }}-metrics
+        image: "{{ .Values.metrics.repository }}:{{ .Values.metrics.tag }}"
+        imagePullPolicy: {{ .Values.metrics.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.metrics.statsdPort }}
+          name: exporter-statsd
+          protocol: "UDP"
+        - containerPort: {{ .Values.metrics.promPort }}
+          name: exporter-prom
+          protocol: "TCP"
+      {{- end }}
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -9,6 +9,16 @@ image:
   tag:
   pullPolicy: IfNotPresent
 
+metrics:
+  enabled: False
+
+  repository: prom/statsd-exporter
+  tag: v0.9.0
+  pullPolicy: IfNotPresent
+
+  statsdPort: 9125
+  promPort: 9102
+
 consulAgent:
   repository: consul
   tag: 1.4.0
@@ -176,6 +186,9 @@ vault:
         tls_cipher_suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA
         # tls_cert_file: /vault/tls/server.crt
         # tls_key_file: /vault/tls/server.key
+    #telemetry:
+    #  statsite_address: "127.0.0.1:9125"
+
     # See https://www.vaultproject.io/docs/configuration/storage/ for storage backends
     storage:
       # consul:

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -186,8 +186,8 @@ vault:
         tls_cipher_suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA
         # tls_cert_file: /vault/tls/server.crt
         # tls_key_file: /vault/tls/server.key
-    #telemetry:
-    #  statsite_address: "127.0.0.1:9125"
+   # telemetry:
+   #   statsite_address: "127.0.0.1:9125"
 
     # See https://www.vaultproject.io/docs/configuration/storage/ for storage backends
     storage:


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR allows users to enable telemetry for Vault, users can then use Prometheus to scrape metrics and alert against specific metrics.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
