### PR TITLE
[stable/keycloak] Allow using an existing secret for keycloak admin user

### DIFF
--- a/stable/keycloak/Chart.yaml
+++ b/stable/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 4.8.0
+version: 4.9.0
 appVersion: 5.0.0
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/stable/keycloak/README.md
+++ b/stable/keycloak/README.md
@@ -51,7 +51,9 @@ Parameter | Description | Default
 `keycloak.image.pullSecrets` | Image pull secrets | `[]`
 `keycloak.basepath` | Path keycloak is hosted at | `auth`
 `keycloak.username` | Username for the initial Keycloak admin user | `keycloak`
-`keycloak.password` | Password for the initial Keycloak admin user. If not set, a random 10 characters password is created | `""`
+`keycloak.password` | Password for the initial Keycloak admin user (if `keycloak.existingSecret=""`). If not set, a random 10 characters password is created | `""`
+`keycloak.existingSecret` | Specifies an existing secret to be used for the admin password | `""`
+`keycloak.existingSecretKey` |  The key in `keycloak.existingSecret` that stores the admin password | `password`
 `keycloak.extraInitContainers` | Additional init containers, e. g. for providing themes, etc. Passed through the `tpl` function and thus to be configured a string | `""`
 `keycloak.extraContainers` | Additional sidecar containers, e. g. for a database proxy, such as Google's cloudsql-proxy. Passed through the `tpl` function and thus to be configured a string | `""`
 `keycloak.extraEnv` | Allows the specification of additional environment variables for Keycloak. Passed through the `tpl` function and thus to be configured a string | `""`

--- a/stable/keycloak/templates/keycloak-secret.yaml
+++ b/stable/keycloak/templates/keycloak-secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.keycloak.existingSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,7 +11,8 @@ metadata:
 type: Opaque
 data:
 {{- if .Values.keycloak.password }}
-  password: {{ .Values.keycloak.password | b64enc | quote }}
+        {{ .Values.keycloak.existingSecretKey }}: {{ .Values.keycloak.password | b64enc | quote }}
 {{- else }}
-  password: {{ randAlphaNum 10 | b64enc | quote }}
+        {{ .Values.keycloak.existingSecretKey }}: {{ randAlphaNum 10 | b64enc | quote }}
 {{- end }}
+{{- end}}

--- a/stable/keycloak/templates/statefulset.yaml
+++ b/stable/keycloak/templates/statefulset.yaml
@@ -78,8 +78,12 @@ spec:
             - name: KEYCLOAK_PASSWORD
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.keycloak.existingSecret }}
+                  name: {{ .Values.keycloak.existingSecret }}
+                  {{- else }}
                   name: {{ template "keycloak.fullname" . }}-http
-                  key: password
+                  {{- end }}
+                  key: {{ .Values.keycloak.existingSecretKey }}
           {{- end }}
           {{- if $highAvailability }}
             - name: JGROUPS_DISCOVERY_PROTOCOL

--- a/stable/keycloak/values.yaml
+++ b/stable/keycloak/values.yaml
@@ -49,9 +49,15 @@ keycloak:
   ## Username for the initial Keycloak admin user
   username: keycloak
 
-  ## Password for the initial Keycloak admin user
+  ## Password for the initial Keycloak admin user. Applicable only if existingSecret is not set.
   ## If not set, a random 10 characters password will be used
   password: ""
+
+  # Specifies an existing secret to be used for the admin password
+  existingSecret: ""
+
+  # The key in the existing secret that stores the password
+  existingSecretKey: password
 
   ## Allows the specification of additional environment variables for Keycloak
   extraEnv: |


### PR DESCRIPTION

Signed-off-by: Andres Alvarez <1671935+kir4h@users.noreply.github.com>

#### What this PR does / why we need it:
This PR allows avoiding creation of a secret for keycloak admin and reusing an existing secret for it instead

The use case is being able to read an existing generated secret for  without the need of exposing those secrets to the values.yaml file. (e.g: An external step, could have created those variables beforehand and we just need to consume them)

The other alternative not to have the secret exposed in the yaml file is to leave it blank and have it autogenerated by the chart, but this approach has 2 problems:
* Complexity is not configurable at the moment, so it's harder to be compliant with policies
* Secret is overriden when upgrading, ending up in a scenario where there is a mismatch between the actual admin password (not overriden) and the secret (that is recreated with a new one)

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md