### PR TITLE
[stable/instana-agent] Add instana-agent chart to stable

### DIFF
--- a/stable/instana-agent/.helmignore
+++ b/stable/instana-agent/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+# OWNERS file for helm
+OWNERS

--- a/stable/instana-agent/Chart.yaml
+++ b/stable/instana-agent/Chart.yaml
@@ -1,0 +1,21 @@
+name: instana-agent
+version: 1.0.4
+appVersion: 1.0
+description: Instana Agent for Kubernetes
+home: https://www.instana.com/
+icon: http://instana-management-assets.s3-website-eu-west-1.amazonaws.com/stan_icon_front_black_big.png
+sources:
+  - https://github.com/instana/instana-agent-docker
+maintainers:
+  - name: jbrisbin
+    email: jon.brisbin@instana.com
+  - name: wiggzz
+    email: william.james@instana.com
+  - name: JeroenSoeters
+    email: jeroen.soeters@instana.com
+  - name: fstab
+    email: fabian.staeber@instana.com
+  - name: mdonkers
+    email: miel.donkers@instana.com
+  - name: dlbock
+    email: dahlia.bock@instana.com

--- a/stable/instana-agent/OWNERS
+++ b/stable/instana-agent/OWNERS
@@ -1,0 +1,14 @@
+approvers:
+- jbrisbin
+- wiggzz
+- JeroenSoeters
+- fstab
+- mdonkers
+- dlbock
+reviewers:
+- jbrisbin
+- wiggzz
+- JeroenSoeters
+- fstab
+- mdonkers
+- dlbock

--- a/stable/instana-agent/README.md
+++ b/stable/instana-agent/README.md
@@ -1,0 +1,149 @@
+# Instana
+
+[Instana](https://www.instana.com/) is a Dynamic APM for Microservice Applications
+
+## Introduction
+
+This chart adds the Instana Agent to all schedulable nodes (e.g. by default, not masters) in your cluster via a `DaemonSet`.
+
+## Prerequisites
+
+Kubernetes 1.8.x - 1.13.x
+
+Working `helm` and `tiller`.
+
+_Note:_ Tiller may need a service account and role binding if RBAC is enabled in your cluster. [1]
+
+## Installing the Chart
+
+To configure the installation you can either specify the options on the command line using the **--set** switch, or you can edit **values.yaml**. Either way you should ensure that you set values for:
+
+* agent.key
+* zone.name
+
+If you're in the EU, you'll probably also want to set the regional equivalent values for:
+
+* agent.endpointHost
+* agent.endpointPort
+
+Optionally, if your infrastructure uses a proxy, you should ensure that you set values for:
+
+* agent.pod.proxyHost
+* agent.pod.proxyPort
+* agent.pod.proxyProtocol
+* agent.pod.proxyUser
+* agent.pod.proxyPassword
+* agent.pod.proxyUseDNS
+
+Optionally, if your infrastructure has multiple networks defined, you might need to allow the agent to listen on all addresses (typically with value set to '*'):
+
+* agent.listenAddress
+
+_Note:_ Check the values for the endpoint entries in the [agent backend configuration](https://docs.instana.io/quick_start/agent_configuration/#backend).
+
+To install the chart with the release name `instana-agent` and set the values on the command line run:
+
+```bash
+$ helm install --name instana-agent --namespace instana-agent \
+--set agent.key=INSTANA_AGENT_KEY \
+--set agent.endpointHost=HOST \
+--set agent.endpointPort=PORT \
+--set zone.name=CLUSTER_NAME \
+--set agent.proxyHost=INSTANA_AGENT_PROXY_HOST \
+--set agent.proxyPort=INSTANA_AGENT_PROXY_PORT \
+--set agent.proxyProtocol=INSTANA_AGENT_PROXY_PROTOCOL \
+--set agent.proxyUser=INSTANA_AGENT_PROXY_USER \
+--set agent.proxyPassword=INSTANA_AGENT_PROXY_PASSWORD \
+--set agent.proxyUseDNS=INSTANA_AGENT_PROXY_USE_DNS \
+--set agent.listenAddress=INSTANA_AGENT_HTTP_LISTEN \
+stable/instana-agent
+```
+
+To install the chart with the release name `instana-agent` after editing the **values.yaml** file, run:
+
+```bash
+$ helm install --name instana-agent --namespace instana-agent stable/instana-agent
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `instana-agent` daemon set:
+
+```bash
+$ helm del --purge instana-agent
+```
+
+## Configuration
+
+### Helm Chart
+
+The following table lists the configurable parameters of the Instana chart and their default values.
+
+|             Parameter              |            Description                                                  |                    Default                |
+|------------------------------------|-------------------------------------------------------------------------|-------------------------------------------|
+| `agent.key`                        | Your Instana Agent key                                                  | `nil` You must provide your own key       |
+| `zone.name`                        | Instana zone/cluster name                                               | `nil` You must provide your own zone name |
+| `agent.image.name`                 | The image name to pull                                                  | `instana/agent`                           |
+| `agent.image.tag`                  | The image tag to pull                                                   | `latest`                                  |
+| `agent.image.pullPolicy`           | Image pull policy                                                       | `IfNotPresent`                            |
+| `agent.leaderElectorPort`          | Instana leader elector sidecar port                                     | `42655`                                   |
+| `agent.endpointHost`               | Instana agent backend endpoint host                                     | `saas-us-west-2.instana.io`               |
+| `agent.endpointPort`               | Instana agent backend endpoint port                                     | `443`                                     |
+| `agent.pod.annotations`            | Additional annotations to apply to the pod                              | `{}`                                      |
+| `agent.pod.tolerations`            | Tolerations for pod assignment                                          | `[]`                                      |
+| `agent.pod.proxyHost`              | Hostname/address of a proxy                                             | `nil`                                     |
+| `agent.pod.proxyPort`              | Port of a proxy                                                         | `nil`                                     |
+| `agent.pod.proxyProtocol`          | Proxy protocol (Supported proxy types are "http", "socks4", "socks5")   | `nil`                                     |
+| `agent.pod.proxyUser`              | Username of the proxy auth                                              | `nil`                                     |
+| `agent.pod.proxyPassword`          | Password of the proxy auth                                              | `nil`                                     |
+| `agent.pod.proxyUseDNS`            | Boolean if proxy also does DNS                                          | `nil`                                     |
+| `agent.listenAddress`              | List of addresses to listen on, or "*" for all interfaces               | `nil`                                     |
+| `agent.pod.requests.memory`        | Container memory requests in MiB                                        | `512`                                     |
+| `agent.pod.requests.cpu`           | Container cpu requests in cpu cores                                     | `0.5`                                     |
+| `agent.pod.limits.memory`          | Container memory limits in MiB                                          | `512`                                     |
+| `agent.pod.limits.cpu`             | Container cpu limits in cpu cores                                       | `1.5`                                     |
+| `rbac.clusterRole.create`          | Whether RBAC ClusterRole should be created by this chart                | `true`                                    |
+| `rbac.roleBinding.create`          | Whether RBAC ClusterRoleBinding should be created by this chart         | `true`                                    |
+| `rbac.serviceAccount.create`       | Whether RBAC ServiceAccount should be created by this chart             | `true`                                    |
+| `rbac.serviceAccount.name`         | Name of RBAC ServiceAccount                                             | `instana-agent`                           |
+
+### Agent
+
+There is a [config map](templates/configmap.yaml) which you can edit to configure the agent. This configuration will be used for all instana agents on all nodes.
+
+#### Notes
+
+[1] - [https://docs.helm.sh/using_helm/#installing-helm](https://docs.helm.sh/using_helm/#installing-helm)
+
+Most Kubernetes clusters have RBAC enabled, therefore, create a service account for helm to use, for example:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kube-system
+```
+
+```bash
+$ kubectl create -f tiller-service-account.yaml
+```
+
+Install tiller to your cluster with
+
+```bash
+$ helm init --service-account tiller
+```

--- a/stable/instana-agent/README.md
+++ b/stable/instana-agent/README.md
@@ -93,7 +93,7 @@ The following table lists the configurable parameters of the Instana chart and t
 | `agent.key`                        | Your Instana Agent key                                                  | `nil` You must provide your own key          |
 | `zone.name`                        | Instana zone/cluster name                                               | `nil` You must provide your own zone name    |
 | `agent.image.name`                 | The image name to pull                                                  | `instana/agent`                              |
-| `agent.image.tag`                  | The image tag to pull                                                   | `latest`                                     |
+| `agent.image.tag`                  | The image tag to pull                                                   | `1.0.17`                                     |
 | `agent.image.pullPolicy`           | Image pull policy                                                       | `IfNotPresent`                               |
 | `agent.leaderElectorPort`          | Instana leader elector sidecar port                                     | `42655`                                      |
 | `agent.endpointHost`               | Instana agent backend endpoint host                                     | `saas-us-west-2.instana.io`                  |

--- a/stable/instana-agent/README.md
+++ b/stable/instana-agent/README.md
@@ -39,6 +39,14 @@ Optionally, if your infrastructure has multiple networks defined, you might need
 
 * agent.listenAddress
 
+If your agent requires download key, you should ensure that you set values for it:
+
+* agent.downloadKey
+
+Agent can have APM, INFRASTRUCTURE or AWS mode. Default is APM and if you want to override that, ensure you set value:
+
+* agent.mode
+
 _Note:_ Check the values for the endpoint entries in the [agent backend configuration](https://docs.instana.io/quick_start/agent_configuration/#backend).
 
 To install the chart with the release name `instana-agent` and set the values on the command line run:
@@ -49,6 +57,7 @@ $ helm install --name instana-agent --namespace instana-agent \
 --set agent.endpointHost=HOST \
 --set agent.endpointPort=PORT \
 --set zone.name=CLUSTER_NAME \
+--set agent.downloadKey=INSTANA_DOWNLOAD_KEY \
 --set agent.proxyHost=INSTANA_AGENT_PROXY_HOST \
 --set agent.proxyPort=INSTANA_AGENT_PROXY_PORT \
 --set agent.proxyProtocol=INSTANA_AGENT_PROXY_PROTOCOL \
@@ -79,33 +88,35 @@ $ helm del --purge instana-agent
 
 The following table lists the configurable parameters of the Instana chart and their default values.
 
-|             Parameter              |            Description                                                  |                    Default                |
-|------------------------------------|-------------------------------------------------------------------------|-------------------------------------------|
-| `agent.key`                        | Your Instana Agent key                                                  | `nil` You must provide your own key       |
-| `zone.name`                        | Instana zone/cluster name                                               | `nil` You must provide your own zone name |
-| `agent.image.name`                 | The image name to pull                                                  | `instana/agent`                           |
-| `agent.image.tag`                  | The image tag to pull                                                   | `latest`                                  |
-| `agent.image.pullPolicy`           | Image pull policy                                                       | `IfNotPresent`                            |
-| `agent.leaderElectorPort`          | Instana leader elector sidecar port                                     | `42655`                                   |
-| `agent.endpointHost`               | Instana agent backend endpoint host                                     | `saas-us-west-2.instana.io`               |
-| `agent.endpointPort`               | Instana agent backend endpoint port                                     | `443`                                     |
-| `agent.pod.annotations`            | Additional annotations to apply to the pod                              | `{}`                                      |
-| `agent.pod.tolerations`            | Tolerations for pod assignment                                          | `[]`                                      |
-| `agent.pod.proxyHost`              | Hostname/address of a proxy                                             | `nil`                                     |
-| `agent.pod.proxyPort`              | Port of a proxy                                                         | `nil`                                     |
-| `agent.pod.proxyProtocol`          | Proxy protocol (Supported proxy types are "http", "socks4", "socks5")   | `nil`                                     |
-| `agent.pod.proxyUser`              | Username of the proxy auth                                              | `nil`                                     |
-| `agent.pod.proxyPassword`          | Password of the proxy auth                                              | `nil`                                     |
-| `agent.pod.proxyUseDNS`            | Boolean if proxy also does DNS                                          | `nil`                                     |
-| `agent.listenAddress`              | List of addresses to listen on, or "*" for all interfaces               | `nil`                                     |
-| `agent.pod.requests.memory`        | Container memory requests in MiB                                        | `512`                                     |
-| `agent.pod.requests.cpu`           | Container cpu requests in cpu cores                                     | `0.5`                                     |
-| `agent.pod.limits.memory`          | Container memory limits in MiB                                          | `512`                                     |
-| `agent.pod.limits.cpu`             | Container cpu limits in cpu cores                                       | `1.5`                                     |
-| `rbac.clusterRole.create`          | Whether RBAC ClusterRole should be created by this chart                | `true`                                    |
-| `rbac.roleBinding.create`          | Whether RBAC ClusterRoleBinding should be created by this chart         | `true`                                    |
-| `rbac.serviceAccount.create`       | Whether RBAC ServiceAccount should be created by this chart             | `true`                                    |
-| `rbac.serviceAccount.name`         | Name of RBAC ServiceAccount                                             | `instana-agent`                           |
+|             Parameter              |            Description                                                  |                    Default                   |
+|------------------------------------|-------------------------------------------------------------------------|----------------------------------------------|
+| `agent.key`                        | Your Instana Agent key                                                  | `nil` You must provide your own key          |
+| `zone.name`                        | Instana zone/cluster name                                               | `nil` You must provide your own zone name    |
+| `agent.image.name`                 | The image name to pull                                                  | `instana/agent`                              |
+| `agent.image.tag`                  | The image tag to pull                                                   | `latest`                                     |
+| `agent.image.pullPolicy`           | Image pull policy                                                       | `IfNotPresent`                               |
+| `agent.leaderElectorPort`          | Instana leader elector sidecar port                                     | `42655`                                      |
+| `agent.endpointHost`               | Instana agent backend endpoint host                                     | `saas-us-west-2.instana.io`                  |
+| `agent.endpointPort`               | Instana agent backend endpoint port                                     | `443`                                        |
+| `agent.downloadKey`                | Your Instana Download key                                               | `nil` You must provide your own download key |
+| `agent.mode`                       | Agent mode (Supported values are APM, INFRASTRUCTURE, AWS)              | `APM`                                        |
+| `agent.pod.annotations`            | Additional annotations to apply to the pod                              | `{}`                                         |
+| `agent.pod.tolerations`            | Tolerations for pod assignment                                          | `[]`                                         |
+| `agent.pod.proxyHost`              | Hostname/address of a proxy                                             | `nil`                                        |
+| `agent.pod.proxyPort`              | Port of a proxy                                                         | `nil`                                        |
+| `agent.pod.proxyProtocol`          | Proxy protocol (Supported proxy types are "http", "socks4", "socks5")   | `nil`                                        |
+| `agent.pod.proxyUser`              | Username of the proxy auth                                              | `nil`                                        |
+| `agent.pod.proxyPassword`          | Password of the proxy auth                                              | `nil`                                        |
+| `agent.pod.proxyUseDNS`            | Boolean if proxy also does DNS                                          | `nil`                                        |
+| `agent.listenAddress`              | List of addresses to listen on, or "*" for all interfaces               | `nil`                                        |
+| `agent.pod.requests.memory`        | Container memory requests in MiB                                        | `512`                                        |
+| `agent.pod.requests.cpu`           | Container cpu requests in cpu cores                                     | `0.5`                                        |
+| `agent.pod.limits.memory`          | Container memory limits in MiB                                          | `512`                                        |
+| `agent.pod.limits.cpu`             | Container cpu limits in cpu cores                                       | `1.5`                                        |
+| `rbac.clusterRole.create`          | Whether RBAC ClusterRole should be created by this chart                | `true`                                       |
+| `rbac.roleBinding.create`          | Whether RBAC ClusterRoleBinding should be created by this chart         | `true`                                       |
+| `rbac.serviceAccount.create`       | Whether RBAC ServiceAccount should be created by this chart             | `true`                                       |
+| `rbac.serviceAccount.name`         | Name of RBAC ServiceAccount                                             | `instana-agent`                              |
 
 ### Agent
 

--- a/stable/instana-agent/README.md
+++ b/stable/instana-agent/README.md
@@ -12,7 +12,7 @@ Kubernetes 1.8.x - 1.13.x
 
 Working `helm` and `tiller`.
 
-_Note:_ Tiller may need a service account and role binding if RBAC is enabled in your cluster. [1]
+_Note:_ Tiller may need a service account and role binding if RBAC is enabled in your cluster.
 
 ## Installing the Chart
 
@@ -121,40 +121,3 @@ The following table lists the configurable parameters of the Instana chart and t
 ### Agent
 
 There is a [config map](templates/configmap.yaml) which you can edit to configure the agent. This configuration will be used for all instana agents on all nodes.
-
-#### Notes
-
-[1] - [https://docs.helm.sh/using_helm/#installing-helm](https://docs.helm.sh/using_helm/#installing-helm)
-
-Most Kubernetes clusters have RBAC enabled, therefore, create a service account for helm to use, for example:
-
-```yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: tiller
-  namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: tiller
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-  - kind: ServiceAccount
-    name: tiller
-    namespace: kube-system
-```
-
-```bash
-$ kubectl create -f tiller-service-account.yaml
-```
-
-Install tiller to your cluster with
-
-```bash
-$ helm init --service-account tiller
-```

--- a/stable/instana-agent/README.md
+++ b/stable/instana-agent/README.md
@@ -113,10 +113,9 @@ The following table lists the configurable parameters of the Instana chart and t
 | `agent.pod.requests.cpu`           | Container cpu requests in cpu cores                                     | `0.5`                                        |
 | `agent.pod.limits.memory`          | Container memory limits in MiB                                          | `512`                                        |
 | `agent.pod.limits.cpu`             | Container cpu limits in cpu cores                                       | `1.5`                                        |
-| `rbac.clusterRole.create`          | Whether RBAC ClusterRole should be created by this chart                | `true`                                       |
-| `rbac.roleBinding.create`          | Whether RBAC ClusterRoleBinding should be created by this chart         | `true`                                       |
-| `rbac.serviceAccount.create`       | Whether RBAC ServiceAccount should be created by this chart             | `true`                                       |
-| `rbac.serviceAccount.name`         | Name of RBAC ServiceAccount                                             | `instana-agent`                              |
+| `rbac.create`                      | Whether RBAC resources should be created                                | `true`                                       |
+| `serviceAccount.create`            | Whether a ServiceAccount should be created                              | `true`                                       |
+| `serviceAccount.name`              | Name of the ServiceAccount to use                                       | `instana-agent`                              |
 
 ### Agent
 

--- a/stable/instana-agent/templates/NOTES.txt
+++ b/stable/instana-agent/templates/NOTES.txt
@@ -1,0 +1,49 @@
+{{- if (and (not .Values.agent.key) (not .Values.zone.name)) }}
+##############################################################################
+####    ERROR: You did not specify your secret agent key.                 ####
+####    ERROR: You also did not specify a zone name for this cluster.     ####
+##############################################################################
+
+This agent deployment will be incomplete until you set your agent key and zone name for this cluster:
+
+    helm upgrade {{ .Release.Name }} --reuse-values \
+        --set agent.key=$(YOUR_SECRET_AGENT_KEY) \
+        --set zone.name=$(YOUR_CLUSTER_NAME) stable/instana-agent
+
+- YOUR_SECRET_AGENT_KEY can be obtained from the Management Portal section of your Instana installation.
+- YOUR_CLUSTER_NAME should be a name that uniquely identifies this cluster.
+
+{{- else if not .Values.zone.name }}
+##############################################################################
+####    ERROR: You did not specify a zone name for this cluster.          ####
+##############################################################################
+
+This agent deployment will be incomplete until you set a zone name for this cluster:
+
+    helm upgrade {{ .Release.Name }} --reuse-values \
+        --set zone.name=$(YOUR_CLUSTER_NAME) stable/instana-agent
+
+- YOUR_CLUSTER_NAME should be a name that uniquely identifies this cluster.
+
+{{- else if not .Values.agent.key }}
+##############################################################################
+####    ERROR: You did not specify your secret agent key.                 ####
+##############################################################################
+
+This agent deployment will be incomplete until you set your agent key:
+
+    helm upgrade {{ .Release.Name }} --reuse-values \
+        --set agent.key=$(YOUR_SECRET_AGENT_KEY) stable/instana-agent
+
+- YOUR_SECRET_AGENT_KEY can be obtained from the Management Portal section of your Instana installation.
+
+{{- else -}}
+It may take a few moments for the agents to fully deploy. You can see what agents are running by listing resources in the {{ .Release.Namespace }} namespace:
+
+    kubectl get all -n {{ .Release.Namespace }}
+
+You can get the logs for all of the agents with `kubectl logs`:
+
+    kubectl logs -f $(kubectl get pods -n {{ .Release.Namespace }} -o name) -n {{ .Release.Namespace }} -c instana-agent
+
+{{- end }}

--- a/stable/instana-agent/templates/_helpers.tpl
+++ b/stable/instana-agent/templates/_helpers.tpl
@@ -1,15 +1,41 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "instana-agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "instana-agent.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "instana-agent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{/*
 The version of the RBAC API to use.
 */}}
 {{- define "instana-agent.rbacApiVersion" -}}
 "rbac.authorization.k8s.io/v1"
-{{- end -}}
-
-{{/*
-The baseName used by resources for the name attribute.
-*/}}
-{{- define "instana-agent.baseName" -}}
-{{ default "instana-agent" .Values.baseName -}}
 {{- end -}}
 
 {{/*

--- a/stable/instana-agent/templates/_helpers.tpl
+++ b/stable/instana-agent/templates/_helpers.tpl
@@ -53,7 +53,17 @@ The name of the ServiceAccount used.
 Add Helm metadata to resource labels.
 */}}
 {{- define "instana-agent.helmChartLabels" -}}
-helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-helm.sh/release: {{ .Release.Name }}
-helm.sh/managed-by: {{ .Release.Service }}
+app.kubernetes.io/name: {{ include "instana-agent.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: {{ include "instana-agent.name" . }}
+helm.sh/chart: {{ include "instana-agent.chart" . }}
+{{- end -}}
+
+{{/*
+Add Helm metadata to selector labels specifically for deployments/daemonsets/statefulsets.
+*/}}
+{{- define "instana-agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "instana-agent.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}

--- a/stable/instana-agent/templates/_helpers.tpl
+++ b/stable/instana-agent/templates/_helpers.tpl
@@ -41,8 +41,12 @@ The version of the RBAC API to use.
 {{/*
 The name of the ServiceAccount used.
 */}}
-{{- define "instana-agent.serviceAccount" -}}
-{{ default "instana-agent" .Values.rbac.serviceAccount.name -}}
+{{- define "instana-agent.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "instana-agent.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/instana-agent/templates/_helpers.tpl
+++ b/stable/instana-agent/templates/_helpers.tpl
@@ -1,12 +1,8 @@
 {{/*
-Get the version of the RBAC API to use based on the version of Kubernetes used.
+The version of the RBAC API to use.
 */}}
 {{- define "instana-agent.rbacApiVersion" -}}
-{{- if ge .Capabilities.KubeVersion.Minor "8" -}}
 "rbac.authorization.k8s.io/v1"
-{{- else -}}
-"rbac.authorization.k8s.io/v1beta1"
-{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/instana-agent/templates/_helpers.tpl
+++ b/stable/instana-agent/templates/_helpers.tpl
@@ -52,11 +52,10 @@ The name of the ServiceAccount used.
 {{/*
 Add Helm metadata to resource labels.
 */}}
-{{- define "instana-agent.helmChartLabels" -}}
+{{- define "instana-agent.commonLabels" -}}
 app.kubernetes.io/name: {{ include "instana-agent.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/component: {{ include "instana-agent.name" . }}
 helm.sh/chart: {{ include "instana-agent.chart" . }}
 {{- end -}}
 

--- a/stable/instana-agent/templates/_helpers.tpl
+++ b/stable/instana-agent/templates/_helpers.tpl
@@ -1,0 +1,33 @@
+{{/*
+Get the version of the RBAC API to use based on the version of Kubernetes used.
+*/}}
+{{- define "instana-agent.rbacApiVersion" -}}
+{{- if ge .Capabilities.KubeVersion.Minor "8" -}}
+"rbac.authorization.k8s.io/v1"
+{{- else -}}
+"rbac.authorization.k8s.io/v1beta1"
+{{- end -}}
+{{- end -}}
+
+{{/*
+The baseName used by resources for the name attribute.
+*/}}
+{{- define "instana-agent.baseName" -}}
+{{ default "instana-agent" .Values.baseName -}}
+{{- end -}}
+
+{{/*
+The name of the ServiceAccount used.
+*/}}
+{{- define "instana-agent.serviceAccount" -}}
+{{ default "instana-agent" .Values.rbac.serviceAccount.name -}}
+{{- end -}}
+
+{{/*
+Add Helm metadata to resource labels.
+*/}}
+{{- define "instana-agent.helmChartLabels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+helm.sh/release: {{ .Release.Name }}
+helm.sh/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/stable/instana-agent/templates/_helpers.tpl
+++ b/stable/instana-agent/templates/_helpers.tpl
@@ -32,13 +32,6 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
-The version of the RBAC API to use.
-*/}}
-{{- define "instana-agent.rbacApiVersion" -}}
-"rbac.authorization.k8s.io/v1"
-{{- end -}}
-
-{{/*
 The name of the ServiceAccount used.
 */}}
 {{- define "instana-agent.serviceAccountName" -}}

--- a/stable/instana-agent/templates/agentsecret.yaml
+++ b/stable/instana-agent/templates/agentsecret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "instana-agent.name" . }}-agent-secret
+  name: {{ template "instana-agent.fullname" . }}-agent-secret
   labels:
     {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
 type: Opaque

--- a/stable/instana-agent/templates/agentsecret.yaml
+++ b/stable/instana-agent/templates/agentsecret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: {{ template "instana-agent.fullname" . }}-agent-secret
   labels:
-    {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
+    {{- include "instana-agent.commonLabels" . | nindent 4 }}
 type: Opaque
 data:
   key: {{ .Values.agent.key | b64enc | quote }}

--- a/stable/instana-agent/templates/agentsecret.yaml
+++ b/stable/instana-agent/templates/agentsecret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "instana-agent.baseName" . }}-secret
+  name: {{ template "instana-agent.baseName" . }}-agent-secret
   labels:
     {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
 type: Opaque

--- a/stable/instana-agent/templates/agentsecret.yaml
+++ b/stable/instana-agent/templates/agentsecret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "instana-agent.baseName" . }}-agent-secret
+  name: {{ template "instana-agent.name" . }}-agent-secret
   labels:
     {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
 type: Opaque

--- a/stable/instana-agent/templates/clusterrole.yaml
+++ b/stable/instana-agent/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.clusterRole.create -}}
+{{- if .Values.rbac.create -}}
 kind: ClusterRole
 apiVersion: {{ template "instana-agent.rbacApiVersion" . }}
 metadata:

--- a/stable/instana-agent/templates/clusterrole.yaml
+++ b/stable/instana-agent/templates/clusterrole.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRole
 apiVersion: {{ template "instana-agent.rbacApiVersion" . }}
 metadata:
-  name: {{ template "instana-agent.name" . }}-role
+  name: {{ template "instana-agent.fullname" . }}
   labels:
     {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
 rules:

--- a/stable/instana-agent/templates/clusterrole.yaml
+++ b/stable/instana-agent/templates/clusterrole.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.rbac.clusterRole.create -}}
+kind: ClusterRole
+apiVersion: {{ template "instana-agent.rbacApiVersion" . }}
+metadata:
+  name: {{ template "instana-agent.baseName" . }}-role
+  labels:
+    {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
+rules:
+- nonResourceURLs:
+    - "/version"
+    - "/healthz"
+  verbs: ["get"]
+- apiGroups: ["batch"]
+  resources:
+    - "jobs"
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["extensions"]
+  resources:
+    - "deployments"
+    - "replicasets"
+    - "ingresses"
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+    - "deployments"
+    - "replicasets"
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+    - "namespaces"
+    - "events"
+    - "services"
+    - "endpoints"
+    - "nodes"
+    - "pods"
+    - "replicationcontrollers"
+    - "componentstatuses"
+    - "resourcequotas"
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+    - "endpoints"
+  verbs: ["create", "update", "patch"]
+{{- end -}}

--- a/stable/instana-agent/templates/clusterrole.yaml
+++ b/stable/instana-agent/templates/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: {{ template "instana-agent.rbacApiVersion" . }}
 metadata:
   name: {{ template "instana-agent.fullname" . }}
   labels:
-    {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
+    {{- include "instana-agent.commonLabels" . | nindent 4 }}
 rules:
 - nonResourceURLs:
     - "/version"

--- a/stable/instana-agent/templates/clusterrole.yaml
+++ b/stable/instana-agent/templates/clusterrole.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create -}}
 kind: ClusterRole
-apiVersion: {{ template "instana-agent.rbacApiVersion" . }}
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "instana-agent.fullname" . }}
   labels:

--- a/stable/instana-agent/templates/clusterrole.yaml
+++ b/stable/instana-agent/templates/clusterrole.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRole
 apiVersion: {{ template "instana-agent.rbacApiVersion" . }}
 metadata:
-  name: {{ template "instana-agent.baseName" . }}-role
+  name: {{ template "instana-agent.name" . }}-role
   labels:
     {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
 rules:

--- a/stable/instana-agent/templates/clusterrolebinding.yaml
+++ b/stable/instana-agent/templates/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: {{ template "instana-agent.rbacApiVersion" . }}
 metadata:
   name: {{ template "instana-agent.fullname" . }}
   labels:
-    {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
+    {{- include "instana-agent.commonLabels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "instana-agent.serviceAccountName" . }}

--- a/stable/instana-agent/templates/clusterrolebinding.yaml
+++ b/stable/instana-agent/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.roleBinding.create -}}
+kind: ClusterRoleBinding
+apiVersion: {{ template "instana-agent.rbacApiVersion" . }}
+metadata:
+  name: {{ template "instana-agent.baseName" . }}-role-binding
+  labels:
+    {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "instana-agent.serviceAccount" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "instana-agent.baseName" . }}-role
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/stable/instana-agent/templates/clusterrolebinding.yaml
+++ b/stable/instana-agent/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.roleBinding.create -}}
+{{- if .Values.rbac.create -}}
 kind: ClusterRoleBinding
 apiVersion: {{ template "instana-agent.rbacApiVersion" . }}
 metadata:
@@ -7,7 +7,7 @@ metadata:
     {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "instana-agent.serviceAccount" . }}
+  name: {{ template "instana-agent.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/stable/instana-agent/templates/clusterrolebinding.yaml
+++ b/stable/instana-agent/templates/clusterrolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create -}}
 kind: ClusterRoleBinding
-apiVersion: {{ template "instana-agent.rbacApiVersion" . }}
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "instana-agent.fullname" . }}
   labels:

--- a/stable/instana-agent/templates/clusterrolebinding.yaml
+++ b/stable/instana-agent/templates/clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRoleBinding
 apiVersion: {{ template "instana-agent.rbacApiVersion" . }}
 metadata:
-  name: {{ template "instana-agent.name" . }}-role-binding
+  name: {{ template "instana-agent.fullname" . }}
   labels:
     {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
 subjects:
@@ -11,6 +11,6 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ template "instana-agent.name" . }}-role
+  name: {{ template "instana-agent.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end -}}

--- a/stable/instana-agent/templates/clusterrolebinding.yaml
+++ b/stable/instana-agent/templates/clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRoleBinding
 apiVersion: {{ template "instana-agent.rbacApiVersion" . }}
 metadata:
-  name: {{ template "instana-agent.baseName" . }}-role-binding
+  name: {{ template "instana-agent.name" . }}-role-binding
   labels:
     {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
 subjects:
@@ -11,6 +11,6 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ template "instana-agent.baseName" . }}-role
+  name: {{ template "instana-agent.name" . }}-role
   apiGroup: rbac.authorization.k8s.io
 {{- end -}}

--- a/stable/instana-agent/templates/configmap.yaml
+++ b/stable/instana-agent/templates/configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "instana-agent.fullname" . }}
   labels:
-    {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
+    {{- include "instana-agent.commonLabels" . | nindent 4 }}
 data:
   configuration.yaml: |
     # Manual a-priori configuration. Configuration will be only used when the sensor

--- a/stable/instana-agent/templates/configmap.yaml
+++ b/stable/instana-agent/templates/configmap.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "instana-agent.baseName" . }}-configuration
+  labels:
+    {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
+data:
+  configuration.yaml: |
+    # Manual a-priori configuration. Configuration will be only used when the sensor
+    # is actually installed by the agent.
+    # The commented out example values represent example configuration and are not
+    # necessarily defaults. Defaults are usually 'absent' or mentioned separately.
+    # Changes are hot reloaded unless otherwise mentioned.
+
+    # It is possible to create files called 'configuration-abc.yaml' which are
+    # merged with this file in file system order. So 'configuration-cde.yaml' comes
+    # after 'configuration-abc.yaml'. Only nested structures are merged, values are
+    # overwritten by subsequent configurations.
+
+    # Secrets
+    # To filter sensitive data from collection by the agent, all sensors respect
+    # the following secrets configuration. If a key collected by a sensor matches
+    # an entry from the list, the value is redacted.
+    #com.instana.secrets:
+    #  matcher: 'contains-ignore-case' # 'contains-ignore-case', 'contains', 'regex'
+    #  list:
+    #    - 'key'
+    #    - 'password'
+    #    - 'secret'
+
+    # Host
+    #com.instana.plugin.host:
+    #  tags:
+    #    - 'dev'
+    #    - 'app1'
+
+    # Hardware & Zone
+    #com.instana.plugin.generic.hardware:
+    #  enabled: true # disabled by default
+    #  availability-zone: 'zone'

--- a/stable/instana-agent/templates/configmap.yaml
+++ b/stable/instana-agent/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "instana-agent.baseName" . }}-configuration
+  name: {{ template "instana-agent.name" . }}-configuration
   labels:
     {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
 data:

--- a/stable/instana-agent/templates/configmap.yaml
+++ b/stable/instana-agent/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "instana-agent.name" . }}-configuration
+  name: {{ template "instana-agent.fullname" . }}
   labels:
     {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
 data:

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -41,8 +41,19 @@ spec:
             - name: INSTANA_AGENT_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "instana-agent.baseName" . }}-secret
+                  name: {{ template "instana-agent.baseName" . }}-agent-secret
                   key: key
+            {{- if .Values.agent.mode }}
+            - name: INSTANA_AGENT_MODE
+              value: {{ int .Values.agent.mode | quote }}
+            {{- end }}
+            {{- if .Values.agent.downloadKey }}
+            - name: INSTANA_DOWNLOAD_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "instana-agent.baseName" . }}-download-secret
+                  key: key
+            {{- end }}
             {{- if .Values.agent.proxyHost }}
             - name: INSTANA_AGENT_PROXY_HOST
               value: {{ .Values.agent.proxyHost | quote }}

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -16,7 +16,7 @@ spec:
         {{- include "instana-agent.commonLabels" . | nindent 8 }}
       {{- if .Values.agent.pod.annotations }}
       annotations:
-        {{ toYaml .Values.agent.pod.annotations | nindent 8}}
+        {{- toYaml .Values.agent.pod.annotations | nindent 8 }}
       {{- end }}
     spec:
       serviceAccount: {{ template "instana-agent.serviceAccountName" . }}
@@ -29,13 +29,13 @@ spec:
           imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
           env:
             - name: INSTANA_AGENT_LEADER_ELECTOR_PORT
-              value: {{ int .Values.agent.leaderElectorPort | quote }}
+              value: {{ .Values.agent.leaderElectorPort | quote }}
             - name: INSTANA_ZONE
               value: {{ .Values.zone.name | quote }}
             - name: INSTANA_AGENT_ENDPOINT
               value: {{ .Values.agent.endpointHost | quote }}
             - name: INSTANA_AGENT_ENDPOINT_PORT
-              value: {{ int .Values.agent.endpointPort | quote }}
+              value: {{ .Values.agent.endpointPort | quote }}
             - name: INSTANA_AGENT_KEY
               valueFrom:
                 secretKeyRef:
@@ -43,7 +43,7 @@ spec:
                   key: key
             {{- if .Values.agent.mode }}
             - name: INSTANA_AGENT_MODE
-              value: {{ int .Values.agent.mode | quote }}
+              value: {{ .Values.agent.mode | quote }}
             {{- end }}
             {{- if .Values.agent.downloadKey }}
             - name: INSTANA_DOWNLOAD_KEY
@@ -139,7 +139,7 @@ spec:
             - containerPort: {{ .Values.agent.leaderElectorPort }}
       {{- if .Values.agent.pod.tolerations }}
       tolerations:
-        {{ toYaml .Values.agent.pod.tolerations | nindent 8 }}
+        {{- toYaml .Values.agent.pod.tolerations | nindent 8 }}
       {{- end }}
       volumes:
         - name: dev

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: {{ template "instana-agent.fullname" . }}
   labels:
-    {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
+    {{- include "instana-agent.commonLabels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "instana-agent.helmChartLabels" . | nindent 8 }}
+        {{- include "instana-agent.commonLabels" . | nindent 8 }}
       {{- if .Values.agent.pod.annotations }}
       annotations:
         {{ toYaml .Values.agent.pod.annotations | nindent 8}}

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -22,13 +22,8 @@ spec:
       hostPID: true
       containers:
         - name: {{ template "instana-agent.baseName" . }}
-{{- if .Values.agent.image }}
           image: "{{ .Values.agent.image.name }}:{{ .Values.agent.image.tag }}"
           imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
-{{- else -}}
-          image: "instana/agent:latest"
-          imagePullPolicy: IfNotPresent
-{{- end }}
           env:
             - name: INSTANA_AGENT_LEADER_ELECTOR_PORT
               value: {{ int .Values.agent.leaderElectorPort | quote }}

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.agent.key -}}
 {{- if .Values.zone.name -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: {{ template "instana-agent.name" . }}

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -1,0 +1,155 @@
+{{- if .Values.agent.key -}}
+{{- if .Values.zone.name -}}
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: {{ template "instana-agent.baseName" . }}
+  labels:
+    {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
+spec:
+  template:
+    metadata:
+      labels:
+        k8s.instana.io/name: {{ template "instana-agent.baseName" . }}
+{{- if .Values.agent.pod.annotations }}
+      annotations:
+{{ toYaml .Values.agent.pod.annotations | indent 8}}
+{{- end }}
+    spec:
+      serviceAccount: {{ template "instana-agent.serviceAccount" . }}
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      containers:
+        - name: {{ template "instana-agent.baseName" . }}
+{{- if .Values.agent.image }}
+          image: "{{ .Values.agent.image.name }}:{{ .Values.agent.image.tag }}"
+          imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+{{- else -}}
+          image: "instana/agent:latest"
+          imagePullPolicy: IfNotPresent
+{{- end }}
+          env:
+            - name: INSTANA_AGENT_LEADER_ELECTOR_PORT
+              value: {{ int .Values.agent.leaderElectorPort | quote }}
+            - name: INSTANA_ZONE
+              value: {{ .Values.zone.name | quote }}
+            - name: INSTANA_AGENT_ENDPOINT
+              value: {{ .Values.agent.endpointHost | quote }}
+            - name: INSTANA_AGENT_ENDPOINT_PORT
+              value: {{ int .Values.agent.endpointPort | quote }}
+            - name: INSTANA_AGENT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "instana-agent.baseName" . }}-secret
+                  key: key
+            {{- if .Values.agent.proxyHost }}
+            - name: INSTANA_AGENT_PROXY_HOST
+              value: {{ .Values.agent.proxyHost | quote }}
+            {{- end }}
+            {{- if .Values.agent.proxyPort }}
+            - name: INSTANA_AGENT_PROXY_PORT
+              value: {{ .Values.agent.proxyPort | quote }}
+            {{- end }}
+            {{- if .Values.agent.proxyProtocol }}
+            - name: INSTANA_AGENT_PROXY_PROTOCOL
+              value: {{ .Values.agent.proxyProtocol | quote }}
+            {{- end }}
+            {{- if .Values.agent.proxyUser }}
+            - name: INSTANA_AGENT_PROXY_USER
+              value: {{ .Values.agent.proxyUser | quote }}
+            {{- end }}
+            {{- if .Values.agent.proxyPassword }}
+            - name: INSTANA_AGENT_PROXY_PASSWORD
+              value: {{ .Values.agent.proxyPassword | quote }}
+            {{- end }}
+            {{- if .Values.agent.proxyUseDNS }}
+            - name: INSTANA_AGENT_PROXY_USE_DNS
+              value: {{ .Values.agent.proxyUseDNS | quote }}
+            {{- end }}
+            {{- if .Values.agent.listenAddress }}
+            - name: INSTANA_AGENT_HTTP_LISTEN
+              value: {{ .Values.agent.listenAddress | quote }}
+            {{- end }}
+            - name: JAVA_OPTS
+              value: "-Xmx{{ div (default 512 .Values.agent.pod.requests.memory) 3 }}M -XX:+ExitOnOutOfMemoryError"
+            - name: INSTANA_AGENT_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: dev
+              mountPath: /dev
+            - name: run
+              mountPath: /var/run/docker.sock
+            - name: sys
+              mountPath: /sys
+            - name: log
+              mountPath: /var/log
+            - name: machine-id
+              mountPath: /etc/machine-id
+            - name: configuration
+              subPath: configuration.yaml
+              mountPath: /root/configuration.yaml
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 42699
+            initialDelaySeconds: 75
+            periodSeconds: 5
+          resources:
+            requests:
+              memory: "{{ default 512 .Values.agent.pod.requests.memory }}Mi"
+              cpu: {{ default 0.5 .Values.agent.pod.requests.cpu }}
+            limits:
+              memory: "{{ default 512 .Values.agent.pod.limits.memory }}Mi"
+              cpu: {{ default 1.5 .Values.agent.pod.limits.cpu }}
+          ports:
+            - containerPort: 42699
+        - name: {{ template "instana-agent.baseName" . }}-leader-elector
+          image: instana/leader-elector:0.5.1
+          env:
+            - name: INSTANA_AGENT_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          args: ["--election=instana", "--http=localhost:{{ default 42655 .Values.agent.leaderElectorPort }}", "--id=$(INSTANA_AGENT_POD_NAME)"]
+          resources:
+            requests:
+              cpu: 0.1
+              memory: 64Mi
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 42699
+            initialDelaySeconds: 75
+            periodSeconds: 5
+          ports:
+            - containerPort: {{ .Values.agent.leaderElectorPort }}
+{{- if .Values.agent.pod.tolerations }}
+      tolerations:
+{{ toYaml .Values.agent.pod.tolerations | indent 8}}
+{{- end }}
+      volumes:
+        - name: dev
+          hostPath:
+            path: /dev
+        - name: run
+          hostPath:
+            path: /var/run/docker.sock
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: log
+          hostPath:
+            path: /var/log
+        - name: machine-id
+          hostPath:
+            path: /etc/machine-id
+        - name: configuration
+          configMap:
+            name: {{ template "instana-agent.baseName" . }}-configuration
+{{- end -}}
+{{- end -}}

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -3,14 +3,14 @@
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: {{ template "instana-agent.baseName" . }}
+  name: {{ template "instana-agent.name" . }}
   labels:
     {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
 spec:
   template:
     metadata:
       labels:
-        k8s.instana.io/name: {{ template "instana-agent.baseName" . }}
+        k8s.instana.io/name: {{ template "instana-agent.name" . }}
       {{- if .Values.agent.pod.annotations }}
       annotations:
         {{ toYaml .Values.agent.pod.annotations | nindent 8}}
@@ -21,7 +21,7 @@ spec:
       hostNetwork: true
       hostPID: true
       containers:
-        - name: {{ template "instana-agent.baseName" . }}
+        - name: {{ template "instana-agent.name" . }}
           image: "{{ .Values.agent.image.name }}:{{ .Values.agent.image.tag }}"
           imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
           env:
@@ -36,7 +36,7 @@ spec:
             - name: INSTANA_AGENT_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "instana-agent.baseName" . }}-agent-secret
+                  name: {{ template "instana-agent.name" . }}-agent-secret
                   key: key
             {{- if .Values.agent.mode }}
             - name: INSTANA_AGENT_MODE
@@ -46,7 +46,7 @@ spec:
             - name: INSTANA_DOWNLOAD_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "instana-agent.baseName" . }}-download-secret
+                  name: {{ template "instana-agent.name" . }}-download-secret
                   key: key
             {{- end }}
             {{- if .Values.agent.proxyHost }}
@@ -114,7 +114,7 @@ spec:
               cpu: {{ default 1.5 .Values.agent.pod.limits.cpu }}
           ports:
             - containerPort: 42699
-        - name: {{ template "instana-agent.baseName" . }}-leader-elector
+        - name: {{ template "instana-agent.name" . }}-leader-elector
           image: instana/leader-elector:0.5.1
           env:
             - name: INSTANA_AGENT_POD_NAME
@@ -156,6 +156,6 @@ spec:
             path: /etc/machine-id
         - name: configuration
           configMap:
-            name: {{ template "instana-agent.baseName" . }}-configuration
+            name: {{ template "instana-agent.name" . }}-configuration
 {{- end -}}
 {{- end -}}

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -16,7 +16,7 @@ spec:
         {{ toYaml .Values.agent.pod.annotations | nindent 8}}
       {{- end }}
     spec:
-      serviceAccount: {{ template "instana-agent.serviceAccount" . }}
+      serviceAccount: {{ template "instana-agent.serviceAccountName" . }}
       hostIPC: true
       hostNetwork: true
       hostPID: true

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
-  name: {{ template "instana-agent.name" . }}
+  name: {{ template "instana-agent.fullname" . }}
   labels:
     {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
 spec:
@@ -39,7 +39,7 @@ spec:
             - name: INSTANA_AGENT_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "instana-agent.name" . }}-agent-secret
+                  name: {{ template "instana-agent.fullname" . }}-agent-secret
                   key: key
             {{- if .Values.agent.mode }}
             - name: INSTANA_AGENT_MODE
@@ -49,7 +49,7 @@ spec:
             - name: INSTANA_DOWNLOAD_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "instana-agent.name" . }}-download-secret
+                  name: {{ template "instana-agent.fullname" . }}-download-secret
                   key: key
             {{- end }}
             {{- if .Values.agent.proxyHost }}
@@ -159,6 +159,6 @@ spec:
             path: /etc/machine-id
         - name: configuration
           configMap:
-            name: {{ template "instana-agent.name" . }}-configuration
+            name: {{ template "instana-agent.fullname" . }}
 {{- end -}}
 {{- end -}}

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -7,10 +7,13 @@ metadata:
   labels:
     {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
 spec:
+  selector:
+    matchLabels:
+      {{- include "instana-agent.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        k8s.instana.io/name: {{ template "instana-agent.name" . }}
+        {{- include "instana-agent.helmChartLabels" . | nindent 8 }}
       {{- if .Values.agent.pod.annotations }}
       annotations:
         {{ toYaml .Values.agent.pod.annotations | nindent 8}}

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -11,10 +11,10 @@ spec:
     metadata:
       labels:
         k8s.instana.io/name: {{ template "instana-agent.baseName" . }}
-{{- if .Values.agent.pod.annotations }}
+      {{- if .Values.agent.pod.annotations }}
       annotations:
-{{ toYaml .Values.agent.pod.annotations | indent 8}}
-{{- end }}
+        {{ toYaml .Values.agent.pod.annotations | nindent 8}}
+      {{- end }}
     spec:
       serviceAccount: {{ template "instana-agent.serviceAccount" . }}
       hostIPC: true
@@ -134,10 +134,10 @@ spec:
             periodSeconds: 5
           ports:
             - containerPort: {{ .Values.agent.leaderElectorPort }}
-{{- if .Values.agent.pod.tolerations }}
+      {{- if .Values.agent.pod.tolerations }}
       tolerations:
-{{ toYaml .Values.agent.pod.tolerations | indent 8}}
-{{- end }}
+        {{ toYaml .Values.agent.pod.tolerations | nindent 8 }}
+      {{- end }}
       volumes:
         - name: dev
           hostPath:

--- a/stable/instana-agent/templates/downloadsecret.yaml
+++ b/stable/instana-agent/templates/downloadsecret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: {{ template "instana-agent.fullname" . }}-download-secret
   labels:
-    {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
+    {{- include "instana-agent.commonLabels" . | nindent 4 }}
 type: Opaque
 data:
   key: {{ .Values.agent.downloadKey | b64enc | quote }}

--- a/stable/instana-agent/templates/downloadsecret.yaml
+++ b/stable/instana-agent/templates/downloadsecret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.agent.downloadKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "instana-agent.baseName" . }}-download-secret
+  labels:
+    {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
+type: Opaque
+data:
+  key: {{ .Values.agent.downloadKey | b64enc | quote }}
+{{- end }}

--- a/stable/instana-agent/templates/downloadsecret.yaml
+++ b/stable/instana-agent/templates/downloadsecret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "instana-agent.name" . }}-download-secret
+  name: {{ template "instana-agent.fullname" . }}-download-secret
   labels:
     {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
 type: Opaque

--- a/stable/instana-agent/templates/downloadsecret.yaml
+++ b/stable/instana-agent/templates/downloadsecret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "instana-agent.baseName" . }}-download-secret
+  name: {{ template "instana-agent.name" . }}-download-secret
   labels:
     {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
 type: Opaque

--- a/stable/instana-agent/templates/secret.yaml
+++ b/stable/instana-agent/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.agent.key }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "instana-agent.baseName" . }}-secret
+  labels:
+    {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
+type: Opaque
+data:
+  key: {{ .Values.agent.key | b64enc | quote }}
+{{- end }}

--- a/stable/instana-agent/templates/serviceaccount.yaml
+++ b/stable/instana-agent/templates/serviceaccount.yaml
@@ -4,5 +4,5 @@ kind: ServiceAccount
 metadata:
   name: {{ template "instana-agent.serviceAccountName" . }}
   labels:
-    {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
+    {{- include "instana-agent.commonLabels" . | nindent 4 }}
 {{- end -}}

--- a/stable/instana-agent/templates/serviceaccount.yaml
+++ b/stable/instana-agent/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.rbac.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "instana-agent.serviceAccount" . }}
+  labels:
+    {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
+{{- end -}}

--- a/stable/instana-agent/templates/serviceaccount.yaml
+++ b/stable/instana-agent/templates/serviceaccount.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.rbac.serviceAccount.create -}}
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "instana-agent.serviceAccount" . }}
+  name: {{ template "instana-agent.serviceAccountName" . }}
   labels:
     {{- include "instana-agent.helmChartLabels" . | nindent 4 }}
 {{- end -}}

--- a/stable/instana-agent/values.yaml
+++ b/stable/instana-agent/values.yaml
@@ -1,0 +1,72 @@
+# baseName is the value which will be used as the base resource name for various resources associated with the agent.
+# baseName: instana-agent
+
+zone:
+  # zone.name is the uniquely-identifiable name by which your cluster will be known inside Instana.
+  name: null
+
+agent:
+  # agent.key is the secret token which your agent uses to authenticate to Instana's servers.
+  key: null
+  # agent.listenAddress is the IP address the agent HTTP server will listen to.
+  # listenAddress: *
+  # agent.leaderElectorPort is the port on which the leader elector sidecar is exposed.
+  leaderElectorPort: 42655
+
+  # agent.endpointHost is the hostname of the Instana server your agents will connect to.
+  endpointHost: saas-us-west-2.instana.io
+  # agent.endpointPort is the port number (as a String) of the Instana server your agents will connect to.
+  endpointPort: 443
+
+  image:
+    # agent.image.name is the name of the container image of the Instana agent.
+    name: instana/agent
+    # agent.image.tag is the tag name of the agent container image.
+    tag: latest
+    # agent.image.pullPolicy specifies when to pull the image container.
+    pullPolicy: IfNotPresent
+
+  pod:
+    # agent.pod.annotations are additional annotations to be added to the agent pods.
+    annotations: {}
+
+    # agent.pod.tolerations are tolerations to influence agent pod assignment.
+    #   https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    tolerations: []
+
+    requests:
+      # agent.pod.requests.memory is the requested memory allocation in MiB for the agent pods.
+      memory: 512
+      # agent.pod.requests.cpu are the requested CPU units allocation for the agent pods.
+      cpu: 0.5
+    limits:
+      # agent.pod.limits.memory set the memory allocation limits in MiB for the agent pods.
+      memory: 512
+      # agent.pod.limits.cpu sets the CPU units allocation limits for the agent pods.
+      cpu: 1.5
+
+  # agent.proxyHost sets the INSTANA_AGENT_PROXY_HOST environment variable.
+  # proxyHost: null
+  # agent.proxyPort sets the INSTANA_AGENT_PROXY_PORT environment variable.
+  # proxyPort: null
+  # agent.proxyProtocol sets the INSTANA_AGENT_PROXY_PROTOCOL environment variable.
+  # proxyProtocol: null
+  # agent.proxyUser sets the INSTANA_AGENT_PROXY_USER environment variable.
+  # proxyUser: null
+  # agent.proxyPassword sets the INSTANA_AGENT_PROXY_PASSWORD environment variable.
+  # proxyPassword: null
+  # agent.proxyUseDNS sets the INSTANA_AGENT_PROXY_USE_DNS environment variable.
+  # proxyUseDNS: null
+
+rbac:
+  clusterRole:
+    # rbac.clusterRole.create indicates whether RBAC ClusterRole should be created by this chart.
+    create: true
+  roleBinding:
+    # rbac.roleBinding.create indicates whether RBAC ClusterRoleBinding should be created by this chart.
+    create: true
+  serviceAccount:
+    # rbac.serviceAccount.create indicates whether RBAC ServiceAccount should be created by this chart.
+    create: true
+    # rbac.serviceAccount.name indicates what RBAC ServiceAccount name to use (whether created by this chart or not).
+    name: instana-agent

--- a/stable/instana-agent/values.yaml
+++ b/stable/instana-agent/values.yaml
@@ -26,7 +26,7 @@ agent:
     # agent.image.name is the name of the container image of the Instana agent.
     name: instana/agent
     # agent.image.tag is the tag name of the agent container image.
-    tag: latest
+    tag: 1.0.17
     # agent.image.pullPolicy specifies when to pull the image container.
     pullPolicy: IfNotPresent
 

--- a/stable/instana-agent/values.yaml
+++ b/stable/instana-agent/values.yaml
@@ -63,14 +63,12 @@ agent:
   # proxyUseDNS: null
 
 rbac:
-  clusterRole:
-    # rbac.clusterRole.create indicates whether RBAC ClusterRole should be created by this chart.
-    create: true
-  roleBinding:
-    # rbac.roleBinding.create indicates whether RBAC ClusterRoleBinding should be created by this chart.
-    create: true
-  serviceAccount:
-    # rbac.serviceAccount.create indicates whether RBAC ServiceAccount should be created by this chart.
-    create: true
-    # rbac.serviceAccount.name indicates what RBAC ServiceAccount name to use (whether created by this chart or not).
-    name: instana-agent
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: instana-agent

--- a/stable/instana-agent/values.yaml
+++ b/stable/instana-agent/values.yaml
@@ -1,5 +1,5 @@
-# baseName is the value which will be used as the base resource name for various resources associated with the agent.
-# baseName: instana-agent
+# name is the value which will be used as the base resource name for various resources associated with the agent.
+# name: instana-agent
 
 zone:
   # zone.name is the uniquely-identifiable name by which your cluster will be known inside Instana.

--- a/stable/instana-agent/values.yaml
+++ b/stable/instana-agent/values.yaml
@@ -8,6 +8,10 @@ zone:
 agent:
   # agent.key is the secret token which your agent uses to authenticate to Instana's servers.
   key: null
+  # agent.mode is used to set agent mode and it can be APM, INFRASTRUCTURE or AWS
+  # mode: APM
+  # agent.downloadKey is optional, if used it doesn't have to match agent.key
+  # downloadKey: null
   # agent.listenAddress is the IP address the agent HTTP server will listen to.
   # listenAddress: *
   # agent.leaderElectorPort is the port on which the leader elector sidecar is exposed.

--- a/stable/instana-agent/values.yaml
+++ b/stable/instana-agent/values.yaml
@@ -71,4 +71,4 @@ serviceAccount:
   create: true
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: instana-agent
+  # name: instana-agent


### PR DESCRIPTION
#### What this PR does / why we need it:
Adding an [Instana](https://www.instana.com/) agent chart that adds the Instana Agent to all schedulable nodes (e.g. by default, not masters) in a k8s cluster via a `DaemonSet`. Instana is a Dynamic APM for Microservice Applications.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] DCO signed
- [x] Variables are documented in the README.md