### PR TITLE
[stable/prometheus-blackbox-exporter] update default image version

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 0.2.0
-appVersion: 0.12.0
+version: 0.3.0
+appVersion: 0.14.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:
   - https://github.com/prometheus/blackbox_exporter

--- a/stable/prometheus-blackbox-exporter/README.md
+++ b/stable/prometheus-blackbox-exporter/README.md
@@ -53,7 +53,7 @@ The following table lists the configurable parameters of the Blackbox-Exporter c
 | `configmapReload.resources`            | configmap-reload pod resource requests & limits | `{}`                          |
 | `extraArgs`                            | Optional flags for blackbox                     | `[]`                          |
 | `image.repository`                     | container image repository                      | `prom/blackbox-exporter`      |
-| `image.tag`                            | container image tag                             | `v0.12.0`                     |
+| `image.tag`                            | container image tag                             | `v0.14.0`                     |
 | `image.pullPolicy`                     | container image pull policy                     | `IfNotPresent`                |
 | `ingress.annotations`                  | Ingress annotations                             | None                          |
 | `ingress.enabled`                      | Enables Ingress                                 | `false`                       |

--- a/stable/prometheus-blackbox-exporter/values.yaml
+++ b/stable/prometheus-blackbox-exporter/values.yaml
@@ -2,7 +2,7 @@ restartPolicy: Always
 
 image:
   repository: prom/blackbox-exporter
-  tag: v0.12.0
+  tag: v0.14.0
   pullPolicy: IfNotPresent
 
 nodeSelector: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates to the latest blackbox-exporter image

#### Special notes for your reviewer:

I have 2 PRs open against this chart right now, if one is merged the other one will need an additional version bump.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

@gianrubio 