### PR TITLE
[stable/airflow] Airflow worker log persistence

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 2.8.3
+version: 2.8.4
 appVersion: 1.10.2
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -278,6 +278,8 @@ You can also persist logs using a `PersistentVolume` using `logsPersistence.enab
 To use an existing volume, pass the name to `logsPersistence.existingClaim`.
 Otherwise, a new volume will be created.
 
+Note that it is also possible to persist logs by mounting a `PersistentVolume` to the log directory (`/usr/local/airflow/logs` by default) using `airflow.extraVolumes` and `airflow.extraVolumeMounts`. 
+
 Refer to the `Mount a Shared Persistent Volume` section above for details on using persistent volumes.
 
 ## Service monitor

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -271,13 +271,12 @@ Example of procedure:
 
 ## Logs
 
-You can store Airflow logs on an external volume and mount this volume inside Airflow pods.
-
-This is useful when running the Kubernetes executor to centralize logs across the
-Airflow UI, scheduler, and kubernetes worker pods, which allows for viewing worker log output
-in the airflow UI.
-
-This is controlled by the `logsPersistence.enabled` setting.
+By default (`logsPersistence.enabled: false`) logs from the web server, scheduler, and Celery workers are written to within the Docker container's filesystem.
+Therefore, any restart of the pod will wipe the logs.
+For production purposes, you will likely want to persist the logs externally (e.g. S3), which you have to set up yourself through configuration.
+You can also persist logs using a `PersistentVolume` using `logsPersistence.enabled: true`.
+To use an existing volume, pass the name to `logsPersistence.existingClaim`.
+Otherwise, a new volume will be created.
 
 Refer to the `Mount a Shared Persistent Volume` section above for details on using persistent volumes.
 

--- a/stable/airflow/templates/statefulsets-workers.yaml
+++ b/stable/airflow/templates/statefulsets-workers.yaml
@@ -111,6 +111,10 @@ spec:
             - name: dags-data
               mountPath: {{ .Values.dags.path }}
           {{- end }}
+          {{- if .Values.logsPersistence.enabled }}
+            - name: logs-data
+              mountPath: {{ .Values.logs.path }}
+          {{- end }}
           {{- range .Values.airflow.extraConfigmapMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
@@ -169,6 +173,11 @@ spec:
             claimName: {{ .Values.persistence.existingClaim | default (include "airflow.fullname" .) }}
         {{- else }}
           emptyDir: {}
+        {{- end }}
+        {{- if .Values.logsPersistence.enabled }}
+        - name: logs-data
+          persistentVolumeClaim:
+            claimName: {{ .Values.logsPersistence.existingClaim | default (printf "%s-logs" (include "airflow.fullname" . | trunc 58 )) }}
         {{- end }}
         {{- if .Values.dags.initContainer.enabled }}
         - name: git-clone


### PR DESCRIPTION
Signed-off-by: Steven Anton <steven.m.anton@gmail.com>

#### What this PR does / why we need it:
Local logs on the worker pods aren't persisted across restarts, even if persistence is enabled.

#### Which issue this PR fixes
  - fixes #12798 

#### Special notes for your reviewer:
I've tested this on my deployment and it seems to work: logs are persisted even when the worker pod restarts.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
