### PR TITLE
[stable/grafana] Move security context to container level

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 3.0.1
+version: 3.0.2
 appVersion: 6.0.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -35,7 +35,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `deploymentStrategy`                      | Deployment strategy                           | `RollingUpdate`                                         |
 | `livenessProbe`                           | Liveness Probe settings                       | `{ "httpGet": { "path": "/api/health", "port": 3000 } "initialDelaySeconds": 60, "timeoutSeconds": 30, "failureThreshold": 10 }` |
 | `readinessProbe`                          | Rediness Probe settings                       | `{ "httpGet": { "path": "/api/health", "port": 3000 } }`|
-| `securityContext`                         | Deployment securityContext                    | `{"runAsUser": 472, "fsGroup": 472}`                    |
+| `securityContext`                         | Container securityContext                    | `{"runAsUser": 472, "fsGroup": 472}`                    |
 | `priorityClassName`                       | Name of Priority Class to assign pods         | `nil`                                                   |
 | `image.repository`                        | Image repository                              | `grafana/grafana`                                       |
 | `image.tag`                               | Image tag. (`Must be >= 5.0.0`)               | `6.0.2`                                                 |

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -36,9 +36,9 @@ spec:
 {{- if .Values.schedulerName }}
       schedulerName: "{{ .Values.schedulerName }}"
 {{- end }}
-{{- if .Values.securityContext }}
+{{- if .Values.securityContext.fsGroup }}
       securityContext:
-{{ toYaml .Values.securityContext | indent 8 }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
 {{- end }}
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
@@ -66,6 +66,10 @@ spec:
         - name: download-dashboards
           image: "{{ .Values.downloadDashboardsImage.repository }}:{{ .Values.downloadDashboardsImage.tag }}"
           imagePullPolicy: {{ .Values.downloadDashboardsImage.pullPolicy }}
+{{- if .Values.securityContext }}
+          securityContext:
+{{ toYaml .Values.securityContext | indent 12 }}
+{{- end }}
           command: ["sh", "/etc/grafana/download_dashboards.sh"]
           volumeMounts:
             - name: config
@@ -86,6 +90,10 @@ spec:
         - name: {{ template "grafana.name" . }}-sc-datasources
           image: "{{ .Values.sidecar.image }}"
           imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+{{- if .Values.securityContext }}
+          securityContext:
+{{ toYaml .Values.securityContext | indent 12 }}
+{{- end }}
           env:
             - name: METHOD
               value: LIST
@@ -117,6 +125,10 @@ spec:
         - name: {{ template "grafana.name" . }}-sc-dashboard
           image: "{{ .Values.sidecar.image }}"
           imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+{{- if .Values.securityContext }}
+          securityContext:
+{{ toYaml .Values.securityContext | indent 12 }}
+{{- end }}
           env:
             - name: LABEL
               value: "{{ .Values.sidecar.dashboards.label }}"
@@ -135,6 +147,10 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+{{- if .Values.securityContext }}
+          securityContext:
+{{ toYaml .Values.securityContext | indent 12 }}
+{{- end }}
         {{- if .Values.command }}
           command:
           {{- range .Values.command }}


### PR DESCRIPTION
Move security context to container level to support istio sidecar injection

Signed-off-by: Ben Pehling shinjipehling@gmail.com

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Istio injects containers into pods which inherits the securityContext of the deployment/pod. By moving the securityContext to the containers instead, the istio-init container will not inherit the deployment/pod level securityContext and is able to perform its' init tasks (updating ip tables which requires root)

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
N/A

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
