### PR TITLE
[stable/elasticsearch] Fixing an issue with volumeMount

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.23.0
+version: 1.23.01
 appVersion: 6.7.0
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/stable/elasticsearch/templates/data-statefulset.yaml
+++ b/stable/elasticsearch/templates/data-statefulset.yaml
@@ -101,7 +101,7 @@ spec:
           runAsUser: 0
         volumeMounts:
         - mountPath: /usr/share/elasticsearch/data
-          name: data
+          name: {{ .Values.data.persistence.name }}
 {{- if .Values.extraInitContainers }}
 {{ tpl .Values.extraInitContainers . | indent 6 }}
 {{- end }}
@@ -140,7 +140,7 @@ spec:
 {{ toYaml .Values.data.readinessProbe | indent 10 }}
         volumeMounts:
         - mountPath: /usr/share/elasticsearch/data
-          name: data
+          name: {{ .Values.data.persistence.name }}
         - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
           name: config
           subPath: elasticsearch.yml

--- a/stable/elasticsearch/templates/master-statefulset.yaml
+++ b/stable/elasticsearch/templates/master-statefulset.yaml
@@ -101,7 +101,7 @@ spec:
           runAsUser: 0
         volumeMounts:
         - mountPath: /usr/share/elasticsearch/data
-          name: data
+          name: {{ .Values.master.persistence.name }}
 {{- if .Values.extraInitContainers }}
 {{ tpl .Values.extraInitContainers . | indent 6 }}
 {{- end }}
@@ -144,7 +144,7 @@ spec:
 {{ end }}
         volumeMounts:
         - mountPath: /usr/share/elasticsearch/data
-          name: data
+          name: {{ .Values.master.persistence.name }}
         - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
           name: config
           subPath: elasticsearch.yml


### PR DESCRIPTION
#### What this PR does / why we need it:
The chart currently breaks down with a custom `data.persistence.name`/`master.persistence.name` value (unable to find the `data` volumeMount since it does not exist).

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped

@simonswine 
@icereval 
@rendhalver 
@desaintmartin 