### PR TITLE
[stable/kube-state-metrics] add pod affinity

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - metric
 - monitoring
 - prometheus
-version: 1.4.0
+version: 1.5.0
 appVersion: 1.6.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -32,6 +32,7 @@ $ helm install stable/kube-state-metrics
 | `securityContext.runAsUser`           | User ID for the container                               | `65534`                                     |
 | `priorityClassName`                   | Name of Priority Class to assign pods                   | `nil`                                       |
 | `nodeSelector`                        | Node labels for pod assignment                          | {}                                          |
+| `affinity`                            | Affinity settings for pod assignment                    | {}                                          |
 | `tolerations`                         | Tolerations for pod assignment                          | []                                          |
 | `podAnnotations`                      | Annotations to be added to the pod                      | {}                                          |
 | `resources`                           | kube-state-metrics resource requests and limits         | {}                                          |

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -32,7 +32,7 @@ $ helm install stable/kube-state-metrics
 | `securityContext.runAsUser`           | User ID for the container                               | `65534`                                     |
 | `priorityClassName`                   | Name of Priority Class to assign pods                   | `nil`                                       |
 | `nodeSelector`                        | Node labels for pod assignment                          | {}                                          |
-| `tolerations`                         | Tolerations for pod assignment	                        | []                                          |
+| `tolerations`                         | Tolerations for pod assignment                          | []                                          |
 | `podAnnotations`                      | Annotations to be added to the pod                      | {}                                          |
 | `resources`                           | kube-state-metrics resource requests and limits         | {}                                          |
 | `collectors.certificatesigningrequests` | Enable the certificatesigningrequests collector.      | true                                        |

--- a/stable/kube-state-metrics/templates/deployment.yaml
+++ b/stable/kube-state-metrics/templates/deployment.yaml
@@ -113,6 +113,10 @@ spec:
           timeoutSeconds: 5
         resources:
 {{ toYaml .Values.resources | indent 12 }}
+{{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
 {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -61,6 +61,10 @@ securityContext:
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
 nodeSelector: {}
 
+## Affinity settings for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+affinity: {}
+
 ## Tolerations for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: []


### PR DESCRIPTION
#### What this PR does / why we need it:
Ability to define affinity for pods added to the kube-state-metrics chart.

#### Which issue this PR fixes
  - fixes #12818 

#### Special notes for your reviewer:
@fiunchinho Just a quick addition to the chart.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
