### PR TITLE
Allowing CRD toggling in sealed-secrets chart.

### DIFF
--- a/stable/sealed-secrets/Chart.yaml
+++ b/stable/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.0.1
+version: 1.0.2
 appVersion: 0.7.0
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/stable/sealed-secrets/README.md
+++ b/stable/sealed-secrets/README.md
@@ -39,6 +39,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | **image.pullPolicy** | The image pull policy for the deployment | `IfNotPresent` |
 | **image.repository** | The repository to get the controller image from | `quay.io/bitnami/sealed-secrets-controller` |
 | **resources** | CPU/Memory resource requests/limits | `{}` |
+| **crd.create** | `true` if crd resources should be created | `true` |
 | **crd.keep** | `true` if the sealed secret CRD should be kept when the chart is deleted | `true` |
 
 - In the case that **serviceAccount.create** is `false` and **rbac.create** is `true` it is expected for a service account with the name **serviceAccount.name** to exist _in the same namespace as this chart_ before installation.

--- a/stable/sealed-secrets/templates/sealedsecret-crd.yaml
+++ b/stable/sealed-secrets/templates/sealedsecret-crd.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.crd.create }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -21,3 +22,4 @@ spec:
     singular: sealedsecret
   scope: Namespaced
   version: v1alpha1
+{{ end }}

--- a/stable/sealed-secrets/values.yaml
+++ b/stable/sealed-secrets/values.yaml
@@ -22,5 +22,7 @@ rbac:
 secretName: "sealed-secrets-key"
 
 crd:
+  # crd.create: `true` if the crd resources should be created
+  create: true
   # crd.keep: `true` if the sealed secret CRD should be kept when the chart is deleted
   keep: true


### PR DESCRIPTION
#### What this PR does / why we need it:

The PR allows for the toggling of the CRD to be created for sealed-secrets as part of the helm chart.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
