### PR TITLE
init incubator/status

### DIFF
--- a/incubator/status/.helmignore
+++ b/incubator/status/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/status/Chart.yaml
+++ b/incubator/status/Chart.yaml
@@ -1,0 +1,21 @@
+name: status
+version: 0.0.1
+appVersion: 0.0.1
+description: Status
+home: https://github.com/helm/charts
+icon: https://helm.sh/src/img/helm-logo.svg
+keywords:
+- status
+- uptime
+- health
+- monitoring
+sources:
+- https://github.com/CachetHQ/Cachet
+- https://github.com/hunterlong/statping
+- https://github.com/adamcooke/staytus
+maintainers:
+- name: gregdhill
+  email: greg.hill@monax.io
+apiVersion: v1
+engine: gotpl
+deprecated: false

--- a/incubator/status/OWNERS
+++ b/incubator/status/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- gregdhill
+reviewers:
+- gregdhill

--- a/incubator/status/README.md
+++ b/incubator/status/README.md
@@ -1,0 +1,87 @@
+# Status Pages
+
+Open source service uptime monitoring and reporting pages.
+
+- [Cachet](https://github.com/CachetHQ/Cachet)
+- [Statping](https://github.com/hunterlong/statping)
+- [Staytus](https://github.com/adamcooke/staytus)
+
+## Introduction
+
+This chart bootstraps the chosen status page on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Installation
+
+To install the chart with the release name `my-release`, run:
+
+```bash
+helm install --name my-release incubator/status
+```
+
+The [configuration](#configuration) section below lists all possible parameters that can be configured.
+
+## Uninstall
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+helm delete my-release
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the Status chart and its default values.
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `cachethq.enabled` | enable [cachet](https://github.com/CachetHQ/Cachet) | `true` |
+| `cachethq.prometheus` | link it to prometheus alertmanager | `false` |
+| `cachethq.monitor` | ping website for stats | `false` |
+| `cachethq.image.repository` | - | `"cachethq/docker"` |
+| `cachethq.image.tag` | - | `"2.3.14"` |
+| `cachethq.image.pullPolicy` | - | `"IfNotPresent"` |
+| `cachethq.apiKey` | - | `""` |
+| `statping.enabled` | enable [statping](https://github.com/hunterlong/statping) | `false` |
+| `statping.image.repository` | - | `"hunterlong/statping"` |
+| `statping.image.tag` | - | `"latest"` |
+| `statping.image.pullPolicy` | - | `"IfNotPresent"` |
+| `staytus.enabled` | enable [staytus](https://github.com/adamcooke/staytus) | `false` |
+| `staytus.image.repository` | - | `"quay.io/galexrt/staytus"` |
+| `staytus.image.tag` | - | `"latest"` |
+| `staytus.image.pullPolicy` | - | `"IfNotPresent"` |
+| `environment.APP_KEY` | environment variable | `""` |
+| `environment.VIRTUAL_HOST` | environment variable | `"localhost"` |
+| `environment.VIRTUAL_PORT` | environment variable | `8080` |
+| `environment.NAME` | environment variable | `"Company"` |
+| `environment.DESCRIPTION` | environment variable | `"Service Uptime Reporting"` |
+| `environment.DOMAIN` | environment variable | `"https://status.page"` |
+| `environment.ADMIN_USER` | environment variable | `"username"` |
+| `environment.ADMIN_PASS` | environment variable | `"password"` |
+| `environment.ADMIN_EMAIL` | environment variable | `"company@example.com"` |
+| `postgresql.enabled` | database | `true` |
+| `postgresql.postgresqlDatabase` | database | `"status_page"` |
+| `postgresql.postgresqlUsername` | database | `"status_page"` |
+| `postgresql.postgresqlPassword` | database | `"password"` |
+| `postgresql.image.tag` | database | `"9.6"` |
+| `postgresql.persistence.annotations.resourcePolicy` | database | `"keep"` |
+| `mariadb.enabled` | database | `false` |
+| `mariadb.db.name` | database | `"status_page"` |
+| `mariadb.db.user` | database | `"status_page"` |
+| `mariadb.db.password` | database | `"password"` |
+| `mariadb.rootUser.password` | database | `"password"` |
+| `mariadb.replication.enabled` | database | `false` |
+| `email.type` | email | `"smtp"` |
+| `email.host` | email | `"smtp.sendgrid.net"` |
+| `email.port` | email | `587` |
+| `email.userName` | email | `"apikey"` |
+| `email.fromName` | email | `"company"` |
+| `email.fromEmail` | email | `"company@example.com"` |
+| `email.sendgrid.credentialsSecretName` | email | `"sendgrid-credentials"` |
+| `replicaCount` | - | `1` |
+| `service.type` | - | `"ClusterIP"` |
+| `service.externalPort` | - | `80` |
+| `service.internalPort` | - | `8000` |
+| `ingress.enabled` | - | `false` |
+| `ingress.path` | - | `"/"` |
+| `ingress.hosts` | - | `["status.page"]` |
+| `ingress.tls` | - | `[]` |

--- a/incubator/status/requirements.lock
+++ b/incubator/status/requirements.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 2.7.10
+- name: mariadb
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 5.11.1
+digest: sha256:f7f0c3430ef3d8dd105c0a11bd1c3841e871efaebe76afb305e722cd4c7fa382
+generated: 2019-04-04T15:33:05.035472144+01:00

--- a/incubator/status/requirements.yaml
+++ b/incubator/status/requirements.yaml
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  version: ^2.2.0
+  repository: https://kubernetes-charts.storage.googleapis.com
+  condition: postgresql.enabled
+- name: mariadb
+  version: ^5.2.6
+  repository: https://kubernetes-charts.storage.googleapis.com
+  condition: mariadb.enabled

--- a/incubator/status/templates/NOTES.txt
+++ b/incubator/status/templates/NOTES.txt
@@ -1,0 +1,7 @@
+{{- if .Values.cachet.enabled }}
+You have successfully installed Cachet!
+{{- else if .Values.statping.enabled }}
+You have successfully installed Statping!
+{{- else if .Values.staytus.enabled }}
+You have successfully installed Staytus!
+{{- end }}

--- a/incubator/status/templates/_helpers.tpl
+++ b/incubator/status/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "status.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "status.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "status.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/status/templates/cachet/config.yaml
+++ b/incubator/status/templates/cachet/config.yaml
@@ -1,0 +1,14 @@
+{{- if and (.Values.cachet.enabled) (.Values.cachet.monitor.enabled) }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    app: {{ template "status.name" . }}-cachet-monitor
+    chart: {{ template "status.chart" $ }}
+    heritage: {{ $.Release.Service }}
+    release: {{ $.Release.Name }}
+  name: {{ template "status.fullname" . }}-cachet-monitor
+data:
+  cachet-monitor.config.json: |
+    {{ .Values.cachet.monitor.config | toJson }}
+{{- end }}

--- a/incubator/status/templates/cachet/monitor.yaml
+++ b/incubator/status/templates/cachet/monitor.yaml
@@ -1,0 +1,43 @@
+# https://github.com/CastawayLabs/cachet-monitor
+{{- if and (.Values.cachet.enabled) (.Values.cachet.monitor.enabled) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "status.name" . }}-cachet-monitor
+    chart: {{ template "status.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "status.fullname" . }}-cachet-monitor
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "status.name" . }}-cachet-monitor
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "status.name" . }}-cachet-monitor
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: monitor
+          image: "castawaylabs/cachet-monitor:{{ .Values.cachet.monitor.version }}"
+          volumeMounts:
+            - mountPath: /etc/cachet-monitor.config.json
+              subPath: cachet-monitor.config.json
+              name: config-volume
+          ports:
+            - containerPort: {{ .Values.service.internalPort }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ template "status.fullname" . }}-cachet-monitor
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- end }}

--- a/incubator/status/templates/cachet/prometheus.yaml
+++ b/incubator/status/templates/cachet/prometheus.yaml
@@ -1,0 +1,38 @@
+# https://github.com/gregdhill/cachet-prometheus
+{{- if and (.Values.cachet.enabled) (.Values.cachet.prometheus.enabled) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "status.name" . }}-cachet-prometheus
+    chart: {{ template "status.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "status.fullname" . }}-cachet-prometheus
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "status.name" . }}-cachet-prometheus
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "status.name" . }}-cachet-prometheus
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: bridge
+          image: "gregdhill/cachet-prometheus:{{ .Values.cachet.prometheus.version }}"
+          env:
+            - name: CACHET_URL
+              value: "{{ index .Values.ingress.hosts 0 }}"
+            - name: CACHET_KEY
+              value: "{{ .Values.cachet.prometheus.api_token }}"
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- end }}

--- a/incubator/status/templates/cachet/service.yaml
+++ b/incubator/status/templates/cachet/service.yaml
@@ -1,0 +1,20 @@
+{{- if and (.Values.cachet.enabled) (.Values.cachet.prometheus.enabled) }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "status.name" . }}-cachet-prometheus
+    chart: {{ template "status.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name:  {{ template "status.fullname" . }}-cachet-prometheus
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.externalPort }}
+      targetPort: {{ .Values.service.externalPort }}
+      protocol: TCP
+  selector:
+    app: {{ template "status.name" . }}-cachet-prometheus
+    release: {{ .Release.Name }}
+{{- end }}

--- a/incubator/status/templates/deployment.yaml
+++ b/incubator/status/templates/deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "status.name" . }}
+    chart: {{ template "status.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "status.fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "status.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "status.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: report
+{{- if .Values.cachet.enabled }}
+          image: "{{ .Values.cachet.image.repository }}:{{ .Values.cachet.image.tag }}"
+          imagePullPolicy: {{ .Values.cachet.image.pullPolicy }}
+{{- else if .Values.statping.enabled }}
+          image: "{{ .Values.statping.image.repository }}:{{ .Values.statping.image.tag }}"
+          imagePullPolicy: {{ .Values.statping.image.pullPolicy }}
+{{- else if .Values.staytus.enabled }}
+          image: "{{ .Values.staytus.image.repository }}:{{ .Values.staytus.image.tag }}"
+          imagePullPolicy: {{ .Values.staytus.image.pullPolicy }}
+{{- end }}
+          env:
+{{ include "dbInfo" . | indent 12 }}
+{{ include "emailInfo" . | indent 12 }}
+{{- range $key, $val := .Values.environment }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+{{- end}}
+          ports:
+            - containerPort: {{ .Values.service.internalPort }}
+{{- if .Values.cachet.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /api/v1/ping
+              port: {{ .Values.service.internalPort }}
+          readinessProbe:
+            httpGet:
+              path: /api/v1/ping
+              port: {{ .Values.service.internalPort }}
+{{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}

--- a/incubator/status/templates/ingress.yaml
+++ b/incubator/status/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "status.fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "status.fullname" . }}
+  labels:
+    app: {{ template "status.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- range $key, $value := .Values.ingress.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+{{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+{{- end -}}
+{{- end -}}

--- a/incubator/status/templates/partials/_database.yaml
+++ b/incubator/status/templates/partials/_database.yaml
@@ -1,0 +1,55 @@
+{{- define "dbInfo" -}}
+
+- name: DB_PORT
+  value: {{ printf "%d" 5432 | quote }}
+
+- name: DB_HOST
+{{- if .Values.mariadb.enabled }}
+  value: {{ .Release.Name }}-mariadb
+{{- else }}
+  value: {{ .Release.Name }}-postgresql
+{{- end }}
+
+{{- if .Values.mariadb.enabled }}
+- name: DB_DATABASE
+  value: {{ .Values.mariadb.db.name }}
+- name: DB_ADAPTER
+  value: mysql2
+{{- else }}
+- name: DB_DATABASE
+  value: {{ .Values.postgresql.postgresqlDatabase }}
+- name: DB_DRIVER
+  value: pgsql
+- name: DB_CONN
+  value: postgres
+{{- end }}
+
+- name: DB_USER
+{{- if .Values.mariadb.enabled }}
+  value: {{ .Values.mariadb.db.user }}
+{{- else }}
+  value: {{ .Values.postgresql.postgresqlUsername }}
+{{- end }}
+
+- name: DB_USERNAME
+{{- if .Values.mariadb.enabled }}
+  value: {{ .Values.mariadb.db.user }}
+{{- else }}
+  value: {{ .Values.postgresql.postgresqlUsername }}
+{{- end }}
+
+- name: DB_PASS
+{{- if .Values.mariadb.enabled }}
+  value: {{ .Values.mariadb.db.password }}
+{{- else }}
+  value: {{ .Values.postgresql.postgresqlPassword }}
+{{- end }}
+
+- name: DB_PASSWORD
+{{- if .Values.mariadb.enabled }}
+  value: {{ .Values.mariadb.db.password }}
+{{- else }}
+  value: {{ .Values.postgresql.postgresqlPassword }}
+{{- end }}
+
+{{- end -}}

--- a/incubator/status/templates/partials/_email.yaml
+++ b/incubator/status/templates/partials/_email.yaml
@@ -1,0 +1,21 @@
+{{- define "emailInfo" -}}
+- name: MAIL_DRIVER
+  value: {{ .Values.email.type }}
+- name: MAIL_HOST
+  value: {{ .Values.email.host }}
+- name: MAIL_PORT
+  value: {{ .Values.email.port | quote }}
+- name: MAIL_USERNAME
+  value: {{ .Values.email.userName }}
+- name: MAIL_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ default "sendgrid-credentials" .Values.email.sendgrid.credentialsSecretName }}
+      key: key
+- name: MAIL_ADDRESS
+  value: {{ .Values.email.fromEmail }}
+- name: MAIL_NAME
+  value: {{ .Values.email.fromName }}
+- name: MAIL_ENCRYPTION
+  value: tls
+{{- end -}}

--- a/incubator/status/templates/service.yaml
+++ b/incubator/status/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "status.name" . }}
+    chart: {{ template "status.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name:  {{ template "status.fullname" . }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.externalPort }}
+      targetPort: {{ .Values.service.internalPort }}
+      protocol: TCP
+  selector:
+    app: {{ template "status.name" . }}
+    release: {{ .Release.Name }}

--- a/incubator/status/values.yaml
+++ b/incubator/status/values.yaml
@@ -1,0 +1,109 @@
+cachet:
+  enabled: true
+  image:
+    repository: cachethq/docker
+    tag: 2.3.14
+    pullPolicy: IfNotPresent
+  prometheus:
+    enabled: false
+    version: latest
+    api_token: ""
+  monitor:
+    enabled: false
+    version: latest
+    config:
+      api_url: https://status.page/api/v1
+      api_token: ""
+      interval: 60
+      monitors:
+      - name: Website
+        url: "https://example.com"
+        metric_id: 1
+        component_id: 1
+        threshold: 80
+        expected_status_code: 200
+        strict_tls: true
+      insecure_api: false
+
+statping:
+  enabled: false
+  image:
+    repository: hunterlong/statping
+    tag: latest
+    pullPolicy: IfNotPresent
+
+staytus:
+  enabled: false
+  image:
+    repository: quay.io/galexrt/staytus
+    tag: latest
+    pullPolicy: IfNotPresent
+
+environment:
+  APP_KEY: ""
+  VIRTUAL_HOST: localhost
+  VIRTUAL_PORT: 8080
+  NAME: Company
+  DESCRIPTION: Service Uptime Reporting
+  DOMAIN: https://status.page
+  ADMIN_USER: username
+  ADMIN_PASS: password
+  ADMIN_EMAIL: "company@example.com"
+
+postgresql:
+  enabled: true
+  postgresqlDatabase: status_page
+  postgresqlUsername: status_page
+  postgresqlPassword: password
+  image:
+    tag: "9.6"
+  persistence:
+    annotations:
+      resourcePolicy: keep
+
+mariadb:
+  enabled: false
+  db:
+    name: status_page
+    user: status_page
+    password: password
+  rootUser:
+    password: password
+  replication:
+    enabled: false
+
+email:
+  type: smtp
+  host: smtp.sendgrid.net
+  port: 587
+  userName: apikey
+  fromName: "company"
+  fromEmail: "company@example.com"
+  sendgrid:
+    credentialsSecretName: "sendgrid-credentials"
+
+replicaCount: 1
+
+resources: {}
+  # limits:
+  #   cpu: 400m
+  #   memory: 512Mi
+  # requests:
+  #   cpu: 250m
+  #   memory: 256Mi
+
+service:
+  type: ClusterIP
+  externalPort: 80
+  internalPort: 8000
+
+ingress:
+  enabled: false
+  annotations: {}
+  path: /
+  hosts:
+    - status.page
+  tls: []
+  #  - secretName: status-tls
+  #    hosts:
+  #      - status.page


### PR DESCRIPTION
Signed-off-by: Gregory Hill <greg.hill@monax.io>

#### What this PR does / why we need it:
There are a number of open source status pages for monitoring / reporting service health, but currently there is no easy way to bootstrap these in a cloud environment. This chart introduces a generic wrapper into incubator that allows the installer to chose between (currently) one of three web services for performing this task.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
