### PR TITLE
Add pod security policies for prometheus components

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 8.9.1
+version: 8.9.2
 appVersion: 2.8.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -233,6 +233,7 @@ Parameter | Description | Default
 `pushgateway.service.servicePort` | pushgateway service port | `9091`
 `pushgateway.service.type` | type of pushgateway service to create | `ClusterIP`
 `rbac.create` | If true, create & use RBAC resources | `true`
+`rbac.podSecurityPolicy.enabled` | If true, create & use pod security policies resources | `false`
 `server.name` | Prometheus server container name | `server`
 `server.image.repository` | Prometheus server container image repository | `prom/prometheus`
 `server.image.tag` | Prometheus server container image tag | `v2.8.0`

--- a/stable/prometheus/templates/alertmanager-podsecuritypolicy.yaml
+++ b/stable/prometheus/templates/alertmanager-podsecuritypolicy.yaml
@@ -1,18 +1,18 @@
 {{- if .Values.rbac.create }}
 {{- if .Values.rbac.podSecurityPolicy.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ template "prometheus.nodeExporter.fullname" . }}
+  name: {{ template "prometheus.alertmanager.fullname" . }}
   labels:
     app: {{ template "prometheus.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.nodeExporter.name }}"
+    component: "{{ .Values.alertmanager.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
-{{- if .Values.nodeExporter.podSecurityPolicy.annotations }}
-{{ toYaml .Values.nodeExporter.podSecurityPolicy.annotations | indent 4 }}
+{{- if .Values.alertmanager.podSecurityPolicy.annotations }}
+{{ toYaml .Values.alertmanager.podSecurityPolicy.annotations | indent 4 }}
 {{- end }}
 spec:
   privileged: false
@@ -21,19 +21,15 @@ spec:
     - ALL
   volumes:
     - 'configMap'
-    - 'hostPath'
+    - 'persistentVolumeClaim'
+    - 'emptyDir'
     - 'secret'
   allowedHostPaths:
-    - pathPrefix: /proc
+    - pathPrefix: /etc
       readOnly: true
-    - pathPrefix: /sys
-      readOnly: true
-  {{- range .Values.nodeExporter.extraHostPathMounts }}
-    - pathPrefix: {{ .hostPath }}
-      readOnly: {{ .readOnly }}
-  {{- end }}
-  hostNetwork: {{ .Values.nodeExporter.hostNetwork }}
-  hostPID: {{ .Values.nodeExporter.hostPID }}
+    - pathPrefix: {{ .Values.alertmanager.persistentVolume.mountPath }}
+  hostNetwork: false
+  hostPID: false
   hostIPC: false
   runAsUser:
     rule: 'RunAsAny'
@@ -51,9 +47,9 @@ spec:
       # Forbid adding the root group.
       - min: 1
         max: 65535
-  readOnlyRootFilesystem: false
-  hostPorts:
-    - min: 1
-      max: 65535
+  readOnlyRootFilesystem: true
+  # hostPorts:
+  #   - min: 1
+  #     max: 65535
 {{- end }}
 {{- end }}

--- a/stable/prometheus/templates/kube-state-metrics-podsecuritypolicy.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-podsecuritypolicy.yaml
@@ -1,18 +1,18 @@
 {{- if .Values.rbac.create }}
 {{- if .Values.rbac.podSecurityPolicy.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ template "prometheus.nodeExporter.fullname" . }}
+  name: {{ template "prometheus.kubeStateMetrics.fullname" . }}
   labels:
     app: {{ template "prometheus.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.nodeExporter.name }}"
+    component: "{{ .Values.kubeStateMetrics.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
-{{- if .Values.nodeExporter.podSecurityPolicy.annotations }}
-{{ toYaml .Values.nodeExporter.podSecurityPolicy.annotations | indent 4 }}
+{{- if .Values.kubeStateMetrics.podSecurityPolicy.annotations }}
+{{ toYaml .Values.kubeStateMetrics.podSecurityPolicy.annotations | indent 4 }}
 {{- end }}
 spec:
   privileged: false
@@ -20,20 +20,10 @@ spec:
   requiredDropCapabilities:
     - ALL
   volumes:
-    - 'configMap'
-    - 'hostPath'
     - 'secret'
-  allowedHostPaths:
-    - pathPrefix: /proc
-      readOnly: true
-    - pathPrefix: /sys
-      readOnly: true
-  {{- range .Values.nodeExporter.extraHostPathMounts }}
-    - pathPrefix: {{ .hostPath }}
-      readOnly: {{ .readOnly }}
-  {{- end }}
-  hostNetwork: {{ .Values.nodeExporter.hostNetwork }}
-  hostPID: {{ .Values.nodeExporter.hostPID }}
+  allowedHostPaths: []
+  hostNetwork: false
+  hostPID: false
   hostIPC: false
   runAsUser:
     rule: 'RunAsAny'
@@ -51,9 +41,9 @@ spec:
       # Forbid adding the root group.
       - min: 1
         max: 65535
-  readOnlyRootFilesystem: false
-  hostPorts:
-    - min: 1
-      max: 65535
+  readOnlyRootFilesystem: true
+  # hostPorts:
+  #   - min: 1
+  #     max: 65535
 {{- end }}
 {{- end }}

--- a/stable/prometheus/templates/server-podsecuritypolicy.yaml
+++ b/stable/prometheus/templates/server-podsecuritypolicy.yaml
@@ -1,39 +1,40 @@
 {{- if .Values.rbac.create }}
 {{- if .Values.rbac.podSecurityPolicy.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ template "prometheus.nodeExporter.fullname" . }}
+  name: {{ template "prometheus.server.fullname" . }}
   labels:
     app: {{ template "prometheus.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.nodeExporter.name }}"
+    component: "{{ .Values.server.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
-{{- if .Values.nodeExporter.podSecurityPolicy.annotations }}
-{{ toYaml .Values.nodeExporter.podSecurityPolicy.annotations | indent 4 }}
+{{- if .Values.server.podSecurityPolicy.annotations }}
+{{ toYaml .Values.server.podSecurityPolicy.annotations | indent 4 }}
 {{- end }}
 spec:
   privileged: false
   allowPrivilegeEscalation: false
-  requiredDropCapabilities:
-    - ALL
+  allowedCapabilities:
+    - 'CHOWN'
   volumes:
     - 'configMap'
-    - 'hostPath'
+    - 'persistentVolumeClaim'
+    - 'emptyDir'
     - 'secret'
+    - 'hostPath'
   allowedHostPaths:
-    - pathPrefix: /proc
+    - pathPrefix: /etc
       readOnly: true
-    - pathPrefix: /sys
-      readOnly: true
-  {{- range .Values.nodeExporter.extraHostPathMounts }}
+    - pathPrefix: {{ .Values.server.persistentVolume.mountPath }}
+  {{- range .Values.server.extraHostPathMounts }}
     - pathPrefix: {{ .hostPath }}
       readOnly: {{ .readOnly }}
   {{- end }}
-  hostNetwork: {{ .Values.nodeExporter.hostNetwork }}
-  hostPID: {{ .Values.nodeExporter.hostPID }}
+  hostNetwork: false
+  hostPID: false
   hostIPC: false
   runAsUser:
     rule: 'RunAsAny'
@@ -52,8 +53,5 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
-  hostPorts:
-    - min: 1
-      max: 65535
 {{- end }}
 {{- end }}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -1,5 +1,7 @@
 rbac:
   create: true
+  podSecurityPolicy:
+    enabled: false
 
 imagePullSecrets:
 # - name: "image-pull-secret"
@@ -183,6 +185,20 @@ alertmanager:
   ##
   podAnnotations: {}
 
+  ## Specify if a Pod Security Policy for node-exporter must be created
+  ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+  ##
+  podSecurityPolicy:
+    annotations: {}
+      ## Specify pod annotations
+      ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
+      ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
+      ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#sysctl
+      ##
+      # seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+      # seccomp.security.alpha.kubernetes.io/defaultProfileName: 'docker/default'
+      # apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'
+
   ## Use a StatefulSet if replicaCount needs to be greater than 1 (see below)
   ##
   replicaCount: 1
@@ -343,6 +359,20 @@ kubeStateMetrics:
   ## Annotations to be added to kube-state-metrics pods
   ##
   podAnnotations: {}
+
+  ## Specify if a Pod Security Policy for node-exporter must be created
+  ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+  ##
+  podSecurityPolicy:
+    annotations: {}
+      ## Specify pod annotations
+      ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
+      ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
+      ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#sysctl
+      ##
+      # seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+      # seccomp.security.alpha.kubernetes.io/defaultProfileName: 'docker/default'
+      # apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'
 
   pod:
     labels: {}
@@ -720,6 +750,20 @@ server:
   ##
   podAnnotations: {}
     # iam.amazonaws.com/role: prometheus
+
+  ## Specify if a Pod Security Policy for node-exporter must be created
+  ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+  ##
+  podSecurityPolicy:
+    annotations: {}
+      ## Specify pod annotations
+      ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
+      ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
+      ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#sysctl
+      ##
+      # seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+      # seccomp.security.alpha.kubernetes.io/defaultProfileName: 'docker/default'
+      # apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'
 
   ## Use a StatefulSet if replicaCount needs to be greater than 1 (see below)
   ##


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR adds basic Pod Security Policies for the promethues components. This will allow this chart to be installed in an environment that has the PSP admission controller enabled. 

Interestingly, there was a PSP included just for the node-exporter job. We just mimicked that PSP and added some for the other jobs.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
