### PR TITLE
make nodePort configurable

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 1.3.1
+version: 1.3.2
 appVersion: 9.0
 keywords:
   - debugging

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -100,6 +100,7 @@ The following table lists the configurable parameters of the Sentry chart and th
 | `service.externalPort`               | Kubernetes external service port            | `9000`                                                     |
 | `service.internalPort`               | Kubernetes internal service port            | `9000`                                                     |
 | `service.annotations`                | Service annotations                         | `{}`                                                       |
+| `service.nodePort`                   | Kubernetes service NodePort port            | Randomly chosen by Kubernetes                              |
 | `ingress.enabled`                    | Enable ingress controller resource          | `false`                                                    |
 | `ingress.annotations`                | Ingress annotations                         | `{}`                                                       |
 | `ingress.hostname`                   | URL to address your Sentry installation     | `sentry.local`                                             |

--- a/stable/sentry/templates/service.yaml
+++ b/stable/sentry/templates/service.yaml
@@ -22,6 +22,9 @@ spec:
     targetPort: {{ .Values.service.internalPort }}
     protocol: TCP
     name: {{ .Values.service.name }}
+{{- if and (.Values.service.nodePort) (eq .Values.service.type "NodePort") }}
+    nodePort: {{ .Values.service.nodePort }}
+{{- end }}
 {{- if .Values.service.externalIPs }}
   externalIPs:
 {{ toYaml .Values.service.externalIPs | indent 4 }}


### PR DESCRIPTION
#### What this PR does / why we need it:
This pull request adds option to set the NodePort to desired port. The port can be set with the following values file:

```
service:
   type: "NodePort"
   nodePort: 31111
```
Only when Values.service.type equals "NodePort" and Values.service.nodePort is specified the NodePort port will be set.

#### Which issue this PR fixes
When a helm release is deleted and a chart is installed again, the NodePort may be different. Depending on the load balancing infrastructure a randomly chosen NodePort causes manual changes on the load balancing infrastructure as well.
After merging this PR, the NodePort can be set to a static value.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
