### PR TITLE
[stable/elasticsearch] Adding static nodeport support to elasticsearch client service

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.24.0
+version: 1.25.0
 appVersion: 6.7.0
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/stable/elasticsearch/README.md
+++ b/stable/elasticsearch/README.md
@@ -86,7 +86,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `client.tolerations`                 | Client tolerations                                                  | `[]`                                                |
 | `client.serviceAnnotations`          | Client Service annotations                                          | `{}`                                                |
 | `client.serviceType`                 | Client service type                                                 | `ClusterIP`                                         |
-| `client.nodePort`                    | Client service NodePort port number. Has no effect if client.serviceType is not `nodePort`.   | `nil`                                         |
+| `client.httpNodePort`                | Client service HTTP NodePort port number. Has no effect if client.serviceType is not `NodePort`.   | `nil`                                         |
 | `client.loadBalancerIP`              | Client loadBalancerIP                                               | `{}`                                                |
 | `client.loadBalancerSourceRanges`    | Client loadBalancerSourceRanges                                     | `{}`                                                |
 | `client.antiAffinity`                | Client anti-affinity policy                                         | `soft`                                              |

--- a/stable/elasticsearch/README.md
+++ b/stable/elasticsearch/README.md
@@ -86,6 +86,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `client.tolerations`                 | Client tolerations                                                  | `[]`                                                |
 | `client.serviceAnnotations`          | Client Service annotations                                          | `{}`                                                |
 | `client.serviceType`                 | Client service type                                                 | `ClusterIP`                                         |
+| `client.nodePort`                    | Client service NodePort port number                                 | `nil`                                         |
 | `client.loadBalancerIP`              | Client loadBalancerIP                                               | `{}`                                                |
 | `client.loadBalancerSourceRanges`    | Client loadBalancerSourceRanges                                     | `{}`                                                |
 | `client.antiAffinity`                | Client anti-affinity policy                                         | `soft`                                              |

--- a/stable/elasticsearch/README.md
+++ b/stable/elasticsearch/README.md
@@ -86,7 +86,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `client.tolerations`                 | Client tolerations                                                  | `[]`                                                |
 | `client.serviceAnnotations`          | Client Service annotations                                          | `{}`                                                |
 | `client.serviceType`                 | Client service type                                                 | `ClusterIP`                                         |
-| `client.nodePort`                    | Client service NodePort port number                                 | `nil`                                         |
+| `client.nodePort`                    | Client service NodePort port number. Has no effect if client.serviceType is not `nodePort`.   | `nil`                                         |
 | `client.loadBalancerIP`              | Client loadBalancerIP                                               | `{}`                                                |
 | `client.loadBalancerSourceRanges`    | Client loadBalancerSourceRanges                                     | `{}`                                                |
 | `client.antiAffinity`                | Client anti-affinity policy                                         | `soft`                                              |

--- a/stable/elasticsearch/templates/client-svc.yaml
+++ b/stable/elasticsearch/templates/client-svc.yaml
@@ -17,8 +17,8 @@ spec:
   ports:
     - name: http
       port: 9200
-{{- if and .Values.client.nodePort (eq .Values.client.serviceType "NodePort") }}
-      nodePort: {{ .Values.client.nodePort }}
+{{- if and .Values.client.httpNodePort (eq .Values.client.serviceType "NodePort") }}
+      nodePort: {{ .Values.client.httpNodePort }}
 {{- end }}
       targetPort: http
   selector:

--- a/stable/elasticsearch/templates/client-svc.yaml
+++ b/stable/elasticsearch/templates/client-svc.yaml
@@ -17,6 +17,9 @@ spec:
   ports:
     - name: http
       port: 9200
+{{- if and .Values.client.nodePort (eq .Values.client.serviceType "NodePort") }}
+      nodePort: {{ .Values.client.nodePort }}
+{{- end }}
       targetPort: http
   selector:
     app: {{ template "elasticsearch.name" . }}

--- a/stable/elasticsearch/values.yaml
+++ b/stable/elasticsearch/values.yaml
@@ -75,6 +75,8 @@ client:
   name: client
   replicas: 2
   serviceType: ClusterIP
+  ## If coupled with serviceType = "NodePort", this will set a specific nodePort to the client HTTP port
+  # nodePort: 30920
   loadBalancerIP: {}
   loadBalancerSourceRanges: {}
 ## (dict) If specified, apply these annotations to the client service

--- a/stable/elasticsearch/values.yaml
+++ b/stable/elasticsearch/values.yaml
@@ -76,7 +76,7 @@ client:
   replicas: 2
   serviceType: ClusterIP
   ## If coupled with serviceType = "NodePort", this will set a specific nodePort to the client HTTP port
-  # nodePort: 30920
+  # httpNodePort: 30920
   loadBalancerIP: {}
   loadBalancerSourceRanges: {}
 ## (dict) If specified, apply these annotations to the client service


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Augments the elasticsearch chart to set a specific port number to the HTTP client service when service type is NodePort.

#### Special notes for your reviewer:

Commented the nodePort variable, only to be used if needed by the user and only in conjunction with the NodePort service type.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
