### PR TITLE
[stable/fluent-bit] Add Elasticsearch Path setting

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.0.5
+version: 2.0.6
 appVersion: 1.1.2
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -41,6 +41,7 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | **ElasticSearch Backend**  |
 | `backend.es.host`          | IP address or hostname of the target Elasticsearch instance | `elasticsearch` |
 | `backend.es.port`          | TCP port of the target Elasticsearch instance. | `9200` |
+| `backend.es.path`          | Path prefix if Elasticsearch is served behind a reverse proxy on a subpath. | `` |
 | `backend.es.index`         | Elastic Index name | `kubernetes_cluster` |
 | `backend.es.type`          | Elastic Type name | `flb_type` |
 | `backend.es.time_key`          | Elastic Time Key | `@timestamp` |
@@ -98,7 +99,7 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `filter.kubeTagPrefix`             | Optional tag prefix used by Tail   | `kube.var.log.containers.`                                |
 | `filter.mergeJSONLog`              | If the log field content is a JSON string map, append the map fields as part of the log structure         | `true`                                 |
 | `image.fluent_bit.repository`      | Image                                      | `fluent/fluent-bit`                               |
-| `image.fluent_bit.tag`             | Image tag                                  | `1.0.6`                                          |
+| `image.fluent_bit.tag`             | Image tag                                  | `1.1.2`                                          |
 | `image.pullPolicy`                 | Image pull policy                          | `IfNotPresent`                                          |
 | `nameOverride`                     | Override name of app                   | `nil`                                        |
 | `fullnameOverride`                 | Override full name of app              | `nil`                                        |

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -90,6 +90,9 @@ data:
         Match *
         Host  {{ .Values.backend.es.host }}
         Port  {{ .Values.backend.es.port }}
+{{- if .Values.backend.es.path }}
+        Path {{ .Values.backend.es.path }}
+{{- end }}
         Logstash_Format On
         Retry_Limit False
         Type  {{ .Values.backend.es.type }}

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -48,6 +48,7 @@ backend:
   es:
     host: elasticsearch
     port: 9200
+    path: ""
     # Elastic Index Name
     index: kubernetes_cluster
     type: flb_type


### PR DESCRIPTION
#### What this PR does / why we need it:

Add a path option for the Elasticsearch backend. From the [upstream documentation](https://github.com/c445/fluent-bit-docs/blob/ef9cbbc6528ac9309a40d9366ebd8806f73aab08/output/elasticsearch.md):

> Elasticsearch accepts new data on HTTP query path "/\_bulk". But it is also possible to serve Elasticsearch behind a reverse proxy on a subpath. This option defines such path on the fluent-bit side. It simply adds a path prefix in the indexing HTTP POST URI.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

Support was added in fluent/fluent-bit#901 and docs updated in
fluent/fluent-bit-docs#107

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

CC: kfox1111