### PR TITLE
Vault and Azure

### DIFF
--- a/stable/atlantis/Chart.yaml
+++ b/stable/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.6.0"
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 2.0.1
+version: 2.0.2
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/stable/atlantis/README.md
+++ b/stable/atlantis/README.md
@@ -57,6 +57,7 @@ The following options are supported.  See [values.yaml](values.yaml) for more de
 | `storageClassName`                          | Storage class of the volume mounted for the Atlantis data directory.                                                                                                                                                                                                                                      | n/a     |
 | `tlsSecretName`                             | Name of a Secret for Atlantis' HTTPS certificate containing the following data items `tls.crt` with the public certificate and `tls.key` with the private key.                                                                                                                                            | n/a     |
 
+
 ## Upgrading
 ### From 1.* to 2.*
 * The following value names have changed:

--- a/stable/atlantis/templates/atlantis-consul-template.yaml
+++ b/stable/atlantis/templates/atlantis-consul-template.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.vault }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: atlantis-consul-template
+  namespace: atlantis
+data:
+  consul-template-config.hcl: |
+    vault {
+      vault_agent_token_file = "/home/vault/.vault-token"
+      retry {
+        backoff = "30s"
+      }
+      ssl {
+        verify = false
+      }
+    }
+
+    template {
+      destination = "/etc/secrets/values.sh"
+      contents = <<EOH
+      export VAULT_ADDR="{{ .Values.vault.vaultAddr }}"
+      export VAULT_TOKEN="{{"{{"}} file "/home/vault/.vault-token" {{"}}"}}"
+      EOH
+    }
+{{- end }}

--- a/stable/atlantis/templates/atlantis-entrypoint.yaml
+++ b/stable/atlantis/templates/atlantis-entrypoint.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.vault }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: atlantis-entrypoint
+  namespace: atlantis
+data:
+  entrypoint.sh: |
+    while [ ! -f /etc/secrets/values.sh ]
+    do
+      sleep 5
+    done
+    source /etc/secrets/values.sh
+    /usr/local/bin/docker-entrypoint.sh server
+{{- end}}

--- a/stable/atlantis/templates/atlantis-vault-autoauth.yaml
+++ b/stable/atlantis/templates/atlantis-vault-autoauth.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.vault }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: atlantis-vault-autoauth
+  namespace: atlantis
+data:
+  vault-agent-config.hcl: |
+    pid_file = "/home/vault/pidfile"
+
+    auto_auth {
+      method "kubernetes" {
+        mount_path = "{{ .Values.vault.mountPath }}"
+        config = {
+          role = "{{ .Values.vault.vaultRole }}"
+        }
+      }
+      sink "file" {
+        config = {
+          path = "/home/vault/.vault-token"
+        }
+      }
+    }
+{{- end}}

--- a/stable/atlantis/templates/statefulset.yaml
+++ b/stable/atlantis/templates/statefulset.yaml
@@ -31,6 +31,23 @@ spec:
       securityContext:
         fsGroup: 1000
       volumes:
+      containers:
+      {{- if .Values.vault }}
+      - name: vault-token
+        emptyDir:
+          medium: Memory
+      - name: vault-config
+        configMap:
+          name: atlantis-vault-autoauth
+      - name: atlantis-consul-template
+        configMap:
+          name: atlantis-consul-template
+      - name: shared-data
+        emptyDir: {}
+      - name: entrypoint
+        configMap:
+          name: atlantis-entrypoint
+      {{- end }}
       {{- if .Values.tlsSecretName }}
       - name: tls
         secret:
@@ -58,6 +75,40 @@ spec:
       {{- end }}
       {{- end }}
       containers:
+      {{- if .Values.vault }}
+        - name: vault-agent-auth
+          image: vault
+          volumeMounts:
+            - name: vault-config
+              mountPath: /etc/vault
+            - name: vault-token
+              mountPath: /home/vault
+          env:
+            - name: VAULT_ADDR
+              value: {{ .Values.vault.vaultAddr }}
+            - name: VAULT_SKIP_VERIFY
+              value: '1'
+          args:
+            - agent
+            - -config=/etc/vault/vault-agent-config.hcl
+            - -log-level=debug
+        - name: consul-template
+          image: hashicorp/consul-template:alpine
+          volumeMounts:
+            - name: vault-token
+              mountPath: /home/vault
+            - name: atlantis-consul-template
+              mountPath: /etc/consul-template
+            - name: shared-data
+              mountPath: /etc/secrets
+          env:
+            - name: HOME
+              value: /home/vault
+            - name: VAULT_ADDR
+              value: {{ .Values.vault.vaultAddr }}
+          args:
+            - -config=/etc/consul-template/consul-template-config.hcl
+      {{- end }}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -156,14 +207,10 @@ spec:
                 name: {{ template "atlantis.fullname" . }}-webhook
                 key: bitbucket_secret
           {{- end }}
+          {{- range .Values.envVar }}
+           - name: {{ .name }}
+             value: {{ .value }}
           {{- end }}
-          {{- if .Values.requireApproval }}
-          - name: ATLANTIS_REQUIRE_APPROVAL
-            value: "true"
-          {{- end }}
-          {{- if .Values.requireMergeable }}
-          - name: ATLANTIS_REQUIRE_MERGEABLE
-            value: "true"
           {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:

--- a/stable/atlantis/values.yaml
+++ b/stable/atlantis/values.yaml
@@ -69,6 +69,24 @@ serviceAccountSecrets:
   # credentials-staging: <json file as base64 encoded string>
 
 
+environment:
+  # To specify Azure credentials to be mapped as env vars if deploying to Azure cloud
+  #  - name: ARM_CLIENT_SECRET
+  #    value: myvalue
+  #  - name: ARM_SUBSCRIPTION_ID
+  #    value: myvalue2
+  #  - name: ARM_TENANT_ID
+  #    value: myvalue2
+  #  - name: ARM_CLIENT_ID
+  #    value: myvalue2
+
+# To specify vault variables for hashicorp vault integration with k8s
+# vault:
+#   vaultAddr: <Your vault address>
+#   vaultRole: <Your vault role>
+#   mountPath: <your vault mount path>
+
+
 ## -------------------------- ##
 # Default values for atlantis (override as needed).
 ## -------------------------- ##


### PR DESCRIPTION
#### What this PR does / why we need it:
##### What it does:
1) Adds environment variable options for Azure credentials
2) Adds in Vault kubernetes implementation for secret management via vault
##### Why this is needed:
1) There are currently no values to add in for Azure. Without this, adding this in currently involves creating an additional secret and mounting env vars to go along with the Stateful set or deployment. This resolves this.
2) This adds in the ability to securely pull secrets into the terraform files people people deploy through Atlantis. Example, securely sending in database credentials to the .tf file so they are not stored in Git.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes  https://github.com/runatlantis/atlantis/issues/571

#### Special notes for your reviewer:
I know there is probably a want to keep the main atlantis chart clean, but this is an optional piece that only needs to have the additional components deployed if the vault value in values.yaml is specified. Adding this in will give anyone using Vault the ability to do secrets management in Terraform through Atlantis. This answers a major problem about pulling secrets/secrets getting committed to git through deploys.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
