### PR TITLE
[stable/concourse] preStop Script bug fix

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 5.1.1
+version: 5.1.2
 appVersion: 5.0.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/worker-prestop-configmap.yaml
+++ b/stable/concourse/templates/worker-prestop-configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "concourse.worker.fullname" . }}
+  labels:
+    app: {{ template "concourse.worker.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  pre-stop-hook.sh: |
+    #!/bin/bash
+    kill -s {{ .Values.concourse.worker.shutdownSignal }} 1
+    while [ -e /proc/1 ]; do sleep 1; done
+

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -82,10 +82,8 @@ spec:
             preStop:
               exec:
                 command:
-                  - "kill"
-                  - "-s"
-                  - {{ .Values.concourse.worker.shutdownSignal | quote }}
-                  - "1"
+                  - "/bin/bash"
+                  - "/pre-stop-hook.sh"
           env:
             {{- if .Values.concourse.worker.rebalanceInterval }}
             - name: CONCOURSE_REBALANCE_INTERVAL
@@ -259,6 +257,10 @@ spec:
               readOnly: true
             - name: concourse-work-dir
               mountPath: {{ .Values.concourse.worker.workDir | quote }}
+            - name: pre-stop-hook
+              mountPath: /pre-stop-hook.sh
+              subPath: pre-stop-hook.sh
+
 {{- if .Values.worker.additionalVolumeMounts }}
 {{ toYaml .Values.worker.additionalVolumeMounts | indent 12 }}
 {{- end }}
@@ -288,6 +290,9 @@ spec:
 {{- if .Values.worker.additionalVolumes }}
 {{ toYaml .Values.worker.additionalVolumes | indent 8 }}
 {{- end }}
+        - name: pre-stop-hook
+          configMap:
+            name: {{ template "concourse.worker.fullname" . }}
         - name: concourse-keys
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:
- previously, the preStop script only signalled a `kill` command without waiting for the worker process to exit.
- This resulted in `kubernetes` terminating the worker pod immediately without waiting for the worker to retire.
- Also, moved the preStop script to a separate ConfigMap so it can be easy to modify and append more check later on.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped

cc: @taylorsilva, @xtreme-sameer-vohra

