### PR TITLE
[stable/prometheus-mongodb-exporter] Add pod annotations to deployment template

### DIFF
--- a/stable/prometheus-mongodb-exporter/Chart.yaml
+++ b/stable/prometheus-mongodb-exporter/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 name: prometheus-mongodb-exporter
 sources:
 - https://github.com/percona/mongodb_exporter
-version: 1.1.0
+version: 1.2.0

--- a/stable/prometheus-mongodb-exporter/README.md
+++ b/stable/prometheus-mongodb-exporter/README.md
@@ -45,6 +45,7 @@ service:
 | `mongodb.uri` | The required [URI](https://docs.mongodb.com/manual/reference/connection-string) to connect to MongoDB | `` |
 | `nameOverride` | Override the application name  | `` |
 | `nodeSelector` | Node labels for pod assignment | `{}` |
+| `podAnnotations` | Annotations for the pod | `{}` |
 | `priorityClassName` | Pod priority class name | `` |
 | `replicas` | Number of replicas in the replica set | `1` |
 | `resources` | Pod resource requests and limits | `{}` |

--- a/stable/prometheus-mongodb-exporter/ci/pod-annotation-values.yaml
+++ b/stable/prometheus-mongodb-exporter/ci/pod-annotation-values.yaml
@@ -1,0 +1,10 @@
+---
+# Test adding pod annotations
+
+mongodb:
+  uri: mongodb://localhost:9216
+serviceMonitor:
+  enabled: false
+podAnnotations:
+  test.io/key1: true
+  test.io/key2: https://example.com

--- a/stable/prometheus-mongodb-exporter/templates/deployment.yaml
+++ b/stable/prometheus-mongodb-exporter/templates/deployment.yaml
@@ -20,6 +20,10 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       containers:
       - name: mongodb-exporter

--- a/stable/prometheus-mongodb-exporter/values.yaml
+++ b/stable/prometheus-mongodb-exporter/values.yaml
@@ -31,6 +31,8 @@ nameOverride: ""
 
 nodeSelector: {}
 
+podAnnotations: {}
+
 priorityClassName: ""
 
 readinessProbe:


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR allows annotations to be applied to the exporter pod.

We store the HTTP auth credentials to access our MongoDB cluster in Vault, the init pod we use to grab these credentials pulls the required Vault details (like what policy to use, what service endpoint to connect to, etc.) from the annotations on the pod.

#### Which issue this PR fixes
None

#### Special notes for your reviewer:
None

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
