### PR TITLE
[stable/jenkins] cleanup the RollingUpdate logic

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.37.3
+version: 0.37.4
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -19,7 +19,7 @@ spec:
   strategy:
     {{- if .Values.Persistence.Enabled }}
     type: Recreate
-    {{- else -}}
+    {{- else }}
     type: RollingUpdate
     rollingUpdate:
 {{ toYaml .Values.Master.RollingUpdate | indent 6 }}

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -17,9 +17,11 @@ metadata:
 spec:
   replicas: 1
   strategy:
-    type: {{ if .Values.Persistence.Enabled }}Recreate{{ else }}RollingUpdate{{ end }}
+    {{- if .Values.Persistence.Enabled }}
+    type: Recreate
+    {{- else -}}
+    type: RollingUpdate
     rollingUpdate:
-    {{- if not .Values.Persistence.Enabled }}
 {{ toYaml .Values.Master.RollingUpdate | indent 6 }}
     {{- end }}
   selector:


### PR DESCRIPTION
Signed-off-by: Jeff Knurek <j.knurek@travelaudience.com>

#### What this PR does / why we need it:

the previous configuration resulted in:
```
spec:
  replicas: 1
  strategy:
    type: Recreate
    rollingUpdate:
  selector:
  ...
```
which I guess "works", but is unclear. 

#### Special notes for your reviewer:

new results are either:
```
  replicas: 1
  strategy:
    type: Recreate
  selector:
```
or 
```
  replicas: 1
  strategy:
    type: RollingUpdate
    rollingUpdate:
      {}

  selector:
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
