### PR TITLE
[stable/prometheus-rabbitmq-exporter] Fix default parameters in readme 

### DIFF
--- a/stable/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/stable/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 0.4.0
+version: 0.5.0
 appVersion: v0.29.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/stable/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/stable/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 0.5.0
+version: 0.4.1
 appVersion: v0.29.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/stable/prometheus-rabbitmq-exporter/README.md
+++ b/stable/prometheus-rabbitmq-exporter/README.md
@@ -51,9 +51,9 @@ The following table lists the configurable parameters and their default values.
 | `service.externalPort`   | public service port                                                    | `9419`                    |
 | `resources`              | cpu/memory resource requests/limits                                    | {}                        |
 | `loglevel`               | exporter log level                                                     | {}                        |
-| `rabbitmq.url`           | rabbitm management url                                                 | `http://myrabbit:15672`   |
-| `rabbitmq.user`          | rabbitm user login                                                     | `guest`                   |
-| `rabbitmq.password`      | rabbitm password login                                                 | `guest`                   |
+| `rabbitmq.url`           | rabbitmq management url                                                | `http://myrabbit:15672`   |
+| `rabbitmq.user`          | rabbitmq user login                                                    | `guest`                   |
+| `rabbitmq.password`      | rabbitmq password login                                                | `guest`                   |
 | `rabbitmq.capabilities`  | comma-separated list of capabilities supported by the RabbitMQ server  | `bert,no_sort`            |
 | `rabbitmq.include_queues`| regex queue filter. just matching names are exported                   | `.*`                      |
 | `rabbitmq.skip_queues`   | regex, matching queue names are not exported                           | `^$`                      |

--- a/stable/prometheus-rabbitmq-exporter/README.md
+++ b/stable/prometheus-rabbitmq-exporter/README.md
@@ -44,14 +44,14 @@ The following table lists the configurable parameters and their default values.
 | ------------------------ | ---------------------------------------------------------------------- | ------------------------- |
 | `replicaCount`           | desired number of prometheus-rabbitmq-exporter pods                    | `1`                       |
 | `image.repository`       | prometheus-rabbitmq-exporter image repository                          | `kbudde/rabbitmq-exporter`|
-| `image.tag`              | prometheus-rabbitmq-exporter image tag                                 | `v0.28.0`                 |
+| `image.tag`              | prometheus-rabbitmq-exporter image tag                                 | `v0.29.0`                 |
 | `image.pullPolicy`       | image pull policy                                                      | `IfNotPresent`            |
 | `service.type`           | desired service type                                                   | `ClusterIP`               |
-| `service.internalport`   | service listening port                                                 | `9121`                    |
+| `service.internalport`   | service listening port                                                 | `9419`                    |
 | `service.externalPort`   | public service port                                                    | `9419`                    |
 | `resources`              | cpu/memory resource requests/limits                                    | {}                        |
 | `loglevel`               | exporter log level                                                     | {}                        |
-| `rabbitmq.url`           | rabbitm management url                                                  | `http://myrabbit:15672`   |
+| `rabbitmq.url`           | rabbitm management url                                                 | `http://myrabbit:15672`   |
 | `rabbitmq.user`          | rabbitm user login                                                     | `guest`                   |
 | `rabbitmq.password`      | rabbitm password login                                                 | `guest`                   |
 | `rabbitmq.capabilities`  | comma-separated list of capabilities supported by the RabbitMQ server  | `bert,no_sort`            |
@@ -59,7 +59,7 @@ The following table lists the configurable parameters and their default values.
 | `rabbitmq.skip_queues`   | regex, matching queue names are not exported                           | `^$`                      |
 | `rabbitmq.include_vhost` | regex vhost filter. Only queues in matching vhosts are exported        | `.*`                      |
 | `rabbitmq.skip_vhost`    | regex, matching vhost names are not exported. First performs include_vhost, then skip_vhost | `^$` |
-| `rabbitmq.skip_verify    | true/0 will ignore certificate errors of the management plugin         | `false`                   |
+| `rabbitmq.skip_verify`   | true/0 will ignore certificate errors of the management plugin         | `false`                   |
 | `rabbitmq.exporters`     | List of enabled modules. Just "connections" is not enabled by default  | `exchange,node,overview,queue` |
 | `rabbitmq.output_format` | Log ouput format. TTY and JSON are suported                            | `TTY`                     |
 | `rabbitmq.timeout`       | timeout in seconds for retrieving data from management plugin          | `30`                      |

--- a/stable/prometheus-rabbitmq-exporter/values.yaml
+++ b/stable/prometheus-rabbitmq-exporter/values.yaml
@@ -47,4 +47,4 @@ rabbitmq:
 annotations: {}
 #  prometheus.io/scrape: "true"
 #  prometheus.io/path: "/metrics"
-#  prometheus.io/port: 9419
+#  prometheus.io/port: "9419"


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR fix the information given by the README vs the `values.yaml` file

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped

