### PR TITLE
[stable/etcd-operator] Add pod disruption budget

### DIFF
--- a/stable/etcd-operator/Chart.yaml
+++ b/stable/etcd-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: CoreOS etcd-operator Helm chart for Kubernetes
 name: etcd-operator
-version: 0.8.3
+version: 0.8.4
 appVersion: 0.9.3
 home: https://github.com/coreos/etcd-operator
 icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png

--- a/stable/etcd-operator/README.md
+++ b/stable/etcd-operator/README.md
@@ -62,6 +62,7 @@ The following table lists the configurable parameters of the etcd-operator chart
 | `customResources.createEtcdClusterCRD`            | Create a custom resource: EtcdCluster                                | `false`                                        |
 | `customResources.createBackupCRD`                 | Create an a custom resource: EtcdBackup                              | `false`                                        |
 | `customResources.createRestoreCRD`                | Create an a custom resource: EtcdRestore                             | `false`                                        |
+| `customResources.createEtcdClusterCRDPDB`                | Create a Pod Disruption Budget for the EtcdCluster resource                             | `true`                                        |
 | `etcdOperator.name`                               | Etcd Operator name                                                   | `etcd-operator`                                |
 | `etcdOperator.replicaCount`                       | Number of operator replicas to create (only 1 is supported)          | `1`                                            |
 | `etcdOperator.image.repository`                   | etcd-operator container image                                        | `quay.io/coreos/etcd-operator`                 |

--- a/stable/etcd-operator/templates/etcd-cluster-crd-pdb.yaml
+++ b/stable/etcd-operator/templates/etcd-cluster-crd-pdb.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.customResources.createEtcdClusterCRDPDB }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.etcdCluster.name }}
+spec:
+  minAvailable: {{ add1 (div .Values.etcdCluster.size 2) }}
+  selector:
+    matchLabels:
+      etcd_cluster: {{ .Values.etcdCluster.name }}
+{{- end }}

--- a/stable/etcd-operator/values.yaml
+++ b/stable/etcd-operator/values.yaml
@@ -36,6 +36,7 @@ customResources:
   createEtcdClusterCRD: false
   createBackupCRD: false
   createRestoreCRD: false
+  createEtcdClusterCRDPDB: true
 
 # etcdOperator
 etcdOperator:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Adds a Pod Disruption Budget for the etcd-cluster pods. This should prevent rolling restarts of the cluster from obliterating the contents of your etcd cluster.

#### Which issue this PR fixes

  - fixes coreos/etcd-operator#1116 -- Admittedly not part of _this_ project but obviously an issue that users of the `etcd-operator` generally care about.

#### Special notes for your reviewer:

Ideally I think this should just depend on the value of `.customResources.createEtcdClusterCRD` but #5900 didn't really fix things for me and I am still having to create the CRD manually after installing the chart.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
