### PR TITLE
Fix incorrect template reference in stable/graylog

### DIFF
--- a/stable/graylog/templates/NOTES.txt
+++ b/stable/graylog/templates/NOTES.txt
@@ -6,7 +6,7 @@ To connect to your Graylog server:
   http://{{ . }}
 {{- end }}
 {{- else if contains "NodePort" .Values.graylog.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "graylog.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.graylog.service.type }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Change incorrect template reference `fullname` to `graylog.fullname` in stable/graylog NOTES.txt

#### Which issue this PR fixes
  - fixes #12867 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md