### PR TITLE
[incubator/kafka] Update service-brokers-external.yaml to remove incorrect mapping to headless port

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.14.2
+version: 0.14.3
 appVersion: 5.0.1
 keywords:
 - kafka

--- a/incubator/kafka/templates/service-brokers-external.yaml
+++ b/incubator/kafka/templates/service-brokers-external.yaml
@@ -2,7 +2,6 @@
   {{- $fullName := include "kafka.fullname" . }}
   {{- $replicas := .Values.replicas | int }}
   {{- $servicePort := .Values.external.servicePort }}
-  {{- $externalTargetPort := .Values.headless.port }}
   {{- $dnsPrefix := printf "%s" .Release.Name }}
   {{- $root := . }}
   {{- range $i, $e := until $replicas }}
@@ -50,10 +49,8 @@ spec:
       {{- else }}
       port: {{ $servicePort }}
       {{- end }}
-      {{- if and (eq $root.Values.external.type "LoadBalancer") (not $root.Values.external.distinct) }}
-      targetPort: {{ $externalTargetPort  }}
-      {{- else if and (eq $root.Values.external.type "NodePort") (not $root.Values.external.distinct)  }}
-      targetPort: {{ $externalTargetPort  }}
+      {{- if and (eq $root.Values.external.type "LoadBalancer") ($root.Values.external.distinct) }}
+      targetPort: {{ $servicePort }}
       {{- else }}
       targetPort: {{ $externalListenerPort }}
       {{- end }}

--- a/incubator/kafka/values.yaml
+++ b/incubator/kafka/values.yaml
@@ -127,15 +127,18 @@ headless:
 ## External access.
 ##
 external:
+  enabled: false
+  # type can be either NodePort or LoadBalancer
   type: NodePort
   # annotations:
   #  service.beta.kubernetes.io/openstack-internal-load-balancer: "true"
   dns:
     useInternal: false
     useExternal: true
-  # create an A record for each statefulset pod
+  # If using external service type LoadBalancer and external dns, set distinct to true below.
+  # This creates an A record for each statefulset pod/broker. You should then map the
+  # A record of the broker to the EXTERNAL IP given by the LoadBalancer in your DNS server.
   distinct: false
-  enabled: false
   servicePort: 19092
   firstListenerPort: 31090
   domain: cluster.local
@@ -165,9 +168,14 @@ configurationOverrides:
   ## - http://kafka.apache.org/documentation/#security_configbroker
   ## - https://cwiki.apache.org/confluence/display/KAFKA/KIP-103%3A+Separation+of+Internal+and+External+traffic
   ##
-  ## Setting "advertised.listeners" here appends to "PLAINTEXT://${POD_IP}:9092,"
+  ## Setting "advertised.listeners" here appends to "PLAINTEXT://${POD_IP}:9092,", ensure you update the domain
+  ## If external service type is Nodeport:
   # "advertised.listeners": |-
   #   EXTERNAL://kafka.cluster.local:$((31090 + ${KAFKA_BROKER_ID}))
+  ## If external service type is LoadBalancer:
+  # "advertised.listeners": |-
+  #   EXTERNAL://kafka-$((${KAFKA_BROKER_ID})).cluster.local:19092
+  ## Uncomment to define the EXTERNAL Listener protocol
   # "listener.security.protocol.map": |-
   #   PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This fixes an issue caused by an earlier commit where the external
brokers were returning internal broker urls.

#### Which issue this PR fixes
  - fixes #12876, fixes #12853


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
