### PR TITLE
[incubator/jenkins] introduce development version

### DIFF
--- a/incubator/jenkins/.helmignore
+++ b/incubator/jenkins/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/jenkins/Chart.yaml
+++ b/incubator/jenkins/Chart.yaml
@@ -1,0 +1,20 @@
+name: jenkins
+home: https://jenkins.io/
+version: 0.37.0
+appVersion: lts
+description: Open source continuous integration server. It supports multiple SCM tools
+  including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based
+  projects as well as arbitrary scripts.
+sources:
+- https://github.com/jenkinsci/jenkins
+- https://github.com/jenkinsci/docker-jnlp-slave
+- https://github.com/nuvo/kube-tasks
+- https://github.com/jenkinsci/configuration-as-code-plugin
+maintainers:
+- name: lachie83
+  email: lachlan.evenson@microsoft.com
+- name: viglesiasce
+  email: viglesias@google.com
+- name: maorfr
+  email: maorfr@gmail.com
+icon: https://wiki.jenkins-ci.org/download/attachments/2916393/logo.png

--- a/incubator/jenkins/OWNERS
+++ b/incubator/jenkins/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- lachie83
+- viglesiasce
+- maorfr
+reviewers:
+- lachie83
+- viglesiasce
+- maorfr

--- a/incubator/jenkins/README.md
+++ b/incubator/jenkins/README.md
@@ -1,7 +1,9 @@
 # Jenkins Helm Chart
 
 Jenkins master and slave cluster utilizing the Jenkins Kubernetes plugin
+
 * https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin
+
 Inspired by the awesome work of Carlos Sanchez <mailto:carlos@apache.org>
 
 ## Note

--- a/incubator/jenkins/README.md
+++ b/incubator/jenkins/README.md
@@ -1,0 +1,454 @@
+# Jenkins Helm Chart
+
+Jenkins master and slave cluster utilizing the Jenkins Kubernetes plugin
+* https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin
+Inspired by the awesome work of Carlos Sanchez <mailto:carlos@apache.org>
+
+## Note
+
+This version of the chart is for development towards a new 1.0 version. Contributions are most welcome!
+
+The goal is to make this chart follow [chart best practices](https://helm.sh/docs/chart_best_practices/), and then return it to the `stable` repository.
+The reason behind making this copy is that despite the chart being in major version `0`, it is in the `stable` repository. This means that the chart version indicates that [anything can change at any time](https://semver.org/#spec-item-4), but is in effect considered stable.
+
+If you are wondering where your PR should go, here are some rules of thumb:
+* If this is a breaking change, it should go to `incubator` only.
+* If this is a new feature, it should go to `incubator` and then optionally to `stable`.
+* If this is a fix, it should go to `stable` and then to `incubator`.
+  * To avoid regression, be sure to reference the `stable` PR when creating the `incubator` PR.
+* If you are introducing documentation, it should go to `incubator` and then to `stable`.
+
+## Chart Details
+
+This chart will do the following:
+
+* 1 x Jenkins Master with port 8080 exposed on an external LoadBalancer
+* All using Kubernetes Deployments
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release incubator/jenkins
+```
+
+## Configuration
+
+The following tables list the configurable parameters of the Jenkins chart and their default values.
+
+### Jenkins Master
+| Parameter                         | Description                          | Default                                                                      |
+| --------------------------------- | ------------------------------------ | ---------------------------------------------------------------------------- |
+| `nameOverride`                    | Override the resource name prefix    | `jenkins`                                                                    |
+| `fullnameOverride`                | Override the full resource names     | `jenkins-{release-name}` (or `jenkins` if release-name is `jenkins`)         |
+| `Master.Name`                     | Jenkins master name                  | `jenkins-master`                                                             |
+| `Master.Image`                    | Master image name                    | `jenkins/jenkins`                                                            |
+| `Master.ImageTag`                 | Master image tag                     | `lts`                                                                     |
+| `Master.ImagePullPolicy`          | Master image pull policy             | `Always`                                                                     |
+| `Master.ImagePullSecret`          | Master image pull secret             | Not set                                                                      |
+| `Master.Component`                | k8s selector key                     | `jenkins-master`                                                             |
+| `Master.NumExecutors`             | Set Number of executors              | 0                                                                             |
+| `Master.UseSecurity`              | Use basic security                   | `true`                                                                       |
+| `Master.SecurityRealm`            | Custom Security Realm                | Not set                                                                      |
+| `Master.AuthorizationStrategy`    | Jenkins XML job config for AuthorizationStrategy | Not set                                                                      |
+| `Master.DeploymentLabels`         | Custom Deployment labels             | Not set                                                                      |
+| `Master.ServiceLabels`            | Custom Service labels                | Not set                                                                      |
+| `Master.PodLabels`                | Custom Pod labels                    | Not set                                                                      |
+| `Master.AdminUser`                | Admin username (and password) created as a secret if useSecurity is true | `admin`                                  |
+| `Master.AdminPassword`            | Admin password (and user) created as a secret if useSecurity is true | Random value                                  |
+| `Master.JenkinsAdminEmail`        | Email address for the administrator of the Jenkins instance | Not set                                               |
+| `Master.resources`                | Resources allocation (Requests and Limits) | `{requests: {cpu: 50m, memory: 256Mi}, limits: {cpu: 2000m, memory: 2048Mi}}`|
+| `Master.InitContainerEnv`         | Environment variables for Init Container                                 | Not set                                  |
+| `Master.ContainerEnv`             | Environment variables for Jenkins Container                              | Not set                                  |
+| `Master.UsePodSecurityContext`    | Enable pod security context (must be `true` if `RunAsUser` or `FsGroup` are set) | `true`                           |
+| `Master.RunAsUser`                | uid that jenkins runs with           | `0`                                                                          |
+| `Master.FsGroup`                  | uid that will be used for persistent volume | `0`                                                                   |
+| `Master.HostAliases`              | Aliases for IPs in `/etc/hosts`      | `[]`                                                                         |
+| `Master.ServiceAnnotations`       | Service annotations                  | `{}`                                                                         |
+| `Master.ServiceType`              | k8s service type                     | `LoadBalancer`                                                               |
+| `Master.ServicePort`              | k8s service port                     | `8080`                                                                       |
+| `Master.NodePort`                 | k8s node port                        | Not set                                                                      |
+| `Master.HealthProbes`             | Enable k8s liveness and readiness probes | `true`                                                                   |
+| `Master.HealthProbesLivenessTimeout`      | Set the timeout for the liveness probe | `120`                                                       |
+| `Master.HealthProbesReadinessTimeout` | Set the timeout for the readiness probe | `60`                                                       |
+| `Master.HealthProbeReadinessPeriodSeconds` | Set how often (in seconds) to perform the liveness probe | `10`                                                       |
+| `Master.HealthProbeLivenessFailureThreshold` | Set the failure threshold for the liveness probe | `12`                                                       |
+| `Master.SlaveListenerPort`        | Listening port for agents            | `50000`                                                                      |
+| `Master.SlaveHostPort`        | Host port to listen for agents            | Not set                                                                |
+| `Master.DisabledAgentProtocols`   | Disabled agent protocols             | `JNLP-connect JNLP2-connect`                                                                      |
+| `Master.CSRF.DefaultCrumbIssuer.Enabled` | Enable the default CSRF Crumb issuer | `true`                                                                      |
+| `Master.CSRF.DefaultCrumbIssuer.ProxyCompatability` | Enable proxy compatibility | `true`                                                                      |
+| `Master.CLI`                      | Enable CLI over remoting             | `false`                                                                      |
+| `Master.LoadBalancerSourceRanges` | Allowed inbound IP addresses         | `0.0.0.0/0`                                                                  |
+| `Master.LoadBalancerIP`           | Optional fixed external IP           | Not set                                                                      |
+| `Master.JMXPort`                  | Open a port, for JMX stats           | Not set                                                                      |
+| `Master.ExtraPorts`               | Open extra ports, for other uses     | Not set                                                                      |
+| `Master.OverwriteConfig`          | Replace init scripts and config w/ ConfigMap on boot  | `false`                                                                      |
+| `Master.ingress.enabled`          | Enables ingress      | `false`                                                                         |
+| `Master.ingress.apiVersion`       | Ingress API version                  | `extensions/v1beta1`                                                         |
+| `Master.ingress.hostName`         | Ingress host name      | Not set                                                                         |
+| `Master.ingress.annotations`      | Ingress annotations                  | `{}`                                                                         |
+| `Master.ingress.labels`           | Ingress labels                       | `{}`                                                                         |
+| `Master.ingress.path`             | Ingress path                         | Not set                                                                         |
+| `Master.ingress.tls`              | Ingress TLS configuration            | `[]`                                                                         |
+| `Master.JCasC.enabled`            | Wheter Jenkins Configuration as Code is enabled or not | `false`                                                    |
+| `Master.JCasC.ConfigScripts`      | List of Jenkins Config as Code scripts | False                                                                      |
+| `Master.Sidecars.configAutoReload` | Jenkins Config as Code auto-reload settings |                                                                      |
+| `Master.Sidecars.configAutoReload.enabled` | Jenkins Config as Code auto-reload settings (Attention: rbac needs to be enabled otherwise the sidecar can't read the config map) | `false`                                                      |
+| `Master.Sidecars.configAutoReload.image` | Image which triggers the reload | `shadwell/k8s-sidecar:0.0.2`                        ````                       |
+| `Master.Sidecars.others`          | Configures additional sidecar container(s) for Jenkins master | `{}`                                                |
+| `Master.InitScripts`              | List of Jenkins init scripts         | Not set                                                                      |
+| `Master.CredentialsXmlSecret`     | Kubernetes secret that contains a 'credentials.xml' file | Not set                                                  |
+| `Master.SecretsFilesSecret`       | Kubernetes secret that contains 'secrets' files | Not set                                                           |
+| `Master.Jobs`                     | Jenkins XML job configs              | Not set                                                                      |
+| `Master.overwriteJobs`          | Replace jobs w/ ConfigMap on boot  | `false`                                                                      |
+| `Master.InstallPlugins`           | List of Jenkins plugins to install   | `kubernetes:1.14.0 workflow-aggregator:2.6 credentials-binding:1.17 git:3.9.1 workflow-job:2.31` |
+| `Master.OverwritePlugins`         | Overwrite installed plugins on start.| `false`                                                                      |
+| `Master.EnableRawHtmlMarkupFormatter` | Enable HTML parsing using (see below) | Not set                                                                 |
+| `Master.ScriptApproval`           | List of groovy functions to approve  | Not set                                                                      |
+| `Master.NodeSelector`             | Node labels for pod assignment       | `{}`                                                                         |
+| `Master.Affinity`                 | Affinity settings                    | `{}`                                                                         |
+| `Master.Tolerations`              | Toleration labels for pod assignment | `{}`                                                                         |
+| `Master.PodAnnotations`           | Annotations for master pod           | `{}`                                                                         |
+| `Master.CustomConfigMap`          | Deprecated: Use a custom ConfigMap               | `false`                                                                      |
+| `Master.AdditionalConfig`         | Deprecated: Add additional config files         | `{}`
+| `Master.JenkinsUriPrefix`         | Root Uri Jenkins will be served on         | Not set
+| `NetworkPolicy.Enabled`           | Enable creation of NetworkPolicy resources. | `false`                                                               |
+| `NetworkPolicy.ApiVersion`        | NetworkPolicy ApiVersion             | `networking.k8s.io/v1`                                                         |
+| `rbac.install`                    | Create service account and ClusterRoleBinding for Kubernetes plugin | `false`                                       |
+| `rbac.roleRef`                    | Cluster role name to bind to         | `cluster-admin`                                                              |
+| `rbac.roleKind`            | Role kind (`Role` or `ClusterRole`)| `ClusterRole`
+| `rbac.roleBindingKind`            | Role binding kind (`RoleBinding` or `ClusterRoleBinding`)| `ClusterRoleBinding`                                             |
+
+Some third-party systems, e.g. GitHub, use HTML-formatted data in their payload sent to a Jenkins webhooks, e.g. URL of a pull-request being built. To display such data as processed HTML instead of raw text set `Master.EnableRawHtmlMarkupFormatter` to true. This option requires installation of OWASP Markup Formatter Plugin (antisamy-markup-formatter). The plugin is **not** installed by default, please update `Master.InstallPlugins`.
+
+### Jenkins Agent
+
+| Parameter                  | Description                                     | Default                |
+| -------------------------- | ----------------------------------------------- | ---------------------- |
+| `Agent.AlwaysPullImage`    | Always pull agent container image before build  | `false`                |
+| `Agent.CustomJenkinsLabels`| Append Jenkins labels to the agent              | `{}`                   |
+| `Agent.Enabled`            | Enable Kubernetes plugin jnlp-agent podTemplate | `true`                 |
+| `Agent.Image`              | Agent image name                                | `jenkins/jnlp-slave` |
+| `Agent.ImagePullSecret`    | Agent image pull secret                         | Not set                |
+| `Agent.ImageTag`           | Agent image tag                                 | `3.27-1`                 |
+| `Agent.Privileged`         | Agent privileged container                      | `false`                |
+| `Agent.resources`          | Resources allocation (Requests and Limits)      | `{requests: {cpu: 200m, memory: 256Mi}, limits: {cpu: 200m, memory: 256Mi}}`|
+| `Agent.volumes`            | Additional volumes                              | `nil`                  |
+| `Agent.envVars`            | Environment variables for the slave Pod         | Not set                |
+| `Agent.Command`            | Executed command when side container starts     | Not set                |
+| `Agent.Args`               | Arguments passed to executed command            | Not set                |
+| `Agent.SideContainerName`  | Side container name in agent                    | jnlp                   |
+| `Agent.TTYEnabled`         | Allocate pseudo tty to the side container       | false                  |
+| `Agent.ContainerCap`       | Maximum number of agent                         | 10                     |
+| `Agent.PodName`            | slave Pod base name                             | Not set                |
+
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml incubator/jenkins
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Mounting volumes into your Agent pods
+
+Your Jenkins Agents will run as pods, and it's possible to inject volumes where needed:
+
+```yaml
+Agent:
+  volumes:
+  - type: Secret
+    secretName: jenkins-mysecrets
+    mountPath: /var/run/secrets/jenkins-mysecrets
+```
+
+The supported volume types are: `ConfigMap`, `EmptyDir`, `HostPath`, `Nfs`, `Pod`, `Secret`. Each type supports a different set of configurable attributes, defined by [the corresponding Java class](https://github.com/jenkinsci/kubernetes-plugin/tree/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes).
+
+## NetworkPolicy
+
+To make use of the NetworkPolicy resources created by default,
+install [a networking plugin that implements the Kubernetes
+NetworkPolicy spec](https://kubernetes.io/docs/tasks/administer-cluster/declare-network-policy#before-you-begin).
+
+For Kubernetes v1.5 & v1.6, you must also turn on NetworkPolicy by setting
+the DefaultDeny namespace annotation. Note: this will enforce policy for _all_ pods in the namespace:
+
+    kubectl annotate namespace default "net.beta.kubernetes.io/network-policy={\"ingress\":{\"isolation\":\"DefaultDeny\"}}"
+
+Install helm chart with network policy enabled:
+
+    $ helm install incubator/jenkins --set NetworkPolicy.Enabled=true
+
+## Adding customized securityRealm
+
+`Master.SecurityRealm` in values can be used to support custom security realm instead of default `LegacySecurityRealm`. For example, you can add a security realm to authenticate via keycloak.
+
+```yaml
+SecurityRealm: |-
+  <securityRealm class="org.jenkinsci.plugins.oic.OicSecurityRealm" plugin="oic-auth@1.0">
+    <clientId>testId</clientId>
+    <clientSecret>testsecret</clientSecret>
+    <tokenServerUrl>https:testurl</tokenServerUrl>
+    <authorizationServerUrl>https:testAuthUrl</authorizationServerUrl>
+    <userNameField>email</userNameField>
+    <scopes>openid email</scopes>
+  </securityRealm>
+```
+
+## Adding additional configs
+
+`Master.AdditionalConfig` can be used to add additional config files in `config.yaml`. For example, it can be used to add additional config files for keycloak authentication.
+
+```yaml
+AdditionalConfig:
+  testConfig.txt: |-
+    - name: testName
+      clientKey: testKey
+      clientURL: testUrl
+```
+
+## Adding customized labels
+
+`Master.ServiceLabels` can be used to add custom labels in `jenkins-master-svc.yaml`. For example,
+
+```yaml
+ServiceLabels:
+  expose: true
+```
+
+## Persistence
+
+The Jenkins image stores persistence under `/var/jenkins_home` path of the container. A dynamically managed Persistent Volume
+Claim is used to keep the data across deployments, by default. This is known to work in GCE, AWS, and minikube. Alternatively,
+a previously configured Persistent Volume Claim can be used.
+
+It is possible to mount several volumes using `Persistence.volumes` and `Persistence.mounts` parameters.
+
+### Persistence Values
+
+| Parameter                   | Description                     | Default         |
+| --------------------------- | ------------------------------- | --------------- |
+| `Persistence.Enabled`       | Enable the use of a Jenkins PVC | `true`          |
+| `Persistence.ExistingClaim` | Provide the name of a PVC       | `nil`           |
+| `Persistence.AccessMode`    | The PVC access mode             | `ReadWriteOnce` |
+| `Persistence.Size`          | The size of the PVC             | `8Gi`           |
+| `Persistence.SubPath`       | SubPath for jenkins-home mount  | `nil`           |
+| `Persistence.volumes`       | Additional volumes              | `nil`           |
+| `Persistence.mounts`        | Additional mounts               | `nil`           |
+
+#### Existing PersistentVolumeClaim
+
+1. Create the PersistentVolume
+2. Create the PersistentVolumeClaim
+3. Install the chart
+
+```bash
+$ helm install --name my-release --set Persistence.ExistingClaim=PVC_NAME incubator/jenkins
+```
+
+## Configuration as Code
+Jenkins Configuration as Code is now a standard component in the Jenkins project.  Add a key under ConfigScripts for each configuration area, where each corresponds to a plugin or section of the UI.  The keys (prior to | character) are just labels, and can be any value.  They are only used to give the section a meaningful name.  The only restriction is they must conform to RFC 1123 definition of a DNS label, so may only contain lowercase letters, numbers, and hyphens.  Each key will become the name of a configuration yaml file on the master in /var/jenkins_home/casc_configs (by default) and will be processed by the Configuration as Code Plugin during Jenkins startup.  The lines after each | become the content of the configuration yaml file.  The first line after this is a JCasC root element, eg jenkins, credentials, etc.  Best reference is the Documentation link here: https://<jenkins_url>/configuration-as-code.  The example below creates ldap settings:
+
+```yaml
+ConfigScripts:
+  ldap-settings: |
+    jenkins:
+      securityRealm:
+        ldap:
+          configurations:
+            configurations:
+              - server: ldap.acme.com
+                rootDN: dc=acme,dc=uk
+                managerPasswordSecret: ${LDAP_PASSWORD}
+              - groupMembershipStrategy:
+                  fromUserRecord:
+                    attributeName: "memberOf"
+```
+
+Further JCasC examples can be found [here.](https://github.com/jenkinsci/configuration-as-code-plugin/tree/master/demos)
+### Config as Code with and without auto-reload 
+Config as Code changes (to Master.JCasC.ConfigScripts) can either force a new pod to be created and only be applied at next startup, or can be auto-reloaded on-the-fly.  If you choose `Master.Sidecars.autoConfigReload.enabled: true`, a second, auxiliary container will be installed into the Jenkins master pod, known as a "sidecar".  This watches for changes to ConfigScripts, copies the content onto the Jenkins file-system and issues a CLI command via SSH to reload configuration.  The admin user (or account you specify in Master.AdminUser) will have a random SSH private key (RSA 4096) assigned unless you specify a key in `Master.AdminSshKey`.  This will be saved to a k8s secret.  You can monitor this sidecar's logs using command `kubectl logs <master_pod> -c jenkins-sc-config -f`
+If you want to enable auto-reload then you also need to configure rbac as the container which triggers the reload needs to watch the config maps.
+
+```yaml
+Master:
+  JCasC:
+    enabled: true
+  Sidecars:
+    configAutoReload:
+      enabled: true
+rbac:
+  install: true
+```
+
+### Auto-reload with non-Jenkins identities
+When enabling LDAP or another non-Jenkins identity source, the built-in admin account will no longer exist.  Since the admin account is used by the sidecar to reload config, in order to use auto-reload, you must change the .Master.AdminUser to a valid username on your LDAP (or other) server.  If you use the matrix-auth plugin, this user must also be granted Overall\Administer rights in Jenkins.  Failure to do this will cause the sidecar container to fail to authenticate via SSH and enter a restart loop.  You can enable LDAP using the example above and add a Config as Code block for matrix security that includes:
+```yaml
+ConfigScripts:
+  matrix-auth: |
+    jenkins:
+      authorizationStrategy:
+        projectMatrix:
+          grantedPermissions:
+          - "Overall/Administer:<AdminUser_LDAP_username>"
+```
+You can instead grant this permission via the UI. When this is done, you can set `Master.Sidecars.configAutoReload.enabled: true` and upon the next Helm upgrade, auto-reload will be successfully enabled.
+
+## RBAC
+
+If running upon a cluster with RBAC enabled you will need to do the following:
+
+* `helm install incubator/jenkins --set rbac.install=true`
+* Create a Jenkins credential of type Kubernetes service account with service account name provided in the `helm status` output.
+* Under configure Jenkins -- Update the credentials config in the cloud section to use the service account credential you created in the step above.
+
+## Backup
+
+Adds a backup CronJob for jenkins, along with required RBAC resources.
+
+### Backup Values
+
+| Parameter                   | Description                                | Default                           |
+| --------------------------- | ------------------------------------------ | --------------------------------- |
+| `backup.enabled`            | Enable the use of a backup CronJob         | `false`                           |
+| `backup.schedule`           | Schedule to run jobs                       | `0 2 * * *`                       |
+| `backup.annotations`        | Backup pod annotations                     | iam.amazonaws.com/role: `jenkins` |
+| `backup.image.repo`         | Backup image repository                    | `nuvo/kube-tasks`                 |
+| `backup.image.tag`          | Backup image tag                           | `0.1.2`                           |
+| `backup.extraArgs`          | Additional arguments for kube-tasks        | `[]`                              |
+| `backup.env`                | Backup environment variables               | AWS_REGION: `us-east-1`           |
+| `backup.resources`          | Backup CPU/Memory resource requests/limits | Memory: `1Gi`, CPU: `1`           |
+| `backup.destination`        | Destination to store backup artifacts      | `s3://nuvo-jenkins-data/backup`   |
+
+### Restore from backup
+
+To restore a backup, you can use the `kube-tasks` underlying tool called [skbn](https://github.com/nuvo/skbn), which copies files from cloud storage to Kubernetes.
+The best way to do it would be using a `Job` to copy files from the desired backup tag to the Jenkins pod.
+See the [skbn in-cluster example](https://github.com/nuvo/skbn/tree/master/examples/in-cluster) for more details.
+
+
+## Run Jenkins as non root user
+
+The default settings of this helm chart let Jenkins run as root user with uid `0`.
+Due to security reasons you may want to run Jenkins as a non root user.
+Fortunately the default jenkins docker image `jenkins/jenkins` contains a user `jenkins` with uid `1000` that can be used for this purpose.
+
+Simply use the following settings to run Jenkins as `jenkins` user with uid `1000`.
+
+```yaml
+jenkins:
+  Master:
+    RunAsUser: 1000
+    FsGroup: 1000
+```
+
+## Providing jobs xml
+
+Jobs can be created (and overwritten) by providing jenkins config xml within the `values.yaml` file.
+The keys of the map will become a directory within the jobs directory.
+The values of the map will become the `config.xml` file in the respective directory.
+
+Below is an example of a `values.yaml` file and the directory structure created:
+
+#### values.yaml
+```yaml
+Master:
+  Jobs:
+    test-job: |-
+      <?xml version='1.0' encoding='UTF-8'?>
+      <project>
+        <keepDependencies>false</keepDependencies>
+        <properties/>
+        <scm class="hudson.scm.NullSCM"/>
+        <canRoam>false</canRoam>
+        <disabled>false</disabled>
+        <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+        <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+        <triggers/>
+        <concurrentBuild>false</concurrentBuild>
+        <builders/>
+        <publishers/>
+        <buildWrappers/>
+      </project>
+    test-job-2: |-
+      <?xml version='1.0' encoding='UTF-8'?>
+      <project>
+        <keepDependencies>false</keepDependencies>
+        <properties/>
+        <scm class="hudson.scm.NullSCM"/>
+        <canRoam>false</canRoam>
+        <disabled>false</disabled>
+        <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+        <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+        <triggers/>
+        <concurrentBuild>false</concurrentBuild>
+        <builders/>
+        <publishers/>
+        <buildWrappers/>
+```
+
+#### Directory structure of jobs directory
+```
+.
+├── _test-job-1
+|   └── config.xml
+├── _test-job-2
+|   └── config.xml
+```
+
+Docs taken from https://github.com/jenkinsci/docker/blob/master/Dockerfile:
+_Jenkins is run with user `jenkins`, uid = 1000. If you bind mount a volume from the host or a data container,ensure you use the same uid_
+
+## Running behind a forward proxy
+
+The master pod uses an Init Container to install plugins etc. If you are behind a corporate proxy it may be useful to set `Master.InitContainerEnv` to add environment variables such as `http_proxy`, so that these can be downloaded.
+
+Additionally, you may want to add env vars for the Jenkins container, and the JVM (`Master.JavaOpts`).
+
+```yaml
+Master:
+  InitContainerEnv:
+    - name: http_proxy
+      value: "http://192.168.64.1:3128"
+    - name: https_proxy
+      value: "http://192.168.64.1:3128"
+    - name: no_proxy
+      value: ""
+  ContainerEnv:
+    - name: http_proxy
+      value: "http://192.168.64.1:3128"
+    - name: https_proxy
+      value: "http://192.168.64.1:3128"
+  JavaOpts: >-
+    -Dhttp.proxyHost=192.168.64.1
+    -Dhttp.proxyPort=3128
+    -Dhttps.proxyHost=192.168.64.1
+    -Dhttps.proxyPort=3128
+```
+
+## Custom ConfigMap
+
+The following configuration method is deprecated and will be removed in an upcoming version of this chart.
+We recommend you use Jenkins Configuration as Code to configure instead.
+When creating a new parent chart with this chart as a dependency, the `CustomConfigMap` parameter can be used to override the default config.xml provided.
+It also allows for providing additional xml configuration files that will be copied into `/var/jenkins_home`. In the parent chart's values.yaml,
+set the `jenkins.Master.CustomConfigMap` value to true like so
+
+```yaml
+jenkins:
+  Master:
+    CustomConfigMap: true
+```
+
+and provide the file `templates/config.tpl` in your parent chart for your use case. You can start by copying the contents of `config.yaml` from this chart into your parent charts `templates/config.tpl` as a basis for customization. Finally, you'll need to wrap the contents of `templates/config.tpl` like so:
+
+```yaml
+{{- define "override_config_map" }}
+    <CONTENTS_HERE>
+{{ end }}
+```

--- a/incubator/jenkins/templates/NOTES.txt
+++ b/incubator/jenkins/templates/NOTES.txt
@@ -1,0 +1,64 @@
+#### This chart is undergoing work which may result in breaking changes. ####
+#### Please consult the following table and the README ####
+
+Master.HostName --> Master.ingress.hostName
+New value - Master.ingress.enabled
+Master.Ingress.ApiVersion --> Master.ingress.apiVersion
+Master.Ingress.Annotations --> Master.ingress.annotations
+Master.Ingress.Labels --> Master.ingress.labels
+Master.Ingress.Path --> Master.ingress.path
+Master.Ingress.TLS --> Master.ingress.tls
+Master.OwnSshKey, a bool, has been replaced with Master.AdminSshKey, which is expected to be a string containing the actual key
+
+1. Get your '{{ .Values.Master.AdminUser }}' user password by running:
+  printf $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "jenkins.fullname" . }} -o jsonpath="{.data.jenkins-admin-password}" | base64 --decode);echo
+
+{{- if .Values.Master.HostName }}
+
+2. Visit http://{{ .Values.Master.HostName }}
+{{- else }}
+2. Get the Jenkins URL to visit by running these commands in the same shell:
+{{- if contains "NodePort" .Values.Master.ServiceType }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "jenkins.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT/login
+
+{{- else if contains "LoadBalancer" .Values.Master.ServiceType }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        You can watch the status of by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "jenkins.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "jenkins.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+  echo http://$SERVICE_IP:{{ .Values.Master.ServicePort }}/login
+
+{{- else if contains "ClusterIP"  .Values.Master.ServiceType }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "component={{ .Release.Name }}-{{ .Values.Master.Component }}" -o jsonpath="{.items[0].metadata.name}")
+  echo http://127.0.0.1:{{ .Values.Master.ServicePort }}
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.Master.ServicePort }}:{{ .Values.Master.ServicePort }}
+
+{{- end }}
+{{- end }}
+
+3. Login with the password from step 1 and the username: {{ .Values.Master.AdminUser }}
+{{ if .Values.Master.JCasC.enabled }}
+4. Use Jenkins Configuration as Code by specifying ConfigScripts in your values.yaml file, see documentation: http://{{ .Values.Master.HostName }}/configuration-as-code and examples: https://github.com/jenkinsci/configuration-as-code-plugin/tree/master/demos
+{{- end }}
+
+For more information on running Jenkins on Kubernetes, visit:
+https://cloud.google.com/solutions/jenkins-on-container-engine
+{{- if .Values.Master.JCasC.enabled }}
+For more information about Jenkins Configuration as Code, visit:
+https://jenkins.io/projects/jcasc/
+{{- end }}
+
+{{- if .Values.Persistence.Enabled }}
+{{- else }}
+#################################################################################
+######   WARNING: Persistence is disabled!!! You will lose your data when   #####
+######            the Jenkins pod is terminated.                            #####
+#################################################################################
+{{- end }}
+
+{{- if .Values.rbac.install }}
+Configure the Kubernetes plugin in Jenkins to use the following Service Account name {{ template "jenkins.fullname" . }} using the following steps:
+  Create a Jenkins credential of type Kubernetes service account with service account name {{ template "jenkins.fullname" . }}
+  Under configure Jenkins -- Update the credentials config in the cloud section to use the service account credential you created in the step above.
+{{- end }}

--- a/incubator/jenkins/templates/_helpers.tpl
+++ b/incubator/jenkins/templates/_helpers.tpl
@@ -1,0 +1,44 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "jenkins.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "jenkins.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "jenkins.kubernetes-version" -}}
+  {{- range .Values.Master.InstallPlugins -}}
+    {{ if hasPrefix "kubernetes:" . }}
+      {{- $split := splitList ":" . }}
+      {{- printf "%s" (index $split 1 ) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Generate private key for jenkins CLI
+*/}}
+{{- define "jenkins.gen-key" -}}
+{{- if not .Values.Master.AdminSshKey -}}
+{{- $key := genPrivateKey "rsa" -}}
+jenkins-admin-private-key: {{ $key | b64enc | quote }}
+{{- end -}}
+{{- end -}}

--- a/incubator/jenkins/templates/config.yaml
+++ b/incubator/jenkins/templates/config.yaml
@@ -1,0 +1,335 @@
+{{- if not .Values.Master.CustomConfigMap }}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "jenkins.fullname" . }}
+data:
+  config.xml: |-
+    <?xml version='1.0' encoding='UTF-8'?>
+    <hudson>
+      <disabledAdministrativeMonitors/>
+      <version>{{ .Values.Master.ImageTag }}</version>
+      <numExecutors>{{ .Values.Master.NumExecutors }}</numExecutors>
+      <mode>NORMAL</mode>
+      <useSecurity>{{ .Values.Master.UseSecurity }}</useSecurity>
+{{- if not (empty .Values.Master.AuthorizationStrategy ) }}
+{{ .Values.Master.AuthorizationStrategy | indent 6 }}
+{{- else }}
+      <authorizationStrategy class="hudson.security.FullControlOnceLoggedInAuthorizationStrategy">
+        <denyAnonymousReadAccess>true</denyAnonymousReadAccess>
+      </authorizationStrategy>
+{{- end }}
+{{- if .Values.Master.SecurityRealm }}
+{{ .Values.Master.SecurityRealm | indent 6 }}
+{{- else }}
+      <securityRealm class="hudson.security.LegacySecurityRealm"/>
+{{- end }}
+      <disableRememberMe>false</disableRememberMe>
+      <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
+      <workspaceDir>${JENKINS_HOME}/workspace/${ITEM_FULLNAME}</workspaceDir>
+      <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+{{- if .Values.Master.EnableRawHtmlMarkupFormatter }}
+      <markupFormatter class="hudson.markup.RawHtmlMarkupFormatter" plugin="antisamy-markup-formatter">
+        <disableSyntaxHighlighting>true</disableSyntaxHighlighting>
+      </markupFormatter>
+{{- else }}
+      <markupFormatter class="hudson.markup.EscapedMarkupFormatter"/>
+{{- end }}
+      <jdks/>
+      <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+      <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+      <clouds>
+        <org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud plugin="kubernetes@{{ template "jenkins.kubernetes-version" . }}">
+          <name>kubernetes</name>
+          <templates>
+{{- if .Values.Agent.Enabled }}
+            <org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
+              <inheritFrom></inheritFrom>
+              <name>{{ .Values.Agent.PodName }}</name>
+              <instanceCap>2147483647</instanceCap>
+              <idleMinutes>0</idleMinutes>
+              <label>{{ .Release.Name }}-{{ .Values.Agent.Component }} {{ .Values.Agent.CustomJenkinsLabels  | join " " }}</label>
+              <nodeSelector>
+                {{- $local := dict "first" true }}
+                {{- range $key, $value := .Values.Agent.NodeSelector }}
+                  {{- if not $local.first }},{{- end }}
+                  {{- $key }}={{ $value }}
+                  {{- $_ := set $local "first" false }}
+                {{- end }}</nodeSelector>
+                <nodeUsageMode>NORMAL</nodeUsageMode>
+              <volumes>
+{{- range $index, $volume := .Values.Agent.volumes }}
+                <org.csanchez.jenkins.plugins.kubernetes.volumes.{{ $volume.type }}Volume>
+{{- range $key, $value := $volume }}{{- if not (eq $key "type") }}
+                  <{{ $key }}>{{ $value }}</{{ $key }}>
+{{- end }}{{- end }}
+                </org.csanchez.jenkins.plugins.kubernetes.volumes.{{ $volume.type }}Volume>
+{{- end }}
+              </volumes>
+              <containers>
+                <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
+                  <name>{{ .Values.Agent.SideContainerName }}</name>
+                  <image>{{ .Values.Agent.Image }}:{{ .Values.Agent.ImageTag }}</image>
+{{- if .Values.Agent.Privileged }}
+                  <privileged>true</privileged>
+{{- else }}
+                  <privileged>false</privileged>
+{{- end }}
+                  <alwaysPullImage>{{ .Values.Agent.AlwaysPullImage }}</alwaysPullImage>
+                  <workingDir>/home/jenkins</workingDir>
+                  <command>{{ .Values.Agent.Command }}</command>
+{{- if .Values.Agent.Args }}
+                  <args>{{ .Values.Agent.Args }}</args>
+{{- else }}
+                  <args>${computer.jnlpmac} ${computer.name}</args>
+{{- end }}
+                  <ttyEnabled>{{ .Values.Agent.TTYEnabled }}</ttyEnabled>
+                  # Resources configuration is a little hacky. This was to prevent breaking
+                  # changes, and should be cleanned up in the future once everybody had
+                  # enough time to migrate.
+                  <resourceRequestCpu>{{.Values.Agent.Cpu | default .Values.Agent.resources.requests.cpu}}</resourceRequestCpu>
+                  <resourceRequestMemory>{{.Values.Agent.Memory | default .Values.Agent.resources.requests.memory}}</resourceRequestMemory>
+                  <resourceLimitCpu>{{.Values.Agent.Cpu | default .Values.Agent.resources.limits.cpu}}</resourceLimitCpu>
+                  <resourceLimitMemory>{{.Values.Agent.Memory | default .Values.Agent.resources.limits.memory}}</resourceLimitMemory>
+                  <envVars>
+                    <org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar>
+                      <key>JENKINS_URL</key>
+{{- if .Values.Master.SlaveKubernetesNamespace }}
+                      <value>http://{{ template "jenkins.fullname" . }}.{{.Release.Namespace}}:{{.Values.Master.ServicePort}}{{ default "" .Values.Master.JenkinsUriPrefix }}</value>
+{{- else }}
+                      <value>http://{{ template "jenkins.fullname" . }}:{{.Values.Master.ServicePort}}{{ default "" .Values.Master.JenkinsUriPrefix }}</value>
+{{- end }}
+                    </org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar>
+                  </envVars>
+                </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
+              </containers>
+              <envVars>
+{{- range $index, $var := .Values.Agent.envVars }}
+                <org.csanchez.jenkins.plugins.kubernetes.PodEnvVar>
+                  <key>{{ $var.name }}</key>
+                  <value>{{ $var.value }}</value>
+                </org.csanchez.jenkins.plugins.kubernetes.PodEnvVar>
+{{- end }}
+              </envVars>
+              <annotations/>
+{{- if .Values.Agent.ImagePullSecret }}
+              <imagePullSecrets>
+                <org.csanchez.jenkins.plugins.kubernetes.PodImagePullSecret>
+                  <name>{{ .Values.Agent.ImagePullSecret }}</name>
+                </org.csanchez.jenkins.plugins.kubernetes.PodImagePullSecret>
+              </imagePullSecrets>
+{{- else }}
+              <imagePullSecrets/>
+{{- end }}
+              <nodeProperties/>
+              <podRetention class="org.csanchez.jenkins.plugins.kubernetes.pod.retention.Default"/>
+            </org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
+{{- end -}}
+          </templates>
+          <serverUrl>https://kubernetes.default</serverUrl>
+          <skipTlsVerify>false</skipTlsVerify>
+          <namespace>{{ default .Release.Namespace .Values.Master.SlaveKubernetesNamespace }}</namespace>
+{{- if .Values.Master.SlaveKubernetesNamespace }}
+          <jenkinsUrl>http://{{ template "jenkins.fullname" . }}.{{.Release.Namespace}}:{{.Values.Master.ServicePort}}{{ default "" .Values.Master.JenkinsUriPrefix }}</jenkinsUrl>
+          <jenkinsTunnel>{{ template "jenkins.fullname" . }}-agent.{{.Release.Namespace}}:{{ .Values.Master.SlaveListenerPort }}</jenkinsTunnel>
+{{- else }}
+          <jenkinsUrl>http://{{ template "jenkins.fullname" . }}:{{.Values.Master.ServicePort}}{{ default "" .Values.Master.JenkinsUriPrefix }}</jenkinsUrl>
+          <jenkinsTunnel>{{ template "jenkins.fullname" . }}-agent:{{ .Values.Master.SlaveListenerPort }}</jenkinsTunnel>
+{{- end }}
+          <containerCap>{{ .Values.Agent.ContainerCap }}</containerCap>
+          <retentionTimeout>5</retentionTimeout>
+          <connectTimeout>0</connectTimeout>
+          <readTimeout>0</readTimeout>
+          <podRetention class="org.csanchez.jenkins.plugins.kubernetes.pod.retention.{{ .Values.Agent.PodRetention }}"/>
+        </org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud>
+      </clouds>
+      <quietPeriod>5</quietPeriod>
+      <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+      <views>
+        <hudson.model.AllView>
+          <owner class="hudson" reference="../../.."/>
+          <name>All</name>
+          <filterExecutors>false</filterExecutors>
+          <filterQueue>false</filterQueue>
+          <properties class="hudson.model.View$PropertyList"/>
+        </hudson.model.AllView>
+      </views>
+      <primaryView>All</primaryView>
+      <slaveAgentPort>{{ .Values.Master.SlaveListenerPort }}</slaveAgentPort>
+      <disabledAgentProtocols>
+{{- range .Values.Master.DisabledAgentProtocols }}
+        <string>{{ . }}</string>
+{{- end }}
+      </disabledAgentProtocols>
+      <label></label>
+{{- if .Values.Master.CSRF.DefaultCrumbIssuer.Enabled }}
+      <crumbIssuer class="hudson.security.csrf.DefaultCrumbIssuer">
+{{- if .Values.Master.CSRF.DefaultCrumbIssuer.ProxyCompatability }}
+        <excludeClientIPFromCrumb>true</excludeClientIPFromCrumb>
+{{- end }}
+      </crumbIssuer>
+{{- end }}
+      <nodeProperties/>
+      <globalNodeProperties/>
+      <noUsageStatistics>true</noUsageStatistics>
+    </hudson>
+{{- if .Values.Master.ScriptApproval }}
+  scriptapproval.xml: |-
+    <?xml version='1.0' encoding='UTF-8'?>
+    <scriptApproval plugin="script-security@1.27">
+      <approvedScriptHashes/>
+      <approvedSignatures>
+{{- range $key, $val := .Values.Master.ScriptApproval }}
+        <string>{{ $val }}</string>
+{{- end }}
+      </approvedSignatures>
+      <aclApprovedSignatures/>
+      <approvedClasspathEntries/>
+      <pendingScripts/>
+      <pendingSignatures/>
+      <pendingClasspathEntries/>
+    </scriptApproval>
+{{- end }}
+  jenkins.model.JenkinsLocationConfiguration.xml: |-
+    <?xml version='1.1' encoding='UTF-8'?>
+    <jenkins.model.JenkinsLocationConfiguration>
+      <adminAddress>{{ default "" .Values.Master.JenkinsAdminEmail }}</adminAddress>
+{{- if .Values.Master.JenkinsUrl }}
+      <jenkinsUrl>{{ .Values.Master.JenkinsUrl }}</jenkinsUrl>
+{{- else }}
+  {{- if .Values.Master.ingress.hostName }}
+    {{- if .Values.Master.ingress.tls }}
+      <jenkinsUrl>https://{{ .Values.Master.ingress.hostName }}{{ default "" .Values.Master.JenkinsUriPrefix }}</jenkinsUrl>
+    {{- else }}
+      <jenkinsUrl>http://{{ .Values.Master.ingress.hostName }}{{ default "" .Values.Master.JenkinsUriPrefix }}</jenkinsUrl>
+    {{- end }}
+  {{- else }}
+      <jenkinsUrl>http://{{ template "jenkins.fullname" . }}:{{.Values.Master.ServicePort}}{{ default "" .Values.Master.JenkinsUriPrefix }}</jenkinsUrl>
+  {{- end}}
+{{- end}}
+    </jenkins.model.JenkinsLocationConfiguration>
+  jenkins.CLI.xml: |-
+    <?xml version='1.1' encoding='UTF-8'?>
+    <jenkins.CLI>
+{{- if .Values.Master.CLI }}
+      <enabled>true</enabled>
+{{- else }}
+      <enabled>false</enabled>
+{{- end }}
+    </jenkins.CLI>
+  apply_config.sh: |-
+    mkdir -p /usr/share/jenkins/ref/secrets/;
+    echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch;
+{{- if .Values.Master.OverwriteConfig }}
+    cp /var/jenkins_config/config.xml /var/jenkins_home;
+    cp /var/jenkins_config/jenkins.CLI.xml /var/jenkins_home;
+    cp /var/jenkins_config/jenkins.model.JenkinsLocationConfiguration.xml /var/jenkins_home;
+  {{- else }}
+    yes n | cp -i /var/jenkins_config/config.xml /var/jenkins_home;
+    yes n | cp -i /var/jenkins_config/jenkins.CLI.xml /var/jenkins_home;
+    yes n | cp -i /var/jenkins_config/jenkins.model.JenkinsLocationConfiguration.xml /var/jenkins_home;
+  {{- if .Values.Master.AdditionalConfig }}
+{{- range $key, $val := .Values.Master.AdditionalConfig }}
+    cp /var/jenkins_config/{{- $key }} /var/jenkins_home;
+  {{- end }}
+  {{- end }}
+{{- end }}
+{{- if .Values.Master.OverwritePlugins }}
+    # remove all plugins from shared volume
+    rm -rf /var/jenkins_home/plugins/*
+{{- end }}
+{{- if .Values.Master.InstallPlugins }}
+    # Install missing plugins
+    cp /var/jenkins_config/plugins.txt /var/jenkins_home;
+    rm -rf /usr/share/jenkins/ref/plugins/*.lock
+    /usr/local/bin/install-plugins.sh `echo $(cat /var/jenkins_home/plugins.txt)`;
+    # Copy plugins to shared volume
+    yes n | cp -i /usr/share/jenkins/ref/plugins/* /var/jenkins_plugins/;
+{{- end }}
+{{- if .Values.Master.ScriptApproval }}
+    yes n | cp -i /var/jenkins_config/scriptapproval.xml /var/jenkins_home/scriptApproval.xml;
+{{- end }}
+{{- if and (.Values.Master.JCasC.enabled) (.Values.Master.Sidecars.configAutoReload.enabled) }}
+  {{- if not .Values.Master.InitScripts }}
+    mkdir -p /var/jenkins_home/init.groovy.d/;
+    yes n | cp -i /var/jenkins_config/*.groovy /var/jenkins_home/init.groovy.d/;
+  {{- end }}
+{{- end }}
+{{- if .Values.Master.InitScripts }}
+    mkdir -p /var/jenkins_home/init.groovy.d/;
+    {{- if .Values.Master.OverwriteConfig }}
+    rm -f /var/jenkins_home/init.groovy.d/*.groovy
+    {{- end }}
+    yes n | cp -i /var/jenkins_config/*.groovy /var/jenkins_home/init.groovy.d/;
+{{- end }}
+{{- if .Values.Master.JCasC.enabled }}
+  {{- if .Values.Master.Sidecars.configAutoReload.enabled }}
+    bash -c 'ssh-keygen -y -f <(echo "${ADMIN_PRIVATE_KEY}") > /var/jenkins_home/key.pub'
+  {{- else }}
+    mkdir -p /var/jenkins_home/casc_configs;
+    rm -rf /var/jenkins_home/casc_configs/*
+    cp -v /var/jenkins_config/*.yaml /var/jenkins_home/casc_configs
+  {{- end }}
+{{- end }}
+{{- if .Values.Master.CredentialsXmlSecret }}
+    yes n | cp -i /var/jenkins_credentials/credentials.xml /var/jenkins_home;
+{{- end }}
+{{- if .Values.Master.SecretsFilesSecret }}
+    yes n | cp -i /var/jenkins_secrets/* /usr/share/jenkins/ref/secrets/;
+{{- end }}
+{{- if .Values.Master.Jobs }}
+    for job in $(ls /var/jenkins_jobs); do
+      mkdir -p /var/jenkins_home/jobs/$job
+      yes {{ if not .Values.Master.overwriteJobs }}n{{ end }} | cp -i /var/jenkins_jobs/$job /var/jenkins_home/jobs/$job/config.xml
+    done
+{{- end }}
+{{- range $key, $val := .Values.Master.InitScripts }}
+  init{{ $key }}.groovy: |-
+{{ $val | indent 4 }}
+{{- end }}
+{{- if .Values.Master.JCasC.enabled }}
+  {{- if .Values.Master.Sidecars.configAutoReload.enabled }}
+  init-add-ssh-key-to-admin.groovy: |-
+    import jenkins.security.*
+    import hudson.model.User
+    import jenkins.security.ApiTokenProperty
+    import jenkins.model.Jenkins
+    User u = User.get("{{ .Values.Master.AdminUser | default "admin" }}")
+    ApiTokenProperty t = u.getProperty(ApiTokenProperty.class)
+    String sshKeyString = new File('/var/jenkins_home/key.pub').text
+    keys_param = new org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl(sshKeyString)
+    u.addProperty(keys_param)
+    def inst = Jenkins.getInstance()
+    def sshDesc = inst.getDescriptor("org.jenkinsci.main.modules.sshd.SSHD")
+    sshDesc.setPort({{ .Values.Master.Sidecars.configAutoReload.sshTcpPort | default 1044 }})
+    sshDesc.getActualPort()
+    sshDesc.save()
+  {{- else }}
+# Only add config to this script if we aren't auto-reloading otherwise the pod will restart upon each config change:
+{{- range $key, $val := .Values.Master.JCasC.ConfigScripts }}
+  {{ $key }}.yaml: |-
+{{ tpl $val $| indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}
+  plugins.txt: |-
+{{- if .Values.Master.InstallPlugins }}
+{{- range $index, $val := .Values.Master.InstallPlugins }}
+{{ $val | indent 4 }}
+{{- end }}
+{{- if .Values.Master.JCasC.enabled }}
+  {{- if not (contains "configuration-as-code" (quote .Values.Master.InstallPlugins)) }}
+    configuration-as-code:{{ .Values.Master.JCasC.PluginVersion }}
+  {{- end }}
+  {{- if not (contains "configuration-as-code-support" (quote .Values.Master.InstallPlugins)) }}
+    configuration-as-code-support:{{ .Values.Master.JCasC.SupportPluginVersion }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{ else }}
+{{ include "override_config_map" . }}
+{{- end -}}
+{{- if .Values.Master.AdditionalConfig }}
+{{- toYaml .Values.Master.AdditionalConfig | indent 2 }}
+{{- end }}

--- a/incubator/jenkins/templates/home-pvc.yaml
+++ b/incubator/jenkins/templates/home-pvc.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.Persistence.Enabled (not .Values.Persistence.ExistingClaim) -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+{{- if .Values.Persistence.Annotations }}
+  annotations:
+{{ toYaml .Values.Persistence.Annotations | indent 4 }}
+{{- end }}
+  name: {{ template "jenkins.fullname" . }}
+  labels:
+    app: {{ template "jenkins.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  accessModes:
+    - {{ .Values.Persistence.AccessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.Persistence.Size | quote }}
+{{- if .Values.Persistence.StorageClass }}
+{{- if (eq "-" .Values.Persistence.StorageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.Persistence.StorageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/incubator/jenkins/templates/jcasc-config.yaml
+++ b/incubator/jenkins/templates/jcasc-config.yaml
@@ -1,0 +1,19 @@
+{{- $root := . }}
+{{- if and (.Values.Master.JCasC.enabled) (.Values.Master.Sidecars.configAutoReload.enabled) }}
+{{- range $key, $val := .Values.Master.JCasC.ConfigScripts }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "jenkins.fullname" $root }}-jenkins-config-{{ $key }}
+  labels:
+    {{ template "jenkins.fullname" $root }}-jenkins-config: "true"
+    {{ $.Values.Master.Sidecars.configAutoReload.label | default "jenkins_config" }}: "true"
+    release: {{ $root.Release.Name }}
+    chart: "{{ $root.Chart.Name }}-{{ $root.Chart.Version }}"
+    component: "{{ $root.Release.Name }}-{{ $.Values.Master.Name }}"
+data:
+  {{ $key }}.yaml: |-
+{{ tpl $val $| indent 4 }}
+{{- end }}
+{{- end }}

--- a/incubator/jenkins/templates/jenkins-agent-svc.yaml
+++ b/incubator/jenkins/templates/jenkins-agent-svc.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "jenkins.fullname" . }}-agent
+  labels:
+    app: {{ template "jenkins.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Release.Name }}-{{ .Values.Master.Component }}"
+{{- if .Values.Master.SlaveListenerServiceAnnotations }}
+  annotations:
+{{ toYaml .Values.Master.SlaveListenerServiceAnnotations | indent 4 }}
+{{- end }}
+spec:
+  ports:
+    - port: {{ .Values.Master.SlaveListenerPort }}
+      targetPort: {{ .Values.Master.SlaveListenerPort }}
+      {{ if (and (eq .Values.Master.SlaveListenerServiceType "NodePort") (not (empty .Values.Master.SlaveListenerPort))) }}
+      nodePort: {{.Values.Master.SlaveListenerPort}}
+      {{end}}
+      name: slavelistener
+  selector:
+    component: "{{ .Release.Name }}-{{ .Values.Master.Component }}"
+  type: {{ .Values.Master.SlaveListenerServiceType }}

--- a/incubator/jenkins/templates/jenkins-backup-cronjob.yaml
+++ b/incubator/jenkins/templates/jenkins-backup-cronjob.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.backup.enabled }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ template "jenkins.fullname" . }}-backup
+  labels:
+    app: {{ template "jenkins.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 120
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            {{ toYaml .Values.backup.annotations }}
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: {{ template "jenkins.fullname" . }}-backup
+          containers:
+          - name: jenkins-backup
+            image: "{{ .Values.backup.image.repository }}:{{ .Values.backup.image.tag }}"
+            command: ["kube-tasks"]
+            args:
+            - simple-backup
+            - -n
+            - {{ .Release.Namespace }}
+            - -l
+            - release={{ .Release.Name }}
+            - --container
+            - {{ template "jenkins.fullname" . }}
+            - --path
+            - /var/jenkins_home
+            - --dst
+            - {{ .Values.backup.destination }}
+            {{- with .Values.backup.extraArgs }}
+{{ toYaml . | indent 12 }}
+            {{- end }}
+            {{- with .Values.backup.env }}
+            env:
+{{ toYaml . | indent 12 }}
+            {{- end }}
+          {{- with .Values.backup.resources }}
+            resources:
+{{ toYaml . | indent 14 }}
+          {{- end }}
+        affinity:
+          podAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - {{ template "jenkins.fullname" . }}
+                - key: release
+                  operator: In
+                  values:
+                  - {{ .Release.Name }}
+              topologyKey: "kubernetes.io/hostname"
+      {{- with .Values.tolerations }}
+        tolerations:
+{{ toYaml . | indent 10 }}
+      {{- end }}
+{{- end }}

--- a/incubator/jenkins/templates/jenkins-backup-rbac.yaml
+++ b/incubator/jenkins/templates/jenkins-backup-rbac.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.backup.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "jenkins.fullname" . }}-backup
+  labels:
+    app: {{ template "jenkins.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "jenkins.fullname" . }}-backup
+  labels:
+    app: {{ template "jenkins.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "jenkins.fullname" . }}-backup
+  labels:
+    app: {{ template "jenkins.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "jenkins.fullname" . }}-backup
+subjects:
+- kind: ServiceAccount
+  name: {{ template "jenkins.fullname" . }}-backup
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/incubator/jenkins/templates/jenkins-master-deployment.yaml
+++ b/incubator/jenkins/templates/jenkins-master-deployment.yaml
@@ -1,0 +1,363 @@
+{{- if .Capabilities.APIVersions.Has "apps/v1" }}
+apiVersion: apps/v1
+{{- else }}
+apiVersion: apps/v1beta1
+{{- end }}
+kind: Deployment
+metadata:
+  name: {{ template "jenkins.fullname" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Release.Name }}-{{ .Values.Master.Name }}"
+    {{- range $key, $val := .Values.Master.DeploymentLabels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end}}
+spec:
+  replicas: 1
+  strategy:
+    type: {{ if .Values.Persistence.Enabled }}Recreate{{ else }}RollingUpdate{{ end }}
+    rollingUpdate:
+    {{- if not .Values.Persistence.Enabled }}
+{{ toYaml .Values.Master.RollingUpdate | indent 6 }}
+    {{- end }}
+  selector:
+    matchLabels:
+      component: "{{ .Release.Name }}-{{ .Values.Master.Component }}"
+  template:
+    metadata:
+      labels:
+        app: {{ template "jenkins.fullname" . }}
+        heritage: {{ .Release.Service | quote }}
+        release: {{ .Release.Name | quote }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        component: "{{ .Release.Name }}-{{ .Values.Master.Component }}"
+        {{- range $key, $val := .Values.Master.PodLabels }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end}}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+        {{- if .Values.Master.PodAnnotations }}
+{{ toYaml .Values.Master.PodAnnotations | indent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.Master.NodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.Master.NodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.Master.Tolerations }}
+      tolerations:
+{{ toYaml .Values.Master.Tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.Master.Affinity }}
+      affinity:
+{{ toYaml .Values.Master.Affinity | indent 8 }}
+      {{- end }}
+{{- if .Values.Master.UsePodSecurityContext }}
+      securityContext:
+        runAsUser: {{ default 0 .Values.Master.RunAsUser }}
+{{- if and (.Values.Master.RunAsUser) (.Values.Master.FsGroup) }}
+{{- if not (eq .Values.Master.RunAsUser 0.0) }}
+        fsGroup: {{ .Values.Master.FsGroup }}
+{{- end }}
+{{- end }}
+{{- end }}
+      serviceAccountName: {{ if .Values.rbac.install }}{{ template "jenkins.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+{{- if .Values.Master.HostNetworking }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+{{- end }}
+      {{- if .Values.Master.HostAliases }}
+      hostAliases:
+        {{- toYaml .Values.Master.HostAliases | nindent 8 }}
+      {{- end }}
+      initContainers:
+        - name: "copy-default-config"
+          image: "{{ .Values.Master.Image }}:{{ .Values.Master.ImageTag }}"
+          imagePullPolicy: "{{ .Values.Master.ImagePullPolicy }}"
+          command: [ "sh", "/var/jenkins_config/apply_config.sh" ]
+          env:
+          {{- if .Values.Master.UseSecurity }}
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "jenkins.fullname" . }}
+                  key: jenkins-admin-password
+            - name: ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "jenkins.fullname" . }}
+                  key: jenkins-admin-user
+            {{- if or (.Values.Master.AdminSshKey) (.Values.Master.Sidecars.configAutoReload.enabled) }}
+            {{- if .Values.Master.JCasC.enabled }}
+            - name: ADMIN_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "jenkins.fullname" . }}
+                  key: {{ "jenkins-admin-private-key" | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.Master.InitContainerEnv }}
+{{ toYaml .Values.Master.InitContainerEnv | indent 12 }}
+            {{- end }}
+          resources:
+{{ toYaml .Values.Master.resources | indent 12 }}
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /var/jenkins_home
+              name: jenkins-home
+              {{- if .Values.Persistence.SubPath }}
+              subPath: {{ .Values.Persistence.SubPath }}
+              {{- end }}
+            - mountPath: /var/jenkins_config
+              name: jenkins-config
+            {{- if .Values.Master.CredentialsXmlSecret }}
+            - mountPath: /var/jenkins_credentials
+              name: jenkins-credentials
+              readOnly: true
+            {{- end }}
+            {{- if .Values.Master.SecretsFilesSecret }}
+            - mountPath: /var/jenkins_secrets
+              name: jenkins-secrets
+              readOnly: true
+            {{- end }}
+            {{- if .Values.Master.Jobs }}
+            - mountPath: /var/jenkins_jobs
+              name: jenkins-jobs
+              readOnly: true
+            {{- end }}
+            {{- if .Values.Master.InstallPlugins }}
+            - mountPath: /usr/share/jenkins/ref/plugins
+              name: plugins
+            - mountPath: /var/jenkins_plugins
+              name: plugin-dir
+            {{- end }}
+            - mountPath: /usr/share/jenkins/ref/secrets/
+              name: secrets-dir
+      containers:
+        - name: {{ template "jenkins.fullname" . }}
+          image: "{{ .Values.Master.Image }}:{{ .Values.Master.ImageTag }}"
+          imagePullPolicy: "{{ .Values.Master.ImagePullPolicy }}"
+          {{- if .Values.Master.UseSecurity }}
+          args: [ "--argumentsRealm.passwd.$(ADMIN_USER)=$(ADMIN_PASSWORD)",  "--argumentsRealm.roles.$(ADMIN_USER)=admin"]
+          {{- end }}
+          env:
+            - name: JAVA_OPTS
+              value: {{ default "" .Values.Master.JavaOpts | quote }}
+            - name: JENKINS_OPTS
+              value: "{{ if .Values.Master.JenkinsUriPrefix }}--prefix={{ .Values.Master.JenkinsUriPrefix }} {{ end }}{{ default "" .Values.Master.JenkinsOpts}}"
+            - name: JENKINS_SLAVE_AGENT_PORT
+              value: "{{ .Values.Master.SlaveListenerPort }}"
+            {{- if .Values.Master.UseSecurity }}
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "jenkins.fullname" . }}
+                  key: jenkins-admin-password
+            - name: ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "jenkins.fullname" . }}
+                  key: jenkins-admin-user
+            {{- if or (.Values.Master.AdminSshKey) (.Values.Master.Sidecars.configAutoReload.enabled) }}
+            {{- if .Values.Master.JCasC.enabled }}
+            - name: ADMIN_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "jenkins.fullname" . }}
+                  key: {{ "jenkins-admin-private-key" | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.Master.ContainerEnv }}
+{{ toYaml .Values.Master.ContainerEnv | indent 12 }}
+            {{- end }}
+            {{- if .Values.Master.JCasC.enabled }}
+            - name: CASC_JENKINS_CONFIG
+              value: {{ .Values.Master.Sidecars.configAutoReload.folder | default "/var/jenkins_home/casc_configs" | quote }}
+            {{- end }}
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: {{ .Values.Master.SlaveListenerPort }}
+              name: slavelistener
+              {{- if .Values.Master.SlaveHostPort }}
+              hostPort: {{ .Values.Master.SlaveHostPort }}
+              {{- end }}
+            {{- if .Values.Master.JMXPort }}
+            - containerPort: {{ .Values.Master.JMXPort }}
+              name: jmx
+            {{- end }}
+{{- range $index, $port := .Values.Master.ExtraPorts }}
+            - containerPort: {{ $port.port }}
+              name: {{ $port.name }}
+{{- end }}
+{{- if .Values.Master.HealthProbes }}
+          livenessProbe:
+            httpGet:
+              path: "{{ default "" .Values.Master.JenkinsUriPrefix }}/login"
+              port: http
+            initialDelaySeconds: {{ .Values.Master.HealthProbesLivenessTimeout }}
+            timeoutSeconds: 5
+            failureThreshold: {{ .Values.Master.HealthProbeLivenessFailureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: "{{ default "" .Values.Master.JenkinsUriPrefix }}/login"
+              port: http
+            initialDelaySeconds: {{ .Values.Master.HealthProbesReadinessTimeout }}
+            periodSeconds: {{ .Values.Master.HealthProbeReadinessPeriodSeconds }}
+{{- end }}
+          # Resources configuration is a little hacky. This was to prevent breaking
+          # changes, and should be cleanned up in the future once everybody had
+          # enough time to migrate.
+          resources:
+{{ if or .Values.Master.Cpu .Values.Master.Memory }}
+            requests:
+              cpu: "{{ .Values.Master.Cpu }}"
+              memory: "{{ .Values.Master.Memory }}"
+{{ else }}
+{{ toYaml .Values.Master.resources | indent 12 }}
+{{ end }}
+          volumeMounts:
+{{- if .Values.Persistence.mounts }}
+{{ toYaml .Values.Persistence.mounts | indent 12 }}
+{{- end }}
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /var/jenkins_home
+              name: jenkins-home
+              readOnly: false
+              {{- if .Values.Persistence.SubPath }}
+              subPath: {{ .Values.Persistence.SubPath }}
+              {{- end }}
+            - mountPath: /var/jenkins_config
+              name: jenkins-config
+              readOnly: true
+            {{- if .Values.Master.CredentialsXmlSecret }}
+            - mountPath: /var/jenkins_credentials
+              name: jenkins-credentials
+              readOnly: true
+            {{- end }}
+            {{- if .Values.Master.SecretsFilesSecret }}
+            - mountPath: /var/jenkins_secrets
+              name: jenkins-secrets
+              readOnly: true
+            {{- end }}
+            {{- if .Values.Master.Jobs }}
+            - mountPath: /var/jenkins_jobs
+              name: jenkins-jobs
+              readOnly: true
+            {{- end }}
+            {{- if .Values.Master.InstallPlugins }}
+            - mountPath: /usr/share/jenkins/ref/plugins/
+              name: plugin-dir
+              readOnly: false
+            {{- end }}
+            - mountPath: /usr/share/jenkins/ref/secrets/
+              name: secrets-dir
+              readOnly: false
+            {{- if and (.Values.Master.JCasC.enabled) (.Values.Master.Sidecars.configAutoReload.enabled) }}
+            - name: sc-config-volume
+              mountPath: {{ .Values.Master.Sidecars.configAutoReload.folder | default "/var/jenkins_home/casc_configs" | quote }}
+            {{- end }}
+
+{{- if and (.Values.Master.JCasC.enabled) (.Values.Master.Sidecars.configAutoReload.enabled) }}
+        - name: {{ template "jenkins.name" . }}-sc-config
+          image: "{{ .Values.Master.Sidecars.configAutoReload.image }}"
+          imagePullPolicy: {{ .Values.Master.Sidecars.configAutoReload.imagePullPolicy }}
+          env:
+            - name: JENKINSRELOADCONFIG
+              value: "true"
+            - name: LABEL
+              value: "{{ template "jenkins.fullname" . }}-jenkins-config"
+            - name: FOLDER
+              value: "{{ .Values.Master.Sidecars.configAutoReload.folder }}"
+            - name: NAMESPACE
+              value: "{{ .Values.Master.Sidecars.configAutoReload.searchNamespace }}"
+            - name: SSH_PORT
+              value: "{{ .Values.Master.Sidecars.configAutoReload.sshTcpPort }}"
+            - name: JENKINS_PORT
+              value: "{{ .Values.Master.ServicePort }}"
+            {{- if .Values.Master.UseSecurity }}
+            - name: ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "jenkins.fullname" . }}
+                  key: jenkins-admin-user
+            {{- if or (.Values.Master.AdminSshKey) (.Values.Master.Sidecars.configAutoReload.enabled) }}
+            {{- if .Values.Master.JCasC.enabled }}
+            - name: ADMIN_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "jenkins.fullname" . }}
+                  key: {{ "jenkins-admin-private-key" | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+          resources:
+{{ toYaml .Values.Master.Sidecars.configAutoReload.resources | indent 12 }}
+          volumeMounts:
+            - name: sc-config-volume
+              mountPath: {{ .Values.Master.Sidecars.configAutoReload.folder | quote }}
+            - name: jenkins-home
+              mountPath: /var/jenkins_home
+              {{- if .Values.Persistence.SubPath }}
+                subPath: {{ .Values.Persistence.SubPath }}
+              {{- end }}
+{{- end}}
+
+
+{{- if .Values.Master.Sidecars.other}}
+{{ tpl (toYaml .Values.Master.Sidecars.other | indent 8) .}}
+{{- end }}
+
+      volumes:
+{{- if .Values.Persistence.volumes }}
+{{ tpl (toYaml .Values.Persistence.volumes | indent 6) . }}
+{{- end }}
+      - name: plugins
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+      - name: jenkins-config
+        configMap:
+          name: {{ template "jenkins.fullname" . }}
+      {{- if .Values.Master.CredentialsXmlSecret }}
+      - name: jenkins-credentials
+        secret:
+          secretName: {{ .Values.Master.CredentialsXmlSecret }}
+      {{- end }}
+      {{- if .Values.Master.SecretsFilesSecret }}
+      - name: jenkins-secrets
+        secret:
+          secretName: {{ .Values.Master.SecretsFilesSecret }}
+      {{- end }}
+      {{- if .Values.Master.Jobs }}
+      - name: jenkins-jobs
+        configMap:
+          name: {{ template "jenkins.fullname" . }}-jobs
+      {{- end }}
+      {{- if .Values.Master.InstallPlugins }}
+      - name: plugin-dir
+        emptyDir: {}
+      {{- end }}
+      - name: secrets-dir
+        emptyDir: {}
+      - name: jenkins-home
+      {{- if .Values.Persistence.Enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.Persistence.ExistingClaim | default (include "jenkins.fullname" .) }}
+      {{- else }}
+        emptyDir: {}
+      {{- end -}}
+      {{- if .Values.Master.JCasC.enabled }}
+      - name: sc-config-volume
+        emptyDir: {}
+      {{- end }}
+{{- if .Values.Master.ImagePullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.Master.ImagePullSecret }}
+{{- end -}}

--- a/incubator/jenkins/templates/jenkins-master-ingress.yaml
+++ b/incubator/jenkins/templates/jenkins-master-ingress.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.Master.ingress.enabled }}
+apiVersion: {{ .Values.Master.ingress.apiVersion }}
+kind: Ingress
+metadata:
+{{- if .Values.Master.ingress.labels }}
+  labels:
+{{ toYaml .Values.Master.ingress.labels | indent 4 }}
+{{- end }}
+{{- if .Values.Master.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.Master.ingress.annotations | indent 4 }}
+{{- end }}
+  name: {{ template "jenkins.fullname" . }}
+spec:
+  rules:
+  - http:
+      paths:
+      - backend:
+          serviceName: {{ template "jenkins.fullname" . }}
+          servicePort: {{ .Values.Master.ServicePort }}
+{{- if .Values.Master.ingress.path }}
+        path: {{ .Values.Master.ingress.path }}
+{{- end -}}
+{{- if .Values.Master.ingress.hostName }}
+    host: {{ .Values.Master.ingress.hostName | quote }}
+{{- end }}
+{{- if .Values.Master.ingress.tls }}
+  tls:
+{{ toYaml .Values.Master.ingress.tls | indent 4 }}
+{{- end -}}
+{{- end }}

--- a/incubator/jenkins/templates/jenkins-master-networkpolicy.yaml
+++ b/incubator/jenkins/templates/jenkins-master-networkpolicy.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.NetworkPolicy.Enabled }}
+kind: NetworkPolicy
+apiVersion: {{ .Values.NetworkPolicy.ApiVersion }}
+metadata:
+  name: "{{ .Release.Name }}-{{ .Values.Master.Component }}"
+spec:
+  podSelector:
+    matchLabels:
+      component: "{{ .Release.Name }}-{{ .Values.Master.Component }}"
+  ingress:
+    # Allow web access to the UI
+    - ports:
+      - port: 8080
+    # Allow inbound connections from slave
+    - from:
+      - podSelector:
+          matchLabels:
+            "jenkins/{{ .Release.Name }}-{{ .Values.Agent.Component }}": "true"
+      ports:
+      - port: {{ .Values.Master.SlaveListenerPort }}
+{{- if .Values.Agent.Enabled }}
+---
+kind: NetworkPolicy
+apiVersion: {{ .Values.NetworkPolicy.ApiVersion }}
+metadata:
+  name: "{{ .Release.Name }}-{{ .Values.Agent.Component }}"
+spec:
+  podSelector:
+    matchLabels:
+      # DefaultDeny
+      "jenkins/{{ .Release.Name }}-{{ .Values.Agent.Component }}": "true"
+{{- end }}
+{{- end }}

--- a/incubator/jenkins/templates/jenkins-master-svc.yaml
+++ b/incubator/jenkins/templates/jenkins-master-svc.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{template "jenkins.fullname" . }}
+  labels:
+    app: {{ template "jenkins.fullname" . }}
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    component: "{{.Release.Name}}-{{.Values.Master.Component}}"
+    {{- if .Values.Master.ServiceLabels }}
+{{ toYaml .Values.Master.ServiceLabels | indent 4 }}
+    {{- end }}
+{{- if .Values.Master.ServiceAnnotations }}
+  annotations:
+{{ toYaml .Values.Master.ServiceAnnotations | indent 4 }}
+{{- end }}
+spec:
+  ports:
+    - port: {{.Values.Master.ServicePort}}
+      name: http
+      targetPort: 8080
+      {{if (and (eq .Values.Master.ServiceType "NodePort") (not (empty .Values.Master.NodePort)))}}
+      nodePort: {{.Values.Master.NodePort}}
+      {{end}}
+  selector:
+    component: "{{.Release.Name}}-{{.Values.Master.Component}}"
+  type: {{.Values.Master.ServiceType}}
+  {{if eq .Values.Master.ServiceType "LoadBalancer"}}
+{{- if .Values.Master.LoadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.Master.LoadBalancerSourceRanges | indent 4 }}
+{{- end }}
+  {{if .Values.Master.LoadBalancerIP}}
+  loadBalancerIP: {{.Values.Master.LoadBalancerIP}}
+  {{end}}
+  {{end}}

--- a/incubator/jenkins/templates/jobs.yaml
+++ b/incubator/jenkins/templates/jobs.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.Master.Jobs }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "jenkins.fullname" . }}-jobs
+data:
+{{ toYaml .Values.Master.Jobs | indent 2 }}
+{{- end -}}

--- a/incubator/jenkins/templates/rbac.yaml
+++ b/incubator/jenkins/templates/rbac.yaml
@@ -1,0 +1,26 @@
+{{ if .Values.rbac.install }}
+{{- $serviceName := include "jenkins.fullname" . -}}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1alpha1" }}
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- end }}
+kind: {{ .Values.rbac.roleBindingKind }}
+metadata:
+  name: {{ $serviceName }}-role-binding
+  labels:
+    app: {{ $serviceName }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: {{ .Values.rbac.roleKind }}
+  name: {{ .Values.rbac.roleRef }}
+subjects:
+- kind: ServiceAccount
+  name: {{ $serviceName }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/incubator/jenkins/templates/secret.yaml
+++ b/incubator/jenkins/templates/secret.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.Master.UseSecurity -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "jenkins.fullname" . }}
+  labels:
+    app: {{ template "jenkins.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  {{ if .Values.Master.AdminPassword -}}
+  jenkins-admin-password: {{ .Values.Master.AdminPassword | b64enc | quote }}
+  {{ else -}}
+  jenkins-admin-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ end -}}
+  {{ if and (.Values.Master.JCasC.enabled) (.Values.Master.Sidecars.configAutoReload.enabled) -}}
+  {{ if not .Values.Master.AdminSshKey -}}
+  {{ ( include "jenkins.gen-key" . ) }}
+  {{ else -}}
+  jenkins-admin-private-key: {{ .Values.Master.AdminSshKey | b64enc | quote }}
+  {{ end -}}
+  {{ end -}}
+  jenkins-admin-user: {{ .Values.Master.AdminUser | b64enc | quote }}
+{{- end }}

--- a/incubator/jenkins/templates/service-account.yaml
+++ b/incubator/jenkins/templates/service-account.yaml
@@ -1,0 +1,12 @@
+{{ if .Values.rbac.install }}
+{{- $serviceName := include "jenkins.fullname" . -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $serviceName }}
+  labels:
+    app: {{ $serviceName }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{ end }}

--- a/incubator/jenkins/templates/tests/jenkins-test.yaml
+++ b/incubator/jenkins/templates/tests/jenkins-test.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-ui-test-{{ randAlphaNum 5 | lower }}"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  {{- if .Values.Master.NodeSelector }}
+  nodeSelector:
+{{ toYaml .Values.Master.NodeSelector | indent 4 }}
+  {{- end }}
+  {{- if .Values.Master.Tolerations }}
+  tolerations:
+{{ toYaml .Values.Master.Tolerations | indent 4 }}
+  {{- end }}
+  initContainers:
+    - name: "test-framework"
+      image: "dduportal/bats:0.4.0"
+      command:
+      - "bash"
+      - "-c"
+      - |
+        set -ex
+        # copy bats to tools dir
+        cp -R /usr/local/libexec/ /tools/bats/
+      volumeMounts:
+      - mountPath: /tools
+        name: tools
+  containers:
+    - name: {{ .Release.Name }}-ui-test
+      image: {{ .Values.Master.Image }}:{{ .Values.Master.ImageTag }}
+      command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
+      volumeMounts:
+      - mountPath: /tests
+        name: tests
+        readOnly: true
+      - mountPath: /tools
+        name: tools
+  volumes:
+  - name: tests
+    configMap:
+      name: {{ template "jenkins.fullname" . }}-tests
+  - name: tools
+    emptyDir: {}
+  restartPolicy: Never

--- a/incubator/jenkins/templates/tests/test-config.yaml
+++ b/incubator/jenkins/templates/tests/test-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "jenkins.fullname" . }}-tests
+data:
+  run.sh: |-
+    @test "Testing Jenkins UI is accessible" {
+      curl --retry 48 --retry-delay 10 {{ template "jenkins.fullname" . }}:{{ .Values.Master.ServicePort }}{{ default "" .Values.Master.JenkinsUriPrefix }}/login
+    }

--- a/incubator/jenkins/values.yaml
+++ b/incubator/jenkins/values.yaml
@@ -1,0 +1,405 @@
+# Default values for jenkins.
+# This is a YAML-formatted file.
+# Declare name/value pairs to be passed into your templates.
+# name: value
+
+## Overrides for generated resource names
+# See templates/_helpers.tpl
+# nameOverride:
+# fullnameOverride:
+
+Master:
+  Name: jenkins-master
+  Image: "jenkins/jenkins"
+  ImageTag: "lts"
+  ImagePullPolicy: "Always"
+# ImagePullSecret: jenkins
+  Component: "jenkins-master"
+  NumExecutors: 0
+  # configAutoReload requires UseSecurity is set to true:
+  UseSecurity: true
+  # SecurityRealm:
+  # Optionally configure a different AuthorizationStrategy using Jenkins XML
+  # AuthorizationStrategy: |-
+  #    <authorizationStrategy class="hudson.security.FullControlOnceLoggedInAuthorizationStrategy">
+  #      <denyAnonymousReadAccess>true</denyAnonymousReadAccess>
+  #    </authorizationStrategy>
+  HostNetworking: false
+  # When enabling LDAP or another non-Jenkins identity source, the built-in admin account will no longer exist.
+  # Since the AdminUser is used by configAutoReload, in order to use configAutoReload you must change the
+  # .Master.AdminUser to a valid username on your LDAP (or other) server.  This user does not need
+  # to have administrator rights in Jenkins (the default Overall:Read is sufficient) nor will it be granted any
+  # additional rights.  Failure to do this will cause the sidecar container to fail to authenticate via SSH and enter
+  # a restart loop.  Likewise if you disable the non-Jenkins identity store and instead use the Jenkins internal one,
+  # you should revert Master.AdminUser to your preferred admin user:
+  AdminUser: admin
+  # AdminPassword: <defaults to random>
+  # AdminSshKey: <defaults to auto-generated>
+  # If CasC auto-reload is enabled, an SSH (RSA) keypair is needed.  Can either provide your own, or leave unconfigured to allow a random key to be auto-generated.
+  # If you supply your own, it is recommended that the values file that contains your key not be committed to source control in an unencrypted format
+  RollingUpdate: {}
+  # Ignored if Persistence is enabled
+  # maxSurge: 1
+  # maxUnavailable: 25%
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "256Mi"
+    limits:
+      cpu: "2000m"
+      memory: "4096Mi"
+  # Environment variables that get added to the init container (useful for e.g. http_proxy)
+  # InitContainerEnv:
+  #   - name: http_proxy
+  #     value: "http://192.168.64.1:3128"
+  # ContainerEnv:
+  #   - name: http_proxy
+  #     value: "http://192.168.64.1:3128"
+  # Set min/max heap here if needed with:
+  # JavaOpts: "-Xms512m -Xmx512m"
+  # JenkinsOpts: ""
+  # JenkinsUrl: ""
+  # If you set this prefix and use ingress controller then you might want to set the ingress path below
+  # JenkinsUriPrefix: "/jenkins"
+  # Enable pod security context (must be `true` if RunAsUser or FsGroup are set)
+  UsePodSecurityContext: true
+  # Set RunAsUser to 1000 to let Jenkins run as non-root user 'jenkins' which exists in 'jenkins/jenkins' docker image.
+  # When setting RunAsUser to a different value than 0 also set FsGroup to the same value:
+  # RunAsUser: <defaults to 0>
+  # FsGroup: <will be omitted in deployment if RunAsUser is 0>
+  ServicePort: 8080
+  # For minikube, set this to NodePort, elsewhere use LoadBalancer
+  # Use ClusterIP if your setup includes ingress controller
+  ServiceType: LoadBalancer
+  # Master Service annotations
+  ServiceAnnotations: {}
+  # Master Custom Labels
+  DeploymentLabels: {}
+  #   foo: bar
+  #   bar: foo
+  # Master Service Labels
+  ServiceLabels: {}
+  #   service.beta.kubernetes.io/aws-load-balancer-backend-protocol: https
+  # Put labels on jeknins-master pod
+  PodLabels: {}
+  # Used to create Ingress record (should used with ServiceType: ClusterIP)
+  # HostName: jenkins.cluster.local
+  # NodePort: <to set explicitly, choose port between 30000-32767
+  # Enable Kubernetes Liveness and Readiness Probes
+  # ~ 2 minutes to allow Jenkins to restart when upgrading plugins. Set ReadinessTimeout to be shorter than LivenessTimeout.
+  HealthProbes: true
+  HealthProbesLivenessTimeout: 90
+  HealthProbesReadinessTimeout: 60
+  HealthProbeReadinessPeriodSeconds: 10
+  HealthProbeLivenessFailureThreshold: 12
+  SlaveListenerPort: 50000
+#  SlaveHostPort: 50000
+  DisabledAgentProtocols:
+    - JNLP-connect
+    - JNLP2-connect
+  CSRF:
+    DefaultCrumbIssuer:
+      Enabled: true
+      ProxyCompatability: true
+  CLI: false
+  # Kubernetes service type for the JNLP slave service
+  # SlaveListenerServiceType is the Kubernetes Service type for the JNLP slave service,
+  # either 'LoadBalancer', 'NodePort', or 'ClusterIP'
+  # Note if you set this to 'LoadBalancer', you *must* define annotations to secure it. By default
+  # this will be an external load balancer and allowing inbound 0.0.0.0/0, a HUGE
+  # security risk:  https://github.com/kubernetes/charts/issues/1341
+  SlaveListenerServiceType: ClusterIP
+  SlaveListenerServiceAnnotations: {}
+
+  # Example of 'LoadBalancer' type of slave listener with annotations securing it
+  # SlaveListenerServiceType: LoadBalancer
+  # SlaveListenerServiceAnnotations:
+  #   service.beta.kubernetes.io/aws-load-balancer-internal: "True"
+  #   service.beta.kubernetes.io/load-balancer-source-ranges: "172.0.0.0/8, 10.0.0.0/8"
+
+  # LoadBalancerSourcesRange is a list of allowed CIDR values, which are combined with ServicePort to
+  # set allowed inbound rules on the security group assigned to the master load balancer
+  LoadBalancerSourceRanges:
+  - 0.0.0.0/0
+  # Optionally assign a known public LB IP
+  # LoadBalancerIP: 1.2.3.4
+  # Optionally configure a JMX port
+  # requires additional JavaOpts, ie
+  # JavaOpts: >
+  #   -Dcom.sun.management.jmxremote.port=4000
+  #   -Dcom.sun.management.jmxremote.authenticate=false
+  #   -Dcom.sun.management.jmxremote.ssl=false
+  # JMXPort: 4000
+  # Optionally configure other ports to expose in the Master container
+  ExtraPorts:
+  # - name: BuildInfoProxy
+  #   port: 9000
+
+  # List of plugins to be install during Jenkins master start
+  InstallPlugins:
+    - kubernetes:1.14.0
+    - workflow-job:2.31
+    - workflow-aggregator:2.6
+    - credentials-binding:1.17
+    - git:3.9.1
+
+  # Enable to always override the installed plugins with the values of 'Master.InstallPlugins' on upgrade or redeployment.
+  # OverwritePlugins: true
+  # Enable HTML parsing using OWASP Markup Formatter Plugin (antisamy-markup-formatter), useful with ghprb plugin.
+  # The plugin is not installed by default, please update Master.InstallPlugins.
+  # EnableRawHtmlMarkupFormatter: true
+  # Used to approve a list of groovy functions in pipelines used the script-security plugin. Can be viewed under /scriptApproval
+  # ScriptApproval:
+  #   - "method groovy.json.JsonSlurperClassic parseText java.lang.String"
+  #   - "new groovy.json.JsonSlurperClassic"
+  # List of groovy init scripts to be executed during Jenkins master start
+  InitScripts:
+  #  - |
+  #    print 'adding global pipeline libraries, register properties, bootstrap jobs...'
+  # Kubernetes secret that contains a 'credentials.xml' for Jenkins
+  # CredentialsXmlSecret: jenkins-credentials
+  # Kubernetes secret that contains files to be put in the Jenkins 'secrets' directory,
+  # useful to manage encryption keys used for credentials.xml for instance (such as
+  # master.key and hudson.util.Secret)
+  # SecretsFilesSecret: jenkins-secrets
+  # Jenkins XML job configs to provision
+  # Jobs:
+  #   test: |-
+  #     <<xml here>>
+
+  # Below is the implementation of Jenkins Configuration as Code.  Add a key under ConfigScripts for each configuration area,
+  # where each corresponds to a plugin or section of the UI.  Each key (prior to | character) is just a label, and can be any value.
+  # Keys are only used to give the section a meaningful name.  The only restriction is they may only contain RFC 1123 \ DNS label
+  # characters: lowercase letters, numbers, and hyphens.  The keys become the name of a configuration yaml file on the master in
+  # /var/jenkins_home/casc_configs (by default) and will be processed by the Configuration as Code Plugin.  The lines after each |
+  # become the content of the configuration yaml file.  The first line after this is a JCasC root element, eg jenkins, credentials,
+  # etc.  Best reference is https://<jenkins_url>/configuration-as-code/reference.  The example below creates a welcome message:
+  JCasC:
+    enabled: false
+    PluginVersion: 1.5
+    SupportPluginVersion: 1.5
+    ConfigScripts:
+      welcome-message: |
+        jenkins:
+          systemMessage: Welcome to our CI\CD server.  This Jenkins is configured and managed 'as code'.
+
+  Sidecars:
+    configAutoReload:
+      # If enabled: true, Jenkins Configuration as Code will be reloaded on-the-fly without a reboot.  If false or not-specified,
+      # jcasc changes will cause a reboot and will only be applied at the subsequent start-up.  Auto-reload uses the Jenkins CLI
+      # over SSH to reapply config when changes to the ConfigScripts are detected.  The admin user (or account you specify in
+      # Master.AdminUser) will have a random SSH private key (RSA 4096) assigned unless you specify AdminSshKey.  This will be saved to a k8s secret.
+      enabled: false
+      image: shadwell/k8s-sidecar:0.0.2
+      imagePullPolicy: IfNotPresent
+      resources:
+        #   limits:
+        #     cpu: 100m
+        #     memory: 100Mi
+        #   requests:
+        #     cpu: 50m
+        #     memory: 50Mi
+      # SSH port value can be set to any unused TCP port.  The default, 1044, is a non-standard SSH port that has been chosen at random.
+      # Is only used to reload jcasc config from the sidecar container running in the Jenkins master pod.
+      # This TCP port will not be open in the pod (unless you specifically configure this), so Jenkins will not be
+      # accessible via SSH from outside of the pod.  Note if you use non-root pod privileges (RunAsUser & FsGroup),
+      # this must be > 1024:
+      sshTcpPort: 1044
+      # folder in the pod that should hold the collected dashboards:
+      folder: /var/jenkins_home/casc_configs
+      # If specified, the sidecar will search for dashboard config-maps inside this namespace.
+      # Otherwise the namespace in which the sidecar is running will be used.
+      # It's also possible to specify ALL to search in all namespaces:
+      # searchNamespace:
+
+    # Allows you to inject additional/other sidecars
+    other:
+    ## The example below runs the client for https://smee.io as sidecar container next to Jenkins,
+    ## that allows to trigger build behind a secure firewall.
+    ## https://jenkins.io/blog/2019/01/07/webhook-firewalls/#triggering-builds-with-webhooks-behind-a-secure-firewall
+    ##
+    ## Note: To use it you should go to https://smee.io/new and update the url to the generete one.
+    # - name: smee
+    #   image: docker.io/twalter/smee-client:1.0.2
+    #   args: ["--port", "{{ .Values.Master.ServicePort }}", "--path", "/github-webhook/", "--url", "https://smee.io/new"]
+    #   resources:
+    #     limits:
+    #       cpu: 50m
+    #       memory: 128Mi
+    #     requests:
+    #       cpu: 10m
+    #       memory: 32Mi
+  # Node labels and tolerations for pod assignment
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+  NodeSelector: {}
+  Tolerations: {}
+  PodAnnotations: {}
+
+  # The below two configuration-related values are deprecated and replaced by Jenkins Configuration as Code (see above
+  # JCasC key).  They will be deleted in an upcoming version.
+  CustomConfigMap: false
+  # By default, the configMap is only used to set the initial config the first time
+  # that the chart is installed.  Setting `OverwriteConfig` to `true` will overwrite
+  # the jenkins config with the contents of the configMap every time the pod starts.
+  # This will also overwrite all init scripts
+  OverwriteConfig: false
+
+  # By default, the Jobs Map is only used to set the initial jobs the first time
+  # that the chart is installed.  Setting `overwriteJobs` to `true` will overwrite
+  # the jenkins jobs configuration with the contents of Jobs every time the pod starts.
+  overwriteJobs: false
+
+  ingress:
+    enabled: false
+    # For Kubernetes v1.14+, use 'networking.k8s.io/v1beta1'
+    apiVersion: extensions/v1beta1
+    labels: {}
+    annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    # Set this path to JenkinsUriPrefix above or use annotations to rewrite path
+    # path: "/jenkins"
+    tls:
+    # - secretName: jenkins.cluster.local
+    #   hosts:
+    #     - jenkins.cluster.local
+  AdditionalConfig: {}
+
+  # Master.HostAliases allows for adding entries to Pod /etc/hosts:
+  # https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  HostAliases: []
+  # - ip: 192.168.50.50
+  #   hostnames:
+  #     - something.local
+  # - ip: 10.0.50.50
+  #   hostnames:
+  #     - other.local
+
+Agent:
+  Enabled: true
+  Image: jenkins/jnlp-slave
+  ImageTag: 3.27-1
+  CustomJenkinsLabels: []
+# ImagePullSecret: jenkins
+  Component: "jenkins-slave"
+  Privileged: false
+  resources:
+    requests:
+      cpu: "200m"
+      memory: "256Mi"
+    limits:
+      cpu: "200m"
+      memory: "256Mi"
+  # You may want to change this to true while testing a new image
+  AlwaysPullImage: false
+  # Controls how slave pods are retained after the Jenkins build completes
+  # Possible values: Always, Never, OnFailure
+  PodRetention: Never
+  # You can define the volumes that you want to mount for this container
+  # Allowed types are: ConfigMap, EmptyDir, HostPath, Nfs, Pod, Secret
+  # Configure the attributes as they appear in the corresponding Java class for that type
+  # https://github.com/jenkinsci/kubernetes-plugin/tree/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes
+  # Pod-wide ennvironment, these vars are visible to any container in the slave pod
+  envVars:
+  # - name: PATH
+  #   value: /usr/local/bin
+  volumes:
+  # - type: Secret
+  #   secretName: mysecret
+  #   mountPath: /var/myapp/mysecret
+  NodeSelector: {}
+  # Key Value selectors. Ex:
+  # jenkins-agent: v1
+
+  # Executed command when side container gets started
+  Command:
+  Args:
+  # Side container name
+  SideContainerName: jnlp
+  # Doesn't allocate pseudo TTY by default
+  TTYEnabled: false
+  # Max number of spawned agent
+  ContainerCap: 10
+  # Pod name
+  PodName: default
+
+Persistence:
+  Enabled: true
+  ## A manually managed Persistent Volume and Claim
+  ## Requires Persistence.Enabled: true
+  ## If defined, PVC must be created manually before volume will be bound
+  # ExistingClaim:
+  ## jenkins data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # StorageClass: "-"
+  Annotations: {}
+  AccessMode: ReadWriteOnce
+  Size: 8Gi
+  volumes:
+  #  - name: nothing
+  #    emptyDir: {}
+  mounts:
+  #  - mountPath: /var/nothing
+  #    name: nothing
+  #    readOnly: true
+
+NetworkPolicy:
+  # Enable creation of NetworkPolicy resources.
+  Enabled: false
+  # For Kubernetes v1.4, v1.5 and v1.6, use 'extensions/v1beta1'
+  # For Kubernetes v1.7, use 'networking.k8s.io/v1'
+  ApiVersion: networking.k8s.io/v1
+
+## Install Default RBAC roles and bindings
+rbac:
+  install: false
+  serviceAccountName: default
+  # Role reference
+  roleRef: cluster-admin
+  # Role kind (Role or ClusterRole)
+  roleKind: ClusterRole
+  # Role binding kind (RoleBinding or ClusterRoleBinding)
+  roleBindingKind: ClusterRoleBinding
+
+## Backup cronjob configuration
+## Ref: https://github.com/nuvo/kube-tasks
+backup:
+  # Backup must use RBAC
+  # So by enabling backup you are enabling RBAC specific for backup
+  enabled: false
+  # Schedule to run jobs. Must be in cron time format
+  # Ref: https://crontab.guru/
+  schedule: "0 2 * * *"
+  annotations:
+    # Example for authorization to AWS S3 using kube2iam
+    # Can also be done using environment variables
+    iam.amazonaws.com/role: jenkins
+  image:
+    repository: nuvo/kube-tasks
+    tag: 0.1.2
+  # Additional arguments for kube-tasks
+  # Ref: https://github.com/nuvo/kube-tasks#simple-backup
+  extraArgs: []
+  # Add additional environment variables
+  env:
+  # Example environment variable required for AWS credentials chain
+  - name: AWS_REGION
+    value: us-east-1
+  resources:
+    requests:
+      memory: 1Gi
+      cpu: 1
+    limits:
+      memory: 1Gi
+      cpu: 1
+  # Destination to store the backup artifacts
+  # Supported cloud storage services: AWS S3, Minio S3, Azure Blob Storage
+  # Additional support can added. Visit this repository for details
+  # Ref: https://github.com/nuvo/skbn
+  destination: s3://nuvo-jenkins-data/backup


### PR DESCRIPTION
#### What this PR does / why we need it:
As chart maintainers, we have been working towards making the stable/jenkins chart follow chart best practices, while attempting to simplify it.
Over time, some breaking changes have been introduced to the chart. As this chart is in major version `0`, the major version was not bumped, which is confusing as the chart is in the `stable` repository.
This has led to some discussions [[1](https://github.com/helm/charts/pull/11960)] around these changes, and we have decided to move active development to the `incubator` repository.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
