### PR TITLE
[stable/ark] Fix objectStorage.prefix (over-indented)

### DIFF
--- a/stable/ark/Chart.yaml
+++ b/stable/ark/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.10.1
 description: A Helm chart for ark
 name: ark
-version: 4.1.0
+version: 4.1.1
 home: https://github.com/heptio/ark
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/stable/ark/templates/backupstoragelocation.yaml
+++ b/stable/ark/templates/backupstoragelocation.yaml
@@ -15,7 +15,7 @@ spec:
   objectStorage:
     bucket: {{ .bucket  }}
     {{- with .prefix }}
-      prefix: {{ . }}
+    prefix: {{ . }}
     {{- end }}
 {{- with .config }}
   config:

--- a/stable/ark/values.yaml
+++ b/stable/ark/values.yaml
@@ -47,9 +47,9 @@ configuration:
   backupStorageLocation:
     name:
     bucket:
+  #  prefix:
     config: {}
     #  region:
-    #  prefix:
     #  s3ForcePathStyle:
     #  s3Url:
     #  kmsKeyId:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Fix `objectStorage.prefix` parameter which is over-indented and makes Helm fail if you specify it.

Reference:
https://heptio.github.io/velero/v0.11.0/api-types/backupstoragelocation.html

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
