### PR TITLE
[stable/kafka-manager] allow custom service annotations

### DIFF
--- a/stable/kafka-manager/Chart.yaml
+++ b/stable/kafka-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: kafka-manager
-version: 1.1.2
+version: 1.1.3
 appVersion: 1.3.3.22
 kubeVersion: "^1.8.0-0"
 description: A tool for managing Apache Kafka.

--- a/stable/kafka-manager/README.md
+++ b/stable/kafka-manager/README.md
@@ -54,6 +54,7 @@ Parameter | Description | Default
 `javaOptions` | Java runtime options | `""`
 `service.type` | Kafka-manager service type | `ClusterIP`
 `service.port` | Kafka-manager service port | `9000`
+`service.annotations` | Optional service annotations | `{}`
 `ingress.enabled` | If true, create an ingress resource | `false`
 `ingress.annotations` | Optional ingress annotations | `{}`
 `ingress.path` | Ingress path | `/`

--- a/stable/kafka-manager/templates/service.yaml
+++ b/stable/kafka-manager/templates/service.yaml
@@ -8,6 +8,10 @@ metadata:
     app.kubernetes.io/name: {{ include "kafka-manager.name" . }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" | trunc 63 }}
     helm.sh/chart: {{ include "kafka-manager.chart" . }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/stable/kafka-manager/values.yaml
+++ b/stable/kafka-manager/values.yaml
@@ -97,6 +97,7 @@ javaOptions: ""
 service:
   type: ClusterIP
   port: 9000
+  annotations: {}
 
 ## Ingress configuration
 ## Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/


### PR DESCRIPTION
@giacomoguiulfo  @ssalaues 

#### What this PR does / why we need it:
Allow custom annotations on kafka-manager service. In our case we need to add custom annotation for external-dns, but I guess there could be many other use cases.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped => waiting for validation to bump version
- [x] Variables are documented in the README.md
