### PR TITLE
[stable/dask] Improve getting LoadBalancer address in chart NOTES, fix env var name

### DIFF
--- a/stable/dask/Chart.yaml
+++ b/stable/dask/Chart.yaml
@@ -1,5 +1,5 @@
 name: dask
-version: 2.2.0
+version: 2.2.1
 appVersion: 1.1.0
 description: Distributed computation in Python with task scheduling
 home: https://dask.pydata.org

--- a/stable/dask/templates/NOTES.txt
+++ b/stable/dask/templates/NOTES.txt
@@ -11,7 +11,7 @@ The Jupyter notebook server and Dask scheduler expose external services to
 which you can connect to manage notebooks, or connect directly to the Dask
 cluster.   You can get these addresses by running the following:
 
-  export DASK_SCHEDULER_ADDRESS=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "dask.fullname" . }}-scheduler -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  export DASK_SCHEDULER_ADDRESS=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "dask.fullname" . }}-scheduler --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   export DASK_SCHEDULER_UI_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "dask.fullname" . }}-scheduler -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   export JUPYTER_NOTEBOOK_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "dask.fullname" . }}-jupyter -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$JUPYTER_NOTEBOOK_IP:{{ .Values.jupyter.servicePort }} -- Jupyter notebook

--- a/stable/dask/templates/NOTES.txt
+++ b/stable/dask/templates/NOTES.txt
@@ -11,7 +11,7 @@ The Jupyter notebook server and Dask scheduler expose external services to
 which you can connect to manage notebooks, or connect directly to the Dask
 cluster.   You can get these addresses by running the following:
 
-  export DASK_SCHEDULER=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "dask.fullname" . }}-scheduler -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  export DASK_SCHEDULER_ADDRESS=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "dask.fullname" . }}-scheduler -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   export DASK_SCHEDULER_UI_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "dask.fullname" . }}-scheduler -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   export JUPYTER_NOTEBOOK_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "dask.fullname" . }}-jupyter -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$JUPYTER_NOTEBOOK_IP:{{ .Values.jupyter.servicePort }} -- Jupyter notebook


### PR DESCRIPTION
#### What this PR does / why we need it:
Update extraction of load-balancer address in-accordance with #84.  Currently null is returned as there is no `ip` field in the response.

Additionally, in Dask, the environment variable is incorrect (it changed), and should be `DASK_SCHEDULER_ADDRESS` not `DASK_SCHEDULER`.

#### Which issue this PR fixes
  - fixes https://github.com/dask/dask/issues/4253

#### Special notes for your reviewer:
/cc @danielfrg @mrocklin 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
