### PR TITLE
[stable/rabbitmq] Support configuration for the rabbitmq metrics exporter

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 4.11.1
+version: 4.12.0
 appVersion: 3.7.14
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -111,7 +111,9 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `metrics.image.repository`           | Exporter image name                              | `kbudde/rabbitmq-exporter`                              |
 | `metrics.image.tag`                  | Exporter image tag                               | `v0.29.0`                                               |
 | `metrics.image.pullPolicy`           | Exporter image pull policy                       | `IfNotPresent`                                          |
+| `metrics.env`                        | Exporter [configuration environment variables](https://github.com/kbudde/rabbitmq_exporter#configuration) | `{}` |
 | `metrics.resources`                  | Exporter resource requests/limit                 | `nil`                                                   |
+| `metrics.capabilities`               | Exporter: Comma-separated list of extended [scraping capabilities supported by the target RabbitMQ server](https://github.com/kbudde/rabbitmq_exporter#extended-rabbitmq-capabilities) | `bert,no_sort` |
 | `podLabels`                          | Additional labels for the statefulset pod(s).    | {}                                                      |
 | `volumePermissions.enabled`         | Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work)                                                               | `false`                                          |
 | `volumePermissions.image.registry`         | Init container volume-permissions image registry                                                               | `docker.io`                                          |

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -211,6 +211,14 @@ spec:
           value: "http://localhost:{{ .Values.service.managerPort }}"
         - name: RABBIT_USER
           value: {{ .Values.rabbitmq.username }}
+        {{ if .Values.metrics.capabilities }}
+        - name: RABBIT_CAPABILITIES
+          value: "{{ .Values.metrics.capabilities }}"
+        {{- end }}
+        {{- range $key, $value := .Values.metrics.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
         ports:
         - name: metrics
           containerPort: 9090

--- a/stable/rabbitmq/values-production.yaml
+++ b/stable/rabbitmq/values-production.yaml
@@ -125,7 +125,7 @@ service:
   ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
   ##
   managerPort: 15672
-  
+
   ## Service annotations
   annotations:
     # service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
@@ -254,6 +254,12 @@ metrics:
     ##
     # pullSecrets:
     #   - myRegistryKeySecretName
+  ## environment variables to configure rabbitmq_exporter
+  ## ref: https://github.com/kbudde/rabbitmq_exporter#configuration
+  env: {}
+  ## Comma-separated list of extended scraping capabilities supported by the target RabbitMQ server
+  ## ref: https://github.com/kbudde/rabbitmq_exporter#extended-rabbitmq-capabilities
+  capabilities: "bert,no_sort"
   resources: {}
   annotations:
     prometheus.io/scrape: "true"

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -251,6 +251,13 @@ metrics:
     ##
     # pullSecrets:
     #   - myRegistryKeySecretName
+
+  ## environment variables to configure rabbitmq_exporter
+  ## ref: https://github.com/kbudde/rabbitmq_exporter#configuration
+  env: {}
+  ## Comma-separated list of extended scraping capabilities supported by the target RabbitMQ server
+  ## ref: https://github.com/kbudde/rabbitmq_exporter#extended-rabbitmq-capabilities
+  capabilities: "bert,no_sort"
   resources: {}
   annotations:
     prometheus.io/scrape: "true"


### PR DESCRIPTION
#### What this PR does / why we need it:
- generic configuration via environment variables: `metrics.env`
  see https://github.com/kbudde/rabbitmq_exporter#configuration
- better default `capabilities` (faster metrics collection with recent
  rabbitmq servers): `metrics.capabilities`
  see https://github.com/kbudde/rabbitmq_exporter#extended-rabbitmq-capabilities

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #12907

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
