### PR TITLE
[stable/sentry] make worker concurrency configurable

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 1.3.1
+version: 1.3.2
 appVersion: 9.0
 keywords:
   - debugging

--- a/stable/sentry/templates/workers-deployment.yaml
+++ b/stable/sentry/templates/workers-deployment.yaml
@@ -43,7 +43,7 @@ spec:
       - name: {{ .Chart.Name }}-workers
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        args: ["run", "worker"]
+        args: ["run", "worker", "-c", {{ quote .Values.worker.concurrency }}]
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         env:

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -51,6 +51,10 @@ cron:
 # How many worker instances to run
 worker:
   replicacount: 2
+  # `-c` or `--concurrency` flag for the `sentry run worker` command.
+  # Specifies the number of child processes processing the queue for a
+  # particular worker pod.
+  concurrency: 4
   resources:
     limits:
       cpu: 300m


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR makes the worker's `concurrency` flag configurable in `values.yaml` file. By default, sentry worker pods set their concurrency to the number of cores available on the machine on which the pod is running. This is often a waste, and without setting the memory resource limit to something high for such pods, the pods are inevitably OOM killed.

#### Which issue this PR fixes
  - fixes https://github.com/helm/charts/issues/12865

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
