### PR TITLE
stable/concourse: separate worker, web deployments

### DIFF
--- a/stable/concourse/CHANGELOG.md
+++ b/stable/concourse/CHANGELOG.md
@@ -1,0 +1,4 @@
+## v6.0.0:
+
+- added the ability to create worker only and web only deployments using web.enabled and worker.enabled
+- **[breaking]** worker and web secrets are now separated into 2 different templates, `worker-secrets.yaml` and `web-secrets.yaml`. users bringing their own secrets will have to split them into 2 different k8s objects.

--- a/stable/concourse/CHANGELOG.md
+++ b/stable/concourse/CHANGELOG.md
@@ -1,4 +1,4 @@
 ## v6.0.0:
 
-- added the ability to create worker only and web only deployments using web.enabled and worker.enabled
-- **[breaking]** worker and web secrets are now separated into 2 different templates, `worker-secrets.yaml` and `web-secrets.yaml`. users bringing their own secrets will have to split them into 2 different k8s objects.
+- added the ability to create worker only and web-only deployments using `web.enabled` and `worker.enabled`
+- **[breaking]** worker and web secrets are now separated into 2 different templates, `worker-secrets.yaml` and `web-secrets.yaml`. Users bringing their own secrets will have to split them into 2 different k8s objects.

--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 5.2.3
+version: 6.0.0
 appVersion: 5.1.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -154,6 +154,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.additionalVolumes` | Volumes to be added to the web pods | `nil` |
 | `web.annotations`| Concourse Web deployment annotations | `nil` |
 | `web.authSecretsPath` | Specify the mount directory of the web auth secrets | `/concourse-auth` |
+| `web.enabled` | enable or disable the web component | `true` |
 | `web.env` | Configure additional environment variables for the web containers | `[]` |
 | `web.ingress.annotations` | Concourse Web Ingress annotations | `{}` |
 | `web.ingress.enabled` | Enable Concourse Web Ingress | `false` |
@@ -193,6 +194,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `worker.annotations` | Annotations to be added to the worker pods | `{}` |
 | `worker.cleanUpWorkDirOnStart` | Removes any previous state created in `concourse.worker.workDir` | `true` |
 | `worker.emptyDirSize` | When persistance is disabled this value will be used to limit the emptyDir volume size | `nil` |
+| `worker.enabled` | enable or disable the worker component | `true` |
 | `worker.env` | Configure additional environment variables for the worker container(s) | `[]` |
 | `worker.hardAntiAffinity` | Should the workers be forced (as opposed to preferred) to be on different nodes? | `false` |
 | `worker.keySecretsPath` | Specify the mount directory of the worker keys secrets | `/concourse-keys` |

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -194,7 +194,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `worker.annotations` | Annotations to be added to the worker pods | `{}` |
 | `worker.cleanUpWorkDirOnStart` | Removes any previous state created in `concourse.worker.workDir` | `true` |
 | `worker.emptyDirSize` | When persistance is disabled this value will be used to limit the emptyDir volume size | `nil` |
-| `worker.enabled` | enable or disable the worker component | `true` |
+| `worker.enabled` | enable or disable the worker component. you should set postgres.enabled=false in order not to get an unnecessary postgres chart deployed | `true` |
 | `worker.env` | Configure additional environment variables for the worker container(s) | `[]` |
 | `worker.hardAntiAffinity` | Should the workers be forced (as opposed to preferred) to be on different nodes? | `false` |
 | `worker.keySecretsPath` | Specify the mount directory of the worker keys secrets | `/concourse-keys` |
@@ -264,7 +264,13 @@ rm session-signing-key.pub
 printf "%s:%s" "concourse" "$(openssl rand -base64 24)" > local-users
 ```
 
-You'll also need to create/copy secret values for optional features. See [templates/secrets.yaml](templates/secrets.yaml) for possible values.
+all the worker-specific secrets, namely, `workerKey`, `workerKeyPub`, `hostKeyPub` are to be added to a separate Kubernetes secrets object with the name [release name]-worker.
+
+all other secrets are to be added to a secrets object with the name [release name]-web.
+
+for the time being, the secret `workerKeyPub` is to be added to both the worker and the web secret objects, until investigated within issue #13019
+
+You'll also need to create/copy secret values for optional features. See [templates/web-secrets.yaml](templates/web-secrets.yaml) and [templates/web-secrets.yaml](templates/web-secrets.yaml)  for possible values.
 
 In the example below, we are not using the [PostgreSQL](#postgresql) chart dependency, and so we must set `postgresql-user` and `postgresql-password` secrets.
 

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -154,7 +154,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.additionalVolumes` | Volumes to be added to the web pods | `nil` |
 | `web.annotations`| Concourse Web deployment annotations | `nil` |
 | `web.authSecretsPath` | Specify the mount directory of the web auth secrets | `/concourse-auth` |
-| `web.enabled` | enable or disable the web component | `true` |
+| `web.enabled` | Enable or disable the web component | `true` |
 | `web.env` | Configure additional environment variables for the web containers | `[]` |
 | `web.ingress.annotations` | Concourse Web Ingress annotations | `{}` |
 | `web.ingress.enabled` | Enable Concourse Web Ingress | `false` |
@@ -194,7 +194,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `worker.annotations` | Annotations to be added to the worker pods | `{}` |
 | `worker.cleanUpWorkDirOnStart` | Removes any previous state created in `concourse.worker.workDir` | `true` |
 | `worker.emptyDirSize` | When persistance is disabled this value will be used to limit the emptyDir volume size | `nil` |
-| `worker.enabled` | enable or disable the worker component. you should set postgres.enabled=false in order not to get an unnecessary postgres chart deployed | `true` |
+| `worker.enabled` | Enable or disable the worker component. You should set postgres.enabled=false in order not to get an unnecessary Postgres chart deployed | `true` |
 | `worker.env` | Configure additional environment variables for the worker container(s) | `[]` |
 | `worker.hardAntiAffinity` | Should the workers be forced (as opposed to preferred) to be on different nodes? | `false` |
 | `worker.keySecretsPath` | Specify the mount directory of the worker keys secrets | `/concourse-keys` |
@@ -264,11 +264,11 @@ rm session-signing-key.pub
 printf "%s:%s" "concourse" "$(openssl rand -base64 24)" > local-users
 ```
 
-all the worker-specific secrets, namely, `workerKey`, `workerKeyPub`, `hostKeyPub` are to be added to a separate Kubernetes secrets object with the name [release name]-worker.
+All the worker-specific secrets, namely, `workerKey`, `workerKeyPub`, `hostKeyPub` are to be added to a separate Kubernetes secrets object with the name [release name]-worker.
 
-all other secrets are to be added to a secrets object with the name [release name]-web.
+All other secrets are to be added to a secrets object with the name `[release name]-web`.
 
-for the time being, the secret `workerKeyPub` is to be added to both the worker and the web secret objects, until investigated within issue #13019
+For the time being, the secret `workerKeyPub` is to be added to both the worker and the web secret objects, until investigated within issue #13019.
 
 You'll also need to create/copy secret values for optional features. See [templates/web-secrets.yaml](templates/web-secrets.yaml) and [templates/web-secrets.yaml](templates/web-secrets.yaml)  for possible values.
 

--- a/stable/concourse/templates/_helpers.tpl
+++ b/stable/concourse/templates/_helpers.tpl
@@ -7,19 +7,18 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
-Create a default fully qualified concourse name.
+Create a default fully qualified web node(s) name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "concourse.concourse.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
 {{- define "concourse.web.fullname" -}}
 {{- $name := default "web" .Values.web.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Create a default fully qualified worker node(s) name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
 {{- define "concourse.worker.fullname" -}}
 {{- $name := default "worker" .Values.worker.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}

--- a/stable/concourse/templates/namespace.yaml
+++ b/stable/concourse/templates/namespace.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.web.enabled -}}
 {{- if and .Values.concourse.web.kubernetes.enabled .Values.concourse.web.kubernetes.createTeamNamespaces -}}
 {{- range .Values.concourse.web.kubernetes.teams }}
 ---
@@ -10,9 +11,10 @@ metadata:
 {{- end }}
   name: {{ template "concourse.namespacePrefix" $ }}{{ . }}
   labels:
-    app: {{ template "concourse.concourse.fullname" $ }}
+    app: {{ template "concourse.web.fullname" $ }}
     chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
+{{- end }}
 {{- end }}
 {{- end -}}

--- a/stable/concourse/templates/required-check.yaml
+++ b/stable/concourse/templates/required-check.yaml
@@ -1,0 +1,3 @@
+{{ if not (or .Values.web.enabled .Values.worker.enabled) }}
+{{- required "Must set either web.enabled or worker.enabled to create a concourse deployment" "" }}
+{{ end }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.web.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -92,12 +93,12 @@ spec:
             - name: CONCOURSE_BITBUCKET_CLOUD_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: bitbucket-cloud-client-id
             - name: CONCOURSE_BITBUCKET_CLOUD_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: bitbucket-cloud-client-secret
             {{- end }}
             {{- if .Values.concourse.web.logLevel }}
@@ -116,7 +117,7 @@ spec:
             - name: CONCOURSE_ADD_LOCAL_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: local-users
             {{- end }}
             {{- if .Values.concourse.web.tls.enabled }}
@@ -140,12 +141,12 @@ spec:
             - name: CONCOURSE_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: encryption-key
             - name: CONCOURSE_OLD_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: old-encryption-key
             {{- end }}
             {{- if .Values.concourse.web.debugBindIp }}
@@ -236,12 +237,12 @@ spec:
             - name: CONCOURSE_POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: postgresql-user
             - name: CONCOURSE_POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: postgresql-password
             {{- if .Values.concourse.web.postgres.sslmode }}
             - name: CONCOURSE_POSTGRES_SSLMODE
@@ -288,18 +289,18 @@ spec:
             - name: CONCOURSE_AWS_SECRETSMANAGER_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: aws-secretsmanager-access-key
             - name: CONCOURSE_AWS_SECRETSMANAGER_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: aws-secretsmanager-secret-key
             {{- if .Values.concourse.web.awsSecretsManager.keyAuth.useSessionToken }}
             - name: CONCOURSE_AWS_SECRETSMANAGER_SESSION_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: aws-secretsmanager-session-token
             {{- end }}
             {{- end }}
@@ -317,18 +318,18 @@ spec:
             - name: CONCOURSE_AWS_SSM_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: aws-ssm-access-key
             - name: CONCOURSE_AWS_SSM_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: aws-ssm-secret-key
             {{- if .Values.concourse.web.awsSsm.keyAuth.useSessionToken }}
             - name: CONCOURSE_AWS_SSM_SESSION_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: aws-ssm-session-token
             {{- end }}
             {{- end }}
@@ -360,7 +361,7 @@ spec:
             - name: CONCOURSE_VAULT_CLIENT_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: vault-client-token
             {{- end }}
             {{- if eq .Values.concourse.web.vault.authBackend "cert" }}
@@ -373,7 +374,7 @@ spec:
             - name: CONCOURSE_VAULT_AUTH_PARAM
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: vault-client-auth-param
             {{- end }}
             {{- if .Values.concourse.web.vault.authBackendMaxTtl }}
@@ -461,7 +462,7 @@ spec:
             - name: CONCOURSE_INFLUXDB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: influxdb-password
             - name: CONCOURSE_INFLUXDB_INSECURE_SKIP_VERIFY
               value: {{ .Values.concourse.web.influxdb.insecureSkipVerify | quote}}
@@ -622,12 +623,12 @@ spec:
             - name: CONCOURSE_CF_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: cf-client-id
             - name: CONCOURSE_CF_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: cf-client-secret
             {{- if .Values.concourse.web.auth.cf.apiUrl }}
             - name: CONCOURSE_CF_API_URL
@@ -646,12 +647,12 @@ spec:
             - name: CONCOURSE_GITHUB_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: github-client-id
             - name: CONCOURSE_GITHUB_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: github-client-secret
             {{- if .Values.concourse.web.auth.github.host }}
             - name: CONCOURSE_GITHUB_HOST
@@ -666,12 +667,12 @@ spec:
             - name: CONCOURSE_GITLAB_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: gitlab-client-id
             - name: CONCOURSE_GITLAB_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: gitlab-client-secret
             {{- if .Values.concourse.web.auth.gitlab.host }}
             - name: CONCOURSE_GITLAB_HOST
@@ -772,12 +773,12 @@ spec:
             - name: CONCOURSE_OAUTH_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: oauth-client-id
             - name: CONCOURSE_OAUTH_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: oauth-client-secret
             {{- if .Values.concourse.web.auth.oauth.authUrl }}
             - name: CONCOURSE_OAUTH_AUTH_URL
@@ -828,12 +829,12 @@ spec:
             - name: CONCOURSE_OIDC_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: oidc-client-id
             - name: CONCOURSE_OIDC_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
+                  name: {{ template "concourse.web.fullname" . }}
                   key: oidc-client-secret
             {{- if .Values.concourse.web.auth.oidc.scope }}
             - name: CONCOURSE_OIDC_SCOPE
@@ -990,7 +991,7 @@ spec:
 {{- end }}
         - name: concourse-keys
           secret:
-            secretName: {{ template "concourse.concourse.fullname" . }}
+            secretName: {{ template "concourse.web.fullname" . }}
             defaultMode: 0400
             items:
               - key: host-key
@@ -1002,7 +1003,7 @@ spec:
         {{- if .Values.secrets.teamAuthorizedKeys }}
         - name: team-authorized-keys
           secret:
-            secretName: {{ template "concourse.concourse.fullname" . }}
+            secretName: {{ template "concourse.web.fullname" . }}
             defaultMode: 0400
             items:
             {{- range .Values.secrets.teamAuthorizedKeys }}
@@ -1013,7 +1014,7 @@ spec:
         {{- if .Values.concourse.web.tls.enabled }}
         - name: web-tls
           secret:
-            secretName: {{ template "concourse.concourse.fullname" . }}
+            secretName: {{ template "concourse.web.fullname" . }}
             defaultMode: 0400
             items:
               - key: web-tls-cert
@@ -1024,7 +1025,7 @@ spec:
         {{- if .Values.concourse.web.vault.enabled }}
         - name: vault-keys
           secret:
-            secretName: {{ template "concourse.concourse.fullname" . }}
+            secretName: {{ template "concourse.web.fullname" . }}
             defaultMode: 0400
             items:
             {{- if .Values.concourse.web.vault.useCaCert }}
@@ -1041,7 +1042,7 @@ spec:
         {{- if not (eq .Values.concourse.web.postgres.sslmode "disable") }}
         - name: postgresql-keys
           secret:
-            secretName: {{ template "concourse.concourse.fullname" . }}
+            secretName: {{ template "concourse.web.fullname" . }}
             defaultMode: 0400
             items:
               - key: postgresql-ca-cert
@@ -1054,7 +1055,7 @@ spec:
         {{- if .Values.concourse.web.syslog.enabled }}
         - name: syslog-keys
           secret:
-            secretName: {{ template "concourse.concourse.fullname" . }}
+            secretName: {{ template "concourse.web.fullname" . }}
             defaultMode: 0400
             items:
               - key: syslog-ca-cert
@@ -1062,7 +1063,7 @@ spec:
         {{- end }}
         - name: auth-keys
           secret:
-            secretName: {{ template "concourse.concourse.fullname" . }}
+            secretName: {{ template "concourse.web.fullname" . }}
             defaultMode: 0400
             items:
               {{- if .Values.concourse.web.auth.cf.useCaCert }}
@@ -1085,3 +1086,4 @@ spec:
               - key: oidc-ca-cert
                 path: oidc_ca.cert
               {{- end }}
+{{- end }}

--- a/stable/concourse/templates/web-ingress.yaml
+++ b/stable/concourse/templates/web-ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.web.enabled -}}
 {{- if .Values.web.ingress.enabled -}}
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := default "web" .Values.web.nameOverride -}}
@@ -29,4 +30,5 @@ spec:
   tls:
 {{ toYaml .Values.web.ingress.tls | indent 4 }}
   {{- end -}}
+{{- end -}}
 {{- end -}}

--- a/stable/concourse/templates/web-role.yaml
+++ b/stable/concourse/templates/web-role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.web.enabled -}}
 {{- if .Values.rbac.create -}}
 {{- if .Values.concourse.web.kubernetes.enabled -}}
 apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
@@ -13,5 +14,6 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get"]
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stable/concourse/templates/web-rolebinding.yaml
+++ b/stable/concourse/templates/web-rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.web.enabled -}}
 {{- if .Values.rbac.create -}}
 {{- if .Values.concourse.web.kubernetes.enabled -}}
 {{- range .Values.concourse.web.kubernetes.teams }}
@@ -21,5 +22,6 @@ subjects:
   name: {{ template "concourse.web.fullname" $ }}
   namespace: {{ $.Release.Namespace }}
 {{- end }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stable/concourse/templates/web-secrets.yaml
+++ b/stable/concourse/templates/web-secrets.yaml
@@ -1,20 +1,20 @@
+{{- if .Values.web.enabled  }}
 {{- if .Values.secrets.create }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "concourse.concourse.fullname" . }}
+  name: {{ template "concourse.web.fullname" . }}
   labels:
-    app: {{ template "concourse.concourse.fullname" . }}
+    app: {{ template "concourse.web.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
   host-key: {{ .Values.secrets.hostKey | b64enc | quote }}
-  host-key-pub: {{ .Values.secrets.hostKeyPub | b64enc | quote }}
   session-signing-key: {{ .Values.secrets.sessionSigningKey | b64enc | quote }}
-  worker-key: {{ .Values.secrets.workerKey | b64enc | quote }}
   worker-key-pub: {{ .Values.secrets.workerKeyPub | b64enc | quote }}
+
   {{- if not .Values.postgresql.enabled }}
   postgresql-user: {{ template "concourse.secret.required" dict "key" "postgresUser" "isnt" "postgresql.enabled" "root" . }}
   postgresql-password: {{ template "concourse.secret.required" dict "key" "postgresPassword" "isnt" "postgresql.enabled" "root" . }}
@@ -94,4 +94,5 @@ data:
   {{- range .Values.secrets.teamAuthorizedKeys}}
   {{ .team }}-team-authorized-key: {{ .key | b64enc | quote }}
   {{- end}}
+{{- end }}
 {{- end }}

--- a/stable/concourse/templates/web-serviceaccount.yaml
+++ b/stable/concourse/templates/web-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.web.enabled -}}
 {{- if .Values.rbac.create -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -9,3 +10,4 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 {{- end -}}
+{{- end }}

--- a/stable/concourse/templates/web-svc.yaml
+++ b/stable/concourse/templates/web-svc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.web.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -59,3 +60,4 @@ spec:
     {{- end }}
   selector:
     app: {{ template "concourse.web.fullname" . }}
+{{- end }}

--- a/stable/concourse/templates/worker-policy.yaml
+++ b/stable/concourse/templates/worker-policy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.worker.enabled -}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -12,3 +13,4 @@ spec:
   selector:
     matchLabels:
       app: {{ template "concourse.worker.fullname" . }}
+{{- end }}

--- a/stable/concourse/templates/worker-role.yaml
+++ b/stable/concourse/templates/worker-role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.worker.enabled -}}
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
 kind: Role
@@ -18,3 +19,4 @@ rules:
   verbs:
   - use
 {{- end -}}
+{{- end }}

--- a/stable/concourse/templates/worker-rolebinding.yaml
+++ b/stable/concourse/templates/worker-rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.worker.enabled -}}
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
 kind: RoleBinding
@@ -16,3 +17,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "concourse.worker.fullname" . }}
 {{- end -}}
+{{- end }}

--- a/stable/concourse/templates/worker-secrets.yaml
+++ b/stable/concourse/templates/worker-secrets.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.worker.enabled  }}
+{{- if .Values.secrets.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "concourse.worker.fullname" . }}
+  labels:
+    app: {{ template "concourse.worker.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  host-key-pub: {{ .Values.secrets.hostKeyPub | b64enc | quote }}
+  worker-key: {{ .Values.secrets.workerKey | b64enc | quote }}
+  worker-key-pub: {{ .Values.secrets.workerKeyPub | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/stable/concourse/templates/worker-serviceaccount.yaml
+++ b/stable/concourse/templates/worker-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.worker.enabled -}}
 {{- if .Values.rbac.create -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -9,3 +10,4 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 {{- end -}}
+{{- end }}

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -170,9 +170,9 @@ spec:
             - name: CONCOURSE_LOG_LEVEL
               value: {{ .Values.concourse.worker.logLevel | quote }}
             {{- end }}
-            {{ if .Values.concourse.worker.tsa.host }}
+            {{ if and .Values.worker.enabled (not .Values.web.enabled) }}
             - name: CONCOURSE_TSA_HOST
-              value: "{{ .Values.concourse.worker.tsa.host }}:{{ .Values.concourse.worker.tsa.port}}"
+              value: "{{ required "concourse.worker.tsa.host must be set in case of worker only deployment" .Values.concourse.worker.tsa.host }}:{{ .Values.concourse.worker.tsa.port}}"
             {{ else }}
             - name: CONCOURSE_TSA_HOST
               value: "{{ template "concourse.web.fullname" . }}:{{ .Values.concourse.worker.tsa.port}}"

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.worker.enabled -}}
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
@@ -169,8 +170,13 @@ spec:
             - name: CONCOURSE_LOG_LEVEL
               value: {{ .Values.concourse.worker.logLevel | quote }}
             {{- end }}
+            {{ if .Values.concourse.worker.tsa.host }}
             - name: CONCOURSE_TSA_HOST
-              value: "{{ template "concourse.web.fullname" . }}:{{ .Values.concourse.web.tsa.bindPort}}"
+              value: "{{ .Values.concourse.worker.tsa.host }}:{{ .Values.concourse.worker.tsa.port}}"
+            {{ else }}
+            - name: CONCOURSE_TSA_HOST
+              value: "{{ template "concourse.web.fullname" . }}:{{ .Values.concourse.worker.tsa.port}}"
+            {{ end }}
             - name: CONCOURSE_TSA_PUBLIC_KEY
               value: "{{ .Values.worker.keySecretsPath }}/host_key.pub"
             - name: CONCOURSE_TSA_WORKER_PRIVATE_KEY
@@ -299,7 +305,7 @@ spec:
             name: {{ template "concourse.worker.fullname" . }}
         - name: concourse-keys
           secret:
-            secretName: {{ template "concourse.concourse.fullname" . }}
+            secretName: {{ template "concourse.worker.fullname" . }}
             defaultMode: 0400
             items:
               - key: host-key-pub
@@ -341,3 +347,4 @@ spec:
   {{- if .Values.worker.podManagementPolicy }}
   podManagementPolicy: {{ .Values.worker.podManagementPolicy }}
   {{- end }}
+{{- end }}

--- a/stable/concourse/templates/worker-svc.yaml
+++ b/stable/concourse/templates/worker-svc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.worker.enabled -}}
 ## A Headless Service is required when using a StatefulSet
 ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/
 ##
@@ -19,3 +20,4 @@ spec:
   ports: []
   selector:
     app: {{ template "concourse.worker.fullname" . }}
+{{- end }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1008,9 +1008,13 @@ concourse:
     volumeSweeperMaxInFlight: 5
 
     tsa:
-      ## TSA host to forward the worker through. Can be specified multiple times.
+      ## TSA host to forward the worker through.
       ##
       host:
+
+      ## TSA port to forward the worker through.
+      ##
+      port: 2222
 
       ## File containing a public key to expect from the TSA.
       ##
@@ -1096,6 +1100,11 @@ concourse:
 ## Concourse Web nodes, see https://concourse-ci.org/concourse-web.html.
 ##
 web:
+
+  ## enable/disable web component
+  ## This can allow users to create worker only releases by setting this to false
+  ##
+  enabled: true
 
   ## Override the components name (defaults to web).
   ##
@@ -1324,6 +1333,12 @@ web:
 ## Concourse Workers, see https://concourse-ci.org/concourse-worker.html
 ##
 worker:
+
+  ## enable/disable worker component
+  ## This can allow users to create web only releases by setting this to false
+  ##
+  enabled: true
+
   ## Override the components name (defaults to worker).
   ##
   nameOverride:
@@ -1530,6 +1545,7 @@ postgresql:
 
   ## Use the PostgreSQL chart dependency.
   ## Set to false if bringing your own PostgreSQL, and set secret value postgresql-uri.
+  ## Should be set to false if using the chart as a worker only deployment.
   ##
   enabled: true
 

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1101,8 +1101,8 @@ concourse:
 ##
 web:
 
-  ## enable/disable web component
-  ## This can allow users to create worker only releases by setting this to false
+  ## Enable or disable the web component.
+  ## This allows the creation of worker-only releases by setting this to false.
   ##
   enabled: true
 
@@ -1334,7 +1334,7 @@ web:
 ##
 worker:
 
-  ## enable/disable worker component
+  ## Enable or disable the worker component.
   ## This can allow users to create web only releases by setting this to false
   ##
   enabled: true


### PR DESCRIPTION
#### What this PR does / why we need it:

- Added `.Values.Web.enabled` and `.Values.worker.enabled` (with default to
true).
- if only `.Values.web.enabled` is enabled: only web resources are going to
be created, as well as secrets namespace.
- if only `.Values.worker.enabled` is enabled: only worker resources are going to
be created.
- moved the worker-specific and web-specific secrets each to a separate
file and secrets object.
- added `.Values.concourse.worker.tsa.port` and utilised
`.Values.concourse.worker.host` in order to allow the user to set the
`CONCOURSE_TSA_HOST` easily.
- removed the template `concourse.concourse.fullname` as it is not used
anymore.
- bumped the chart version to 6.0.0, as this adds new ways to use the
chart.
- added the new variables to the README doc.

#### Which issue this PR fixes
  - fixes #11280

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md


cc: @taylorsilva