### PR TITLE
Shorten long job name

### DIFF
--- a/stable/minio/templates/post-install-create-bucket-job.yaml
+++ b/stable/minio/templates/post-install-create-bucket-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "minio.fullname" . }}-make-bucket-job
+  name: {{ template "minio.fullname" . }}-make-bucket
   labels:
     app: {{ template "minio.name" . }}
     chart: {{ template "minio.chart" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

The job name `{{ template "minio.fullname" . }}-make-bucket-job` can easily get too long. The `fullname` part truncated at 63 characters, but the whole job name is causing issues (`spec.template.labels: Invalid value: "[our-relatively-long-release-name]-minio-make-bucket-job": must be no more than 63 characters`).

While not an absolute solution, shortening the suffix `-make-bucket-job` to just `-make-bucket` works in our case. Other resources also don't include the resource type in their name.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed