### PR TITLE
[stable/odoo] Fix service selectors

### DIFF
--- a/stable/odoo/Chart.yaml
+++ b/stable/odoo/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: odoo
-version: 6.2.0
+version: 6.2.1
 appVersion: 11.0.20190315
 description: A suite of web based open source business apps.
 home: https://www.odoo.com/

--- a/stable/odoo/templates/svc.yaml
+++ b/stable/odoo/templates/svc.yaml
@@ -23,4 +23,4 @@ spec:
     nodePort: {{ .Values.service.nodePort }}
     {{- end }}
   selector:
-    app: {{ template "odoo.name" . }}
+    app: {{ template "odoo.fullname" . }}

--- a/stable/odoo/templates/svc.yaml
+++ b/stable/odoo/templates/svc.yaml
@@ -23,4 +23,5 @@ spec:
     nodePort: {{ .Values.service.nodePort }}
     {{- end }}
   selector:
-    app: {{ template "odoo.fullname" . }}
+    app: {{ template "odoo.name" . }}
+    release: {{ .Release.Name | quote }}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR fixes an issue with selectors on Odoo service. Currently, non-unique selector are used and pods from different releases are mixed.

```bash
$ helm install stable/odoo --name odoo1
$ helm install stable/odoo --name odoo2
$ kubectl get svc odoo1-odoo -o jsonpath='{.spec.selector}'
map[app:odoo]
$ kubectl get svc odoo2-odoo -o jsonpath='{.spec.selector}'
map[app:odoo]
$ kubectl get endpoints odoo1-odoo
NAME         ENDPOINTS                           AGE
odoo2-odoo   172.17.0.10:8069,172.17.0.11:8069   6m38s
$ kubectl get endpoints odoo2-odoo
NAME         ENDPOINTS                           AGE
odoo2-odoo   172.17.0.10:8069,172.17.0.11:8069   6m38s
```

With this new approach, unique selectors are used:

```bash
$ kubectl get svc odoo3-odoo -o jsonpath='{.spec.selector}'
map[app:odoo release:odoo3]
```

#### Which issue this PR fixes

  - fixes #12884

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped

