### PR TITLE
[stable/rabbitmq] Add parameter to indicate 'extraPlugins' to install

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 5.0.0
+version: 5.1.0
 appVersion: 3.7.14
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -61,7 +61,8 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `rabbitmq.existingPasswordSecret`    | Existing secret with RabbitMQ credentials        | nil                                                     |
 | `rabbitmq.erlangCookie`              | Erlang cookie                                    | _random 32 character long alphanumeric string_          |
 | `rabbitmq.existingErlangSecret`      | Existing secret with RabbitMQ Erlang cookie      | nil                                                     |
-| `rabbitmq.plugins`                   | configuration file for plugins to enable         | `[rabbitmq_management,rabbitmq_peer_discovery_k8s].`    |
+| `rabbitmq.plugins`                   | List of plugins to enable                        | `rabbitmq_management rabbitmq_peer_discovery_k8s`       |
+| `rabbitmq.extraPlugins`              | Extra plugings to enable                         | `nil`                                                   |
 | `rabbitmq.clustering.address_type`   | Switch clustering mode                           | `ip` or `hostname`                                      |
 | `rabbitmq.clustering.k8s_domain`     | Customize internal k8s cluster domain            | `cluster.local`                                         |
 | `rabbitmq.logs`                      | Value for the RABBITMQ_LOGS environment variable | `-`                                                     |

--- a/stable/rabbitmq/templates/_helpers.tpl
+++ b/stable/rabbitmq/templates/_helpers.tpl
@@ -32,6 +32,19 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Return the proper RabbitMQ plugin list
+*/}}
+{{- define "rabbitmq.plugins" -}}
+{{- $plugins := .Values.rabbitmq.plugins | replace " " ", " -}}
+{{- if .Values.rabbitmq.extraPlugins -}}
+{{- $extraPlugins := .Values.rabbitmq.extraPlugins | replace " " ", " -}}
+{{- printf "[%s, %s]." $plugins $extraPlugins | indent 4 -}}
+{{- else -}}
+{{- printf "[%s]." $plugins | indent 4 -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the proper RabbitMQ image name
 */}}
 {{- define "rabbitmq.image" -}}

--- a/stable/rabbitmq/templates/configuration.yaml
+++ b/stable/rabbitmq/templates/configuration.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 data:
   enabled_plugins: |-
-{{ .Values.rabbitmq.plugins | indent 4 }}
+{{ template "rabbitmq.plugins" . }}
   rabbitmq.conf: |-
     ##username and password
     default_user={{.Values.rabbitmq.username}}

--- a/stable/rabbitmq/values-production.yaml
+++ b/stable/rabbitmq/values-production.yaml
@@ -71,8 +71,11 @@ rabbitmq:
   ulimitNofiles: '65536'
 
   ## Plugins to enable
-  plugins: |-
-      [rabbitmq_management, rabbitmq_peer_discovery_k8s].
+  plugins: "rabbitmq_management rabbitmq_peer_discovery_k8s"
+
+  ## Extra plugins to enable
+  ## Use this instead of `plugins` to add new plugins
+  # extraPlugins: ""
 
   ## Clustering settings
   clustering:

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -71,8 +71,11 @@ rabbitmq:
   ulimitNofiles: '65536'
 
   ## Plugins to enable
-  plugins: |-
-      [rabbitmq_management, rabbitmq_peer_discovery_k8s].
+  plugins: "rabbitmq_management rabbitmq_peer_discovery_k8s"
+
+  ## Extra plugins to enable
+  ## Use this instead of `plugins` to add new plugins
+  # extraPlugins: ""
 
   ## Clustering settings
   clustering:


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR defines two different parameters to form the RabbitMQ plugins file:

- plugins: List of default plugins to install
- extraPlugins: In order to add custom plugins to RabbitMQ

#### Which issue this PR fixes

  - fixes https://github.com/helm/charts/issues/12760

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
