### PR TITLE
[stable/drone] Fix DRONE_STASH_PRIVATE_KEY, correct bitbucketServer params

### DIFF
--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 2.0.0-rc.13
+version: 2.0.0-rc.14
 appVersion: 1.0.0-rc.5
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/stable/drone/templates/_provider-envs.yaml
+++ b/stable/drone/templates/_provider-envs.yaml
@@ -47,17 +47,14 @@
             valueFrom:
               secretKeyRef:
                 name: {{ template "drone.sourceControlSecret" . }}
-                key: {{ .Values.sourceControl.bitbucketCloud.passwordKey }}
+                key: {{ .Values.sourceControl.bitbucketServer.passwordKey }}
           - name: DRONE_STASH_CONSUMER_KEY
             valueFrom:
               secretKeyRef:
                 name: {{ template "drone.sourceControlSecret" . }}
-                key: {{ .Values.sourceControl.bitbucketCloud.consumerKey }}
+                key: {{ .Values.sourceControl.bitbucketServer.consumerKey }}
           - name: DRONE_STASH_PRIVATE_KEY
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "drone.sourceControlSecret" . }}
-                key: {{ .Values.sourceControl.bitbucketCloud.privateKey }}
+            value: /etc/bitbucket/key.pem
 {{- end -}}
 {{- end -}}
 

--- a/stable/drone/templates/deployment-server.yaml
+++ b/stable/drone/templates/deployment-server.yaml
@@ -102,12 +102,25 @@ spec:
         resources:
 {{ toYaml .Values.server.resources | indent 10 }}
         volumeMounts:
-          - name: data
-            mountPath: /var/lib/drone
+        {{ if eq .Values.sourceControl.provider "bitbucketServer" -}}
+        - name: bitbucket-private-key
+          mountPath: /etc/bitbucket
+          readOnly: true
+        {{ end }}
+        - name: data
+          mountPath: /var/lib/drone
 {{- with .Values.server.extraContainers }}
 {{ tpl . $ | indent 6 }}
 {{- end }}
       volumes:
+      {{ if eq .Values.sourceControl.provider "bitbucketServer" -}}
+      - name: bitbucket-private-key
+        secret:
+          secretName: {{ template "drone.sourceControlSecret" . }}
+          items:
+            - key: {{ .Values.sourceControl.bitbucketServer.privateKey }}
+              path: key.pem
+      {{ end -}}
       - name: data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:


### PR DESCRIPTION
#### What this PR does / why we need it:
Currently the environment variable `DRONE_STASH_PRIVATE_KEY` contains the private key but [drone expects a path to the key](https://docs.drone.io/installation/bitbucket-server/kubernetes/#drone-stash-private-key).

This fix contains:
* Correct prefix of bitbucketServer.passwordKey and  bitbucketServer.consumerKey
* Provide the path of the mounted bitbucket key in `DRONE_STASH_PRIVATE_KEY`
* Mount bitbucket key under `/etc/bitbucket/key.pem`

/edit: Updated syntax to docs

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
