### PR TITLE
[stable/spinnaker] Add a support of halyard resource definitions

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.9.1
+version: 1.9.2
 appVersion: 1.12.5
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/statefulsets/halyard.yaml
+++ b/stable/spinnaker/templates/statefulsets/halyard.yaml
@@ -108,6 +108,10 @@ spec:
         ports:
         - containerPort: 8064
           name: daemon
+        {{- if .Values.halyard.resources }}
+        resources:
+{{ toYaml .Values.halyard.resources | indent 10 }}
+        {{- end }}
         volumeMounts:
         {{- if .Values.gcs.enabled }}
         - name: gcs-key

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -45,6 +45,16 @@ halyard:
   # annotations:
   #   iam.amazonaws.com/role: <role_arn>
 
+  ## Uncomment the following resources definitions to control the cpu and memory
+  # resources allocated for the halyard pod
+  resources: {}
+    # requests:
+    #   memory: "1Gi"
+    #   cpu: "100m"
+    # limits:
+    #   memory: "2Gi"
+    #   cpu: "200m"
+
 # Define which registries and repositories you want available in your
 # Spinnaker pipeline definitions
 # For more info visit:


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR allows to specify `resources` block for halyard pod in `stable/spinnaker` chart.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
