### PR TITLE
run kubernetes namespace values through tpl

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.66.0
+version: 1.66.1
 appVersion: 1.7.9
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -122,7 +122,7 @@ data:
     namespaces = [
         {{- range $idx, $element := .Values.kubernetes.namespaces }}
             {{- if $idx }}, {{ end }}
-            {{- $element | quote }}
+            {{- tpl $element $ | quote }}
         {{- end -}}
         ]
       {{- end}}


### PR DESCRIPTION
allows better re-use as a subchart

regular string:
```
$ helm template --set 'kubernetes.namespaces[0]=nontemplate' -x templates/configmap.yaml . | grep 'namespaces ='
    namespaces = ["nontemplate"]
```

templated value:
```
$ helm template --namespace monitoring --set 'kubernetes.namespaces[0]=\{\{.Release.Namespace\}\}' -x templates/configmap.yaml . | grep 'namespaces ='
    namespaces = ["monitoring"]
```

Signed-off-by: Aron Parsons <aron@knackworks.com>


#### What this PR does / why we need it:

#### Which issue this PR fixes
This allow the traefik chart to be used as a sub-chart in a namespace and only monitor ingresses within that namespace.  Otherwise we run into this issue of traefik constantly reloading: https://github.com/containous/traefik/issues/3980

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
