### PR TITLE
Replace hardcoded .Values.metrics.service.port values and add more ES output options

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 1.9.1
+version: 1.9.2
 appVersion: 1.0.6
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -45,6 +45,8 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `backend.es.type`          | Elastic Type name | `flb_type` |
 | `backend.es.time_key`          | Elastic Time Key | `@timestamp` |
 | `backend.es.logstash_prefix`  | Index Prefix. If Logstash_Prefix is equals to 'mydata' your index will become 'mydata-YYYY.MM.DD'. | `kubernetes_cluster` |
+| `backend.es.include_tag_key`  | Enable/Disable Include_Tag_Key option. | `Off` |
+| `backend.es.logstash_format`  | Enable/Disable Logstash_Format option. | `On` |
 | `backend.es.replace_dots`     | Enable/Disable Replace_Dots option. | `On` |
 | `backend.es.http_user`        | Optional username credential for Elastic X-Pack access. | `` |
 | `backend.es.http_passwd:`     | Password for user defined in HTTP_User. | `` |

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -11,7 +11,7 @@ metadata:
 data:
   fluent-bit-service.conf: |-
     [SERVICE]
-        Flush        {{ .Values.service.flush }} 
+        Flush        {{ .Values.service.flush }}
         Daemon       Off
         Log_Level    {{ .Values.service.logLevel }}
         Parsers_File parsers.conf
@@ -21,7 +21,7 @@ data:
 {{- if .Values.metrics.enabled }}
         HTTP_Server  On
         HTTP_Listen  0.0.0.0
-        HTTP_Port    2020
+        HTTP_Port    {{ .Values.metrics.service.port | default "2020" }}
 {{- end }}
 
   fluent-bit-input.conf: |-
@@ -89,14 +89,19 @@ data:
         Match *
         Host  {{ .Values.backend.es.host }}
         Port  {{ .Values.backend.es.port }}
-        Logstash_Format On
         Retry_Limit False
         Type  {{ .Values.backend.es.type }}
 {{- if .Values.backend.es.time_key }}
         Time_Key {{ .Values.backend.es.time_key }}
 {{- end }}
+{{- if .Values.backend.es.include_tag_key }}
+        Include_Tag_Key {{ .Values.backend.es.include_tag_key }}
+{{- end }}
 {{- if .Values.backend.es.replace_dots }}
         Replace_Dots {{ .Values.backend.es.replace_dots }}
+{{- end }}
+{{- if .Values.backend.es.logstash_format }}
+        Logstash_Format {{ .Values.backend.es.logstash_format }}
 {{- end }}
 {{- if .Values.backend.es.logstash_prefix }}
         Logstash_Prefix {{ .Values.backend.es.logstash_prefix }}

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -21,7 +21,7 @@ data:
 {{- if .Values.metrics.enabled }}
         HTTP_Server  On
         HTTP_Listen  0.0.0.0
-        HTTP_Port    {{ .Values.metrics.service.port | default "2020" }}
+        HTTP_Port    {{ .Values.metrics.service.port }}
 {{- end }}
 
   fluent-bit-input.conf: |-

--- a/stable/fluent-bit/templates/daemonset.yaml
+++ b/stable/fluent-bit/templates/daemonset.yaml
@@ -43,7 +43,7 @@ spec:
         ports:
 {{- if .Values.metrics.enabled }}
         - name: metrics
-          containerPort: 2020
+          containerPort: {{ .Values.metrics.service.port | default "2020" }}
           protocol: TCP
 {{- end -}}
 {{- if .Values.extraPorts }}

--- a/stable/fluent-bit/templates/daemonset.yaml
+++ b/stable/fluent-bit/templates/daemonset.yaml
@@ -43,7 +43,7 @@ spec:
         ports:
 {{- if .Values.metrics.enabled }}
         - name: metrics
-          containerPort: {{ .Values.metrics.service.port | default "2020" }}
+          containerPort: {{ .Values.metrics.service.port }}
           protocol: TCP
 {{- end -}}
 {{- if .Values.extraPorts }}

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -48,6 +48,8 @@ backend:
     logstash_prefix: kubernetes_cluster
     replace_dots: "On"
     time_key: "@timestamp"
+    include_tag_key: "Off"
+    logstash_format: "On"
     # Optional username credential for Elastic X-Pack access
     http_user:
     # Password for user defined in HTTP_User


### PR DESCRIPTION
* Replace hardcoded .Values.metrics.service.port values
* Add more ES output options

Signed-off-by: Nuno Tavares <n.tavares@portavita.eu>

#### What this PR does / why we need it:
* Replace hardcoded .Values.metrics.service.port values
* Add more ES output options

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
