### PR TITLE
stable/cert-manager: deprecate cert-manager chart

### DIFF
--- a/stable/cert-manager/Chart.yaml
+++ b/stable/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.6.6
+version: v0.6.7
 appVersion: v0.6.2
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager
@@ -10,6 +10,11 @@ keywords:
   - tls
 sources:
   - https://github.com/jetstack/cert-manager
-maintainers:
-  - name: munnerz
-    email: james@jetstack.io
+# Deprecated charts cannot have maintainers
+maintainers: []
+  # - name: munnerz
+  #   email: james@jetstack.io
+# This version of the Helm chart is deprecated.
+# All future updates should be instead made to the official cert-manager
+# repository, found at https://github.com/jetstack/cert-manager/tree/master/deploy
+deprecated: true

--- a/stable/cert-manager/README.md
+++ b/stable/cert-manager/README.md
@@ -1,5 +1,10 @@
 # cert-manager
 
+> **This Helm chart is deprecated**.
+> All future changes to the cert-manager Helm chart should be made in the
+> [official repository](https://github.com/jetstack/cert-manager/tree/master/deploy).
+> The latest version of the chart can be found on the [Helm Hub](https://hub.helm.sh/charts/jetstack/cert-manager).
+
 cert-manager is a Kubernetes addon to automate the management and issuance of
 TLS certificates from various issuing sources.
 

--- a/stable/cert-manager/templates/NOTES.txt
+++ b/stable/cert-manager/templates/NOTES.txt
@@ -13,3 +13,8 @@ Certificates for Ingress resources, take a look at the `ingress-shim`
 documentation:
 
 https://cert-manager.readthedocs.io/en/latest/reference/ingress-shim.html
+
+**This Helm chart is deprecated**.
+All future changes to the cert-manager Helm chart should be made in the
+official repository: https://github.com/jetstack/cert-manager/tree/master/deploy.
+The latest version of the chart can be found on the Helm Hub: https://hub.helm.sh/charts/jetstack/cert-manager.


### PR DESCRIPTION
#### What this PR does / why we need it:

Deprecates the cert-manager chart in favour of the new chart hosted by Jetstack on Helm Hub.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
