### PR TITLE
[stable/grafana] allow user-provided ENV variables for datasources and dashboards sidecars

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 3.2.0
+version: 3.3.0
 appVersion: 6.1.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -88,13 +88,15 @@ The command removes all the Kubernetes components associated with the chart and 
 | `podAnnotations`                          | Pod annotations                               | `{}`                                                    |
 | `sidecar.image`                           | Sidecar image                                 | `kiwigrid/k8s-sidecar:0.0.16`                           |
 | `sidecar.imagePullPolicy`                 | Sidecar image pull policy                     | `IfNotPresent`                                          |
-| `sidecar.resources`              | Sidecar resources | `{}`       |
+| `sidecar.resources`                       | Sidecar resources | `{}`       |
 | `sidecar.dashboards.enabled`              | Enabled the cluster wide search for dashboards and adds/updates/deletes them in grafana | `false`       |
 | `sidecar.dashboards.label`                | Label that config maps with dashboards should have to be added | `grafana_dashboard`                                |
 | `sidecar.dashboards.searchNamespace`      | If specified, the sidecar will search for dashboard config-maps inside this namespace. Otherwise the namespace in which the sidecar is running will be used. It's also possible to specify ALL to search in all namespaces | `nil`                                |
+| `sidecar.dashboards.env`                  | Additional ENV variables for the dashboards container | `{}` |
 | `sidecar.datasources.enabled`             | Enabled the cluster wide search for datasources and adds/updates/deletes them in grafana |`false`       |
 | `sidecar.datasources.label`               | Label that config maps with datasources should have to be added | `grafana_datasource`                               |
 | `sidecar.datasources.searchNamespace`     | If specified, the sidecar will search for datasources config-maps inside this namespace. Otherwise the namespace in which the sidecar is running will be used. It's also possible to specify ALL to search in all namespaces | `nil`                               |
+| `sidecar.datasources.env`                 | Additional ENV variables for the datasources container | `{}` |
 | `smtp.existingSecret`                     | The name of an existing secret containing the SMTP credentials. | `""`                                  |
 | `smtp.userKey`                            | The key in the existing SMTP secret containing the username. | `"user"`                                 |
 | `smtp.passwordKey`                        | The key in the existing SMTP secret containing the password. | `"password"`                             |

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -97,6 +97,12 @@ spec:
             - name: NAMESPACE
               value: "{{ .Values.sidecar.datasources.searchNamespace }}"
             {{- end }}
+            {{- if .Values.sidecar.datasources.env }}
+            {{- range $name, $value := .Values.sidecar.datasources.env }}
+            - name: {{ $name  }}
+              value: "{{ $value }}"
+            {{ end -}}
+            {{ end -}}
           resources:
 {{ toYaml .Values.sidecar.resources | indent 12 }}
           volumeMounts:
@@ -126,6 +132,12 @@ spec:
             - name: NAMESPACE
               value: "{{ .Values.sidecar.dashboards.searchNamespace }}"
             {{- end }}
+            {{- if .Values.sidecar.datasources.env }}
+            {{- range $name, $value := .Values.sidecar.datasources.env }}
+            - name: {{ $name }}
+              value: "{{ $value }}"
+            {{ end -}}
+            {{ end -}}
           resources:
 {{ toYaml .Values.sidecar.resources | indent 12 }}
           volumeMounts:

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -388,6 +388,7 @@ sidecar:
     # Otherwise the namespace in which the sidecar is running will be used.
     # It's also possible to specify ALL to search in all namespaces
     searchNamespace: null
+    env: {}
   datasources:
     enabled: false
     # label that the configmaps with datasources are marked with
@@ -396,3 +397,4 @@ sidecar:
     # Otherwise the namespace in which the sidecar is running will be used.
     # It's also possible to specify ALL to search in all namespaces
     searchNamespace: null
+    env: {}


### PR DESCRIPTION
Allow user-provided ENV variables for datasources and dashboards sidecars

Resolves https://github.com/helm/charts/issues/12984

Signed-off-by: Denis Iskandarov <d.iskandarov@gmail.com>

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
