### PR TITLE
[incubator/cassandra] allow exporter resources

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,5 +1,5 @@
 name: cassandra
-version: 0.11.0
+version: 0.11.1
 appVersion: 3.11.3
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/README.md
+++ b/incubator/cassandra/README.md
@@ -141,6 +141,7 @@ The following table lists the configurable parameters of the Cassandra chart and
 | `exporter.image.tag`                 | Exporter image tag                              | `2.0.2`                                                    |
 | `exporter.port`                      | Exporter port                                   | `5556`                                                     |
 | `exporter.jvmOpts`                   | Exporter additional JVM options                 |                                                            |
+| `exporter.resources`                 | Exporter CPU/Memory resource requests/limits    | `{}`                                                       |
 | `affinity`                           | Kubernetes node affinity                        | `{}`                                                       |
 | `tolerations`                        | Kubernetes node tolerations                     | `[]`                                                       |
 

--- a/incubator/cassandra/templates/statefulset.yaml
+++ b/incubator/cassandra/templates/statefulset.yaml
@@ -51,6 +51,8 @@ spec:
 {{- if .Values.exporter.enabled }}
       - name: cassandra-exporter
         image: "{{ .Values.exporter.image.repo }}:{{ .Values.exporter.image.tag }}"
+        resources:
+{{ toYaml .Values.exporter.resources | indent 10 }}
         env:
           - name: CASSANDRA_EXPORTER_CONFIG_listenPort
             value: {{ .Values.exporter.port | quote }}

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -211,3 +211,10 @@ exporter:
     tag: 2.0.2
   port: 5556
   jvmOpts: ""
+  resources: {}
+    # limits:
+    #   cpu: 1
+    #   memory: 1Gi
+    # requests:
+    #   cpu: 1
+    #   memory: 1Gi


### PR DESCRIPTION
#### What this PR does / why we need it:

Allow to specify explicit cpu/memory values for the exporter resources container instead of using defaults from kubernetes namespace

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

Signed-off-by: Victor Ryzhkov <vretishhe@gmail.com>