### PR TITLE
ADD dedicated PodSecurityPolicy and bindings

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 1.9.1
+version: 1.9.2
 appVersion: 1.0.6
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -111,6 +111,8 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `input.systemd.readFromTail`       | Please see https://docs.fluentbit.io/manual/input/systemd | `true`                             |
 | `input.systemd.tag`                | Please see https://docs.fluentbit.io/manual/input/systemd | `host.*`                           |
 | `rbac.create`                      | Specifies whether RBAC resources should be created.   | `true`                                 |
+| `rbac.pspEnabled`                  | Deploy and use a dedicated PodSecurityPolicy          | `true`                                 |
+| `rbac.pspUseAppArmor`              | Enable AppArmor in the dedicated PodSecurityPolicy    | `true`                                 |
 | `serviceAccount.create`            | Specifies whether a ServiceAccount should be created. | `true`                                 |
 | `serviceAccount.name`              | The name of the ServiceAccount to use.     | `NULL`                                            |
 | `rawConfig`                        | Raw contents of fluent-bit.conf            | `@INCLUDE fluent-bit-service.conf`<br>`@INCLUDE fluent-bit-input.conf`<br>`@INCLUDE fluent-bit-filter.conf`<br>` @INCLUDE fluent-bit-output.conf`                                                                         |

--- a/stable/fluent-bit/templates/podsecuritypolicy.yaml
+++ b/stable/fluent-bit/templates/podsecuritypolicy.yaml
@@ -1,0 +1,45 @@
+{{- if and .Values.rbac.create .Values.rbac.pspEnabled -}}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "fluent-bit.name" . }}
+  labels:
+    app: {{ template "fluent-bit.name" . }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    {{- if .Values.rbac.pspUseAppArmor }}
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+    {{- end }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'secret'
+    - 'hostPath'
+  hostNetwork: {{ .Values.hostNetwork }}
+{{- if .Values.metrics.enabled }}
+  hostPorts:
+  - min: {{ .Values.metrics.service.port | default "2020" }}
+    max: {{ .Values.metrics.service.port | default "2020" }}
+{{- end }}
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: true
+{{- end }}

--- a/stable/fluent-bit/templates/role.yaml
+++ b/stable/fluent-bit/templates/role.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.rbac.create .Values.rbac.pspEnabled -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ template "fluent-bit.fullname" . }}
+  labels:
+    app: {{ template "fluent-bit.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- if .Values.rbac.pspEnabled }}
+rules:
+- apiGroups:      ['extensions']
+  resources:      ['podsecuritypolicies']
+  verbs:          ['use']
+  resourceNames:  [{{ template "fluent-bit.name" . }}]
+{{- end }}
+{{- end }}

--- a/stable/fluent-bit/templates/rolebinding.yaml
+++ b/stable/fluent-bit/templates/rolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.rbac.create .Values.rbac.pspEnabled -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ template "fluent-bit.fullname" . }}
+  labels:
+    app: {{ template "fluent-bit.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "fluent-bit.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "fluent-bit.serviceAccountName" . }}
+{{- end -}}

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -226,6 +226,8 @@ filter:
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
+  pspEnabled: false
+  pspUseAppArmor: false
 
 taildb:
   directory: /var/lib/fluent-bit


### PR DESCRIPTION

#### What this PR does / why we need it:
Adds a dedicated podsecuritypolicy for environments that run more restrictive PSPs.

#### Special notes for your reviewer:
Tested on our clusters. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
