### PR TITLE
[stable/eventrouter] Make podLabels get applied to actual pods (and document it)

### DIFF
--- a/stable/eventrouter/Chart.yaml
+++ b/stable/eventrouter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for eventruter (https://github.com/heptiolabs/eventrouter)
 name: eventrouter
-version: 0.2.0
+version: 0.2.1
 appVersion: 0.2
 home: https://github.com/heptiolabs/eventrouter
 sources:

--- a/stable/eventrouter/README.md
+++ b/stable/eventrouter/README.md
@@ -24,4 +24,5 @@ The following table lists the configurable parameters of the eventrouter chart a
 | `nodeSelector`          | Node labels for pod assignment                                                                                              | `{}`                               |
 | `sink`                  | Sink to send the events to                                                                                                  | `glog`                             |
 | `podAnnotations`        | Annotations for pod metadata                                                                                                | `{}`                               |
+| `podLabels`             | Labels for all metadata (ClusterRole, Deployment, etc.)                                                                     | `{}`                               |
 | `containerPorts`        | List of ports for the container                                                                                             | `[]`                               |

--- a/stable/eventrouter/templates/deployment.yaml
+++ b/stable/eventrouter/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         app: {{ template "eventrouter.name" . }}
         release: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
     {{- if .Values.podAnnotations }}
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Currently there is an undocumented value called `podLabels` which somewhat misleadingly gets applied to all labels **except** labels that will be applied to pods (i.e.`.spec.template.metadata.labels`). This PR fixes that.

It also adds `podLabels` to the README.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
