### PR TITLE
[stable/metrics-server] v0.3.2 & other improvements

### DIFF
--- a/stable/metrics-server/Chart.yaml
+++ b/stable/metrics-server/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.3.1
+appVersion: 0.3.2
 description: Metrics Server is a cluster-wide aggregator of resource usage data.
 name: metrics-server
-version: 2.5.1
+version: 2.6.0
 keywords:
 - metrics-server
 home: https://github.com/kubernetes-incubator/metrics-server

--- a/stable/metrics-server/README.md
+++ b/stable/metrics-server/README.md
@@ -1,6 +1,6 @@
 # metrics-server
 
-[Metrics Server](https://github.com/kubernetes-incubator/metrics-server) is a cluster-wide aggregator of resource usage data.
+[Metrics Server](https://github.com/kubernetes-incubator/metrics-server) is a cluster-wide aggregator of resource usage data. Resource metrics are used by components like `kubectl top` and the [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale) to scale workloads. To autoscale based upon a custom metric, see the [Prometheus Adapter chart](https://github.com/helm/charts/blob/master/stable/prometheus-adapter).
 
 ## Configuration
 
@@ -13,9 +13,10 @@ Parameter | Description | Default
 `apiService.create` | Create the v1beta1.metrics.k8s.io API service | `true`
 `hostNetwork.enabled` | Enable hostNetwork mode | `false`
 `image.repository` | Image repository | `gcr.io/google_containers/metrics-server-amd64`
-`image.tag` | Image tag | `v0.3.1`
+`image.tag` | Image tag | `v0.3.2`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
-`args` | Command line arguments | `--logtostderr`
+`imagePullSecrets` | Image pull secrets | `[]`
+`args` | Command line arguments | `[]`
 `resources` | CPU/Memory resource requests/limits. | `{}`
 `tolerations` | List of node taints to tolerate (requires Kubernetes >=1.6) | `[]`
 `nodeSelector` | Node labels for pod assignment | `{}`
@@ -23,5 +24,10 @@ Parameter | Description | Default
 `replicas` | Number of replicas | `1`
 `extraVolumeMounts` | Ability to provide volume mounts to the pod | `[]`
 `extraVolumes` | Ability to provide volumes to the pod | `[]`
-`podAnnotations` | annotations to be added to pods | `{}`
-`priorityClassName` | priorityClassName to be added to pods | `""`
+`livenessProbe` | Container liveness probe | See values.yaml
+`podAnnotations` | Annotations to be added to pods | `{}`
+`priorityClassName` | Pod priority class | `""`
+`readinessProbe` | Container readiness probe | See values.yaml
+`service.annotations` | Annotations to add to the service | `{}`
+`service.port` | Service port to expose | `443`
+`service.type` | Type of service to create | `ClusterIP`

--- a/stable/metrics-server/templates/cluster-role.yaml
+++ b/stable/metrics-server/templates/cluster-role.yaml
@@ -14,18 +14,11 @@ rules:
     resources:
       - pods
       - nodes
-      - namespaces
+      - nodes/stats
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-    - ""
-    resources:
-    - nodes/stats
-    verbs:
-    - get
-    - create
   {{- if .Values.rbac.pspEnabled }}
   - apiGroups:
     - extensions

--- a/stable/metrics-server/templates/metric-server-service.yaml
+++ b/stable/metrics-server/templates/metric-server-service.yaml
@@ -7,11 +7,15 @@ metadata:
     chart: {{ template "metrics-server.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
 spec:
   ports:
-    - port: 443
+    - port: {{ .Values.service.port }}
       protocol: TCP
-      targetPort: 443
+      targetPort: https
   selector:
     app: {{ template "metrics-server.name" . }}
     release: {{ .Release.Name }}
+  type: {{ .Values.service.type }}
+

--- a/stable/metrics-server/templates/metrics-server-deployment.yaml
+++ b/stable/metrics-server/templates/metrics-server-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "metrics-server.fullname" . }}
@@ -25,9 +25,15 @@ spec:
       {{- end }}
       {{- end }}
     spec:
-{{- if .Values.priorityClassName }}
+    {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
-{{- end }}
+    {{- end }}
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
       serviceAccountName: {{ template "metrics-server.serviceAccountName" . }}
 {{- if .Values.hostNetwork.enabled }}
       hostNetwork: true
@@ -38,30 +44,38 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /metrics-server
+            - --cert-dir=/tmp
+            - --logtostderr
+            - --secure-port=8443
             {{- range .Values.args }}
             - {{ . | quote }}
             {{- end }}
-{{- if .Values.extraVolumeMounts }}
-          volumeMounts:
-{{ toYaml .Values.extraVolumeMounts | indent 12}}
-{{- end }}
-        {{- with .Values.resources }}
+          ports:
+          - containerPort: 8443
+            name: https
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
-{{ toYaml . | indent 12 }}
-        {{- end }}
-    {{- with .Values.nodeSelector }}
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+          - name: tmp
+            mountPath: /tmp
+          {{- with .Values.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
       affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+        {{- toYaml .Values.affinity | nindent 8 }}
       tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-{{- if .Values.extraVolumes }}
+        {{- toYaml .Values.tolerations | nindent 8 }}
       volumes:
-{{ toYaml .Values.extraVolumes | indent 8}}
-{{- end }}
+      - name: tmp
+        emptyDir: {}
+      {{- with .Values.extraVolumes }}
+      {{- toYaml . | nindent 6}}
+      {{- end }}

--- a/stable/metrics-server/templates/tests/test-version.yaml
+++ b/stable/metrics-server/templates/tests/test-version.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ template "metrics-server.fullname" . }}-test
+  labels:
+    app: {{ template "metrics-server.name" . }}
+    chart: {{ template "metrics-server.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+  - name: wget
+    image: busybox
+    command: ['/bin/sh']
+    args:
+    - -c
+    - 'wget -qO- https://{{ include "metrics-server.fullname" . }}:{{ .Values.service.port }}/version | grep -F {{ .Values.image.tag }}'
+  restartPolicy: Never
+

--- a/stable/metrics-server/values.yaml
+++ b/stable/metrics-server/values.yaml
@@ -28,11 +28,13 @@ hostNetwork:
 
 image:
   repository: gcr.io/google_containers/metrics-server-amd64
-  tag: v0.3.1
+  tag: v0.3.2
   pullPolicy: IfNotPresent
 
-args:
-  - --logtostderr
+imagePullSecrets: []
+# - registrySecretName
+
+args: []
 # enable this if you have self-signed certificates, see: https://github.com/kubernetes-incubator/metrics-server
 #  - --kubelet-insecure-tls
 
@@ -60,3 +62,31 @@ extraVolumes: []
 #  - name: secrets
 #    secret:
 #      secretName: kube-apiserver
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: https
+    scheme: HTTPS
+  initialDelaySeconds: 20
+
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: https
+    scheme: HTTPS
+  initialDelaySeconds: 20
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["all"]
+  readOnlyRootFilesystem: true
+  runAsGroup: 10001
+  runAsNonRoot: true
+  runAsUser: 10001
+
+service:
+  annotations: {}
+  port: 443
+  type: ClusterIP


### PR DESCRIPTION
#### What this PR does / why we need it:
- Bumps version to v0.3.2
- Adds liveness and readiness probes now that my upstream [PR](https://github.com/kubernetes-incubator/metrics-server/pull/177) is available
- Adds ability to customize service annotations, port and type
- Adds `imagePullSecrets`
- Adds `securityContext` and defaults to non-root and and read only filesystem
- Adds a test pod
- Adds a temp volume to allow for generation of certs when using read only filesystem
- Changes container port from 443 to 8443 to allow non-root users
- Moved `--logtostderr` to hardcoded flags since we shouldn't write logs to file as klog does
- Removes unneeded RBAC permissions (ported from upstream [PR](https://github.com/kubernetes-incubator/metrics-server/pull/195))
- Simplify helm templating by using `nindent` and `with`
- Use named ports to reduce duplication

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
