### PR TITLE
[stable/keycloak] Supply 'extraEnv' as dict instead of multiline string

### DIFF
--- a/stable/keycloak/Chart.yaml
+++ b/stable/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 4.10.0
+version: 4.11.0
 appVersion: 5.0.0
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/stable/keycloak/README.md
+++ b/stable/keycloak/README.md
@@ -56,7 +56,7 @@ Parameter | Description | Default
 `keycloak.existingSecretKey` |  The key in `keycloak.existingSecret` that stores the admin password | `password`
 `keycloak.extraInitContainers` | Additional init containers, e. g. for providing themes, etc. Passed through the `tpl` function and thus to be configured a string | `""`
 `keycloak.extraContainers` | Additional sidecar containers, e. g. for a database proxy, such as Google's cloudsql-proxy. Passed through the `tpl` function and thus to be configured a string | `""`
-`keycloak.extraEnv` | Allows the specification of additional environment variables for Keycloak. Passed through the `tpl` function and thus to be configured a string | `""`
+`keycloak.extraEnv` | Allows the specification of additional environment variables for Keycloak. To be configured as a dict in the form `key: value` | `{}`
 `keycloak.extraVolumeMounts` | Add additional volumes mounts, e. g. for custom themes. Passed through the `tpl` function and thus to be configured a string | `""`
 `keycloak.extraVolumes` | Add additional volumes, e. g. for custom themes. Passed through the `tpl` function and thus to be configured a string | `""`
 `keycloak.extraPorts` | Add additional ports, e. g. for custom admin console port. Passed through the `tpl` function and thus to be configured a string | `""`
@@ -124,7 +124,6 @@ The `tpl` function allows us to pass string values from `values.yaml` through th
 
 * `keycloak.extraInitContainers`
 * `keycloak.extraContainers`
-* `keycloak.extraEnv`
 * `keycloak.affinity`
 * `keycloak.extraVolumeMounts`
 * `keycloak.extraVolumes`
@@ -176,19 +175,13 @@ See also:
 
 ```yaml
 keycloak:
-  extraEnv: |
-    - name: KEYCLOAK_LOGLEVEL
-      value: DEBUG
-    - name: WILDFLY_LOGLEVEL
-      value: DEBUG
-    - name: CACHE_OWNERS
-      value: "3"
-    - name: DB_QUERY_TIMEOUT
-      value: "60"
-    - name: DB_VALIDATE_ON_MATCH
-      value: true
-    - name: DB_USE_CAST_FAIL
-      value: false
+  extraEnv:
+    KEYCLOAK_LOGLEVEL: DEBUG
+    WILDFLY_LOGLEVEL: DEBUG
+    CACHE_OWNERS: 3
+    DB_QUERY_TIMEOUT: 60
+    DB_VALIDATE_ON_MATCH: true
+    DB_USE_CAST_FAIL: false
 ```
 
 ### Providing a Custom Theme

--- a/stable/keycloak/templates/statefulset.yaml
+++ b/stable/keycloak/templates/statefulset.yaml
@@ -97,7 +97,14 @@ spec:
           {{- end }}
 {{ include "keycloak.dbEnvVars" . | indent 12 }}
 {{- with .Values.keycloak.extraEnv }}
+{{- if eq (typeOf .) "string" }}
 {{ tpl . $ | indent 12 }}
+{{- else }}
+{{- range $key, $value := . }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+{{- end }}
+{{- end }}
 {{- end }}
           volumeMounts:
             - name: scripts

--- a/stable/keycloak/values.yaml
+++ b/stable/keycloak/values.yaml
@@ -66,19 +66,13 @@ keycloak:
   existingSecretKey: password
 
   ## Allows the specification of additional environment variables for Keycloak
-  extraEnv: |
-    # - name: KEYCLOAK_LOGLEVEL
-    #   value: DEBUG
-    # - name: WILDFLY_LOGLEVEL
-    #   value: DEBUG
-    # - name: CACHE_OWNERS
-    #   value: "2"
-    # - name: DB_QUERY_TIMEOUT
-    #   value: "60"
-    # - name: DB_VALIDATE_ON_MATCH
-    #   value: true
-    # - name: DB_USE_CAST_FAIL
-    #   value: false
+  extraEnv: {}
+   # KEYCLOAK_LOGLEVEL: DEBUG
+   # WILDFLY_LOGLEVEL: DEBUG
+   # CACHE_OWNERS: 2
+   # DB_QUERY_TIMEOUT 60
+   # DB_VALIDATE_ON_MATCH: true
+   # DB_USE_CAST_FAIL: false
 
   affinity: |
     podAntiAffinity:


### PR DESCRIPTION
Signed-off-by: Heiko Nickerl <dev@heiko-nickerl.com>

#### What this PR does / why we need it:
Currently, it is not possible to override the `keycloak.extraEnv` value only partially from outside the `values.yaml` - it is a multiline string and thus can only be replaced as a whole.

We are using keycloak as a dependency in our own chart. We have implemented custom SPIs and therefore need to dynamically override some env variables at deploy time, something like `helm upgrade --set keycloak.keycloak.extraEnv.myCustomVar=myCustomValue`. This needs to be done without overriding the rest of the configured env variables.
It would be awesome if this addition would make it into the chart as I don't really see the benefit of using the `tpl` function for `extraEnv`.

#### Special notes for your reviewer:
I've implemented this feature in a backward compatible manner by supporting both a multiline string and a dict.

#### Checklist
- [x ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ x] Chart Version bumped
- [ x] Variables are documented in the README.md


@unguiculus 
@thomasdarimont 