### PR TITLE
Openldap inject tls and CA certificates via secrets

### DIFF
--- a/stable/openldap/Chart.yaml
+++ b/stable/openldap/Chart.yaml
@@ -1,6 +1,6 @@
 name: openldap
 home: https://www.openldap.org
-version: 0.3.0
+version: 0.4.0
 appVersion: 2.4.44
 description: Community developed LDAP software
 icon: http://www.openldap.org/images/headers/LDAPworm.gif

--- a/stable/openldap/README.md
+++ b/stable/openldap/README.md
@@ -40,11 +40,11 @@ The following table lists the configurable parameters of the openldap chart and 
 | `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)                                                                           | `[]`                |
 | `service.sslLdapPort`              | External service port for SSL+LDAP                                                                                                        | `636`               |
 | `service.type`                     | Service type                                                                                                                              | `ClusterIP`         |
+| `env`                              | List of key value pairs as env variables to be sent to the docker image. See https://github.com/osixia/docker-openldap for available ones | `[see values.yaml]` |
 | `tls.enabled`                      | Set to enable TLS/LDAPS - should also set `tls.secret`                                                                                    | `false`             |
 | `tls.secret`                       | Secret containing TLS cert and key (eg, generated via cert-manager)                                                                       | `""`                |
 | `tls.CA.enabled`                   | Set to enable custom CA crt file - should also set `tls.CA.secret`                                                                        | `false`             |
 | `tls.CA.secret`                    | Secret containing CA certificate (ca.crt)                                                                                                 | `""`                |
-| `env`                              | List of key value pairs as env variables to be sent to the docker image. See https://github.com/osixia/docker-openldap for available ones | `[see values.yaml]` |
 | `adminPassword`                    | Password for admin user. Unset to auto-generate the password                                                                              | None                |
 | `configPassword`                   | Password for config user. Unset to auto-generate the password                                                                             | None                |
 | `customLdifFiles`                  | Custom ldif files to seed the LDAP server. List of filename -> data pairs                                                                 | None                |

--- a/stable/openldap/README.md
+++ b/stable/openldap/README.md
@@ -23,35 +23,39 @@ We use the docker images provided by https://github.com/osixia/docker-openldap. 
 
 The following table lists the configurable parameters of the openldap chart and their default values.
 
-| Parameter                          | Description                                                               | Default           |
-| ---------------------------------- | ------------------------------------------------------------------------- | ------------------|
-| `replicaCount`                     | Number of replicas                                                        | `1`               |
-| `strategy`                         | Deployment strategy                                                       | `{}`              |
-| `image.repository`                 | Container image repository                                                | `osixia/openldap` |
-| `image.tag`                        | Container image tag                                                       | `1.1.10`          |
-| `image.pullPolicy`                 | Container pull policy                                                     | `IfNotPresent`    |
-| `extraLabels`                      | Labels to add to the Resources                                            | `{}`              |
-| `existingSecret`                   | Use an existing secret for admin and config user passwords                | `""`              |
-| `service.annotations`              | Annotations to add to the service                                         | `{}`              |
-| `service.clusterIP`                | IP address to assign to the service                                       | `""`              |
-| `service.externalIPs`              | Service external IP addresses                                             | `[]`              |
-| `service.ldapPort`                 | External service port for LDAP                                            | `389`             |
-| `service.loadBalancerIP`           | IP address to assign to load balancer (if supported)                      | `""`              |
-| `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)           | `[]`              |
-| `service.sslLdapPort`              | External service port for SSL+LDAP                                        | `636`             |
-| `service.type`                     | Service type                                                              | `ClusterIP`       |
-| `env`                              | List of key value pairs as env variables to be sent to the docker image. See https://github.com/osixia/docker-openldap for available ones | `[see values.yaml]`  |
-| `adminPassword`                    | Password for admin user. Unset to auto-generate the password              | None              |
-| `configPassword`                   | Password for config user. Unset to auto-generate the password             | None              |
-| `customLdifFiles`                  | Custom ldif files to seed the LDAP server. List of filename -> data pairs | None              |
-| `persistence.enabled`              | Whether to use PersistentVolumes or not                                   | `false`           |
-| `persistence.storageClass`         | Storage class for PersistentVolumes.                                      | `<unset>`         |
-| `persistence.accessMode`           | Access mode for PersistentVolumes                                         | `ReadWriteOnce`   |
-| `persistence.size`                 | PersistentVolumeClaim storage size                                        | `8Gi`             |
-| `resources`                        | Container resource requests and limits in yaml                            | `{}`              |
-| `test.enabled`                     | Conditionally provision test resources                                    | `false`           |
-| `test.image.repository`            | Test container image requires bats framework                              | `dduportal/bats`  |
-| `test.image.tag`                   | Test container tag                                                        | `0.4.0`           |
+| Parameter                          | Description                                                                                                                               | Default             |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `replicaCount`                     | Number of replicas                                                                                                                        | `1`                 |
+| `strategy`                         | Deployment strategy                                                                                                                       | `{}`                |
+| `image.repository`                 | Container image repository                                                                                                                | `osixia/openldap`   |
+| `image.tag`                        | Container image tag                                                                                                                       | `1.1.10`            |
+| `image.pullPolicy`                 | Container pull policy                                                                                                                     | `IfNotPresent`      |
+| `extraLabels`                      | Labels to add to the Resources                                                                                                            | `{}`                |
+| `existingSecret`                   | Use an existing secret for admin and config user passwords                                                                                | `""`                |
+| `service.annotations`              | Annotations to add to the service                                                                                                         | `{}`                |
+| `service.clusterIP`                | IP address to assign to the service                                                                                                       | `""`                |
+| `service.externalIPs`              | Service external IP addresses                                                                                                             | `[]`                |
+| `service.ldapPort`                 | External service port for LDAP                                                                                                            | `389`               |
+| `service.loadBalancerIP`           | IP address to assign to load balancer (if supported)                                                                                      | `""`                |
+| `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)                                                                           | `[]`                |
+| `service.sslLdapPort`              | External service port for SSL+LDAP                                                                                                        | `636`               |
+| `service.type`                     | Service type                                                                                                                              | `ClusterIP`         |
+| `tls.enabled`                      | Set to enable TLS/LDAPS - should also set `tls.secret`                                                                                    | `false`             |
+| `tls.secret`                       | Secret containing TLS cert and key (eg, generated via cert-manager)                                                                       | `""`                |
+| `tls.CA.enabled`                   | Set to enable custom CA crt file - should also set `tls.CA.secret`                                                                        | `false`             |
+| `tls.CA.secret`                    | Secret containing CA certificate (ca.crt)                                                                                                 | `""`                |
+| `env`                              | List of key value pairs as env variables to be sent to the docker image. See https://github.com/osixia/docker-openldap for available ones | `[see values.yaml]` |
+| `adminPassword`                    | Password for admin user. Unset to auto-generate the password                                                                              | None                |
+| `configPassword`                   | Password for config user. Unset to auto-generate the password                                                                             | None                |
+| `customLdifFiles`                  | Custom ldif files to seed the LDAP server. List of filename -> data pairs                                                                 | None                |
+| `persistence.enabled`              | Whether to use PersistentVolumes or not                                                                                                   | `false`             |
+| `persistence.storageClass`         | Storage class for PersistentVolumes.                                                                                                      | `<unset>`           |
+| `persistence.accessMode`           | Access mode for PersistentVolumes                                                                                                         | `ReadWriteOnce`     |
+| `persistence.size`                 | PersistentVolumeClaim storage size                                                                                                        | `8Gi`               |
+| `resources`                        | Container resource requests and limits in yaml                                                                                            | `{}`                |
+| `test.enabled`                     | Conditionally provision test resources                                                                                                    | `false`             |
+| `test.image.repository`            | Test container image requires bats framework                                                                                              | `dduportal/bats`    |
+| `test.image.tag`                   | Test container tag                                                                                                                        | `0.4.0`             |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/stable/openldap/templates/deployment.yaml
+++ b/stable/openldap/templates/deployment.yaml
@@ -31,9 +31,11 @@ spec:
         app: {{ template "openldap.name" . }}
         release: {{ .Release.Name }}
     spec:
-      {{- if .Values.customLdifFiles }}
+      {{- if or .Values.customLdifFiles .Values.tls.enabled }}
       initContainers:
-      - name: {{ .Chart.Name }}-init
+      {{- end }}
+      {{- if .Values.customLdifFiles }}
+      - name: {{ .Chart.Name }}-init-ldif
         image: busybox
         command: ['sh', '-c', 'cp /customldif/* /ldifworkingdir']
         volumeMounts:
@@ -41,6 +43,26 @@ spec:
           mountPath: /customldif
         - name: ldifworkingdir
           mountPath: /ldifworkingdir
+      {{- end }}
+      {{- if .Values.tls.enabled }}
+      - name: {{ .Chart.Name }}-init-tls
+        image: busybox
+        command: ['sh', '-c', 'cp /tls/* /certs']
+        volumeMounts:
+          - name: tls
+            mountPath: /tls
+          - name: certs
+            mountPath: /certs
+      {{- if .Values.tls.CA.enabled }}
+      - name: {{ .Chart.Name }}-init-catls
+        image: busybox
+        command: ['sh', '-c', 'cp /catls/ca.crt /certs']
+        volumeMounts:
+          - name: catls
+            mountPath: /catls
+          - name: certs
+            mountPath: /certs
+      {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -70,6 +92,21 @@ spec:
             - name: ldifworkingdir
               mountPath: /container/service/slapd/assets/config/bootstrap/ldif/custom
             {{- end }}
+            {{- if .Values.tls.enabled }}
+            - name: certs
+              mountPath: /container/service/slapd/assets/certs
+            {{- end }}
+          env:
+          {{- if .Values.tls.enabled }}
+            - name: LDAP_TLS_CRT_FILENAME
+              value: tls.crt
+            - name: LDAP_TLS_KEY_FILENAME
+              value: tls.key
+          {{- if .Values.tls.CA.enabled }}
+            - name: LDAP_TLS_CA_CRT_FILENAME
+              value: ca.crt
+          {{- end }}
+          {{- end }}
           livenessProbe:
             tcpSocket:
               port: ldap-port
@@ -104,6 +141,19 @@ spec:
         - name: ldifworkingdir
           emptyDir: {}
         {{- end }}
+        {{- if .Values.tls.enabled }}
+        - name: tls
+          secret:
+            secretName: {{ .Values.tls.secret }}
+        {{- if .Values.tls.CA.enabled }}
+        - name: catls
+          secret:
+            secretName: {{ .Values.tls.CA.secret }}
+        {{- end }}
+        {{- end }}
+        - name: certs
+          emptyDir:
+            medium: Memory
         - name: data
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/stable/openldap/values.yaml
+++ b/stable/openldap/values.yaml
@@ -25,6 +25,13 @@ image:
 # Spcifies an existing secret to be used for admin and config user passwords
 existingSecret: ""
 
+# settings for enabling TLS
+tls:
+  enabled: false
+  secret: ""  # The name of a kubernetes.io/tls type secret to use for TLS
+  CA:
+    enabled: false
+    secret: "" # The name of a generic secret to use for custom CA certificate (ca.crt)
 ## Add additional labels to all resources
 extraLabels: {}
 
@@ -33,7 +40,7 @@ service:
   clusterIP: ""
 
   ldapPort: 389
-  sslLdapPort: 636
+  sslLdapPort: 636  # Only used if tls.enabled is true
   ## List of IP addresses at which the service is available
   ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
   ##

--- a/stable/openldap/values.yaml
+++ b/stable/openldap/values.yaml
@@ -31,7 +31,7 @@ tls:
   secret: ""  # The name of a kubernetes.io/tls type secret to use for TLS
   CA:
     enabled: false
-    secret: "" # The name of a generic secret to use for custom CA certificate (ca.crt)
+    secret: ""  # The name of a generic secret to use for custom CA certificate (ca.crt)
 ## Add additional labels to all resources
 extraLabels: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Ensures the ability to inject custom tls and CA certificate for production environments
#### Which issue this PR fixes
  - fixes #11719 

#### Special notes for your reviewer:
As from @enis's review in the pull request #12318 now, the custom certificates are injected via initContainers

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md