### PR TITLE
[stable/redis] Add missing imagePullPolicy for init-sysctl

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 6.4.4
+version: 6.4.5
 appVersion: 4.0.14
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/redis-master-statefulset.yaml
+++ b/stable/redis/templates/redis-master-statefulset.yaml
@@ -170,6 +170,7 @@ spec:
       {{- if .Values.sysctlImage.enabled }}
       - name: init-sysctl
         image: {{ template "redis.sysctl.image" . }}
+        imagePullPolicy: {{ default "" .Values.sysctlImage.pullPolicy | quote }}
         resources:
 {{ toYaml .Values.sysctlImage.resources | indent 10 }}
         {{- if .Values.sysctlImage.mountHostSys }}

--- a/stable/redis/templates/redis-slave-deployment.yaml
+++ b/stable/redis/templates/redis-slave-deployment.yaml
@@ -166,6 +166,7 @@ spec:
       initContainers:
       - name: init-sysctl
         image: {{ template "redis.sysctl.image" . }}
+        imagePullPolicy: {{ default "" .Values.sysctlImage.pullPolicy | quote }}
         resources:
 {{ toYaml .Values.sysctlImage.resources | indent 10 }}
         {{- if .Values.sysctlImage.mountHostSys }}


### PR DESCRIPTION
The `sysctlImage.pullPolicy` value is documented, but is to used in the templates.
Signed-off-by: Eduardo Baitello <eduardobaitello@gmail.com>

#### What this PR does / why we need it:
Fix imagePullPolicy for "init-sysctl" init-containers


#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
