### PR TITLE
Adds ingress.path information

### DIFF
--- a/stable/atlantis/README.md
+++ b/stable/atlantis/README.md
@@ -56,6 +56,7 @@ The following options are supported.  See [values.yaml](values.yaml) for more de
 | `service.loadBalancerSourceRanges`          | Array of whitelisted IP addresses for the Atlantis Service. If no value is specified, the Service will allow incoming traffic from all IP addresses (0.0.0.0/0).                                                                                                                                          | n/a     |
 | `storageClassName`                          | Storage class of the volume mounted for the Atlantis data directory.                                                                                                                                                                                                                                      | n/a     |
 | `tlsSecretName`                             | Name of a Secret for Atlantis' HTTPS certificate containing the following data items `tls.crt` with the public certificate and `tls.key` with the private key.                                                                                                                                            | n/a     |
+| `ingress.path`                             | Path to use in the `Ingress`. Should be set to `/*` if using gce-ingress in Google Cloud.                                                                                                                                                                                                              | `/`     |
 
 ## Upgrading
 ### From 1.* to 2.*


### PR DESCRIPTION
#### What this PR does / why we need it:
Updates the documentation to help Google Cloud users.
When using gce-ingress in Google Cloud the ingress path needs to be set to /*. This note may help others in the future.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed