### PR TITLE
[RabbitMQ] Add podManagementPolicy for cluster recovery.

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 5.4.1
+version: 5.5.0
 appVersion: 3.7.14
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -56,6 +56,7 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `image.pullSecrets`                  | Specify docker-registry secret names as an array | `nil`                                                   |
 | `image.debug`                        | Specify if debug values should be set            | `false`                                                 |
 | `rbacEnabled`                        | Specify if rbac is enabled in your cluster       | `true`                                                  |
+| `podManagementPolicy`                | Pod management policy                            | `OrderedReady`                                          |
 | `rabbitmq.username`                  | RabbitMQ application username                    | `user`                                                  |
 | `rabbitmq.password`                  | RabbitMQ application password                    | _random 10 character long alphanumeric string_          |
 | `rabbitmq.existingPasswordSecret`    | Existing secret with RabbitMQ credentials        | nil                                                     |

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -9,6 +9,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   serviceName: {{ template "rabbitmq.fullname" . }}-headless
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
   replicas: {{ .Values.replicas }}
   updateStrategy:
     type: {{ .Values.updateStrategy.type }}

--- a/stable/rabbitmq/values-production.yaml
+++ b/stable/rabbitmq/values-production.yaml
@@ -35,6 +35,19 @@ image:
 ## does your cluster have rbac enabled? assume yes by default
 rbacEnabled: true
 
+
+## RabbitMQ should be initialized one by one when building cluster for the first time.
+## Therefore, the default value of podManagementPolicy is 'OrderedReady'
+## Once the RabbitMQ participates in the cluster, it waits for a response from another
+## RabbitMQ in the same cluster at reboot, except the last RabbitMQ of the same cluster.
+## If the cluster exits gracefully, you do not need to change the podManagementPolicy
+## because the first RabbitMQ of the statefulset always will be last of the cluster.
+## However if the last RabbitMQ of the cluster is not the first RabbitMQ due to a failure,
+## you must change podManagementPolicy to 'Parallel'.
+## ref : https://www.rabbitmq.com/clustering.html#restarting
+##
+podManagementPolicy: OrderedReady
+
 ## section of specific values for rabbitmq
 rabbitmq:
   ## RabbitMQ application username

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -35,6 +35,18 @@ image:
 ## does your cluster have rbac enabled? assume yes by default
 rbacEnabled: true
 
+## RabbitMQ should be initialized one by one when building cluster for the first time.
+## Therefore, the default value of podManagementPolicy is 'OrderedReady'
+## Once the RabbitMQ participates in the cluster, it waits for a response from another
+## RabbitMQ in the same cluster at reboot, except the last RabbitMQ of the same cluster.
+## If the cluster exits gracefully, you do not need to change the podManagementPolicy
+## because the first RabbitMQ of the statefulset always will be last of the cluster.
+## However if the last RabbitMQ of the cluster is not the first RabbitMQ due to a failure,
+## you must change podManagementPolicy to 'Parallel'.
+## ref : https://www.rabbitmq.com/clustering.html#restarting
+##
+podManagementPolicy: OrderedReady
+
 ## section of specific values for rabbitmq
 rabbitmq:
   ## RabbitMQ application username


### PR DESCRIPTION
Signed-off-by: Jungsub Shin <supsup5642@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

rabbitmq should be initialized one by one when building cluster for the first time.
Therefore, the default value of podManagementPolicy is 'OrderedReady'

Once the rabbitmq participates in the cluster, it waits for a response from another
rabbitMQ in the same cluster at reboot, except the last rabbitmq of the same cluster.
If the cluster exits gracefully, you do not need to change the podManagementPolicy
because the first rabbitmq of the statefulset always will be last of the cluster.
However if the last rabbitmq of the cluster is not the first rabbitmq due to a failure,
you must change podManagementPolicy to 'Parallel'.
Otherwide the first rabbitmq waits Infinitely.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
