### PR TITLE
Use latest version of helm-exporter

### DIFF
--- a/stable/helm-exporter/Chart.yaml
+++ b/stable/helm-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.1.0"
+appVersion: "0.3.1"
 description: Exports helm release stats to prometheus
 name: helm-exporter
-version: 0.2.0
+version: 0.2.1
 home: https://github.com/sstarcher/helm-exporter
 sources:
 - https://github.com/sstarcher/helm-exporter

--- a/stable/helm-exporter/README.md
+++ b/stable/helm-exporter/README.md
@@ -42,7 +42,7 @@ Parameter | Description | Default
 --- | --- | ---
 `affinity` | affinity configuration for pod assignment | `{}`
 `image.repository` | Image | `sstarcher/helm-exporter`
-`image.tag` | Image tag | `0.1.0`
+`image.tag` | Image tag | `0.3.1`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `nodeSelector` | node labels for pod assignment | `{}`
 `resources` | pod resource requests & limits | `{}`

--- a/stable/helm-exporter/templates/deployment.yaml
+++ b/stable/helm-exporter/templates/deployment.yaml
@@ -25,15 +25,15 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 9100
+              containerPort: 9571
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /metrics
+              path: /healthz
               port: http
           readinessProbe:
             httpGet:
-              path: /metrics
+              path: /healthz
               port: http
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/stable/helm-exporter/templates/service.yaml
+++ b/stable/helm-exporter/templates/service.yaml
@@ -15,7 +15,7 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - port: 9100
+    - port: 9571
       targetPort: http
       protocol: TCP
       name: metrics

--- a/stable/helm-exporter/values.yaml
+++ b/stable/helm-exporter/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: sstarcher/helm-exporter
-  tag: 0.1.0
+  tag: 0.3.1
   pullPolicy: Always
 
 nameOverride: ""


### PR DESCRIPTION
Signed-off-by: Arvind Naidu <techmaxed.net@gmail.com>

#### What this PR does / why we need it:
This PR updates the version of helm-exporter to export the values of the appVersion which was a very recent fix. 

#### Special notes for your reviewer:
I am currently using the latest version of the image since v0.2.0 is 2 days old but latest is 14 hours old which [fixes this PR](https://github.com/sstarcher/helm-exporter/issues/2) over in the original application repository.

<img width="1124" alt="Screenshot 2019-04-14 at 12 57 08 PM" src="https://user-images.githubusercontent.com/6829472/56088707-09546f80-5eb9-11e9-9733-e441533bd51a.png">

I personally am against using the latest tag so I will create a new issue over in the original repository to address this matter and hopefully be able to add a tag for the latest Docker image.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
