### PR TITLE
Dask version 1.1.5.  Fixed #13036.

### DIFF
--- a/stable/dask/Chart.yaml
+++ b/stable/dask/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: dask
-version: 2.2.1
-appVersion: 1.1.0
+version: 2.2.2
+appVersion: 1.1.5
 description: Distributed computation in Python with task scheduling
 home: https://dask.pydata.org
 icon: https://avatars3.githubusercontent.com/u/17131925?v=3&s=200

--- a/stable/dask/README.md
+++ b/stable/dask/README.md
@@ -33,7 +33,7 @@ The following tables list the configurable parameters of the Dask chart and thei
 | -------------------------- | -------------------------| -----------------|
 | `scheduler.name`           | Dask scheduler name      | `scheduler`      |
 | `scheduler.image`          | Container image name     | `daskdev/dask`   |
-| `scheduler.imageTag`       | Container image tag      | `1.1.0`         |
+| `scheduler.imageTag`       | Container image tag      | `1.1.5`         |
 | `scheduler.replicas`       | k8s deployment replicas  | `1`              |
 | `scheduler.tolerations`    | Tolerations              | `[]`             |
 | `scheduler.nodeSelector`   | nodeSelector             | `{}`             |
@@ -52,7 +52,7 @@ The following tables list the configurable parameters of the Dask chart and thei
 | -----------------------      | ---------------------------------| ---------------|
 | `worker.name`                | Dask worker name                 | `worker`       |
 | `worker.image`               | Container image name             | `daskdev/dask` |
-| `worker.imageTag`            | Container image tag              | `1.1.0`        |
+| `worker.imageTag`            | Container image tag              | `1.1.5`        |
 | `worker.replicas`            | k8s hpa and deployment replicas  | `3`            |
 | `worker.resources`           | Container resources              | `{}`           |
 | `worker.tolerations`         | Tolerations                      | `[]`           |
@@ -67,7 +67,7 @@ The following tables list the configurable parameters of the Dask chart and thei
 | `jupyter.name`          | Jupyter name                     | `jupyter`                |
 | `jupyter.enabled`       | Include optional Jupyter server  | `true`                   |
 | `jupyter.image`         | Container image name             | `daskdev/dask-notebook`  |
-| `jupyter.imageTag`      | Container image tag              | `1.1.0`                  |
+| `jupyter.imageTag`      | Container image tag              | `1.1.5`                  |
 | `jupyter.replicas`      | k8s deployment replicas          | `1`                      |
 | `jupyter.servicePort`   | k8s service port                 | `80`                     |
 | `jupyter.resources`     | Container resources              | `{}`                     |

--- a/stable/dask/values.yaml
+++ b/stable/dask/values.yaml
@@ -5,7 +5,7 @@ scheduler:
   name: scheduler
   image:
     repository: "daskdev/dask"
-    tag: 1.1.0
+    tag: 1.1.5
     pullPolicy: IfNotPresent
   replicas: 1
   serviceType: "LoadBalancer"
@@ -29,7 +29,7 @@ worker:
   name: worker
   image:
     repository: "daskdev/dask"
-    tag: 1.1.0
+    tag: 1.1.5
     pullPolicy: IfNotPresent
   replicas: 3
   aptPackages: >-
@@ -57,7 +57,7 @@ jupyter:
   enabled: true
   image:
     repository: "daskdev/dask-notebook"
-    tag: 1.1.0
+    tag: 1.1.5
     pullPolicy: IfNotPresent
   replicas: 1
   serviceType: "LoadBalancer"


### PR DESCRIPTION
Dask image tags to `1.1.5` from `1.1.0`.  Needed for `pandas` version upgrade.

Fixed #13036.