### PR TITLE
[stable/rabbitmq] Add parameters to limit the number of scheduler threads.

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 5.1.0
+version: 5.2.0
 appVersion: 3.7.14
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -67,6 +67,8 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `rabbitmq.clustering.k8s_domain`     | Customize internal k8s cluster domain            | `cluster.local`                                         |
 | `rabbitmq.logs`                      | Value for the RABBITMQ_LOGS environment variable | `-`                                                     |
 | `rabbitmq.ulimitNofiles`             | Max File Descriptor limit                        | `65536`                                                 |
+| `rabbitmq.maxAvailableSchedulers     | RabbitMQ maximum available scheduler threads     | `2`                                                     |
+| `rabbitmq.onlineSchedulers           | RabbitMQ online scheduler threads                | `1`                                                     |
 | `rabbitmq.configuration`             | Required cluster configuration                   | See values.yaml                                         |
 | `rabbitmq.extraConfiguration`        | Extra configuration to add to rabbitmq.conf      | See values.yaml                                         |
 | `service.type`                       | Kubernetes Service type                          | `ClusterIP`                                             |

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -185,6 +185,10 @@ spec:
             value: {{ .Values.rabbitmq.logs | quote }}
           - name: RABBITMQ_ULIMIT_NOFILES
             value: {{ .Values.rabbitmq.ulimitNofiles | quote }}
+          {{- if and .Values.rabbitmq.maxAvailableSchedulers }}
+          - name: RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS
+            value: {{ printf "+S %s:%s" (toString .Values.rabbitmq.maxAvailableSchedulers) (toString .Values.rabbitmq.onlineSchedulers) -}}
+         {{- end }}
           - name: RABBITMQ_USE_LONGNAME
             value: "true"
           - name: RABBITMQ_ERL_COOKIE

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -188,7 +188,7 @@ spec:
           {{- if and .Values.rabbitmq.maxAvailableSchedulers }}
           - name: RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS
             value: {{ printf "+S %s:%s" (toString .Values.rabbitmq.maxAvailableSchedulers) (toString .Values.rabbitmq.onlineSchedulers) -}}
-         {{- end }}
+          {{- end }}
           - name: RABBITMQ_USE_LONGNAME
             value: "true"
           - name: RABBITMQ_ERL_COOKIE

--- a/stable/rabbitmq/values-production.yaml
+++ b/stable/rabbitmq/values-production.yaml
@@ -70,6 +70,12 @@ rabbitmq:
   ##
   ulimitNofiles: '65536'
 
+  ## RabbitMQ maximum available scheduler threads and online scheduler threads
+  ## ref: https://hamidreza-s.github.io/erlang/scheduling/real-time/preemptive/migration/2016/02/09/erlang-scheduler-details.html#scheduler-threads
+  ##
+  maxAvailableSchedulers: 2
+  onlineSchedulers: 1
+
   ## Plugins to enable
   plugins: "rabbitmq_management rabbitmq_peer_discovery_k8s"
 

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -70,6 +70,12 @@ rabbitmq:
   ##
   ulimitNofiles: '65536'
 
+  ## RabbitMQ maximum available scheduler threads and online scheduler threads
+  ## ref: https://hamidreza-s.github.io/erlang/scheduling/real-time/preemptive/migration/2016/02/09/erlang-scheduler-details.html#scheduler-threads
+  ##
+  maxAvailableSchedulers: 2
+  onlineSchedulers: 1
+
   ## Plugins to enable
   plugins: "rabbitmq_management rabbitmq_peer_discovery_k8s"
 


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

RabbitMQ sets the number of threads based on the available CPU cores. Find more information in the link below:

https://hamidreza-s.github.io/erlang/scheduling/real-time/preemptive/migration/2016/02/09/erlang-scheduler-details.html#scheduler-threads

However, on K8s the number of available cores on a K8s node and the amount of CPU assigned to a specific pod can be different. 

This PR allows to the user to limit the the number of scheduler threads so RabbitMQ doesn't create too many threads causing high CPU usage.

#### Which issue this PR fixes

  - fixes #3855 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
