### PR TITLE
[stable/spinnaker] Use "tpl" function to render the content of additional scripts

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.10.0
+version: 1.10.1
 appVersion: 1.12.5
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/README.md
+++ b/stable/spinnaker/README.md
@@ -41,24 +41,24 @@ for Spinnaker. If you want to add arbitrary clusters need to do the following:
 
 1. Upload your kubeconfig to a secret with the key `config` in the cluster you are installing Spinnaker to.
 
-    ```shell
-    $ kubectl create secret generic --from-file=$HOME/.kube/config my-kubeconfig
-    ```
+```shell
+$ kubectl create secret generic --from-file=$HOME/.kube/config my-kubeconfig
+```
 
 1. Set the following values of the chart:
 
-    ```yaml
-    kubeConfig:
-      enabled: true
-      secretName: my-kubeconfig
-      secretKey: config
-      contexts:
-      # Names of contexts available in the uploaded kubeconfig
-      - my-context
-      # This is the context from the list above that you would like
-      # to deploy Spinnaker itself to.
-      deploymentContext: my-context
-    ```
+```yaml
+kubeConfig:
+  enabled: true
+  secretName: my-kubeconfig
+  secretKey: config
+  contexts:
+  # Names of contexts available in the uploaded kubeconfig
+  - my-context
+  # This is the context from the list above that you would like
+  # to deploy Spinnaker itself to.
+  deploymentContext: my-context
+```
 
 ## Specifying Docker Registries and Valid Images (Repositories)
 
@@ -134,14 +134,14 @@ If you would rather the chart make the config file for you, you can set `halyard
 halyard:
   additionalScripts:
     create: true
-    data: 
+    data:
       enable_oauth.sh: |-
         echo "Setting oauth2 security"
         $HAL_COMMAND config security authn oauth2 enable
   additionalSecrets:
     create: true
     data:
-      password.txt: aHVudGVyMgo=    
+      password.txt: aHVudGVyMgo=
   additionalConfigMaps:
     create: true
     data:

--- a/stable/spinnaker/templates/configmap/additional-scripts.yaml
+++ b/stable/spinnaker/templates/configmap/additional-scripts.yaml
@@ -9,7 +9,7 @@ data:
 {{- if  and .Values.halyard.additionalScripts.create .Values.halyard.additionalScripts.data }}
 {{- range $index, $content := .Values.halyard.additionalScripts.data }}
   {{ $index }}: |-
-{{ $content | indent 4 }}
+{{ tpl $content $ | indent 4 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/spinnaker/templates/configmap/halyard-init-script.yaml
+++ b/stable/spinnaker/templates/configmap/halyard-init-script.yaml
@@ -22,5 +22,5 @@ data:
 
     {{- if hasKey .Values.halyard "additionalInitScript" }}
     # additionalInitScript
-    {{ .Values.halyard.additionalInitScript | indent 4 }}
+    {{ tpl .Values.halyard.additionalInitScript $ | indent 4 }}
     {{- end }}

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -10,6 +10,7 @@ halyard:
     configMapName: my-halyard-config
     configMapKey: config.sh
     # If you'd rather do an inline script, set create to true and put the content in the data dict like you would a configmap
+    # The content will be passed through `tpl`, so value interpolation is supported.
     create: false
     data: {}
   additionalSecrets:
@@ -53,6 +54,7 @@ halyard:
 
   ## Uncomment if you want to add extra commands to the init script
   ## run by the init container before halyard is started.
+  ## The content will be passed through `tpl`, so value interpolation is supported.
   # additionalInitScript: |-
 
   ## Uncomment if you want to add annotations on halyard and install-using-hal pods


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds `tpl` fuction into templates for `additionalScripts` and `additionalInitScript`.
This allows to use variable interpolation in the body of these scripts. For example:

```yaml
# custom_values.yaml

halyard:
  additionalScripts:
    create: true
    data:
      00_customize_accounts.sh: |-
        #!/bin/bash
        $HAL_COMMAND config provider kubernetes account edit {{ .Values.kubeConfig.deploymentContext }} \
          --namespaces {{ .Release.Namespace }} \
          --only-spinnaker-managed=true \
          --check-permissions-on-startup=false
```

Up until now we would have to hard-code the namespace and the account name in the custom script, which is not flexible.

#### Special notes for your reviewer:
These changes are backward compatible, because `tpl` works seamlessly with plain strings (which is the expected value there at this moment).
However, since that is a new feature for this chart, I bumped the minor version number.

`tpl` function is available in Helm >= v2.5.0.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
