### PR TITLE
[stable/spinnaker] Add a value for customizing service settings 

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.9.2
+version: 1.10.0
 appVersion: 1.12.5
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/_helpers.tpl
+++ b/stable/spinnaker/templates/_helpers.tpl
@@ -39,3 +39,16 @@ Create comma separated list of omitted namespaces in Kubernetes
 {{- define "omittedNameSpaces" -}}
 {{- join "," .Values.kubeConfig.omittedNameSpaces }}
 {{- end -}}
+
+{{/*
+Redis base URL for Spinnaker
+*/}}
+{{- define "spinnaker.redisBaseURL" -}}
+{{- if .Values.redis.enabled }}
+{{- printf "redis://:%s@%s-redis-master:6379" .Values.redis.password .Release.Name -}}
+{{- else if .Values.redis.external.password }}
+{{- printf "redis://:%s@%s:%s" .Values.redis.external.password .Values.redis.external.host (.Values.redis.external.port | toString) -}}
+{{- else }}
+{{- printf "redis://%s:%s" .Values.redis.external.host (.Values.redis.external.port | toString) -}}
+{{- end }}
+{{- end }}

--- a/stable/spinnaker/templates/configmap/service-settings.yaml
+++ b/stable/spinnaker/templates/configmap/service-settings.yaml
@@ -4,30 +4,45 @@ metadata:
   name: {{ template "spinnaker.fullname" . }}-service-settings
   labels:
 {{ include "spinnaker.standard-labels" . | indent 4 }}
-data:
-  redis.yml: |-
 
-    {{- if .Values.redis.enabled }}
-    overrideBaseUrl: redis://:{{ .Values.redis.password }}@{{ .Release.Name }}-redis-master:6379
-    {{- else }}
-    {{ if .Values.redis.external.password }}
-    overrideBaseUrl: redis://:{{ .Values.redis.external.password }}@{{ .Values.redis.external.host }}:{{ .Values.redis.external.port }}
-    {{- else }}
-    overrideBaseUrl: redis://{{ .Values.redis.external.host }}:{{ .Values.redis.external.port }}
-    {{- end }}
-    {{- end }}
-    skipLifeCycleManagement: true
-  gate.yml: |-
-    kubernetes:
-    {{- if .Values.ingress.enabled }}
-      useExecHealthCheck: false
-      serviceType: NodePort
-    {{- end }}
-  deck.yml: |-
-    env:
-      API_HOST: http://spin-gate:8084
-    kubernetes:
-    {{- if .Values.ingress.enabled }}
-      useExecHealthCheck: false
-      serviceType: NodePort
-    {{- end }}
+{{/*
+Render settings for each service by merging predefined defaults with values passed by
+.Values.halyard.additionalServiceSettings
+*/}}
+{{- $settings := dict -}}
+
+{{- /* Defaults: redis service */}}
+{{- $redisDefaults := dict -}}
+{{- $_ := set $redisDefaults "skipLifeCycleManagement" true -}}
+{{- $_ := set $redisDefaults "overrideBaseUrl" (include "spinnaker.redisBaseURL" $) -}}
+{{- $_ := set $settings "redis.yml" $redisDefaults -}}
+
+{{/* Defaults: gate service */}}
+{{- if .Values.ingress.enabled -}}
+{{- $gateDefaults := dict -}}
+{{- $_ := set $gateDefaults "kubernetes" (dict "useExecHealthCheck" false "serviceType" "NodePort") -}}
+{{- $_ := set $settings "gate.yml" $gateDefaults -}}
+{{- end -}}
+
+{{/* Defaults: deck service */}}
+{{- $deckDefaults := dict -}}
+{{- $_ := set $deckDefaults "API_HOST" "http://spin-gate:8084" -}}
+{{- if .Values.ingress.enabled -}}
+{{- $_ := set $deckDefaults "kubernetes" (dict "useExecHealthCheck" false "serviceType" "NodePort") -}}
+{{- end -}}
+{{- $_ := set $settings "deck.yml" $deckDefaults -}}
+
+{{- /* Merge dictionaries with passed values */}}
+{{- if .Values.halyard.additionalServiceSettings -}}
+{{- $_ := mergeOverwrite $settings .Values.halyard.additionalServiceSettings -}}
+{{- end -}}
+
+{{- /* Convert the content of settings key to YAML string */}}
+{{- range $filename, $content := $settings -}}
+{{- if not (typeIs "string" $content) -}}
+{{- $_ := set $settings $filename ($content | toYaml) -}}
+{{- end -}}
+{{- end -}}
+
+data:
+{{ $settings | toYaml | indent 2 }}

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -37,6 +37,20 @@ halyard:
       #       internalProxies: .*
       #       httpsServerPort: X-Forwarded-Port
 
+  ## Define custom settings for Spinnaker services. Read more for details:
+  ## https://www.spinnaker.io/reference/halyard/custom/#custom-service-settings
+  ## You can use it to add annotations for pods, override the image, etc.
+  additionalServiceSettings: {}
+    # deck.yml:
+    #   artifactId: gcr.io/spinnaker-marketplace/deck:2.9.0-20190412012808
+    #   kubernetes:
+    #     podAnnotations:
+    #       iam.amazonaws.com/role: <role_arn>
+    # clouddriver.yml:
+    #   kubernetes:
+    #     podAnnotations:
+    #       iam.amazonaws.com/role: <role_arn>
+
   ## Uncomment if you want to add extra commands to the init script
   ## run by the init container before halyard is started.
   # additionalInitScript: |-


### PR DESCRIPTION
Closes #12032, #11631, #12719, #13588, #13385  (as superseded)  

#### What this PR does / why we need it:

Using the newly added `additionalServiceSettings` value it's possible to override service-specific
parameters, which could not be done the custom profile.
For example, that might be used to override the version of some components, adding pod annotations, etc.
Read more: https://www.spinnaker.io/reference/halyard/custom/#custom-service-settings

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] ~Variables are documented in the README.md~ _This chart README doesn't contain the documentation of values_
