### PR TITLE
[incubator/kafka]Fix dependency for umbrella charts

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.15.4
+version: 0.15.5
 appVersion: 5.0.1
 keywords:
 - kafka

--- a/incubator/kafka/requirements.lock
+++ b/incubator/kafka/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: zookeeper
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
   version: 1.3.1
-digest: sha256:c21214b1f44972d0c120e73c9ff4af5f420a1e6c5c387e0ef440a181c45f053e
-generated: 2019-05-23T15:54:57.740788654-04:00
+digest: sha256:999c6b2e0886316ebf1709a44523fe87ee63cf09db66949babbcc1c6d5210723
+generated: 2019-05-24T09:49:23.731997103+02:00

--- a/incubator/kafka/requirements.yaml
+++ b/incubator/kafka/requirements.yaml
@@ -2,5 +2,4 @@ dependencies:
 - name: zookeeper
   version: 1.3.1
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  condition: zookeeper.enabled
-
+  condition: kafka.zookeeper.enabled,zookeeper.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:
When you include the kafka chart as a dependency of an "umbrella" chart you can't toggle the installation of the zookeeper dependency using the subchart namespace `kafka.zookeeper.enabled`. I know this fix doesn't fix the case of aliases but it has been the de facto workaround for many charts. cf https://github.com/helm/helm/issues/4490 for more information.
 
#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
