### PR TITLE
[incubator/haproxy-ingress] haproxy-ingress configurable side-car containers

### DIFF
--- a/incubator/haproxy-ingress/Chart.yaml
+++ b/incubator/haproxy-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: haproxy-ingress
-version: 0.0.11
+version: 0.0.12
 appVersion: 0.7.1
 home: https://github.com/jcmoraisjr/haproxy-ingress
 description: Ingress controller implementation for haproxy loadbalancer.

--- a/incubator/haproxy-ingress/README.md
+++ b/incubator/haproxy-ingress/README.md
@@ -115,9 +115,11 @@ Parameter | Description | Default
 `controller.stats.service.servicePort` | the port number exposed by the stats service | `1936`
 `controller.stats.service.type` | type of controller service to create | `ClusterIP`
 `controller.metrics.enabled` | If `controller.stats.enabled = true` and `controller.metrics.enabled = true`, Prometheus metrics will be exported |  `false`
-`controller.metrics.image.repository` | prometheus exporter container image repository | `quay.io/prometheus/haproxy-exporter`
-`controller.metrics.image.tag` | prometheus exporter image tag | `v0.9.0`
-`controller.metrics.image.pullPolicy` | prometheus exporter image pullPolicy | `IfNotPresent`
+`controller.metrics.image.repository` | prometheus-exporter image repository | `quay.io/prometheus/haproxy-exporter`
+`controller.metrics.image.tag` | prometheus-exporter image tag | `v0.10.0`
+`controller.metrics.image.pullPolicy` | prometheus-exporter image pullPolicy | `IfNotPresent`
+`controller.metrics.extraArgs` | Extra arguments to the haproxy_exporter |  `{}`
+`controller.metrics.resources` | prometheus-exporter container resource requests & limits |  `{}`
 `controller.metrics.service.annotations` | annotations for metrics service | `{}`
 `controller.metrics.service.clusterIP` | internal metrics cluster service IP | `""`
 `controller.metrics.service.externalIPs` | list of IP addresses at which the metrics service is available | `[]`

--- a/incubator/haproxy-ingress/README.md
+++ b/incubator/haproxy-ingress/README.md
@@ -95,7 +95,6 @@ Parameter | Description | Default
 `controller.tolerations` | to control scheduling to servers with taints | `[]`
 `controller.affinity` | to control scheduling | `{}`
 `controller.nodeSelector` | to control scheduling | `{}`
-`controller.accessLogsSidecar` | enable a sidecar container that collects access logs from haproxy and outputs to stdout | `true`
 `controller.service.annotations` | annotations for controller service | `{}`
 `controller.service.labels` | labels for controller service | `{}`
 `controller.service.clusterIP` | internal controller cluster service IP | `""`
@@ -126,6 +125,11 @@ Parameter | Description | Default
 `controller.metrics.service.loadBalancerSourceRanges` |  | `[]`
 `controller.metrics.service.servicePort` | the port number exposed by the metrics service | `1936`
 `controller.metrics.service.type` | type of controller service to create | `ClusterIP`
+`controller.logs.enabled` | enable an access-logs sidecar container that collects access logs from haproxy and outputs to stdout | `false`
+`controller.logs.image.repository` | access-logs container image repository | `quay.io/prometheus/haproxy-exporter`
+`controller.logs.image.tag` | access-logs image tag | `v0.10.0`
+`controller.logs.image.pullPolicy` | access-logs image pullPolicy | `IfNotPresent`
+`controller.logs.resources` | access-logs container resource requests & limits |  `{}`
 `defaultBackend.enabled` | whether to use the default backend component | `true`
 `defaultBackend.name` | name of the default backend component | `default-backend`
 `defaultBackend.image.repository` | default backend container image repository | `gcr.io/google_containers/defaultbackend`

--- a/incubator/haproxy-ingress/README.md
+++ b/incubator/haproxy-ingress/README.md
@@ -64,11 +64,11 @@ Parameter | Description | Default
 `controller.readinessProbe.periodSeconds` | The readiness probe period (in seconds) | `10`
 `controller.readinessProbe.successThreshold` | The readiness probe success threshold | `1`
 `controller.readinessProbe.timeoutSeconds` | The readiness probe timeout (in seconds) | `1`
-`controller.podAnnotations` | Annotations for the haproxy-ingress-conrtoller pod | `{}`
-`controller.podLabels` | Labels for the haproxy-ingress-conrtoller pod | `{}`
+`controller.podAnnotations` | Annotations for the haproxy-ingress-controller pod | `{}`
+`controller.podLabels` | Labels for the haproxy-ingress-controller pod | `{}`
 `controller.podAffinity` | Add affinity to the controller pods to control scheduling | `{}`
 `controller.priorityClassName` | Priority Class to be used | ``
-`controller.securityContext` | Security context settings for the haproxy-ingress-conrtoller pod | `{}`
+`controller.securityContext` | Security context settings for the haproxy-ingress-controller pod | `{}`
 `controller.config` | additional haproxy-ingress [ConfigMap entries](https://github.com/jcmoraisjr/haproxy-ingress/blob/v0.6/README.md#configmap) | `{}`
 `controller.hostNetwork` | Optionally set to true when using CNI based kubernetes installations | `false`
 `controller.dnsPolicy` | Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true' | `ClusterFirst`
@@ -85,7 +85,7 @@ Parameter | Description | Default
 `controller.minReadySeconds` | seconds to avoid killing pods before we are ready | `0`
 `controller.replicaCount` | the number of replicas to deploy (when `controller.kind` is `Deployment`) | `1`
 `controller.minAvailable` | PodDisruptionBudget minimum available controller pods | `1`
-`controller.resources` | controller pod resource requests & limits | `{}`
+`controller.resources` | controller container resource requests & limits | `{}`
 `controller.autoscaling.enabled` | enabling controller horizontal pod autoscaling (when `controller.kind` is `Deployment`) | `false`
 `controller.autoscaling.minReplicas` | minimum number of replicas | 
 `controller.autoscaling.maxReplicas` | maximum number of replicas | 

--- a/incubator/haproxy-ingress/templates/controller-configmap.yaml
+++ b/incubator/haproxy-ingress/templates/controller-configmap.yaml
@@ -11,7 +11,7 @@ metadata:
 data:
   healthz-port: {{ .Values.controller.healthzPort | quote }}
   stats-port: {{ .Values.controller.stats.port | quote }}
-{{- if .Values.controller.accessLogsSidecar }}
+{{- if .Values.controller.logs.enabled }}
   syslog-endpoint: "localhost:514"
 {{- end }}
 {{- if .Values.controller.config }}

--- a/incubator/haproxy-ingress/templates/controller-daemonset.yaml
+++ b/incubator/haproxy-ingress/templates/controller-daemonset.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.controller.kind "DaemonSet" }}
+{{ if eq .Values.controller.kind "DaemonSet" -}}
 apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:

--- a/incubator/haproxy-ingress/templates/controller-daemonset.yaml
+++ b/incubator/haproxy-ingress/templates/controller-daemonset.yaml
@@ -148,6 +148,13 @@ spec:
           imagePullPolicy: "{{ .Values.controller.metrics.image.pullPolicy }}"
           args:
             - '--haproxy.scrape-uri=http://localhost:{{ .Values.controller.stats.port }}/haproxy?stats;csv'
+          {{- range $key, $value := .Values.controller.metrics.extraArgs }}
+            {{- if $value }}
+            - --{{ $key }}={{ $value }}
+            {{- else }}
+            - --{{ $key }}
+            {{- end }}
+          {{- end }}
           ports:
             - name: metrics
               containerPort: 9101
@@ -157,12 +164,7 @@ spec:
               path: /
               port: metrics
           resources:
-            limits:
-              cpu: 200m
-              memory: 512Mi
-            requests:
-              cpu: 100m
-              memory: 256Mi
+{{ toYaml .Values.controller.metrics.resources | indent 12 }}
       {{- end }}
 {{- if .Values.controller.template }}
       volumes:

--- a/incubator/haproxy-ingress/templates/controller-daemonset.yaml
+++ b/incubator/haproxy-ingress/templates/controller-daemonset.yaml
@@ -131,20 +131,16 @@ spec:
 {{- end }}
           resources:
 {{ toYaml .Values.controller.resources | indent 12 }}
-      {{- if .Values.controller.accessLogsSidecar }}
+      {{- if .Values.controller.logs.enabled }}
         - name: access-logs
-          image: whereisaaron/kube-syslog-sidecar
+          image:  "{{ .Values.controller.logs.image.repository }}:{{ .Values.controller.logs.image.tag }}"
+          imagePullPolicy: "{{ .Values.controller.logs.image.pullPolicy }}"
           ports:
             - name: udp
               containerPort: 514
               protocol: UDP
           resources:
-            limits:
-              cpu: 200m
-              memory: 512Mi
-            requests:
-              cpu: 100m
-              memory: 256Mi
+{{ toYaml .Values.controller.logs.resources | indent 12 }}
       {{- end }}
       {{- if and .Values.controller.stats.enabled .Values.controller.metrics.enabled }}
         - name: prometheus-exporter

--- a/incubator/haproxy-ingress/templates/controller-deployment.yaml
+++ b/incubator/haproxy-ingress/templates/controller-deployment.yaml
@@ -139,6 +139,13 @@ spec:
           imagePullPolicy: "{{ .Values.controller.metrics.image.pullPolicy }}"
           args:
             - '--haproxy.scrape-uri=http://localhost:{{ .Values.controller.stats.port }}/haproxy?stats;csv'
+          {{- range $key, $value := .Values.controller.metrics.extraArgs }}
+            {{- if $value }}
+            - --{{ $key }}={{ $value }}
+            {{- else }}
+            - --{{ $key }}
+            {{- end }}
+          {{- end }}
           ports:
             - name: metrics
               containerPort: 9101
@@ -148,12 +155,7 @@ spec:
               path: /
               port: metrics
           resources:
-            limits:
-              cpu: 200m
-              memory: 512Mi
-            requests:
-              cpu: 100m
-              memory: 256Mi
+{{ toYaml .Values.controller.metrics.resources | indent 12 }}
       {{- end }}
 {{- if .Values.controller.template }}
       volumes:

--- a/incubator/haproxy-ingress/templates/controller-deployment.yaml
+++ b/incubator/haproxy-ingress/templates/controller-deployment.yaml
@@ -122,20 +122,16 @@ spec:
 {{- end }}
           resources:
 {{ toYaml .Values.controller.resources | indent 12 }}
-      {{- if .Values.controller.accessLogsSidecar }}
+      {{- if .Values.controller.logs.enabled }}
         - name: access-logs
-          image: whereisaaron/kube-syslog-sidecar
+          image:  "{{ .Values.controller.logs.image.repository }}:{{ .Values.controller.logs.image.tag }}"
+          imagePullPolicy: "{{ .Values.controller.logs.image.pullPolicy }}"
           ports:
             - name: udp
               containerPort: 514
               protocol: UDP
           resources:
-            limits:
-              cpu: 200m
-              memory: 512Mi
-            requests:
-              cpu: 100m
-              memory: 256Mi
+{{ toYaml .Values.controller.logs.resources | indent 12 }}
       {{- end }}
       {{- if and .Values.controller.stats.enabled .Values.controller.metrics.enabled }}
         - name: prometheus-exporter

--- a/incubator/haproxy-ingress/templates/controller-deployment.yaml
+++ b/incubator/haproxy-ingress/templates/controller-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.controller.kind "Deployment" }}
+{{ if eq .Values.controller.kind "Deployment" -}}
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:

--- a/incubator/haproxy-ingress/values.yaml
+++ b/incubator/haproxy-ingress/values.yaml
@@ -237,8 +237,22 @@ controller:
     # (scrapes the stats port and exports metrics to prometheus)
     image:
       repository: quay.io/prometheus/haproxy-exporter
-      tag: "v0.9.0"
+      tag: "v0.10.0"
       pullPolicy: IfNotPresent
+
+    ## Additional command line arguments to pass to haproxy_exporter
+    ## E.g. to specify the client timeout you can use
+    ## extraArgs:
+    ##   haproxy.timeout: 15s
+    extraArgs: {}
+
+    resources: {}
+    #  limits:
+    #    cpu: 500m
+    #    memory: 600Mi
+    #  requests:
+    #    cpu: 200m
+    #    memory: 400Mi
 
     service:
       annotations: {}

--- a/incubator/haproxy-ingress/values.yaml
+++ b/incubator/haproxy-ingress/values.yaml
@@ -180,8 +180,6 @@ controller:
   ##
   nodeSelector: {}
 
-  accessLogsSidecar: true
-
   service:
     annotations: {}
     labels: {}
@@ -258,6 +256,28 @@ controller:
       loadBalancerSourceRanges: []
       servicePort: 9101
       type: ClusterIP
+
+  ## access-logs side-car container for collecting haproxy logs
+  ## Enabling this will configure haproxy to emit logs to syslog localhost:514 UDP port.
+  ## The access-logs container starts a syslog process that listens on UDP 514 and outputs to stdout.
+  logs:
+    enabled: false
+
+    # syslog for haproxy
+    # https://github.com/whereisaaron/kube-syslog-sidecar
+    # (listens on UDP port 514 and outputs to stdout)
+    image:
+      repository: whereisaaron/kube-syslog-sidecar
+      tag: latest
+      pullPolicy: IfNotPresent
+
+    resources: {}
+    #  limits:
+    #    cpu: 200m
+    #    memory: 128Mi
+    #  requests:
+    #    cpu: 100m
+    #    memory: 32Mi
 
 # Default 404 backend
 defaultBackend:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
* Updates haproxy_exporter image to v0.10.0
* Allows configuring the prometheus-exporter and access-logs side-car containers
  * image
  * resources
  * extra args (for haproxy_exporter)

I created the `controller.logs` section in the values file, and renamed `controller.accessLogsSidecar` to `controller.logs.enabled`, now defaulting to false. Resources are not set by default on the side-car containers.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
