### PR TITLE
adds mongodb prometheus exporter scrape timeout config option

### DIFF
--- a/stable/prometheus-mongodb-exporter/Chart.yaml
+++ b/stable/prometheus-mongodb-exporter/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 name: prometheus-mongodb-exporter
 sources:
 - https://github.com/percona/mongodb_exporter
-version: 1.1.0
+version: 1.1.1

--- a/stable/prometheus-mongodb-exporter/README.md
+++ b/stable/prometheus-mongodb-exporter/README.md
@@ -55,6 +55,7 @@ service:
 | `service.type` | The type of service to expose | `ClusterIP` |
 | `serviceMonitor.enabled` | Set to true if using the Prometheus Operator | `true` |
 | `serviceMonitor.interval` | Interval at which metrics should be scraped | `30s` |
+| `serviceMonitor.scrapeTimeout` | Interval at which metric scrapes should time out | `10s` |
 | `serviceMonitor.namespace` | The namespace where the Prometheus Operator is deployed | `` |
 | `serviceMonitor.additionalLabels` | Additional labels to add to the ServiceMonitor | `{}` |
 | `tolerations` | List of node taints to tolerate  | `[]` |

--- a/stable/prometheus-mongodb-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-mongodb-exporter/templates/servicemonitor.yaml
@@ -18,6 +18,7 @@ spec:
   endpoints:
   - port: metrics
     interval: {{ .Values.serviceMonitor.interval }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/stable/prometheus-mongodb-exporter/values.yaml
+++ b/stable/prometheus-mongodb-exporter/values.yaml
@@ -70,6 +70,7 @@ service:
 serviceMonitor:
   enabled: true
   interval: 30s
+  scrapeTimeout: 10s
   namespace:
   additionalLabels: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
this pr allows configuration of scrapeTimeout for the mongodb-exporter

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

@steven-sheehy 