### PR TITLE
Prometheus operator enhancements

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 5.0.11
+version: 5.0.12
 appVersion: 0.29.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -357,6 +357,8 @@ The following tables list the configurable parameters of the prometheus-operator
 | `kubeScheduler.serviceMonitor.https` | Scheduler service scrape over https | `false` |
 | `kubeScheduler.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
 | `kubeStateMetrics.enabled` | Deploy the `kube-state-metrics` chart and configure a servicemonitor to scrape | `true` |
+| `kubeStateMetrics.existingRelease.namespace` | Namespace of the existing `kube-state-metrics` release | `nil` |
+| `kubeStateMetrics.existingRelease.labels` | Labels used to target the existing `kube-state-metrics` release | `{}` |
 | `kubeStateMetrics.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
 | `kubeStateMetrics.serviceMonitor.metricRelabelings` | Metric relablings for the `kube-state-metrics` ServiceMonitor | `[]` |
 | `kube-state-metrics.rbac.create` | Create RBAC components in kube-state-metrics. See `global.rbac.create` | `true` |

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -320,6 +320,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `kubelet.enabled` | Deploy servicemonitor to scrape the kubelet service. See also `prometheusOperator.kubeletService` | `true` |
 | `kubelet.namespace` | Namespace where the kubelet is deployed. See also `prometheusOperator.kubeletService.namespace` | `kube-system` |
 | `kubelet.serviceMonitor.https` | Enable scraping of the kubelet over HTTPS. For more information, see https://github.com/coreos/prometheus-operator/issues/926 | `true` |
+| `kubelet.serviceMonitor.metricRelabelings` | The `metric_relabel_configs` for scraping the kubelet. | `` |
 | `kubelet.serviceMonitor.cAdvisorMetricRelabelings` | The `metric_relabel_configs` for scraping cAdvisor. | `` |
 | `kubelet.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
 | `kubeControllerManager.enabled` | Deploy a `service` and `serviceMonitor` to scrape the Kubernetes controller-manager | `true` |

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -365,6 +365,8 @@ The following tables list the configurable parameters of the prometheus-operator
 | `kube-state-metrics.podSecurityPolicy.enabled` | Create pod security policy resource for kube-state-metrics. | `true` |
 | `nodeExporter.enabled` | Deploy the `prometheus-node-exporter` and scrape it | `true` |
 | `nodeExporter.jobLabel` | The name of the label on the target service to use as the job name in prometheus. See `prometheus-node-exporter.podLabels.jobLabel=node-exporter` default | `jobLabel` |
+| `nodeExporter.existingRelease.namespace` | Namespace of the existing `prometheus-node-exporter` release | `nil` |
+| `nodeExporter.existingRelease.labels` | Labels used to target the existing `prometheus-node-exporter` release | `{}` |
 | `nodeExporter.serviceMonitor.metricRelabelings` | Metric relablings for the `prometheus-node-exporter` ServiceMonitor | `[]` |
 | `nodeExporter.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
 | `prometheus-node-exporter.podLabels` | Additional labels for pods in the DaemonSet | `{"jobLabel":"node-exporter"}` |

--- a/stable/prometheus-operator/templates/exporters/kube-state-metrics/serviceMonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-state-metrics/serviceMonitor.yaml
@@ -16,7 +16,7 @@ spec:
     honorLabels: true
 {{- if .Values.kubeStateMetrics.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml .Values.kubeStateMetrics.serviceMonitor.metricRelabelings | indent 4 }}
+{{ tpl (toYaml .Values.kubeStateMetrics.serviceMonitor.metricRelabelings | indent 4) . }}
 {{- end }}
   {{- if .Values.kubeStateMetrics.existingRelease }}
   namespaceSelector:

--- a/stable/prometheus-operator/templates/exporters/kube-state-metrics/serviceMonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-state-metrics/serviceMonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kubeStateMetrics.enabled }}
+{{- if or .Values.kubeStateMetrics.enabled .Values.kubeStateMetrics.existingRelease }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: ServiceMonitor
 metadata:
@@ -18,8 +18,17 @@ spec:
     metricRelabelings:
 {{ toYaml .Values.kubeStateMetrics.serviceMonitor.metricRelabelings | indent 4 }}
 {{- end }}
+  {{- if .Values.kubeStateMetrics.existingRelease }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Values.kubeStateMetrics.existingRelease.namespace }}
+  {{- end }}
   selector:
     matchLabels:
+      {{- if .Values.kubeStateMetrics.existingRelease }}
+{{ toYaml .Values.kubeStateMetrics.existingRelease.labels | indent 6 }}
+      {{- else }}
       app: kube-state-metrics
       release: "{{ .Release.Name }}"
+      {{- end }}
 {{- end }}

--- a/stable/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
@@ -19,6 +19,10 @@ spec:
       insecureSkipVerify: true
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     honorLabels: true
+    {{- if .Values.kubelet.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ toYaml .Values.kubelet.serviceMonitor.metricRelabelings | indent 4 }}
+    {{- end }}
   - port: https-metrics
     scheme: https
     path: /metrics/cadvisor
@@ -40,6 +44,10 @@ spec:
     interval: {{ .Values.kubelet.serviceMonitor.interval }}
     {{- end }}
     honorLabels: true
+    {{- if .Values.kubelet.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ toYaml .Values.kubelet.serviceMonitor.metricRelabelings | indent 4 }}
+    {{- end }}
   - port: http-metrics
     path: /metrics/cadvisor
     {{- if .Values.kubelet.serviceMonitor.interval }}

--- a/stable/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
@@ -21,7 +21,7 @@ spec:
     honorLabels: true
     {{- if .Values.kubelet.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml .Values.kubelet.serviceMonitor.metricRelabelings | indent 4 }}
+{{ tpl (toYaml .Values.kubelet.serviceMonitor.metricRelabelings | indent 4) . }}
     {{- end }}
   - port: https-metrics
     scheme: https
@@ -36,7 +36,7 @@ spec:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
 {{- if .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings }}
     metricRelabelings:
-{{ toYaml .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings | indent 4 }}
+{{ tpl (toYaml .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings | indent 4) . }}
 {{- end }}
   {{- else }}
   - port: http-metrics
@@ -46,7 +46,7 @@ spec:
     honorLabels: true
     {{- if .Values.kubelet.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml .Values.kubelet.serviceMonitor.metricRelabelings | indent 4 }}
+{{ tpl (toYaml .Values.kubelet.serviceMonitor.metricRelabelings | indent 4) . }}
     {{- end }}
   - port: http-metrics
     path: /metrics/cadvisor
@@ -56,7 +56,7 @@ spec:
     honorLabels: true
 {{- if .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings }}
     metricRelabelings:
-{{ toYaml .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings | indent 4 }}
+{{ tpl (toYaml .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings | indent 4) . }}
 {{- end }}
   {{- end }}
   jobLabel: k8s-app

--- a/stable/prometheus-operator/templates/exporters/node-exporter/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/node-exporter/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.nodeExporter.enabled }}
+{{- if or .Values.nodeExporter.enabled .Values.nodeExporter.existingRelease }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: ServiceMonitor
 metadata:
@@ -8,10 +8,19 @@ metadata:
 {{ include "prometheus-operator.labels" . | indent 4 }}
 spec:
   jobLabel: {{ .Values.nodeExporter.jobLabel }}
+  {{- if .Values.nodeExporter.existingRelease }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Values.nodeExporter.existingRelease.namespace }}
+  {{- end }}
   selector:
     matchLabels:
+      {{- if .Values.nodeExporter.existingRelease }}
+{{ toYaml .Values.nodeExporter.existingRelease.labels | indent 6 }}
+      {{- else }}
       app: prometheus-node-exporter
       release: {{ .Release.Name }}
+      {{- end }}
   endpoints:
   - port: metrics
     {{- if .Values.nodeExporter.serviceMonitor.interval }}

--- a/stable/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/stable/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -11,13 +11,15 @@ spec:
     alertmanagers:
 {{- if .Values.prometheus.prometheusSpec.alertingEndpoints }}
 {{ toYaml .Values.prometheus.prometheusSpec.alertingEndpoints | indent 6 }}
-{{- else }}
+{{- else if .Values.alertmanager.enabled }}
       - namespace: {{ .Release.Namespace }}
         name: {{ template "prometheus-operator.fullname" . }}-alertmanager
         port: web
         {{- if .Values.alertmanager.alertmanagerSpec.routePrefix }}
         pathPrefix: "{{ .Values.alertmanager.alertmanagerSpec.routePrefix }}"
         {{- end }}
+{{- else }}
+      []
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.image }}
   baseImage: {{ .Values.prometheus.prometheusSpec.image.repository }}

--- a/stable/prometheus-operator/templates/prometheus/rules/kubernetes-absent.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/kubernetes-absent.yaml
@@ -94,7 +94,7 @@ spec:
       labels:
         severity: critical
 {{- end }}
-{{- if .Values.nodeExporter.enabled }}
+{{- if or .Values.nodeExporter.enabled .Values.nodeExporter.existingRelease }}
     - alert: NodeExporterDown
       annotations:
         message: NodeExporter has disappeared from Prometheus target discovery.

--- a/stable/prometheus-operator/templates/prometheus/rules/kubernetes-absent.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/kubernetes-absent.yaml
@@ -74,7 +74,7 @@ spec:
       labels:
         severity: critical
 {{- end }}
-{{- if .Values.kubeStateMetrics.enabled }}
+{{- if or .Values.kubeStateMetrics.enabled .Values.kubeStateMetrics.existingRelease }}
     - alert: KubeStateMetricsDown
       annotations:
         message: KubeStateMetrics has disappeared from Prometheus target discovery.

--- a/stable/prometheus-operator/templates/prometheus/rules/kubernetes-apps.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/kubernetes-apps.yaml
@@ -1,7 +1,7 @@
 # Generated from 'kubernetes-apps' group from https://raw.githubusercontent.com/coreos/prometheus-operator/master/contrib/kube-prometheus/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and .Values.defaultRules.create .Values.kubeStateMetrics.enabled .Values.defaultRules.rules.kubernetesApps }}
+{{- if and .Values.defaultRules.create (or .Values.kubeStateMetrics.enabled .Values.kubeStateMetrics.existingRelease) .Values.defaultRules.rules.kubernetesApps }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules/node.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/node.rules.yaml
@@ -1,7 +1,7 @@
 # Generated from 'node.rules' group from https://raw.githubusercontent.com/coreos/prometheus-operator/master/contrib/kube-prometheus/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and .Values.defaultRules.create .Values.nodeExporter.enabled .Values.defaultRules.rules.node }}
+{{- if and .Values.defaultRules.create (or .Values.nodeExporter.enabled .Values.nodeExporter.existingRelease) .Values.defaultRules.rules.node }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -624,6 +624,15 @@ nodeExporter:
   ##
   jobLabel: jobLabel
 
+  ## Namespace and labels used to target the Endpoints of an existing release
+  ## of prometheus-node-exporter
+  ##
+  existingRelease: {}
+    # namespace:
+    # labels:
+    #   key1: value1
+    #   key2: value2
+
   serviceMonitor:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -585,6 +585,16 @@ kubeScheduler:
 ##
 kubeStateMetrics:
   enabled: true
+
+  ## Namespace and labels used to target the Endpoints of an existing release
+  ## of kube-state-metrics
+  ##
+  existingRelease: {}
+    # namespace:
+    # labels:
+    #   key1: value1
+    #   key2: value2
+
   serviceMonitor:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -441,6 +441,10 @@ kubelet:
 
     ## Metric relabellings to apply to samples before ingestion
     ##
+    metricRelabelings: []
+
+    ## Metric relabellings to apply to samples before ingestion
+    ##
     cAdvisorMetricRelabelings: []
     # - sourceLabels: [__name__, image]
     #   separator: ;


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR attempts to do two main things:

1. Allow scraping metrics from existing deployments of `kube-state-metrics` and `prometheus-node-exporter` when `.Values.kubeStateMetrics.enabled` and `.Values.nodeExporter.enabled` have been set to `false`. This is useful when attempting to deploy multiple releases of `prometheus-operator` in a single cluster. Without this change, secondary deployments are not able to scrape metrics provided by either chart

2. Allow values used for metric relabeling configurations to support template strings. This is useful so that consumers of the chart can pass template strings as values to do things such as only keep metrics for the current namespace as follows:

```
    kubelet:
      serviceMonitor:
        metricRelabelings:
        - sourceLabels:
          - namespace
          regex: '{{ .Release.Namespace }}'
          action: keep
        cAdvisorMetricRelabelings:
        - sourceLabels:
          - namespace
          regex: '{{ .Release.Namespace }}'
          action: keep
```

It also makes a minor change that disables the default AlertManager connection when `.Values.alertmanager.enabled` has been set to `false`

#### Special notes for your reviewer:

I've only supported passing template strings in metric relabeling configurations for the exporters that our organization needs, but I'd be happy to make the change elsewhere if you all think doing so would be beneficial. On that note, I also noticed that not all of the exporters currently support passing metric relabeling configurations via values

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
