### PR TITLE
Add support for kmsg in fluent-bit

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 1.9.2
+version: 1.10.0
 appVersion: 1.0.6
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -81,9 +81,12 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `podLabels`                        | Optional pod labels                       | `NULL`                |
 | `fullConfigMap`                    | User has provided entire config (parsers + system)  | `false`      |
 | `existingConfigMap`                | ConfigMap override                         | ``                    |
-| `extraEntries.input`               |    Extra entries for existing [INPUT] section                     | ``                    |
-| `extraEntries.filter`              |    Extra entries for existing [FILTER] section                     | ``                    |
-| `extraEntries.output`              |   Extra entries for existing [OUPUT] section                     | ``                    |
+| `extraEntries.kubernetes_input`    |    Extra entries for existing Kubernetes [INPUT] section           | ``                    |
+| `extraEntries.systemd_input`       |    Extra entries for the optional systemd [INPUT] section          | ``                    |
+| `extraEntries.kubernetes_input`    |    Extra entries for existing Kubernetes [INPUT] section           | ``                    |
+| `extraEntries.kubernetes_filter`   |    Extra entries for existing Kubernetes [FILTER] section          | ``                    |
+| `extraEntries.kmsg_filter`         |    Extra entries for the optional kmsg [FILTER] section            | ``                    |
+| `extraEntries.output`              |    Extra entries for existing [OUPUT] section                      | ``                    |
 | `extraPorts`                       | List of extra ports                        |                       |
 | `extraVolumeMounts`                | Mount an extra volume, required to mount ssl certificates when elasticsearch has tls enabled |          |
 | `extraVolume`                      | Extra volume                               |                                                |
@@ -94,7 +97,7 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `filter.kubeURL`                   | Optional custom configmaps                 | `https://kubernetes.default.svc:443`            |
 | `filter.kubeCAFile`                | Optional custom configmaps       | `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`    |
 | `filter.kubeTokenFile`             | Optional custom configmaps       | `/var/run/secrets/kubernetes.io/serviceaccount/token`     |
-| `filter.kubeTag`                   | Optional top-level tag for matching in filter         | `kube`                                 |
+| `filter.kubeTag`                   | Optional top-level tag for matching in filter         | `kube`  (`.*` is automatically appended) |
 | `filter.mergeJSONLog`              | If the log field content is a JSON string map, append the map fields as part of the log structure         | `true`                                 |
 | `image.fluent_bit.repository`      | Image                                      | `fluent/fluent-bit`                               |
 | `image.fluent_bit.tag`             | Image tag                                  | `1.0.6`                                          |
@@ -105,11 +108,13 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `input.tail.memBufLimit`           | Specify Mem_Buf_Limit in tail input        | `5MB`                                             |
 | `input.tail.parser`                | Specify Parser in tail input.        | `docker`                                             |
 | `input.tail.path`                  | Specify log file(s) through the use of common wildcards.        | `/var/log/containers/*.log`                                             |
+| `input.kmsg.enabled`               | [Enable kmsg input](https://docs.fluentbit.io/manual/input/kmsg) **Warning: Enabling this sets `securityContext.privileged: true`**| `false` |
+| `input.kmsg.tag`                   | Top-level tag for kmsg | `kernel` |
 | `input.systemd.enabled`            | [Enable systemd input](https://docs.fluentbit.io/manual/input/systemd)                   | `false`                                       |
 | `input.systemd.filters.systemdUnit` | Please see https://docs.fluentbit.io/manual/input/systemd | `[docker.service, kubelet.service`, `node-problem-detector.service]`                                       |
 | `input.systemd.maxEntries`         | Please see https://docs.fluentbit.io/manual/input/systemd | `1000`                             |
 | `input.systemd.readFromTail`       | Please see https://docs.fluentbit.io/manual/input/systemd | `true`                             |
-| `input.systemd.tag`                | Please see https://docs.fluentbit.io/manual/input/systemd | `host.*`                           |
+| `input.systemd.tag`                | Please see https://docs.fluentbit.io/manual/input/systemd | `host` (`.*` is automatically appended) |
 | `rbac.create`                      | Specifies whether RBAC resources should be created.   | `true`                                 |
 | `serviceAccount.create`            | Specifies whether a ServiceAccount should be created. | `true`                                 |
 | `serviceAccount.name`              | The name of the ServiceAccount to use.     | `NULL`                                            |

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -24,7 +24,7 @@ data:
         HTTP_Port    2020
 {{- end }}
 
-  fluent-bit-input.conf: |-
+  fluent-bit-kubernetes-input.conf: |-
     [INPUT]
         Name             tail
         Path             {{ .Values.input.tail.path }}
@@ -37,6 +37,9 @@ data:
         DB               /tail-db/tail-containers-state.db
         DB.Sync          Normal
 {{- end }}
+{{ .Values.extraEntries.kubernetes_input | indent 8 }}
+
+  fluent-bit-systemd-input.conf: |-
 {{- if .Values.input.systemd.enabled }}
     [INPUT]
         Name            systemd
@@ -46,10 +49,30 @@ data:
 {{- end }}
         Max_Entries     {{ .Values.input.systemd.maxEntries }}
         Read_From_Tail  {{ .Values.input.systemd.readFromTail }}
+{{ .Values.extraEntries.systemd_input | indent 8 }}
 {{- end }}
-{{ .Values.extraEntries.input | indent 8 }}
 
-  fluent-bit-filter.conf: |-
+  fluent-bit-kmsg-input.conf: |-
+{{- if .Values.input.kmsg.enabled }}
+    [INPUT]
+        Name             kmsg
+        Tag              {{ .Values.input.kmsg.tag }}
+{{- end }}
+
+  fluent-bit-kmsg-filter.conf: |-
+{{- if .Values.input.kmsg.enabled }}
+    [FILTER]
+        Name               record_modifier
+        Match              {{ .Values.input.kmsg.tag }}
+        Record             node_name ${NODE_NAME}
+        Record             pod_name ${POD_NAME}
+        Record             pod_namespace ${POD_NAMESPACE}
+        Record             pod_ip ${POD_IP}
+        Record             host_ip ${HOST_IP}
+{{ .Values.extraEntries.kmsg_filter | indent 8 }}
+{{- end }}
+
+  fluent-bit-kubernetes-filter.conf: |-
     [FILTER]
         Name                kubernetes
         Match               {{ .Values.filter.kubeTag }}.*
@@ -65,7 +88,7 @@ data:
 {{- if .Values.filter.enableExclude }}
         K8S-Logging.Exclude On
 {{- end }}
-{{ .Values.extraEntries.filter | indent 8 }}
+{{ .Values.extraEntries.kubernetes_filter | indent 8 }}
 
   fluent-bit-output.conf: |-
 {{ if eq .Values.backend.type "test" }}

--- a/stable/fluent-bit/templates/daemonset.yaml
+++ b/stable/fluent-bit/templates/daemonset.yaml
@@ -34,9 +34,35 @@ spec:
       containers:
       - name: fluent-bit
         image: "{{ .Values.image.fluent_bit.repository }}:{{ .Values.image.fluent_bit.tag }}"
+{{- if .Values.input.kmsg.enabled }}
+        securityContext:
+          privileged: true
+{{- end }}
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         env:
-{{ toYaml .Values.env | indent 10 }}
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+{{- if .Values.env }}
+{{ toYaml .Values.env | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
 {{- if or .Values.metrics.enabled .Values.extraPorts }}
@@ -56,6 +82,10 @@ spec:
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
+{{- if .Values.input.kmsg.enabled }}
+        - name: kmsg
+          mountPath: /dev/kmsg
+{{- end }}
       {{- if .Values.input.systemd.enabled }}
         - name: etcmachineid
           mountPath: /etc/machine-id
@@ -72,11 +102,20 @@ spec:
           mountPath: /fluent-bit/etc/fluent-bit-service.conf
           subPath: fluent-bit-service.conf
         - name: config
-          mountPath: /fluent-bit/etc/fluent-bit-input.conf
-          subPath: fluent-bit-input.conf
+          mountPath: /fluent-bit/etc/fluent-bit-kubernetes-input.conf
+          subPath: fluent-bit-kubernetes-input.conf
         - name: config
-          mountPath: /fluent-bit/etc/fluent-bit-filter.conf
-          subPath: fluent-bit-filter.conf
+          mountPath: /fluent-bit/etc/fluent-bit-systemd-input.conf
+          subPath: fluent-bit-systemd-input.conf
+        - name: config
+          mountPath: /fluent-bit/etc/fluent-bit-kmsg-input.conf
+          subPath: fluent-bit-kmsg-input.conf
+        - name: config
+          mountPath: /fluent-bit/etc/fluent-bit-kubernetes-filter.conf
+          subPath: fluent-bit-kubernetes-filter.conf
+        - name: config
+          mountPath: /fluent-bit/etc/fluent-bit-kmsg-filter.conf
+          subPath: fluent-bit-kmsg-filter.conf
         - name: config
           mountPath: /fluent-bit/etc/fluent-bit-output.conf
           subPath: fluent-bit-output.conf
@@ -124,6 +163,11 @@ spec:
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers
+{{- if .Values.input.kmsg.enabled }}
+      - name: kmsg
+        hostPath:
+          path: /dev/kmsg
+{{- end }}
     {{- if .Values.input.systemd.enabled }}
       - name: etcmachineid
         hostPath:

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -129,14 +129,22 @@ existingConfigMap: ""
 
 rawConfig: |-
   @INCLUDE fluent-bit-service.conf
-  @INCLUDE fluent-bit-input.conf
-  @INCLUDE fluent-bit-filter.conf
+  @INCLUDE fluent-bit-kubernetes-input.conf
+  @INCLUDE fluent-bit-kubernetes-filter.conf
+  @INCLUDE fluent-bit-systemd-input.conf
+  @INCLUDE fluent-bit-kmsg-input.conf
+  @INCLUDE fluent-bit-kmsg-filter.conf
   @INCLUDE fluent-bit-output.conf
 
+# These are the extraEntries that can be appended to the sections respectively
 extraEntries:
-  input: |-
+  kubernetes_input: |-
 #     # >=1 additional Key/Value entrie(s) for existing Input section
-  filter: |-
+  kubernetes_filter: |-
+#     # >=1 additional Key/Value entrie(s) for existing Filter section
+  systemd_input: |-
+#     # >=1 additional Key/Value entrie(s) for existing Input section
+  kmsg_filter: |-
 #     # >=1 additional Key/Value entrie(s) for existing Filter section
   output: |-
 #     # >=1 additional Key/Value entrie(s) for existing Ouput section
@@ -194,6 +202,9 @@ input:
     memBufLimit: 5MB
     parser: docker
     path: /var/log/containers/*.log
+  kmsg:
+    enabled: false
+    tag: kernel
   systemd:
     enabled: false
     filters:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

* Add an optional input for kmsg (kernel messages), mounting /dev/kmsg into the container
* Modify the records for kmesg to include node name, fluent-bit pod name/namespace,  and node IP
* Generalize extra... options to correspond to the sections they're extending

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
