### PR TITLE
[stable/minio] Use Parallel pod management policy

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: MinIO is a high performance distributed object storage server, designed for large-scale private cloud infrastructure.
 name: minio
-version: 2.5.2
+version: 2.5.3
 appVersion: RELEASE.2019-07-17T22-54-12Z
 keywords:
 - storage

--- a/stable/minio/templates/statefulset.yaml
+++ b/stable/minio/templates/statefulset.yaml
@@ -30,6 +30,7 @@ metadata:
 spec:
   updateStrategy:
     type: {{ .Values.StatefulSetUpdate.updateStrategy }}
+  podManagementPolicy: "Parallel"
   serviceName: {{ template "minio.fullname" . }}-svc
   replicas: {{ .Values.replicas }}
   selector:


### PR DESCRIPTION
Signed-off-by: Heiko Nickerl <dev@heiko-nickerl.com>

#### What this PR does / why we need it:
Minio startup time can be shortened by using `spec.podManagementPolicy: Parallel` in statefulset.
AFAIK this would not break the distributed mode - there's no master/slave election etc..

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped

@wlan0
@nitisht