### PR TITLE
[stable/bitcoin] Configure deployment to use custom terminationGracePeriodSe…

### DIFF
--- a/stable/bitcoind/Chart.yaml
+++ b/stable/bitcoind/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: bitcoind
-version: 0.2.6
+version: 0.2.0
 appVersion: 0.17.1
 description: Bitcoin is an innovative payment network and a new kind of money.
 keywords:

--- a/stable/bitcoind/Chart.yaml
+++ b/stable/bitcoind/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: bitcoind
-version: 0.1.6
+version: 0.2.6
 appVersion: 0.17.1
 description: Bitcoin is an innovative payment network and a new kind of money.
 keywords:

--- a/stable/bitcoind/README.md
+++ b/stable/bitcoind/README.md
@@ -40,21 +40,22 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the bitcoind chart and their default values.
 
-Parameter                  | Description                        | Default
------------------------    | ---------------------------------- | ----------------------------------------------------------
-`image.repository`         | Image source repository name       | `arilot/docker-bitcoind`
-`image.tag`                | `bitcoind` release tag.            | `0.17.1`
-`image.pullPolicy`         | Image pull policy                  | `IfNotPresent`
-`service.rpcPort`          | RPC port                           | `8332`
-`service.p2pPort`          | P2P port                           | `8333`
-`service.testnetPort`      | Testnet port                       | `18332`
-`service.testnetP2pPort`   | Testnet p2p ports                  | `18333`
-`service.selector`         | Node selector                      | `tx-broadcast-svc`
-`persistence.enabled`      | Create a volume to store data      | `true`
-`persistence.accessMode`   | ReadWriteOnce or ReadOnly          | `ReadWriteOnce`
-`persistence.size`         | Size of persistent volume claim    | `300Gi`
-`resources`                | CPU/Memory resource requests/limits| `{}`
-`configurationFile`        | Config file ConfigMap entry        |
+Parameter                 	 	| Description                        				| Default
+------------------------------- | ------------------------------------------------- | ----------------------------------------------------------
+`image.repository`         		| Image source repository name       				| `arilot/docker-bitcoind`
+`image.tag`                		| `bitcoind` release tag.            				| `0.17.1`
+`image.pullPolicy`         		| Image pull policy                  				| `IfNotPresent`
+`service.rpcPort`          		| RPC port                           				| `8332`
+`service.p2pPort`          		| P2P port                           				| `8333`
+`service.testnetPort`      		| Testnet port                       				| `18332`
+`service.testnetP2pPort`   		| Testnet p2p ports                  				| `18333`
+`service.selector`         		| Node selector                      				| `tx-broadcast-svc`
+`persistence.enabled`      		| Create a volume to store data      				| `true`
+`persistence.accessMode`   		| ReadWriteOnce or ReadOnly          				| `ReadWriteOnce`
+`persistence.size`         		| Size of persistent volume claim    				| `300Gi`
+`resources`                		| CPU/Memory resource requests/limits				| `{}`
+`configurationFile`        		| Config file ConfigMap entry      				    |
+`terminationGracePeriodSeconds` | Wait time before forcefully terminating container | `30`
 
 For more information about Bitcoin configuration please see [Bitcoin.conf_Configuration_File](https://en.bitcoin.it/wiki/Running_Bitcoin#Bitcoin.conf_Configuration_File).
 

--- a/stable/bitcoind/templates/deployment.yaml
+++ b/stable/bitcoind/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         app: {{ template "bitcoind.name" . }}
         release: {{ .Release.Name }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- if .Values.configurationFile }}
       initContainers:
         - name: copy-bitcoind-config

--- a/stable/bitcoind/values.yaml
+++ b/stable/bitcoind/values.yaml
@@ -1,7 +1,7 @@
 # Default values for bitcoind.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-
+terminationGracePeriodSeconds: 30
 image:
   repository: arilot/docker-bitcoind
   tag: 0.15.1


### PR DESCRIPTION
#### What this PR does / why we need it:
The default `terminationGracePeriodSeconds` for kubernetes is 30 secods which is enough when running Bitcoin node on test network or private development network ("regtest"), but it is not enough for production usage where `dbCache` values are larger and so the termination takes longer.

On the other hand it is extremely important to take nodes down gracefully because of long db reindex time.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
