### PR TITLE
[stable/rabbitmq] using rabbitmqClusterNodeName variable fix

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 5.4.0
+version: 5.4.1
 appVersion: 3.7.14
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -182,7 +182,7 @@ spec:
             {{- if .Values.rabbitmq.rabbitmqClusterNodeName }}
             value: {{ .Values.rabbitmq.rabbitmqClusterNodeName | quote }}
             {{- else }}
-            value: "rabbit@$(MY_POD_IP)"
+            value: "rabbit@$(MY_POD_NAME)"
             {{- end }}
           {{- end }}
           - name: RABBITMQ_LOGS

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -171,15 +171,19 @@ spec:
           - name: K8S_SERVICE_NAME
             value: "{{ template "rabbitmq.fullname" . }}-headless"
           - name: K8S_ADDRESS_TYPE
-            value: {{ .Values.rabbitmq.clustering.address_type }}
+            value: {{ .Values.rabbitmq.clustering.address_type }}        
           {{- if (eq "hostname" .Values.rabbitmq.clustering.address_type) }}
           - name: RABBITMQ_NODENAME
-            value: "rabbit@$(MY_POD_NAME).$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.{{ .Values.rabbitmq.clustering.k8s_domain }}"
+            value: "rabbit@$(HOSTNAME).$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.{{ .Values.rabbitmq.clustering.k8s_domain }}"
           - name: K8S_HOSTNAME_SUFFIX
             value: ".$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.{{ .Values.rabbitmq.clustering.k8s_domain }}"
           {{- else }}
           - name: RABBITMQ_NODENAME
+            {{- if .Values.rabbitmq.rabbitmqClusterNodeName }}
+            value: {{ .Values.rabbitmq.rabbitmqClusterNodeName | quote }}
+            {{- else }}
             value: "rabbit@$(MY_POD_IP)"
+            {{- end }}
           {{- end }}
           - name: RABBITMQ_LOGS
             value: {{ .Values.rabbitmq.logs | quote }}

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -171,10 +171,10 @@ spec:
           - name: K8S_SERVICE_NAME
             value: "{{ template "rabbitmq.fullname" . }}-headless"
           - name: K8S_ADDRESS_TYPE
-            value: {{ .Values.rabbitmq.clustering.address_type }}        
+            value: {{ .Values.rabbitmq.clustering.address_type }}
           {{- if (eq "hostname" .Values.rabbitmq.clustering.address_type) }}
           - name: RABBITMQ_NODENAME
-            value: "rabbit@$(HOSTNAME).$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.{{ .Values.rabbitmq.clustering.k8s_domain }}"
+            value: "rabbit@$(MY_POD_NAME).$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.{{ .Values.rabbitmq.clustering.k8s_domain }}"
           - name: K8S_HOSTNAME_SUFFIX
             value: ".$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.{{ .Values.rabbitmq.clustering.k8s_domain }}"
           {{- else }}


### PR DESCRIPTION
#### What this PR does / why we need it:
there's `rabbitmqClusterNodeName` on values but it's not being used on statefulset

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
