### PR TITLE
[stable/datadog] setting default daemonset updateStrategy to RollingUpdate

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.28.0
+version: 1.29.0
 appVersion: 6.10.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -296,6 +296,6 @@ spec:
 {{ toYaml .Values.daemonset.nodeSelector | indent 8 }}
       {{- end }}
   updateStrategy:
-    type: {{ default "OnDelete" .Values.daemonset.updateStrategy | quote }}
+    type: {{ default "RollingUpdate" .Values.daemonset.updateStrategy | quote }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Sets default `updateStrategy` to `RollingUpdate` for the daemonset. Reading through the `values.yaml` it shows this is the default anyway but in `daemonset.yaml` uses `OnDelete`. I think 99% of the time, people want `RollingUpdate` though, otherwise you have to manually go and delete the pods.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
