### PR TITLE
[stable/sentry] delete install hooks on success

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 1.3.3
+version: 1.3.4
 appVersion: 9.0
 keywords:
   - debugging

--- a/stable/sentry/templates/hooks/db-init.job.yaml
+++ b/stable/sentry/templates/hooks/db-init.job.yaml
@@ -13,6 +13,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     metadata:

--- a/stable/sentry/templates/hooks/user-create.job.yaml
+++ b/stable/sentry/templates/hooks/user-create.job.yaml
@@ -13,6 +13,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     metadata:


### PR DESCRIPTION
#### What this PR does / why we need it:
The two post-install hooks (`user-create` and `db-init`) remain in kubernetes, even when they are succesfull. Even if one does a `helm delete --purge`, they are not deleted, so that in order to do a re-install of sentry, e.g. they need to be deleted manually.

This PR uses the `hook-delete-policy` introduced in helm 2.7 (see https://github.com/helm/helm/pull/2692) to delete the jobs on success.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
