### PR TITLE
Update docker-registry to 2.7.1

### DIFF
--- a/stable/docker-registry/Chart.yaml
+++ b/stable/docker-registry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Docker Registry
 name: docker-registry
-version: 1.7.1
+version: 1.8.0
 appVersion: 2.7.1
 home: https://hub.docker.com/_/registry/
 icon: https://hub.docker.com/public/images/logos/mini-logo.svg

--- a/stable/docker-registry/Chart.yaml
+++ b/stable/docker-registry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart for Docker Registry
 name: docker-registry
 version: 1.7.1
-appVersion: 2.6.2
+appVersion: 2.7.1
 home: https://hub.docker.com/_/registry/
 icon: https://hub.docker.com/public/images/logos/mini-logo.svg
 sources:

--- a/stable/docker-registry/README.md
+++ b/stable/docker-registry/README.md
@@ -29,7 +29,7 @@ their default values.
 |:----------------------------|:-------------------------------------------------------------------------------------------|:----------------|
 | `image.pullPolicy`          | Container pull policy                                                                      | `IfNotPresent`  |
 | `image.repository`          | Container image to use                                                                     | `registry`      |
-| `image.tag`                 | Container image tag to deploy                                                              | `2.6.2`         |
+| `image.tag`                 | Container image tag to deploy                                                              | `2.7.1`         |
 | `imagePullSecrets`          | Specify image pull secrets                                                                 | `nil` (does not add image pull secrets to deployed pods) |
 | `persistence.accessMode`    | Access mode to use for PVC                                                                 | `ReadWriteOnce` |
 | `persistence.enabled`       | Whether to use a PVC for the Docker storage                                                | `false`         |

--- a/stable/docker-registry/values.yaml
+++ b/stable/docker-registry/values.yaml
@@ -14,7 +14,7 @@ podLabels: {}
 
 image:
   repository: registry
-  tag: 2.6.2
+  tag: 2.7.1
   pullPolicy: IfNotPresent
 # imagePullSecrets:
     # - name: docker


### PR DESCRIPTION
#### What this PR does / why we need it:

It updates the almost 2 year old version of the docker-registry to a more recent one.

It mainly fixes s3 support, as it wasn't working with 2.6.2. Which is why I think this would be also be helpful for others.

The [Changelog](https://github.com/docker/distribution/releases) indicates that nothing major has changed.

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
