### PR TITLE
[stable/prometheus-adapter] Adds support for external metrics v0.5.0

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 name: prometheus-adapter
-version: v0.4.2
-appVersion: v0.4.1
+version: v0.5.0
+appVersion: v0.5.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter
 keywords:

--- a/stable/prometheus-adapter/README.md
+++ b/stable/prometheus-adapter/README.md
@@ -50,7 +50,7 @@ The following table lists the configurable parameters of the Prometheus Adapter 
 | `resources`                     | CPU/Memory resource requests/limits                                             | `{}`                                        |
 | `rules.default`                 | If `true`, enable a set of default rules in the configmap                       | `true`                                      |
 | `rules.custom`                  | A list of custom configmap rules                                                | `[]`                                        |
-| `rules.existing`                | The name of an existing configMap with rules. Overrides default and custom.     | ``                                          |                                                                                                        
+| `rules.existing`                | The name of an existing configMap with rules. Overrides default, custom and external. | ``                                    |
 | `rules.external`                | A list of custom rules for external metrics API                                 | `[]`                                        |
 | `service.annotations`           | Annotations to add to the service                                               | `{}`                                        |
 | `service.port`                  | Service port to expose                                                          | `443`                                       |

--- a/stable/prometheus-adapter/README.md
+++ b/stable/prometheus-adapter/README.md
@@ -50,7 +50,8 @@ The following table lists the configurable parameters of the Prometheus Adapter 
 | `resources`                     | CPU/Memory resource requests/limits                                             | `{}`                                        |
 | `rules.default`                 | If `true`, enable a set of default rules in the configmap                       | `true`                                      |
 | `rules.custom`                  | A list of custom configmap rules                                                | `[]`                                        |
-| `rules.existing`                | The name of an existing configMap with rules. Overrides default and custom.     | ``                                          |
+| `rules.existing`                | The name of an existing configMap with rules. Overrides default and custom.     | ``                                          |                                                                                                        
+| `externalRules.custom`          | A list of custom rules for external metrics API                                 | `[]`                                        |
 | `service.annotations`           | Annotations to add to the service                                               | `{}`                                        |
 | `service.port`                  | Service port to expose                                                          | `443`                                       |
 | `service.type`                  | Type of service to create                                                       | `ClusterIP`                                 |

--- a/stable/prometheus-adapter/README.md
+++ b/stable/prometheus-adapter/README.md
@@ -51,7 +51,7 @@ The following table lists the configurable parameters of the Prometheus Adapter 
 | `rules.default`                 | If `true`, enable a set of default rules in the configmap                       | `true`                                      |
 | `rules.custom`                  | A list of custom configmap rules                                                | `[]`                                        |
 | `rules.existing`                | The name of an existing configMap with rules. Overrides default and custom.     | ``                                          |                                                                                                        
-| `externalRules.custom`          | A list of custom rules for external metrics API                                 | `[]`                                        |
+| `rules.external`                | A list of custom rules for external metrics API                                 | `[]`                                        |
 | `service.annotations`           | Annotations to add to the service                                               | `{}`                                        |
 | `service.port`                  | Service port to expose                                                          | `443`                                       |
 | `service.type`                  | Type of service to create                                                       | `ClusterIP`                                 |

--- a/stable/prometheus-adapter/README.md
+++ b/stable/prometheus-adapter/README.md
@@ -38,7 +38,7 @@ The following table lists the configurable parameters of the Prometheus Adapter 
 | ------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------|
 | `affinity`                      | Node affinity                                                                   | `{}`                                        |
 | `image.repository`              | Image repository                                                                | `directxman12/k8s-prometheus-adapter-amd64` |
-| `image.tag`                     | Image tag                                                                       | `v0.4.1`                                    |
+| `image.tag`                     | Image tag                                                                       | `v0.5.0`                                    |
 | `image.pullPolicy`              | Image pull policy                                                               | `IfNotPresent`                              |
 | `image.pullSecrets`             | Image pull secrets                                                              | `{}`                                        |
 | `logLevel`                      | Log level                                                                       | `4`                                         |

--- a/stable/prometheus-adapter/templates/custom-metrics-configmap.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-configmap.yaml
@@ -10,6 +10,10 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   config.yaml: |
+    externalRules:
+{{- if .Values.externalRules.custom }}
+{{ toYaml .Values.externalRules.custom | indent 4 }}
+{{- end -}}
     rules:
 {{- if .Values.rules.default }}
     - seriesQuery: '{__name__=~"^container_.*",container_name!="POD",namespace!="",pod_name!=""}'

--- a/stable/prometheus-adapter/templates/custom-metrics-configmap.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-configmap.yaml
@@ -10,10 +10,6 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   config.yaml: |
-    externalRules:
-{{- if .Values.externalRules.custom }}
-{{ toYaml .Values.externalRules.custom | indent 4 }}
-{{- end -}}
     rules:
 {{- if .Values.rules.default }}
     - seriesQuery: '{__name__=~"^container_.*",container_name!="POD",namespace!="",pod_name!=""}'
@@ -85,5 +81,9 @@ data:
 {{- end -}}
 {{- if .Values.rules.custom }}
 {{ toYaml .Values.rules.custom | indent 4 }}
+{{- end -}}
+{{- if .Values.rules.external }}
+    externalRules:
+{{ toYaml .Values.rules.external | indent 4 }}
 {{- end -}}
 {{- end -}}

--- a/stable/prometheus-adapter/templates/external-metrics-apiservice.yaml
+++ b/stable/prometheus-adapter/templates/external-metrics-apiservice.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  labels:
+    app: {{ template "k8s-prometheus-adapter.name" . }}
+    chart: {{ template "k8s-prometheus-adapter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: v1beta1.external.metrics.k8s.io
+spec:
+  service:
+    name: {{ template "k8s-prometheus-adapter.fullname" . }}
+    namespace: {{ .Release.Namespace | quote }}
+  {{ if .Values.tls.enable -}}
+  caBundle: {{ b64enc .Values.tls.ca }}
+  {{- end }}
+  group: external.metrics.k8s.io
+  version: v1beta1
+  insecureSkipTLSVerify: {{ if .Values.tls.enable }}false{{ else }}true{{ end }}
+  groupPriorityMinimum: 100
+  versionPriority: 100

--- a/stable/prometheus-adapter/templates/external-metrics-cluster-role.yaml
+++ b/stable/prometheus-adapter/templates/external-metrics-cluster-role.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "k8s-prometheus-adapter.name" . }}
+    chart: {{ template "k8s-prometheus-adapter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "k8s-prometheus-adapter.name" . }}-external-metrics
+rules:
+- apiGroups:
+  - "external.metrics.k8s.io"
+  resources:
+  - "*"
+  verbs:
+  - list
+  - get
+  - watch
+{{- end -}}

--- a/stable/prometheus-adapter/templates/hpa-external-metrics-cluster-role-binding.yaml
+++ b/stable/prometheus-adapter/templates/hpa-external-metrics-cluster-role-binding.yaml
@@ -1,0 +1,20 @@
+
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "k8s-prometheus-adapter.name" . }}
+    chart: {{ template "k8s-prometheus-adapter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "k8s-prometheus-adapter.name" . }}-hpa-controller-external-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "k8s-prometheus-adapter.name" . }}-external-metrics
+subjects:
+- kind: ServiceAccount
+  name: horizontal-pod-autoscaler
+  namespace: kube-system
+{{- end -}}

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -51,8 +51,7 @@ rules:
   # Mounts a configMap with pre-generated rules for use. Overrides the
   # default and custom entries
   existing:
-externalRules:
-  custom: []
+  external: []
 # - seriesQuery: '{__name__=~"^some_metric_count$"}'
 #   resources:
 #     template: <<.Resource>>

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -49,7 +49,7 @@ rules:
 #     as: "my_custom_metric"
 #   metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
   # Mounts a configMap with pre-generated rules for use. Overrides the
-  # default and custom entries
+  # default, custom and external entries
   existing:
   external: []
 # - seriesQuery: '{__name__=~"^some_metric_count$"}'
@@ -59,8 +59,6 @@ rules:
 #     matches: ""
 #     as: "my_custom_metric"
 #   metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
-  # Mounts a configMap with pre-generated rules for use. Overrides the
-  # default and custom entries
 
 service:
   annotations: {}

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -3,7 +3,7 @@ affinity: {}
 
 image:
   repository: directxman12/k8s-prometheus-adapter-amd64
-  tag: v0.4.1
+  tag: v0.5.0
   pullPolicy: IfNotPresent
 
 logLevel: 4
@@ -49,8 +49,19 @@ rules:
 #     as: "my_custom_metric"
 #   metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
   # Mounts a configMap with pre-generated rules for use. Overrides the
-  # default and custom entries
+  # default and custom entries  
   existing:
+externalRules:
+  custom: []
+# - seriesQuery: '{__name__=~"^some_metric_count$"}'
+#   resources:
+#     template: <<.Resource>>
+#   name:
+#     matches: ""
+#     as: "my_custom_metric"
+#   metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+  # Mounts a configMap with pre-generated rules for use. Overrides the
+  # default and custom entries
 
 service:
   annotations: {}

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -49,7 +49,7 @@ rules:
 #     as: "my_custom_metric"
 #   metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
   # Mounts a configMap with pre-generated rules for use. Overrides the
-  # default and custom entries  
+  # default and custom entries
   existing:
 externalRules:
   custom: []


### PR DESCRIPTION
@MattiasGees @prydonius Please review:

#### What this PR does / why we need it:
Adds support for external metrics with v0.5.0 bump:
https://github.com/DirectXMan12/k8s-prometheus-adapter/releases/tag/v0.5.0


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
