### PR TITLE
Update target port of forwarding to 3000

### DIFF
--- a/stable/hackmd/templates/NOTES.txt
+++ b/stable/hackmd/templates/NOTES.txt
@@ -15,5 +15,5 @@
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "hackmd.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80
+  kubectl port-forward $POD_NAME 8080:3000
 {{- end }}


### PR DESCRIPTION
HackMD runs on port 3000 according `values.yaml / service / port`

Hello @yuanying,

i found this little misleading piece of information in the `NOTES.txt`. Just an update to have it print the proper port number.

Regards
Joachim
