### PR TITLE
[stable/datadog] Remove default resources requests and limits

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.30.6
+version: 1.30.7
 appVersion: 6.10.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -258,13 +258,13 @@ datadog:
   ## Make sure to keep requests and limits equal to keep the pods in the Guaranteed QoS class
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
   #
-  resources:
-    requests:
-      cpu: 200m
-      memory: 256Mi
-    limits:
-      cpu: 200m
-      memory: 256Mi
+  resources: {}
+#    requests:
+#      cpu: 200m
+#      memory: 256Mi
+#    limits:
+#      cpu: 200m
+#      memory: 256Mi
 
 ## @param clusterAgent - object - required
 ## This is the Datadog Cluster Agent implementation that handles cluster-wide
@@ -325,13 +325,13 @@ clusterAgent:
   ## @param resources - object -required
   ## Datadog cluster-agent resource requests and limits.
   #
-  resources:
-    requests:
-      cpu: 200m
-      memory: 256Mi
-    limits:
-      cpu: 200m
-      memory: 256Mi
+  resources: {}
+#    requests:
+#      cpu: 200m
+#      memory: 256Mi
+#    limits:
+#      cpu: 200m
+#      memory: 256Mi
 
   ## @param livenessProbe - object - optional
   ## Override the agent's liveness probe logic from the default:
@@ -532,13 +532,13 @@ clusterchecksDeployment:
   ## @param resources - object -required
   ## Datadog clusterchecks-agent resource requests and limits.
   #
-  resources:
-    requests:
-      cpu: 200m
-      memory: 500Mi
-    limits:
-      cpu: 200m
-      memory: 500Mi
+  resources: {}
+#    requests:
+#      cpu: 200m
+#      memory: 500Mi
+#    limits:
+#      cpu: 200m
+#      memory: 500Mi
 
   ## @param affinity - object - optional
   ## Allow the ClusterChecks Deployment to schedule using affinity rules.


### PR DESCRIPTION
#### What this PR does / why we need it:

Resources should not be limited by default because nobody knows where
the chart will be installed to. Especially worth not to set CPU limits
by default as per https://github.com/kubernetes/kubernetes/issues/67577

#### Special notes for your reviewer:

Null

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
