### PR TITLE
[stable/nginx-ingress] Update image to 0.24.1

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 name: nginx-ingress
-version: 1.4.0
-appVersion: 0.23.0
+version: 1.6.0
+appVersion: 0.24.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -47,7 +47,7 @@ Parameter | Description | Default
 --- | --- | ---
 `controller.name` | name of the controller component | `controller`
 `controller.image.repository` | controller container image repository | `quay.io/kubernetes-ingress-controller/nginx-ingress-controller`
-`controller.image.tag` | controller container image tag | `0.23.0`
+`controller.image.tag` | controller container image tag | `0.24.1`
 `controller.image.pullPolicy` | controller container image pull policy | `IfNotPresent`
 `controller.image.runAsUser` | User ID of the controller process. Value depends on the Linux distribution used inside of the container image. By default uses debian one. | `33`
 `controller.config` | nginx ConfigMap entries | none

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -5,7 +5,7 @@ controller:
   name: controller
   image:
     repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-    tag: "0.23.0"
+    tag: "0.24.1"
     pullPolicy: IfNotPresent
     # www-data -> uid 33
     runAsUser: 33


### PR DESCRIPTION
Signed-off-by: Rauny Brandão rauny.brandao@gmail.com

**What this PR does / why we need it:**

Update image to 0.24.1 for more info please see: [https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.24.1](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.24.1)

The version was increased from 1.4.0 to 1.6.0, because of this pull request: [https://github.com/helm/charts/pull/13115](https://github.com/helm/charts/pull/13115).

#### Checklist

- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
