### PR TITLE
[stable/luigi] support pod disruption budget in chart

### DIFF
--- a/stable/luigi/Chart.yaml
+++ b/stable/luigi/Chart.yaml
@@ -18,5 +18,5 @@ keywords:
 - spark
 - kubernetes job manager
 name: luigi
-version: 2.7.4
+version: 2.8.0
 appVersion: 2.7.2

--- a/stable/luigi/README.md
+++ b/stable/luigi/README.md
@@ -50,6 +50,8 @@ The following table lists the configurable parameters of the Sentry chart and th
 | `persistence.enabled`                | Persistence flag                           | `false`                                                    |
 | `ingressUI.enabled`                  | UI Ingress Flag                            | `false`                                                    |
 | `ingressAPI.enabled`                 | API Ingress Flag                           | `false`                                                    |
+| `podDisruptionBudget.enabled`        | Pod Disruption Budget Flag                 | `false`                                                     |
+| `podDisruptionBudget.minAvailable`   | Pod Disruption Minimum Available Pods      | `1`                                                        |
 
 Dependent charts can also have values overwritten. Preface values with postgresql.* or redis.*
 

--- a/stable/luigi/templates/pdb.yaml
+++ b/stable/luigi/templates/pdb.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "luigi.fullname" . }}
+  labels:
+    app: {{ template "luigi.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ template "luigi.name" . }}
+      release: {{ .Release.Name }}
+
+{{- end -}}

--- a/stable/luigi/values.yaml
+++ b/stable/luigi/values.yaml
@@ -83,3 +83,7 @@ mysql:
   mysqlAllowEmptyPassword: true
   persistence:
     enabled: false
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1


### PR DESCRIPTION
Signed-off-by: Zhongyi Luo <zluo@rmn.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
When there's need to cycle/drain nodes in the cluster, to ensure high availability of Lugi service in those disruption times, we can support PodDisruptionBudget in chart. for more information: https://kubernetes.io/docs/tasks/run-application/configure-pdb/

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #13149

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
