### PR TITLE
fix: Cannot configure advertised listeners to use host ip for external clients [in Review]

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.14.5
+version: 0.14.6
 appVersion: 5.0.1
 keywords:
 - kafka

--- a/incubator/kafka/templates/service-brokers-external.yaml
+++ b/incubator/kafka/templates/service-brokers-external.yaml
@@ -2,6 +2,7 @@
   {{- $fullName := include "kafka.fullname" . }}
   {{- $replicas := .Values.replicas | int }}
   {{- $servicePort := .Values.external.servicePort }}
+  {{- $firstListenerPort := .Values.external.firstListenerPort }}
   {{- $dnsPrefix := printf "%s" .Release.Name }}
   {{- $root := . }}
   {{- range $i, $e := until $replicas }}
@@ -45,12 +46,14 @@ spec:
   ports:
     - name: external-broker
       {{- if and (eq $root.Values.external.type "LoadBalancer") (not $root.Values.external.distinct) }}
-      port: {{ $externalListenerPort }}
+      port: {{ $firstListenerPort }}
       {{- else }}
       port: {{ $servicePort }}
       {{- end }}
       {{- if and (eq $root.Values.external.type "LoadBalancer") ($root.Values.external.distinct) }}
       targetPort: {{ $servicePort }}
+      {{- else if and (eq $root.Values.external.type "LoadBalancer") (not $root.Values.external.distinct) }}
+      targetPort: {{ $firstListenerPort }}
       {{- else }}
       targetPort: {{ $externalListenerPort }}
       {{- end }}

--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -186,6 +186,9 @@ spec:
         - |
           unset KAFKA_PORT && \
           export KAFKA_BROKER_ID=${POD_NAME##*-} && \
+          {{- if eq .Values.external.type "LoadBalancer" }}
+          export LOAD_BALANCER_IP=$(echo '{{ .Values.external.loadBalancerIP }}' | tr -d '[]' | cut -d ' ' -f "$(($KAFKA_BROKER_ID + 1))") && \
+          {{- end }}
           export KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://${POD_NAME}.{{ include "kafka.fullname" . }}-headless.${POD_NAMESPACE}:9092{{ if kindIs "string" $advertisedListenersOverride }}{{ printf ",%s" $advertisedListenersOverride }}{{ end }} && \
           exec /etc/confluent/docker/run
         volumeMounts:


### PR DESCRIPTION
Hi @benjigoldberg

I re-create the PR to clean up the messy commit log of this PR. 
This change is the same. Keep on review on this. 

https://github.com/helm/charts/pull/12921

You comment like this on  the PR. 
```
@TsuyoshiUshio awesome work on this PR, the writeup, etc. I think your naming conventions for LOAD_BALANCER_IP look good to me. I also like the behavior you decided on re port numbers. Thank you for putting so much effort into this.
```
If you are OK, I'll write the document for merging this PR. 

I'll put the original header in here. 

#### What this PR does / why we need it:

Hello @faraazkhan @h0tbird @benjigoldberg ,

This PR is a fix the the following issue. 

* [Cannot configure advertised listeners to use host ip for external clients #11370](https://github.com/helm/charts/issues/11370)

I solved the LoadBalancer setting scenario. This fix doesn't affects for NodePort configuration. This fix enable to use this chart for LoadBalancer settings. I tested on Azure. However, it is the same for other cloud platforms.  The change is small. However, I'd like to discuss the spec with you guys before writing the document.

#### Special notes for your reviewer:

## Root Cause
The issue is caused by this reason. If the external client get the metadata (e.g. `kafkacat -b <IP ADDRESS>:<PORT> -L) and access trough LoadBalancer, the Service transport the message with TargetPort. Currently, it is 9092(headless default).  The broker pods receives get message with 9092, they return the metadata of 9092 which is for internal metadata. 

### Fix
In case of the Load Balancer setting, set the TargetPort as the same Port number as the Service. 
It returns correct listener address.

## Additional Fix
However, once we enable it, it works for single broker.  Once you try to configure multiple brokers, it cause a problem. First, we need to get the LoadBalancer IP address at the broker container side to configure `advertised.listeners`.  I add `LOAD_BALANCER_IP` environment variables for it. If it is not fit the naming convention, please let me know. 
It solves the configuration issue, then,  I'll receive this error.  (I change the IP address to be fake.)

```
[2019-04-08 07:46:40,288] ERROR [MetadataCache brokerId=0] Listeners are not identical across brokers: Map(2 -> Map(ListenerName(PLAINTEXT) -> md-kafkas-2.md-kafkas-headless.default:9092 (id: 2 rack: null), ListenerName(EXTERNAL2) -> 13.66.160.999:31092 (id: 2 rack: null)), 1 -> Map(ListenerName(PLAINTEXT) -> md-kafkas-1.md-kafkas-headless.default:9092 (id: 1 rack: null), ListenerName(EXTERNAL1) -> 52.247.212.999:31091 (id: 1 rack: null)), 0 -> Map(ListenerName(PLAINTEXT) -> md-kafkas-0.md-kafkas-headless.default:9092 (id: 0 rack: null), ListenerName(EXTERNAL0) -> 13.77.176.999:31090 (id: 0 rack: null))) (kafka.server.MetadataCache)
```
Since current configuration of helm, if we have several brokers which means several LoadBalancers, It have a different Port number. like `31090` , `31091`... and so on. Which means we need to define Listeners for corresponding to the Port number. However, this feature might be for NodePort settings. Since LoadBalancer settings requires different IP address, It doesn't make sense, and also, it cause that error because of kafka checking if the advertised.listener is identical or not. However, if I configure listener like EXTERNAL0, EXTERNAL1... it also cause a problem. The first pod works correctly, the second pod fails because of the duplicated entry. 

So, In case of LoadBalancer, I change not to change the LoadBancer Port for each LoadBalancers.

Now, we can configure something like this.  IP Addresses are fake. 

_values.yaml_ 

```
## External access.
##
external:
  type: LoadBalancer
  # annotations:
  #  service.beta.kubernetes.io/openstack-internal-load-balancer: "true"
  dns:
    useInternal: false
    useExternal: false
  # create an A record for each statefulset pod
  distinct: false
  enabled: true
  servicePort: 19092
  firstListenerPort: 31090
  domain: cluster.local
  loadBalancerIP: 
    - 13.77.176.999
    - 52.247.212.999
    - 13.66.160.999

  externalTrafficPolicy: Local
  init:
    image: "lwolf/kubectl_deployer"
    imageTag: "0.4"
    imagePullPolicy: "IfNotPresent"

# Annotation to be added to Kafka pods
podAnnotations: {}

## Configuration Overrides. Specify any Kafka settings you would like set on the StatefulSet
## here in map format, as defined in the official docs.
## ref: https://kafka.apache.org/documentation/#brokerconfigs
##
configurationOverrides:
  "offsets.topic.replication.factor": 3
  "confluent.support.metrics.enable": false  # Disables confluent metric submission
  "auto.leader.rebalance.enable": true
  # "auto.create.topics.enable": true
  # "controlled.shutdown.enable": trueooder0
  # "controlled.shutdown.max.retries": 100

  ## Options required for external access via NodePort
  ## ref:
  ## - http://kafka.apache.org/documentation/#security_configbroker
  ## - https://cwiki.apache.org/confluence/display/KAFKA/KIP-103%3A+Separation+of+Internal+and+External+traffic
  ##
  ## Setting "advertised.listeners" here appends to "PLAINTEXT://${POD_IP}:9092,"
  "advertised.listeners": EXTERNAL://${LOAD_BALANCER_IP}:31090
  "listener.security.protocol.map": PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
  "listeners": PLAINTEXT://:9092,EXTERNAL://:31090
  "inter.broker.listener.name": "PLAINTEXT"
```
## Comments for reviewers

I need some discussion. 

### Variable name which we can use in the advertised.listerner
I use it as LOAD_BALANCER_ID. However, I don't know it is good for you guys. 

### Specification of LoadBalancer settings

In case of LoadBalancer, I believe, we should configure that all LoadBalancer can have the same port number. However, according to the helm chart, You change the source of the port number according to the `external.distinct` . 

the service-brokers-external.yaml
* external.distinct : true, external.type: LoadBalancer
port: servicePort, targetPort: servicePort
* external.distinct : false, external.type. LoadBalancer
port: externalListenerPort (current -> I change it to firstListerPort) , targetPort: externalListenerPort(current ->I change it to firstListenerPort)

However, I don't know your intention for it. We might introduce new parameter which enable to use the same port in case of LoadBalancer. I'm not sure the case of the LoadBalancer with inclement port number. If it is necessary, I'd happy to modify it to add the new parameter like `enableSinglePort` or something. 

I don't write a document, however, once discussion is finished, I'd happy to write it. 

I hope this PR helps people enjoy kafka more easily on k8s. 

I explain what it looks like on this blog.
https://medium.com/@tsuyoshiushio/configuring-kafka-on-kubernetes-makes-available-from-an-external-client-with-helm-96e9308ee9f4

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
