### PR TITLE
Add maorfr to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -11,6 +11,7 @@ approvers:
   - paulczar
   - cpanato
   - jlegrone
+  - maorfr
 emeritus:
   - linki
   - mgoodness


### PR DESCRIPTION
Signed-off-by: Vic Iglesias <viglesias@google.com>

Moar Friedman as been approved by 2/3 vote to be added as a chart maintainer.