### PR TITLE
add resources/limits to specs in postgres chart

### DIFF
--- a/stable/postgresql/values-production.yaml
+++ b/stable/postgresql/values-production.yaml
@@ -257,6 +257,9 @@ resources:
   requests:
     memory: 256Mi
     cpu: 250m
+  limits:
+    memory: 512Mi
+    cpu: 500m
 
 networkPolicy:
   ## Enable creation of NetworkPolicy resources.
@@ -317,6 +320,13 @@ metrics:
     enabled: false
     runAsUser: 1001
 
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 250m
+    limits:
+      memory: 512Mi
+      cpu: 500m
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
   ## Configure extra options for liveness and readiness probes
   livenessProbe:

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -264,6 +264,9 @@ resources:
   requests:
     memory: 256Mi
     cpu: 250m
+  limits:
+    memory: 512Mi
+    cpu: 500m
 
 networkPolicy:
   ## Enable creation of NetworkPolicy resources.
@@ -323,6 +326,14 @@ metrics:
   securityContext:
     enabled: false
     runAsUser: 1001
+
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 250m
+    limits:
+      memory: 512Mi
+      cpu: 500m
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
   ## Configure extra options for liveness and readiness probes
   livenessProbe:


### PR DESCRIPTION
-Add limits to postgres container
-Add limits/resources to metrics container

Some production Kubernetes environments will require that resources/limits be explicitly defined for all containers. This PR adds limits to the postgres container and limits/resources to the metrics container. This will allow for more "plug'n'play" functionality for production environments. 