### PR TITLE
[stable/jenkins] Fix rendering of customInitContainers and lifecycle

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 1.1.0
+version: 1.1.1
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -77,9 +77,9 @@ spec:
         {{- toYaml .Values.master.hostAliases | nindent 8 }}
       {{- end }}
       initContainers:
-        {{- if .Values.master.customInitContainers }}
-          {{ toYaml .Values.master.customInitContainers | indent 8 }}
-        {{- end }}
+{{- if .Values.master.customInitContainers }}
+{{ toYaml .Values.master.customInitContainers | indent 8 }}
+{{- end }}
         - name: "copy-default-config"
           image: "{{ .Values.master.image }}:{{ .Values.master.imageTag }}"
           imagePullPolicy: "{{ .Values.master.imagePullPolicy }}"
@@ -153,7 +153,7 @@ spec:
           {{- end }}
           {{- if .Values.master.lifecycle }}
           lifecycle:
-            {{ toYaml .Values.master.lifecycle | indent 12 }}
+{{ toYaml .Values.master.lifecycle | indent 12 }}
           {{- end }}
           env:
             - name: JAVA_OPTS


### PR DESCRIPTION
Signed-off-by: Ian Paredes <cp@redbluemagenta.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Current revision of Jenkins helm chart will bail out if `customInitContainers` or `lifecycle` is specified - this is because the `toYaml ... | indent` call was rendering the yaml incorrectly.

#### Which issue this PR fixes


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
