### PR TITLE
WIP - fix flag on install

### DIFF
--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -86,7 +86,7 @@ and their default values.
 | proxy.ingress.tls              | Name of secret resource, containing TLS secret                                   |                     |
 | proxy.ingress.hosts            | List of ingress hosts.                                                           | `[]`                |
 | proxy.ingress.path             | Ingress path.                                                                    | `/`                 |
-| proxy.ingress.annotations      | Ingress annotations. See documentation for your ingress controller for details   | `{}`                |
+| proxy.annotations      | Ingress annotations. See documentation for your ingress controller for details   | `{}`                |
 | env                            | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/) |                     |
 | runMigrations                  | Run Kong migrations job                                                          | `true`              |
 | readinessProbe                 | Kong readiness probe                                                             |                     |


### PR DESCRIPTION
Ping @shashiranjan84 

I found this issue on documentation, with this fix, works, but don't make sense. I think that need to refactor to improve ingress section, what you think?

Based on documentation
```bash
    helm install \
        --name=kong \
        --namespace=kong \
        --set=proxy.ingress.annotations."foo"="bar"
```

Based on fix
```bash
    helm install \
        --name=kong \
        --namespace=kong \
        --set=proxy.annotations."foo"="bar"
```