### PR TITLE
Setting more effective livenessProbe

### DIFF
--- a/stable/consul/templates/consul-statefulset.yaml
+++ b/stable/consul/templates/consul-statefulset.yaml
@@ -107,9 +107,15 @@ spec:
         livenessProbe:
           exec:
             command:
-            - consul
-            - members
-            - -http-addr=http://127.0.0.1:{{ .Values.HttpPort }}
+            - sh
+            - -c
+            - |
+              curl --silent  http://127.0.0.1:{{ .Values.HttpPort }}/v1/health/node/$(hostname) |grep alive >> /dev/null
+              node_status=$(echo $?)
+              if [ "$node_status" != "0" ]; then
+                 echo "$(hostname) node is not healthy, pod is going to be restarted";
+                 exit 1;
+              fi
           initialDelaySeconds: 300
           timeoutSeconds: 5
         command:


### PR DESCRIPTION
I have tried the livenessProbe indicated in this repository and if one consul node is unhealthy, the pod is not restarted. With this change the pod will be restarted because it checks if the consul node is healthy. If you want, you can give a chance to this livenessProbe.