### PR TITLE
stackdriver-exporter: allow using a google service account

### DIFF
--- a/stable/stackdriver-exporter/Chart.yaml
+++ b/stable/stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: stackdriver-exporter
-version: 1.0.0
+version: 1.1.0
 appVersion: 0.6.0
 home: https://www.stackdriver.com/
 sources:

--- a/stable/stackdriver-exporter/README.md
+++ b/stable/stackdriver-exporter/README.md
@@ -67,6 +67,8 @@ Parameter                           | Description                               
 `service.type`                      | Type of service to create                                                       | `ClusterIP`
 `service.httpPort`                  | Port for the http service                                                       | `9255`
 `stackdriver.projectId`             | GCP Project ID                                                                  | ``
+`stackdriver.serviceAccountSecret`  | Optionally specify an existing secret which contains credentials.json if necessary. | `""`
+`stackdriver.serviceAccountKey`     | Optionally specify the service account key JSON file. Must be provided when no existing secret is used, in this case a new secret will be created holding this service account | `""`
 `stackdriver.maxRetries`            | Max number of retries that should be attempted on errors from Stackdriver       | `0`
 `stackdriver.httpTimeout`           | How long should Stackdriver_exporter wait for a result from the Stackdriver API | `10s`
 `stackdriver.maxBackoff`            | Max time between each request in an exponential backoff scenario                | `5s`

--- a/stable/stackdriver-exporter/templates/deployment.yaml
+++ b/stable/stackdriver-exporter/templates/deployment.yaml
@@ -33,12 +33,31 @@ spec:
 {{ toYaml .Values.affinity | indent 8 }}
 {{- end }}
       restartPolicy: {{ .Values.restartPolicy }}
+      volumes:
+      {{- if .Values.stackdriver.serviceAccountSecret }}
+        - name: stackdriver-service-account
+          secret:
+            secretName: {{ .Values.stackdriver.serviceAccountSecret | quote }}
+      {{- else if .Values.stackdriver.serviceAccountKey }}
+        - name: stackdriver-service-account
+          secret:
+            secretName: {{ template "stackdriver-exporter.fullname" . }}
+      {{- end}}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["stackdriver_exporter"]
+          volumeMounts:
+          {{- if or .Values.stackdriver.serviceAccountSecret .Values.stackdriver.serviceAccountKey }}
+            - name: stackdriver-service-account
+              mountPath: /etc/secrets/service-account/
+          {{- end}}
           env:
+          {{- if or .Values.stackdriver.serviceAccountSecret .Values.stackdriver.serviceAccountKey }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /etc/secrets/service-account/credentials.json
+          {{- end }}
             - name: STACKDRIVER_EXPORTER_GOOGLE_PROJECT_ID
               value: {{ .Values.stackdriver.projectId | quote }}
             - name: STACKDRIVER_EXPORTER_MONITORING_METRICS_TYPE_PREFIXES

--- a/stable/stackdriver-exporter/templates/secret.yaml
+++ b/stable/stackdriver-exporter/templates/secret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.stackdriver.serviceAccountKey -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "stackdriver-exporter.fullname" . }}
+  labels:
+    chart: {{ template "stackdriver-exporter.chart" . }}
+    app: {{ template "stackdriver-exporter.name" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  credentials.json: {{ .Values.stackdriver.serviceAccountKey | b64enc | quote }}
+{{- end }}

--- a/stable/stackdriver-exporter/values.yaml
+++ b/stable/stackdriver-exporter/values.yaml
@@ -25,6 +25,10 @@ service:
 stackdriver:
   # The Google Project ID to gather metrics for
   projectId: "FALSE"
+  # An existing secret which contains credentials.json
+  serviceAccountSecret: ""
+  # A service account key JSON file. Must be provided when no existing secret is used, in this case a new secret will be created holding this service account
+  serviceAccountKey: ""
   # Max number of retries that should be attempted on 503 errors from Stackdriver
   maxRetries: 0
   # How long should Stackdriver_exporter wait for a result from the Stackdriver API


### PR DESCRIPTION
#### What this PR does / why we need it:
Enables the use of a google service account from a key or existing secret.

My use case is to monitor a project other than the one in which the chart is hosted and/or from outside gke.

@apenney 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
