### PR TITLE
Moving foxish to emeritus status

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,7 +3,6 @@ approvers:
   - prydonius
   - sameersbn
   - viglesiasce
-  - foxish
   - unguiculus
   - scottrigby
   - mattfarina
@@ -13,6 +12,7 @@ approvers:
   - jlegrone
   - maorfr
 emeritus:
+  - foxish
   - linki
   - mgoodness
   - seanknox


### PR DESCRIPTION
This is per a conversation with foxish about > 3 months of inactivity
which there is a provision for in the governance.

On the bright side, he won't have so many GitHub notifications. Maybe he can use them again.
