### PR TITLE
Improve consul livenessProbe

### DIFF
--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,6 +1,6 @@
 name: consul
 home: https://github.com/hashicorp/consul
-version: 3.6.1
+version: 3.6.2
 appVersion: 1.0.0
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/stable/consul/templates/consul-statefulset.yaml
+++ b/stable/consul/templates/consul-statefulset.yaml
@@ -107,9 +107,15 @@ spec:
         livenessProbe:
           exec:
             command:
-            - consul
-            - members
-            - -http-addr=http://127.0.0.1:{{ .Values.HttpPort }}
+            - sh
+            - -c
+            - |
+              curl --silent  http://127.0.0.1:{{ .Values.HttpPort }}/v1/health/node/$(hostname) |grep alive >> /dev/null
+              node_status=$(echo $?)
+              if [ "$node_status" != "0" ]; then
+                 echo "$(hostname) node is not healthy, pod is going to be restarted";
+                 exit 1;
+              fi
           initialDelaySeconds: 300
           timeoutSeconds: 5
         command:


### PR DESCRIPTION
Setting more effective consul livenessProbe and also bump chart version
Signed-off-by: Nikolay Zlatarev <nikolay.zlatarev1@ibm.com>

I have tried the livenessProbe indicated in this repository and if one consul node is unhealthy, the pod is not restarted. With this change the pod will be restarted because it checks if the consul node is healthy. If you want, you can give a chance to this livenessProbe.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
