### PR TITLE
Add max sync duration setting

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 2.1.1
+version: 2.1.2
 appVersion: 2.1.5
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -104,6 +104,7 @@ The following table lists the configurable parameters of the CockroachDB chart a
 | `Locality`                     | Locality attribute for this deployment           | `""`                                      |
 | `ExtraArgs`                    | Additional command-line arguments                | `[]`                                      |
 | `ExtraSecretMounts`            | Additional secrets to mount at cluster members   | `[]`                                      |
+| `MaxSyncDuration`              | sets COCKROACH_ENGINE_MAX_SYNC_DURATION          | `""`                                      |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
+++ b/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
@@ -283,6 +283,10 @@ spec:
           value: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}.{{ .Release.Namespace }}.svc.{{ .Values.ClusterDomain }}"
         - name: COCKROACH_CHANNEL
           value: kubernetes-helm
+{{- if .Values.MaxSyncDuration }}
+        - name: COCKROACH_ENGINE_MAX_SYNC_DURATION
+          value: {{ .Values.MaxSyncDuration | quote }}
+{{- end }}
         volumeMounts:
         - name: datadir
           mountPath: /cockroach/cockroach-data

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -72,3 +72,5 @@ Locality: ""
 ExtraArgs: []
 # ExtraSecretMounts is a list of names from secrets in the same namespace as the cockroachdb cluster, which shall be mounted into /etc/cockroach/secrets/ for every cluster member.
 ExtraSecretMounts: []
+## If specified, sets COCKROACH_ENGINE_MAX_SYNC_DURATION, which under certain circumstances can smooth out disk/sync durations
+# MaxSyncDuration: "24h"


### PR DESCRIPTION
Signed-off-by: Christian Hüning <christian.huening@figo.io>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Allow to set COCKROACH_ENGINE_MAX_SYNC_DURATION via the cockroachdb helm chart

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

#### Special notes for your reviewer:
we were told to set this option be CRDB support, but the helm chart does not support it.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
