### PR TITLE
Detect current network and netmask

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 3.12.2
+version: 3.12.3
 appVersion: 1.1.0
 maintainers:
 - name: jfelten

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -135,7 +135,7 @@ data:
       user nobody
       group nogroup
 
-      push "route NETWORK 255.255.240.0"
+      push "route NETWORK NETMASK"
 {{ if (.Values.openvpn.OVPN_K8S_POD_NETWORK) (.Values.openvpn.OVPN_K8S_POD_SUBNET) }}
       push "route {{ .Values.openvpn.OVPN_K8S_POD_NETWORK }} {{ .Values.openvpn.OVPN_K8S_POD_SUBNET }}"
 {{ end }}

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -53,6 +53,35 @@ data:
 
   configure.sh: |-
       #!/bin/sh
+
+      cidr2mask() {
+         # Number of args to shift, 255..255, first non-255 byte, zeroes
+         set -- $(( 5 - ($1 / 8) )) 255 255 255 255 $(( (255 << (8 - ($1 % 8))) & 255 )) 0 0 0
+         [ $1 -gt 1 ] && shift "$1" || shift
+         echo ${1-0}.${2-0}.${3-0}.${4-0}
+      }
+
+      cidr2net() {
+          local i ip mask netOctets octets
+          ip="${1%/*}"
+          mask="${1#*/}"
+          octets=$(echo "$ip" | tr '.' '\n')
+
+          for octet in $octets; do
+              i=$((i+1))
+              if [ $i -le $(( mask / 8)) ]; then
+                  netOctets="$netOctets.$octet"
+              elif [ $i -eq  $(( mask / 8 +1 )) ]; then
+                  echo $octet
+                  netOctets="$netOctets.$((((octet / ((256 / ((2**((mask % 8)))))))) * ((256 / ((2**((mask % 8))))))))"
+              else
+                  netOctets="$netOctets.0"
+              fi
+          done
+
+          echo ${netOctets#.}
+      }
+
       /etc/openvpn/setup/setup-certs.sh
       iptables -t nat -A POSTROUTING -s {{ .Values.openvpn.OVPN_NETWORK }}/{{ .Values.openvpn.OVPN_SUBNET }} -o eth0 -j MASQUERADE
       mkdir -p /dev/net
@@ -65,9 +94,16 @@ data:
           cat "${OVPN_CONFIG}"
           echo ====================================
       fi
-      IP=$(ip route get 8.8.8.8 | awk '/8.8.8.8/ {print $NF}')
-      BASEIP=`echo $IP | cut -d"." -f1-3`
-      NETWORK=`echo $BASEIP".0"`
+
+      intAndIP="$(ip route get 8.8.8.8 | awk '/8.8.8.8/ {print $5 "-" $7}')"
+      int="${intAndIP%-*}"
+      ip="${intAndIP#*-}"
+
+      echo $int "and" $ip
+      cidr="$(ip addr show dev "$int" | awk -vip="$ip" '($2 ~ ip) {print $2}')"
+
+      NETWORK="$(cidr2net $cidr)"
+      NETMASK="$(cidr2mask ${cidr#*/})"
       DNS=$(cat /etc/resolv.conf | grep -v '^#' | grep nameserver | awk '{print $2}')
       SEARCH=$(cat /etc/resolv.conf | grep -v '^#' | grep search | awk '{$1=""; print $0}')
       FORMATTED_SEARCH=""
@@ -78,6 +114,7 @@ data:
       sed 's|OVPN_K8S_SEARCH|'"${FORMATTED_SEARCH}"'|' -i /etc/openvpn/openvpn.conf
       sed 's|OVPN_K8S_DNS|'"${DNS}"'|' -i /etc/openvpn/openvpn.conf
       sed 's|NETWORK|'"${NETWORK}"'|' -i /etc/openvpn/openvpn.conf
+      sed 's|NETMASK|'"${NETMASK}"'|' -i /etc/openvpn/openvpn.conf
 
       openvpn --config /etc/openvpn/openvpn.conf
   openvpn.conf: |-

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -72,7 +72,6 @@ data:
               if [ $i -le $(( mask / 8)) ]; then
                   netOctets="$netOctets.$octet"
               elif [ $i -eq  $(( mask / 8 +1 )) ]; then
-                  echo $octet
                   netOctets="$netOctets.$((((octet / ((256 / ((2**((mask % 8)))))))) * ((256 / ((2**((mask % 8))))))))"
               else
                   netOctets="$netOctets.0"
@@ -98,8 +97,6 @@ data:
       intAndIP="$(ip route get 8.8.8.8 | awk '/8.8.8.8/ {print $5 "-" $7}')"
       int="${intAndIP%-*}"
       ip="${intAndIP#*-}"
-
-      echo $int "and" $ip
       cidr="$(ip addr show dev "$int" | awk -vip="$ip" '($2 ~ ip) {print $2}')"
 
       NETWORK="$(cidr2net $cidr)"


### PR DESCRIPTION
@jfelten Please consider this pull request.

#### What this PR does / why we need it:
This PR detects the IP address and Netmask correctly. Which results in only valid routes being passed to the clients.

Previously the network was guessed (assumed it was a /24 by replacing the last octet with a 0) and then later the netmask was hardcoded to 255.255.240.0 as a result the requested route was almost always incorrect. As most people supply their own or use the vpn tunnel as a default gateway it was probably rare to cause any issues.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #13211

#### Special notes for your reviewer:
the `cidr2mask()` function was copied from [here](https://forum.archive.openwrt.org/viewtopic.php?id=47986&p=1#p220781) the rest was written from scratch.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
