### PR TITLE
[stable/fluent-bit] Support formatting tag

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 1.9.2
+version: 1.9.3
 appVersion: 1.0.6
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -105,6 +105,7 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `input.tail.memBufLimit`           | Specify Mem_Buf_Limit in tail input        | `5MB`                                             |
 | `input.tail.parser`                | Specify Parser in tail input.        | `docker`                                             |
 | `input.tail.path`                  | Specify log file(s) through the use of common wildcards.        | `/var/log/containers/*.log`                                             |
+| `input.tail.formatTag`             | Format tag using the following pattern: {`filter.kubeTag`}.{namespace}.{pod}.{container}      | `false`                                            |
 | `input.systemd.enabled`            | [Enable systemd input](https://docs.fluentbit.io/manual/input/systemd)                   | `false`                                       |
 | `input.systemd.filters.systemdUnit` | Please see https://docs.fluentbit.io/manual/input/systemd | `[docker.service, kubelet.service`, `node-problem-detector.service]`                                       |
 | `input.systemd.maxEntries`         | Please see https://docs.fluentbit.io/manual/input/systemd | `1000`                             |

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -29,7 +29,12 @@ data:
         Name             tail
         Path             {{ .Values.input.tail.path }}
         Parser           {{ .Values.input.tail.parser }}
+{{- if .Values.input.tail.formatTag }}
+        Tag               {{ .Values.filter.kubeTag }}.<namespace>.<pod>.<container>
+        Tag_Regex         /var/log/containers/(?<pod>.+)_(?<namespace>.+)_(?<container>.+)-(?<docker_id>[a-f0-9]{64})\.log
+{{- else }}
         Tag              {{ .Values.filter.kubeTag }}.*
+{{- end }}
         Refresh_Interval 5
         Mem_Buf_Limit    {{ .Values.input.tail.memBufLimit }}
         Skip_Long_Lines  On
@@ -64,6 +69,9 @@ data:
 {{- end }}
 {{- if .Values.filter.enableExclude }}
         K8S-Logging.Exclude On
+{{- end }}
+{{- if .Values.input.tail.formatTag }}
+        Regex_Parser        kubernetes-tag
 {{- end }}
 {{ .Values.extraEntries.filter | indent 8 }}
 
@@ -153,6 +161,12 @@ data:
 {{ .Values.rawConfig | indent 4 }}
 
   parsers.conf: |-
+{{- if .Values.input.tail.formatTag }}
+    [PARSER]
+        Name        kubernetes-tag
+        Format      regex
+        Regex       ^{{ .Values.filter.kubeTag }}\.[^.]+\.(?<namespace_name>[^.]+)\.(?<pod_name>[^.]+)\.(?<container_name>[^.]+)$
+{{- end }}
 {{- if .Values.parsers.regex }}
 {{- range .Values.parsers.regex }}
     [PARSER]

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -194,6 +194,7 @@ input:
     memBufLimit: 5MB
     parser: docker
     path: /var/log/containers/*.log
+    formatTag: false
   systemd:
     enabled: false
     filters:


### PR DESCRIPTION
Add support to optionally format tag based on a regex against filename.

Signed-off-by: Christian Meunier <chris@jumpn.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Allow to easily route kubernetes logs based on the namespace, pod and container.

#### Special notes for your reviewer:
See: https://github.com/fluent/fluent-bit/pull/753

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
