### PR TITLE
Cert-manager support in opa chart

### DIFF
--- a/stable/opa/Chart.yaml
+++ b/stable/opa/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - opa
 - admission control
 - policy
-version: 1.3.2
+version: 1.4.0
 home: https://www.openpolicyagent.org
 icon: https://raw.githubusercontent.com/open-policy-agent/opa/master/logo/logo.png
 sources:

--- a/stable/opa/README.md
+++ b/stable/opa/README.md
@@ -7,6 +7,7 @@ engine designed for cloud-native environments.
 
 - Kubernetes 1.9 (or newer) for validating and mutating webhook admission
   controller support.
+- Optional, cert-manager (https://docs.cert-manager.io/en/latest/)
 
 ## Overview
 
@@ -56,6 +57,7 @@ Reference](https://www.openpolicyagent.org/docs/configuration.html).
 
 | Parameter | Description | Default |
 | --- | --- | --- |
+| `certManager.enabled` | Setup the Webhook using cert-manager | `false` |
 | `admissionControllerKind` | Type of admission controller to install. | `ValidatingWebhookConfiguration` |
 | `admissionControllerFailurePolicy` | Fail-open (`Ignore`) or fail-closed (`Fail`)? | `Ignore` |
 | `admissionControllerRules` | Types of operations resources to check. | `*` |

--- a/stable/opa/templates/_helpers.tpl
+++ b/stable/opa/templates/_helpers.tpl
@@ -61,3 +61,19 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{- define "opa.selfSignedIssuer" -}}
+{{ printf "%s-selfsign" (include "opa.fullname" .) }}
+{{- end -}}
+
+{{- define "opa.rootCAIssuer" -}}
+{{ printf "%s-ca" (include "opa.fullname" .) }}
+{{- end -}}
+
+{{- define "opa.rootCACertificate" -}}
+{{ printf "%s-ca" (include "opa.fullname" .) }}
+{{- end -}}
+
+{{- define "opa.servingCertificate" -}}
+{{ printf "%s-webhook-tls" (include "opa.fullname" .) }}
+{{- end -}}

--- a/stable/opa/templates/webhookconfiguration.yaml
+++ b/stable/opa/templates/webhookconfiguration.yaml
@@ -5,6 +5,10 @@ kind: {{ .Values.admissionControllerKind }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 metadata:
   name: {{ template "opa.fullname" . }}
+  annotations:
+{{- if .Values.certManager.enabled }}
+    certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s" .Release.Namespace (include "opa.rootCACertificate" .) | quote }}
+{{- end }}
   labels:
 {{ include "opa.labels.standard" . | indent 4 }}
 webhooks:
@@ -13,14 +17,78 @@ webhooks:
     rules:
 {{ toYaml .Values.admissionControllerRules | indent 6 }}
     clientConfig:
+{{ if not .Values.certManager.enabled }}
 {{ if .Values.generateAdmissionControllerCerts }}
       caBundle: {{ b64enc $ca.Cert }}
 {{ else }}
       caBundle: {{ b64enc .Values.admissionControllerCA }}
 {{ end }}
+{{ end }}
       service:
         name: {{ template "opa.fullname" . }}
         namespace: {{ .Release.Namespace }}
+
+{{ if .Values.certManager.enabled }}
+---
+# Create a selfsigned Issuer, in order to create a root CA certificate for
+# signing webhook serving certificates
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Issuer
+metadata:
+  name: {{ include "opa.selfSignedIssuer" . }}
+  labels:
+{{ include "opa.labels.standard" . | indent 4 }}
+spec:
+  selfSigned: {}
+
+---
+# Generate a CA Certificate used to sign certificates for the webhook
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: {{ include "opa.rootCACertificate" . }}
+  labels:
+{{ include "opa.labels.standard" . | indent 4 }}
+spec:
+  secretName: {{ include "opa.rootCACertificate" . }}
+  duration: 43800h # 5y
+  issuerRef:
+    name: {{ include "opa.selfSignedIssuer" . }}
+  commonName: "ca.webhook.opa"
+  isCA: true
+
+---
+# Create an Issuer that uses the above generated CA certificate to issue certs
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Issuer
+metadata:
+  name: {{ include "opa.rootCAIssuer" . }}
+  labels:
+{{ include "opa.labels.standard" . | indent 4 }}
+spec:
+  ca:
+    secretName: {{ include "opa.rootCACertificate" . }}
+
+---
+
+# Finally, generate a serving certificate for the webhook to use
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: {{ include "opa.servingCertificate" . }}
+  labels:
+{{ include "opa.labels.standard" . | indent 4 }}
+spec:
+  secretName: {{ template "opa.fullname" . }}-cert
+  duration: 8760h # 1y
+  issuerRef:
+    name: {{ include "opa.rootCAIssuer" . }}
+  dnsNames:
+  - {{ include "opa.fullname" . }}
+  - {{ include "opa.fullname" . }}.{{ .Release.Namespace }}
+  - {{ include "opa.fullname" . }}.{{ .Release.Namespace }}.svc
+{{ end }}
+{{- if not .Values.certManager.enabled }}
 ---
 apiVersion: v1
 kind: Secret
@@ -40,4 +108,4 @@ data:
   tls.crt: {{ b64enc .Values.admissionControllerCert }}
   tls.key: {{ b64enc .Values.admissionControllerKey }}
 {{ end }}
-
+{{ end }}

--- a/stable/opa/values.yaml
+++ b/stable/opa/values.yaml
@@ -12,6 +12,10 @@ opa:
     name: "helm-kubernetes-quickstart"
   default_decision: "/helm_kubernetes_quickstart/main"
 
+# Setup the webhook using cert-manager
+certManager:
+  enabled: false
+
 # To enforce mutating policies, change to MutatingWebhookConfiguration.
 admissionControllerKind: ValidatingWebhookConfiguration
 


### PR DESCRIPTION
Add support automatic provisioning of webhook certs via cert-manager
in opa chart.
