### PR TITLE
Move invalid attributes from PodSecurityContext

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus-adapter
-version: v0.4.1
+version: v0.4.2
 appVersion: v0.4.1
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
@@ -25,9 +25,6 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/custom-metrics-configmap.yaml") . | sha256sum }}
     spec:
       securityContext:
-        allowPrivilegeEscalation: false
-        capabilities:
-          drop: ["all"]
         runAsNonRoot: true
         runAsUser: 10001
       serviceAccountName: {{ template "k8s-prometheus-adapter.serviceAccountName" . }}
@@ -69,6 +66,9 @@ spec:
 {{- end }}
         securityContext:
           readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["all"]
         volumeMounts:
         - mountPath: /etc/adapter/
           name: config


### PR DESCRIPTION
#### What this PR does / why we need it:

allowPrivilegeEscalation and capabilities are not allowed in the PodSecurityContext
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#podsecuritycontext-v1-core
but only in the SecurityContext
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#securitycontext-v1-core
The old version was silently ignored.
Move the attributes to actually enable them.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
