### PR TITLE
[stable/falco] Remove the toJson pipeline when adding Google Cloud Credentials

### DIFF
--- a/stable/falco/CHANGELOG.md
+++ b/stable/falco/CHANGELOG.md
@@ -3,7 +3,22 @@
 This file documents all notable changes to Sysdig Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.7.3
+
+### Minor Changes
+
+* Remove the toJson pipeline when storing Google Credentials. It makes strange
+ stuff with double quotes and does not allow to use base64 encoded credentials
+
+## v0.7.2
+
+### Minor Changes
+
+* Fix typos in README.md
+
 ## v0.7.1
+
+### Minor Changes
 
 * Add Google Pub/Sub Output integration
 

--- a/stable/falco/Chart.yaml
+++ b/stable/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: falco
-version: 0.7.2
+version: 0.7.3
 appVersion: 0.14.0
 description: Sysdig Falco
 keywords:

--- a/stable/falco/templates/secret.yaml
+++ b/stable/falco/templates/secret.yaml
@@ -16,7 +16,7 @@ data:
   aws_secret_access_key: {{ .Values.integrations.snsOutput.aws_secret_access_key | b64enc | quote }}
 {{- end }}
 {{- if .Values.integrations.pubsubOutput.enabled }}
-  gcp-credentials-data: {{ .Values.integrations.pubsubOutput.credentialsData | toJson | b64enc | quote }}
+  gcp-credentials-data: {{ .Values.integrations.pubsubOutput.credentialsData | b64enc | quote }}
   gcp-project-id: {{ .Values.integrations.pubsubOutput.projectID | b64enc | quote }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Néstor Salceda <nestor.salceda@sysdig.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR fixes the storage of google cloud credentials in a secret. When we apply a toJson to a string, it double quotes it.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
