### PR TITLE
[stable/concourse] Update flags for 5.2

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: concourse
-version: 6.1.1
-appVersion: 5.1.0
+version: 6.2.0
+appVersion: 5.2.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479
 keywords:

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -256,6 +256,14 @@ spec:
             - name: CONCOURSE_MAX_BUILD_LOGS_TO_RETAIN
               value: {{ .Values.concourse.web.maxBuildLogsToRetain | quote }}
             {{- end }}
+            {{- if .Values.concourse.web.defaultDaysToRetainBuildLogs }}
+            - name: CONCOURSE_DEFAULT_DAYS_TO_RETAIN_BUILD_LOGS
+              value: {{ .Values.concourse.web.defaultDaysToRetainBuildLogs | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.maxDaysToRetainBuildLogs }}
+            - name: CONCOURSE_MAX_DAYS_TO_RETAIN_BUILD_LOGS
+              value: {{ .Values.concourse.web.maxDaysToRetainBuildLogs | quote }}
+            {{- end }}
             {{- if .Values.concourse.web.defaultTaskCpuLimit }}
             - name: CONCOURSE_DEFAULT_TASK_CPU_LIMIT
               value: {{ .Values.concourse.web.defaultTaskCpuLimit | quote }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -68,6 +68,18 @@ spec:
             - name: CONCOURSE_SECRET_RETRY_INTERVAL
               value: {{ .Values.concourse.web.secretRetryInterval | quote }}
             {{- end }}
+            {{- if .Values.concourse.web.secretCacheDuration }}
+            - name: CONCOURSE_SECRET_CACHE_DURATION
+              value: {{ .Values.concourse.web.secretCacheDuration | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.secretCacheEnabled }}
+            - name: CONCOURSE_SECRET_CACHE_ENABLED
+              value: {{ .Values.concourse.web.secretCacheEnabled | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.secretCachePurgeInterval }}
+            - name: CONCOURSE_SECRET_CACHE_PURGE_INTERVAL
+              value: {{ .Values.concourse.web.secretCachePurgeInterval | quote }}
+            {{- end }}
             {{- if .Values.concourse.web.awsSecretsManager.region }}
             - name: CONCOURSE_AWS_SECRETSMANAGER_REGION
               value: {{ .Values.concourse.web.awsSecretsManager.region | quote }}
@@ -388,10 +400,6 @@ spec:
             - name: CONCOURSE_VAULT_AUTH_BACKEND_MAX_TTL
               value: {{ .Values.concourse.web.vault.authBackendMaxTtl | quote }}
             {{- end }}
-            {{- if .Values.concourse.web.vault.cache }}
-            - name: CONCOURSE_VAULT_CACHE
-              value: {{ .Values.concourse.web.vault.cache | quote }}
-            {{- end }}
             {{- if .Values.concourse.web.vault.caPath }}
             - name: CONCOURSE_VAULT_CA_PATH
               value: {{ .Values.concourse.web.vault.caPath | quote }}
@@ -399,10 +407,6 @@ spec:
             {{- if .Values.concourse.web.vault.insecureSkipVerify }}
             - name: CONCOURSE_VAULT_INSECURE_SKIP_VERIFY
               value: {{ .Values.concourse.web.vault.insecureSkipVerify | quote }}
-            {{- end }}
-            {{- if .Values.concourse.web.vault.maxLease }}
-            - name: CONCOURSE_VAULT_MAX_LEASE
-              value: {{ .Values.concourse.web.vault.maxLease | quote }}
             {{- end }}
             {{- if .Values.concourse.web.vault.retryInitial }}
             - name: CONCOURSE_VAULT_RETRY_INITIAL

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -52,6 +52,10 @@ spec:
           args:
             - web
           env:
+            {{- if .Values.concourse.web.clusterName }}
+            - name: CONCOURSE_CLUSTER_NAME
+              value: {{ .Values.concourse.web.clusterName | quote }}
+            {{- end }}
             {{- if .Values.concourse.web.enableGlobalResources }}
             - name: CONCOURSE_ENABLE_GLOBAL_RESOURCES
               value: {{ .Values.concourse.web.enableGlobalResources | quote }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -60,6 +60,42 @@ spec:
             - name: CONCOURSE_ENABLE_GLOBAL_RESOURCES
               value: {{ .Values.concourse.web.enableGlobalResources | quote }}
             {{- end }}
+            {{- if .Values.concourse.web.enableBuildAuditing }}
+            - name: CONCOURSE_ENABLE_BUILD_AUDITING
+              value: {{ .Values.concourse.web.enableBuildAuditing | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.enableContainerAuditing }}
+            - name: CONCOURSE_ENABLE_CONTAINER_AUDITING
+              value: {{ .Values.concourse.web.enableContainerAuditing | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.enableJobAuditing }}
+            - name: CONCOURSE_ENABLE_JOB_AUDITING
+              value: {{ .Values.concourse.web.enableJobAuditing | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.enablePipelineAuditing }}
+            - name: CONCOURSE_ENABLE_PIPELINE_AUDITING
+              value: {{ .Values.concourse.web.enablePipelineAuditing | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.enableResourceAuditing }}
+            - name: CONCOURSE_ENABLE_RESOURCE_AUDITING
+              value: {{ .Values.concourse.web.enableResourceAuditing | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.enableSystemAuditing }}
+            - name: CONCOURSE_ENABLE_SYSTEM_AUDITING
+              value: {{ .Values.concourse.web.enableSystemAuditing | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.enableTeamAuditing }}
+            - name: CONCOURSE_ENABLE_TEAM_AUDITING
+              value: {{ .Values.concourse.web.enableTeamAuditing | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.enableWorkerAuditing }}
+            - name: CONCOURSE_ENABLE_WORKER_AUDITING
+              value: {{ .Values.concourse.web.enableWorkerAuditing | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.enableVolumeAuditing }}
+            - name: CONCOURSE_ENABLE_VOLUME_AUDITING
+              value: {{ .Values.concourse.web.enableVolumeAuditing | quote }}
+            {{- end }}
             {{- if .Values.concourse.web.secretRetryAttempts }}
             - name: CONCOURSE_SECRET_RETRY_ATTEMPTS
               value: {{ .Values.concourse.web.secretRetryAttempts | quote }}

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -181,8 +181,12 @@ spec:
               value: "{{ .Values.worker.keySecretsPath }}/host_key.pub"
             - name: CONCOURSE_TSA_WORKER_PRIVATE_KEY
               value: "{{ .Values.worker.keySecretsPath }}/worker_key"
+            {{- if .Values.concourse.worker.externalGardenUrl }}
+            - name: CONCOURSE_EXTERNAL_GARDEN_URL
+              value: {{ .Values.concourse.worker.externalGardenUrl | quote }}
+            {{- end }}
             {{- if .Values.concourse.worker.garden.useHoudini }}
-              - name: CONCOURSE_GARDEN_USE_HOUDINI
+            - name: CONCOURSE_GARDEN_USE_HOUDINI
               value: {{ .Values.concourse.worker.garden.useHoudini | quote }}
             {{- end }}
             {{- if .Values.concourse.worker.garden.bin }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -70,6 +70,20 @@ concourse:
     ##
     secretRetryInterval:
 
+    ## Enable in-memory cache for secrets.
+    ##
+    secretCacheEnabled: false
+
+    ## If the cache is enabled, secret values will be cached for not longer
+    ## than this duration (it can be less, if underlying secret lease time
+    ## is smaller).
+    ##
+    secretCacheDuration:
+
+    ## If the cache is enabled, expired items will be removed on this internal.
+    ##
+    secretCachePurgeInterval:
+
     ## Minimum level of logs to see. Possible options: debug, info, error.
     ##
     logLevel:
@@ -332,14 +346,6 @@ concourse:
       ## Currently supported backends: token, approle, cert.
       ##
       authBackend: ""
-
-      ## Cache returned secrets for their lease duration in memory
-      ##
-      cache: false
-
-      ## If the cache is enabled, and this is set, override secrets lease duration with a maximum value
-      ##
-      maxLease:
 
       ## Path to a directory of PEMEncoded CA cert files to verify the vault server SSL cert.
       ##

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -19,7 +19,7 @@ image: concourse/concourse
 ##      of `concourse/concourse`.
 ## Ref: https://hub.docker.com/r/concourse/concourse/tags/
 ##
-imageTag: "5.1.0"
+imageTag: "5.2.0"
 
 ## Specific image digest to use in place of a tag.
 ## Ref: https://kubernetes.io/docs/concepts/configuration/overview/#container-images

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1078,6 +1078,11 @@ concourse:
       ##
       workerPrivateKey:
 
+    ## API endpoint of an externally managed Garden server to use instead of
+    ## running the embedded Garden server.
+    ##
+    externalGardenUrl:
+
     garden:
       ## Path to the 'gdn' executable (or leave as 'gdn' to find it in $PATH)
       ##

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -61,6 +61,42 @@ concourse:
     ##
     enableGlobalResources: true
 
+    ## Enable auditing for all api requests connected to builds.
+    ##
+    enableBuildAuditing: false
+
+    ## Enable auditing for all api requests connected to containers.
+    ##
+    enableContainerAuditing: false
+
+    ## Enable auditing for all api requests connected to jobs.
+    ##
+    enableJobAuditing: false
+
+    ## Enable auditing for all api requests connected to pipelines.
+    ##
+    enablePipelineAuditing: false
+
+    ## Enable auditing for all api requests connected to resources.
+    ##
+    enableResourceAuditing: false
+
+    ## Enable auditing for all api requests connected to system transactions.
+    ##
+    enableSystemAuditing: false
+
+    ## Enable auditing for all api requests connected to teams.
+    ##
+    enableTeamAuditing: false
+
+    ## Enable auditing for all api requests connected to workers.
+    ##
+    enableWorkerAuditing: false
+
+    ## Enable auditing for all api requests connected to volumes.
+    ##
+    enableVolumeAuditing: false
+
     ## The number of attempts secret will be retried to be fetched,
     ## in case a retryable error happens.
     ##

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -52,6 +52,10 @@ concourse:
   ## through the `concourse web` command.
   ##
   web:
+    ## A name for this Concourse cluster, to be displayed on the dashboard page.
+    ##
+    clusterName:
+
     ## Enable equivalent resources across pipelines and teams to share a single version history.
     ## Ref: https://concourse-ci.org/global-resources.html
     ##

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -228,6 +228,14 @@ concourse:
     ##
     maxBuildLogsToRetain:
 
+    ## Default days to retain build logs. 0 means unlimited.
+    ##
+    defaultDaysToRetainBuildLogs:
+
+    ## Maximum days to retain build logs, 0 means not specified. Will override values configured in jobs.
+    ##
+    maxDaysToRetainBuildLogs:
+
     ## Default max number of cpu shares per task, 0 means unlimited.
     ##
     defaultTaskCpuLimit:


### PR DESCRIPTION
#### What this PR does / why we need it:

There's a new version of Concourse being prepared! This PR is about continuously adding the necessary flags to make it happen with Helm as well.

Once the next version ships, we can then promote this PR to non-draft.

So far, new configurations:
- [ability to configure the Concourse cluster name](https://github.com/concourse/concourse/pull/3736)
- [cacheing of secret lookups](https://github.com/concourse/concourse/pull/3628)
- [auditing of user actions](https://github.com/concourse/concourse/pull/3577)
- [time-based retention for the build collector](https://github.com/concourse/concourse/pull/3560)

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
