### PR TITLE
Add k8up upstream

### DIFF
--- a/stable/k8up/.helmignore
+++ b/stable/k8up/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/k8up/Chart.yaml
+++ b/stable/k8up/Chart.yaml
@@ -17,3 +17,7 @@ maintainers:
     email: simon.ruegg@vshn.ch
   - name: kidswiss
     email: simon.beck@vshn.ch
+  - name: ccremer
+  - name: akosma
+  - name: anothertobi
+  - name: bittner

--- a/stable/k8up/Chart.yaml
+++ b/stable/k8up/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+description: k8up Operator
+name: k8up
+home: https://vshn.github.io/k8up/
+keywords:
+  - backup
+  - operator
+  - appuio
+version: 0.1.0
+appVersion: v0.1.4
+sources:
+  - https://github.com/vshn/k8up
+maintainers:
+  - name: janPhil
+    email: jan.heinrich@vshn.ch
+  - name: srueg
+    email: simon.ruegg@vshn.ch
+  - name: kidswiss
+    email: simon.beck@vshn.ch

--- a/stable/k8up/OWNERS
+++ b/stable/k8up/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+  - akosma
+  - anothertobi
+  - bittner
+  - ccremer
+  - janPhil
+  - srueg
+  - kidswiss

--- a/stable/k8up/README.md
+++ b/stable/k8up/README.md
@@ -1,0 +1,55 @@
+# k8up
+
+k8up is an operator which simplifies the process of application data backup in a kubernetes cluster.
+
+## TL;DR;
+
+```console
+helm install stable/k8up
+```
+
+## Introduction
+
+This chart bootstraps a [k8up](https://vshn.github.io/k8up/) operator on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager. To start backing up your application data just create a schedule object in the namespace you would like to backup. For more information on k8up and its capabilities please check the [documentation](https://vshn.github.io/k8up/)
+
+## Prerequisites Details
+
+As the k8up operator is working cluster wide it needs an appropriate cluster role and rolebinding. If your tiller (the server-side component of Helm) doesnt have the right privileges to define roles and rolebindings, it might be that you need to define these per hand.
+
+k8up uses Wrestic as a backup runner, to learn more about it, please visit [wrestic on github](https://github.com/vshn/wrestic/tree/master). 
+
+## Installing the Chart
+
+To install the chart with the release name `k8up`:
+
+```console
+$ helm install --name k8up stable/k8up
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `k8up` deployment:
+
+```console
+$ helm delete k8up
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the k8up chart. For defaults please consult `values.yaml`
+
+| Parameter                   | Description                                             | Default
+| ---                         | ---                                                     | ---
+| `k8up_operator.image`       | The k8up operator image                                     | docker.io/vshn/k8up:v0.1.4
+| `k8up_operator.envVars`     | Allows the specification of additional environment variables for the k8up operator. | BACKUP_IMAGE:docker.io/vshn/wrestic:v0.0.10
+| `rbac.create`               | Create cluster roles and rolebinding                    | true
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+### Usage of the `tpl` Function
+
+The `tpl` function allows us to pass string values from `values.yaml` through the templating engine. It is used for the following values:
+
+* `k8up_operator.envVars`
+
+It is important that these values be configured as strings. Otherwise, installation will fail. See example for Google Cloud Proxy or default affinity configuration in `values.yaml`.

--- a/stable/k8up/templates/_helpers.tpl
+++ b/stable/k8up/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "k8up-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "k8up-operator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "k8up-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/k8up/templates/clusterrole.yaml
+++ b/stable/k8up/templates/clusterrole.yaml
@@ -1,0 +1,94 @@
+{{- if .Values.rbac.create }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ template "k8up-operator.fullname" $ }}
+  labels:
+    app: {{ template "k8up-operator.name" $ }}
+    chart: {{ template "k8up-operator.chart" $ }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
+  verbs:
+    - get
+    - watch
+    - list
+    - create
+    - edit
+    - patch
+- apiGroups:
+  - backup.appuio.ch
+  resources:
+    - '*'
+  verbs:
+    - '*'
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/exec
+  - persistentvolumeclaims
+  - events
+  - serviceaccounts
+  verbs:
+  - '*'
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - '*'
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "k8up-operator.fullname" $ }}-edit
+  labels:
+    app: {{ template "k8up-operator.name" $ }}
+    chart: {{ template "k8up-operator.chart" $ }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    # Add these permissions to the "admin" and "edit" default roles.
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - apiGroups:
+      - backup.appuio.ch
+    resources:
+      - "*"
+    verbs:
+      - "*"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "k8up-operator.fullname" $ }}-view
+  labels:
+    app: {{ template "k8up-operator.name" $ }}
+    chart: {{ template "k8up-operator.chart" $ }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    # Add these permissions to the "view" default role.
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups:
+      - backup.appuio.ch
+    resources:
+      - "*"
+    verbs:
+      - get
+      - list
+      - watch
+{{- end }}

--- a/stable/k8up/templates/clusterrolebinding.yaml
+++ b/stable/k8up/templates/clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.create }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  labels:
+    app: {{ template "k8up-operator.fullname" $ }}
+    chart: {{ template "k8up-operator.chart" $ }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "k8up-operator.fullname" $ }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "k8up-operator.fullname" $ }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  name: {{ template "k8up-operator.fullname" $ }}
+  kind: ClusterRole
+{{- end }}

--- a/stable/k8up/templates/deployment.yaml
+++ b/stable/k8up/templates/deployment.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "k8up-operator.fullname" $ }}
+  labels:
+    app: {{ template "k8up-operator.name" $ }}
+    chart: {{ template "k8up-operator.chart" $ }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "k8up-operator.name" $ }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "k8up-operator.name" $ }}
+    spec:
+      containers:
+        - name: k8up-operator
+          image: {{ .Values.k8up_operator.image }}
+          imagePullPolicy: Always
+          env:
+{{- if .Values.k8up_operator.envVars }}
+{{ toYaml .Values.k8up_operator.envVars | indent 10 }}
+{{- end }}
+{{- if .Values.k8up_operator.extraEnvVars}}
+{{ toYaml .Values.k8up_operator.extraEnvVars | indent 10 }}
+{{- end }}
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+      serviceAccountName: {{ template "k8up-operator.fullname" $ }}

--- a/stable/k8up/templates/service.yaml
+++ b/stable/k8up/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "k8up-operator.fullname" $ }}-metrics
+  labels:
+    app: {{ template "k8up-operator.name" $ }}
+    chart: {{ template "k8up-operator.chart" $ }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ports:
+  - name: "8080"
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: {{ template "k8up-operator.name" $ }}
+  sessionAffinity: None
+  type: ClusterIP

--- a/stable/k8up/templates/serviceaccount.yaml
+++ b/stable/k8up/templates/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "k8up-operator.fullname" $ }}

--- a/stable/k8up/values.yaml
+++ b/stable/k8up/values.yaml
@@ -1,0 +1,15 @@
+---
+k8up_operator:
+  image: docker.io/vshn/k8up:v0.1.4
+  ## Allows the specification of additional environment variables
+  envVars:
+    - name: BACKUP_IMAGE
+      value: docker.io/vshn/wrestic:v0.0.10
+    # - name: BACKUP_GLOBALACCESSKEYID
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: global-s3-credentials
+    #       key: access-key-id
+
+rbac:
+  create: true


### PR DESCRIPTION
#### What this PR does / why we need it:

With this PR we would like to add our k8up backup operator to the offical helm charts repo. The k8up operator simplifies backup on kubernetes clusters.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
