### PR TITLE
[stable/spinnaker] Allow to mount existing ConfigMaps as additionalConfigMaps for halyard

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.9.0
+version: 1.9.1
 appVersion: 1.12.5
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/statefulsets/halyard.yaml
+++ b/stable/spinnaker/templates/statefulsets/halyard.yaml
@@ -82,10 +82,14 @@ spec:
           secretName: {{ .Values.halyard.additionalSecrets.name }}
         {{- end }}
       {{- end }}
-      {{- if .Values.halyard.additionalConfigMaps.create }}
+      {{- if or .Values.halyard.additionalConfigMaps.create (hasKey .Values.halyard.additionalConfigMaps "name") }}
       - name: additional-config-maps
         configMap:
+        {{- if .Values.halyard.additionalConfigMaps.create }}
           name: {{ template "spinnaker.fullname" . }}-additional-config-maps
+        {{- else if .Values.halyard.additionalConfigMaps.name }}
+          name: {{ .Values.halyard.additionalConfigMaps.name }}
+        {{- end }}
       {{- end }}
       - name: additional-profile-config-maps
         configMap:
@@ -121,7 +125,7 @@ spec:
         - name: additional-secrets
           mountPath: /opt/halyard/additionalSecrets
         {{- end }}
-        {{- if .Values.halyard.additionalConfigMaps.create }}
+        {{- if or .Values.halyard.additionalConfigMaps.create (hasKey .Values.halyard.additionalConfigMaps "name") }}
         - name: additional-config-maps
           mountPath: /opt/halyard/additionalConfigMaps
         {{- end }}

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -20,7 +20,8 @@ halyard:
   additionalConfigMaps:
     create: false
     data: {}
-
+    ## Uncomment if you want to use a pre-created ConfigMap rather than feeding data in via helm.
+    # name:
   additionalProfileConfigMaps:
     data: {}
       ## if you're running spinnaker behind a reverse proxy such as a GCE ingress


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR makes `additionalConfigMaps` mounting similar to the way how it's already done for `additionalSecrets` (https://github.com/helm/charts/pull/10862/files#diff-a8cc52a7798c5800b91baff110876f24)

E.q. the user can define `halyard.additionalConfigMaps.name` value with the name of pre-created ConfigMap (which is not managed by this helm chart) and it will be mounted to the halyard pod.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped