### PR TITLE
[stable/graylog] Fix issue #13328, adjusting journal directory permissions

### DIFF
--- a/stable/graylog/Chart.yaml
+++ b/stable/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: graylog
 home: https://www.graylog.org
-version: 1.0.0
+version: 1.0.1
 appVersion: 2.5.1-3
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:

--- a/stable/graylog/templates/statefulset.yaml
+++ b/stable/graylog/templates/statefulset.yaml
@@ -60,7 +60,8 @@ spec:
             - -c
             - rm -rf /usr/share/graylog/data/journal/lost+found &&
               wget https://storage.googleapis.com/kubernetes-release/release/v1.11.4/bin/linux/amd64/kubectl -O /k8s/kubectl &&
-              chmod +x /k8s/kubectl
+              chmod +x /k8s/kubectl &&
+              chmod 777 /usr/share/graylog/data/journal
           securityContext:
             privileged: true
           volumeMounts:


### PR DESCRIPTION
This should fix https://github.com/helm/charts/issues/13328, by allowing the initContainer to correctly adjust permissions on the journal directory before the main graylog container starts.