### PR TITLE
[stable/spinnaker] Add support for adding env vars to Halyard

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.10.2
+version: 1.11.0
 appVersion: 1.12.5
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/README.md
+++ b/stable/spinnaker/README.md
@@ -163,3 +163,12 @@ halyard:
   annotations:
     iam.amazonaws.com/role: <role_arn>
 ```
+
+### Set environment variables on the halyard pod
+
+```yaml
+halyard:
+  env:
+    - name: DEFAULT_JVM_OPTS
+      value: -Dhttp.proxyHost=proxy.example.com
+```

--- a/stable/spinnaker/templates/statefulsets/halyard.yaml
+++ b/stable/spinnaker/templates/statefulsets/halyard.yaml
@@ -139,6 +139,10 @@ spec:
           mountPath: /opt/halyard/config
         - name: reg-secrets
           mountPath: /opt/registry/passwords
+        {{- if .Values.halyard.env }}
+        env:
+{{ toYaml .Values.halyard.env | indent 8 }}
+        {{- end }}
   volumeClaimTemplates:
   - metadata:
       name: halyard-home

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -71,6 +71,11 @@ halyard:
     #   memory: "2Gi"
     #   cpu: "200m"
 
+  ## Uncomment if you want to set environment variables on the Halyard pod.
+  # env:
+  #   - name: DEFAULT_JVM_OPTS
+  #     value: -Dhttp.proxyHost=proxy.example.com
+
 # Define which registries and repositories you want available in your
 # Spinnaker pipeline definitions
 # For more info visit:


### PR DESCRIPTION
#### What this PR does / why we need it:
Environment variables such as DEFAULT_JVM_OPTS need to be set in order
for Halyard to use a proxy. This adds an option to let you pass through
any env vars to the Halyard pod.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
