### PR TITLE
[stable/prometheus-operator] Allows option to configure kubernetes service spec externalTrafficPolicy

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: grafana
-version: 3.4.2
-appVersion: 6.2.2
+version: 3.3.4
+appVersion: 6.1.4
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 3.3.3
+version: 3.3.4
 appVersion: 6.1.4
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: grafana
-version: 3.3.4
-appVersion: 6.1.4
+version: 3.4.2
+appVersion: 6.2.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -41,6 +41,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.tag`                               | Image tag. (`Must be >= 5.0.0`)               | `6.1.4`                                                 |
 | `image.pullPolicy`                        | Image pull policy                             | `IfNotPresent`                                          |
 | `service.type`                            | Kubernetes service type                       | `ClusterIP`                                             |
+| `service.externalTrafficPolicy`           | Kubernetes External Traffic Policy            | `Cluster`                                               |
 | `service.port`                            | Kubernetes port where service is exposed      | `80`                                                    |
 | `service.targetPort`                      | internal service is port                      | `3000`                                                  |
 | `service.annotations`                     | Service annotations                           | `{}`                                                    |

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -38,10 +38,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `securityContext`                         | Deployment securityContext                    | `{"runAsUser": 472, "fsGroup": 472}`                    |
 | `priorityClassName`                       | Name of Priority Class to assign pods         | `nil`                                                   |
 | `image.repository`                        | Image repository                              | `grafana/grafana`                                       |
-| `image.tag`                               | Image tag. (`Must be >= 5.0.0`)               | `6.2.2`                                                 |
+| `image.tag`                               | Image tag. (`Must be >= 5.0.0`)               | `6.1.4`                                                 |
 | `image.pullPolicy`                        | Image pull policy                             | `IfNotPresent`                                          |
-| `image.pullSecrets`                       | Image pull secrets                            | `{}`                                                    |
 | `service.type`                            | Kubernetes service type                       | `ClusterIP`                                             |
+| `service.externalTrafficPolicy`           | Kubernetes External Traffic Policy            | `Cluster`                                               |
 | `service.port`                            | Kubernetes port where service is exposed      | `80`                                                    |
 | `service.targetPort`                      | internal service is port                      | `3000`                                                  |
 | `service.annotations`                     | Service annotations                           | `{}`                                                    |
@@ -58,7 +58,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `affinity`                                | Affinity settings for pod assignment          | `{}`                                                    |
 | `extraInitContainers`                     | Init containers to add to the grafana pod     | `{}` |
 | `extraContainers`                         | Sidecar containers to add to the grafana pod  | `{}` |
-| `schedulerName`                           | Name of the k8s scheduler (other than default) | `nil`                                                  |
 | `persistence.enabled`                     | Use persistent volume to store data           | `false`                                                 |
 | `persistence.size`                        | Size of persistent volume claim               | `10Gi`                                                  |
 | `persistence.existingClaim`               | Use an existing PVC to persist data           | `nil`                                                   |
@@ -106,9 +105,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `admin.existingSecret`                    | The name of an existing secret containing the admin credentials. | `""`                                 |
 | `admin.userKey`                           | The key in the existing admin secret containing the username. | `"admin-user"`                          |
 | `admin.passwordKey`                       | The key in the existing admin secret containing the password. | `"admin-password"`                      |
-| `serviceAccount.create`                   | Create service account | `true` |
-| `serviceAccount.name`                     | Service account name to use, when empty will be set to created account if `serviceAccount.create` is set else to `default` | `` |
-| `serviceAccount.nameTest`                 | Service account name to use for test, when empty will be set to created account if `serviceAccount.create` is set else to `default` | `` |
 | `rbac.create`                             | Create and use RBAC resources | `true` |
 | `rbac.namespaced`                         | Creates Role and Rolebinding instead of the default ClusterRole and ClusteRoleBindings for the grafana instance  | `false` |
 | `rbac.pspEnabled`                         | Create PodSecurityPolicy (with `rbac.create`, grant roles permissions as well) | `true` |

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -38,10 +38,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `securityContext`                         | Deployment securityContext                    | `{"runAsUser": 472, "fsGroup": 472}`                    |
 | `priorityClassName`                       | Name of Priority Class to assign pods         | `nil`                                                   |
 | `image.repository`                        | Image repository                              | `grafana/grafana`                                       |
-| `image.tag`                               | Image tag. (`Must be >= 5.0.0`)               | `6.1.4`                                                 |
+| `image.tag`                               | Image tag. (`Must be >= 5.0.0`)               | `6.2.2`                                                 |
 | `image.pullPolicy`                        | Image pull policy                             | `IfNotPresent`                                          |
+| `image.pullSecrets`                       | Image pull secrets                            | `{}`                                                    |
 | `service.type`                            | Kubernetes service type                       | `ClusterIP`                                             |
-| `service.externalTrafficPolicy`           | Kubernetes External Traffic Policy            | `Cluster`                                               |
 | `service.port`                            | Kubernetes port where service is exposed      | `80`                                                    |
 | `service.targetPort`                      | internal service is port                      | `3000`                                                  |
 | `service.annotations`                     | Service annotations                           | `{}`                                                    |
@@ -58,6 +58,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `affinity`                                | Affinity settings for pod assignment          | `{}`                                                    |
 | `extraInitContainers`                     | Init containers to add to the grafana pod     | `{}` |
 | `extraContainers`                         | Sidecar containers to add to the grafana pod  | `{}` |
+| `schedulerName`                           | Name of the k8s scheduler (other than default) | `nil`                                                  |
 | `persistence.enabled`                     | Use persistent volume to store data           | `false`                                                 |
 | `persistence.size`                        | Size of persistent volume claim               | `10Gi`                                                  |
 | `persistence.existingClaim`               | Use an existing PVC to persist data           | `nil`                                                   |
@@ -105,6 +106,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `admin.existingSecret`                    | The name of an existing secret containing the admin credentials. | `""`                                 |
 | `admin.userKey`                           | The key in the existing admin secret containing the username. | `"admin-user"`                          |
 | `admin.passwordKey`                       | The key in the existing admin secret containing the password. | `"admin-password"`                      |
+| `serviceAccount.create`                   | Create service account | `true` |
+| `serviceAccount.name`                     | Service account name to use, when empty will be set to created account if `serviceAccount.create` is set else to `default` | `` |
+| `serviceAccount.nameTest`                 | Service account name to use for test, when empty will be set to created account if `serviceAccount.create` is set else to `default` | `` |
 | `rbac.create`                             | Create and use RBAC resources | `true` |
 | `rbac.namespaced`                         | Creates Role and Rolebinding instead of the default ClusterRole and ClusteRoleBindings for the grafana instance  | `false` |
 | `rbac.pspEnabled`                         | Create PodSecurityPolicy (with `rbac.create`, grant roles permissions as well) | `true` |

--- a/stable/grafana/templates/service.yaml
+++ b/stable/grafana/templates/service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "grafana.fullname" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}
@@ -32,6 +31,9 @@ spec:
   {{- end -}}
 {{- else }}
   type: {{ .Values.service.type }}
+{{- end }}
+{{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
 {{- end }}
 {{- if .Values.service.externalIPs }}
   externalIPs:

--- a/stable/grafana/templates/service.yaml
+++ b/stable/grafana/templates/service.yaml
@@ -32,6 +32,9 @@ spec:
 {{- else }}
   type: {{ .Values.service.type }}
 {{- end }}
+{{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+{{- end }}
 {{- if .Values.service.externalIPs }}
   externalIPs:
 {{ toYaml .Values.service.externalIPs | indent 4 }}

--- a/stable/grafana/templates/service.yaml
+++ b/stable/grafana/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "grafana.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}
@@ -31,9 +32,6 @@ spec:
   {{- end -}}
 {{- else }}
   type: {{ .Values.service.type }}
-{{- end }}
-{{- if .Values.service.externalTrafficPolicy }}
-  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
 {{- end }}
 {{- if .Values.service.externalIPs }}
   externalIPs:

--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -5,12 +5,14 @@ engine: gotpl
 maintainers:
   - name: gianrubio
     email: gianrubio@gmail.com
+  - name: anothertobi
+  - name: vsliouniaev
 name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 5.3.1
-appVersion: 0.29.0
+version: 5.12.4
+appVersion: 0.30.1
 home: https://github.com/coreos/prometheus-operator
 keywords:
 - operator

--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 5.2.0
+version: 5.2.1
 appVersion: 0.29.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 5.2.1
+version: 5.3.1
 appVersion: 0.29.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -149,6 +149,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.service.externalIPs` | List of IP addresses at which the Prometheus Operator server service is available  | `[]` |
 | `prometheusOperator.service.loadBalancerIP` |  Prometheus Operator Loadbalancer IP | `""` |
 | `prometheusOperator.service.loadBalancerSourceRanges` | Prometheus Operator Load Balancer Source Ranges | `[]` |
+| `prometheusOperator.service.externalTrafficPolicy` | Prometheus Operator External Traffic Policy | `Cluster` |
 | `prometheusOperator.resources` | Resource limits for prometheus operator | `{}` |
 | `prometheusOperator.securityContext` | SecurityContext for prometheus operator | `{"runAsNonRoot": true, "runAsUser": 65534}` |
 | `prometheusOperator.nodeSelector` | Prometheus operator node selector https://kubernetes.io/docs/user-guide/node-selection/ | `{}` |
@@ -195,6 +196,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheus.service.externalIPs` | List of IP addresses at which the Prometheus server service is available  | `[]` |
 | `prometheus.service.loadBalancerIP` |  Prometheus Loadbalancer IP | `""` |
 | `prometheus.service.loadBalancerSourceRanges` | Prometheus Load Balancer Source Ranges | `[]` |
+| `prometheus.service.externalTrafficPolicy` | Prometheus External Traffic Policy | `Cluster` |
 | `prometheus.service.sessionAffinity` | Prometheus Service Session Affinity | `""` |
 | `prometheus.additionalServiceMonitors` | List of `serviceMonitor` objects to create. See https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitorspec | `[]` |
 | `prometheus.prometheusSpec.podMetadata` | Standard object’s metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata Metadata Labels and Annotations gets propagated to the prometheus pods. | `{}` |
@@ -262,6 +264,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `alertmanager.service.externalIPs` | List of IP addresses at which the Alertmanager server service is available  | `[]` |
 | `alertmanager.service.loadBalancerIP` |  Alertmanager Loadbalancer IP | `""` |
 | `alertmanager.service.loadBalancerSourceRanges` | Alertmanager Load Balancer Source Ranges | `[]` |
+| `alertmanager.service.externalTrafficPolicy` | Alertmanager External Traffic Policy | `Cluster` |
 | `alertmanager.config` | Provide YAML to configure Alertmanager. See https://prometheus.io/docs/alerting/configuration/#configuration-file. The default provided works to suppress the Watchdog alert from `defaultRules.create` | `{"global":{"resolve_timeout":"5m"},"route":{"group_by":["job"],"group_wait":"30s","group_interval":"5m","repeat_interval":"12h","receiver":"null","routes":[{"match":{"alertname":"Watchdog"},"receiver":"null"}]},"receivers":[{"name":"null"}]}` |
 | `alertmanager.alertmanagerSpec.podMetadata` | Standard object’s metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata Metadata Labels and Annotations gets propagated to the prometheus pods. | `{}` |
 | `alertmanager.alertmanagerSpec.image.tag` | Tag of Alertmanager container image to be deployed. | `v0.16.2` |

--- a/stable/prometheus-operator/templates/alertmanager/service.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/service.yaml
@@ -38,5 +38,8 @@ spec:
   selector:
     app: alertmanager
     alertmanager: {{ template "prometheus-operator.fullname" . }}-alertmanager
+{{- if .Values.alertmanager.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.alertmanager.service.externalTrafficPolicy }}
+{{- end }}
   type: "{{ .Values.alertmanager.service.type }}"
 {{- end }}

--- a/stable/prometheus-operator/templates/prometheus-operator/service.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/service.yaml
@@ -37,5 +37,8 @@ spec:
   selector:
     app: {{ template "prometheus-operator.name" . }}-operator
     release: {{ .Release.Name | quote }}
+{{- if .Values.prometheusOperator.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.prometheusOperator.service.externalTrafficPolicy }}
+{{- end }}
   type: "{{ .Values.prometheusOperator.service.type }}"
 {{- end }}

--- a/stable/prometheus-operator/templates/prometheus/service.yaml
+++ b/stable/prometheus-operator/templates/prometheus/service.yaml
@@ -43,5 +43,8 @@ spec:
 {{- if .Values.prometheus.service.sessionAffinity }}
   sessionAffinity: {{ .Values.prometheus.service.sessionAffinity }}
 {{- end }}
+{{- if .Values.prometheus.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.prometheus.service.externalTrafficPolicy }}
+{{- end }}
   type: "{{ .Values.prometheus.service.type }}"
 {{- end }}

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -178,6 +178,10 @@ alertmanager:
     ##
     type: ClusterIP
 
+    ## Feature to preserve the client source IP
+    ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/
+    externalTrafficPolicy: Cluster
+
   ## If true, create a serviceMonitor for alertmanager
   ##
   serviceMonitor:
@@ -809,6 +813,10 @@ prometheusOperator:
     ##
     externalIPs: []
 
+    ## Feature to preserve the client source IP
+    ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/
+    externalTrafficPolicy: Cluster
+
   ## Deploy CRDs used by Prometheus Operator.
   ##
   createCustomResource: true
@@ -971,6 +979,10 @@ prometheus:
     type: ClusterIP
 
     sessionAffinity: ""
+
+    ## Feature to preserve the client source IP
+    ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/
+    externalTrafficPolicy: Cluster
 
   rbac:
     ## Create role bindings in the specified namespaces, to allow Prometheus monitoring


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR gives you the option to configure kubernetes service spec externalTrafficPolicy, in prometheus-operator: alertmanager, prometheus, prometheus-operator and in the grafana chart

This is useful where you would like to always see the external traffic origin and keep traffic local.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
