### PR TITLE
[incubator/vault] Fix setting serviceaccount label

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.18.4
+version: 0.18.5
 appVersion: 1.0.1
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.18.3
+version: 0.18.4
 appVersion: 1.0.1
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/templates/_helpers.tpl
+++ b/incubator/vault/templates/_helpers.tpl
@@ -29,3 +29,10 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "vault.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/vault/templates/configmap.yaml
+++ b/incubator/vault/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     app: "{{ template "vault.name" . }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    chart: "{{ template "vault.chart" }}"
 data:
   config.json: |
     {{ .Values.vault.config | toJson }}

--- a/incubator/vault/templates/configmap.yaml
+++ b/incubator/vault/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     app: "{{ template "vault.name" . }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-    chart: "{{ template "vault.chart" }}"
+    chart: "{{ template "vault.chart" . }}"
 data:
   config.json: |
     {{ .Values.vault.config | toJson }}

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "vault.fullname" . }}
   labels:
     app: {{ template "vault.name" . }}
-    chart: {{ template "vault.chart" }}
+    chart: {{ template "vault.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 {{- if .Values.labels }}

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "vault.fullname" . }}
   labels:
     app: {{ template "vault.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "vault.chart" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 {{- if .Values.labels }}

--- a/incubator/vault/templates/ingress.yaml
+++ b/incubator/vault/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ template "vault.fullname" . }}
   labels:
     app: {{ template "vault.name" . }}
-    chart: "{{ template "vault.chart" }}"
+    chart: "{{ template "vault.chart" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.ingress.labels }}

--- a/incubator/vault/templates/ingress.yaml
+++ b/incubator/vault/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ template "vault.fullname" . }}
   labels:
     app: {{ template "vault.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    chart: "{{ template "vault.chart" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.ingress.labels }}

--- a/incubator/vault/templates/service.yaml
+++ b/incubator/vault/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "vault.fullname" . }}
   labels:
     app: {{ template "vault.name" . }}
-    chart: {{ template "vault.chart" }}
+    chart: {{ template "vault.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 {{- if .Values.service.annotations }}

--- a/incubator/vault/templates/service.yaml
+++ b/incubator/vault/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "vault.fullname" . }}
   labels:
     app: {{ template "vault.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "vault.chart" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 {{- if .Values.service.annotations }}

--- a/incubator/vault/templates/serviceaccount.yaml
+++ b/incubator/vault/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "vault.serviceAccountName" . }}
   labels:
     app: {{ template "vault.name" . }}
-    chart: "{{ template "vault.chart" }}"
+    chart: "{{ template "vault.chart" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- end -}}

--- a/incubator/vault/templates/serviceaccount.yaml
+++ b/incubator/vault/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "vault.serviceAccountName" . }}
   labels:
     app: {{ template "vault.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    chart: "{{ template "vault.chart" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- end -}}

--- a/incubator/vault/templates/serviceaccount.yaml
+++ b/incubator/vault/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "vault.serviceAccountName" . }}
   labels:
     app: {{ template "vault.name" . }}
-    chart: {{ template "vault.chart" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

When attempting to deploy Vault with the serviceaccount flag enabled, i.e. `serviceAccount.create=true`, helm is unable to interpolate `vault.chart` as a label because the function is not defined, returning a templating error: `template "vault.chart" not defined`

This PR fixes this by setting the label using a combination of the `.Chart.Name` and `.Chart.Version`. Thanks to https://github.com/helm/charts/pull/9429#pullrequestreview-231684380 for pointing this out!

#### Which issue this PR fixes
  - Related to PR https://github.com/helm/charts/pull/9429

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

Signed-off-by: Janusz Bialy <jbialy@gmail.com>