### PR TITLE
[stable/k8s-spot-termination-handler] Add priorityClass support 

### DIFF
--- a/stable/k8s-spot-termination-handler/Chart.yaml
+++ b/stable/k8s-spot-termination-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.13.0-1"
 description: The K8s Spot Termination handler handles draining AWS Spot Instances in response to termination requests.
 name: k8s-spot-termination-handler
-version: 1.1.0
+version: 1.2.0
 keywords:
   - spot
   - termination

--- a/stable/k8s-spot-termination-handler/README.md
+++ b/stable/k8s-spot-termination-handler/README.md
@@ -42,3 +42,4 @@ Parameter | Description | Default
 `nodeSelector` | node labels for pod assignment | `{}`
 `tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
 `affinity` | node/pod affinities (requires Kubernetes >=1.6) | `{}`
+`priorityClassName` | pod priorityClassName for pod | `{}`

--- a/stable/k8s-spot-termination-handler/README.md
+++ b/stable/k8s-spot-termination-handler/README.md
@@ -42,4 +42,4 @@ Parameter | Description | Default
 `nodeSelector` | node labels for pod assignment | `{}`
 `tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
 `affinity` | node/pod affinities (requires Kubernetes >=1.6) | `{}`
-`priorityClassName` | pod priorityClassName for pod | `{}`
+`priorityClassName` | pod priorityClassName for pod. | ``

--- a/stable/k8s-spot-termination-handler/templates/daemonset.yaml
+++ b/stable/k8s-spot-termination-handler/templates/daemonset.yaml
@@ -51,6 +51,9 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}
+      {{- if .Values.priorityClassName }} 
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}

--- a/stable/k8s-spot-termination-handler/templates/daemonset.yaml
+++ b/stable/k8s-spot-termination-handler/templates/daemonset.yaml
@@ -51,9 +51,6 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}
-      {{- if .Values.priorityClassName }} 
-      priorityClassName: {{ .Values.priorityClassName }}
-      {{- end }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
@@ -64,4 +61,7 @@ spec:
     {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- if .Values.priorityClassName }} 
+      priorityClassName: {{ .Values.priorityClassName }}
     {{- end }}

--- a/stable/k8s-spot-termination-handler/values.yaml
+++ b/stable/k8s-spot-termination-handler/values.yaml
@@ -48,7 +48,7 @@ resources: {}
   #   memory: 32Mi
 
 # Add a priority class to the deamonset
-priorityClassName : "system-node-critical"
+priorityClassName: "system-node-critical"
 
 nodeSelector: {}
   # "node-role.kubernetes.io/spot-worker": "true"

--- a/stable/k8s-spot-termination-handler/values.yaml
+++ b/stable/k8s-spot-termination-handler/values.yaml
@@ -48,7 +48,7 @@ resources: {}
   #   memory: 32Mi
 
 # Add a priority class to the deamonset
-priorityClassName: "system-node-critical"
+priorityClassName: ""
 
 nodeSelector: {}
   # "node-role.kubernetes.io/spot-worker": "true"

--- a/stable/k8s-spot-termination-handler/values.yaml
+++ b/stable/k8s-spot-termination-handler/values.yaml
@@ -47,6 +47,9 @@ resources: {}
   #   cpu: 10m
   #   memory: 32Mi
 
+# Add a priority class to the deamonset
+priorityClassName : "system-node-critical"
+
 nodeSelector: {}
   # "node-role.kubernetes.io/spot-worker": "true"
 


### PR DESCRIPTION
 What this PR does / why we need it:

This PR adds the possibility of specifying a priorityClassName for the pod.  
With this in place we can guarantee that the DS will be the one of the first to be scheduled , and guarantee that will be always have resources for it .

