### PR TITLE
[stable/jenkins] Add existingSecret for Jenkins backup AWS credentials

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 1.1.9
+version: 1.1.10
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based
@@ -19,4 +19,6 @@ maintainers:
   email: maorfr@gmail.com
 - name: torstenwalter
   email: mail@torstenwalter.de
+- name: hajowieland
+  email: mail@wieland.tech
 icon: https://wiki.jenkins-ci.org/download/attachments/2916393/logo.png

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -344,17 +344,21 @@ Adds a backup CronJob for jenkins, along with required RBAC resources.
 
 ### Backup Values
 
-| Parameter                   | Description                                | Default                           |
-| --------------------------- | ------------------------------------------ | --------------------------------- |
-| `backup.enabled`            | Enable the use of a backup CronJob         | `false`                           |
-| `backup.schedule`           | Schedule to run jobs                       | `0 2 * * *`                       |
-| `backup.annotations`        | Backup pod annotations                     | iam.amazonaws.com/role: `jenkins` |
-| `backup.image.repo`         | Backup image repository                    | `nuvo/kube-tasks`                 |
-| `backup.image.tag`          | Backup image tag                           | `0.1.2`                           |
-| `backup.extraArgs`          | Additional arguments for kube-tasks        | `[]`                              |
-| `backup.env`                | Backup environment variables               | AWS_REGION: `us-east-1`           |
-| `backup.resources`          | Backup CPU/Memory resource requests/limits | Memory: `1Gi`, CPU: `1`           |
-| `backup.destination`        | Destination to store backup artifacts      | `s3://nuvo-jenkins-data/backup`   |
+| Parameter                              | Description                                            | Default                           |
+| -------------------------------------- | ------------------------------------------------------ | --------------------------------- |
+| `backup.enabled`                       | Enable the use of a backup CronJob                     | `false`                           |
+| `backup.schedule`                      | Schedule to run jobs                                   | `0 2 * * *`                       |
+| `backup.annotations`                   | Backup pod annotations                                 | iam.amazonaws.com/role: `jenkins` |
+| `backup.image.repo`                    | Backup image repository                                | `nuvo/kube-tasks`                 |
+| `backup.image.tag`                     | Backup image tag                                       | `0.1.2`                           |
+| `backup.extraArgs`                     | Additional arguments for kube-tasks                    | `[]`                              |
+| `backup.existingSecret`                | Environment variables to add to the cronjob container  | {}                                |
+| `backup.existingSecret.*`              | Specify the secret name containing the AWS credentials | `jenkinsaws`                      |
+| `backup.existingSecret.*.awsaccesskey` | `secretKeyRef.key` used for `AWS_ACCESS_KEY_ID`        | `jenkins_aws_access_key`          |
+| `backup.existingSecret.*.awssecretkey` | `secretKeyRef.key` used for `AWS_SECRET_ACCESS_KEY`    | `jenkins_aws_secret_key`          |
+| `backup.env`                           | Backup environment variables                           | AWS_REGION: `us-east-1`           |
+| `backup.resources`                     | Backup CPU/Memory resource requests/limits             | Memory: `1Gi`, CPU: `1`           |
+| `backup.destination`                   | Destination to store backup artifacts                  | `s3://nuvo-jenkins-data/backup`   |
 
 ### Restore from backup
 

--- a/stable/jenkins/templates/jenkins-backup-cronjob.yaml
+++ b/stable/jenkins/templates/jenkins-backup-cronjob.yaml
@@ -45,6 +45,20 @@ spec:
             env:
 {{ toYaml . | indent 12 }}
             {{- end }}
+            {{- if .Values.backup.existingSecret }}
+            {{- range $key,$value := .Values.backup.existingSecret }}
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $key }}
+                  key: {{ $value.awsaccesskeyid | quote }}
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $key }}
+                  key: {{ $value.awssecretaccesskey | quote}}
+            {{- end }}
+            {{- end }}
           {{- with .Values.backup.resources }}
             resources:
 {{ toYaml . | indent 14 }}

--- a/stable/jenkins/templates/jenkins-backup-cronjob.yaml
+++ b/stable/jenkins/templates/jenkins-backup-cronjob.yaml
@@ -51,12 +51,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ $key }}
-                  key: {{ $value.awsaccesskeyid | quote }}
+                  key: {{ $value.awsaccesskey | quote }}
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ $key }}
-                  key: {{ $value.awssecretaccesskey | quote}}
+                  key: {{ $value.awssecretkey | quote}}
             {{- end }}
             {{- end }}
           {{- with .Values.backup.resources }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -428,6 +428,14 @@ backup:
   # Additional arguments for kube-tasks
   # Ref: https://github.com/nuvo/kube-tasks#simple-backup
   extraArgs: []
+  # Add existingSecret for AWS credentials
+  existingSecret:
+  ## Example for using an existing secret
+   # mysecretname:
+  ## Use this key for AWS access key ID
+     # awsaccesskeyid: jenkins_aws_access_key
+  ## Use this key for AWS secret access key
+     # awssecretaccesskey: jenkins_aws_secret_key
   # Add additional environment variables
   env:
   # Example environment variable required for AWS credentials chain

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -429,13 +429,13 @@ backup:
   # Ref: https://github.com/nuvo/kube-tasks#simple-backup
   extraArgs: []
   # Add existingSecret for AWS credentials
-  existingSecret:
+  existingSecret: {}
   ## Example for using an existing secret
-   # mysecretname:
+   # jenkinsaws:
   ## Use this key for AWS access key ID
-     # awsaccesskeyid: jenkins_aws_access_key
+     # awsaccesskey: jenkins_aws_access_key
   ## Use this key for AWS secret access key
-     # awssecretaccesskey: jenkins_aws_secret_key
+     # awssecretkey: jenkins_aws_secret_key
   # Add additional environment variables
   env:
   # Example environment variable required for AWS credentials chain


### PR DESCRIPTION
#### What this PR does / why we need it:

Add option to allow specifying an existing Kubernetes secret for AWS credentials used by the Jenkins backup container.


#### Special notes for your reviewer:

#### Checklist

- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [x] Variables are documented in the README.md
