### PR TITLE
[stable/nginx] add simple nginx chart

### DIFF
--- a/stable/nginx/.helmignore
+++ b/stable/nginx/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/nginx/Chart.yaml
+++ b/stable/nginx/Chart.yaml
@@ -1,0 +1,15 @@
+---
+name: nginx
+version: 0.1.0
+appVersion: 1.15.12
+home: https://hub.docker.com/_/nginx
+description: A Helm chart for NGINX
+keywords:
+  - nginx
+  - server
+sources:
+  - https://github.com/nginxinc/docker-nginx
+  - https://github.com/nginx/nginx
+maintainers:
+  - name: joejulian
+    email: me@joejulian.name

--- a/stable/nginx/README.md
+++ b/stable/nginx/README.md
@@ -1,0 +1,100 @@
+# nginx
+
+## Introduction
+
+This chart is for deploying nginx with static content.
+
+## Prerequisites
+
+Kubernetes >= 1.8.x
+
+Working `helm` and `tiller`.
+
+_Note:_ Tiller may need a service account and role binding if RBAC is enabled in your cluster.
+
+## Installing nginx
+
+```bash
+helm install nginx --name hello-world
+```
+
+This command deploys a simple "Hello World" static web site.
+
+```text
+NAME:   hello-world
+LAST DEPLOYED: Fri Apr 26 07:20:55 2019
+NAMESPACE: default
+STATUS: DEPLOYED
+
+RESOURCES:
+==> v1/ConfigMap
+NAME                       DATA  AGE
+hello-world-nginx-content  1     1s
+
+==> v1/Deployment
+NAME               READY  UP-TO-DATE  AVAILABLE  AGE
+hello-world-nginx  0/1    1           0          1s
+
+==> v1/Pod(related)
+NAME                                READY  STATUS             RESTARTS  AGE
+hello-world-nginx-7b45f684cc-npl89  0/1    ContainerCreating  0         1s
+
+==> v1/Role
+NAME               AGE
+hello-world-nginx  1s
+
+==> v1/RoleBinding
+NAME               AGE
+hello-world-nginx  1s
+
+==> v1/Service
+NAME               TYPE       CLUSTER-IP     EXTERNAL-IP  PORT(S)         AGE
+hello-world-nginx  ClusterIP  10.103.29.216  <none>       80/TCP,443/TCP  1s
+
+==> v1/ServiceAccount
+NAME               SECRETS  AGE
+hello-world-nginx  1        1s
+
+
+NOTES:
+1. Get the application URL by running these commands:
+  export POD_NAME=$(kubectl get pods --namespace default -l "app.kubernetes.io/name=nginx,app.kubernetes.io/instance=hello-world" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+```
+
+Copy/paste and execute the commands shown and see the website contents:
+
+```bash
+$ curl http://localhost:8080
+<html><body><h1>Hello World!</h1></body></html>
+```
+
+## Uninstalling
+
+To uninstall/delete the `hello-world` deployment:
+
+```bash
+helm delete hello-world --purge
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+Refer to [values.yaml](values.yaml) for the full run-down on defaults. 
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name hello-world \
+    --set deployment.replicaCount 3
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name hello-world -f values.yaml stable/nginx
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/nginx/README.md
+++ b/stable/nginx/README.md
@@ -82,7 +82,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-Refer to [values.yaml](values.yaml) for the full run-down on defaults. 
+Refer to [values.yaml](values.yaml) for the full run-down on defaults.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -94,7 +94,7 @@ $ helm install --name hello-world \
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name hello-world -f values.yaml stable/nginx
+helm install --name hello-world -f values.yaml stable/nginx
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/nginx/templates/NOTES.txt
+++ b/stable/nginx/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "nginx.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "nginx.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "nginx.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "nginx.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/stable/nginx/templates/_helpers.tpl
+++ b/stable/nginx/templates/_helpers.tpl
@@ -1,0 +1,65 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nginx.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nginx.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nginx.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a content configmap name
+*/}}
+{{- define "nginx.content" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 55 | trimSuffix "-" | printf "%s-content" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 55 | trimSuffix "-" | printf "%s-content" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 55 | trimSuffix "-" | printf "%s-content" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a configuration configmap name
+*/}}
+{{- define "nginx.config" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 56 | trimSuffix "-" | printf "%s-config" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 56 | trimSuffix "-" | printf "%s-config" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 56 | trimSuffix "-" | printf "%s-config" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+

--- a/stable/nginx/templates/_helpers.tpl
+++ b/stable/nginx/templates/_helpers.tpl
@@ -63,3 +63,13 @@ Create a configuration configmap name
 {{- end -}}
 {{- end -}}
 
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "nginx.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "nginx.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/nginx/templates/configmap.yaml
+++ b/stable/nginx/templates/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nginx.content" . }}
+data:
+{{- if .Values.content.fromDir }}
+{{- (.Files.Glob ".Values.content.fromDir").AsConfig | nindent 2 }}
+{{- end }}
+{{- if .Values.content.data }}
+{{- range $key, $value := .Values.content.data}}
+  {{ $key }}: "{{ $value }}"
+{{- end }}
+{{- end }}
+

--- a/stable/nginx/templates/configmap.yaml
+++ b/stable/nginx/templates/configmap.yaml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "nginx.content" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nginx.name" . }}
+    helm.sh/chart: {{ include "nginx.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
 {{- if .Values.content.fromDir }}
 {{- (.Files.Glob ".Values.content.fromDir").AsConfig | nindent 2 }}

--- a/stable/nginx/templates/deployment.yaml
+++ b/stable/nginx/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
     {{- if .Values.deployment.initContainers }}
       initContainers:
-{{ toYaml .Values.deployment.initControllers | indent 8 }}
+        {{- toYaml .Values.deployment.initControllers | nindent 8 }}
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/stable/nginx/templates/deployment.yaml
+++ b/stable/nginx/templates/deployment.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "nginx.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nginx.name" . }}
+    helm.sh/chart: {{ include "nginx.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.deployment.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "nginx.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "nginx.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+    {{- if .Values.deployment.initContainers }}
+      initContainers:
+{{ toYaml .Values.deployment.initControllers | indent 8 }}
+    {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}"
+          imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
+          args:
+          {{- range $key, $value := .Values.deployment.extraArgs }}
+            - --{{ $key }}={{ $value }}
+          {{- end }}
+          env:
+          {{- range $key, $value := .Values.deployment.extraEnvs }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+          {{- end }}
+          ports:
+          {{- range .Values.service.httpPorts }}
+            - name: "{{ .port }}-http"
+              containerPort: {{ .port }}
+              protocol: TCP
+          {{- end }}
+          {{- range .Values.service.httpsPorts }}
+            - name: "{{ .port }}-https"
+              containerPort: {{ .port }}
+              protocol: TCP
+          {{- end }}
+          {{- with (.Values.service.httpPorts | first) }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .port }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .port }}
+          {{- end }}
+          volumeMounts:
+            - name: content
+              mountPath: /usr/share/nginx/html
+          {{- if .Values.config }}
+            - name: config
+              mountPath: /etc/nginx
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: content
+          configMap:
+            name: {{ include "nginx.content" . }}
+      {{- if .Values.config }}
+        - name: config
+          configMap:
+            name: {{ include "nginx.config" . }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/stable/nginx/templates/ingress.yaml
+++ b/stable/nginx/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "nginx.fullname" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "nginx.name" . }}
+    helm.sh/chart: {{ include "nginx.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/stable/nginx/templates/rbac.yaml
+++ b/stable/nginx/templates/rbac.yaml
@@ -1,18 +1,25 @@
-{{- if .Values.rbac.enabled }}
+{{- if .Values.rbac.create }}
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: {{ template "nginx.fullname" . }}
+  name: {{ template "nginx.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "nginx.name" . }}
+    helm.sh/chart: {{ include "nginx.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 ---
-kind: Role 
-{{- if semverCompare "^1.8-0" .Capabilities.KubeVersion.GitVersion }}
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
-{{- else }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-{{- end }}
 metadata:
   name: {{ template "nginx.fullname" . }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "nginx.name" . }}
+    helm.sh/chart: {{ include "nginx.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 rules:
   - apiGroups:
       - ""
@@ -27,19 +34,21 @@ rules:
       - watch
 ---
 kind: RoleBinding
-{{- if semverCompare "^1.8-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: rbac.authorization.k8s.io/v1
-{{- else }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-{{- end }}
 metadata:
   name: {{ template "nginx.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "nginx.name" . }}
+    helm.sh/chart: {{ include "nginx.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ template "nginx.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "nginx.fullname" . }}
+  name: {{ template "nginx.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/stable/nginx/templates/rbac.yaml
+++ b/stable/nginx/templates/rbac.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.rbac.enabled }}
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{ template "nginx.fullname" . }}
+---
+kind: Role 
+{{- if semverCompare "^1.8-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
+metadata:
+  name: {{ template "nginx.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - configmaps
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+---
+kind: RoleBinding
+{{- if semverCompare "^1.8-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
+metadata:
+  name: {{ template "nginx.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "nginx.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "nginx.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/stable/nginx/templates/service.yaml
+++ b/stable/nginx/templates/service.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nginx.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nginx.name" . }}
+    helm.sh/chart: {{ include "nginx.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  {{- range .Values.service.httpPorts }}
+    - name: "{{ .port }}-http"
+      port: {{ .port }}
+      protocol: TCP
+      targetPort: "{{ .port }}-http"
+      {{- if (not (empty .nodePort)) }}
+      nodePort: {{ .nodePort }}
+      {{- end }}
+  {{- end }}
+  {{- range .Values.service.httpsPorts }}
+    - name: "{{ .port }}-https"
+      port: {{ .port }}
+      protocol: TCP
+      targetPort: "{{ .port }}-https"
+      {{- if (not (empty .nodePort)) }}
+      nodePort: {{ .nodePort }}
+      {{- end }}
+  {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ include "nginx.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/nginx/templates/tests/test-connection.yaml
+++ b/stable/nginx/templates/tests/test-connection.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "nginx.fullname" . }}-test-connection"
+  labels:
+    app.kubernetes.io/name: {{ include "nginx.name" . }}
+    helm.sh/chart: {{ include "nginx.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ include "nginx.fullname" . }}:{{ (.Values.service.httpPorts | first).port }}']
+  restartPolicy: Never

--- a/stable/nginx/values.yaml
+++ b/stable/nginx/values.yaml
@@ -1,10 +1,17 @@
 # Default values for nginx.
 # This is a YAML-formatted file.
 
-## enable to create a service account, role, and rolebinding with least required
+## create a service account, role, and rolebinding with least required
 ## permissions
 rbac:
-  enabled: true
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
 
 deployment:
   ## Number of pods in the replicaSet. Increate as needed to handle SLA and load requirements

--- a/stable/nginx/values.yaml
+++ b/stable/nginx/values.yaml
@@ -1,0 +1,117 @@
+# Default values for nginx.
+# This is a YAML-formatted file.
+
+## enable to create a service account, role, and rolebinding with least required
+## permissions
+rbac:
+  enabled: true
+
+deployment:
+  ## Number of pods in the replicaSet. Increate as needed to handle SLA and load requirements
+  replicaCount: 1
+
+  ## The image source. Default is to get the official nginx container image from docker hub.
+  image:
+    repository: nginx
+    tag: "1.15.12"
+    pullPolicy: IfNotPresent
+
+  ## Additional command line arguments to pass to nginx (if any)
+  extraArgs: {}
+
+  ## Additional environment variables to set (if any)
+  extraEnvs: []
+
+  ## Additional containers that can initialize the pod. See https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+  ## These might be used to pull content from a git repo or build content (eg. hugo) prior to starting the actual
+  ## nginx container.
+  initContainers: []
+
+
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+  resources: {}
+
+  ## select specific nodes to run on. https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  nodeSelector: {}
+
+  ## tolerate node taints. https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
+
+  ## assign pod affinities. https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+
+## select a specific name/fullname for generated primitives instead of using the generated name
+nameOverride: ""
+fullnameOverride: ""
+
+
+service:
+  ## service types can be ClusterIP, NodePort, or LoadBalancer
+  type: ClusterIP
+  httpPorts:
+    - port: 80
+      ## nodePort is a port in a range specific to the cluster configuration, but defaults
+      ## between 30000-32767. Select a specific one to keep it static, otherwise a different
+      ## port is selected with each deployment.
+      # nodePort:
+  httpsPorts:
+    - port: 443
+      # nodePort:
+  ## set arbitrary annotations and labels on this service
+  annotations: {}
+  labels: {}
+
+ingress:
+  ## enable if you have an ingress controller to allow access from outside the cluster
+  enabled: false
+  ## annotations on ingress records can be set to modify the behavior of the ingress
+  ## controller. See your ingress controller documentation for details.
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+
+  tls: []
+  ## replace the closed braces with a list similar to the example below to enable
+  ## tls
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+## If defined, this will be used to create a ConfigMap that will replace /etc/nginx
+## so the configuration will need to be complete.
+##
+## The contents of this map will replace /etc/nginx
+config: {}
+  # nginx.conf |
+    # worker_processes 1;
+    # daemon off;
+    # events {
+    #     worker_connections 1024;
+    # }
+    # http {
+    #     server {
+    #         listen 80;
+    #         location / {
+    #             root /usr/share/nginx/html;
+    #         }
+    #     }
+    # }
+
+## This will create a ConfigMap that will be mounted at /usr/share/nginx/html
+content:
+  data:
+    index.html: "<html><body><h1>Hello World!</h1></body></html>"
+  ## alternatively, _instead_ of `data` you can use this to pull content from a directory
+  # fromDir: mycontentdir


### PR DESCRIPTION
Add an nginx chart for hosting simple static content

Signed-off-by: Joe Julian <me@joejulian.name>

#### What this PR does / why we need it:
There are no simple small charts for adding static web sites to a cluster. This adds one.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
  - I documented them in the values file and referenced that documentation in the readme
