### PR TITLE
[stable/coredns] Adding the ability to add a pod priority class. 

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 name: coredns
-version: 1.5.0
-appVersion: 1.5.0
+version: 1.5.1
+appVersion: 1.5.1
 description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services
 keywords:
 - coredns

--- a/stable/coredns/templates/deployment.yaml
+++ b/stable/coredns/templates/deployment.yaml
@@ -52,6 +52,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
       containers:
       - name: "coredns"
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -45,6 +45,9 @@ rbac:
 # isClusterService specifies whether chart should be deployed as cluster-service or normal k8s app.
 isClusterService: true
 
+# Optional priority class to be used for the coredns pods
+priorityClassName: ""
+
 servers:
 - zones:
   - zone: .

--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.16.0
+version: 0.17.0
 appVersion: 5.7.14
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.

--- a/stable/mysql/README.md
+++ b/stable/mysql/README.md
@@ -46,6 +46,7 @@ The following table lists the configurable parameters of the MySQL chart and the
 
 | Parameter                                    | Description                                                                                  | Default                                              |
 | -------------------------------------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `initContainer.resources`                    | initContainer resource requests/limits                                                         | Memory: `10Mi`, CPU: `10m`                         |
 | `image`                                      | `mysql` image repository.                                                                    | `mysql`                                              |
 | `imageTag`                                   | `mysql` image tag.                                                                           | `5.7.14`                                             |
 | `busybox.image`                                    | `busybox` image repository.                                                                    | `busybox`                                            |

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -31,6 +31,8 @@ spec:
       - name: "remove-lost-found"
         image: "{{ .Values.busybox.image}}:{{ .Values.busybox.tag }}"
         imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+        resources:
+{{ toYaml .Values.initContainer.resources | indent 10 }}
         command:  ["rm", "-fr", "/var/lib/mysql/lost+found"]
         volumeMounts:
         - name: data

--- a/stable/mysql/values.yaml
+++ b/stable/mysql/values.yaml
@@ -177,3 +177,11 @@ podLabels: {}
 
 ## Set pod priorityClassName
 # priorityClassName: {}
+
+
+## Init container resources defaults
+initContainer:
+  resources:
+    requests:
+      memory: 10Mi
+      cpu: 10m


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows for a pod priority class to be added to the CoreDNS pods. 

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
