### PR TITLE
[stable/prometheus]: Support disabling the Prometheus server

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 8.15.1
+version: 9.0.0
 appVersion: 2.11.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -46,6 +46,10 @@ Users of this chart will need to update their alerting rules to the new format b
 
 ## Upgrading from previous chart versions.
 
+Version 9.0 adds a new option to enable or disable the Prometheus Server.
+This supports the use case of running a Prometheus server in one k8s cluster and scraping exporters in another cluster while using the same chart for each deployment.
+To install the server `server.enabled` must be set to `true`.
+
 As of version 5.0, this chart uses Prometheus 2.x. This version of prometheus introduces a new data format and is not compatible with prometheus 1.x. It is recommended to install this as a new release, as updating existing releases will not work. See the [prometheus docs](https://prometheus.io/docs/prometheus/latest/migration/#storage) for instructions on retaining your old data.
 
 ### Example migration
@@ -235,6 +239,7 @@ Parameter | Description | Default
 `pushgateway.service.servicePort` | pushgateway service port | `9091`
 `pushgateway.service.type` | type of pushgateway service to create | `ClusterIP`
 `rbac.create` | If true, create & use RBAC resources | `true`
+`server.enabled` | If false, Prometheus server will not be created | `true`
 `server.name` | Prometheus server container name | `server`
 `server.image.repository` | Prometheus server container image repository | `prom/prometheus`
 `server.image.tag` | Prometheus server container image tag | `v2.11.1`

--- a/stable/prometheus/templates/NOTES.txt
+++ b/stable/prometheus/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled -}}
 The Prometheus server can be accessed via port {{ .Values.server.service.servicePort }} on the following DNS name from within your cluster:
 {{ template "prometheus.server.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
@@ -30,6 +31,7 @@ Get the Prometheus server URL by running these commands in the same shell:
 ######   WARNING: Persistence is disabled!!! You will lose your data when   #####
 ######            the Server pod is terminated.                             #####
 #################################################################################
+{{- end }}
 {{- end }}
 
 {{ if .Values.alertmanager.enabled }}

--- a/stable/prometheus/templates/server-clusterrole.yaml
+++ b/stable/prometheus/templates/server-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled -}}
 {{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -33,4 +34,5 @@ rules:
       - "/metrics"
     verbs:
       - get
+{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/server-clusterrolebinding.yaml
+++ b/stable/prometheus/templates/server-clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled -}}
 {{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -13,4 +14,5 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ template "prometheus.server.fullname" . }}
+{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/server-configmap.yaml
+++ b/stable/prometheus/templates/server-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled -}}
 {{- if (empty .Values.server.configMapOverrideName) -}}
 apiVersion: v1
 kind: ConfigMap
@@ -42,6 +43,7 @@ data:
         - source_labels: [__meta_kubernetes_pod_container_port_number]
           regex:
           action: drop
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled -}}
 {{- if not .Values.server.statefulSet.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -202,4 +203,5 @@ spec:
           configMap:
             name: {{ .configMap }}
       {{- end }}
+{{- end -}}
 {{- end -}}

--- a/stable/prometheus/templates/server-ingress.yaml
+++ b/stable/prometheus/templates/server-ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled -}}
 {{- if .Values.server.ingress.enabled -}}
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := include "prometheus.server.fullname" . }}
@@ -31,4 +32,5 @@ spec:
   tls:
 {{ toYaml .Values.server.ingress.tls | indent 4 }}
   {{- end -}}
+{{- end -}}
 {{- end -}}

--- a/stable/prometheus/templates/server-networkpolicy.yaml
+++ b/stable/prometheus/templates/server-networkpolicy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled -}}
 {{- if .Values.networkPolicy.enabled }}
 apiVersion: {{ template "prometheus.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
@@ -12,4 +13,5 @@ spec:
   ingress:
     - ports:
       - port: 9090
+{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/server-pvc.yaml
+++ b/stable/prometheus/templates/server-pvc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled -}}
 {{- if not .Values.server.statefulSet.enabled -}}
 {{- if .Values.server.persistentVolume.enabled -}}
 {{- if not .Values.server.persistentVolume.existingClaim -}}
@@ -24,6 +25,7 @@ spec:
   resources:
     requests:
       storage: "{{ .Values.server.persistentVolume.size }}"
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stable/prometheus/templates/server-service-headless.yaml
+++ b/stable/prometheus/templates/server-service-headless.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled -}}
 {{- if .Values.server.statefulSet.enabled -}}
 apiVersion: v1
 kind: Service
@@ -21,4 +22,5 @@ spec:
       targetPort: 9090
   selector:
     {{- include "prometheus.server.matchLabels" . | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/stable/prometheus/templates/server-service.yaml
+++ b/stable/prometheus/templates/server-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -39,3 +40,4 @@ spec:
   selector:
     {{- include "prometheus.server.matchLabels" . | nindent 4 }}
   type: "{{ .Values.server.service.type }}"
+{{- end -}}

--- a/stable/prometheus/templates/server-serviceaccount.yaml
+++ b/stable/prometheus/templates/server-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled -}}
 {{- if .Values.serviceAccounts.server.create }}
 apiVersion: v1
 kind: ServiceAccount
@@ -5,4 +6,5 @@ metadata:
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.serviceAccountName.server" . }}
+{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/server-statefulset.yaml
+++ b/stable/prometheus/templates/server-statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled -}}
 {{- if .Values.server.statefulSet.enabled -}}
 apiVersion: apps/v1
 kind: StatefulSet
@@ -214,5 +215,6 @@ spec:
 {{- else }}
         - name: storage-volume
           emptyDir: {}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -505,6 +505,7 @@ nodeExporter:
 server:
   ## Prometheus server container name
   ##
+  enabled: true
   name: server
   sidecarContainers:
 


### PR DESCRIPTION
* This supports the use case of running a Prometheus server in one
cluster and scraping exporters in another cluster while using the same
helm chart (with different values.yaml) for each deployment.

Signed-off-by: Nicholas Capo <nicholas.capo@gmail.com>

For testing I created a `values.yaml` with everything disabled:
```
$ helm upgrade --install monitoring ./stable/prometheus --values test-values.yaml
Release "monitoring" does not exist. Installing it now.
Error: release monitoring failed: no objects visited
```
I was then able to enable just the components I wanted.

@mgoodness @gianrubio 

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
