### PR TITLE
[stable/ark] Allow the use of a specific image digest

### DIFF
--- a/stable/ark/Chart.yaml
+++ b/stable/ark/Chart.yaml
@@ -6,7 +6,7 @@ appVersion: 0.10.2
 deprecated: true
 description: DEPRECATED A Helm chart for ark
 name: ark
-version: 4.2.2
+version: 4.2.3
 home: https://github.com/heptio/ark
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/stable/ark/README.md
+++ b/stable/ark/README.md
@@ -57,6 +57,7 @@ Parameter | Description | Default
 --- | --- | ---
 `image.repository` | Image repository | `gcr.io/heptio-images/ark`
 `image.tag` | Image tag | `v0.9.1`
+`image.digest` | Image digest, takes precedence over tag if defined | `{}`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `podAnnotations` | Annotations for the Ark server pod | `{}`
 `rbac.create` | If true, create and use RBAC resources | `true`

--- a/stable/ark/templates/restic-daemonset.yaml
+++ b/stable/ark/templates/restic-daemonset.yaml
@@ -40,7 +40,11 @@ spec:
           emptyDir: {}
       containers:
         - name: ark
+          {{- if .Values.image.digest }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+          {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /ark

--- a/stable/ark/values.yaml
+++ b/stable/ark/values.yaml
@@ -5,7 +5,7 @@ image:
   ## Specific image digest to use in place of a tag. Digest takes precedence over tag if it is defined.
   ## ref: https://kubernetes.io/docs/concepts/configuration/overview/#container-images
   ##
-  # image.digest: sha256:4b39fca2ae9bcbac3d74a2a28eb5c0b5630ed982684bd911e929ef2b6a718cab
+  # digest: sha256:4b39fca2ae9bcbac3d74a2a28eb5c0b5630ed982684bd911e929ef2b6a718cab
 
 # Only kube2iam/kiam: change the AWS_ACCOUNT_ID and HEPTIO_ARK_ROLE_NAME
 podAnnotations: {}

--- a/stable/ark/values.yaml
+++ b/stable/ark/values.yaml
@@ -2,6 +2,10 @@ image:
   repository: gcr.io/heptio-images/ark
   tag: v0.10.2
   pullPolicy: IfNotPresent
+  ## Specific image digest to use in place of a tag. Digest takes precedence over tag if it is defined.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/overview/#container-images
+  ##
+  # image.digest: sha256:4b39fca2ae9bcbac3d74a2a28eb5c0b5630ed982684bd911e929ef2b6a718cab
 
 # Only kube2iam/kiam: change the AWS_ACCOUNT_ID and HEPTIO_ARK_ROLE_NAME
 podAnnotations: {}


### PR DESCRIPTION
What this PR does / why we need it:

Using a digest ensures the image being pulled has not been compromised and allows testing release against images without having to tag them.

Special notes for your reviewer:

This pr is closely based on #8910

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
