### PR TITLE
[incubator/buzzfeed-sso] add ingress.extraLabels, optional tls, extraEnv, and fix cluster variable

### DIFF
--- a/incubator/buzzfeed-sso/Chart.yaml
+++ b/incubator/buzzfeed-sso/Chart.yaml
@@ -1,12 +1,8 @@
 apiVersion: v1
 description: Single sign-on for your Kubernetes services using Google OAuth
 name: buzzfeed-sso
-<<<<<<< HEAD
 version: 0.0.3
-=======
-version: 0.0.2
->>>>>>> [buzzfeed-sso] add ingress.extraLabels
-appVersion: 1.1.0
+appVersion: 1.2.0
 home: https://github.com/buzzfeed/sso
 sources:
   - https://hub.docker.com/r/buzzfeed/sso/

--- a/incubator/buzzfeed-sso/Chart.yaml
+++ b/incubator/buzzfeed-sso/Chart.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 description: Single sign-on for your Kubernetes services using Google OAuth
 name: buzzfeed-sso
+<<<<<<< HEAD
 version: 0.0.3
+=======
+version: 0.0.2
+>>>>>>> [buzzfeed-sso] add ingress.extraLabels
 appVersion: 1.1.0
 home: https://github.com/buzzfeed/sso
 sources:

--- a/incubator/buzzfeed-sso/Chart.yaml
+++ b/incubator/buzzfeed-sso/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Single sign-on for your Kubernetes services using Google OAuth
 name: buzzfeed-sso
-version: 0.0.3
+version: 0.0.4
 appVersion: 1.2.0
 home: https://github.com/buzzfeed/sso
 sources:

--- a/incubator/buzzfeed-sso/README.md
+++ b/incubator/buzzfeed-sso/README.md
@@ -85,6 +85,7 @@ Parameter | Description | Default
 `image.tag` | container image tag | `v1.0.0`
 `image.pullPolicy` | container image pull policy | `IfNotPresent`
 `ingress.annotations` | ingress load balancer annotations | `{}`
+`ingress.extraLabels` | extra ingress labels | `{}`
 `ingress.hosts` | proxied hosts | `[]`
 `ingress.tls` | tls certificates for the proxied hosts | `[]`
 `upstreams` | configuration of services that use sso | `[]`

--- a/incubator/buzzfeed-sso/README.md
+++ b/incubator/buzzfeed-sso/README.md
@@ -65,7 +65,7 @@ Parameter | Description | Default
 `auth.service.type` | type of auth service to create | `ClusterIP`
 `auth.service.port` | port for the http auth service | `80`
 `auth.secret` | secrets to be generated randomly with `openssl rand -base64 32 | head -c 32`. | REQUIRED if `auth.customSecret` is not set
-`auth.tls` | tls configuration for central sso auth ingress. | `{ secretName: "sso-auth-tls-secret" }`
+`auth.tls` | tls configuration for central sso auth ingress. | `{}`
 `auth.customSecret` | the secret key to reuse (avoids secret creation via helm) | REQUIRED if `auth.secret` is not set
 `proxy.annotations` | extra annotations for proxy pods | `{}`
 `proxy.providerUrlInternal` | url for split dns deployments |
@@ -84,7 +84,7 @@ Parameter | Description | Default
 `provider.google.secret` | the Google OAuth secrets | REQUIRED if `provider.google.customSecret` is not set
 `provider.google.customSecret` | the secret key to reuse instead of creating it via helm | REQUIRED if `provider.google.secret` is not set
 `image.repository` | container image repository | `buzzfeed/sso`
-`image.tag` | container image tag | `v1.0.0`
+`image.tag` | container image tag | `v1.2.0`
 `image.pullPolicy` | container image pull policy | `IfNotPresent`
 `ingress.annotations` | ingress load balancer annotations | `{}`
 `ingress.extraLabels` | extra ingress labels | `{}`

--- a/incubator/buzzfeed-sso/README.md
+++ b/incubator/buzzfeed-sso/README.md
@@ -53,8 +53,10 @@ Parameter | Description | Default
 `namespace` | namespace to use | `default`
 `emailDomain` | the sso email domain for authentication | REQUIRED
 `rootDomain` | the parent domain used for protecting your backends | REQUIRED
+`cluster` | the cluster name for SSO | `dev`
 `auth.annotations` | extra annotations for auth pods | `{}`
 `auth.domain` | the auth domain used for OAuth callbacks | REQUIRED
+`auth.extraEnv` | extra auth env vars | `[]`
 `auth.replicaCount` | desired number of auth pods | `1`
 `auth.resources` | resource limits and requests for auth pods | `{ limits: { memory: "256Mi", cpu: "200m" }}`
 `auth.nodeSelector` | node selector logic for auth pods | `{}`
@@ -67,7 +69,7 @@ Parameter | Description | Default
 `auth.customSecret` | the secret key to reuse (avoids secret creation via helm) | REQUIRED if `auth.secret` is not set
 `proxy.annotations` | extra annotations for proxy pods | `{}`
 `proxy.providerUrlInternal` | url for split dns deployments |
-`proxy.cluster` | the cluster name for SSO | `dev`
+`proxy.extraEnv` | extra proxy env vars | `[]`
 `proxy.replicaCount` | desired number of proxy pods | `1`
 `proxy.resources` | resource limits and requests for proxy pods | `{ limits: { memory: "256Mi", cpu: "200m" }}`
 `proxy.nodeSelector` | node selector logic for proxy pods | `{}`

--- a/incubator/buzzfeed-sso/templates/auth-deployment.yaml
+++ b/incubator/buzzfeed-sso/templates/auth-deployment.yaml
@@ -115,6 +115,9 @@ spec:
                   name: {{ $googleSecret }}
                   key: google-client-secret
           {{- end }}
+          {{- if .Values.auth.extraEnv }}
+{{ toYaml .Values.auth.extraEnv | indent 12 }}
+          {{- end }}
           readinessProbe:
             httpGet:
               path: /ping

--- a/incubator/buzzfeed-sso/templates/auth-deployment.yaml
+++ b/incubator/buzzfeed-sso/templates/auth-deployment.yaml
@@ -95,7 +95,7 @@ spec:
             - name: COOKIE_SECURE
               value: "true"
             - name: CLUSTER
-              value: dev
+              value: {{ .Values.cluster | quote }}
             # Provider variables
           {{- with .Values.provider.google }}
           {{- if .adminEmail }}

--- a/incubator/buzzfeed-sso/templates/ingress.yaml
+++ b/incubator/buzzfeed-sso/templates/ingress.yaml
@@ -18,6 +18,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+{{- if .Values.auth.tls }}
   tls:
     - hosts:
         - {{ $authDomain }}
@@ -29,6 +30,7 @@ spec:
       {{- end }}
       secretName: {{ .secretName }}
   {{- end }}
+{{- end }}
   rules:
     # Upstreams that need SSO authentication
   {{- range .Values.ingress.hosts }}

--- a/incubator/buzzfeed-sso/templates/ingress.yaml
+++ b/incubator/buzzfeed-sso/templates/ingress.yaml
@@ -10,6 +10,9 @@ metadata:
     chart: {{ template "buzzfeed-sso.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- range $key, $value := .Values.ingress.extraLabels }}
+    {{ $key }}: {{ $value }}
+{{- end }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/incubator/buzzfeed-sso/templates/ingress.yaml
+++ b/incubator/buzzfeed-sso/templates/ingress.yaml
@@ -18,11 +18,13 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- if .Values.auth.tls }}
+{{- if or .Values.auth.tls .Values.ingress.tls }}
   tls:
+  {{- if .Values.auth.tls }}
     - hosts:
         - {{ $authDomain }}
       secretName: {{ .Values.auth.tls.secretName -}}
+  {{- end }}
   {{- range .Values.ingress.tls }}
     - hosts:
       {{- range .hosts }}

--- a/incubator/buzzfeed-sso/templates/proxy-deployment.yaml
+++ b/incubator/buzzfeed-sso/templates/proxy-deployment.yaml
@@ -75,7 +75,7 @@ spec:
             - name: COOKIE_SECURE
               value: "true"
             - name: CLUSTER
-              value: {{ .Values.proxy.cluster | quote }}
+              value: {{ .Values.cluster | quote }}
           {{- if .Values.proxy.providerUrlInternal }}
             - name: PROVIDER_URL_INTERNAL
               value: {{ .Values.proxy.providerUrlInternal | quote }}

--- a/incubator/buzzfeed-sso/templates/proxy-deployment.yaml
+++ b/incubator/buzzfeed-sso/templates/proxy-deployment.yaml
@@ -80,7 +80,7 @@ spec:
             - name: PROVIDER_URL_INTERNAL
               value: {{ .Values.proxy.providerUrlInternal | quote }}
           {{- end }}
-          {{- if .Values.auth.extraEnv }}
+          {{- if .Values.proxy.extraEnv }}
 {{ toYaml .Values.proxy.extraEnv | indent 12 }}
           {{- end }}
           readinessProbe:

--- a/incubator/buzzfeed-sso/templates/proxy-deployment.yaml
+++ b/incubator/buzzfeed-sso/templates/proxy-deployment.yaml
@@ -80,6 +80,9 @@ spec:
             - name: PROVIDER_URL_INTERNAL
               value: {{ .Values.proxy.providerUrlInternal | quote }}
           {{- end }}
+          {{- if .Values.auth.extraEnv }}
+{{ toYaml .Values.proxy.extraEnv | indent 12 }}
+          {{- end }}
           readinessProbe:
             httpGet:
               path: /ping

--- a/incubator/buzzfeed-sso/values.yaml
+++ b/incubator/buzzfeed-sso/values.yaml
@@ -24,8 +24,8 @@ auth:
     # cookieSecret: ''
   # # Or if you do not want to create the secret via helm
   # customSecret: my-sso-auth-secret
-  tls:
-    secretName: sso-auth-tls-secret
+  tls: {}
+    # secretName: sso-auth-tls-secret
 
 proxy:
   annotations: {}

--- a/incubator/buzzfeed-sso/values.yaml
+++ b/incubator/buzzfeed-sso/values.yaml
@@ -74,6 +74,7 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # certmanager.k8s.io/cluster-issuer: my-letsencrypt-issuer
     # ingress.kubernetes.io/ssl-redirect: "true"
+  extraLabels: {}
   hosts: []
   #  - domain: mybackend.mydomain.foo
   #    path: /

--- a/incubator/buzzfeed-sso/values.yaml
+++ b/incubator/buzzfeed-sso/values.yaml
@@ -7,6 +7,7 @@ cluster: dev
 auth:
   annotations: {}
   domain: "<your_auth_domain>"  # Required. e.g "sso-auth.mydomain.foo"
+  extraEnv: []
   replicaCount: 1
   resources:
     limits:
@@ -30,6 +31,7 @@ auth:
 
 proxy:
   annotations: {}
+  extraEnv: []
   # providerUrlInternal: https://sso-auth.mydomain.com
   replicaCount: 1
   resources:

--- a/incubator/buzzfeed-sso/values.yaml
+++ b/incubator/buzzfeed-sso/values.yaml
@@ -68,7 +68,7 @@ provider:
 
 image:
   repository: buzzfeed/sso
-  tag: v1.1.0
+  tag: v1.2.0
   pullPolicy: IfNotPresent
 
 ingress:

--- a/incubator/buzzfeed-sso/values.yaml
+++ b/incubator/buzzfeed-sso/values.yaml
@@ -2,6 +2,7 @@
 
 emailDomain: "<your_email_domain>"  # Required. e.g "email.mydomain.foo"
 rootDomain: "<your_root_domain>"  # Required. e.g "mydomain.foo"
+cluster: dev
 
 auth:
   annotations: {}
@@ -30,7 +31,6 @@ auth:
 proxy:
   annotations: {}
   # providerUrlInternal: https://sso-auth.mydomain.com
-  cluster: dev
   replicaCount: 1
   resources:
     limits:


### PR DESCRIPTION
Signed-off-by: Cameron Attard <cameron.attard@siteminder.com>

#### What this PR does / why we need it:

Allows specifying extra ingress labels. This is useful for ingress controllers that selectively serve ingresses based on labels.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`

@darioblanco 