### PR TITLE
[stable/airflow] Pass through annotations for web service

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,6 +1,6 @@
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 2.8.1
+version: 2.8.2
 appVersion: 1.10.2
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -277,6 +277,8 @@ This is useful when running the Kubernetes executor to centralize logs across th
 Airflow UI, scheduler, and kubernetes worker pods, which allows for viewing worker log output
 in the airflow UI.
 
+It's also useful for persistent logs when the worker pods are deleted and recreated.
+
 This is controlled by the `logsPersistence.enabled` setting.
 
 Refer to the `Mount a Shared Persistent Volume` section above for details on using persistent volumes.

--- a/stable/airflow/templates/service-flower.yaml
+++ b/stable/airflow/templates/service-flower.yaml
@@ -9,8 +9,12 @@ metadata:
     chart: {{ template "airflow.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+  {{- if .Values.flower.service.annotations }}
+{{ toYaml .Values.flower.service.annotations | trim | indent 4 }}
+  {{- end }}
 spec:
-  type: {{ .Values.airflow.service.type }}
+  type: {{ .Values.flower.service.type | default "ClusterIP" }}
   selector:
     app: {{ template "airflow.name" . }}
     component: flower
@@ -18,5 +22,6 @@ spec:
   ports:
     - name: flower
       protocol: TCP
-      port: 5555
+      port: {{ .Values.flower.service.externalPort | default 5555 }}
+      targetPort: 5555
 {{- end }}

--- a/stable/airflow/templates/service-web.yaml
+++ b/stable/airflow/templates/service-web.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: {{ template "airflow.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+  {{- if .Values.airflow.service.annotations }}
+{{ toYaml .Values.airflow.service.annotations | trim | indent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.airflow.service.type }}
   selector:
@@ -17,4 +21,5 @@ spec:
   ports:
     - name: web
       protocol: TCP
-      port: 8080
+      port: {{ .Values.airflow.service.externalPort | default 8080 }}
+      targetPort: 8080

--- a/stable/airflow/templates/statefulsets-workers.yaml
+++ b/stable/airflow/templates/statefulsets-workers.yaml
@@ -111,6 +111,10 @@ spec:
             - name: dags-data
               mountPath: {{ .Values.dags.path }}
           {{- end }}
+          {{- if .Values.logsPersistence.enabled }}
+            - name: logs-data
+              mountPath: {{ .Values.logs.path }}
+          {{- end }}
           {{- range .Values.airflow.extraConfigmapMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
@@ -169,6 +173,11 @@ spec:
             claimName: {{ .Values.persistence.existingClaim | default (include "airflow.fullname" .) }}
         {{- else }}
           emptyDir: {}
+        {{- end }}
+        {{- if .Values.logsPersistence.enabled }}
+        - name: logs-data
+          persistentVolumeClaim:
+            claimName: {{ .Values.logsPersistence.existingClaim | default (printf "%s-logs" (include "airflow.fullname" . | trunc 58 )) }}
         {{- end }}
         {{- if .Values.dags.initContainer.enabled }}
         - name: git-clone

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -495,6 +495,11 @@ postgresql:
     ## Enable PostgreSQL persistence using Persistent Volume Claims.
     enabled: true
     ##
+    ## A manually managed Persistent Volume and Claim
+    ## If defined, PVC must be created manually before volume will be bound
+    ## The value is evaluated as a template, so, for example, the name can depend on .Release or .Chart
+    # existingClaim:
+    ##
     ## Persistant class
     # storageClass: classname
     ##

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -196,6 +196,10 @@ flower:
     # requests:
     #   cpu: "100m"
     #   memory: "128Mi"
+  service:
+    annotations: {}
+    type: ClusterIP
+    externalPort: 5555
 
 web:
   resources: {}

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -59,7 +59,9 @@ airflow:
   ## fernetKey: ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD
   fernetKey: ""
   service:
+    annotations: {}
     type: ClusterIP
+    externalPort: 8080
   ##
   ## The executor to use.
   ##


### PR DESCRIPTION
#### What this PR does / why we need it:

Modifies the airflow chart:

- Pass through annotations for the web and flower services from the values file, to make it easier to use K8s External DNS, AWS ELBs and setup SSL certs on those ELBs. Also allow the external port for the services to be configured via the values file.

- Decoupled the flower service type from the web service's type

- Add commented-out existingClaim to the postgresql section of the values file, to make it more obvious that this is supported.

#### Which issue this PR fixes

No existing issue. Do I need one before the PR is accepted?

#### Special notes for your reviewer:

It's my first time contributing to this project, please let me know if I've missed anything. I'm also on the Kubernetes Slack as "Jonathan Miles".

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
