### PR TITLE
[stable/datadog] Allow the use of a specific image digest

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.27.2
+version: 1.27.3
 appVersion: 6.10.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -220,6 +220,7 @@ helm install --name <RELEASE_NAME> \
 | `datadog.appKeyExistingSecret`           | If set, use the secret with a provided name instead of creating a new one                 | `nil`                                       |
 | `image.repository`                       | The image repository to pull from                                                         | `datadog/agent`                             |
 | `image.tag`                              | The image tag to pull                                                                     | `6.10.1`                                     |
+| `image.digest`                           | The image digest to pull. Takes precedence over tag if defined                            | `nil`                                       |
 | `image.pullPolicy`                       | Image pull policy                                                                         | `IfNotPresent`                              |
 | `image.pullSecrets`                      | Image pull secrets                                                                        | `nil`                                       |
 | `nameOverride`                           | Override name of app                                                                      | `nil`                                       |
@@ -278,6 +279,7 @@ helm install --name <RELEASE_NAME> \
 | `clusterAgent.containerName`             | The container name for the Cluster Agent                                                  | `cluster-agent`                             |
 | `clusterAgent.image.repository`          | The image repository for the cluster-agent                                                | `datadog/cluster-agent`                     |
 | `clusterAgent.image.tag`                 | The image tag to pull                                                                     | `1.2.0`                                     |
+| `clusterAgent.image.digest`              | The image digest to pull. Takes precedence over tag if defined                            | `nil`                                       |
 | `clusterAgent.image.pullPolicy`          | Image pull policy                                                                         | `IfNotPresent`                              |
 | `clusterAgent.image.pullSecrets`         | Image pull secrets                                                                        | `nil`                                       |
 | `clusterAgent.metricsProvider.enabled`   | Enable Datadog metrics as a source for HPA scaling                                        | `false`                                     |

--- a/stable/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/stable/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -23,7 +23,11 @@ spec:
       {{- end }}
       containers:
       - name: {{ default .Chart.Name .Values.datadog.name }}
+        {{- if .Values.image.digest }}
+        image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+        {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
           - name: DD_API_KEY

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -39,7 +39,11 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Values.clusterAgent.containerName }}
+        {{- if .Values.clusterAgent.image.digest }}
+        image: "{{ .Values.clusterAgent.image.repository }}@{{ .Values.clusterAgent.image.digest }}"
+        {{- else }}
         image: "{{ .Values.clusterAgent.image.repository }}:{{ .Values.clusterAgent.image.tag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.clusterAgent.image.pullPolicy }}
         resources:
 {{ toYaml .Values.clusterAgent.resources | indent 12 }}

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -43,7 +43,11 @@ spec:
       {{- end }}
       containers:
       - name: {{ default .Chart.Name .Values.datadog.name }}
+        {{- if .Values.image.digest }}
+        image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+        {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:
 {{ toYaml .Values.datadog.resources | indent 12 }}

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -35,7 +35,11 @@ spec:
       {{- end }}
       containers:
       - name: {{ default .Chart.Name .Values.datadog.name }}
+        {{- if .Values.image.digest }}
+        image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+        {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:
 {{ toYaml .Values.datadog.resources | indent 12 }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -20,6 +20,12 @@ image:
   #
   tag: 6.10.1
 
+  ## @param digest - string - optional
+  ## Define the Agent version to use with the image digest.
+  ## Digest takes precedence over tag if defined
+  #
+  # digest: sha256:33b6011daca178ac082762866e16d59bdc5478d8e45f23a7a272287d1251e369
+
   ## @param pullPolicy - string - required
   ## The Kubernetes pull policy.
   #
@@ -284,6 +290,11 @@ clusterAgent:
     repository: datadog/cluster-agent
     tag: 1.2.0
     pullPolicy: IfNotPresent
+    ## @param digest - string - optional
+    ## Define the Agent version to use with the image digest.
+    ## Digest takes precedence over tag if defined
+    #
+    # digest: sha256:5be1524c9607de10224aa0cce3794d7ab52f3b1f83cb605d39b20681c1183725
 
   ## @param token - string - required
   ## This needs to be at least 32 characters a-zA-z


### PR DESCRIPTION
Signed-off-by: Dominik Rastawicki <dominik@takescoop.com>

#### What this PR does / why we need it:

Using a digest ensures the image being pulled has not been compromised and allows testing release against images without having to tag them.

#### Special notes for your reviewer:

This pr is closely based on https://github.com/helm/charts/pull/8910

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
