### PR TITLE
[stable/kubewatch] Allow the use of a specific image digest

### DIFF
--- a/stable/kubewatch/Chart.yaml
+++ b/stable/kubewatch/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubewatch
-version: 0.7.0
+version: 0.7.1
 apiVersion: v1
 appVersion: 0.0.4
 home: https://github.com/bitnami-labs/kubewatch

--- a/stable/kubewatch/README.md
+++ b/stable/kubewatch/README.md
@@ -45,6 +45,7 @@ The following table lists the configurable parameters of the kubewatch chart and
 | `image.registry`                         | Image registry                       | `docker.io`                       |
 | `image.repository`                       | Image repository                     | `bitnami/kubewatch`               |
 | `image.tag`                              | Image tag                            | `{VERSION}`                       |
+| `image.digest`                           | Image digest. Takes precedence over tag if defined | `""`                |
 | `image.pullPolicy`                       | Image pull policy                    | `Always`                          |
 | `nodeSelector`                           | node labels for pod assignment       | `{}`                              |
 | `podAnnotations`                         | annotations to add to each pod       | `{}`                              |

--- a/stable/kubewatch/templates/_helpers.tpl
+++ b/stable/kubewatch/templates/_helpers.tpl
@@ -56,12 +56,24 @@ Also, we can't use a single if because lazy evaluation is not an option
 */}}
 {{- if .Values.global }}
     {{- if .Values.global.imageRegistry }}
+      {{- if .Values.image.digest }}
+        {{- printf "%s/%s@%s" .Values.global.imageRegistry $repositoryName $digest -}}
+      {{- else }}
         {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+       {{- end }}
     {{- else -}}
+      {{- if .Values.image.digest }}
+        {{- printf "%s/%s@%s" $registryName $repositoryName $digest -}}
+      {{- else }}
         {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+       {{- end }}
     {{- end -}}
 {{- else -}}
+  {{- if .Values.image.digest }}
+    {{- printf "%s/%s@%s" $registryName $repositoryName $digest -}}
+  {{- else }}
     {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+  {{- end }}
 {{- end -}}
 {{- end -}}
 

--- a/stable/kubewatch/templates/_helpers.tpl
+++ b/stable/kubewatch/templates/_helpers.tpl
@@ -49,6 +49,7 @@ Return the proper Kubewatch image name
 {{- $registryName := .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
 {{- $tag := .Values.image.tag | toString -}}
+{{- $digest := .Values.image.digest | toString -}}
 {{/*
 Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
 but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.

--- a/stable/kubewatch/values.yaml
+++ b/stable/kubewatch/values.yaml
@@ -55,6 +55,11 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+  ## Specific image digest to use in place of a tag. Digest takes precedence over tag if it is defined.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/overview/#container-images
+  ##
+  # digest: sha256:b023da59a11baff97d7abcd11e1c58e2696665a9756b6297d81530fb59bd749e
+
 rbac:
   # If true, create & use RBAC resources
   #


### PR DESCRIPTION
Signed-off-by: Dominik Rastawicki <dominik@takescoop.com>

#### What this PR does / why we need it:

Using a digest ensures the image being pulled has not been compromised and allows testing release against images without having to tag them.

#### Special notes for your reviewer:

This pr is closely based on #8910

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
