### PR TITLE
[stable/sumologic-fluentd] Allow the use of a specific image digest

### DIFF
--- a/stable/sumologic-fluentd/Chart.yaml
+++ b/stable/sumologic-fluentd/Chart.yaml
@@ -1,5 +1,5 @@
 name: sumologic-fluentd
-version: 0.12.0
+version: 0.12.1
 appVersion: 2.3.0
 description: Sumologic Log Collector
 keywords:

--- a/stable/sumologic-fluentd/README.md
+++ b/stable/sumologic-fluentd/README.md
@@ -99,6 +99,7 @@ The following table lists the configurable parameters of the sumologic-fluentd c
 | `sumologic.enableStatWatcher` | Option to control the enabling of [stat_watcher](https://docs.fluentd.org/v1.0/articles/in_tail#enable_stat_watcher). | `true`
 | `image.name` | The image repository and name to pull from | `sumologic/fluentd-kubernetes-sumologic` |
 | `image.tag` | The image tag to pull | `v2.3.0` |
+| `image.digest` | The image digest to pull. Digest takes precedence over tag if it is defined. | `Nil` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `persistence.enabled` | Boolean value, used to turn on or off fluentd position file persistence, on nodes (requires Kubernetes >= 1.8) | `false` |
 | `persistence.hostPath` | The path, on each node, to a directory for fluentd pos files. You must create the directory on each node first or set `persistence.createPath` (requires Kubernetes >= 1.8) | `/var/run/fluentd-pos` |

--- a/stable/sumologic-fluentd/README.md
+++ b/stable/sumologic-fluentd/README.md
@@ -99,7 +99,7 @@ The following table lists the configurable parameters of the sumologic-fluentd c
 | `sumologic.enableStatWatcher` | Option to control the enabling of [stat_watcher](https://docs.fluentd.org/v1.0/articles/in_tail#enable_stat_watcher). | `true`
 | `image.name` | The image repository and name to pull from | `sumologic/fluentd-kubernetes-sumologic` |
 | `image.tag` | The image tag to pull | `v2.3.0` |
-| `image.digest` | The image digest to pull. Digest takes precedence over tag if it is defined. | `Nil` |
+| `image.digest` | The image digest to pull. Digest takes precedence over tag if defined. | `Nil` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `persistence.enabled` | Boolean value, used to turn on or off fluentd position file persistence, on nodes (requires Kubernetes >= 1.8) | `false` |
 | `persistence.hostPath` | The path, on each node, to a directory for fluentd pos files. You must create the directory on each node first or set `persistence.createPath` (requires Kubernetes >= 1.8) | `/var/run/fluentd-pos` |

--- a/stable/sumologic-fluentd/templates/daemonset.yaml
+++ b/stable/sumologic-fluentd/templates/daemonset.yaml
@@ -26,7 +26,11 @@ spec:
       {{- end }}
       containers:
         - name: {{ template "sumologic-fluentd.fullname" . }}
+          {{- if .Values.image.digest }}
+          image: "{{ .Values.image.name }}@{{ .Values.image.digest }}"
+          {{- else }}
           image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
+          {{- end }}
           imagePullPolicy: {{.Values.image.pullPolicy}}
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/stable/sumologic-fluentd/values.yaml
+++ b/stable/sumologic-fluentd/values.yaml
@@ -3,6 +3,10 @@ image:
   name: sumologic/fluentd-kubernetes-sumologic
   tag: v2.3.0
   pullPolicy: IfNotPresent
+  ## Specific image digest to use in place of a tag. Digest takes precedence over tag if it is defined.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/overview/#container-images
+  ##
+  # digest: sha256:0ecf6b71aee94b4d33ce185e20529c7d470fe0d2f0c98d88faeaed0b0a59fa50
 
 ## Annotations to add to the DaemonSet's Pods
 podAnnotations: {}


### PR DESCRIPTION
Signed-off-by: Dominik Rastawicki <dominik@takescoop.com>

#### What this PR does / why we need it:

Using a digest ensures the image being pulled has not been compromised and allows testing release against images without having to tag them.

#### Special notes for your reviewer:

This pr is closely based on #8910

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
