### PR TITLE
Document the recommended usage of image digest

### DIFF
--- a/REVIEW_GUIDELINES.md
+++ b/REVIEW_GUIDELINES.md
@@ -128,14 +128,14 @@ because it would prevent automatic `PersistentVolume` provisioning.
 
 ## Configuration
 
-* Docker images should be configurable. Image tags should use stable versions. Pulling image by digest should be allowed and supersede the tag if defined.
+* Docker images should be configurable. Pulling an image by digest alone, by tag alone as well as by both tag and digest should be allowed. The default values for image tags and digests should be both specified and use stable versions.
 
 ```yaml
 image:
   repository: myapp
   tag: 1.2.3
   pullPolicy: IfNotPresent
-  # digest: sha256:33b6011daca178ac082762866e16d59bdc5478d8e45f23a7a272287d1251e369
+  digest: sha256:33b6011daca178ac082762866e16d59bdc5478d8e45f23a7a272287d1251e369
 ```
 
 * The use of the `default` function should be avoided if possible in favor of defaults in `values.yaml`.

--- a/REVIEW_GUIDELINES.md
+++ b/REVIEW_GUIDELINES.md
@@ -128,13 +128,14 @@ because it would prevent automatic `PersistentVolume` provisioning.
 
 ## Configuration
 
-* Docker images should be configurable. Image tags should use stable versions.
+* Docker images should be configurable. Image tags should use stable versions. Pulling image by digest should be allowed and supersede the tag if defined.
 
 ```yaml
 image:
   repository: myapp
   tag: 1.2.3
   pullPolicy: IfNotPresent
+  # digest: sha256:33b6011daca178ac082762866e16d59bdc5478d8e45f23a7a272287d1251e369
 ```
 
 * The use of the `default` function should be avoided if possible in favor of defaults in `values.yaml`.


### PR DESCRIPTION
Signed-off-by: Dominik Rastawicki <dominik@takescoop.com>

#### What this PR does / why we need it:

We should encourage chart developers to enable specifying docker image by digest in addition to tag. 

Pulling images by digest ensures the kubernetes cluster does not pull potentially compromised images from the source repository. The images could be compromised if an attacker gains access to the source repository and manipulates the tags to point to a malicious image.
 
Additionally pulling by digest can be helpful in image development when tagging an image on each build can become cumbersome.

#### Which issue this PR fixes
  - fixes #13449 

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
