### PR TITLE
Removed namespace for clusterRoleBinding

### DIFF
--- a/incubator/sparkoperator/Chart.yaml
+++ b/incubator/sparkoperator/Chart.yaml
@@ -1,6 +1,6 @@
 name: sparkoperator
 description: A Helm chart for Spark on Kubernetes operator
-version: 0.2.1
+version: 0.2.2
 appVersion: v2.4.0-v1beta1-0.8.2
 kubeVersion: ">=1.8.0-0"
 keywords:

--- a/incubator/sparkoperator/templates/spark-operator-rbac.yaml
+++ b/incubator/sparkoperator/templates/spark-operator-rbac.yaml
@@ -38,7 +38,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "sparkoperator.fullname" . }}-crb
-  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
     helm.sh/chart: {{ include "sparkoperator.chart" . }}


### PR DESCRIPTION
I just realized that the ClusterRoleBinding had a namespace, which it shouldn't. Apparently that didn't affect the chart installation. But it's best to make things right.