### PR TITLE
stable/hazelcast fix: statefulset should have serviceName and fix securityContext

### DIFF
--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 1.3.2
+version: 1.3.3
 appVersion: "3.11.2"
 description: Hazelcast IMDG is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.
 keywords:

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -8,6 +8,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  serviceName: {{ template "hazelcast.fullname" . }}
   replicas: {{ .Values.cluster.memberCount }}
   selector:
     matchLabels:

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -126,12 +126,10 @@ serviceAccount:
 
 # Default security-context to run unprivileged
 securityContext:
-  fsGroup: 65534
   runAsUser: 65534
   runAsNonRoot: true
   readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
-  defaultAllowPrivilegeEscalation: false
 
 # Allows to enable a Prometheus to scrape pods, implemented for Hazelcast version >= 3.12 (or 'latest')
 metrics:


### PR DESCRIPTION
fsGroup is part of PodSecurityContext and SecurityContext
defaultAllowPrivilegeEscalation is part of PodSecurityPolicySpec

#### What this PR does / why we need it:
The helm chart is not valid.

- StatefulSet should have a spec.serviceName field
- Default SecurityContext is wrong: 
  - fsGroup is part of PodSecurityContext and SecurityContext
  - defaultAllowPrivilegeEscalation is part of PodSecurityPolicySpec

#### Special notes for your reviewer:
Tested on AKS with Kubernetes 1.13.5

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
