### PR TITLE
[stable/kubewatch] Add a parameter to configure the namespace to watch

### DIFF
--- a/stable/kubewatch/Chart.yaml
+++ b/stable/kubewatch/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubewatch
-version: 0.7.0
+version: 0.8.0
 apiVersion: v1
 appVersion: 0.0.4
 home: https://github.com/bitnami-labs/kubewatch

--- a/stable/kubewatch/README.md
+++ b/stable/kubewatch/README.md
@@ -70,6 +70,7 @@ The following table lists the configurable parameters of the kubewatch chart and
 | `webhook.enabled`                        | Enable Webhook notifications         | `false`                           |
 | `webhook.url`                            | Webhook URL                          | `""`                              |
 | `tolerations`                            | List of node taints to tolerate (requires Kubernetes >= 1.6)                                                                | `[]`                              |
+| `namespaceToWatch`                       | namespace to watch, leave it empty for watching all                                                                         | `""`                              |
 | `resourcesToWatch`                       | list of resources which kubewatch should watch and notify slack                                                             | `{pod: true, deployment: true}`   |
 | `resourcesToWatch.pod`                   | watch changes to [Pods](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/)                                   | `true`                            |
 | `resourcesToWatch.deployment`            | watch changes to [Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)                       | `true`                            |

--- a/stable/kubewatch/templates/configmap.yaml
+++ b/stable/kubewatch/templates/configmap.yaml
@@ -32,3 +32,4 @@ data:
 {{- end }}
     resource:
 {{ toYaml .Values.resourcesToWatch | indent 6 }}
+    namespace: {{ .Values.namespaceToWatch | quote }}

--- a/stable/kubewatch/values.yaml
+++ b/stable/kubewatch/values.yaml
@@ -32,6 +32,9 @@ webhook:
   enabled: false
   # url: ""
 
+# namespace to watch, leave it empty for watching all.
+namespaceToWatch: ""
+
 # Resources to watch
 resourcesToWatch:
   deployment: true


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR allows the user to specify the namespaces to watch.

#### Which issue this PR fixes

  - fixes https://github.com/bitnami/charts/issues/1159

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
