### PR TITLE
[stable/instana-agent] Remove docker.sock mount in volumes section also

### DIFF
--- a/stable/instana-agent/Chart.yaml
+++ b/stable/instana-agent/Chart.yaml
@@ -1,5 +1,5 @@
 name: instana-agent
-version: 1.0.5
+version: 1.0.6
 appVersion: 1.0
 description: Instana Agent for Kubernetes
 home: https://www.instana.com/

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -147,7 +147,7 @@ spec:
             path: /dev
         - name: run
           hostPath:
-            path: /var/run/docker.sock
+            path: /var/run
         - name: sys
           hostPath:
             path: /sys


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates also the other place where `docker.sock` was mounted (in the `volumes` section) and changes it to only `/var/run`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
