### PR TITLE
[stable/kube-slack] Add more envVars support

### DIFF
--- a/stable/kube-slack/Chart.yaml
+++ b/stable/kube-slack/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube-slack
-version: 0.4.2
+version: 0.4.3
 appVersion: v4.1.1
 apiVersion: v1
 description: Chart for kube-slack, a monitoring service for Kubernetes

--- a/stable/kube-slack/Chart.yaml
+++ b/stable/kube-slack/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube-slack
-version: 0.4.3
+version: 1.0.0
 appVersion: v4.1.1
 apiVersion: v1
 description: Chart for kube-slack, a monitoring service for Kubernetes

--- a/stable/kube-slack/templates/clusterrole.yaml
+++ b/stable/kube-slack/templates/clusterrole.yaml
@@ -16,4 +16,5 @@ rules:
     verbs:
       - get
       - list
+      - watch
 {{- end -}}

--- a/stable/kube-slack/values.yaml
+++ b/stable/kube-slack/values.yaml
@@ -1,7 +1,7 @@
 ## Environment values for the deployment
 envVars:
   ## URL of your Incoming Webhook in Slack:
-  SLACK_URL: "https://hooks.slack.com/services/Txxxxxxxx/Bxxxxxxxx/XXXXXXXXXXXXXXXXXXXXXXXX"
+  SLACK_URL: "" # https://hooks.slack.com/services/Txxxxxxxx/Bxxxxxxxx/XXXXXXXXXXXXXXXXXXXXXXXX"
   ## Override channel to send
   SLACK_CHANNEL: ""
   ## URL of HTTP proxy used to connect to Slack

--- a/stable/kube-slack/values.yaml
+++ b/stable/kube-slack/values.yaml
@@ -2,7 +2,7 @@
 envVars:
   ## URL of your Incoming Webhook in Slack
   ## e.g. https://hooks.slack.com/services/Txxxxxxxx/Bxxxxxxxx/XXXXXXXXXXXXXXXXXXXXXXXX
-  SLACK_URL: "" 
+  SLACK_URL: ""
   ## Override channel to send
   SLACK_CHANNEL: ""
   ## URL of HTTP proxy used to connect to Slack

--- a/stable/kube-slack/values.yaml
+++ b/stable/kube-slack/values.yaml
@@ -1,9 +1,27 @@
 ## Environment values for the deployment
 envVars:
   ## URL of your Incoming Webhook in Slack:
-  SLACK_URL: ""
+  SLACK_URL: "https://hooks.slack.com/services/Txxxxxxxx/Bxxxxxxxx/XXXXXXXXXXXXXXXXXXXXXXXX"
+  ## Override channel to send
+  SLACK_CHANNEL: ""
+  ## URL of HTTP proxy used to connect to Slack
+  SLACK_PROXY: ""
   ## Time to wait after pod becomes not ready before notifying
   NOT_READY_MIN_TIME: "60000"  # in ms
+  ## Set to false to disable alert on pod recovery
+  RECOVERY_ALERT: true
+  ## How often to update in milliseconds
+  TICK_RATE: 15000
+  ## Repeat notification after this many milliseconds has passed after status returned to normal
+  FLOOD_EXPIRE: 60000
+  ## Enable/disable metric alerting on cpu
+  METRICS_CPU: true
+  ## Enable/disable metric alerting on memory
+  METRICS_MEMORY: true
+  ## Set percentage threshold on metric alerts
+  METRICS_PERCENT: 80
+  ##  If no metrics limit defined, alert if the pod utilization is more than the resource request amount
+  METRICS_REQUESTS: false
 
 ## Configuration for the deployment:
 image:

--- a/stable/kube-slack/values.yaml
+++ b/stable/kube-slack/values.yaml
@@ -1,7 +1,8 @@
 ## Environment values for the deployment
 envVars:
-  ## URL of your Incoming Webhook in Slack:
-  SLACK_URL: "" # https://hooks.slack.com/services/Txxxxxxxx/Bxxxxxxxx/XXXXXXXXXXXXXXXXXXXXXXXX"
+  ## URL of your Incoming Webhook in Slack
+  ## e.g. https://hooks.slack.com/services/Txxxxxxxx/Bxxxxxxxx/XXXXXXXXXXXXXXXXXXXXXXXX
+  SLACK_URL: "" 
   ## Override channel to send
   SLACK_CHANNEL: ""
   ## URL of HTTP proxy used to connect to Slack

--- a/stable/kube-slack/values.yaml
+++ b/stable/kube-slack/values.yaml
@@ -10,19 +10,19 @@ envVars:
   ## Time to wait after pod becomes not ready before notifying
   NOT_READY_MIN_TIME: "60000"  # in ms
   ## Set to false to disable alert on pod recovery
-  RECOVERY_ALERT: true
+  RECOVERY_ALERT: "true"
   ## How often to update in milliseconds
-  TICK_RATE: 15000
+  TICK_RATE: "15000"
   ## Repeat notification after this many milliseconds has passed after status returned to normal
   FLOOD_EXPIRE: "60000"
   ## Enable/disable metric alerting on cpu
-  METRICS_CPU: true
+  METRICS_CPU: "true"
   ## Enable/disable metric alerting on memory
-  METRICS_MEMORY: true
+  METRICS_MEMORY: "true"
   ## Set percentage threshold on metric alerts
-  METRICS_PERCENT: 80
+  METRICS_PERCENT: "80"
   ##  If no metrics limit defined, alert if the pod utilization is more than the resource request amount
-  METRICS_REQUESTS: false
+  METRICS_REQUESTS: "false"
 
 ## Configuration for the deployment:
 image:

--- a/stable/kube-slack/values.yaml
+++ b/stable/kube-slack/values.yaml
@@ -14,7 +14,7 @@ envVars:
   ## How often to update in milliseconds
   TICK_RATE: 15000
   ## Repeat notification after this many milliseconds has passed after status returned to normal
-  FLOOD_EXPIRE: 60000
+  FLOOD_EXPIRE: "60000"
   ## Enable/disable metric alerting on cpu
   METRICS_CPU: true
   ## Enable/disable metric alerting on memory


### PR DESCRIPTION
#### What this PR does / why we need it:

it was originally implement with #12035,
but after  #11883 and #13312 got merged, it break/conflict,
so re-create a new PR for supporting more envVars for kube-slack.

#### Which issue this PR fixes
- N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] title of the PR contains starts with chart name e.g. `[stable/chart]`