### PR TITLE
[stable/docker-registry] add support for readiness/liveness probe toggling

### DIFF
--- a/stable/docker-registry/Chart.yaml
+++ b/stable/docker-registry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart for Docker Registry
 name: docker-registry
 version: 1.8.0
-appVersion: 2.7.1
+appVersion: 2.7.2
 home: https://hub.docker.com/_/registry/
 icon: https://hub.docker.com/public/images/logos/mini-logo.svg
 sources:

--- a/stable/docker-registry/README.md
+++ b/stable/docker-registry/README.md
@@ -37,6 +37,8 @@ their default values.
 | `persistence.size`          | Amount of space to claim for PVC                                                           | `10Gi`          |
 | `persistence.storageClass`  | Storage Class to use for PVC                                                               | `-`             |
 | `persistence.existingClaim` | Name of an existing PVC to use for config                                                  | `nil`           |
+| `livenessProbe.enabled`              | Enable or disable probe                                                   | `true`          |
+| `redinessProbe.enabled`              | Enable or disable probe                                                   | `true`          |
 | `service.port`              | TCP port on which the service is exposed                                                   | `5000`          |
 | `service.type`              | service type                                                                               | `ClusterIP`     |
 | `service.clusterIP`         | if `service.type` is `ClusterIP` and this is non-empty, sets the cluster IP of the service | `nil`           |

--- a/stable/docker-registry/templates/deployment.yaml
+++ b/stable/docker-registry/templates/deployment.yaml
@@ -50,20 +50,24 @@ spec:
           - /etc/docker/registry/config.yml
           ports:
             - containerPort: 5000
-          livenessProbe:
-            httpGet:
+        {{- if .Values.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
 {{- if .Values.tlsSecretName }}
-              scheme: HTTPS
+            scheme: HTTPS
 {{- end }}
-              path: /
-              port: 5000
-          readinessProbe:
-            httpGet:
+            path: /
+            port: 5000
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
 {{- if .Values.tlsSecretName }}
-              scheme: HTTPS
+            scheme: HTTPS
 {{- end }}
-              path: /
-              port: 5000
+            path: /
+            port: 5000
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           env:

--- a/stable/docker-registry/values.yaml
+++ b/stable/docker-registry/values.yaml
@@ -26,6 +26,13 @@ service:
   # nodePort:
   annotations: {}
   # foo.io/bar: "true"
+
+# enable/disable liveness and readiness probes
+livenessProbe:
+  enabled: true
+readinessProbe:
+  enabled: true
+
 ingress:
   enabled: false
   path: /


### PR DESCRIPTION
Signed-off-by: Boris Kurktchiev <boris@diamanti.com>

#### What this PR does / why we need it:
Adds support to toggle the Liveness/Readiness probes of the container


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
