### PR TITLE
[stable/kong] introduce support for dbless Ingress Controller

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.10.3
+version: 0.11.0
 appVersion: 1.1

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -186,6 +186,10 @@ To deploy the ingress controller together with
 kong run the following command:
 
 ```bash
+# without a database
+helm install stable/kong --set ingressController.enabled=true \
+  --set postgresql.enabled=false --set env.database=off
+# with a database
 helm install stable/kong --set ingressController.enabled=true
 ```
 

--- a/stable/kong/ci/dbless.yaml
+++ b/stable/kong/ci/dbless.yaml
@@ -1,0 +1,7 @@
+# CI test for testing dbless deployment
+ingressController:
+  enabled: true
+env:
+  database: "off"
+postgresql:
+  enabled: false

--- a/stable/kong/requirements.lock
+++ b/stable/kong/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 3.18.3
+  version: 3.9.5
 - name: cassandra
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
   version: 0.10.5
-digest: sha256:85e875e2c4a36bcb42c3312fa70e034a86694ef8cc2466b84742b2845ce4afaf
-generated: 2019-05-02T09:31:39.733059563-07:00
+digest: sha256:797c1cf8eb6504c93015f1b8f16b263dd94dca9a73cb647bdf3c0af153fba62c
+generated: 2019-05-09T13:44:59.216637988-07:00

--- a/stable/kong/requirements.yaml
+++ b/stable/kong/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  version: ~3.18.3
+  version: ~3.9.1
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: postgresql.enabled
 - name: cassandra

--- a/stable/kong/templates/controller-deployment.yaml
+++ b/stable/kong/templates/controller-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingressController.enabled -}}
+{{- if (and (.Values.ingressController.enabled) (not (eq .Values.env.database "off"))) }}
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
@@ -74,55 +74,5 @@ spec:
 {{ toYaml .Values.livenessProbe | indent 10 }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
-      - name: ingress-controller
-        args:
-        - /kong-ingress-controller
-        # the default service is the kong proxy service
-        - --default-backend-service={{ .Release.Namespace }}/{{ template "kong.fullname" . }}-proxy
-        # Service from were we extract the IP address/es to use in Ingress status
-        - --publish-service={{ .Release.Namespace }}/{{ template "kong.fullname" . }}-proxy
-        # Set the ingress class
-        - --ingress-class={{ .Values.ingressController.ingressClass }}
-        - --election-id=kong-ingress-controller-leader-{{ .Values.ingressController.ingressClass }}
-        # the kong URL points to the kong admin api server
-        {{- if .Values.admin.useTLS }}
-        - --kong-url=https://localhost:{{ .Values.admin.containerPort }}
-        - --admin-tls-skip-verify # TODO make this configurable
-        {{- else }}
-        - --kong-url=http://localhost:{{ .Values.admin.containerPort }}
-        {{- end }}
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        image: "{{ .Values.ingressController.image.repository }}:{{ .Values.ingressController.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /healthz
-            port: 10254
-            scheme: HTTP
-          initialDelaySeconds: 30
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /healthz
-            port: 10254
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
-        resources:
-{{ toYaml .Values.ingressController.resources | indent 10 }}
+      {{- include "kong.controller-container" . | nindent 6 }}
 {{- end -}}

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -26,15 +26,23 @@ spec:
         release: {{ .Release.Name }}
         component: app
     spec:
+      {{- if (and (.Values.ingressController) (eq .Values.env.database "off")) }}
+      serviceAccountName: {{ template "kong.serviceAccountName" . }}
+      {{ end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if not (eq .Values.env.database "off") }}
       initContainers:
       {{- include "kong.wait-for-db" . | nindent 6 }}
+      {{ end }}
       containers:
+      {{- if (and (.Values.ingressController) (eq .Values.env.database "off")) }}
+      {{- include "kong.controller-container" . | nindent 6 }}
+      {{ end }}
       - name: {{ template "kong.name" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/stable/kong/templates/migrations-post-upgrade.yaml
+++ b/stable/kong/templates/migrations-post-upgrade.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.runMigrations }}
+{{- if (and (.Values.runMigrations) (not (eq .Values.env.database "off"))) }}
 # Why is this Job duplicated and not using only helm hooks?
 # See: https://github.com/helm/charts/pull/7362
 apiVersion: batch/v1

--- a/stable/kong/templates/migrations-pre-upgrade.yaml
+++ b/stable/kong/templates/migrations-pre-upgrade.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.runMigrations }}
+{{- if (and (.Values.runMigrations) (not (eq .Values.env.database "off"))) }}
 # Why is this Job duplicated and not using only helm hooks?
 # See: https://github.com/helm/charts/pull/7362
 apiVersion: batch/v1

--- a/stable/kong/templates/migrations.yaml
+++ b/stable/kong/templates/migrations.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.runMigrations }}
+{{- if (and (.Values.runMigrations) (not (eq .Values.env.database "off"))) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/stable/kong/templates/service-kong-proxy.yaml
+++ b/stable/kong/templates/service-kong-proxy.yaml
@@ -47,8 +47,6 @@ spec:
   {{- end }}
     protocol: TCP
   {{- end }}
-
-
   selector:
     app: {{ template "kong.name" . }}
     release: {{ .Release.Name }}

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -176,7 +176,7 @@ ingressController:
   enabled: false
   image:
     repository: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller
-    tag: 0.3.0
+    tag: 0.4.0
   replicaCount: 1
   livenessProbe:
     failureThreshold: 3


### PR DESCRIPTION
Signed-off-by: Harry Bagdi <harrybagdi@gmail.com>

#### What this PR does / why we need it:
- introduces support to deploy Kong as an Ingress Controller without a database

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
