### PR TITLE
[stable/efs-provisioner] pod annotations fix

### DIFF
--- a/stable/efs-provisioner/Chart.yaml
+++ b/stable/efs-provisioner/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: efs-provisioner
 description: A Helm chart for the AWS EFS external storage provisioner
-version: 0.3.6
+version: 0.3.7
 appVersion: v2.1.0-k8s1.11
 home: https://github.com/kubernetes-incubator/external-storage/tree/master/aws/efs
 sources:

--- a/stable/efs-provisioner/templates/deployment.yaml
+++ b/stable/efs-provisioner/templates/deployment.yaml
@@ -39,8 +39,6 @@ spec:
       labels:
         app: {{ template "efs-provisioner.name" . }}
         release: "{{ .Release.Name }}"
-      annotations:
-{{ toYaml .Values.annotations | indent 8 }}
     spec:
       serviceAccount: {{ template "efs-provisioner.serviceAccountName" . }}
       {{- if .Values.priorityClassName }}


### PR DESCRIPTION
 Signed-off-by: Alessandro Grassi <alessandro.grassi01@gmail.com>

Hi @whereisaaron 👋 

#### What this PR does / why we need it:
Pod annotations were getting overridden by Deployment annotations for no reason.
This was due to duplicate "annotations" key in the spec.template.metadata section of the deployment.yaml.
An example of a case in which this was causing troubles is when you need to annotate the pods with the iam roles for kube2iam but the deployment annotations in the values substituted these pods annotations. Noticed by using the --debug flag in helm install

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
