### PR TITLE
stable/logdna-agent The value autoupdate for logdna-agent should be processed as a string

### DIFF
--- a/stable/logdna-agent/CHANGELOG.md
+++ b/stable/logdna-agent/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change Log
+
+This file documents all notable changes to Sysdig Falco Helm Chart. The release
+numbering uses [semantic versioning](http://semver.org).
+
+## v1.0.1
+
+* Fix autoupdate value handling
+
+## v1.0.0
+
+* Initial release

--- a/stable/logdna-agent/Chart.yaml
+++ b/stable/logdna-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: logdna-agent
 description: Run this, get logs. All cluster containers. LogDNA collector agent daemonset for Kubernetes.
-version: 1.0.0
+version: 1.0.1
 appVersion: 1.5.6
 keywords:
 - logs

--- a/stable/logdna-agent/templates/daemonset.yaml
+++ b/stable/logdna-agent/templates/daemonset.yaml
@@ -37,7 +37,7 @@ spec:
 {{- end }}
 {{- if .Values.logdna.autoupdate }}
           - name: LOGDNA_AUTOUPDATE
-            value: {{ .Values.logdna.autoupdate }}
+            value: "{{ .Values.logdna.autoupdate }}"
 {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/stable/logdna-agent/values.yaml
+++ b/stable/logdna-agent/values.yaml
@@ -10,7 +10,7 @@ logdna:
   # key:
 
   ## Optional settings
-  autoupdate: 0
+  autoupdate: "0"
   # tags:
 
   name: logdna-agent


### PR DESCRIPTION
#### What this PR does / why we need it:

The logdna-agent should be processing the autoupdate value as a string (as all ENV should be). For example, if no value is supplied, the `values.yaml` default is used, which is a number (`0`), which causes a comparison type failure [when this comparison takes place](https://github.com/helm/charts/blob/d716a37c48be8b48d0c6d8caec17a03989d973d9/stable/logdna-agent/templates/daemonset.yaml#L21) against a string.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`

Signed-off-by: Harry Lascelles <harry@harrylascelles.com>