### PR TITLE
stable/logdna-agent The location of the logdna-agent key should be configurable with a secret name

### DIFF
--- a/stable/logdna-agent/CHANGELOG.md
+++ b/stable/logdna-agent/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change Log
+
+This file documents all notable changes to Sysdig Falco Helm Chart. The release
+numbering uses [semantic versioning](http://semver.org).
+
+## v1.0.1
+
+* Allow specifying a secret for the key location
+
+## v1.0.0
+
+* Initial release

--- a/stable/logdna-agent/Chart.yaml
+++ b/stable/logdna-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: logdna-agent
 description: Run this, get logs. All cluster containers. LogDNA collector agent daemonset for Kubernetes.
-version: 1.0.0
+version: 1.0.1
 appVersion: 1.5.6
 keywords:
 - logs

--- a/stable/logdna-agent/README.md
+++ b/stable/logdna-agent/README.md
@@ -49,7 +49,8 @@ The following tables lists the configurable parameters of the LogDNA Agent chart
 
 Parameter | Description | Default
 --- | --- | ---
-`logdna.key` | LogDNA Ingestion Key (Required) | None
+`logdna.key` | LogDNA Ingestion Key (Required if no `secret` provided) | None
+`logdna.secret` | Secret that contains the LogDNA Ingestion Key as `logdna-agent-key` (Required if no `key` provided) | None
 `logdna.tags` | Optional tags such as `production` | None
 `logdna.autoupdate` | Optionally turn on autoupdate by setting to 1 (auto sets image.pullPolicy to always) | `0`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`

--- a/stable/logdna-agent/templates/NOTES.txt
+++ b/stable/logdna-agent/templates/NOTES.txt
@@ -1,7 +1,7 @@
-{{- if not .Values.logdna.key -}}
-#############################################################
-###  ERROR: Please specify an ingestion key `logdna.key`  ###
-#############################################################
+{{- if not (or .Values.logdna.key .Values.logdna.secret) -}}
+###################################################################################################
+###  ERROR: Please specify an ingestion key `logdna.key` or secret location `logdna.secret` ###
+###################################################################################################
 
 
 Please follow directions from https://app.logdna.com/pages/add-source

--- a/stable/logdna-agent/templates/daemonset.yaml
+++ b/stable/logdna-agent/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.logdna.key -}}
+{{- if (or .Values.logdna.key .Values.logdna.secret) -}}
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -27,7 +27,7 @@ spec:
           - name: LOGDNA_AGENT_KEY
             valueFrom:
               secretKeyRef:
-                name: {{ template "logdna.name" . }}
+                name: {{ if .Values.logdna.secret -}}{{ .Values.logdna.secret }}{{ else }}{{ template "logdna.name" . }}{{ end }}
                 key: logdna-agent-key
           - name: LOGDNA_PLATFORM
             value: k8s

--- a/stable/logdna-agent/templates/secrets.yaml
+++ b/stable/logdna-agent/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.logdna.key -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,3 +10,4 @@ metadata:
 type: Opaque
 data:
   logdna-agent-key: {{ default "" .Values.logdna.key | b64enc | quote }}
+{{- end }}

--- a/stable/logdna-agent/values.yaml
+++ b/stable/logdna-agent/values.yaml
@@ -6,8 +6,9 @@ image:
 logdna:
   ## Please follow directions from https://app.logdna.com/pages/add-source
 
-  ## An ingestion key is required for this chart to run
+  ## An ingestion key or secret is required for this chart to run
   # key:
+  # secret:
 
   ## Optional settings
   autoupdate: 0


### PR DESCRIPTION
#### What this PR does / why we need it:

Some deploy flows perform the secret upload and chart release separately. eg, using [Weaveworks Flux](https://github.com/weaveworks/flux).

This change allows a user to specify the Secret location where the ingestion key can be found, rather than supplying it at release time.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`

Signed-off-by: Harry Lascelles <harry@harrylascelles.com>