### PR TITLE
[incubator/zookeeper] Add Prometheus Operator support

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 1.3.1
+version: 1.4.0
 appVersion: 3.4.10
 description: Centralized service for maintaining configuration information, naming,
   providing distributed synchronization, and providing group services.

--- a/incubator/zookeeper/README.md
+++ b/incubator/zookeeper/README.md
@@ -16,7 +16,7 @@ This chart will do the following:
 * Create a [Headless Service](https://kubernetes.io/docs/concepts/services-networking/service/) to control the domain of the ZooKeeper ensemble.
 * Create a Service configured to connect to the available ZooKeeper instance on the configured client port.
 * Optionally apply a [Pod Anti-Affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature) to spread the ZooKeeper ensemble across nodes.
-* Optionally start JMX Exporter and Zookeeper Exporter containers inside Zookeeper pods.
+* Optionally start JMX Exporter and Zookeeper Exporter containers inside Zookeeper pods, with [Prometheus Operator](https://github.com/coreos/prometheus-operator) `ServiceMonitors` if desired.
 * Optionally create a job which creates Zookeeper chroots (e.g. `/kafka1`).
 
 ## Installing the Chart

--- a/incubator/zookeeper/README.md
+++ b/incubator/zookeeper/README.md
@@ -16,7 +16,7 @@ This chart will do the following:
 * Create a [Headless Service](https://kubernetes.io/docs/concepts/services-networking/service/) to control the domain of the ZooKeeper ensemble.
 * Create a Service configured to connect to the available ZooKeeper instance on the configured client port.
 * Optionally apply a [Pod Anti-Affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature) to spread the ZooKeeper ensemble across nodes.
-* Optionally start JMX Exporter and Zookeeper Exporter containers inside Zookeeper pods, with [Prometheus Operator](https://github.com/coreos/prometheus-operator) `ServiceMonitors` if desired.
+* Optionally start JMX Exporter and Zookeeper Exporter containers inside Zookeeper pods, with [Prometheus Operator](https://github.com/coreos/prometheus-operator) `ServiceMonitor` and `PrometheusRule` if desired.
 * Optionally create a job which creates Zookeeper chroots (e.g. `/kafka1`).
 
 ## Installing the Chart

--- a/incubator/zookeeper/templates/prometheusrules.yaml
+++ b/incubator/zookeeper/templates/prometheusrules.yaml
@@ -1,0 +1,20 @@
+{{ if .Values.prometheus.operator.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "zookeeper.fullname" . }}
+  {{- if .Values.prometheus.operator.prometheusRule.namespace }}
+  namespace: {{ .Values.prometheus.operator.prometheusRule.namespace }}
+  {{- end }}
+  labels:
+{{ toYaml .Values.prometheus.operator.prometheusRule.selector | indent 4 }}
+spec:
+  groups:
+  - name: {{ include "zookeeper.fullname" . }}
+    rules:
+{{- $zookeeperFullname := include "zookeeper.fullname" . }}
+{{- range $key, $value := .Values.prometheus.operator.prometheusRule.rules }}
+    - alert: {{ $zookeeperFullname }}-{{ $key }}
+{{ toYaml $value | indent 6 }}
+{{- end }}
+{{- end }}

--- a/incubator/zookeeper/templates/prometheusrules.yaml
+++ b/incubator/zookeeper/templates/prometheusrules.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.prometheus.operator.prometheusRule.enabled }}
+{{ if and (.Values.prometheus.operator.prometheusRule.enabled) (.Values.prometheus.operator.prometheusRule.rules) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/incubator/zookeeper/templates/service.yaml
+++ b/incubator/zookeeper/templates/service.yaml
@@ -18,6 +18,18 @@ spec:
     - name: {{ $key }}
 {{ toYaml $value | indent 6 }}
   {{- end }}
+  {{- if and .Values.exporters.jmx.enabled .Values.prometheus.operator.enabled }}
+    - name: jmxxp
+      protocol: TCP
+      port: {{ .Values.exporters.jmx.port }}
+      targetPort: jmxxp
+  {{- end }}
+  {{- if and .Values.exporters.zookeeper.enabled .Values.prometheus.operator.enabled }}
+    - name: zookeeperxp
+      protocol: TCP
+      port: {{ .Values.exporters.zookeeper.port }}
+      targetPort: zookeeperxp
+  {{- end }}
   selector:
     app: {{ template "zookeeper.name" . }}
     release: {{ .Release.Name }}

--- a/incubator/zookeeper/templates/servicemonitors.yaml
+++ b/incubator/zookeeper/templates/servicemonitors.yaml
@@ -1,0 +1,42 @@
+{{ if and .Values.exporters.jmx.enabled .Values.prometheus.operator.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "zookeeper.fullname" . }}-jmx
+  namespace: {{ .Values.prometheus.operator.serviceMonitor.namespace }}
+  labels:
+{{ toYaml .Values.prometheus.operator.serviceMonitor.selector | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "zookeeper.name" . }}
+      release: {{ .Release.Name }}
+  endpoints:
+  - port: jmxxp
+    interval: {{ .Values.exporters.jmx.interval }}
+  {{- if .Values.exporters.jmx.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.exporters.jmx.scrapeTimeout }}
+  {{- end }}
+{{ end }}
+---
+{{ if and .Values.exporters.zookeeper.enabled .Values.prometheus.operator.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "zookeeper.fullname" . }}-zookeeper
+  namespace: {{ .Values.prometheus.operator.serviceMonitor.namespace }}
+  labels:
+{{ toYaml .Values.prometheus.operator.serviceMonitor.selector | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "zookeeper.name" . }}
+      release: {{ .Release.Name }}
+  endpoints:
+  - port: zookeeperxp
+    interval: {{ .Values.exporters.zookeeper.interval }}
+  {{- if .Values.exporters.zookeeper.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.exporters.zookeeper.scrapeTimeout }}
+  {{- end }}
+{{ end }}
+

--- a/incubator/zookeeper/templates/servicemonitors.yaml
+++ b/incubator/zookeeper/templates/servicemonitors.yaml
@@ -3,7 +3,9 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "zookeeper.fullname" . }}-jmx
+  {{- if .Values.prometheus.operator.serviceMonitor.namespace }}
   namespace: {{ .Values.prometheus.operator.serviceMonitor.namespace }}
+  {{- end }}
   labels:
 {{ toYaml .Values.prometheus.operator.serviceMonitor.selector | indent 4 }}
 spec:
@@ -24,7 +26,9 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "zookeeper.fullname" . }}-zookeeper
+  {{- if .Values.prometheus.operator.serviceMonitor.namespace }}
   namespace: {{ .Values.prometheus.operator.serviceMonitor.namespace }}
+  {{- end }}
   labels:
 {{ toYaml .Values.prometheus.operator.serviceMonitor.selector | indent 4 }}
 spec:

--- a/incubator/zookeeper/templates/statefulset.yaml
+++ b/incubator/zookeeper/templates/statefulset.yaml
@@ -54,7 +54,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.command }}
           command: {{ range . }}
-             - {{ . | quote }}
+            - {{ . | quote }}
           {{- end }}
         {{- end }}
           ports:
@@ -104,17 +104,16 @@ spec:
           image: "{{ .Values.exporters.jmx.image.repository }}:{{ .Values.exporters.jmx.image.tag }}"
           imagePullPolicy: {{ .Values.exporters.jmx.image.pullPolicy }}
           ports:
-  {{- range $key, $port := .Values.exporters.jmx.ports }}
-            - name: {{ $key }}
-{{ toYaml $port | indent 14 }}
-  {{- end }}
+            - name: jmxxp
+              containerPort: {{ .Values.exporters.jmx.port }}
+              protocol: TCP
           livenessProbe:
 {{ toYaml .Values.exporters.jmx.livenessProbe | indent 12 }}
           readinessProbe:
 {{ toYaml .Values.exporters.jmx.readinessProbe | indent 12 }}
           env:
             - name: SERVICE_PORT
-              value: {{ .Values.exporters.jmx.ports.jmxxp.containerPort | quote }}
+              value: {{ .Values.exporters.jmx.port | quote }}
           {{- with .Values.exporters.jmx.env }}
             {{- range $key, $value := . }}
             - name: {{ $key | upper | replace "." "_" }}
@@ -134,16 +133,15 @@ spec:
           image: "{{ .Values.exporters.zookeeper.image.repository }}:{{ .Values.exporters.zookeeper.image.tag }}"
           imagePullPolicy: {{ .Values.exporters.zookeeper.image.pullPolicy }}
           args:
-            - -bind-addr=:{{ .Values.exporters.zookeeper.ports.zookeeperxp.containerPort }}
+            - -bind-addr=:{{ .Values.exporters.zookeeper.port }}
             - -metrics-path={{ .Values.exporters.zookeeper.path }}
             - -zookeeper=localhost:{{ .Values.ports.client.containerPort }}
             - -log-level={{ .Values.exporters.zookeeper.config.logLevel }}
             - -reset-on-scrape={{ .Values.exporters.zookeeper.config.resetOnScrape }}
           ports:
-  {{- range $key, $port := .Values.exporters.zookeeper.ports }}
-            - name: {{ $key }}
-{{ toYaml $port | indent 14 }}
-  {{- end }}
+            - name: zookeeperxp
+              containerPort: {{ .Values.exporters.zookeeper.port }}
+              protocol: TCP
           livenessProbe:
 {{ toYaml .Values.exporters.zookeeper.livenessProbe | indent 12 }}
           readinessProbe:

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -182,11 +182,14 @@ exporters:
       startDelaySeconds: 30
     env: {}
     resources: {}
+    #  limits:
+    #    cpu: 1
+    #    memory: 512Mi
+    #  requests:
+    #    cpu: 20m
+    #    memory: 256Mi
     path: /metrics
-    ports:
-      jmxxp:
-        containerPort: 9404
-        protocol: TCP
+    port: 9404
     livenessProbe:
       httpGet:
         path: /metrics
@@ -206,6 +209,12 @@ exporters:
       failureThreshold: 8
       successThreshold: 1
 
+    ## Interval at which Prometheus scrapes metrics, note: only used by Prometheus Operator
+    interval: 10s
+
+    ## Timeout at which Prometheus timeouts scrape run, note: only used by Prometheus Operator
+    scrapeTimeout: 10s
+
   zookeeper:
   ## refs:
   ## - https://github.com/carlpett/zookeeper_exporter
@@ -221,11 +230,14 @@ exporters:
       resetOnScrape: "true"
     env: {}
     resources: {}
+    #  limits:
+    #    cpu: 1
+    #    memory: 128Mi
+    #  requests:
+    #    cpu: 20m
+    #    memory: 16Mi
     path: /metrics
-    ports:
-      zookeeperxp:
-        containerPort: 9141
-        protocol: TCP
+    port: 9141
     livenessProbe:
       httpGet:
         path: /metrics
@@ -244,6 +256,27 @@ exporters:
       timeoutSeconds: 60
       failureThreshold: 8
       successThreshold: 1
+
+    ## Interval at which Prometheus scrapes metrics, note: only used by Prometheus Operator
+    interval: 10s
+
+    ## Timeout at which Prometheus timeouts scrape run, note: only used by Prometheus Operator
+    scrapeTimeout: 10s
+
+prometheus:
+  operator:
+    ## Are you using Prometheus Operator?
+    enabled: false
+
+    serviceMonitor:
+      # Namespace Prometheus is installed in
+      namespace: monitoring
+
+      ## Defaults to whats used if you follow CoreOS [Prometheus Install Instructions](https://github.com/coreos/prometheus-operator/tree/master/helm#tldr)
+      ## [Prometheus Selector Label](https://github.com/coreos/prometheus-operator/blob/master/helm/prometheus/templates/prometheus.yaml#L65)
+      ## [Kube Prometheus Selector Label](https://github.com/coreos/prometheus-operator/blob/master/helm/kube-prometheus/values.yaml#L298)
+      selector:
+        prometheus: kube-prometheus
 
 ## Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -291,21 +291,21 @@ prometheus:
         release: prometheus
 
       ## Some example rules. It might be an idea to limit these down to the current release e.g. max(zk_synced_followers{service="my-zookeeper-release"}) < 2
-      rules:
-        ZookeeperSyncedFollowers:
-          annotations:
-            message: The number of synced followers for the leader node in Zookeeper deployment {{ "{{" }} $labels.service {{ "}}" }} is less than 2. This usually means that some of the Zookeeper nodes aren't communicating properly. If it doesn't resolve itself you can try killing the pods (one by one).
-          expr: max(zk_synced_followers) by (service) < 2
-          for: 5m
-          labels:
-            severity: critical
-        ZookeeperOutstandingRequests:
-          annotations:
-            message: The number of outstanding requests for Zookeeper pod {{ "{{" }} $labels.pod {{ "}}" }} is greater than 10. This can indicate a performance issue with the Pod or cluster a whole.
-          expr: zk_outstanding_requests > 10
-          for: 5m
-          labels:
-            severity: critical
+      rules: {}
+      #  ZookeeperSyncedFollowers:
+      #    annotations:
+      #      message: The number of synced followers for the leader node in Zookeeper deployment {{ "{{" }} $labels.service {{ "}}" }} is less than 2. This usually means that some of the Zookeeper nodes aren't communicating properly. If it doesn't resolve itself you can try killing the pods (one by one).
+      #    expr: max(zk_synced_followers) by (service) < 2
+      #    for: 5m
+      #    labels:
+      #      severity: critical
+      #  ZookeeperOutstandingRequests:
+      #    annotations:
+      #      message: The number of outstanding requests for Zookeeper pod {{ "{{" }} $labels.pod {{ "}}" }} is greater than 10. This can indicate a performance issue with the Pod or cluster a whole.
+      #    expr: zk_outstanding_requests > 10
+      #    for: 5m
+      #    labels:
+      #      severity: critical
 
 ## Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -269,14 +269,43 @@ prometheus:
     enabled: false
 
     serviceMonitor:
-      # Namespace Prometheus is installed in
-      namespace: monitoring
+      ## Namespace in which to install the ServiceMonitor. Defaults to the same as everything else.
+      # namespace: monitoring
 
-      ## Defaults to whats used if you follow CoreOS [Prometheus Install Instructions](https://github.com/coreos/prometheus-operator/tree/master/helm#tldr)
-      ## [Prometheus Selector Label](https://github.com/coreos/prometheus-operator/blob/master/helm/prometheus/templates/prometheus.yaml#L65)
-      ## [Kube Prometheus Selector Label](https://github.com/coreos/prometheus-operator/blob/master/helm/kube-prometheus/values.yaml#L298)
+      ## Labels to add to the ServiceMonitor so it is picked up by the operator.
+      ## If using the [Helm Chart](https://github.com/helm/charts/tree/master/stable/prometheus-operator) this is the name of the Helm release.
       selector:
-        prometheus: kube-prometheus
+        release: prometheus
+
+    prometheusRule:
+      ## Add Prometheus Rules?
+      enabled: false
+
+      ## Namespace in which to install the PrometheusRule. Defaults to the same as everything else.
+      # namespace: monitoring
+
+      ## Labels to add to the PrometheusRule so it is picked up by the operator.
+      ## If using the [Helm Chart](https://github.com/helm/charts/tree/master/stable/prometheus-operator) this is the name of the Helm release and 'app: prometheus-operator'
+      selector:
+        app: prometheus-operator
+        release: prometheus
+
+      ## Some example rules. It might be an idea to limit these down to the current release e.g. max(zk_synced_followers{service="my-zookeeper-release"}) < 2
+      rules:
+        ZookeeperSyncedFollowers:
+          annotations:
+            message: The number of synced followers for the leader node in Zookeeper deployment {{ "{{" }} $labels.service {{ "}}" }} is less than 2. This usually means that some of the Zookeeper nodes aren't communicating properly. If it doesn't resolve itself you can try killing the pods (one by one).
+          expr: max(zk_synced_followers) by (service) < 2
+          for: 5m
+          labels:
+            severity: critical
+        ZookeeperOutstandingRequests:
+          annotations:
+            message: The number of outstanding requests for Zookeeper pod {{ "{{" }} $labels.pod {{ "}}" }} is greater than 10. This can indicate a performance issue with the Pod or cluster a whole.
+          expr: zk_outstanding_requests > 10
+          for: 5m
+          labels:
+            severity: critical
 
 ## Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds Prometheus Operator support to the existing exporter sidecar containers. More or less copied from incubator/kafka (and verified working in my environment).

#### Special notes for your reviewer:
Only backwards-incompatible change is the removal of the option to add multiple ports to the exporters, which I really can't see anyone using and adds complexity.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md (no existing variables in README, should be addressed separately)
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
