### PR TITLE
[stable/prometheus-node-exporter] Allows deploy ServiceAccount w/o RBAC

### DIFF
--- a/stable/prometheus-node-exporter/Chart.yaml
+++ b/stable/prometheus-node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.17.0"
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 1.4.2
+version: 1.5.0
 home: https://github.com/prometheus/node_exporter/
 sources:
 - https://github.com/prometheus/node_exporter/

--- a/stable/prometheus-node-exporter/templates/serviceaccount.yaml
+++ b/stable/prometheus-node-exporter/templates/serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.rbac.create -}}
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -6,10 +5,9 @@ metadata:
   name: {{ template "prometheus-node-exporter.serviceAccountName" . }}
   labels:
     app: {{ template "prometheus-node-exporter.name" . }}
-    chart: {{ template "prometheus-node-exporter.chart" . }}    
+    chart: {{ template "prometheus-node-exporter.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-imagePullSecrets: 
+imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}
-{{- end -}}
 {{- end -}}


### PR DESCRIPTION
Useful for imagePullSecrets

Signed-off-by: Marcos Estevez <marcos.stvz@gmail.com>

#### What this PR does / why we need it:
Currently it is not possible to disable RBAC and yet deploying the ServiceAccount. In my use case I need that to use imagePullSecrets

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] (Does not apply) Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
