### PR TITLE
[stable/opa] add namespace selector to OPA webhook resource and bump …

### DIFF
--- a/stable/opa/Chart.yaml
+++ b/stable/opa/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - opa
 - admission control
 - policy
-version: 1.4.1
+version: 1.4.2
 home: https://www.openpolicyagent.org
 icon: https://raw.githubusercontent.com/open-policy-agent/opa/master/logo/logo.png
 sources:

--- a/stable/opa/templates/webhookconfiguration.yaml
+++ b/stable/opa/templates/webhookconfiguration.yaml
@@ -13,6 +13,9 @@ metadata:
 {{ include "opa.labels.standard" . | indent 4 }}
 webhooks:
   - name: webhook.openpolicyagent.org
+    namespaceSelector:
+      matchLabels:
+        openpolicyagent.org/policy: rego
     failurePolicy: {{ .Values.admissionControllerFailurePolicy }}
     rules:
 {{ toYaml .Values.admissionControllerRules | indent 6 }}

--- a/stable/opa/templates/webhookconfiguration.yaml
+++ b/stable/opa/templates/webhookconfiguration.yaml
@@ -14,8 +14,8 @@ metadata:
 webhooks:
   - name: webhook.openpolicyagent.org
     namespaceSelector:
-      matchLabels:
-        openpolicyagent.org/policy: rego
+      matchExpressions:
+        - {key: openpolicyagent.org/webhook, operator: NotIn, values: [ignore]}
     failurePolicy: {{ .Values.admissionControllerFailurePolicy }}
     rules:
 {{ toYaml .Values.admissionControllerRules | indent 6 }}


### PR DESCRIPTION
…version

Signed-off-by: Casey Lee <cplee@nektos.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
@tsandall 
When allowing the helm chart to manage the self-signed certs, it causes certs to be recreated on an upgrade and then the webhook restricts the opa chart for upgrading itself...resulting in deadlock.

#### Which issue this PR fixes


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
