### PR TITLE
[incubator/vault] parse ConfigMap with tpl instead of literal from .Values

### DIFF
--- a/incubator/vault/templates/configmap.yaml
+++ b/incubator/vault/templates/configmap.yaml
@@ -10,5 +10,5 @@ metadata:
     chart: "{{ template "vault.chart" . }}"
 data:
   config.json: |
-    {{ .Values.vault.config | toJson }}
+    {{ tpl .Values.vault.config . | toJson }}
 {{ end }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

parse ConfigMap with tpl instead of literal .Values
- enables flexibility by enabling templating in values.yaml file
- ^ can be used to securely pull secrets (ie Consul acl token) from K8s secrets store instead of hardcoding or adding a ton of storage-backend specific variables
ie
```

```

Signed-off-by: Brian Surber <bsurber120@yahoo.com>

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
