### PR TITLE
toggle honorLabels in helm-exporter servicemonitor

### DIFF
--- a/stable/helm-exporter/Chart.yaml
+++ b/stable/helm-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.3.1"
 description: Exports helm release stats to prometheus
 name: helm-exporter
-version: 0.2.1
+version: 0.3.1
 home: https://github.com/sstarcher/helm-exporter
 sources:
 - https://github.com/sstarcher/helm-exporter

--- a/stable/helm-exporter/templates/servicemonitor.yaml
+++ b/stable/helm-exporter/templates/servicemonitor.yaml
@@ -17,6 +17,7 @@ metadata:
 spec:
   endpoints:
   - port: metrics
+    honorLabels: true
     {{- with .Values.serviceMonitor.interval }}
     interval: {{ . }}
     {{- end }}


### PR DESCRIPTION
#### Which issue this PR fixes
Default label renaming which prometheus-operator preforms breaks https://grafana.com/dashboards/9367

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x ] Chart Version bumped
- [ x] title of the PR contains starts with chart name e.g. `[stable/chart]`
