### PR TITLE
[stable/helm-exporter] toggle honorLabels in servicemonitor

### DIFF
--- a/stable/helm-exporter/Chart.yaml
+++ b/stable/helm-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.3.1"
 description: Exports helm release stats to prometheus
 name: helm-exporter
-version: 0.2.1
+version: 0.2.2
 home: https://github.com/sstarcher/helm-exporter
 sources:
 - https://github.com/sstarcher/helm-exporter

--- a/stable/helm-exporter/templates/servicemonitor.yaml
+++ b/stable/helm-exporter/templates/servicemonitor.yaml
@@ -17,6 +17,7 @@ metadata:
 spec:
   endpoints:
   - port: metrics
+    honorLabels: true
     {{- with .Values.serviceMonitor.interval }}
     interval: {{ . }}
     {{- end }}


### PR DESCRIPTION
prometheus-operator renames 'namespace' label to 'exported-namespace'
which breaks https://grafana.com/dashboards/9367

Signed-off-by: Alex Snast <alexsn@fb.com>

#### Which issue this PR fixes
Default label renaming which prometheus-operator preforms breaks https://grafana.com/dashboards/9367

Checklist
[x ] DCO signed
[x ] Chart Version bumped
[ x] title of the PR contains starts with chart name e.g. [stable/chart]
