### PR TITLE
[stable/ambassador] Allow for ambassador to work better on-prem

### DIFF
--- a/stable/ambassador/Chart.yaml
+++ b/stable/ambassador/Chart.yaml
@@ -2,7 +2,11 @@ apiVersion: v1
 appVersion: 0.60.3
 description: A Helm chart for Datawire Ambassador
 name: ambassador
+<<<<<<< HEAD
 version: 2.3.1
+=======
+version: 2.2.6
+>>>>>>> Chart bump
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/stable/ambassador/Chart.yaml
+++ b/stable/ambassador/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.60.3
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 2.3.2
+version: 2.4.0 
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/stable/ambassador/Chart.yaml
+++ b/stable/ambassador/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.60.3
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 2.4.0 
+version: 2.4.0
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/stable/ambassador/Chart.yaml
+++ b/stable/ambassador/Chart.yaml
@@ -2,11 +2,7 @@ apiVersion: v1
 appVersion: 0.60.3
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-<<<<<<< HEAD
-version: 2.3.1
-=======
-version: 2.2.6
->>>>>>> Chart bump
+version: 2.3.2
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/stable/ambassador/README.md
+++ b/stable/ambassador/README.md
@@ -49,6 +49,8 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `adminService.type`                | Ambassador's admin service type to be used                                      | `ClusterIP`                                         |
 | `ambassadorConfig`                 | Config thats mounted to `/ambassador/ambassador-config`                         | `""`                                                |
 | `daemonSet`                        | If `true`, Create a daemonSet. By default Deployment controller will be created | `false`                                             |
+| `hostNetwork`                        | If `true`, uses the host network, useful for on-premise setups                | `false`                                       |
+| `dnsPolicy`                        | Dns policy, when hostNetwork set to ClusterFirstWithHostNet                     | `ClusterFirst`                                       |
 | `env`                              | Any additional environment variables for ambassador pods                        | `{}`                                                |
 | `image.pullPolicy`                 | Ambassador image pull policy                                                    | `IfNotPresent`                                      |
 | `image.repository`                 | Ambassador image                                                                | `quay.io/datawire/ambassador`                       |

--- a/stable/ambassador/templates/deployment.yaml
+++ b/stable/ambassador/templates/deployment.yaml
@@ -194,6 +194,6 @@ spec:
     {{- end }}
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
-      dnsPolicy: {{ .Values.dnsPolicy | default "ClusterFirst" }}
-      hostNetwork: {{ .Values.hostNetwork | default "false" }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      hostNetwork: {{ .Values.hostNetwork }}
 

--- a/stable/ambassador/templates/deployment.yaml
+++ b/stable/ambassador/templates/deployment.yaml
@@ -194,3 +194,6 @@ spec:
     {{- end }}
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      dnsPolicy: {{ .Values.dnsPolicy | default "ClusterFirst" }}
+      hostNetwork: {{ .Values.hostNetwork | default "false" }}
+

--- a/stable/ambassador/values.yaml
+++ b/stable/ambassador/values.yaml
@@ -35,6 +35,8 @@ image:
 
 nameOverride: ""
 fullnameOverride: ""
+dnsPolicy: "ClusterFirst"
+hostNetwork: false
 
 service:
   type: LoadBalancer


### PR DESCRIPTION
#### What this PR does / why we need it:
This allows on-premise to set the dnsPolicy and the usage of the hostNetwork for on-premise usage.

The defaults are set to not interfere with current operations.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] Variables are documented in the README.md
- [ x] title of the PR contains starts with chart name e.g. `[stable/chart]`
