### PR TITLE
[stable/logstash] Mount Custom Binary Files

### DIFF
--- a/stable/logstash/Chart.yaml
+++ b/stable/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 1.8.0
+version: 1.9.0
 appVersion: 6.7.0
 sources:
 - https://www.docker.elastic.co

--- a/stable/logstash/README.md
+++ b/stable/logstash/README.md
@@ -114,6 +114,7 @@ The following table lists the configurable parameters of the chart and its defau
 | `config`                        | Logstash configuration key-values                  | (see `values.yaml`)                              |
 | `patterns`                      | Logstash patterns configuration                    | `nil`                                            |
 | `files`                         | Logstash custom files configuration                | `nil`                                            |
+| `binaryFiles`                   | Logstash custom binary files                       | `nil`                                            |
 | `inputs`                        | Logstash inputs configuration                      | beats                                            |
 | `filters`                       | Logstash filters configuration                     | `nil`                                            |
 | `outputs`                       | Logstash outputs configuration                     | elasticsearch                                    |

--- a/stable/logstash/templates/files-config.yaml
+++ b/stable/logstash/templates/files-config.yaml
@@ -12,3 +12,9 @@ data:
   {{ $key }}: |-
 {{ $value | indent 4 }}
 {{- end }}
+binaryData:
+ {{- range $key, $value := .Values.binaryFiles }}
+   {{ $key }}: |-
+{{ $value | indent 4   }}
+ {{- end }}
+ 

--- a/stable/logstash/values.yaml
+++ b/stable/logstash/values.yaml
@@ -249,6 +249,11 @@ files:
   #     "aliases": {}
   #   }
 
+## Custom binary files encoded as base64 string that can be referenced by plugins
+## Each base64 encoded string is decoded & mounted as a file under logstash home directory under
+## the files subdirectory.
+binaryFiles: {}
+
 ## NOTE: To achieve multiple pipelines with this chart, current best practice
 ## is to maintain one pipeline per chart release. In this way configuration is
 ## simplified and pipelines are more isolated from one another.


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds support to mount binary files inside logstash pod which is required by some plugins like tha kafka plugin in both input and output needs to have ssl keystores in jks (Java Keystore) format for authentication which is basically a binary format.

#### List of Changes
* Add `binaryData` block in the files configmap in addition to the `data` block that takes base64 encoded strings, and eventually these strings are base64 decoded and mounted as binary files in _files_ directory in logstash directory 
* Add templating in _values.yaml_

#### Which issue this PR fixes
  - fixes #13533 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
