### PR TITLE
[stable/nats] support for deploying nats with "Deployment"

### DIFF
--- a/stable/nats/Chart.yaml
+++ b/stable/nats/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nats
-version: 2.4.2
+version: 2.5.0
 appVersion: 1.4.1
 description: An open-source, cloud-native messaging system
 keywords:

--- a/stable/nats/README.md
+++ b/stable/nats/README.md
@@ -68,6 +68,7 @@ The following table lists the configurable parameters of the NATS chart and thei
 | `maxConnections`                     | Max. number of client connections                                                            | `nil`                                                         |
 | `maxControlLine`                     | Max. protocol control line                                                                   | `nil`                                                         |
 | `maxPayload`                         | Max. payload                                                                                 | `nil`                                                         |
+| `mode`                               | NATS cluster running mode                                                                    | `statefulset`                                                 |
 | `writeDeadline`                      | Duration the server can block on a socket write to a client                                  | `nil`                                                         |
 | `replicaCount`                       | Number of NATS nodes                                                                         | `1`                                                           |
 | `securityContext.enabled`            | Enable security context                                                                      | `true`                                                        |

--- a/stable/nats/README.md
+++ b/stable/nats/README.md
@@ -68,9 +68,9 @@ The following table lists the configurable parameters of the NATS chart and thei
 | `maxConnections`                     | Max. number of client connections                                                            | `nil`                                                         |
 | `maxControlLine`                     | Max. protocol control line                                                                   | `nil`                                                         |
 | `maxPayload`                         | Max. payload                                                                                 | `nil`                                                         |
-| `mode`                               | NATS cluster running mode                                                                    | `statefulset`                                                 |
 | `writeDeadline`                      | Duration the server can block on a socket write to a client                                  | `nil`                                                         |
 | `replicaCount`                       | Number of NATS nodes                                                                         | `1`                                                           |
+| `resourceType`                       | NATS cluster resource type under Kubernetes (Supported: StatefulSets, or Deployment)         | `statefulset`                                                 |
 | `securityContext.enabled`            | Enable security context                                                                      | `true`                                                        |
 | `securityContext.fsGroup`            | Group ID for the container                                                                   | `1001`                                                        |
 | `securityContext.runAsUser`          | User ID for the container                                                                    | `1001`                                                        |

--- a/stable/nats/templates/NOTES.txt
+++ b/stable/nats/templates/NOTES.txt
@@ -1,5 +1,17 @@
 ** Please be patient while the chart is being deployed **
 
+{{- if and (not (eq .Values.resourceType "statefulset")) (not (eq .Values.resourceType "deployment")) }}
+
+-------------------------------------------------------------------------------
+ WARNING
+
+   "resourceType" currently only "statefulset", "deployment" are allowed
+   the type specified in values.yaml >> {{ .Values.resourceType }} << is not defined in white list
+   but it will still continuing deploy with default resource type "statefulset"
+
+-------------------------------------------------------------------------------
+{{- end }}
+
 {{- if or (contains .Values.client.service.type "LoadBalancer") (contains .Values.client.service.type "nodePort") }}
 {{- if not .Values.auth.enabled }}
 {{ if and (not .Values.networkPolicy.enabled) (.Values.networkPolicy.allowExternal) }}

--- a/stable/nats/templates/cluster.yaml
+++ b/stable/nats/templates/cluster.yaml
@@ -1,5 +1,10 @@
+{{- if (eq "statefulset" .Values.serviceType) }}
 apiVersion: apps/v1beta2
 kind: StatefulSet
+{{- else }}
+apiVersion: apps/v1
+kind: Deployment
+{{- end }}
 metadata:
   name: {{ template "nats.fullname" . }}
   labels:
@@ -10,6 +15,7 @@ metadata:
 spec:
   serviceName: {{ template "nats.fullname" . }}-headless
   replicas: {{ .Values.replicaCount }}
+{{- if (eq "statefulset" .Values.serviceType) }}
   updateStrategy:
     type: {{ .Values.statefulset.updateStrategy }}
     {{- if (eq "Recreate" .Values.statefulset.updateStrategy) }}
@@ -20,6 +26,13 @@ spec:
       partition: {{ .Values.statefulset.rollingUpdatePartition }}
     {{- end }}
     {{- end }}
+{{- else }}
+  strategy:
+    rollingUpdate:
+      maxSurge: {{ .Values.deployment.maxSurge }}
+      maxUnavailable: {{ .Values.deployment.maxUnavailable }}
+    type: {{ .Values.deployment.updateType }}
+{{- end }}
   selector:
     matchLabels:
       app: "{{ template "nats.name" . }}"

--- a/stable/nats/templates/deployment.yaml
+++ b/stable/nats/templates/deployment.yaml
@@ -1,10 +1,6 @@
-{{- if (eq "statefulset" .Values.serviceType) }}
-apiVersion: apps/v1beta2
-kind: StatefulSet
-{{- else }}
+{{- if eq .Values.mode "deployment" }}
 apiVersion: apps/v1
 kind: Deployment
-{{- end }}
 metadata:
   name: {{ template "nats.fullname" . }}
   labels:
@@ -15,24 +11,11 @@ metadata:
 spec:
   serviceName: {{ template "nats.fullname" . }}-headless
   replicas: {{ .Values.replicaCount }}
-{{- if (eq "statefulset" .Values.serviceType) }}
-  updateStrategy:
-    type: {{ .Values.statefulset.updateStrategy }}
-    {{- if (eq "Recreate" .Values.statefulset.updateStrategy) }}
-    rollingUpdate: null
-    {{- else }}
-    {{- if .Values.statefulset.rollingUpdatePartition }}
-    rollingUpdate:
-      partition: {{ .Values.statefulset.rollingUpdatePartition }}
-    {{- end }}
-    {{- end }}
-{{- else }}
   strategy:
     rollingUpdate:
       maxSurge: {{ .Values.deployment.maxSurge }}
       maxUnavailable: {{ .Values.deployment.maxUnavailable }}
     type: {{ .Values.deployment.updateType }}
-{{- end }}
   selector:
     matchLabels:
       app: "{{ template "nats.name" . }}"
@@ -176,3 +159,4 @@ spec:
       - name: config
         configMap:
           name: {{ template "nats.fullname" . }}
+{{- end }}

--- a/stable/nats/templates/deployment.yaml
+++ b/stable/nats/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.mode "deployment" }}
+{{- if eq .Values.resourceType "deployment" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/stable/nats/templates/deployment.yaml
+++ b/stable/nats/templates/deployment.yaml
@@ -88,7 +88,11 @@ spec:
         - gnatsd
         args:
         - -c
-        - /opt/nats/gnatsd.conf
+        - /opt/bitnami/nats/gnatsd.conf
+        # to ensure nats could run with non-root user, we put the configuration
+        # file under `/opt/bitnami/nats/gnatsd.conf`, please check the link below
+        # for the implementation inside Dockerfile:
+        # - https://github.com/bitnami/bitnami-docker-nats/blob/master/1/debian-9/Dockerfile#L12
         {{- if .Values.extraArgs }}
 {{ toYaml .Values.extraArgs | indent 8 }}
         {{- end }}
@@ -125,7 +129,7 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
           - name: config
-            mountPath: /opt/nats/gnatsd.conf
+            mountPath: /opt/bitnami/nats/gnatsd.conf
             subPath: gnatsd.conf
         {{- if .Values.sidecars }}
 {{ toYaml .Values.sidecars | indent 6 }}

--- a/stable/nats/templates/statefulset.yaml
+++ b/stable/nats/templates/statefulset.yaml
@@ -93,7 +93,11 @@ spec:
         - gnatsd
         args:
         - -c
-        - /opt/nats/gnatsd.conf
+        - /opt/bitnami/nats/gnatsd.conf
+        # to ensure nats could run with non-root user, we put the configuration
+        # file under `/opt/bitnami/nats/gnatsd.conf`, please check the link below
+        # for the implementation inside Dockerfile:
+        # - https://github.com/bitnami/bitnami-docker-nats/blob/master/1/debian-9/Dockerfile#L12
         {{- if .Values.extraArgs }}
 {{ toYaml .Values.extraArgs | indent 8 }}
         {{- end }}
@@ -130,7 +134,7 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
           - name: config
-            mountPath: /opt/nats/gnatsd.conf
+            mountPath: /opt/bitnami/nats/gnatsd.conf
             subPath: gnatsd.conf
         {{- if .Values.sidecars }}
 {{ toYaml .Values.sidecars | indent 6 }}

--- a/stable/nats/templates/statefulset.yaml
+++ b/stable/nats/templates/statefulset.yaml
@@ -1,0 +1,167 @@
+{{- if eq .Values.mode "statefulset" }}
+apiVersion: apps/v1beta2
+kind: StatefulSet
+metadata:
+  name: {{ template "nats.fullname" . }}
+  labels:
+    app: "{{ template "nats.name" . }}"
+    chart: "{{ template "nats.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+spec:
+  serviceName: {{ template "nats.fullname" . }}-headless
+  replicas: {{ .Values.replicaCount }}
+  updateStrategy:
+    type: {{ .Values.statefulset.updateStrategy }}
+    {{- if (eq "Recreate" .Values.statefulset.updateStrategy) }}
+    rollingUpdate: null
+    {{- else }}
+    {{- if .Values.statefulset.rollingUpdatePartition }}
+    rollingUpdate:
+      partition: {{ .Values.statefulset.rollingUpdatePartition }}
+    {{- end }}
+    {{- end }}
+  selector:
+    matchLabels:
+      app: "{{ template "nats.name" . }}"
+      release: {{ .Release.Name | quote }}
+  template:
+    metadata:
+      labels:
+        app: "{{ template "nats.name" . }}"
+        chart: "{{ template "nats.chart" . }}"
+        release: {{ .Release.Name | quote }}
+        {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+        {{- end }}
+{{- if or .Values.podAnnotations .Values.metrics.enabled }}
+      annotations:
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+{{- if .Values.metrics.podAnnotations }}
+{{ toYaml .Values.metrics.podAnnotations | indent 8 }}
+{{- end }}
+{{- end }}
+    spec:
+{{- include "nats.imagePullSecrets" . | indent 6 }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.schedulerName }}
+      schedulerName: {{ .Values.schedulerName | quote }}
+      {{- end }}
+      {{- if eq .Values.antiAffinity "hard" }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  app: "{{ template "nats.name" . }}"
+                  release: {{ .Release.Name | quote }}
+      {{- else if eq .Values.antiAffinity "soft" }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: "{{ template "nats.name" . }}"
+                  release: {{ .Release.Name | quote }}
+      {{- end }}
+      containers:
+      - name: {{ template "nats.name" . }}
+        image: {{ template "nats.image" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - gnatsd
+        args:
+        - -c
+        - /opt/nats/gnatsd.conf
+        {{- if .Values.extraArgs }}
+{{ toYaml .Values.extraArgs | indent 8 }}
+        {{- end }}
+        ports:
+        - name: client
+          containerPort: {{ .Values.client.service.port }}
+        - name: cluster
+          containerPort: {{ .Values.cluster.service.port }}
+        - name: monitoring
+          containerPort: {{ .Values.monitoring.service.port }}
+        {{- if .Values.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            path: /
+            port: monitoring
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: /
+            port: monitoring
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        {{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+          - name: config
+            mountPath: /opt/nats/gnatsd.conf
+            subPath: gnatsd.conf
+        {{- if .Values.sidecars }}
+{{ toYaml .Values.sidecars | indent 6 }}
+        {{- end }}
+{{- if .Values.metrics.enabled }}
+      - name: metrics
+        image: {{ template "nats.metrics.image" . }}
+        imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
+        args:
+{{ toYaml .Values.metrics.args | indent 10 -}}
+          - "http://localhost:{{ .Values.monitoring.service.port }}"
+        ports:
+        - name: metrics
+          containerPort: {{ .Values.metrics.port }}
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        resources:
+{{ toYaml .Values.metrics.resources | indent 10 }}
+{{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "nats.fullname" . }}
+{{- end }}

--- a/stable/nats/templates/statefulset.yaml
+++ b/stable/nats/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.mode "statefulset" }}
+{{- if or (eq .Values.resourceType "statefulset") (not (contains .Values.resourceType "deployment")) }}
 apiVersion: apps/v1beta2
 kind: StatefulSet
 metadata:

--- a/stable/nats/values-production.yaml
+++ b/stable/nats/values-production.yaml
@@ -65,10 +65,11 @@ podLabels: {}
 ##
 # priorityClassName: ""
 
-## Select Kind of Deployment:
-## - statefulset
-## - deployment (default)
-serviceType: "statefulset"
+## nats-cluster running mode. Allowed values: statefulset (default) or deployment
+## ref:
+## - https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
+## - https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+mode: "statefulset"
 
 ## Update strategy for statefulset, can be set to RollingUpdate or OnDelete by default.
 ## https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets
@@ -82,8 +83,8 @@ statefulset:
 ## https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
 deployment:
   updateType: RollingUpdate
-  maxSurge: 25%
-  maxUnavailable: 25%
+  # maxSurge: 25%
+  # maxUnavailable: 25%
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/stable/nats/values-production.yaml
+++ b/stable/nats/values-production.yaml
@@ -65,7 +65,12 @@ podLabels: {}
 ##
 # priorityClassName: ""
 
-## Update strategy, can be set to RollingUpdate or OnDelete by default.
+## Select Kind of Deployment:
+## - statefulset
+## - deployment (default)
+serviceType: "statefulset"
+
+## Update strategy for statefulset, can be set to RollingUpdate or OnDelete by default.
 ## https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets
 statefulset:
   updateStrategy: OnDelete
@@ -73,6 +78,12 @@ statefulset:
   ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
   # rollingUpdatePartition:
 
+## Update strategy for deployment, can be set to RollingUpdate or OnDelete by default.
+## https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+deployment:
+  updateType: RollingUpdate
+  maxSurge: 25%
+  maxUnavailable: 25%
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/stable/nats/values-production.yaml
+++ b/stable/nats/values-production.yaml
@@ -65,11 +65,11 @@ podLabels: {}
 ##
 # priorityClassName: ""
 
-## nats-cluster running mode. Allowed values: statefulset (default) or deployment
+## NATS cluster resource type under Kubernetes. Allowed values: statefulset (default) or deployment
 ## ref:
 ## - https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 ## - https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
-mode: "statefulset"
+resourceType: "statefulset"
 
 ## Update strategy for statefulset, can be set to RollingUpdate or OnDelete by default.
 ## https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets

--- a/stable/nats/values.yaml
+++ b/stable/nats/values.yaml
@@ -69,11 +69,11 @@ podLabels: {}
 ##
 # priorityClassName: ""
 
-## nats-cluster running mode. Allowed values: statefulset (default) or deployment
+## NATS cluster resource type under Kubernetes. Allowed values: statefulset (default) or deployment
 ## ref:
 ## - https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 ## - https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
-mode: "statefulset"
+resourceType: "statefulset"
 
 ## Update strategy for statefulset, can be set to RollingUpdate or OnDelete by default.
 ## https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets

--- a/stable/nats/values.yaml
+++ b/stable/nats/values.yaml
@@ -69,7 +69,12 @@ podLabels: {}
 ##
 # priorityClassName: ""
 
-## Update strategy, can be set to RollingUpdate or OnDelete by default.
+## Select Kind of Deployment:
+## - statefulset
+## - deployment (default)
+serviceType: "statefulset"
+
+## Update strategy for statefulset, can be set to RollingUpdate or OnDelete by default.
 ## https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets
 statefulset:
   updateStrategy: OnDelete
@@ -77,6 +82,12 @@ statefulset:
   ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
   # rollingUpdatePartition:
 
+## Update strategy for deployment, can be set to RollingUpdate or OnDelete by default.
+## https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+deployment:
+  updateType: RollingUpdate
+  maxSurge: 25%
+  maxUnavailable: 25%
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/stable/nats/values.yaml
+++ b/stable/nats/values.yaml
@@ -69,10 +69,11 @@ podLabels: {}
 ##
 # priorityClassName: ""
 
-## Select Kind of Deployment:
-## - statefulset
-## - deployment (default)
-serviceType: "statefulset"
+## nats-cluster running mode. Allowed values: statefulset (default) or deployment
+## ref:
+## - https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
+## - https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+mode: "statefulset"
 
 ## Update strategy for statefulset, can be set to RollingUpdate or OnDelete by default.
 ## https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets
@@ -86,8 +87,8 @@ statefulset:
 ## https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
 deployment:
   updateType: RollingUpdate
-  maxSurge: 25%
-  maxUnavailable: 25%
+  # maxSurge: 25%
+  # maxUnavailable: 25%
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently, nats-cluster is deploy via StatefulSets with no volume defined, also, scaling with Deployment is much more faster than StatefulSets.

#### Which issue this PR fixes
- Slow scaling
- Support for "Deployment"

#### Special notes for your reviewer:
- N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] title of the PR contains starts with chart name e.g. `[stable/chart]`