### PR TITLE
[stable/home-assistant] support for optional VS Code server sidecar

### DIFF
--- a/stable/home-assistant/Chart.yaml
+++ b/stable/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.92.2
 description: Home Assistant
 name: home-assistant
-version: 0.8.2
+version: 0.9.0
 keywords:
 - home-assistant
 - hass
@@ -12,6 +12,7 @@ icon: https://upload.wikimedia.org/wikipedia/commons/thumb/6/6e/Home_Assistant_L
 sources:
 - https://github.com/home-assistant/home-assistant
 - https://github.com/danielperna84/hass-configurator
+- https://github.com/cdr/code-server
 maintainers:
 - name: billimek
   email: jeff@billimek.com

--- a/stable/home-assistant/README.md
+++ b/stable/home-assistant/README.md
@@ -100,7 +100,8 @@ The following tables lists the configurable parameters of the Home Assistant cha
 | `vscode.image.repository`         | Image repository | `codercom/code-server` |
 | `vscode.image.tag`                | Image tag | `1.939`|
 | `vscode.image.pullPolicy`         | Image pull policy | `IfNotPresent` |
-| `vscode.basepath`                 | Base path of the home assistant configuration files | `/config` |
+| `vscode.hassConfig`               | Base path of the home assistant configuration files | `/config` |
+| `vscode.vscodePath`               | Base path of the VS Code configuration files | `/config/.vscode` |
 | `vscode.password`                 | If this is set, will require a password to access the VS Code Server UI | `` |
 | `vscode.extraEnv`                 | Extra ENV vars to pass to the configuration UI | `{}` |
 | `vscode.ingress.enabled`          | Enables Ingress for the VS Code UI | `false` |
@@ -139,15 +140,21 @@ helm install --name my-release -f values.yaml stable/home-assistant
 
 Read through the [values.yaml](values.yaml) file. It has several commented out suggested values.
 
-## Regarding configuring home assistant
+## Configuring home assistant
 
-Much of the home assistant configuration occurs inside the various files persisted to the `/config` directory.  This will require external access to the persistent storage location where the home assistant configuration data is stored.
+Much of the home assistant configuration occurs inside the various files persisted to the `/config` directory.  This will require external access to the persistent storage location where the home assistant configuration data is stored.  Because this may be a limitation, there are two options built-in to this chart:
 
-Because this may be a limitation, the [Home Assistant Configurator UI](https://github.com/danielperna84/hass-configurator) and/or the [VS Code Server](https://github.com/cdr/code-server) are added to the chart as an option to provide a webUI for editing the various configuration files.
+### Configurator UI
+
+[Home Assistant Configurator UI](https://github.com/danielperna84/hass-configurator) is added as an optional sidecar container to Home Assistant with access to the home assistant configuration for easy in-browser editing and manipulation of Home Assistant.
+
+### VS Code Server
+
+[VS Code Server](https://github.com/cdr/code-server) is added as an optional sidecar container to Home Assistant with access to the home assistant configuration for easy in-browser editing and manipulation of Home Assistant.  If using this, it is possible to manually install the [Home Assistant Config Helper Extension](https://github.com/keesschollaart81/vscode-home-assistant) in order to have a deeper integration with Home Assistant within VS Code while editing the configuration files.
 
 ## Git sync secret
 
-In order to sync the home assistent from a git repo, you have to store a ssh key as a kubernetes git secret
+In order to sync the home assistant from a git repo, you have to store a ssh key as a kubernetes git secret
 ```console
 kubectl create secret generic git-creds --from-file=id_rsa=git/k8s_id_rsa --from-file=known_hosts=git/known_hosts --from-file=id_rsa.pub=git/k8s_id_rsa.pub
 ```

--- a/stable/home-assistant/README.md
+++ b/stable/home-assistant/README.md
@@ -96,6 +96,28 @@ The following tables lists the configurable parameters of the Home Assistant cha
 | `configurator.service.externalIPs`      | External IPs for the configurator UI | `[]` |
 | `configurator.service.loadBalancerIP`   | Loadbalancer IP for the configurator UI | `` |
 | `configurator.service.loadBalancerSourceRanges`   | Loadbalancer client IP restriction range for the configurator UI | `[]` |
+| `vscode.enabled`                  | Enable the optional [VS Code Server Sidecar](https://github.com/cdr/code-server) | `false` |
+| `vscode.image.repository`         | Image repository | `codercom/code-server` |
+| `vscode.image.tag`                | Image tag | `1.939`|
+| `vscode.image.pullPolicy`         | Image pull policy | `IfNotPresent` |
+| `vscode.basepath`                 | Base path of the home assistant configuration files | `/config` |
+| `vscode.password`                 | If this is set, will require a password to access the VS Code Server UI | `` |
+| `vscode.extraEnv`                 | Extra ENV vars to pass to the configuration UI | `{}` |
+| `vscode.ingress.enabled`          | Enables Ingress for the VS Code UI | `false` |
+| `vscode.ingress.annotations`      | Ingress annotations for the VS Code UI | `{}` |
+| `vscode.ingress.hosts`            | Ingress accepted hostnames for the VS Code UI | `chart-example.local` |
+| `vscode.ingress.tls`              | Ingress TLS configuration for the VS Code UI | `[]` |
+| `vscode.resources`                | CPU/Memory resource requests/limits for the VS Code UI | `{}` |
+| `vscode.securityContext`          | Security context to be added to hass-vscode pods for the VS Code UI | `{}` |
+| `vscode.service.type`             | Kubernetes service type for the VS Code UI | `ClusterIP` |
+| `vscode.service.port`             | Kubernetes port where the vscode UI is exposed| `80` |
+| `vscode.service.nodePort`         | nodePort to listen on for the VS Code UI | `` |
+| `vscode.service.annotations`      | Service annotations for the VS Code UI | `{}` |
+| `vscode.service.labels`           | Service labels to use for the VS Code UI | `{}` |
+| `vscode.service.clusterIP`        | Cluster IP for the VS Code UI | `` |
+| `vscode.service.externalIPs`      | External IPs for the VS Code UI | `[]` |
+| `vscode.service.loadBalancerIP`   | Loadbalancer IP for the VS Code UI | `` |
+| `vscode.service.loadBalancerSourceRanges`   | Loadbalancer client IP restriction range for the VS Code UI | `[]` |
 | `resources`                | CPU/Memory resource requests/limits or the home-assistant GUI | `{}` |
 | `nodeSelector`             | Node labels for pod assignment or the home-assistant GUI | `{}` |
 | `tolerations`              | Toleration labels for pod assignment or the home-assistant GUI | `[]` |
@@ -121,7 +143,7 @@ Read through the [values.yaml](values.yaml) file. It has several commented out s
 
 Much of the home assistant configuration occurs inside the various files persisted to the `/config` directory.  This will require external access to the persistent storage location where the home assistant configuration data is stored.
 
-Because this may be a limitation, the [Home Assistant Configurator UI](https://github.com/danielperna84/hass-configurator) is added to the chart as an option to provide a webUI for editing the various configuration files.
+Because this may be a limitation, the [Home Assistant Configurator UI](https://github.com/danielperna84/hass-configurator) and/or the [VS Code Server](https://github.com/cdr/code-server) are added to the chart as an option to provide a webUI for editing the various configuration files.
 
 ## Git sync secret
 

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -109,16 +109,16 @@ spec:
           image: "{{ .Values.configurator.image.repository }}:{{ .Values.configurator.image.tag }}"
           imagePullPolicy: {{ .Values.configurator.image.pullPolicy }}
           ports:
-            - name: http
+            - name: configurator
               containerPort: {{ .Values.configurator.service.port }}
               protocol: TCP
           livenessProbe:
             tcpSocket:
-              port: http
+              port: configurator
             initialDelaySeconds: 30
           readinessProbe:
             tcpSocket:
-              port: http
+              port: configurator
             initialDelaySeconds: 15
           env:
             {{- if .Values.configurator.hassApiPassword }}
@@ -194,13 +194,24 @@ spec:
             - --user-data-dir={{ .Values.vscode.vscodePath }}
             {{- end }}
           ports:
-            - name: http
+            - name: vscode
               containerPort: {{ .Values.vscode.service.port }}
               protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: vscode
+            initialDelaySeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: vscode
+            initialDelaySeconds: 15
           env:
             {{- if .Values.vscode.password }}
             - name: PASSWORD
-              value: {{ .Values.vscode.password }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "home-assistant.fullname" . }}-vscode
+                  key: password
             {{- end }}
             {{- range $key, $value := .Values.vscode.extraEnv }}
             - name: {{ $key }}

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -182,15 +182,17 @@ spec:
         - name: vscode
           image: "{{ .Values.vscode.image.repository }}:{{ .Values.vscode.image.tag }}"
           imagePullPolicy: {{ .Values.vscode.image.pullPolicy }}
-          workingDir: {{ .Values.vscode.basepath }}
+          workingDir: {{ .Values.vscode.hassConfig }}
           args:
             - --allow-http
             - --port={{ .Values.vscode.service.port }}
             {{- if not (.Values.vscode.password) }}
             - --no-auth
             {{- end }}
-            - --extensions-dir=/config/vscode
-            - --user-data-dir=/config/vscode
+            {{- if .Values.vscode.vscodePath }}
+            - --extensions-dir={{ .Values.vscode.vscodePath }}
+            - --user-data-dir={{ .Values.vscode.vscodePath }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.vscode.service.port }}

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -52,6 +52,14 @@ spec:
         {{- end }}
         {{- end }}
       {{- end }}
+      {{- if .Values.vscode.enabled }}
+      - name: init-vscode
+        image: appropriate/curl
+        command: ['sh', '-c', '[ -f /config/vscode/vscode-home-assistant-0.5.0-beta.4.vsix ] || mkdir -p /config/vscode && curl -s -L --retry 3 -o /config/vscode/vscode-home-assistant-0.5.0-beta.4.vsix "https://github.com/keesschollaart81/vscode-home-assistant/releases/download/v0.5.0-beta4/vscode-home-assistant-0.5.0-beta.4.vsix"']
+        volumeMounts:
+        - mountPath: /config
+          name: config
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -177,6 +185,48 @@ spec:
           {{- end }}
           resources:
 {{ toYaml .Values.configurator.resources | indent 12 }}
+        {{- end }}
+        {{- if .Values.vscode.enabled }}
+        - name: vscode
+          image: "{{ .Values.vscode.image.repository }}:{{ .Values.vscode.image.tag }}"
+          imagePullPolicy: {{ .Values.vscode.image.pullPolicy }}
+          workingDir: {{ .Values.vscode.basepath }}
+          args:
+            - --allow-http
+            - --port={{ .Values.vscode.service.port }}
+            # - --install-extension=/config/vscode/vscode-home-assistant-0.5.0-beta.4.vsix
+            {{- if not (.Values.vscode.password) }}
+            - --no-auth
+            {{- end }}
+            - --extensions-dir=/config/vscode
+            - --user-data-dir=/config/vscode
+          ports:
+            - name: http
+              containerPort: {{ .Values.vscode.service.port }}
+              protocol: TCP
+          env:
+            {{- if .Values.vscode.password }}
+            - name: PASSWORD
+              value: {{ .Values.vscode.password }}
+            {{- end }}
+            {{- range $key, $value := .Values.vscode.extraEnv }}
+            - name: {{ $key }}
+              value: {{ $value }}
+            {{- end }}
+          volumeMounts:
+          - mountPath: /config
+            name: config
+          {{- if .Values.usePodSecurityContext }}
+          securityContext:
+            runAsUser: {{ default 0 .Values.runAsUser }}
+          {{- if and (.Values.runAsUser) (.Values.fsGroup) }}
+          {{- if not (eq .Values.runAsUser 0.0) }}
+            fsGroup: {{ .Values.fsGroup }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          resources:
+{{ toYaml .Values.vscode.resources | indent 12 }}
         {{- end }}
       volumes:
       - name: config

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -52,14 +52,6 @@ spec:
         {{- end }}
         {{- end }}
       {{- end }}
-      {{- if .Values.vscode.enabled }}
-      - name: init-vscode
-        image: appropriate/curl
-        command: ['sh', '-c', '[ -f /config/vscode/vscode-home-assistant-0.5.0-beta.4.vsix ] || mkdir -p /config/vscode && curl -s -L --retry 3 -o /config/vscode/vscode-home-assistant-0.5.0-beta.4.vsix "https://github.com/keesschollaart81/vscode-home-assistant/releases/download/v0.5.0-beta4/vscode-home-assistant-0.5.0-beta.4.vsix"']
-        volumeMounts:
-        - mountPath: /config
-          name: config
-      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -194,7 +186,6 @@ spec:
           args:
             - --allow-http
             - --port={{ .Values.vscode.service.port }}
-            # - --install-extension=/config/vscode/vscode-home-assistant-0.5.0-beta.4.vsix
             {{- if not (.Values.vscode.password) }}
             - --no-auth
             {{- end }}

--- a/stable/home-assistant/templates/secret.yaml
+++ b/stable/home-assistant/templates/secret.yaml
@@ -20,3 +20,20 @@ data:
   password: {{ .Values.configurator.password | b64enc | quote }}
   {{- end }}
 {{- end }}
+---
+{{- if .Values.vscode.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "home-assistant.fullname" . }}-vscode
+  labels:
+    app.kubernetes.io/name: {{ include "home-assistant.name" . }}
+    helm.sh/chart: {{ include "home-assistant.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+data:
+  {{- if .Values.vscode.password }}
+  password: {{ .Values.vscode.password | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/stable/home-assistant/templates/service.yaml
+++ b/stable/home-assistant/templates/service.yaml
@@ -45,7 +45,7 @@ spec:
       nodePort: {{.Values.service.nodePort}}
 {{ end }}
 {{- if .Values.configurator.enabled }}
-    - name: http
+    - name: configurator
       port: {{ .Values.configurator.service.port }}
       protocol: TCP
       targetPort: 3218
@@ -54,7 +54,7 @@ spec:
 {{ end }}
 {{- end }}
 {{- if .Values.vscode.enabled }}
-    - name: http
+    - name: vscode
       port: {{ .Values.vscode.service.port }}
       protocol: TCP
       targetPort: 80

--- a/stable/home-assistant/templates/service.yaml
+++ b/stable/home-assistant/templates/service.yaml
@@ -53,6 +53,15 @@ spec:
       nodePort: {{.Values.configurator.service.nodePort}}
 {{ end }}
 {{- end }}
+{{- if .Values.vscode.enabled }}
+    - name: http
+      port: {{ .Values.vscode.service.port }}
+      protocol: TCP
+      targetPort: 80
+{{ if (and (eq .Values.vscode.service.type "NodePort") (not (empty .Values.vscode.service.nodePort))) }}
+      nodePort: {{.Values.vscode.service.nodePort}}
+{{ end }}
+{{- end }}
   selector:
     app.kubernetes.io/name: {{ include "home-assistant.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/home-assistant/templates/vscode-ingress.yaml
+++ b/stable/home-assistant/templates/vscode-ingress.yaml
@@ -1,0 +1,39 @@
+{{- if (.Values.vscode.enabled) and (.Values.vscode.ingress.enabled) }}
+{{- $fullName := include "home-assistant.fullname" . -}}
+{{- $servicePort := .Values.vscode.service.port -}}
+{{- $ingressPath := .Values.vscode.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-vscode
+  labels:
+    app.kubernetes.io/name: {{ include "home-assistant.name" . }}
+    helm.sh/chart: {{ include "home-assistant.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.vscode.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.vscode.ingress.tls }}
+  tls:
+  {{- range .Values.vscode.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.vscode.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $servicePort }}
+  {{- end }}
+{{- end }}

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -180,8 +180,12 @@ vscode:
 
   ## VSCode password
   # password:
+
   ## path where the home assistant configuration is stored
-  basepath: /config
+  hassConfig: /config
+
+  ## path where the VS Code data should reside
+  vscodePath: /config/.vscode
 
   ## Additional hass-vscode container environment variable
   ## For instance to add a http_proxy

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -168,6 +168,53 @@ monitoring:
     # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
     # labels:
 
+vscode:
+  enabled: false
+
+  ## code-server container image
+  ##
+  image:
+    repository: codercom/code-server
+    tag: 1.939
+    pullPolicy: IfNotPresent
+
+  ## VSCode password
+  # password:
+  ## path where the home assistant configuration is stored
+  basepath: /config
+
+  ## Additional hass-vscode container environment variable
+  ## For instance to add a http_proxy
+  ##
+  extraEnv: {}
+
+  ingress:
+    enabled: false
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    path: /
+    hosts:
+      - home-assistant.local
+    tls: []
+    #  - secretName: home-assistant-tls
+    #    hosts:
+    #      - home-assistant.local
+
+  service:
+    type: ClusterIP
+    port: 80
+    annotations: {}
+    labels: {}
+    clusterIP: ""
+    ## List of IP addresses at which the hass-vscode service is available
+    ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+    ##
+    externalIPs: []
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+    # nodePort: 30000
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds support for an optional sidecar container running VS Code Server for editing home-assistant configuration files

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
