### PR TITLE
[stable/mm-te] deprecate MM-TE

### DIFF
--- a/stable/mattermost-team-edition/Chart.yaml
+++ b/stable/mattermost-team-edition/Chart.yaml
@@ -12,9 +12,4 @@ home: https://mattermost.com
 icon: http://www.mattermost.org/wp-content/uploads/2016/04/icon.png
 source:
 - https://github.com/mattermost/mattermost-server
-- https://github.com/mattermost/mattermost-kubernetes
-maintainers:
-  - name: cpanato
-    email: carlos@mattermost.com
-  - name: jwilander
-    email: joram@mattermost.com
+- https://github.com/mattermost/mattermost-helm

--- a/stable/mattermost-team-edition/Chart.yaml
+++ b/stable/mattermost-team-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Team Edition server.
 name: mattermost-team-edition
-version: 3.1.1
+version: 3.1.2
 appVersion: 5.9.0
 keywords:
 - mattermost

--- a/stable/mattermost-team-edition/Chart.yaml
+++ b/stable/mattermost-team-edition/Chart.yaml
@@ -3,6 +3,7 @@ description: Mattermost Team Edition server.
 name: mattermost-team-edition
 version: 3.1.2
 appVersion: 5.9.0
+deprecated: true
 keywords:
 - mattermost
 - communication

--- a/stable/mattermost-team-edition/README.md
+++ b/stable/mattermost-team-edition/README.md
@@ -1,4 +1,13 @@
-# Mattermost Team Edition
+# DEPRECATED - Mattermost Team Edition
+
+**This chart has been deprecated and moved to its new home:**
+
+- **GitHub repo:** https://github.com/mattermost/mattermost-helm
+- **Charts repo:** https://helm.mattermost.com
+
+```bash
+$ helm repo add mattermost https://helm.mattermost.com
+```
 
 [Mattermost](https://mattermost.com/) is a hybrid cloud enterprise messaging workspace that brings your messaging and tools together to get more done, faster.
 


### PR DESCRIPTION
#### What this PR does / why we need it:
deprecate MM-TE.
New chart repo: https://helm.mattermost.com

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
