### PR TITLE
[stable/rabbitmq-ha] if securityContext is set, change ownership of the rabbitmq directory…

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.12
-version: 1.25.0
+version: 1.26.0
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.12
-version: 1.26.0
+version: 1.25.1
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -46,7 +46,11 @@ spec:
         - name: copy-rabbitmq-config
           image: {{ .Values.busyboxImage.repository}}:{{ .Values.busyboxImage.tag}}
           imagePullPolicy: {{ .Values.busyboxImage.pullPolicy }}
+          {{- if .Values.securityContext }}
+          command: ['sh', '-c', "cp /configmap/* /etc/rabbitmq; rm -f /var/lib/rabbitmq/.erlang.cookie; chown {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} /var/lib/rabbitmq"]
+          {{- else }}
           command: ['sh', '-c', 'cp /configmap/* /etc/rabbitmq; rm -f /var/lib/rabbitmq/.erlang.cookie']
+          {{- end }}
           resources:
 {{ toYaml .Values.initContainer.resources | indent 12 }}
           volumeMounts:

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -46,10 +46,17 @@ spec:
         - name: copy-rabbitmq-config
           image: {{ .Values.busyboxImage.repository}}:{{ .Values.busyboxImage.tag}}
           imagePullPolicy: {{ .Values.busyboxImage.pullPolicy }}
-          {{- if .Values.securityContext }}
-          command: ['sh', '-c', "cp /configmap/* /etc/rabbitmq; rm -f /var/lib/rabbitmq/.erlang.cookie; chown {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} /var/lib/rabbitmq"]
+          command:
+          - 'sh'
+          - '-c'
+          - 'cp /configmap/* /etc/rabbitmq;'
+          {{- if .Values.rabbitmqErlangCookie }}
+          - "echo \"{{ .Values.rabbitmqErlangCookie }}\" > /var/lib/rabbitmq/.erlang.cookie;"
           {{- else }}
-          command: ['sh', '-c', 'cp /configmap/* /etc/rabbitmq; rm -f /var/lib/rabbitmq/.erlang.cookie']
+          - "rm -f /var/lib/rabbitmq/.erlang.cookie;"
+          {{- end }}
+          {{- if .Values.securityContext }}
+          - "chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} /var/lib/rabbitmq;"
           {{- end }}
           resources:
 {{ toYaml .Values.initContainer.resources | indent 12 }}


### PR DESCRIPTION
#### What this PR does / why we need it:
[stable/rabbitmq-ha] if securityContext is set, change ownership of the rabbitmq directory to the runAsUser and fsGroup ids to ensure rabbitmq can write to the data dir using those ids 

#### Which issue this PR fixes
  - fixes 13517

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
