### PR TITLE
[incubator/couchdb] Configurable liveness and readiness probes

### DIFF
--- a/incubator/couchdb/Chart.yaml
+++ b/incubator/couchdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: couchdb
-version: 1.1.3
+version: 1.2.0
 appVersion: 2.3.0
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/incubator/couchdb/Chart.yaml
+++ b/incubator/couchdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: couchdb
-version: 1.1.2
+version: 1.1.3
 appVersion: 2.3.0
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/incubator/couchdb/README.md
+++ b/incubator/couchdb/README.md
@@ -124,6 +124,8 @@ A variety of other parameters are also configurable. See the comments in the
 | `persistentVolume.storageClass` | Default for the Kube cluster           |
 | `podManagementPolicy`           | Parallel                               |
 | `affinity`                      |                                        |
+| `livenessProbe`                 |                                        |
+| `readinessProbe`                |                                        |
 | `resources`                     |                                        |
 | `service.annotations`           |                                        |
 | `service.enabled`               | true                                   |

--- a/incubator/couchdb/templates/statefulset.yaml
+++ b/incubator/couchdb/templates/statefulset.yaml
@@ -73,6 +73,11 @@ spec:
               path: /
               port: 5984
 {{- end }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           readinessProbe:
 {{- if .Values.couchdbConfig.chttpd.require_valid_user }}
             exec:
@@ -85,6 +90,11 @@ spec:
               path: /_up
               port: 5984
 {{- end }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:

--- a/incubator/couchdb/values.yaml
+++ b/incubator/couchdb/values.yaml
@@ -99,6 +99,13 @@ ingress:
     #   hosts:
     #     - chart-example.local
 
+## Configure liveness Probe
+## ref : https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+livenessProbe: {}
+## Configure readiness Probe
+## ref : https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+readinessProbe: {}
+
 ## Optional resource requests and limits for the CouchDB container
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 resources: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
Add livenessProbe and readinessProbe configurable with following parameters : 
* initialDelaySeconds
* periodSeconds
* timeoutSeconds
* failureThreshold
* successThreshold

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
