### PR TITLE
[stable/kube-state-metrics] upgrade to 1.6.0

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -5,8 +5,8 @@ keywords:
 - metric
 - monitoring
 - prometheus
-version: 1.2.0
-appVersion: 1.5.0
+version: 1.3.0
+appVersion: 1.6.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:
 - https://github.com/kubernetes/kube-state-metrics/

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -35,6 +35,7 @@ $ helm install stable/kube-state-metrics
 | `tolerations`                         | Tolerations for pod assignment	                      | []                                          |
 | `podAnnotations`                      | Annotations to be added to the pod                      | {}                                          |
 | `resources`                           | kube-state-metrics resource requests and limits         | {}                                          |
+| `collectors.certificatesigningrequests` | Enable the certificatesigningrequests collector.      | true                                        |
 | `collectors.configmaps`               | Enable the configmaps collector.                        | true                                        |
 | `collectors.cronjobs`                 | Enable the cronjobs collector.                          | true                                        |
 | `collectors.daemonsets`               | Enable the daemonsets collector.                        | true                                        |

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -14,8 +14,8 @@ $ helm install stable/kube-state-metrics
 
 | Parameter                             | Description                                             | Default                                     |
 |---------------------------------------|---------------------------------------------------------|---------------------------------------------|
-| `image.repository`                    | The image repository to pull from                       | k8s.gcr.io/kube-state-metrics               |
-| `image.tag`                           | The image tag to pull from                              | `v1.5.0`                                    |
+| `image.repository`                    | The image repository to pull from                       | quay.io/coreos/kube-state-metrics           |
+| `image.tag`                           | The image tag to pull from                              | `v1.6.0`                                    |
 | `image.pullPolicy`                    | Image pull policy                                       | IfNotPresent                                |
 | `replicas`                            | Number of replicas                                      | 1                                           |
 | `service.port`                        | The port of the container                               | 8080                                        |

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -41,6 +41,7 @@ $ helm install stable/kube-state-metrics
 | `collectors.deployments`              | Enable the deployments collector.                       | true                                        |
 | `collectors.endpoints`                | Enable the endpoints collector.                         | true                                        |
 | `collectors.horizontalpodautoscalers` | Enable the horizontalpodautoscalers collector.          | true                                        |
+| `collectors.ingresses`                | Enable the ingresses collector.                         | true                                        |
 | `collectors.jobs`                     | Enable the jobs collector.                              | true                                        |
 | `collectors.limitranges`              | Enable the limitranges collector.                       | true                                        |
 | `collectors.namespaces`               | Enable the namespaces collector.                        | true                                        |

--- a/stable/kube-state-metrics/templates/clusterrole.yaml
+++ b/stable/kube-state-metrics/templates/clusterrole.yaml
@@ -45,6 +45,12 @@ rules:
   - horizontalpodautoscalers
   verbs: ["list", "watch"]
 {{ end -}}
+{{ if .Values.collectors.ingresses }}
+- apiGroups: ["extensions"]
+  resources:
+  - ingresses
+  verbs: ["list", "watch"]
+{{ end -}}
 {{ if .Values.collectors.jobs }}
 - apiGroups: ["batch"]
   resources:

--- a/stable/kube-state-metrics/templates/clusterrole.yaml
+++ b/stable/kube-state-metrics/templates/clusterrole.yaml
@@ -9,6 +9,12 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "kube-state-metrics.fullname" . }}
 rules:
+{{ if .Values.collectors.certificatesigningrequests }}
+- apiGroups: ["certificates.k8s.io"]
+  resources:
+  - certificatesigningrequests
+  verbs: ["list", "watch"]
+{{ end -}}
 {{ if .Values.collectors.configmaps }}
 - apiGroups: [""]
   resources:

--- a/stable/kube-state-metrics/templates/clusterrole.yaml
+++ b/stable/kube-state-metrics/templates/clusterrole.yaml
@@ -22,13 +22,13 @@ rules:
   verbs: ["list", "watch"]
 {{ end -}}
 {{ if .Values.collectors.daemonsets }}
-- apiGroups: ["extensions"]
+- apiGroups: ["extensions", "apps"]
   resources:
   - daemonsets
   verbs: ["list", "watch"]
 {{ end -}}
 {{ if .Values.collectors.deployments }}
-- apiGroups: ["extensions"]
+- apiGroups: ["extensions", "apps"]
   resources:
   - deployments
   verbs: ["list", "watch"]
@@ -94,7 +94,7 @@ rules:
   verbs: ["list", "watch"]
 {{ end -}}
 {{ if .Values.collectors.replicasets }}
-- apiGroups: ["extensions"]
+- apiGroups: ["extensions", "apps"]
   resources:
   - replicasets
   verbs: ["list", "watch"]

--- a/stable/kube-state-metrics/templates/deployment.yaml
+++ b/stable/kube-state-metrics/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
 {{  if .Values.collectors.horizontalpodautoscalers  }}
         - --collectors=horizontalpodautoscalers
 {{  end  }}
+{{  if .Values.collectors.ingresses  }}
+        - --collectors=ingresses
+{{  end  }}
 {{  if .Values.collectors.jobs  }}
         - --collectors=jobs
 {{  end  }}

--- a/stable/kube-state-metrics/templates/deployment.yaml
+++ b/stable/kube-state-metrics/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
       containers:
       - name: {{ .Chart.Name }}
         args:
+{{  if .Values.collectors.certificatesigningrequests  }}
+        - --collectors=certificatesigningrequests
+{{  end  }}
 {{  if .Values.collectors.configmaps  }}
         - --collectors=configmaps
 {{  end  }}

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -80,6 +80,7 @@ collectors:
   deployments: true
   endpoints: true
   horizontalpodautoscalers: true
+  ingresses: true
   jobs: true
   limitranges: true
   namespaces: true

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -1,8 +1,8 @@
 # Default values for kube-state-metrics.
 prometheusScrape: true
 image:
-  repository: k8s.gcr.io/kube-state-metrics
-  tag: v1.5.0
+  repository: quay.io/coreos/kube-state-metrics
+  tag: v1.6.0
   pullPolicy: IfNotPresent
 
 replicas: 1

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -74,6 +74,7 @@ podAnnotations: {}
 # Available collectors for kube-state-metrics. By default all available
 # collectors are enabled.
 collectors:
+  certificatesigningrequests: true
   configmaps: true
   cronjobs: true
   daemonsets: true


### PR DESCRIPTION
#### What this PR does / why we need it:

[stable/kube-state-metrics] upgrade app to [1.6.0](https://github.com/kubernetes/kube-state-metrics/releases/tag/v1.6.0)
[stable/kube-state-metrics] Collectors: enable certificatesigningrequests collector
[stable/kube-state-metrics] Collectors: enable ingresses collector
[stable/kube-state-metrics] Clusterrole: Allow to list resource "daemonsets", "deployments" and "replicasets" in API group "apps"

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
