### PR TITLE
[stable/elasticsearch-curator] Adds RBAC and PSP support for elasticsearch-curator

### DIFF
--- a/stable/elasticsearch-curator/Chart.yaml
+++ b/stable/elasticsearch-curator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "5.5.4"
 description: A Helm chart for Elasticsearch Curator
 name: elasticsearch-curator
-version: 1.4.0
+version: 1.5.0
 home: https://github.com/elastic/curator
 keywords:
 - curator

--- a/stable/elasticsearch-curator/README.md
+++ b/stable/elasticsearch-curator/README.md
@@ -43,8 +43,8 @@ their default values.
 | `dryrun`                             | Run Curator in dry-run mode                                 | `false`                                      |
 | `env`                                | Environment variables to add to the cronjob container       | {}                                           |
 | `envFromSecrets`                     | Environment variables from secrets to the cronjob container | {}                                           |
-| `envFromSecrets.*.from.secret`       | - `secretKeyRef.name` used for environment variable         |                                              |              
-| `envFromSecrets.*.from.key`          | - `secretKeyRef.key` used for environment variable          |                                              |              
+| `envFromSecrets.*.from.secret`       | - `secretKeyRef.name` used for environment variable         |                                              |
+| `envFromSecrets.*.from.key`          | - `secretKeyRef.key` used for environment variable          |                                              |
 | `command`                            | Command to execute                                          | ["curator"]                                  |
 | `configMaps.action_file_yml`         | Contents of the Curator action_file.yml                     | See values.yaml                              |
 | `configMaps.config_yml`              | Contents of the Curator config.yml (overrides config)       | See values.yaml                              |
@@ -53,7 +53,12 @@ their default values.
 | `extraVolumeMounts`                  | Mount extra volume(s),                                      |                                              |
 | `extraVolumes`                       | Extra volumes                                               |                                              |
 | `extraInitContainers`                | Init containers to add to the cronjob container             | {}                                           |
-| `securityContext`                    | Configure PodSecurityContext                                |                                              |
+| `securityContext`                    | Configure PodSecurityContext                                | `false`                                      |
+| `rbac.enabled`                       | Enable RBAC resources                                       | `false`                                      |
+| `psp.create`                         | Create pod security policy resources                        | `false`                                      |
+| `serviceAccount.create`              | Create a default serviceaccount for elasticsearch curator   | `true`                                       |
+| `serviceAccount.name`                | Name for elasticsearch curator serviceaccount               | `""`                                         |
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.

--- a/stable/elasticsearch-curator/templates/_helpers.tpl
+++ b/stable/elasticsearch-curator/templates/_helpers.tpl
@@ -42,3 +42,14 @@ Create chart name and version as used by the chart label.
 {{- define "elasticsearch-curator.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "elasticsearch-curator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "elasticsearch-curator.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/elasticsearch-curator/templates/cronjob.yaml
+++ b/stable/elasticsearch-curator/templates/cronjob.yaml
@@ -60,6 +60,9 @@ spec:
 {{ toYaml $value | indent 12 }}
 {{- end }}
 {{- end }}
+        {{- if .Values.rbac.enabled }}
+          serviceAccountName: {{ template "elasticsearch-curator.serviceAccountName" .}}
+        {{- end }}
           containers:
             - name: {{ .Chart.Name }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/elasticsearch-curator/templates/psp.yml
+++ b/stable/elasticsearch-curator/templates/psp.yml
@@ -1,0 +1,36 @@
+{{- if .Values.psp.create }}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+  labels:
+    app: {{ template "elasticsearch-curator.name" . }}
+    chart: {{ template "elasticsearch-curator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "elasticsearch-curator.fullname" . }}-psp
+spec:
+  privileged: true
+  #requiredDropCapabilities:
+  volumes:
+    - 'configMap'
+    - 'secret'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/stable/elasticsearch-curator/templates/role.yaml
+++ b/stable/elasticsearch-curator/templates/role.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.rbac.enabled  }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app: {{ template "elasticsearch-curator.name" . }}
+    chart: {{ template "elasticsearch-curator.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: elasticsearch-curator-configmap
+  name: {{ template "elasticsearch-curator.name" . }}-role
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["update", "patch"]
+{{- if .Values.psp.create }}
+- apiGroups: ["extensions"]
+  resources: ["podsecuritypolicies"]
+  verbs: ["use"]
+  resourceNames:
+  - {{ template "elasticsearch-curator.fullname" . }}-psp
+{{- end -}}
+{{- end -}}

--- a/stable/elasticsearch-curator/templates/rolebinding.yaml
+++ b/stable/elasticsearch-curator/templates/rolebinding.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.rbac.enabled -}}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app: {{ template "elasticsearch-curator.name" . }}
+    chart: {{ template "elasticsearch-curator.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: elasticsearch-curator-configmap
+  name: {{ template "elasticsearch-curator.name" . }}-rolebinding
+roleRef:
+  kind: Role
+  name: {{ template "elasticsearch-curator.name" . }}-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "elasticsearch-curator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}
+

--- a/stable/elasticsearch-curator/templates/serviceaccount.yaml
+++ b/stable/elasticsearch-curator/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.serviceAccount.create .Values.rbac.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "elasticsearch-curator.serviceAccountName" .}}
+  labels:
+    app: {{ template "elasticsearch-curator.fullname" . }}
+    chart: {{ template "elasticsearch-curator.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- end }}
+

--- a/stable/elasticsearch-curator/values.yaml
+++ b/stable/elasticsearch-curator/values.yaml
@@ -13,6 +13,22 @@ cronjob:
 pod:
   annotations: {}
 
+rbac:
+  # Specifies whether RBAC should be enabled
+  enabled: false
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+
+psp:
+  # Specifies whether a podsecuritypolicy should be created
+  create: false
+
 image:
   repository: quay.io/pires/docker-elasticsearch-curator
   tag: 5.5.4


### PR DESCRIPTION


Signed-off-by: Derek Heldt-Werle <derek.heldt-werle@viasat.com>

#### What this PR does / why we need it:
Adds RBAC and pod security policy support for elasticsearch

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
