### PR TITLE
[stable/nginx-ingress] Document full key for external-dns example

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.6.6
+version: 1.6.7
 appVersion: 0.24.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -206,8 +206,10 @@ You can add Prometheus annotations to the metrics service using `controller.metr
 Add an [ExternalDNS](https://github.com/kubernetes-incubator/external-dns) annotation to the LoadBalancer service:
 
 ```yaml
-annotations:
-  external-dns.alpha.kubernetes.io/hostname: kubernetes-example.com.
+controller:
+  service:
+    annotations:
+      external-dns.alpha.kubernetes.io/hostname: kubernetes-example.com.
 ```
 
 ## AWS L7 ELB with SSL Termination


### PR DESCRIPTION
#### What this PR does / why we need it:

Completes the external-dns example using the full nested key, so it could be copy-pasted without wondering where the `annotations` key must go.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`

@jackzampolin @mgoodness