### PR TITLE
[stable/fluent-bit] Add support for forward TLS configuration

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 1.9.2
+version: 1.9.3
 appVersion: 1.0.6
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -38,6 +38,10 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `backend.forward.tls`              | Enable or disable TLS support | `off` |
 | `backend.forward.tls_verify`       | Force certificate validation  | `on` |
 | `backend.forward.tls_debug`        | Set TLS debug verbosity level. It accept the following values: 0-4 | `1` |
+| `backend.forward.tls_use_paths`    | Load the TLS certificates / keys with paths on container rather than directlyvim | `false` |
+| `backend.forward.tls_ca`           | TLS CA certificate for the forward endpoint (in PEM format) | `""` |
+| `backend.forward.tls_crt`          | TLS certificate for the forward endpoint (in PEM format) | `""` |
+| `backend.forward.tls_key`          | TLS key for the forward endpoint (in PEM format) | `""` |
 | **ElasticSearch Backend**  |
 | `backend.es.host`          | IP address or hostname of the target Elasticsearch instance | `elasticsearch` |
 | `backend.es.port`          | TCP port of the target Elasticsearch instance. | `9200` |

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -83,6 +83,32 @@ data:
 {{- if .Values.backend.forward.shared_key }}
         Shared_Key    {{ .Values.backend.forward.shared_key }}
 {{- end }}
+{{- if eq .Values.backend.forward.tls "on" }}
+        tls {{ .Values.backend.forward.tls }}
+        tls.verify {{ .Values.backend.forward.tls_verify }}
+        tls.debug {{ .Values.backend.forward.tls_debug }}
+        {{- if .Values.backend.forward.tls_use_paths }}
+        {{- if .Values.backend.forward.tls_ca }}
+        tls.ca_file {{ .Values.backend.forward.tls_ca }}
+        {{- end }}
+        {{- if .Values.backend.forward.tls_crt }}
+        tls.crt_file {{ .Values.backend.forward.tls_crt }}
+        {{- end }}
+        {{- if .Values.backend.forward.tls_key }}
+        tls.key_file {{ .Values.backend.forward.tls_key }}
+        {{- end }}
+        {{- else }}
+        {{- if .Values.backend.forward.tls_ca }}
+        tls.ca_file /secure/forward-tls-ca.pem
+        {{- end }}
+        {{- if .Values.backend.forward.tls_crt }}
+        tls.crt_file /secure/forward-tls-crt.pem
+        {{- end }}
+        {{- if .Values.backend.forward.tls_key }}
+        tls.key_file /secure/forward-tls-key.pem
+        {{- end }}
+        {{- end }}
+{{- end }}
 {{ else if eq .Values.backend.type "es" }}
     [OUTPUT]
         Name  es

--- a/stable/fluent-bit/templates/daemonset.yaml
+++ b/stable/fluent-bit/templates/daemonset.yaml
@@ -87,6 +87,23 @@ spec:
           subPath: parsers.conf
 {{- end }}
 {{- end }}
+{{- if eq .Values.backend.forward.tls_use_paths false }}
+{{- if .Values.backend.forward.tls_ca }}
+        - name: forward-tls-ca-secret
+          mountPath: /secure/forward-tls-ca.pem
+          subPath: forward-tls-ca.pem
+{{- end }}
+{{- if .Values.backend.forward.tls_crt }}
+        - name: forward-tls-crt-secret
+          mountPath: /secure/forward-tls-crt.pem
+          subPath: forward-tls-crt.pem
+{{- end }}
+{{- if .Values.backend.forward.tls_key }}
+        - name: forward-tls-key-secret
+          mountPath: /secure/forward-tls-key.pem
+          subPath: forward-tls-key.pem
+{{- end }}
+{{- end }}
 {{- if .Values.backend.es.tls_ca }}
         - name: es-tls-secret
           mountPath: /secure/es-tls-ca.crt
@@ -130,6 +147,23 @@ spec:
           path: /etc/machine-id
           type: File
     {{- end }}
+{{- if eq .Values.backend.forward.tls_use_paths false }}
+{{- if .Values.backend.forward.tls_ca }}
+      - name: forward-tls-ca-secret
+        secret:
+          secretName: "{{ template "fluent-bit.fullname" . }}-forward-tls-ca-secret"
+{{- end }}
+{{- if .Values.backend.forward.tls_crt }}
+      - name: forward-tls-crt-secret
+        secret:
+          secretName: "{{ template "fluent-bit.fullname" . }}-forward-tls-crt-secret"
+{{- end }}
+{{- if .Values.backend.forward.tls_key }}
+      - name: forward-tls-key-secret
+        secret:
+          secretName: "{{ template "fluent-bit.fullname" . }}-forward-tls-key-secret"
+{{- end }}
+{{- end }}
 {{- if .Values.backend.es.tls_ca }}
       - name: es-tls-secret
         secret:

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -38,6 +38,10 @@ backend:
     tls: "off"
     tls_verify: "on"
     tls_debug: 1
+    tls_use_paths: false
+    tls_ca: ""
+    tls_crt: ""
+    tls_key: ""
     shared_key:
   es:
     host: elasticsearch


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it: Add support for TLS configuration for forward plugin

Essentially I just came to use the chart and saw it didn't do what I wanted it to do, since I saw there was a mismatch between elasticsearch and forward I thought I'd expand it to have parity. 

Only questionable part is that I tweaked how you can use it slightly so that the TLS secrets are either passed in as text, or as a file on disk.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
