### PR TITLE
[stable/grafana] Adds imagePullSecrets to test pod

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 3.3.6
+version: 3.3.7
 appVersion: 6.1.6
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -40,6 +40,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.repository`                        | Image repository                              | `grafana/grafana`                                       |
 | `image.tag`                               | Image tag. (`Must be >= 5.0.0`)               | `6.1.6`                                                 |
 | `image.pullPolicy`                        | Image pull policy                             | `IfNotPresent`                                          |
+| `image.pullSecrets`                       | Image pull secrets                            | `{}`                                                    |
 | `service.type`                            | Kubernetes service type                       | `ClusterIP`                                             |
 | `service.port`                            | Kubernetes port where service is exposed      | `80`                                                    |
 | `service.targetPort`                      | internal service is port                      | `3000`                                                  |

--- a/stable/grafana/templates/tests/test.yaml
+++ b/stable/grafana/templates/tests/test.yaml
@@ -24,6 +24,12 @@ spec:
       volumeMounts:
       - mountPath: /tools
         name: tools
+  {{- if .Values.image.pullSecrets }}
+  imagePullSecrets:
+  {{- range .Values.image.pullSecrets }}
+    - name: {{ . }}
+  {{- end}}
+  {{- end }}
   containers:
     - name: {{ .Release.Name }}-test
       image: "{{ .Values.testFramework.image}}:{{ .Values.testFramework.tag }}"

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -29,16 +29,16 @@ image:
   tag: 6.1.6
   pullPolicy: IfNotPresent
 
-testFramework:
-  image: "dduportal/bats"
-  tag: "0.4.0"
-
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   ##
   # pullSecrets:
   #   - myRegistrKeySecretName
+
+testFramework:
+  image: "dduportal/bats"
+  tag: "0.4.0"
 
 securityContext:
   runAsUser: 472


### PR DESCRIPTION
#### What this PR does / why we need it:
Test pod lacks imagePullSecrets, makes it fail in closed environments.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
