### PR TITLE
allow changing of the target port to support TLS termination sidecar

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 1.1.15
+version: 1.1.16
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -86,6 +86,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.serviceAnnotations`       | Service annotations                  | `{}`                                      |
 | `master.serviceType`              | k8s service type                     | `LoadBalancer`                            |
 | `master.servicePort`              | k8s service port                     | `8080`                                    |
+| `master.targetPort`               | k8s target port                      | `8080`                                    |
 | `master.nodePort`                 | k8s node port                        | Not set                                   |
 | `master.healthProbes`             | Enable k8s liveness and readiness probes    | `true`                             |
 | `master.healthProbesLivenessTimeout`  | Set the timeout for the liveness probe  | `120`                              |

--- a/stable/jenkins/templates/jenkins-master-networkpolicy.yaml
+++ b/stable/jenkins/templates/jenkins-master-networkpolicy.yaml
@@ -17,7 +17,7 @@ spec:
   ingress:
     # Allow web access to the UI
     - ports:
-      - port: 8080
+      - port: {{ .Values.master.targetPort }}
     # Allow inbound connections from slave
     - from:
       - podSelector:

--- a/stable/jenkins/templates/jenkins-master-svc.yaml
+++ b/stable/jenkins/templates/jenkins-master-svc.yaml
@@ -19,7 +19,7 @@ spec:
   ports:
     - port: {{.Values.master.servicePort}}
       name: http
-      targetPort: 8080
+      targetPort: {{ .Values.master.targetPort }}
       {{if (and (eq .Values.master.serviceType "NodePort") (not (empty .Values.master.nodePort)))}}
       nodePort: {{.Values.master.nodePort}}
       {{end}}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -77,6 +77,7 @@ master:
   # runAsUser: <defaults to 0>
   # fsGroup: <will be omitted in deployment if runAsUser is 0>
   servicePort: 8080
+  targetPort: 8080
   # For minikube, set this to NodePort, elsewhere use LoadBalancer
   # Use ClusterIP if your setup includes ingress controller
   serviceType: LoadBalancer


### PR DESCRIPTION
#### What this PR does / why we need it:

I have a need to have TLS terminated at the pod level and not at the LoadBalancer level.  To do this I run a sidecar pod using master.sidecars.other and I need to change the service target port to be the port of this container.
