### PR TITLE
[stable/signalfx-agent] Adding deprication notice

### DIFF
--- a/stable/signalfx-agent/Chart.yaml
+++ b/stable/signalfx-agent/Chart.yaml
@@ -1,8 +1,13 @@
 apiVersion: v1
-description: The SignalFx Kubernetes agent
+# The singnalfx-agent chart is deprecated and no longer maintained. For details
+# about deprecating, including how to un-deprecate a chart see the PROCESSES.md file.
+# The active chart can be found at:
+# https://github.com/signalfx/signalfx-agent/tree/master/deployments/k8s/helm/signalfx-agent
+deprecated: true
+description: DEPRECATED The SignalFx Kubernetes agent
 name: signalfx-agent
 appVersion: 3.6.1
-version: 0.3.0
+version: 0.3.1
 keywords:
 - monitoring
 - alerting
@@ -11,7 +16,4 @@ keywords:
 home: https://signalfx.com
 sources:
 - https://github.com/signalfx/signalfx-agent
-maintainers:
-- name: keitwb
-  email: bkeith@signalfx.com
 icon: https://signalfx-82c9.kxcdn.com/wp-content/uploads/2015/12/signalfx-main-logo1.png

--- a/stable/signalfx-agent/README.md
+++ b/stable/signalfx-agent/README.md
@@ -1,5 +1,7 @@
 # SignalFx Agent
 
+**This chart has been deprecated. Please use the upstream chart found [here](https://github.com/signalfx/signalfx-agent/tree/master/deployments/k8s/helm/signalfx-agent) instead.**
+
 [SignalFx](https://signalfx.com) is a cloud monitoring and alerting solution
 for modern enterprise infrastructures.
 


### PR DESCRIPTION
Adding depreciation notice to the signalfx-agent readme

Signed-off-by: Eric Lemieux <eric@lemieuxdev.com>

#### What this PR does / why we need it:
This copy of the chart is out of date, and closed prs reference it as being deprecated (#12540).
This change just makes it clearer to new users where they can find the more up to date version.
I used the Istio deprecation notice, in the incubator/istio readme, as a model.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] title of the PR contains starts with chart name e.g. `[stable/chart]`
- [X] Update chart version
