### PR TITLE
[stable/spinnaker] Provide a method to inject additional configuration into the gate.

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.8.1
+version: 1.8.2
 appVersion: 1.12.5
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/README.md
+++ b/stable/spinnaker/README.md
@@ -163,3 +163,14 @@ halyard:
   annotations:
     iam.amazonaws.com/role: <role_arn>
 ```
+
+### Adding configuration to the gate
+
+There are times where additional configuration is required for the gate, one such occasion is
+for the addition of environment variables. To add this information, you can set the `additionalGateConfig`:
+
+```yaml
+additionalGateConfig:
+  env:
+    azureTenantId: 'abc...'
+```

--- a/stable/spinnaker/templates/configmap/service-settings.yaml
+++ b/stable/spinnaker/templates/configmap/service-settings.yaml
@@ -23,6 +23,9 @@ data:
       useExecHealthCheck: false
       serviceType: NodePort
     {{- end }}
+    {{- if .Values.additionalGateConfig }}
+    {{- toYaml .Values.additionalGateConfig | nindent 4 }}
+    {{- end }}
   deck.yml: |-
     env:
       API_HOST: http://spin-gate.{{ .Release.Namespace }}:8084

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -199,6 +199,6 @@ serviceAccount:
   spinnakerName:
 
 # Push additional yaml configuration into the gate.yml file
-#additionalGateConfig:
-#  env:
-#    azureTenantId: 'abc...'
+# additionalGateConfig:
+#   env:
+#     azureTenantId: 'abc...'

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -197,3 +197,8 @@ serviceAccount:
   # If left blank it is auto-generated from the fullname of the release
   halyardName:
   spinnakerName:
+
+# Push additional yaml configuration into the gate.yml file
+#additionalGateConfig:
+#  env:
+#    azureTenantId: 'abc...'


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

There are times when injecting additional data into the configuration for the gate is a requirement, such as setting environment variables spinnaker/spinnaker#2695. This change will provide a value configuration to allow for this.

#### Which issue this PR fixes

N/A.

#### Special notes for your reviewer:

The new value name was selected at the top level, mainly as this affects the ``service-settings.yaml`` component and doesn't fit under another (though a new top-level could be selected instead if desired).

Pinging @viglesiasce + @lwander + @dwardu89 + @paulczar for review.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
