### PR TITLE
[stable/graylog] Allow volumeName to be used in PVC template

### DIFF
--- a/stable/graylog/Chart.yaml
+++ b/stable/graylog/Chart.yaml
@@ -1,6 +1,6 @@
 name: graylog
 home: https://www.graylog.org
-version: 0.1.4
+version: 0.1.5
 appVersion: 2.5.1-3
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:

--- a/stable/graylog/templates/statefulset.yaml
+++ b/stable/graylog/templates/statefulset.yaml
@@ -238,6 +238,9 @@ spec:
     - metadata:
         name: journal
       spec:
+      {{- if .Values.graylog.persistence.volumeName }}
+        volumeName: "{{ .Values.graylog.persistence.volumeName }}"
+      {{- end }}
         accessModes:
           - {{ .Values.graylog.persistence.accessMode | quote }}
       {{- if .Values.graylog.persistence.storageClass }}

--- a/stable/graylog/values.yaml
+++ b/stable/graylog/values.yaml
@@ -85,6 +85,11 @@ graylog:
     ##
     # storageClass: "ssd"
 
+    ## Use this to select a specific PersistentVolume that already exists or
+    ## will exist in the cluster. This is mostly preferred if you do not have
+    ## a storageClass solution to automatically provision PersistentVolumes.
+    # volumeName: "specific-pv-name"
+
   ## Additional plugins you need to install on Graylog.
   plugins: []
     # - name: graylog-plugin-slack-2.7.1.jar


### PR DESCRIPTION
A proposed fix for https://github.com/helm/charts/issues/13594, which allows `volumeName` to be used in the PVC spec for the StatefulSet.

It relates to particular cases where the Kubernetes cluster does not have a `storageClass` for automatic PV provisioning. In such cases, PVs are manually created and their names are assigned to specific PVCs.

The new value is optional and does not break compatibility with previous versions of this chart.