### PR TITLE
[stable/elasticsearch] Allow volumeName to be used in PVC template

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.26.1
+version: 1.26.2
 appVersion: 6.7.0
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/stable/elasticsearch/templates/data-statefulset.yaml
+++ b/stable/elasticsearch/templates/data-statefulset.yaml
@@ -211,6 +211,9 @@ spec:
   - metadata:
       name: {{ .Values.data.persistence.name }}
     spec:
+    {{- if .Values.data.persistence.volumeName }}
+      volumeName: "{{ .Values.data.persistence.volumeName }}"
+    {{- end }}
       accessModes:
         - {{ .Values.data.persistence.accessMode | quote }}
     {{- if .Values.data.persistence.storageClass }}

--- a/stable/elasticsearch/templates/master-statefulset.yaml
+++ b/stable/elasticsearch/templates/master-statefulset.yaml
@@ -199,6 +199,9 @@ spec:
   - metadata:
       name: {{ .Values.master.persistence.name }}
     spec:
+    {{- if .Values.master.persistence.volumeName }}
+      volumeName: "{{ .Values.master.persistence.volumeName }}"
+    {{- end }}
       accessModes:
         - {{ .Values.master.persistence.accessMode | quote }}
     {{- if .Values.master.persistence.storageClass }}

--- a/stable/elasticsearch/values.yaml
+++ b/stable/elasticsearch/values.yaml
@@ -137,6 +137,12 @@ master:
     name: data
     size: "4Gi"
     # storageClass: "ssd"
+
+    ## Use this to select a specific PersistentVolume that already exists or
+    ## will exist in the cluster. This is mostly preferred if you do not have
+    ## a storageClass solution to automatically provision PersistentVolumes.
+    # volumeName: "specific-pv-name"
+
   readinessProbe:
     httpGet:
       path: /_cluster/health?local=true
@@ -184,6 +190,12 @@ data:
     name: data
     size: "30Gi"
     # storageClass: "ssd"
+
+    ## Use this to select a specific PersistentVolume that already exists or
+    ## will exist in the cluster. This is mostly preferred if you do not have
+    ## a storageClass solution to automatically provision PersistentVolumes.
+    # volumeName: "specific-pv-name"
+
   readinessProbe:
     httpGet:
       path: /_cluster/health?local=true


### PR DESCRIPTION
A proposed fix for https://github.com/helm/charts/issues/13597, which allows volumeName to be used in the PVC spec for the StatefulSets.

It relates to particular cases where the Kubernetes cluster does not have a storageClass for automatic PV provisioning. In such cases, PVs are manually created and their names are assigned to specific PVCs.

The new value is optional and does not break compatibility with previous versions of this chart.