### PR TITLE
[stable/mongodb-replicaset] Allow volumeName to be used in PVC template

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.9.2
+version: 3.9.3
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -344,6 +344,9 @@ spec:
           {{ $key }}: {{ $value }}
         {{- end }}
       spec:
+      {{- if .Values.persistentVolume.volumeName }}
+        volumeName: "{{ .Values.persistentVolume.volumeName }}"
+      {{- end }}
         accessModes:
         {{- range .Values.persistentVolume.accessModes }}
           - {{ . | quote }}

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -110,6 +110,11 @@ persistentVolume:
   size: 10Gi
   annotations: {}
 
+  ## Use this to select a specific PersistentVolume that already exists or
+  ## will exist in the cluster. This is mostly preferred if you do not have
+  ## a storageClass solution to automatically provision PersistentVolumes.
+  # volumeName: "specific-pv-name"
+
 # Annotations to be added to the service
 serviceAnnotations: {}
 


### PR DESCRIPTION
A proposed fix for https://github.com/helm/charts/issues/13599, which allows `volumeName` to be used in the PVC spec for the StatefulSets.

It relates to particular cases where the Kubernetes cluster does not have a storageClass for automatic PV provisioning. In such cases, PVs are manually created and their names are assigned to specific PVCs.

The new value is optional and does not break compatibility with previous versions of this chart.