### PR TITLE
[stable/graylog] Move hard coded parts of graylog.conf to values.yaml

### DIFF
--- a/stable/graylog/Chart.yaml
+++ b/stable/graylog/Chart.yaml
@@ -1,6 +1,6 @@
 name: graylog
 home: https://www.graylog.org
-version: 0.1.4
+version: 0.1.5
 appVersion: 2.5.1-3
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:

--- a/stable/graylog/templates/configmap.yaml
+++ b/stable/graylog/templates/configmap.yaml
@@ -85,64 +85,17 @@ data:
         </Loggers>
     </Configuration>
   graylog.conf: |-
-    node_id_file = /usr/share/graylog/data/journal/node-id
-    root_username = {{ .Values.graylog.rootUsername }}
-    root_email = {{ .Values.graylog.rootEmail }}
-    root_timezone = {{ default "UTC" .Values.graylog.rootTimezone }}
-    plugin_dir = /usr/share/graylog/plugin
-    rest_listen_uri = http://0.0.0.0:9000/api/
-    #web_enable = true
-    web_listen_uri = http://0.0.0.0:9000/
   {{- if .Values.graylog.ingress.enabled }}
     web_endpoint_uri =  {{ template "graylog.url" .}}/api
   {{- end }}
     elasticsearch_hosts = {{ template "graylog.elasticsearch.hosts" . }}
-    elasticsearch_connect_timeout = 10s
-    elasticsearch_socket_timeout = 60s
-    #elasticsearch_idle_timeout = -1s
-    #elasticsearch_max_total_connections = 20
-    #elasticsearch_max_total_connections_per_route = 2
-    #elasticsearch_max_retries = 2
-    rotation_strategy = {{ default "time" .Values.graylog.elasticsearch.rotationStrategy }}
-    elasticsearch_max_docs_per_index = {{ default "20000000" .Values.graylog.elasticsearch.maxDocsPerIndex }}
-    elasticsearch_max_time_per_index = 1w
-    elasticsearch_max_number_of_indices = {{ default 24 .Values.graylog.elasticsearch.maxNumberOfIndices }}
-    retention_strategy = {{ default "delete" .Values.graylog.elasticsearch.retentionStrategy }}
-    elasticsearch_shards = {{ default 5 .Values.graylog.elasticsearch.shards }}
-    elasticsearch_replicas = {{ default 0 .Values.graylog.elasticsearch.replicas }}
-    elasticsearch_index_prefix = {{ default "graylog" .Values.graylog.elasticsearch.indexPrefix }}
-    output_batch_size = 500
-    output_flush_interval = 1
-    output_fault_count_threshold = 5
-    output_fault_penalty_seconds = 30
-    processbuffer_processors = 5
-    outputbuffer_processors = 3
-    processor_wait_strategy = blocking
-    ring_size = 65536
-    inputbuffer_ring_size = 65536
-    inputbuffer_processors = 2
-    inputbuffer_wait_strategy = blocking
-    message_journal_enabled = true
-    message_journal_dir = /usr/share/graylog/data/journal
-    lb_recognition_period_seconds = 3
-    # Use a replica set instead of a single host
     mongodb_uri = {{ template "graylog.mongodb.uri" . }}
-    mongodb_max_connections = {{ default 1000 .Values.graylog.mongodb.maxConnections }}
-    mongodb_threads_allowed_to_block_multiplier = 5
-    # Email transport
-    transport_email_enabled = {{ default false .Values.graylog.transportEmail.enabled }}
-    transport_email_hostname = {{ default .Values.graylog.transportEmail.hostname }}
-    transport_email_port = {{ default .Values.graylog.transportEmail.port }}
-    transport_email_use_auth = {{ default .Values.graylog.transportEmail.useAuth }}
-    transport_email_use_tls = {{ default .Values.graylog.transportEmail.useTls }}
-    transport_email_use_ssl = {{ default .Values.graylog.transportEmail.useSsl }}
-    transport_email_auth_username = {{ default .Values.graylog.transportEmail.authUsername }}
-    transport_email_auth_password = {{ default .Values.graylog.transportEmail.authPassword }}
-    transport_email_subject_prefix = {{ default .Values.graylog.transportEmail.subjectPrefix }}
-    transport_email_from_email = {{ default .Values.graylog.transportEmail.fromEmail }}
   {{- if .Values.graylog.ingress.enabled }}
     transport_email_web_interface_url = {{ template "graylog.url" .}}
   {{- end }}
-    content_packs_dir = /usr/share/graylog/data/contentpacks
-    content_packs_auto_load = grok-patterns.json
-    proxied_requests_thread_pool_size = 32
+
+    ################################################################
+    ## Further config included from .graylog.additionalGraylogConf
+    ################################################################
+
+    {{- .Values.graylog.additionalGraylogConf | nindent 4 }}

--- a/stable/graylog/values.yaml
+++ b/stable/graylog/values.yaml
@@ -176,24 +176,12 @@ graylog:
     ##
     enabled: false
 
-  ## Graylog root user name
-  ##
-  rootUsername: "admin"
-
   ## Graylog root password
   ## Defaults to a random 16-character alphanumeric string if not set
   ##
   # rootPassword: ""
 
-  ## Graylog root email
-  ##
-  rootEmail: ""
-
-  ## Graylog root timezone
-  ##
-  rootTimezone: "UTC"
-
-  elasticsearch:
+  elasticsearch: {}
     ## List of Elasticsearch hosts Graylog should connect to.
     ## Need to be specified as a comma-separated list of valid URIs for the http ports of your elasticsearch nodes.
     ## If one or more of your elasticsearch hosts require authentication, include the credentials in each node URI that
@@ -201,37 +189,10 @@ graylog:
     ##
     # hosts: http://elasticsearch-client.graylog.svc.cluster.local:9200
 
-    ## These configuration settings are only used on the first start of Graylog. After that,
-    ## index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-    ## Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
-    rotationStrategy: time
-    maxNumberOfIndices: 24
-    retentionStrategy: delete
-    shards: 5
-    replicas: 1
-    indexPrefix: graylog
-
-  mongodb:
+  mongodb: {}
     ## MongoDB connection string
     ## See https://docs.mongodb.com/manual/reference/connection-string/ for details
     # uri: mongodb://user:pass@host1:27017,host2:27017,host3:27017/graylog?replicaSet=rs01
-
-    ## Increase this value according to the maximum connections your MongoDB server can handle from a single client
-    ## if you encounter MongoDB connection problems.
-    maxConnections: 1000
-
-  transportEmail:
-    ## If true, enable Email transport.
-    enabled: false
-    hostname: ""
-    port: 2587
-    useAuth: true
-    useTls: true
-    useSsl: true
-    authUsername: ""
-    authPassword: ""
-    subjectPrefix: "[graylog]"
-    fromEmail: ""
 
   ## Additional server files will be deployed to /etc/graylog/server
   ## For example, you can put server certificates or authorized clients certificates here
@@ -239,6 +200,86 @@ graylog:
   serverFiles: {}
     # graylog-server.key: |
     # graylog-server.cert: |
+
+  ## Some important values derived from release metadata, such as:
+  ##  * web_endpoint_uri
+  ##  * elasticsearch_hosts
+  ##  * mongodb_uri
+  ##  * transport_email_web_interface_url
+  ##
+  ## All other configuration can be included inline below.
+  additionalGraylogConf: |
+    ## root password defined by .graylog.rootPassword in values.yaml
+    root_username = admin
+    # root_email =
+
+    rest_listen_uri = http://0.0.0.0:9000/api/
+    #web_enable = true
+    web_listen_uri = http://0.0.0.0:9000/
+
+    root_timezone = UTC
+
+    node_id_file = /usr/share/graylog/data/journal/node-id
+    plugin_dir = /usr/share/graylog/plugin
+
+    retention_strategy = delete
+    rotation_strategy = time
+
+    elasticsearch_connect_timeout = 10s
+    elasticsearch_socket_timeout = 60s
+    #elasticsearch_idle_timeout = -1s
+    #elasticsearch_max_total_connections = 20
+    #elasticsearch_max_total_connections_per_route = 2
+    #elasticsearch_max_retries = 2
+    elasticsearch_max_docs_per_index = 20000000
+    elasticsearch_max_time_per_index = 1w
+    elasticsearch_max_number_of_indices = 24
+    elasticsearch_shards = 5
+    elasticsearch_replicas = 1
+    elasticsearch_index_prefix = graylog
+
+    output_batch_size = 500
+    output_flush_interval = 1
+    output_fault_count_threshold = 5
+    output_fault_penalty_seconds = 30
+
+    outputbuffer_processors = 3
+
+    processbuffer_processors = 5
+    processor_wait_strategy = blocking
+
+    ring_size = 65536
+
+    inputbuffer_ring_size = 65536
+    inputbuffer_processors = 2
+    inputbuffer_wait_strategy = blocking
+
+    message_journal_enabled = true
+    message_journal_dir = /usr/share/graylog/data/journal
+    lb_recognition_period_seconds = 3
+
+    ## Increase this value according to the maximum connections your MongoDB server can handle from a single client
+    ## if you encounter MongoDB connection problems.
+    mongodb_max_connections = 1000
+
+    mongodb_threads_allowed_to_block_multiplier = 5
+
+    # Email transport
+    transport_email_enabled = false
+    # transport_email_hostname =
+    transport_email_port = 2587
+    transport_email_use_auth = true
+    transport_email_use_tls = true
+    transport_email_use_ssl = false
+    # transport_email_auth_username =
+    # transport_email_auth_password =
+    transport_email_subject_prefix = [graylog]
+    # transport_email_from_email =
+
+    content_packs_dir = /usr/share/graylog/data/contentpacks
+    content_packs_auto_load = grok-patterns.json
+
+    proxied_requests_thread_pool_size = 32
 
 ## Specify Elasticsearch version from requirement dependencies. Ignore this seection if you install Elasticsearch manually.
 ## Note: Graylog 2.4 requires Elasticsearch version <= 5.6


### PR DESCRIPTION
Proposed fix for https://github.com/helm/charts/issues/13602, creates a more flexible ConfigMap for `graylog.conf`.

This allows pretty much every aspect of `graylog.conf` to be defined in `values.yaml`, instead of hard coding most of it in the ConfigMap template.