### PR TITLE
[stable/concourse] Add possibility to set strategy for rollingUpdates (web)

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 6.0.1
+version: 6.1.0
 appVersion: 5.1.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 6.0.0
+version: 6.0.1
 appVersion: 5.1.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -173,6 +173,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.readinessProbe.httpGet.path` | Path to access on the HTTP server when performing the healthcheck | `/api/v1/info` |
 | `web.readinessProbe.httpGet.port` | Name or number of the port to access on the container | `atc` |
 | `web.replicas` | Number of Concourse Web replicas | `1` |
+| `web.strategy` | Strategy for updates to deployment. | `{}` |
 | `web.resources.requests.cpu` | Minimum amount of cpu resources requested | `100m` |
 | `web.resources.requests.memory` | Minimum amount of memory resources requested | `128Mi` |
 | `web.service.annotations` | Concourse Web Service annotations | `nil` |

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -10,6 +10,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: {{ .Values.web.replicas }}
+{{- if .Values.web.strategy }}
+{{ toYaml .Values.web.strategy | indent 2 }}
+{{- end }}
   template:
     metadata:
       labels:

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1245,6 +1245,17 @@ web:
   ##
   tolerations: []
 
+  ## Strategy for web deployment updates.
+  ##
+  ## Example:
+  ##
+  ##   strategy:
+  ##     type: RollingUpdate
+  ##     rollingUpdate:
+  ##       maxSurge: 1
+  ##       maxUnavailable: 25%
+  strategy: {}
+
   ## Service configuration.
   ## Ref: https://kubernetes.io/docs/user-guide/services/
   ##


### PR DESCRIPTION
Right now using the chart, updating a value cause all the web containers to die and causes downtime. Using the `strategy` and enabling rolling update, we can avoid this.

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
