### PR TITLE
[stable/prometheus] use kube-state-metrics v1.6.0

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 8.10.3
+version: 8.11.0
 appVersion: 2.9.2
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/kube-state-metrics-clusterrole.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-clusterrole.yaml
@@ -30,6 +30,7 @@ rules:
     resources:
       - daemonsets
       - deployments
+      - ingresses
       - replicasets
     verbs:
       - list
@@ -37,6 +38,8 @@ rules:
   - apiGroups:
       - apps
     resources:
+      - daemonsets
+      - deployments
       - statefulsets
     verbs:
       - get
@@ -61,6 +64,13 @@ rules:
       - policy
     resources:
       - poddisruptionbudgets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
     verbs:
       - list
       - watch

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -315,7 +315,7 @@ kubeStateMetrics:
   ##
   image:
     repository: quay.io/coreos/kube-state-metrics
-    tag: v1.5.0
+    tag: v1.6.0
     pullPolicy: IfNotPresent
 
   ## kube-state-metrics priorityClassName


### PR DESCRIPTION
Use the latest version of kube-state-metrics. v1.6.0

Release notes : https://github.com/kubernetes/kube-state-metrics/blob/master/CHANGELOG.md#v160--2019-05-06