### PR TITLE
[stable/prometheus-operator] Bump version dependency

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 5.5.1
+version: 5.6.0
 appVersion: 0.29.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 5.6.0
+version: 5.7.0
 appVersion: 0.29.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/requirements.lock
+++ b/stable/prometheus-operator/requirements.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 1.4.2
 - name: grafana
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 3.3.1
+  version: 3.3.6
 digest: sha256:81f530518f48adc9279b5a874b405a0861ed40bc5cc2ce5e22b97852fe084a4e
-generated: 2019-04-23T11:23:30.215536228+02:00
+generated: 2019-05-08T13:07:21.139618-07:00


### PR DESCRIPTION
Signed-off-by: Ryan Orth <ryanorth@workfront.com>

#### What this PR does / why we need it: Updates the grafana dependency of the prometheus-operator helm chart

#### Which issue this PR fixes
Bump version dependency charts:

grafana

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
