### PR TITLE
stable/nginx-ingress Set hostPort on TCP and UDP listeners

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 1.6.0
+version: 1.6.1
 appVersion: 0.24.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -134,15 +134,22 @@ spec:
               protocol: TCP
             {{- end }}
           {{- end }}
+          {{- $useHostPort := .Values.controller.daemonset.useHostPort -}}
           {{- range $key, $value := .Values.tcp }}
             - name: "{{ $key }}-tcp"
               containerPort: {{ $key }}
               protocol: TCP
+              {{- if $useHostPort }}
+              hostPort: {{ $key }}
+              {{- end }}
           {{- end }}
           {{- range $key, $value := .Values.udp }}
             - name: "{{ $key }}-udp"
               containerPort: {{ $key }}
               protocol: UDP
+              {{- if $useHostPort }}
+              hostPort: {{ $key }}
+              {{- end }}
           {{- end }}
           readinessProbe:
             httpGet:


### PR DESCRIPTION
When .Values.controller.daemonset.useHostPort is true, we should set the hostPort on those tcp and udp listeners as well.

Signed-off-by: John McGowan <john@steakfest.com>

#### What this PR does / why we need it:

@jackzampolin @mgoodness

When .Values.controller.daemonset.useHostPort is true, we should set the hostPort on those tcp and udp listeners as well.  I ran into this issue when exposing new TCP ports in an environment where I was expecting all Ingress to be exposed via hostPort

#### Which issue this PR fixes

I am not aware of a documented issue for this.

#### Special notes for your reviewer:

Looking at the history there seems to be precedent for adding this without total backwards compatibility in mind.  (See previous commit where it was added for the stats endpoint)

That being said, there could be a slightly different way of doing this that would allow existing TCP and UDP listerners to not use hostPorts if that value is set to true.  Instead we could either.  have the user set a different boolean that turns on hostPort for all TCP or UDP listeners, OR we could make it something that we set on a port by port basis.  (that seems like it might be overkill)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
