### PR TITLE
[incubator/mysqlha] According to replicas count to create services for every pod

### DIFF
--- a/incubator/mysqlha/Chart.yaml
+++ b/incubator/mysqlha/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mysqlha
-version: 0.5.2
+version: 0.6.0
 appVersion: 5.7.13
 description: MySQL cluster with a single master and zero or more slave replicas
 keywords:

--- a/incubator/mysqlha/README.md
+++ b/incubator/mysqlha/README.md
@@ -61,6 +61,8 @@ The following table lists the configurable parameters of the MySQL chart and the
 | `metrics.livenessProbe.timeoutSeconds`       | When the probe times out                          | 5                                      |
 | `metrics.readinessProbe.initialDelaySeconds` | Delay before metrics readiness probe is initiated | 5                                      |
 | `metrics.readinessProbe.timeoutSeconds`      | When the probe times out                          | 1                                      |
+| `service.type`                               | Service type                                      | '{}'                                   |
+| `service.annotations`                        | Service annotations                               | '{}'                                   |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/incubator/mysqlha/templates/NOTES.txt
+++ b/incubator/mysqlha/templates/NOTES.txt
@@ -17,3 +17,20 @@ To connect to your database:
 2. Open a connection to one of the MySQL pods
 
     mysql -h {{ template "fullname" . }}-0.{{ template "fullname" . }} -p
+
+{{- if .Values.service.type }}
+{{- if contains "NodePort"  .Values.service.type }}
+3. Obtain the Nodeport:
+   
+    1. For master mysql nodePort
+
+       kubectl get svc --namespace {{ .Release.Namespace }} -l app={{ template "fullname" . }} -o jsonpath='{.items[1].spec.ports[0].nodePort }'; echo
+
+    {{- if .Values.metrics.enabled }}
+
+    2. For master metrics nodePort
+
+       kubectl get svc --namespace {{ .Release.Namespace }} -l app={{ template "fullname" . }} -o jsonpath='{.items[1].spec.ports[1].nodePort }'; echo
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/incubator/mysqlha/templates/statefulset.yaml
+++ b/incubator/mysqlha/templates/statefulset.yaml
@@ -240,7 +240,7 @@ spec:
             port: metrics
           initialDelaySeconds: {{ .Values.metrics.livenessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.metrics.livenessProbe.timeoutSeconds }}
-        readinessprobe:
+        readinessProbe:
           httpGet:
             path: /
             port: metrics

--- a/incubator/mysqlha/templates/svc-headless.yaml
+++ b/incubator/mysqlha/templates/svc-headless.yaml
@@ -1,0 +1,17 @@
+# Headless service for stable DNS entries of StatefulSet members.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  ports:
+  - name: {{ template "fullname" . }}
+    port: 3306
+  clusterIP: None
+  selector:
+    app: {{ template "fullname" . }}

--- a/incubator/mysqlha/templates/svc.yaml
+++ b/incubator/mysqlha/templates/svc.yaml
@@ -1,44 +1,41 @@
-# Headless service for stable DNS entries of StatefulSet members.
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ template "fullname" . }}
-  labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
-spec:
-  ports:
-  - name: {{ template "fullname" . }}
-    port: 3306
-  clusterIP: None
-  selector:
-    app: {{ template "fullname" . }}
----
 # Client service for connecting to any MySQL instance for reads.
-# For writes, you must instead connect to the master: mysql-0.mysql.
+{{- if .Values.service.type }}
+{{- $fullname := include "fullname" . }}
+{{- $rc_number := int .Values.mysqlha.replicaCount }}
+{{- $root := . }}
+{{ range $i := until $rc_number }}
+---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}-readonly
+  name: {{ template "fullname" $root }}-svc-{{ $i }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: {{ template "fullname" $root }}
+    chart: "{{ $root.Chart.Name }}-{{ $root.Chart.Version }}"
+    release: "{{ $root.Release.Name }}"
+    heritage: "{{ $root.Release.Service }}"
   annotations:
-{{- if and (.Values.metrics.enabled) (.Values.metrics.annotations) }}
-{{ toYaml .Values.metrics.annotations | indent 4 }}
+{{- if and ($root.Values.service.type) ($root.Values.service.annotations) }}
+{{ toYaml $root.Values.service.annotations | indent 4 }}
+{{- end }}
+{{- if and ($root.Values.metrics.enabled) ($root.Values.metrics.annotations) }}
+{{ toYaml $root.Values.metrics.annotations | indent 4 }}
 {{- end }}
 spec:
+  type: {{ $root.Values.service.type }}
   ports:
-  - name: {{ template "fullname" . }}
+  - name: mysql
     port: 3306
-  {{- if .Values.metrics.enabled }}
+    protocol: TCP
+    targetPort: mysql
+{{- if $root.Values.metrics.enabled }}
   - name: metrics
     port: 9104
+    protocol: TCP
     targetPort: metrics
-  {{- end }}
+{{- end }}
   selector:
-    app: {{ template "fullname" . }}
+    app: {{ template "fullname" $root }}
+    statefulset.kubernetes.io/pod-name: {{ template "fullname" $root }}-{{ $i }}
+{{- end }}
+{{- end }}

--- a/incubator/mysqlha/values.yaml
+++ b/incubator/mysqlha/values.yaml
@@ -82,3 +82,11 @@ metrics:
     requests:
       cpu: 100m
       memory: 100Mi
+
+
+service:
+  ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
+  type: {}
+
+  annotations: {}


### PR DESCRIPTION
Signed-off-by: Aisuko <urakiny@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
          
 This feature achieved that when the `Service Kind ` is NodePort. User can via every pod's service to connect to the pod and would single get metric container's log on every pod. And the services are the same ordering with the pods.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
