### PR TITLE
[incubator/raw] fix: ConfigMap Artifact created for every raw chart

### DIFF
--- a/incubator/raw/Chart.yaml
+++ b/incubator/raw/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: raw
 home: https://github.com/helm/charts/blob/master/incubator/raw
-version: 0.2.2
-appVersion: 0.2.1
+version: 0.2.3
+appVersion: 0.2.3
 description: A place for all the Kubernetes resources which don't already have a home.
 maintainers:
 - name: josdotso

--- a/incubator/raw/ci/resources-values.yaml
+++ b/incubator/raw/ci/resources-values.yaml
@@ -1,0 +1,8 @@
+resources:
+- apiVersion: scheduling.k8s.io/v1beta1
+  kind: PriorityClass
+  metadata:
+    name: common-critical
+  value: 100000000
+  globalDefault: false
+  description: "This priority class should only be used for critical priority common pods."

--- a/incubator/raw/ci/templates-values.yaml
+++ b/incubator/raw/ci/templates-values.yaml
@@ -1,0 +1,6 @@
+templates:
+- |
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: raw

--- a/incubator/raw/values.yaml
+++ b/incubator/raw/values.yaml
@@ -64,13 +64,12 @@ resources: []
 #    globalDefault: false
 #    description: "This priority class should only be used for low priority app pods."
 
-templates:
-# This is here to pass the chart ci
-- |
-  apiVersion: v1
-  kind: ConfigMap
-  metadata:
-    name: raw
+templates: []
+# - |
+#  apiVersion: v1
+#  kind: ConfigMap
+#  metadata:
+#    name: raw
 #
 #  - |
 #    apiVersion: v1


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR changes the default values.yaml to contain no items under `templates`. It had a dummy item just to pass the charts CI, but after reading the documentation of `ct`, specifically https://github.com/helm/chart-testing/blob/acfb89768ede45c25fa6fa56ae345d23f68e4f82/doc/ct_install.md, I realized that it isn't needed at all. Instead, I added `ci/templates-values.yaml` and `ci/resources-values.yaml` according to the `ct` convension, so that `ct` would use those CI-specific values.yaml for testing.

#### Which issue this PR fixes
  - fixes #13188

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`