### PR TITLE
[stable/wordpress] Add 'none' to SMTP protocol accepted values

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 5.9.2
+version: 5.9.3
 appVersion: 5.2.0
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -71,7 +71,7 @@ The following table lists the configurable parameters of the WordPress chart and
 | `smtpUser`                       | SMTP user                                  | `nil`                                                   |
 | `smtpPassword`                   | SMTP password                              | `nil`                                                   |
 | `smtpUsername`                   | User name for SMTP emails                  | `nil`                                                   |
-| `smtpProtocol`                   | SMTP protocol [`tls`, `ssl`]               | `nil`                                                   |
+| `smtpProtocol`                   | SMTP protocol [`tls`, `ssl`, `none`]       | `nil`                                                   |
 | `replicaCount`                   | Number of WordPress Pods to run            | `1`                                                     |
 | `mariadb.enabled`                | Deploy MariaDB container(s)                | `true`                                                  |
 | `mariadb.rootUser.password`      | MariaDB admin password                     | `nil`                                                   |


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds 'none' to SMTP protocol accepted values in the WordPress README.md.

#### Which issue this PR fixes

  - fixes https://github.com/bitnami/bitnami-docker-wordpress/issues/171

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
