### PR TITLE
[stable/kube-state-metrics]: Fix link to metric docu

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - metric
 - monitoring
 - prometheus
-version: 1.6.0
+version: 1.6.1
 appVersion: 1.6.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/templates/NOTES.txt
+++ b/stable/kube-state-metrics/templates/NOTES.txt
@@ -1,6 +1,6 @@
 kube-state-metrics is a simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.
 The exposed metrics can be found here:
-https://github.com/kubernetes/kube-state-metrics/tree/master/Documentation#documentation.
+https://github.com/kubernetes/kube-state-metrics/blob/master/docs/README.md#exposed-metrics
 
 The metrics are exported on the HTTP endpoint /metrics on the listening port.
 In your case, {{ template "kube-state-metrics.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/metrics


### PR DESCRIPTION
#### What this PR does / why we need it:
I've fixed the link to the metric docu in the NOTES.txt of the kube-state-metrics chart

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
