### PR TITLE
[incubator/buzzfeed-sso] Add ability to add whitelisted emails

### DIFF
--- a/incubator/buzzfeed-sso/Chart.yaml
+++ b/incubator/buzzfeed-sso/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Single sign-on for your Kubernetes services using Google OAuth
 name: buzzfeed-sso
-version: 0.0.5
+version: 0.0.6
 appVersion: 1.2.0
 home: https://github.com/buzzfeed/sso
 sources:

--- a/incubator/buzzfeed-sso/README.md
+++ b/incubator/buzzfeed-sso/README.md
@@ -53,6 +53,7 @@ Parameter | Description | Default
 `namespace` | namespace to use | `default`
 `emailDomain` | the sso email domain for authentication | REQUIRED
 `rootDomain` | the parent domain used for protecting your backends | REQUIRED
+`whitelistedEmails` | comma-seperated list of emails which should be whitelisted | OPTIONAL
 `cluster` | the cluster name for SSO | `dev`
 `auth.annotations` | extra annotations for auth pods | `{}`
 `auth.domain` | the auth domain used for OAuth callbacks | REQUIRED

--- a/incubator/buzzfeed-sso/templates/auth-deployment.yaml
+++ b/incubator/buzzfeed-sso/templates/auth-deployment.yaml
@@ -57,6 +57,10 @@ spec:
               value: {{ .Values.emailDomain | quote }}
             - name: HOST
               value: {{ $authDomain }}
+            {{- if .Values.whitelistedEmails }}
+            - name: SSO_EMAIL_ADDRESSES
+              value: {{ .Values.whitelistedEmails }}
+            {{- end }}
             - name: REDIRECT_URL
               value: https://{{ $authDomain }}
             - name: PROXY_ROOT_DOMAIN

--- a/incubator/buzzfeed-sso/templates/proxy-deployment.yaml
+++ b/incubator/buzzfeed-sso/templates/proxy-deployment.yaml
@@ -63,6 +63,10 @@ spec:
                   key: proxy-cookie-secret
             - name: EMAIL_DOMAIN
               value: {{ .Values.emailDomain | quote }}
+            {{- if .Values.whitelistedEmails }}
+            - name: EMAIL_ADDRESSES
+              value: {{ .Values.whitelistedEmails }}
+            {{- end }}
             - name: UPSTREAM_CONFIGS
               value: /sso/upstream_configs.yml
             - name: PROVIDER_URL

--- a/incubator/buzzfeed-sso/values.yaml
+++ b/incubator/buzzfeed-sso/values.yaml
@@ -2,6 +2,7 @@
 
 emailDomain: "<your_email_domain>"  # Required. e.g "email.mydomain.foo"
 rootDomain: "<your_root_domain>"  # Required. e.g "mydomain.foo"
+# whitelistedEmails: "<whitelisted_addresses>" # Optional. e.g. "userA.nameA@mydomain.foo,userB.nameB@mydomain.foo"
 cluster: dev
 
 auth:


### PR DESCRIPTION
Signed-off-by: StiviiK <stefan.kuerzeder@gmail.com>

#### What this PR does / why we need it:
Adds the ability to define whitelisted emails, as this feature was added in buzzfeed/sso#113.
Just set `whitelistedEmails` to a comma-seprated list of the addresses.   
e.g. `whitelistedEmails: "userA.nameA@mydomain.foo,userB.nameB@mydomain.foo"`, which only allows userA.nameA@mydomain.foo and userB.nameB@mydomain.foo.

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] title of the PR contains starts with chart name e.g. `[stable/chart]`
