### PR TITLE
[stable/jenkins] Correcting descriptive text in values.yaml about AdminUser value

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.33.0
+version: 0.33.1
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.33.1
+version: 1.1.17
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -27,11 +27,10 @@ Master:
   HostNetworking: false
   # When enabling LDAP or another non-Jenkins identity source, the built-in admin account will no longer exist.
   # Since the AdminUser is used by configAutoReload, in order to use configAutoReload you must change the
-  # .Master.AdminUser to a valid username on your LDAP (or other) server.  This user does not need
-  # to have administrator rights in Jenkins (the default Overall:Read is sufficient) nor will it be granted any
-  # additional rights.  Failure to do this will cause the sidecar container to fail to authenticate via SSH and enter
-  # a restart loop.  Likewise if you disable the non-Jenkins identity store and instead use the Jenkins internal one,
-  # you should revert Master.AdminUser to your preferred admin user:
+  # .Master.AdminUser to a valid username on your LDAP (or other) server.   If you use the matrix-auth plugin, this user
+  # must also be granted Overall\Administer rights in Jenkins.  Failure to do this will cause the sidecar container to
+  # fail to authenticate via SSH and enter a restart loop.  Likewise if you disable the non-Jenkins identity store and
+  # instead use the Jenkins internal one, you should revert Master.AdminUser to your preferred admin user:
   AdminUser: admin
   # AdminPassword: <defaults to random>
   OwnSshKey: false


### PR DESCRIPTION
Signed-off-by: brendan <holmesb@users.noreply.github.com>

I think [this issue](https://github.com/helm/charts/issues/12370) was probably caused by confusion due to wrong info in the values.yaml about AdminUser.  It needs to have Overall\Administer rights.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
