### PR TITLE
[stable/atlantis] Make secret-webhook optional

### DIFF
--- a/stable/atlantis/Chart.yaml
+++ b/stable/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.7.1"
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 3.2.0
+version: 3.2.1
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/stable/atlantis/Chart.yaml
+++ b/stable/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.7.1"
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 3.2.1
+version: 3.3.0
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/stable/atlantis/README.md
+++ b/stable/atlantis/README.md
@@ -16,7 +16,7 @@ In order for Atlantis to start and run successfully:
     -  `bitbucket`
 
     Refer to [values.yaml](values.yaml) for detailed examples.
-    They can also be provided directly through a Kubernetes `Secret`, use the variable `secretWebhookName` to reference it.
+    They can also be provided directly through a Kubernetes `Secret`, use the variable `vcsSecretsName` to reference it.
 
 1. Supply a value for `orgWhitelist`, e.g. `github.org/myorg/*`.
 
@@ -43,7 +43,7 @@ The following options are supported.  See [values.yaml](values.yaml) for more de
 | `gitlab.token`                              | Personal access token for the Atlantis GitLab user.                                                                                                                                                                                                                                                       | n/a     |
 | `gitlab.secret`                             | Webhook secret for the Atlantis GitLab integration. All repositories in GitLab that are to be integrated with Atlantis must share the same value.                                                                                                                                                         | n/a     |
 | `gitlab.hostname`                           | Hostname of your GitLab Enterprise installation.                                                                                                                                                                                                                                                          | n/a     |
-| `secretWebhookName`                         | Name of the Kubernetes `Secret` where the webhook cretentials are stored (optional)                                                                                                                                                                                                                                                      | n/a     |
+| `vcsSecretsName` | Name of a pre-existing Kubernetes `Secret` containing `token` and `secret` keys set to your VCS provider's API token and webhook secret, respectively. Use this instead of `github.token`/`github.secret`, etc. (optional) | n/a |
 | `podTemplate.annotations`                   | Additional annotations to use for the StatefulSet.                                                                                                                                                                                                                                                        | n/a     |
 | `logLevel`                                  | Level to use for logging. Either debug, info, warn, or error.                                                                                                                                                                                                                                             | n/a     |
 | `orgWhiteList`                              | Whitelist of repositories from which Atlantis will accept webhooks. **This value must be set for Atlantis to function correctly.** Accepts wildcard characters (`*`). Multiple values may be comma-separated.                                                                                             | none    |

--- a/stable/atlantis/README.md
+++ b/stable/atlantis/README.md
@@ -16,6 +16,7 @@ In order for Atlantis to start and run successfully:
     -  `bitbucket`
 
     Refer to [values.yaml](values.yaml) for detailed examples.
+    They can also be provided directly through a Kubernetes `Secret`, use the variable `secretWebhookName` to reference it.
 
 1. Supply a value for `orgWhitelist`, e.g. `github.org/myorg/*`.
 
@@ -42,6 +43,7 @@ The following options are supported.  See [values.yaml](values.yaml) for more de
 | `gitlab.token`                              | Personal access token for the Atlantis GitLab user.                                                                                                                                                                                                                                                       | n/a     |
 | `gitlab.secret`                             | Webhook secret for the Atlantis GitLab integration. All repositories in GitLab that are to be integrated with Atlantis must share the same value.                                                                                                                                                         | n/a     |
 | `gitlab.hostname`                           | Hostname of your GitLab Enterprise installation.                                                                                                                                                                                                                                                          | n/a     |
+| `secretWebhookName`                         | Name of the Kubernetes `Secret` where the webhook cretentials are stored (optional)                                                                                                                                                                                                                                                      | n/a     |
 | `podTemplate.annotations`                   | Additional annotations to use for the StatefulSet.                                                                                                                                                                                                                                                        | n/a     |
 | `logLevel`                                  | Level to use for logging. Either debug, info, warn, or error.                                                                                                                                                                                                                                             | n/a     |
 | `orgWhiteList`                              | Whitelist of repositories from which Atlantis will accept webhooks. **This value must be set for Atlantis to function correctly.** Accepts wildcard characters (`*`). Multiple values may be comma-separated.                                                                                             | none    |

--- a/stable/atlantis/templates/_helpers.tpl
+++ b/stable/atlantis/templates/_helpers.tpl
@@ -59,3 +59,14 @@ Defines the internal kubernetes address to Atlantis
 {{- define "atlantis.url" -}}
 {{ template "atlantis.url.scheme" . }}://{{ template "atlantis.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
 {{- end -}}
+
+{{/*
+Generates secret-webhook name
+*/}}
+{{- define "atlantis.secretWebhookName" -}}
+{{- if .Values.secretWebhookName -}}
+    {{ .Values.secretWebhookName }}
+{{- else -}}
+    {{ template "atlantis.fullname" . }}-webhook
+{{- end -}}
+{{- end -}}

--- a/stable/atlantis/templates/_helpers.tpl
+++ b/stable/atlantis/templates/_helpers.tpl
@@ -63,9 +63,9 @@ Defines the internal kubernetes address to Atlantis
 {{/*
 Generates secret-webhook name
 */}}
-{{- define "atlantis.secretWebhookName" -}}
-{{- if .Values.secretWebhookName -}}
-    {{ .Values.secretWebhookName }}
+{{- define "atlantis.vcsSecretsName" -}}
+{{- if .Values.vcsSecretsName -}}
+    {{ .Values.vcsSecretsName }}
 {{- else -}}
     {{ template "atlantis.fullname" . }}-webhook
 {{- end -}}

--- a/stable/atlantis/templates/secret-webhook.yaml
+++ b/stable/atlantis/templates/secret-webhook.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.secretWebhookName }}
+{{- if not .Values.vcsSecretsName }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/atlantis/templates/secret-webhook.yaml
+++ b/stable/atlantis/templates/secret-webhook.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.github .Values.gitlab .Values.bitbucket }}
+{{- if not .Values.secretWebhookName }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/atlantis/templates/secret-webhook.yaml
+++ b/stable/atlantis/templates/secret-webhook.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.github .Values.gitlab .Values.bitbucket }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -22,3 +23,4 @@ data:
   bitbucket_secret: {{ required "bitbucket.secret is required if bitbucket.baseurl is specified." .Values.bitbucket.secret | b64enc }}
   {{- end}}
   {{- end }}
+{{- end }}

--- a/stable/atlantis/templates/statefulset.yaml
+++ b/stable/atlantis/templates/statefulset.yaml
@@ -123,12 +123,12 @@ spec:
           - name: ATLANTIS_GH_TOKEN
             valueFrom:
               secretKeyRef:
-                name: {{ template "atlantis.fullname" . }}-webhook
+                name: {{ template "atlantis.secretWebhookName" . }}
                 key: github_token
           - name: ATLANTIS_GH_WEBHOOK_SECRET
             valueFrom:
               secretKeyRef:
-                name: {{ template "atlantis.fullname" . }}-webhook
+                name: {{ template "atlantis.secretWebhookName" . }}
                 key: github_secret
           {{- if .Values.github.hostname }}
           - name: ATLANTIS_GH_HOSTNAME
@@ -141,12 +141,12 @@ spec:
           - name: ATLANTIS_GITLAB_TOKEN
             valueFrom:
               secretKeyRef:
-                name: {{ template "atlantis.fullname" . }}-webhook
+                name: {{ template "atlantis.secretWebhookName" . }}
                 key: gitlab_token
           - name: ATLANTIS_GITLAB_WEBHOOK_SECRET
             valueFrom:
               secretKeyRef:
-                name: {{ template "atlantis.fullname" . }}-webhook
+                name: {{ template "atlantis.secretWebhookName" . }}
                 key: gitlab_secret
           {{- if .Values.gitlab.hostname }}
           - name: ATLANTIS_GITLAB_HOSTNAME
@@ -159,7 +159,7 @@ spec:
           - name: ATLANTIS_BITBUCKET_TOKEN
             valueFrom:
               secretKeyRef:
-                name: {{ template "atlantis.fullname" . }}-webhook
+                name: {{ template "atlantis.secretWebhookName" . }}
                 key: bitbucket_token
           {{- if .Values.bitbucket.baseURL }}
           - name: ATLANTIS_BITBUCKET_BASE_URL
@@ -167,7 +167,7 @@ spec:
           - name: ATLANTIS_BITBUCKET_WEBHOOK_SECRET
             valueFrom:
               secretKeyRef:
-                name: {{ template "atlantis.fullname" . }}-webhook
+                name: {{ template "atlantis.secretWebhookName" . }}
                 key: bitbucket_secret
           {{- end }}
           {{- end }}

--- a/stable/atlantis/templates/statefulset.yaml
+++ b/stable/atlantis/templates/statefulset.yaml
@@ -123,12 +123,12 @@ spec:
           - name: ATLANTIS_GH_TOKEN
             valueFrom:
               secretKeyRef:
-                name: {{ template "atlantis.secretWebhookName" . }}
+                name: {{ template "atlantis.vcsSecretsName" . }}
                 key: github_token
           - name: ATLANTIS_GH_WEBHOOK_SECRET
             valueFrom:
               secretKeyRef:
-                name: {{ template "atlantis.secretWebhookName" . }}
+                name: {{ template "atlantis.vcsSecretsName" . }}
                 key: github_secret
           {{- if .Values.github.hostname }}
           - name: ATLANTIS_GH_HOSTNAME
@@ -141,12 +141,12 @@ spec:
           - name: ATLANTIS_GITLAB_TOKEN
             valueFrom:
               secretKeyRef:
-                name: {{ template "atlantis.secretWebhookName" . }}
+                name: {{ template "atlantis.vcsSecretsName" . }}
                 key: gitlab_token
           - name: ATLANTIS_GITLAB_WEBHOOK_SECRET
             valueFrom:
               secretKeyRef:
-                name: {{ template "atlantis.secretWebhookName" . }}
+                name: {{ template "atlantis.vcsSecretsName" . }}
                 key: gitlab_secret
           {{- if .Values.gitlab.hostname }}
           - name: ATLANTIS_GITLAB_HOSTNAME
@@ -159,7 +159,7 @@ spec:
           - name: ATLANTIS_BITBUCKET_TOKEN
             valueFrom:
               secretKeyRef:
-                name: {{ template "atlantis.secretWebhookName" . }}
+                name: {{ template "atlantis.vcsSecretsName" . }}
                 key: bitbucket_token
           {{- if .Values.bitbucket.baseURL }}
           - name: ATLANTIS_BITBUCKET_BASE_URL
@@ -167,7 +167,7 @@ spec:
           - name: ATLANTIS_BITBUCKET_WEBHOOK_SECRET
             valueFrom:
               secretKeyRef:
-                name: {{ template "atlantis.secretWebhookName" . }}
+                name: {{ template "atlantis.vcsSecretsName" . }}
                 key: bitbucket_secret
           {{- end }}
           {{- end }}

--- a/stable/atlantis/values.yaml
+++ b/stable/atlantis/values.yaml
@@ -38,7 +38,7 @@ orgWhitelist: <replace-me>
 # (The chart will perform the base64 encoding for you for values that are stored in secrets.)
 
 # If managing secrets outside the chart for the webhook, use this variable to reference the secret name
-# secretWebhookName: 'mysecret'
+# vcsSecretsName: 'mysecret'
 
 # When referencing Terraform modules in private repositories, it may be helpful
 # (necessary?) to use redirection in a .gitconfig like so:

--- a/stable/atlantis/values.yaml
+++ b/stable/atlantis/values.yaml
@@ -37,6 +37,8 @@ orgWhitelist: <replace-me>
 #   base_url: https://bitbucket.yourorganization.com
 # (The chart will perform the base64 encoding for you for values that are stored in secrets.)
 
+# If managing secrets outside the chart for the webhook, use this variable to reference the secret name
+# secretWebhookName: 'mysecret'
 
 # When referencing Terraform modules in private repositories, it may be helpful
 # (necessary?) to use redirection in a .gitconfig like so:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
People might want to manage secrets on their own. This PR makes the secret-webhook from the templates optional if no git credentials are given.

#### Which issue this PR fixes
  - fixes https://github.com/helm/charts/issues/12999

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
