### PR TITLE
[stable/mysql] support loadBalancerIP, configurationFilesPath

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.19.1
+version: 0.19.2
 appVersion: 5.7.14
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.

--- a/stable/mysql/README.md
+++ b/stable/mysql/README.md
@@ -46,13 +46,13 @@ The following table lists the configurable parameters of the MySQL chart and the
 
 | Parameter                                    | Description                                                                                  | Default                                              |
 | -------------------------------------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| `initContainer.resources`                    | initContainer resource requests/limits                                                         | Memory: `10Mi`, CPU: `10m`                         |
+| `initContainer.resources`                    | initContainer resource requests/limits                                                       | Memory: `10Mi`, CPU: `10m`                           |
 | `image`                                      | `mysql` image repository.                                                                    | `mysql`                                              |
 | `imageTag`                                   | `mysql` image tag.                                                                           | `5.7.14`                                             |
-| `busybox.image`                                    | `busybox` image repository.                                                                    | `busybox`                                            |
-| `busybox.tag`                                | `busybox` image tag.                                                                           | `1.29.3`                                             |
-| `testFramework.image`                              | `test-framework` image repository.                                                                    | `dduportal/bats`                                            |
-| `testFramework.tag`                          | `test-framework` image tag.                                                                           | `0.4.0`                                              |
+| `busybox.image`                              | `busybox` image repository.                                                                  | `busybox`                                            |
+| `busybox.tag`                                | `busybox` image tag.                                                                         | `1.29.3`                                             |
+| `testFramework.image`                        | `test-framework` image repository.                                                           | `dduportal/bats`                                     |
+| `testFramework.tag`                          | `test-framework` image tag.                                                                  | `0.4.0`                                              |
 | `imagePullPolicy`                            | Image pull policy                                                                            | `IfNotPresent`                                       |
 | `existingSecret`                             | Use Existing secret for Password details                                                     | `nil`                                                |
 | `extraVolumes`                               | Additional volumes as a string to be passed to the `tpl` function                            |                                                      |
@@ -74,11 +74,11 @@ The following table lists the configurable parameters of the MySQL chart and the
 | `readinessProbe.failureThreshold`            | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 3                                                    |
 | `persistence.enabled`                        | Create a volume to store data                                                                | true                                                 |
 | `persistence.size`                           | Size of persistent volume claim                                                              | 8Gi RW                                               |
-| `persistence.storageClass`                   | Type of persistent volume claim                                                              | nil           |
+| `persistence.storageClass`                   | Type of persistent volume claim                                                              | nil                                                  |
 | `persistence.accessMode`                     | ReadWriteOnce or ReadOnly                                                                    | ReadWriteOnce                                        |
 | `persistence.existingClaim`                  | Name of existing persistent volume                                                           | `nil`                                                |
 | `persistence.subPath`                        | Subdirectory of the volume to mount                                                          | `nil`                                                |
-| `persistence.annotations`                    | Persistent Volume annotations                             				      | {}						     |
+| `persistence.annotations`                    | Persistent Volume annotations                                                                | {}                                                   |
 | `nodeSelector`                               | Node labels for pod assignment                                                               | {}                                                   |
 | `tolerations`                                | Pod taint tolerations for deployment                                                         | {}                                                   |
 | `metrics.enabled`                            | Start a side-car prometheus exporter                                                         | `false`                                              |
@@ -93,10 +93,12 @@ The following table lists the configurable parameters of the MySQL chart and the
 | `metrics.flags`                              | Additional flags for the mysql exporter to use                                               | `[]`                                                 |
 | `resources`                                  | CPU/Memory resource requests/limits                                                          | Memory: `256Mi`, CPU: `100m`                         |
 | `configurationFiles`                         | List of mysql configuration files                                                            | `nil`                                                |
+| `configurationFilesPath`                     | Path of mysql configuration files                                                            | `/etc/mysql/conf.d/`                                 |
 | `securityContext.enabled`                    | Enable security context (mysql pod)                                                          | `false`                                              |
-| `securityContext.fsGroup`                    | Group ID for the container (mysql pod)                                                       | 999                                               |
-| `securityContext.runAsUser`                  | User ID for the container (mysql pod)                                                        | 999                                                |
+| `securityContext.fsGroup`                    | Group ID for the container (mysql pod)                                                       | 999                                                  |
+| `securityContext.runAsUser`                  | User ID for the container (mysql pod)                                                        | 999                                                  |
 | `service.annotations`                        | Kubernetes annotations for mysql                                                             | {}                                                   |
+| `service.loadBalancerIP`                     | LoadBalancer service IP                                                                      | `""`                                                 |
 | `ssl.enabled`                                | Setup and use SSL for MySQL connections                                                      | `false`                                              |
 | `ssl.secret`                                 | Name of the secret containing the SSL certificates                                           | mysql-ssl-certs                                      |
 | `ssl.certificates[0].name`                   | Name of the secret containing the SSL certificates                                           | `nil`                                                |
@@ -107,7 +109,7 @@ The following table lists the configurable parameters of the MySQL chart and the
 | `initializationFiles`                        | List of SQL files which are run after the container started                                  | `nil`                                                |
 | `timezone`                                   | Container and mysqld timezone (TZ env)                                                       | `nil` (UTC depending on image)                       |
 | `podAnnotations`                             | Map of annotations to add to the pods                                                        | `{}`                                                 |
-| `podLabels`                                  | Map of labels to add to the pods                                                        | `{}`                                                 |
+| `podLabels`                                  | Map of labels to add to the pods                                                             | `{}`                                                 |
 | `priorityClassName`                          | Set pod priorityClassName                                                                    | `{}`                                                 |
 
 Some of the parameters above map to the env variables defined in the [MySQL DockerHub image](https://hub.docker.com/_/mysql/).

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -135,7 +135,7 @@ spec:
         {{- if .Values.configurationFiles }}
         {{- range $key, $val := .Values.configurationFiles }}
         - name: configurations
-          mountPath: /etc/mysql/conf.d/{{ $key }}
+          mountPath: {{ $.Values.configurationFilesPath }}{{ $key }}
           subPath: {{ $key }}
         {{- end -}}
         {{- end }}

--- a/stable/mysql/templates/svc.yaml
+++ b/stable/mysql/templates/svc.yaml
@@ -16,6 +16,9 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if (and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP))) }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   ports:
   - name: mysql
     port: {{ .Values.service.port }}

--- a/stable/mysql/values.yaml
+++ b/stable/mysql/values.yaml
@@ -109,6 +109,9 @@ resources:
     memory: 256Mi
     cpu: 100m
 
+# Custom mysql configuration files path
+configurationFilesPath: /etc/mysql/conf.d/
+
 # Custom mysql configuration files used to override default mysql settings
 configurationFiles: {}
 #  mysql.cnf: |-
@@ -151,6 +154,7 @@ service:
   type: ClusterIP
   port: 3306
   # nodePort: 32000
+  # loadBalancerIP: 
 
 ssl:
   enabled: false

--- a/stable/mysql/values.yaml
+++ b/stable/mysql/values.yaml
@@ -154,7 +154,7 @@ service:
   type: ClusterIP
   port: 3306
   # nodePort: 32000
-  # loadBalancerIP: 
+  # loadBalancerIP:
 
 ssl:
   enabled: false


### PR DESCRIPTION
Signed-off-by: Travis Glenn Hansen <travisghansen@yahoo.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Supports setting `loadBalancerIP` and allows for modifying the `configurationFiles` mount path.  Trying to use `percona` and `mysql` images with this chart and `percona` seems to have changed their image to use `/etc/my.cnf.d/` for whatever crazy reason.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] title of the PR contains starts with chart name e.g. `[stable/chart]`
