### PR TITLE
[stable/grafana] Do not create test service account if create is set to false

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 3.3.9
+version: 3.3.10
 appVersion: 6.2.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -107,6 +107,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `admin.passwordKey`                       | The key in the existing admin secret containing the password. | `"admin-password"`                      |
 | `serviceAccount.create`                   | Create service account | `true` |
 | `serviceAccount.name`                     | Service account name to use, when empty will be set to created account if `serviceAccount.create` is set else to `default` | `` |
+| `serviceAccount.nameTest`                 | Service account name to use for test, when empty will be set to created account if `serviceAccount.create` is set else to `default` | `` |
 | `rbac.create`                             | Create and use RBAC resources | `true` |
 | `rbac.namespaced`                         | Creates Role and Rolebinding instead of the default ClusterRole and ClusteRoleBindings for the grafana instance  | `false` |
 | `rbac.pspEnabled`                         | Create PodSecurityPolicy (with `rbac.create`, grant roles permissions as well) | `true` |

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -105,6 +105,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `admin.existingSecret`                    | The name of an existing secret containing the admin credentials. | `""`                                 |
 | `admin.userKey`                           | The key in the existing admin secret containing the username. | `"admin-user"`                          |
 | `admin.passwordKey`                       | The key in the existing admin secret containing the password. | `"admin-password"`                      |
+| `serviceAccount.create`                   | Create service account | `true` |
+| `serviceAccount.name`                     | Service account name to use, when empty will be set to created account if `serviceAccount.create` is set else to `default` | `` |
 | `rbac.create`                             | Create and use RBAC resources | `true` |
 | `rbac.namespaced`                         | Creates Role and Rolebinding instead of the default ClusterRole and ClusteRoleBindings for the grafana instance  | `false` |
 | `rbac.pspEnabled`                         | Create PodSecurityPolicy (with `rbac.create`, grant roles permissions as well) | `true` |

--- a/stable/grafana/templates/_helpers.tpl
+++ b/stable/grafana/templates/_helpers.tpl
@@ -41,3 +41,11 @@ Create the name of the service account
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{- define "grafana.serviceAccountNameTest" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (print (include "grafana.fullname" .) "-test") .Values.serviceAccount.nameTest }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.nameTest }}
+{{- end -}}
+{{- end -}}

--- a/stable/grafana/templates/tests/test-rolebinding.yaml
+++ b/stable/grafana/templates/tests/test-rolebinding.yaml
@@ -14,6 +14,6 @@ roleRef:
   name: {{ template "grafana.fullname" . }}-test
 subjects:
 - kind: ServiceAccount
-  name: {{ template "grafana.serviceAccountName" . }}-test
+  name: {{ template "grafana.serviceAccountNameTest" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/stable/grafana/templates/tests/test-serviceaccount.yaml
+++ b/stable/grafana/templates/tests/test-serviceaccount.yaml
@@ -7,5 +7,5 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "grafana.serviceAccountName" . }}-test
+  name: {{ template "grafana.serviceAccountNameTest" . }}
 {{- end }}

--- a/stable/grafana/templates/tests/test-serviceaccount.yaml
+++ b/stable/grafana/templates/tests/test-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,3 +8,4 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "grafana.serviceAccountName" . }}-test
+{{- end }}

--- a/stable/grafana/templates/tests/test.yaml
+++ b/stable/grafana/templates/tests/test.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
     "helm.sh/hook": test-success
 spec:
-  serviceAccountName: {{ template "grafana.serviceAccountName" . }}-test
+  serviceAccountName: {{ template "grafana.serviceAccountNameTest" . }}
   initContainers:
     - name: test-framework
       image: "{{ .Values.testFramework.image}}:{{ .Values.testFramework.tag }}"

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -6,6 +6,7 @@ rbac:
 serviceAccount:
   create: true
   name:
+  nameTest:
 
 replicas: 1
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
If serviceAccount.create is set to false, the test-serviceaccount.yaml is still created even though we are not testing. This prevents me to deploy this chart without creating a service account.

#### Special notes for your reviewer:
Testing with serviceAccount.create set to false is only possible if default-test exists. Probably a similar option should come to override the test serviceAccountName, which is set to "default" if left empty and the create flag is set to false. If you want I can add that as well.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
