### PR TITLE
[stable/prometheus-cloudwatch-exporter] Add scrape timeout option

### DIFF
--- a/stable/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/stable/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.4.4
+version: 0.4.5
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -78,6 +78,7 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | `servicemonitor.interval`   | How frequently Prometheus should scrape                |                            |
 | `servicemonitor.telemetryPath` |  path to cloudwatch-exporter telemtery-path         |                            |
 | `servicemonitor.labels`     |   labels for the ServiceMonitor passed to Prometheus Operator      |  `{}`          |
+| `servicemonitor.timeout`     |  Timeout after which the scrape is ended              |                            |
 | `ingress.enabled`           | Enables Ingress                                        | `false`                    |
 | `ingress.annotations`       | Ingress annotations                                    | `{}`                       |
 | `ingress.labels`            | Custom labels                                          | `{}`                       |

--- a/stable/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
@@ -19,6 +19,9 @@ spec:
 {{- if .Values.serviceMonitor.telemetryPath }}
     path: {{ .Values.serviceMonitor.telemetryPath }}
 {{- end }}
+{{- if .Values.serviceMonitor.timeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.timeout }}
+{{- end }}
   jobLabel: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
   namespaceSelector:
     matchNames:

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -118,6 +118,8 @@ serviceMonitor:
   # telemetryPath: /metrics
   # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
   # labels:
+  # Set timeout for scrape
+  # timeout: 10s
 
 ingress:
   enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR will add a configurable timeout to the scrape of the prometheus-cloudwatch-exporter

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
