### PR TITLE
[stable/traefik] Use chart helper to support SemVer2

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.68.1
+version: 1.68.2
 appVersion: 1.7.9
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/templates/_helpers.tpl
+++ b/stable/traefik/templates/_helpers.tpl
@@ -27,6 +27,13 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "traefik.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create the block for the ProxyProtocol's Trusted IPs.
 */}}
 {{- define "traefik.trustedips" -}}

--- a/stable/traefik/templates/acme-pvc.yaml
+++ b/stable/traefik/templates/acme-pvc.yaml
@@ -9,7 +9,7 @@ metadata:
   name: {{ template "traefik.fullname" . }}-acme
   labels:
     app: {{ template "traefik.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "traefik.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/stable/traefik/templates/config-files.yaml
+++ b/stable/traefik/templates/config-files.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "traefik.fullname" . }}-configs
   labels:
     app: {{ template "traefik.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "traefik.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "traefik.fullname" . }}
   labels:
     app: {{ template "traefik.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "traefik.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 data:

--- a/stable/traefik/templates/dashboard-ingress.yaml
+++ b/stable/traefik/templates/dashboard-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "traefik.fullname" . }}-dashboard
   labels:
     app: {{ template "traefik.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "traefik.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
   {{- if .Values.dashboard.ingress }}

--- a/stable/traefik/templates/dashboard-service.yaml
+++ b/stable/traefik/templates/dashboard-service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "traefik.fullname" . }}-dashboard
   labels:
     app: {{ template "traefik.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "traefik.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
   annotations:

--- a/stable/traefik/templates/default-cert-secret.yaml
+++ b/stable/traefik/templates/default-cert-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "traefik.fullname" . }}-default-cert
   labels:
     app: {{ template "traefik.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "traefik.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 type: Opaque

--- a/stable/traefik/templates/deployment.yaml
+++ b/stable/traefik/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ template "traefik.fullname" . }}
   labels:
     app: {{ template "traefik.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "traefik.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 spec:
@@ -33,7 +33,7 @@ spec:
       {{- end }}
       labels:
         app: {{ template "traefik.name" . }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        chart: {{ template "traefik.chart" . }}
         release: {{ .Release.Name | quote }}
         heritage: {{ .Release.Service | quote }}
         {{- if .Values.deployment.podLabels }}

--- a/stable/traefik/templates/dns-provider-secret.yaml
+++ b/stable/traefik/templates/dns-provider-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "traefik.fullname" . }}-dnsprovider-config
   labels:
     app: {{ template "traefik.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "traefik.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 type: Opaque

--- a/stable/traefik/templates/hpa.yaml
+++ b/stable/traefik/templates/hpa.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "traefik.fullname" . }}
   labels:
     app: {{ template "traefik.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "traefik.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 spec:

--- a/stable/traefik/templates/poddisruptionbudget.yaml
+++ b/stable/traefik/templates/poddisruptionbudget.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "traefik.fullname" . }}
   labels:
     app: {{ template "traefik.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "traefik.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 spec:

--- a/stable/traefik/templates/secret-files.yaml
+++ b/stable/traefik/templates/secret-files.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "traefik.fullname" . }}-secrets
   labels:
     app: {{ template "traefik.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "traefik.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/stable/traefik/templates/service.yaml
+++ b/stable/traefik/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "traefik.fullname" . }}
   labels:
     app: {{ template "traefik.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "traefik.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
   {{- if .Values.service }}

--- a/stable/traefik/templates/storeconfig-job.yaml
+++ b/stable/traefik/templates/storeconfig-job.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "traefik.chart" . }}
     app: {{ template "traefik.name" . }}
 spec:
   template:
@@ -14,7 +14,7 @@ spec:
       name: "storeconfig-job-{{ .Release.Revision }}"
       labels:
         app: {{ template "traefik.name" . }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        chart: {{ template "traefik.chart" . }}
     spec:
       restartPolicy: Never
       containers: 

--- a/stable/traefik/templates/tests/test-configmap.yaml
+++ b/stable/traefik/templates/tests/test-configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "traefik.fullname" . }}-test
   labels:
     app: {{ template "traefik.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "traefik.chart" . }}
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
 data:

--- a/stable/traefik/templates/tests/test.yaml
+++ b/stable/traefik/templates/tests/test.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "traefik.fullname" . }}-test
   labels:
     app: {{ template "traefik.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "traefik.chart" . }}
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
   annotations:


### PR DESCRIPTION
Signed-off-by: Kevin Houdebert <kevin.houdebert@gmail.com>

#### What this PR does / why we need it:

This PR sets `traefik.chart` variable in `_helpers.tpl`. This allow using SemVer2 versioning on forks with the `+` sign.

#### Which issue this PR fixes

When deploying using a SemVer2 version, an error arise.
```
$ grep version Chart.yaml
version: 1.68.1+abcdef
$ helm install .
Error: release flailing-pug failed: ConfigMap "flailing-pug-traefik" is invalid: metadata.labels: Invalid value: "traefik-1.68.1+abcdef": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```

As recommended in https://helm.sh/docs/chart_best_practices/#version-numbers, this PR replaces the `+` character with `_`.

```
$ grep version Chart.yaml
version: 1.68.1+abcdef
$ helm install .
LAST DEPLOYED: Fri May 10 21:50:37 2019
NAMESPACE: default
STATUS: DEPLOYED
[...]
$ helm ls
NAME            REVISION        UPDATED                         STATUS          CHART                   NAMESPACE
washed-whale    1               Fri May 10 21:50:37 2019        DEPLOYED        traefik-1.68.1+abcdef   default
$ helm template . | grep chart -B2
  labels:
    app: traefik
    chart: traefik-1.68.1_abcdef
[...]
```

#### Special notes for your reviewer:

Inspired by fluentd chart https://github.com/helm/charts/blob/master/stable/fluentd/templates/_helpers.tpl#L27-L32

Passes `lint`.
```
$ helm lint
==> Linting .
Lint OK

1 chart(s) linted, no failures
```

#### Checklist

- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md (no new public variable)
- [X] title of the PR contains starts with chart name e.g. `[stable/chart]`
