### PR TITLE
[incubator/raw] fix missing newline after yaml document separator

### DIFF
--- a/incubator/raw/Chart.yaml
+++ b/incubator/raw/Chart.yaml
@@ -1,7 +1,7 @@
 name: raw
 home: https://github.com/helm/charts/blob/master/incubator/raw
-version: 0.2.0
-appVersion: 0.2.0
+version: 0.2.1
+appVersion: 0.2.1
 description: A place for all the Kubernetes resources which don't already have a home.
 maintainers:
 - name: josdotso

--- a/incubator/raw/templates/resources.yaml
+++ b/incubator/raw/templates/resources.yaml
@@ -1,9 +1,9 @@
 {{- $template := fromYaml (include "raw.resource" .) -}}
 {{- range .Values.resources }}
 ---
-{{- toYaml (merge . $template) -}}
+{{ toYaml (merge . $template) -}}
 {{- end }}
 {{- range $i, $t := .Values.templates }}
 ---
-{{- toYaml (merge (tpl $t $ | fromYaml) $template) -}}
+{{ toYaml (merge (tpl $t $ | fromYaml) $template) -}}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
This fixed a bug where the first line of a resource ends up on the same line as the yaml document separator.
before
```
$ helm template incubator/raw
---apiVersion: scheduling.k8s.io/v1beta1
description: This priority class should only be used for critical priority common
  pods.
globalDefault: false
kind: PriorityClass
metadata:
  labels:
    app: raw
    chart: raw-0.2.0
    heritage: Tiller
    release: release-name
  name: common-critical
value: 100000000
```

after
```
$ helm template incubator/raw
---
apiVersion: scheduling.k8s.io/v1beta1
description: This priority class should only be used for critical priority common
  pods.
globalDefault: false
kind: PriorityClass
metadata:
  labels:
    app: raw
    chart: raw-0.2.0
    heritage: Tiller
    release: release-name
  name: common-critical
value: 100000000
```

#### Special notes for your reviewer:
I'll bump the version upon request, just didn't want to do it till it's ready to be merged, especially given there are other open PRs for this chart that also do so and who knows when those will be merged (ie. https://github.com/helm/charts/pull/13633).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
