### PR TITLE
[stable/influxdb] using standardized helm 'image.repository' instead of 'helm.repo'

### DIFF
--- a/stable/influxdb/Chart.yaml
+++ b/stable/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 1.1.6
+version: 1.1.7
 appVersion: 1.7.3
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/stable/influxdb/templates/deployment.yaml
+++ b/stable/influxdb/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: {{ template "influxdb.fullname" . }}
-        image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/stable/influxdb/values.yaml
+++ b/stable/influxdb/values.yaml
@@ -1,7 +1,7 @@
 ## influxdb image version
 ## ref: https://hub.docker.com/r/library/influxdb/tags/
 image:
-  repo: "influxdb"
+  repository: "influxdb"
   tag: "1.7.3-alpine"
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
#### What this PR does / why we need it:

The `helm create` scaffolding creates charts with a standardized `image.repository` and `image.tag` stanza definition.  The influxdb chart uses `image.repo` which is inconsistent with most every other chart.

This PR changes the definition to bring the chart in-line with the rest.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
