### PR TITLE
[stable/heapster] Fix stable heapster fullname

### DIFF
--- a/stable/heapster/Chart.yaml
+++ b/stable/heapster/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Heapster enables Container Cluster Monitoring and Performance Analysis.
 name: heapster
-version: 0.3.4
+version: 1.0.0
 appVersion: 1.5.2
 home: https://github.com/kubernetes/heapster
 sources:

--- a/stable/heapster/Chart.yaml
+++ b/stable/heapster/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Heapster enables Container Cluster Monitoring and Performance Analysis.
 name: heapster
-version: 0.3.3
+version: 0.3.4
 appVersion: 1.5.2
 home: https://github.com/kubernetes/heapster
 sources:

--- a/stable/heapster/templates/_helpers.tpl
+++ b/stable/heapster/templates/_helpers.tpl
@@ -9,10 +9,19 @@ Expand the name of the chart.
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "heapster.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Currently if we install heapster by `helm upgrade --install heapster stable/heapster`,
then we get the fullname `heapster-heapster`.
This PR fixes this so that we'll get the fullname `heapster`.

#### Which issue this PR fixes

There is no associated issue.

#### Special notes for your reviewer:

`helm create` command also creates this `templates/_helpers.tpl`.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
