### PR TITLE
[stable/opa] Reload on config change

### DIFF
--- a/stable/opa/Chart.yaml
+++ b/stable/opa/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - opa
 - admission control
 - policy
-version: 1.4.1
+version: 1.5.0
 home: https://www.openpolicyagent.org
 icon: https://raw.githubusercontent.com/open-policy-agent/opa/master/logo/logo.png
 sources:

--- a/stable/opa/templates/deployment.yaml
+++ b/stable/opa/templates/deployment.yaml
@@ -11,6 +11,15 @@ spec:
       app: {{ template "opa.fullname" . }}
   template:
     metadata:
+{{- if and .Values.generateAdmissionControllerCerts .Values.opa }}
+      annotations:
+{{- if .Values.generateAdmissionControllerCerts }}
+        checksum/certs: {{ include (print $.Template.BasePath "/webhookconfiguration.yaml") . | sha256sum }}
+{{- end }}
+{{- if .Values.opa }}
+        checksum/config: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+{{- end }}
+{{- end }}
       labels:
         app: {{ template "opa.fullname" . }}
       name: {{ template "opa.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:
When using helm to generate the webhook certificate's for kubernetes subsequent helm upgrades produce new certificates. OPA needs to be restarted in this case to use the CA that Kube APIServer is expecting.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
