### PR TITLE
[stable/nats] Use a validate helper to detect invalid configurations

### DIFF
--- a/stable/nats/Chart.yaml
+++ b/stable/nats/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nats
-version: 2.5.0
+version: 2.5.1
 appVersion: 1.4.1
 description: An open-source, cloud-native messaging system
 keywords:

--- a/stable/nats/templates/NOTES.txt
+++ b/stable/nats/templates/NOTES.txt
@@ -1,17 +1,5 @@
 ** Please be patient while the chart is being deployed **
 
-{{- if and (not (eq .Values.resourceType "statefulset")) (not (eq .Values.resourceType "deployment")) }}
-
--------------------------------------------------------------------------------
- WARNING
-
-   "resourceType" currently only "statefulset", "deployment" are allowed
-   the type specified in values.yaml >> {{ .Values.resourceType }} << is not defined in white list
-   but it will still continuing deploy with default resource type "statefulset"
-
--------------------------------------------------------------------------------
-{{- end }}
-
 {{- if or (contains .Values.client.service.type "LoadBalancer") (contains .Values.client.service.type "nodePort") }}
 {{- if not .Values.auth.enabled }}
 {{ if and (not .Values.networkPolicy.enabled) (.Values.networkPolicy.allowExternal) }}
@@ -97,4 +85,7 @@ To access the Monitoring svc from outside the cluster, follow the steps below:
     kubectl port-forward --namespace {{ .Release.Namespace }} {{ template "nats.fullname" . }}-0 {{ .Values.metrics.port }}:{{ .Values.metrics.port }}
 
 4. Access NATS Prometheus metrics by opening the URL obtained in a browser.
+
 {{- end }}
+
+{{- include "nats.validateValues" . -}}

--- a/stable/nats/templates/_helpers.tpl
+++ b/stable/nats/templates/_helpers.tpl
@@ -119,3 +119,27 @@ imagePullSecrets:
 {{- end }}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Compile all warnings into a single message, and call fail.
+*/}}
+{{- define "nats.validateValues" -}}
+{{- $messages := list -}}
+{{- $messages := append $messages (include "nats.validateValues.resourceType" .) -}}
+{{- $messages := without $messages "" -}}
+{{- $message := join "\n" $messages -}}
+
+{{- if $message -}}
+{{-   printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Validate values of NATS - must provide a valid resourceType ("deployment" or "statefulset") */}}
+{{- define "nats.validateValues.resourceType" -}}
+{{- if and (ne .Values.resourceType "deployment") (ne .Values.resourceType "statefulset") -}}
+nats: resourceType
+    Invalid resourceType selected. Valid values are "deployment" and
+    "statefulset". Please set a valid mode (--set resourceType="xxxx")
+{{- end -}}
+{{- end -}}

--- a/stable/nats/templates/_helpers.tpl
+++ b/stable/nats/templates/_helpers.tpl
@@ -120,7 +120,6 @@ imagePullSecrets:
 {{- end -}}
 {{- end -}}
 
-
 {{/*
 Compile all warnings into a single message, and call fail.
 */}}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR substitute some warnings in the NOTES.txt by a function that allows to avoid installing a chart when certain validations aren't passing.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
