### PR TITLE
[stable/sysdig] Hardcode new_k8s value to true

### DIFF
--- a/stable/sysdig/CHANGELOG.md
+++ b/stable/sysdig/CHANGELOG.md
@@ -3,6 +3,12 @@
 This file documents all notable changes to Sysdig Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.4.6
+
+### Minor Changes
+
+* Dont allow to change the value of `new_k8s` flag.
+
 ## v1.4.5
 
 ### Minor Changes

--- a/stable/sysdig/Chart.yaml
+++ b/stable/sysdig/Chart.yaml
@@ -1,5 +1,5 @@
 name: sysdig
-version: 1.4.5
+version: 1.4.6
 appVersion: 0.89.5
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/stable/sysdig/README.md
+++ b/stable/sysdig/README.md
@@ -55,7 +55,7 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `ebpf.enabled`                  | Enable eBPF support for Sysdig instead of `sysdig-probe` kernel module | `false`                                     |
 | `ebpf.settings.mountEtcVolume`  | Needed to detect which kernel version are running in Google COS        | `true`                                      |
 | `sysdig.accessKey`              | Your Sysdig Monitor Access Key                                         | `Nil` You must provide your own key         |
-| `sysdig.settings`               | Settings for agent's configuration file                                | `{ new_k8s: true }`                         |
+| `sysdig.settings`               | Settings for agent's configuration file                                | ` `                                         |
 | `secure.enabled`                | Enable Sysdig Secure                                                   | `false`                                     |
 | `customAppChecks`               | The custom app checks deployed with your agent                         | `{}`                                        |
 | `tolerations`                   | The tolerations for scheduling                                         | `node-role.kubernetes.io/master:NoSchedule` |

--- a/stable/sysdig/templates/configmap.yaml
+++ b/stable/sysdig/templates/configmap.yaml
@@ -1,4 +1,3 @@
-{{- if or .Values.sysdig.settings .Values.secure.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,6 +9,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 data:
   dragent.yaml: |
+    new_k8s: true
 {{- if .Values.secure.enabled }}
     security:
       enabled: true
@@ -20,5 +20,4 @@ data:
 {{- end }}
 {{- if .Values.sysdig.settings }}
 {{ toYaml .Values.sysdig.settings | indent 4 }}
-{{- end }}
 {{- end }}

--- a/stable/sysdig/values.yaml
+++ b/stable/sysdig/values.yaml
@@ -58,7 +58,6 @@ sysdig:
   accessKey: ""
 
   settings:
-    new_k8s: true
     ### Agent tags
     # tags: linux:ubuntu,dept:dev,local:nyc
     #### Sysdig Software related config ####


### PR DESCRIPTION
If you change some agent settings in values.yaml of passing via the
command line, you can alter the value of new_k8s flag

Signed-off-by: Néstor Salceda <nestor.salceda@sysdig.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR forces the new_k8s value to true. It does not allow to override from command line.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
