### PR TITLE
[stable/postgresql] excluding ".snapshot" in chown during init

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 4.2.0
+version: 4.2.1
 appVersion: 10.8.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/statefulset-slaves.yaml
+++ b/stable/postgresql/templates/statefulset-slaves.yaml
@@ -68,12 +68,10 @@ spec:
           - -c
           - |
             set -e
-            for ref in $(find /bitnami -mindepth 1 -maxdepth 1 -not -name ".snapshot"); do
-              chown {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} $ref
-            done
-            for ref in $(find /bitnami -mindepth 2 -maxdepth 2 -not -name ".snapshot"); do
-              chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} $ref
-            done
+            find /bitnami -mindepth 1 -maxdepth 1 -not -name ".snapshot" \
+              -exec chown {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} {} \;
+            find /bitnami -mindepth 2 -maxdepth 2 -not -name ".snapshot" \
+              -exec chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} {} \;
             if [ -d {{ .Values.persistence.mountPath }}/data ]; then
               chmod  0700 {{ .Values.persistence.mountPath }}/data;
             fi

--- a/stable/postgresql/templates/statefulset-slaves.yaml
+++ b/stable/postgresql/templates/statefulset-slaves.yaml
@@ -67,11 +67,8 @@ spec:
           - sh
           - -c
           - |
-            set -e
-            find /bitnami -mindepth 1 -maxdepth 1 -not -name ".snapshot" \
-              -exec chown {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} {} \;
-            find /bitnami -mindepth 2 -maxdepth 2 -not -name ".snapshot" \
-              -exec chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} {} \;
+            find {{ .Values.persistence.mountPath }} -mindepth 1 -maxdepth 1 -not -name ".snapshot" | \
+              xargs chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}
             if [ -d {{ .Values.persistence.mountPath }}/data ]; then
               chmod  0700 {{ .Values.persistence.mountPath }}/data;
             fi

--- a/stable/postgresql/templates/statefulset-slaves.yaml
+++ b/stable/postgresql/templates/statefulset-slaves.yaml
@@ -67,7 +67,13 @@ spec:
           - sh
           - -c
           - |
-            chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} /bitnami
+            set -e
+            for ref in $(find /bitnami -mindepth 1 -maxdepth 1 -not -name ".snapshot"); do
+              chown {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} $ref
+            done
+            for ref in $(find /bitnami -mindepth 2 -maxdepth 2 -not -name ".snapshot"); do
+              chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} $ref
+            done
             if [ -d {{ .Values.persistence.mountPath }}/data ]; then
               chmod  0700 {{ .Values.persistence.mountPath }}/data;
             fi

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -72,12 +72,10 @@ spec:
           - -c
           - |
             set -e
-            for ref in $(find /bitnami -mindepth 1 -maxdepth 1 -not -name ".snapshot"); do
-              chown {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} $ref
-            done
-            for ref in $(find /bitnami -mindepth 2 -maxdepth 2 -not -name ".snapshot"); do
-              chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} $ref
-            done
+            find /bitnami -mindepth 1 -maxdepth 1 -not -name ".snapshot" \
+              -exec chown {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} {} \;
+            find /bitnami -mindepth 2 -maxdepth 2 -not -name ".snapshot" \
+              -exec chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} {} \;
             if [ -d {{ .Values.persistence.mountPath }}/data ]; then
               chmod  0700 {{ .Values.persistence.mountPath }}/data;
             fi

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -71,11 +71,8 @@ spec:
           - sh
           - -c
           - |
-            set -e
-            find /bitnami -mindepth 1 -maxdepth 1 -not -name ".snapshot" \
-              -exec chown {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} {} \;
-            find /bitnami -mindepth 2 -maxdepth 2 -not -name ".snapshot" \
-              -exec chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} {} \;
+            find {{ .Values.persistence.mountPath }} -mindepth 1 -maxdepth 1 -not -name ".snapshot" | \
+              xargs chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}
             if [ -d {{ .Values.persistence.mountPath }}/data ]; then
               chmod  0700 {{ .Values.persistence.mountPath }}/data;
             fi

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
-        fsGroup: {{ .Values.securityContext.fsGroup }}      
+        fsGroup: {{ .Values.securityContext.fsGroup }}
       {{- end }}
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ default (include "postgresql.fullname" . ) .Values.serviceAccount.name }}
@@ -71,7 +71,13 @@ spec:
           - sh
           - -c
           - |
-            chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} /bitnami
+            set -e
+            for ref in $(find /bitnami -mindepth 1 -maxdepth 1 -not -name ".snapshot"); do
+              chown {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} $ref
+            done
+            for ref in $(find /bitnami -mindepth 2 -maxdepth 2 -not -name ".snapshot"); do
+              chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} $ref
+            done
             if [ -d {{ .Values.persistence.mountPath }}/data ]; then
               chmod  0700 {{ .Values.persistence.mountPath }}/data;
             fi
@@ -220,7 +226,7 @@ spec:
        {{- if .Values.metrics.securityContext.enabled }}
         securityContext:
           runAsUser: {{ .Values.metrics.securityContext.runAsUser }}
-      {{- end }}        
+      {{- end }}
         env:
         {{- $database := required "In order to enable metrics you need to specify a database (.Values.postgresqlDatabase or .Values.global.postgresql.postgresqlDatabase)" (include "postgresql.database" .) }}
         - name: DATA_SOURCE_URI


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

In some environment, where PVs are NFS volumes with `.shapshot` directories, such as the case with NetApps, `chown -R` would fail during execution of initContainer command. To avoid failure, `.snapshot` should be excluded from `chown -R`

#### Special notes for your reviewer:

This does the trick in my environment with PVs backed by NetApps over NFS.  
@desaintmartin, please suggest alternatives, if my method is considered sub-optimal.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
