### PR TITLE
[stable/wordpress] Evaluate 'boolean parameters' as booleans

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 5.9.3
+version: 5.9.4
 appVersion: 5.2.0
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -56,6 +56,7 @@ The following table lists the configurable parameters of the WordPress chart and
 | `image.tag`                      | WordPress image tag                        | `{VERSION}`                                             |
 | `image.pullPolicy`               | Image pull policy                          | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
 | `image.pullSecrets`              | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
+| `wordpressSkipInstall`           | Skip wizard installation                   | `false`                                                 |
 | `wordpressUsername`              | User of the application                    | `user`                                                  |
 | `wordpressPassword`              | Application password                       | _random 10 character long alphanumeric string_          |
 | `wordpressEmail`                 | Admin email                                | `user@example.com`                                      |
@@ -64,8 +65,8 @@ The following table lists the configurable parameters of the WordPress chart and
 | `wordpressBlogName`              | Blog name                                  | `User's Blog!`                                          |
 | `wordpressTablePrefix`           | Table prefix                               | `wp_`                                                   |
 | `allowEmptyPassword`             | Allow DB blank passwords                   | `true`                                                  |
-| `allowOverrideNone`              | Set Apache AllowOverride directive to None                   | `no`                                                  |
-| `customHTAccessCM`              | Configmap with custom wordpress-htaccess.conf directives                   | `nil`                                                  |
+| `allowOverrideNone`              | Set Apache AllowOverride directive to None | `false`                                                 |
+| `customHTAccessCM`               | Configmap with custom wordpress-htaccess.conf directives | `nil`                                     |
 | `smtpHost`                       | SMTP host                                  | `nil`                                                   |
 | `smtpPort`                       | SMTP port                                  | `nil`                                                   |
 | `smtpUser`                       | SMTP user                                  | `nil`                                                   |
@@ -90,7 +91,7 @@ The following table lists the configurable parameters of the WordPress chart and
 | `service.externalTrafficPolicy`  | Enable client source IP preservation       | `Cluster`                                               |
 | `service.nodePorts.http`         | Kubernetes http node port                  | `""`                                                    |
 | `service.nodePorts.https`        | Kubernetes https node port                 | `""`                                                    |
-| `service.extraPorts`            | Extra ports to expose in the service (normally used with the `sidecar` value)                        | `nil`                                                    |
+| `service.extraPorts`            | Extra ports to expose in the service (normally used with the `sidecar` value) | `nil`                 |
 | `healthcheckHttps`               | Use https for liveliness and readiness     | `false`                                                 |
 | `livenessProbeHeaders`           | Headers to use for livenessProbe           | `nil`                                                   |
 | `readinessProbeHeaders`          | Headers to use for readinessProbe          | `nil`                                                   |
@@ -120,8 +121,8 @@ The following table lists the configurable parameters of the WordPress chart and
 | `metrics.image.pullPolicy`       | Image pull policy                          | `IfNotPresent`                                          |
 | `metrics.image.pullSecrets`      | Specify docker-registry secret names as an array        | `[]` (does not add image pull secrets to deployed pods)        |
 | `metrics.podAnnotations`         | Additional annotations for Metrics exporter pod         | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}`   |
-| `metrics.resources`              | Exporter resource requests/limit           | {}                                                      |
-| `sidecars`                           | Attach additional containers to the pod                                                      | `nil`                                                         |
+| `metrics.resources`              | Exporter resource requests/limit           | `{}`                                                    |
+| `sidecars`                       | Attach additional containers to the pod    | `nil`                                                   |
 
 The above parameters map to the env variables defined in [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress). For more information please refer to the [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress) image documentation.
 

--- a/stable/wordpress/templates/deployment.yaml
+++ b/stable/wordpress/templates/deployment.yaml
@@ -40,11 +40,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
         - name: ALLOW_EMPTY_PASSWORD
-        {{- if .Values.allowEmptyPassword }}
-          value: "yes"
-        {{- else }}
-          value: "no"
-        {{- end }}
+          value: {{ ternary "yes" "no" .Values.allowEmptyPassword | quote }}
         - name: MARIADB_HOST
         {{- if .Values.mariadb.enabled }}
           value: {{ template "mariadb.fullname" . }}
@@ -93,11 +89,11 @@ spec:
         - name: WORDPRESS_LAST_NAME
           value: {{ .Values.wordpressLastName | quote }}
         - name: WORDPRESS_HTACCESS_OVERRIDE_NONE
-          value: {{ .Values.allowOverrideNone | quote }}
+          value: {{ ternary "yes" "no" .Values.allowOverrideNone | quote }}
         - name: WORDPRESS_BLOG_NAME
           value: {{ .Values.wordpressBlogName | quote }}
         - name: WORDPRESS_SKIP_INSTALL
-          value: {{ .Values.wordpressSkipInstall | quote }}
+          value: {{ ternary "yes" "no" .Values.wordpressSkipInstall | quote }}
         - name: WORDPRESS_TABLE_PREFIX
           value: {{ .Values.wordpressTablePrefix | quote }}
         {{- if .Values.smtpHost }}
@@ -135,12 +131,10 @@ spec:
         livenessProbe:
           httpGet:
             path: /wp-login.php
-          {{- if not .Values.healthcheckHttps }}
-            port: http
-          {{- else }}
-            port: https
+            port: {{ ternary "https" "http" .Values.healthcheckHttps }}
+            {{- if .Values.healthcheckHttps }}
             scheme: HTTPS
-          {{- end }}
+            {{- end }}
           {{- if .Values.livenessProbeHeaders }}
             httpHeaders:
 {{ toYaml .Values.livenessProbeHeaders | indent 14 }}
@@ -149,12 +143,10 @@ spec:
         readinessProbe:
           httpGet:
             path: /wp-login.php
-          {{- if not .Values.healthcheckHttps }}
-            port: http
-          {{- else }}
-            port: https
+            port: {{ ternary "https" "http" .Values.healthcheckHttps }}
+            {{- if .Values.healthcheckHttps }}
             scheme: HTTPS
-          {{- end }}
+            {{- end }}
           {{- if .Values.readinessProbeHeaders }}
             httpHeaders:
 {{ toYaml .Values.readinessProbeHeaders | indent 14 }}

--- a/stable/wordpress/values-production.yaml
+++ b/stable/wordpress/values-production.yaml
@@ -61,14 +61,18 @@ wordpressTablePrefix: wp_
 ## Skip wizard installation (only if you use an external database that already contains WordPress data)
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#connect-wordpress-docker-container-to-an-existing-database
 ##
-wordpressSkipInstall: "no"
+wordpressSkipInstall: false
 
-## Set to `yes` to allow the container to be started with blank passwords
+## Set to `false` to allow the container to be started with blank passwords
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
-allowEmptyPassword: "yes"
+##
+allowEmptyPassword: true
 
 ## Set Apache allowOverride to None
-allowOverrideNone: "yes"
+
+##
+allowOverrideNone: true
+
 # ConfigMap with custom wordpress-htaccess.conf file (requires allowOverrideNone to true)
 customHTAccessCM:
 

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -65,14 +65,17 @@ wordpressTablePrefix: wp_
 ## Skip wizard installation (only if you use an external database that already contains WordPress data)
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#connect-wordpress-docker-container-to-an-existing-database
 ##
-wordpressSkipInstall: "no"
+wordpressSkipInstall: false
 
 ## Set to `false` to allow the container to be started with blank passwords
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
+##
 allowEmptyPassword: true
 
 ## Set Apache allowOverride to None
-allowOverrideNone: "no"
+## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
+##
+allowOverrideNone: false
 
 # ConfigMap with custom wordpress-htaccess.conf file (requires allowOverrideNone to true)
 customHTAccessCM:


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR ensures that we use boolean values instead of "yes/no" string for those parameters that should be booleans.

Treating some parameters as "real" booleans and others as strings is confusing.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`