### PR TITLE
[stable/prometheus-mongodb-exporter] Fix mongodb-exporter default values

### DIFF
--- a/stable/prometheus-mongodb-exporter/Chart.yaml
+++ b/stable/prometheus-mongodb-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "v0.7.1"
+appVersion: "v0.7.0"
 description: A Prometheus exporter for MongoDB metrics
 home: https://github.com/percona/mongodb_exporter
 keywords:
@@ -13,4 +13,4 @@ maintainers:
 name: prometheus-mongodb-exporter
 sources:
 - https://github.com/percona/mongodb_exporter
-version: 2.0.0
+version: 2.0.1

--- a/stable/prometheus-mongodb-exporter/Chart.yaml
+++ b/stable/prometheus-mongodb-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "v0.7.0"
+appVersion: "v0.7.1"
 description: A Prometheus exporter for MongoDB metrics
 home: https://github.com/percona/mongodb_exporter
 keywords:

--- a/stable/prometheus-mongodb-exporter/values.yaml
+++ b/stable/prometheus-mongodb-exporter/values.yaml
@@ -49,10 +49,10 @@ replicas: 1
 
 resources: {}
 # limits:
-#   cpu: 250mm
+#   cpu: 250m
 #   memory: 192Mi
 # requests:
-#   cpu: 100mm
+#   cpu: 100m
 #   memory: 128Mi
 
 # Extra environment variables that will be passed into the exporter pod


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR fixes this error I get when I try to install the chart using the default resources.

The error is:
```
$ helm upgrade --install mongodb-exporter-dev stable/prometheus-mongodb-exporter --values=values.yaml --tls
Release "mongodb-exporter-dev" does not exist. Installing it now.
Error: release mongodb-exporter-dev failed: Deployment in version "v1" cannot be handled as a Deployment: v1.Deployment.Spec: v1.DeploymentSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.Containers: []v1.Container: v1.Container.Resources: v1.ResourceRequirements.Limits: unmarshalerDecoder: unable to parse quantity's suffix, error found in #10 byte of ...|u":"250mm","memory":|..., bigger context ...|ySeconds":10},"resources":{"limits":{"cpu":"250mm","memory":"192Mi"},"requests":{"cpu":"100mm","memo|...
```


#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
