### PR TITLE
stable/external-dns add roleArn missing

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -3,7 +3,7 @@ description: |
   Configure external DNS servers (AWS Route53, Google CloudDNS and others)
   for Kubernetes Ingresses and Services
 name: external-dns
-version: 1.7.5
+version: 1.7.6
 appVersion: 0.5.13
 home: https://github.com/kubernetes-incubator/external-dns
 sources:

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
           {{- if .Values.aws.zoneType }}
             - --aws-zone-type={{ .Values.aws.zoneType }}
           {{- end }}
-         {{- if .Values.aws.roleArn }}
+          {{- if .Values.aws.roleArn }}
             - --aws-assume-role={{ .Values.aws.roleArn }}
           {{- end }}
           {{- if .Values.google.project }}

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -73,6 +73,9 @@ spec:
           {{- if .Values.aws.zoneType }}
             - --aws-zone-type={{ .Values.aws.zoneType }}
           {{- end }}
+         {{- if .Values.aws.roleArn }}
+            - --aws-assume-role={{ .Values.aws.roleArn }}
+          {{- end }}
           {{- if .Values.google.project }}
             - --google-project={{ .Values.google.project }}
           {{- end }}

--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.11.0
+version: 0.11.1
 appVersion: 1.1

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -193,6 +193,12 @@ helm install stable/kong --set ingressController.enabled=true \
 helm install stable/kong --set ingressController.enabled=true
 ```
 
+If you like to use a static IP:
+
+```shell
+helm install stable/kong --set ingressController.enabled=true --set proxy.loadBalancerIP=[Your IP goes there] --set proxy.type=LoadBalancer --name kong --namespace kong
+```
+
 **Note**: Kong Ingress controller doesn't support custom SSL certificates
 on Admin port. We will be removing this limitation in the future.
 


### PR DESCRIPTION
#### What this PR does / why we need it:
This fixes stable/external-dns which is missing a documented value from deployments.yaml file. This PR adds support for the deployments to use the roleArn value. 

#### Which issue this PR fixes
 - fixes https://github.com/helm/charts/issues/10886


Signed-off-by: Christopher Stobie <cjstobie@gmail.com>
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ x] Chart Version bumped
- [x ] Variables are documented in the README.md
- [x ] title of the PR contains starts with chart name e.g. `[stable/chart]`
