### PR TITLE
[stable/logstash] Allow for user defined initContainers

### DIFF
--- a/stable/logstash/Chart.yaml
+++ b/stable/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 1.10.0
+version: 1.11.0
 appVersion: 6.7.0
 sources:
 - https://www.docker.elastic.co

--- a/stable/logstash/README.md
+++ b/stable/logstash/README.md
@@ -99,6 +99,7 @@ The following table lists the configurable parameters of the chart and its defau
 | `podAnnotations`                | Pod annotations                                    | `{}`                                             |
 | `podLabels`                     | Pod labels                                         | `{}`                                             |
 | `extraEnv`                      | Extra pod environment variables                    | `[]`                                             |
+| `extraInitContainers`           | Add additional initContainers                      | `[]`                                             |
 | `livenessProbe`                 | Liveness probe settings for logstash container     | (see `values.yaml`)                              |
 | `readinessProbe`                | Readiness probe settings for logstash container    | (see `values.yaml`)                              |
 | `persistence.enabled`           | Enable persistence                                 | `true`                                           |

--- a/stable/logstash/templates/statefulset.yaml
+++ b/stable/logstash/templates/statefulset.yaml
@@ -46,6 +46,10 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}
       {{- end }}
+      initContainers:
+{{- if .Values.extraInitContainers }}
+{{ toYaml .Values.extraInitContainers | indent 8 }}
+{{- end }}
       containers:
 
         ## logstash

--- a/stable/logstash/values.yaml
+++ b/stable/logstash/values.yaml
@@ -117,6 +117,14 @@ podLabels: {}
 
 extraEnv: []
 
+extraInitContainers: []
+  # - name: echo
+  #   image: busybox
+  #   imagePullPolicy: Always
+  #   args:
+  #     - echo
+  #     - hello
+
 livenessProbe:
   httpGet:
     path: /


### PR DESCRIPTION
Signed-off-by: Marc Sensenich <sensenichm91@gmail.com>

#### What this PR does / why we need it:
Adds the ability for users of the Logstash chart to specify a list of initContainers if need be.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
