### PR TITLE
[stable/aerospike] add apiVersion

### DIFF
--- a/stable/aerospike/Chart.yaml
+++ b/stable/aerospike/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 appVersion: v4.5.0.5
 description: A Helm chart for Aerospike in Kubernetes
 name: aerospike
@@ -5,7 +6,7 @@ keywords:
   - aerospike
   - big-data
 home: http://aerospike.com
-version: 0.2.4
+version: 0.2.5
 icon: https://s3-us-west-1.amazonaws.com/aerospike-fd/wp-content/uploads/2016/06/Aerospike_square_logo.png
 sources:
 - https://github.com/aerospike/aerospike-server


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
