### PR TITLE
[stable/airflow]add apiVersion

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,6 +1,7 @@
+apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 2.8.1
+version: 2.8.2
 appVersion: 1.10.2
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
