### PR TITLE
[stable/chronograf] add apiVersion

### DIFF
--- a/stable/chronograf/Chart.yaml
+++ b/stable/chronograf/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: chronograf
-version: 1.0.1
+version: 1.0.2
 appVersion: 1.7.7
 description: Open-source web application written in Go and React.js that provides
   the tools to visualize your monitoring data and easily create alerting and automation


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
