### PR TITLE
[stable/cloudserver] add apiVersion

### DIFF
--- a/stable/cloudserver/Chart.yaml
+++ b/stable/cloudserver/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 name: cloudserver
 version: 1.0.1
 appVersion: 8.1.5

--- a/stable/cloudserver/Chart.yaml
+++ b/stable/cloudserver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cloudserver
-version: 1.0.1
+version: 1.0.2
 appVersion: 8.1.5
 kubeVersion: "^1.8.0-0"
 description: An open-source Node.js implementation of the Amazon S3 protocol on the front-end and backend storage capabilities to multiple clouds, including Azure and Google.


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
