### PR TITLE
[incubator/storm] Add Apache Storm

### DIFF
--- a/incubator/storm/Chart.yaml
+++ b/incubator/storm/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+appVersion: "1.1.1"
+description: Apache Storm is a free and open source distributed realtime computation system.
+name: storm
+version: 1.0.0
+keywords:
+  - storm
+  - zookeeper
+home: http://storm.apache.org/
+sources:
+  - https://github.com/apache/storm
+maintainers:
+  - name: jorwalk
+    email: jorwalk@gmail.com
+  - name: stackedsax
+    email: stackedsax@users.noreply.github.com
+icon: http://storm.apache.org/images/logo.png

--- a/incubator/storm/Chart.yaml
+++ b/incubator/storm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.1.1"
 description: Apache Storm is a free and open source distributed realtime computation system.
 name: storm
-version: 1.0.0
+version: 1.0.1
 keywords:
   - storm
   - zookeeper

--- a/incubator/storm/Chart.yaml
+++ b/incubator/storm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.1.1"
 description: Apache Storm is a free and open source distributed realtime computation system.
 name: storm
-version: 1.0.1
+version: 1.0.2
 keywords:
   - storm
   - zookeeper

--- a/incubator/storm/OWNERS
+++ b/incubator/storm/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- jorwalk
+- stackedsax
+reviewers:
+- jorwalk
+- stackedsax

--- a/incubator/storm/README.md
+++ b/incubator/storm/README.md
@@ -1,0 +1,75 @@
+## Storm
+[Apache Storm](http://storm.apache.org/) is a free and open source distributed realtime computation system. Storm makes it easy to reliably process unbounded streams of data, doing for realtime processing what Hadoop did for batch processing. Storm is simple, can be used with any programming language, and is a lot of fun to use!
+
+### Prerequisites
+
+This example assumes you have a Kubernetes cluster installed and
+running, and that you have installed the ```kubectl``` command line
+tool somewhere in your path. Please see the [getting
+started](https://kubernetes.io/docs/tutorials/kubernetes-basics/) for installation
+instructions for your platform.
+
+### Installing the Chart
+
+To install the chart with the release name `my-storm`:
+
+```bash
+$ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+$ helm install --name my-storm incubator/storm
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the Storm chart and their default values.
+
+### Nimbus
+| Parameter                         | Description                 | Default             |
+| --------------------------------- | --------------------------- | ------------------- |
+| `nimbus.replicaCount`             | Number of replicas          | 1                   |
+| `nimbus.image.repository`         | Container image name        | storm               |
+| `nimbus.image.tag`                | Container image version     | 1.1.1               |
+| `nimbus.image.pullPolicy`         | The default pull policy     | IfNotPresent        |
+| `nimbus.service.name`             | Service name                | nimbus              |
+| `nimbus.service.type`             | Service Type                | ClusterIP           |
+| `nimbus.service.port`             | Service Port                | 6627                |
+| `nimbus.resources.limits.cpu`     | Compute resources           | 100m                |
+
+### Supervisor
+| Parameter                         | Description                 | Default             |
+| --------------------------------- | --------------------------- | ------------------- |
+| `supervisor.replicaCount`         | Number of replicas          | 3                   |
+| `supervisor.image.repository`     | Container image name        | storm               |
+| `supervisor.image.tag`            | Container image version     | 1.1.1               |
+| `supervisor.image.pullPolicy`     | The default pull policy     | IfNotPresent        |
+| `supervisor.service.name`         | Service Name                | supervisor          |
+| `supervisor.service.port`         | Service Port                | 6700                |
+| `supervisor.resources.limits.cpu` | Compute Resouces            | 200m                |  
+
+### User Interface   
+| Parameter                         | Description                 | Default             |
+| --------------------------------- | --------------------------- | ------------------- |                      
+| `ui.enabled`                      | Enable the UI               | true                |
+| `ui.replicaCount`                 | Number of replicas          | 1                   |
+| `ui.image.repository`             | Container image name        | storm               |
+| `ui.image.tag`                    | UI image version            | 1.1.1               |
+| `ui.image.pullPolicy`             | The default pull policy     | IfNotPresent        |
+| `ui.service.type`                 | UI Service Type             | ClusterIP           |
+| `ui.service.name`                 | UI service name             | ui                  |
+| `ui.service.port`                 | UI service port             | 8080                |
+| `ui.resources.limits.cpu`         | Compute resources           | 100m                |
+
+### Zookeeper
+| Parameter                         | Description                 | Default             |
+| --------------------------------- | --------------------------- | ------------------- |
+| `zookeeper.enabled`               | Enable Zookeeper            | true                |
+| `zookeeper.service.name`          | Service name                | zookeeper           |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml incubator/storm
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/incubator/storm/cluster.xml
+++ b/incubator/storm/cluster.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<configuration monitorInterval="60" shutdownHook="disable">
+<properties>
+    <property name="pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1.} %t [%p] %msg%n</property>
+</properties>
+<appenders>
+    <Console name="STDOUT" target="SYSTEM_OUT">
+        <PatternLayout>
+            <pattern>${pattern}</pattern>
+        </PatternLayout>
+    </Console>
+    <Console name="STDERR" target="SYSTEM_ERR">
+        <PatternLayout>
+            <pattern>${pattern}</pattern>
+        </PatternLayout>
+    </Console>
+    <RollingFile name="A1" immediateFlush="false"
+                 fileName="${sys:storm.log.dir}/${sys:logfile.name}"
+                 filePattern="${sys:storm.log.dir}/${sys:logfile.name}.%i.gz">
+        <PatternLayout>
+            <pattern>${pattern}</pattern>
+        </PatternLayout>
+        <Policies>
+            <SizeBasedTriggeringPolicy size="100 MB"/> <!-- Or every 100 MB -->
+        </Policies>
+        <DefaultRolloverStrategy max="9"/>
+    </RollingFile>
+    <RollingFile name="WEB-ACCESS" immediateFlush="false"
+                 fileName="${sys:storm.log.dir}/access-web-${sys:daemon.name}.log"
+                 filePattern="${sys:storm.log.dir}/access-web-${sys:daemon.name}.log.%i.gz">
+        <PatternLayout>
+            <pattern>${pattern}</pattern>
+        </PatternLayout>
+        <Policies>
+            <SizeBasedTriggeringPolicy size="100 MB"/> <!-- Or every 100 MB -->
+        </Policies>
+        <DefaultRolloverStrategy max="9"/>
+    </RollingFile>
+    <RollingFile name="THRIFT-ACCESS" immediateFlush="false"
+                 fileName="${sys:storm.log.dir}/access-${sys:logfile.name}"
+                 filePattern="${sys:storm.log.dir}/access-${sys:logfile.name}.%i.gz">
+    <PatternLayout>
+        <pattern>${pattern}</pattern>
+    </PatternLayout>
+        <Policies>
+            <SizeBasedTriggeringPolicy size="100 MB"/> <!-- Or every 100 MB -->
+        </Policies>
+        <DefaultRolloverStrategy max="9"/>
+    </RollingFile>
+    <RollingFile name="METRICS"
+                 fileName="${sys:storm.log.dir}/${sys:logfile.name}.metrics"
+                 filePattern="${sys:storm.log.dir}/${sys:logfile.name}.metrics.%i.gz">
+        <PatternLayout>
+            <pattern>${patternMetrics}</pattern>
+        </PatternLayout>
+        <Policies>
+            <SizeBasedTriggeringPolicy size="2 MB"/>
+        </Policies>
+        <DefaultRolloverStrategy max="9"/>
+    </RollingFile>
+    <Syslog name="syslog" format="RFC5424" charset="UTF-8" host="localhost" port="514"
+            protocol="UDP" appName="[${sys:daemon.name}]" mdcId="mdc" includeMDC="true"
+            facility="LOCAL5" enterpriseNumber="18060" newLine="true" exceptionPattern="%rEx{full}"
+            messageId="[${sys:user.name}:S0]" id="storm" immediateFlush="true" immediateFail="true"/>
+</appenders>
+<loggers>
+
+    <Logger name="org.apache.storm.logging.filters.AccessLoggingFilter" level="info" additivity="false">
+        <AppenderRef ref="WEB-ACCESS"/>
+        <AppenderRef ref="syslog"/>
+    </Logger>
+    <Logger name="org.apache.storm.logging.ThriftAccessLogger" level="info" additivity="false">
+        <AppenderRef ref="THRIFT-ACCESS"/>
+        <AppenderRef ref="syslog"/>
+    </Logger>
+    <Logger name="org.apache.storm.metric.LoggingClusterMetricsConsumer" level="info" additivity="false">
+        <appender-ref ref="METRICS"/>
+    </Logger>
+    <root level="info"> <!-- We log everything -->
+        <appender-ref ref="STDERR"/>
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="A1"/>
+        <appender-ref ref="syslog"/>
+    </root>
+</loggers>
+</configuration>

--- a/incubator/storm/requirements.yaml
+++ b/incubator/storm/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+- name: zookeeper
+  version: 0.5.0
+  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+  condition: zookeeper.enabled

--- a/incubator/storm/requirements.yaml
+++ b/incubator/storm/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: zookeeper
-  version: 0.5.0
+  version: ~1.3.0
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
   condition: zookeeper.enabled

--- a/incubator/storm/templates/NOTES.txt
+++ b/incubator/storm/templates/NOTES.txt
@@ -1,0 +1,15 @@
+1. Get the Storm UI URL by running these commands:
+{{- if contains "NodePort" .Values.ui.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "storm.ui.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.ui.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "storm.ui.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "storm.ui.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.ui.service.externalPort }}
+{{- else if contains "ClusterIP" .Values.ui.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "storm.ui.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.ui.service.port }} -n {{ .Release.Namespace }}
+{{- end }}

--- a/incubator/storm/templates/_helpers.tpl
+++ b/incubator/storm/templates/_helpers.tpl
@@ -82,3 +82,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "storm.logging.name" -}}
 {{- printf "%s-logging" (include "storm.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Override the zookeeper service name for the zookeeper chart so that both charts reference the same zookeeper service name.
+*/}}
+{{- define "zookeeper.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}o
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name .Values.stormName $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/incubator/storm/templates/_helpers.tpl
+++ b/incubator/storm/templates/_helpers.tpl
@@ -1,0 +1,84 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "storm.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "storm.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "storm.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "storm.nimbus.name" -}}
+{{- printf "%s-%s" (include "storm.name" .) .Values.nimbus.service.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified nimbus name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "storm.nimbus.fullname" -}}
+{{- $name := default .Chart.Name .Values.nimbus.service.name -}}
+{{- printf "%s-%s" (include "storm.fullname" .) $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "storm.supervisor.name" -}}
+{{- printf "%s-%s" (include "storm.name" .) .Values.supervisor.service.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified supervisor name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "storm.supervisor.fullname" -}}
+{{- $name := default .Chart.Name .Values.supervisor.service.name -}}
+{{- printf "%s-%s" (include "storm.fullname" .) $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "storm.ui.name" -}}
+{{- printf "%s-%s" (include "storm.name" .) .Values.ui.service.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified ui name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "storm.ui.fullname" -}}
+{{- $name := default .Chart.Name .Values.ui.service.name -}}
+{{- printf "%s-%s" (include "storm.fullname" .) $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified zookeeper name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "storm.zookeeper.fullname" -}}
+{{- $name := default .Values.zookeeper.service.name -}}
+{{- printf "%s-%s" (include "storm.fullname" .) $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "storm.logging.name" -}}
+{{- printf "%s-logging" (include "storm.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/storm/templates/configmap.yaml
+++ b/incubator/storm/templates/configmap.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "storm.nimbus.fullname" . }}
+  labels:
+    chart: {{ template "storm.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  storm.yaml: |-
+    ########### These MUST be filled in for a storm configuration
+    storm.zookeeper.servers:
+        - {{ template "storm.zookeeper.fullname" . }}
+    nimbus.seeds:
+        - {{ template "storm.nimbus.fullname" . }}
+    storm.local.hostname: {{ template "storm.nimbus.fullname" . }}
+    storm.log4j2.conf.dir: "/log4j2"
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "storm.supervisor.fullname" . }}
+  labels:
+    chart: {{ template "storm.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  storm.yaml: |-
+    ########### These MUST be filled in for a storm configuration
+    storm.zookeeper.servers:
+        - {{ template "storm.zookeeper.fullname" . }}
+    nimbus.seeds:
+        - {{ template "storm.nimbus.fullname" . }}
+    storm.local.hostname: {{ template "storm.supervisor.fullname" . }}
+    storm.log4j2.conf.dir: "/log4j2"
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "storm.logging.name" . }}
+  labels:
+    chart: {{ template "storm.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  {{- $files := .Files }}
+  {{- range tuple "cluster.xml" "worker.xml" }}
+  {{ . }}: |-
+{{ $files.Get . | indent 4 }}
+  {{- end }}
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "storm.ui.fullname" . }}
+  labels:
+    chart: {{ template "storm.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  storm.yaml: |-
+    ########### These MUST be filled in for a storm configuration
+    storm.zookeeper.servers:
+        - {{ template "storm.zookeeper.fullname" . }}
+    nimbus.seeds:
+        - {{ template "storm.nimbus.fullname" . }}
+    storm.local.hostname: {{ template "storm.ui.fullname" . }}
+    storm.log4j2.conf.dir: "/log4j2"

--- a/incubator/storm/templates/nimbus-deployment.yaml
+++ b/incubator/storm/templates/nimbus-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "storm.nimbus.fullname" . }}
+  labels:
+    app: {{ template "storm.nimbus.name" . }}
+    chart: {{ template "storm.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.nimbus.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "storm.nimbus.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      labels:
+        app: {{ template "storm.nimbus.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      initContainers:
+      - name: init-{{ template "storm.zookeeper.fullname" . }}
+        image: busybox
+        command: ["sh", "-c", "until nslookup {{ template "storm.zookeeper.fullname" . }}; do echo waiting for {{ template "storm.zookeeper.fullname" . }}; sleep 2; done;"]
+      containers:
+      - name: {{ .Values.nimbus.service.name }}
+        image: "{{ .Values.nimbus.image.repository }}:{{ .Values.nimbus.image.tag }}"
+        imagePullPolicy: {{ .Values.nimbus.image.pullPolicy }}
+        command: ["storm", "nimbus"]
+        ports:
+        - containerPort: {{ .Values.nimbus.service.port }}
+        resources:
+{{ toYaml .Values.nimbus.resources | indent 10 }}
+        volumeMounts:
+          - mountPath: "/conf"
+            name: storm-configmap
+          - mountPath: "/log4j2"
+            name: storm-logging-config
+      volumes:
+        - name: storm-configmap
+          configMap:
+            name: {{ template "storm.nimbus.fullname" . }}
+        - name: storm-logging-config
+          configMap:
+            name: {{ template "storm.logging.name" . }}

--- a/incubator/storm/templates/nimbus-service.yaml
+++ b/incubator/storm/templates/nimbus-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "storm.nimbus.fullname" . }}
+  labels:
+    chart: {{ template "storm.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.nimbus.service.type }}
+  ports:
+  - port: {{ .Values.nimbus.service.port }}
+    name: {{ .Values.nimbus.service.name }}
+  selector:
+    app: {{ template "storm.nimbus.name" . }}
+    release: {{ .Release.Name }}

--- a/incubator/storm/templates/supervisor-deployment.yaml
+++ b/incubator/storm/templates/supervisor-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "storm.supervisor.fullname" . }}
+  labels:
+    app: {{ template "storm.supervisor.name" . }}
+    chart: {{ template "storm.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.supervisor.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "storm.supervisor.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "storm.supervisor.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      initContainers:
+      - name: init-{{ template "storm.zookeeper.fullname" . }}
+        image: busybox
+        command: ["sh", "-c", "until nslookup {{ template "storm.zookeeper.fullname" . }}; do echo waiting for {{ template "storm.zookeeper.fullname" . }}; sleep 2; done;"]
+      - name: init-{{ template "storm.nimbus.fullname" . }}
+        image: busybox
+        command: ["sh", "-c", "until nslookup {{ template "storm.nimbus.fullname" . }}; do echo waiting for {{ template "storm.nimbus.fullname" . }}; sleep 2; done;"]
+      containers:
+      - name: {{ .Values.supervisor.service.name }}
+        image: "{{ .Values.supervisor.image.repository }}:{{ .Values.supervisor.image.tag }}"
+        imagePullPolicy: {{ .Values.supervisor.image.pullPolicy }}
+        command: ["storm", "supervisor"]
+        ports:
+        - containerPort: {{ .Values.supervisor.service.port }}
+        resources:
+{{ toYaml .Values.supervisor.resources | indent 10 }}
+        volumeMounts:
+          - mountPath: "/conf"
+            name: storm-configmap
+          - mountPath: "/log4j2"
+            name: storm-logging-config
+      volumes:
+        - name: storm-configmap
+          configMap:
+            name: {{ template "storm.supervisor.fullname" . }}
+        - name: storm-logging-config
+          configMap:
+            name: {{ template "storm.logging.name" . }}

--- a/incubator/storm/templates/supervisor-service.yaml
+++ b/incubator/storm/templates/supervisor-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "storm.supervisor.fullname" . }}
+  labels:
+    chart: {{ template "storm.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ports:
+  - port: {{ .Values.supervisor.service.port }}
+    name: {{ .Values.supervisor.service.name }}
+  selector:
+    app: {{ template "storm.supervisor.name" . }}
+    release: {{ .Release.Name }}

--- a/incubator/storm/templates/ui-deployment.yaml
+++ b/incubator/storm/templates/ui-deployment.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.ui.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "storm.ui.fullname" . }}
+  labels:
+    app: {{ template "storm.ui.name" . }}
+    chart: {{ template "storm.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.ui.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "storm.ui.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      labels:
+        app: {{ template "storm.ui.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      initContainers:
+      - name: init-{{ template "storm.zookeeper.fullname" . }}
+        image: busybox
+        command: ["sh", "-c", "until nslookup {{ template "storm.zookeeper.fullname" . }}; do echo waiting for {{ template "storm.zookeeper.fullname" . }}; sleep 2; done;"]
+      - name: init-{{ template "storm.nimbus.fullname" . }}
+        image: busybox
+        command: ["sh", "-c", "until nslookup {{ template "storm.nimbus.fullname" . }}; do echo waiting for {{ template "storm.nimbus.fullname" . }}; sleep 2; done;"]
+      - name: init-{{ template "storm.supervisor.fullname" . }}
+        image: busybox
+        command: ["sh", "-c", "until nslookup {{ template "storm.supervisor.fullname" . }}; do echo waiting for {{ template "storm.supervisor.fullname" . }}; sleep 2; done;"]
+      containers:
+      - name: {{ .Values.ui.service.name }}
+        image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}"
+        imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
+        command: ["storm", "ui"]
+        ports:
+        - containerPort: {{ .Values.ui.service.port }}
+        resources:
+{{ toYaml .Values.ui.resources | indent 10 }}
+        volumeMounts:
+          - mountPath: "/conf"
+            name: storm-configmap
+          - mountPath: "/log4j2"
+            name: storm-logging-config
+      volumes:
+        - name: storm-configmap
+          configMap:
+            name: {{ template "storm.ui.fullname" . }}
+        - name: storm-logging-config
+          configMap:
+            name: {{ template "storm.logging.name" . }}
+{{- end -}}

--- a/incubator/storm/templates/ui-service.yaml
+++ b/incubator/storm/templates/ui-service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.ui.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "storm.ui.fullname" . }}
+  labels:
+    chart: {{ template "storm.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.ui.service.type }}
+  ports:
+  - protocol: TCP
+    port: {{ .Values.ui.service.port }}
+    name: {{ .Values.ui.service.name }}
+
+  selector:
+    app: {{ template "storm.ui.name" . }}
+    release: {{ .Release.Name }}
+{{- end -}}

--- a/incubator/storm/values.yaml
+++ b/incubator/storm/values.yaml
@@ -1,0 +1,63 @@
+# Default values for storm.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+nameOverride: ""
+fullnameOverride: ""
+name: storm
+enabled: true
+nimbus:
+  replicaCount: 1
+  image:
+    repository: storm
+    tag: 1.1.1
+    pullPolicy: IfNotPresent
+  service:
+    name: nimbus
+    type: ClusterIP
+    port: 6627
+  resources:
+    limits:
+      cpu: 100m
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+supervisor:
+  replicaCount: 3
+  image:
+    repository: storm
+    tag: 1.1.1
+    pullPolicy: IfNotPresent
+  service:
+    name: supervisor
+    port: 6700
+  resources:
+    limits:
+      cpu: 200m
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+ui:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: storm
+    tag: 1.1.1
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    name: ui
+    port: 8080
+  resources:
+    limits:
+      cpu: 100m
+  ingress:
+    enabled: false
+    annotations: {}
+    tls: []
+
+zookeeper:
+  enabled: true
+  service:
+    name: zookeeper

--- a/incubator/storm/values.yaml
+++ b/incubator/storm/values.yaml
@@ -61,3 +61,4 @@ zookeeper:
   enabled: true
   service:
     name: zookeeper
+  stormName: storm

--- a/incubator/storm/worker.xml
+++ b/incubator/storm/worker.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<configuration monitorInterval="60" shutdownHook="disable">
+<properties>
+    <property name="pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1.} %t [%p] %msg%n</property>
+    <property name="patternNoTime">%msg%n</property>
+    <property name="patternMetrics">%d %-8r %m%n</property>
+</properties>
+<appenders>
+    <RollingFile name="A1"
+		fileName="${sys:workers.artifacts}/${sys:storm.id}/${sys:worker.port}/${sys:logfile.name}"
+		filePattern="${sys:workers.artifacts}/${sys:storm.id}/${sys:worker.port}/${sys:logfile.name}.%i.gz">
+        <PatternLayout>
+            <pattern>${pattern}</pattern>
+        </PatternLayout>
+        <Policies>
+            <SizeBasedTriggeringPolicy size="100 MB"/> <!-- Or every 100 MB -->
+        </Policies>
+        <DefaultRolloverStrategy max="9"/>
+    </RollingFile>
+    <Console name="STDOUT" target="SYSTEM_OUT">
+        <PatternLayout>
+            <pattern>${pattern}</pattern>
+        </PatternLayout>
+    </Console>
+    <Console name="STDERR" target="SYSTEM_ERR">
+        <PatternLayout>
+            <pattern>${pattern}</pattern>
+        </PatternLayout>
+    </Console>
+    <RollingFile name="METRICS"
+		fileName="${sys:workers.artifacts}/${sys:storm.id}/${sys:worker.port}/${sys:logfile.name}.metrics"
+		filePattern="${sys:workers.artifacts}/${sys:storm.id}/${sys:worker.port}/${sys:logfile.name}.metrics.%i.gz">
+        <PatternLayout>
+            <pattern>${patternMetrics}</pattern>
+        </PatternLayout>
+        <Policies>
+            <SizeBasedTriggeringPolicy size="2 MB"/>
+        </Policies>
+        <DefaultRolloverStrategy max="9"/>
+    </RollingFile>
+    <Syslog name="syslog" format="RFC5424" charset="UTF-8" host="localhost" port="514"
+        protocol="UDP" appName="[${sys:storm.id}:${sys:worker.port}]" mdcId="mdc" includeMDC="true"
+        facility="LOCAL5" enterpriseNumber="18060" newLine="true" exceptionPattern="%rEx{full}"
+        messageId="[${sys:user.name}:${sys:logging.sensitivity}]" id="storm" immediateFail="true" immediateFlush="true"/>
+</appenders>
+<loggers>
+    <root level="info"> <!-- We log everything -->
+        <appender-ref ref="A1"/>
+        <appender-ref ref="syslog"/>
+    </root>
+    <Logger name="org.apache.storm.metric.LoggingMetricsConsumer" level="info" additivity="false">
+        <appender-ref ref="METRICS"/>
+    </Logger>
+    <Logger name="STDERR" level="INFO">
+        <appender-ref ref="STDERR"/>
+        <appender-ref ref="syslog"/>
+    </Logger>
+    <Logger name="STDOUT" level="INFO">
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="syslog"/>
+    </Logger>
+</loggers>
+</configuration>


### PR DESCRIPTION
#### What this PR does / why we need it:
This pull request adds the necessary templates and manifest files to deploy Apache Storm with Helm.

This PR is a continuation of https://github.com/helm/charts/pull/5748.  Specifically, we believe this addresses the final request from @unguiculus regarding the fullname templates.

In the process these small improvements were made from the original PR:

- Update fullname helper template to the current version created by `helm create`
- Update all individual services name and fullname helpers template to use the base name and fullname helper templates so that all fullname templates respect the `nameOverride` and `fullnameOverride` values
- Change the logging helper to that it uses the fullname template and not the chart name
- Change deployment apiVersions to `apps/v1`
- Add empty values for `nameOverride` and `fullnameOverride`
- Update maintainer usernames and emails


#### Special notes for your reviewer:

@unguiculus, you reviewed this last time -- please take a look and see if your last request from https://github.com/helm/charts/pull/5748 has been taken care of.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
