### PR TITLE
[stable/coredns] add apiVersion

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: coredns
-version: 1.5.2
+version: 1.5.3
 appVersion: 1.5.0
 description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services
 keywords:


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
