### PR TITLE
[stable/cosbench] add apiVersion

### DIFF
--- a/stable/cosbench/Chart.yaml
+++ b/stable/cosbench/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: cosbench
-version: 1.0.0
+version: 1.0.1
 appVersion: 0.0.6
 kubeVersion: "^1.8.0-0"
 description: A benchmark tool for cloud object storage services


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
