### PR TITLE
[stable/coscale] add apiVersion

### DIFF
--- a/stable/coscale/Chart.yaml
+++ b/stable/coscale/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: coscale
-version: 0.3.0
+version: 1.0.0
 appVersion: 3.16.0
 description: CoScale Agent
 keywords:


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
