### PR TITLE
[stable/dask] add apiVersion

### DIFF
--- a/stable/dask/Chart.yaml
+++ b/stable/dask/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: dask
-version: 2.2.0
+version: 2.2.1
 appVersion: 1.1.0
 description: Distributed computation in Python with task scheduling
 home: https://dask.pydata.org


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
