### PR TITLE
[stable/dex] add apiVersion

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: dex
-version: 1.2.0
+version: 1.2.1
 appVersion: 2.16.0
 description: CoreOS Dex
 keywords:


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
