### PR TITLE
[stable/factorio] add apiVersion

### DIFF
--- a/stable/factorio/Chart.yaml
+++ b/stable/factorio/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: factorio
-version: 0.4.0
+version: 1.0.0
 appVersion: 0.15.39
 description: Factorio dedicated server.
 keywords:


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
