### PR TITLE
[stable/fluent-bit] add apiVersion

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: fluent-bit
-version: 1.10.0
+version: 1.10.1
 appVersion: 1.0.6
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
