### PR TITLE
[stable/goldpinger] add apiVersion

### DIFF
--- a/stable/goldpinger/Chart.yaml
+++ b/stable/goldpinger/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: goldpinger
-version: 1.1.2
+version: 1.1.3
 appVersion: 1.5.0
 description: Goldpinger makes calls between its instances for visibility and alerting.
 home: https://github.com/bloomberg/goldpinger


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
