### PR TITLE
[stable/influxdb] add apiVersion

### DIFF
--- a/stable/influxdb/Chart.yaml
+++ b/stable/influxdb/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: influxdb
-version: 1.1.5
+version: 1.1.6
 appVersion: 1.7.3
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
