### PR TITLE
[stable/instana-agent] add apiVersion

### DIFF
--- a/stable/instana-agent/Chart.yaml
+++ b/stable/instana-agent/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: instana-agent
-version: 1.0.6
+version: 1.0.7
 appVersion: 1.0
 description: Instana Agent for Kubernetes
 home: https://www.instana.com/


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
