### PR TITLE
[stable/jenkins] add apiVersion

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,7 @@
+apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.1.16
+version: 1.1.17
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
