### PR TITLE
[stable/kafka-manager] add apiVersion

### DIFF
--- a/stable/kafka-manager/Chart.yaml
+++ b/stable/kafka-manager/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: kafka-manager
-version: 2.1.3
+version: 2.1.4
 appVersion: 1.3.3.22
 kubeVersion: "^1.8.0-0"
 description: A tool for managing Apache Kafka.


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
