### PR TITLE
[stable/kapacitor] add apiVersion

### DIFF
--- a/stable/kapacitor/Chart.yaml
+++ b/stable/kapacitor/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: kapacitor
-version: 1.1.1
+version: 1.1.2
 appVersion: 1.5.2
 description: InfluxDB's native data processing engine. It can process both stream
   and batch data from InfluxDB.


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
