### PR TITLE
[stable/kiam] add apiVersion

### DIFF
--- a/stable/kiam/Chart.yaml
+++ b/stable/kiam/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: kiam
-version: 2.2.3
+version: 2.2.4
 appVersion: 3.2
 description: Integrate AWS IAM with Kubernetes
 keywords:


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
