### PR TITLE
[stable/kube-ops-view] add apiVersion

### DIFF
--- a/stable/kube-ops-view/Chart.yaml
+++ b/stable/kube-ops-view/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: kube-ops-view
-version: 0.8.0
+version: 1.0.0
 appVersion: 0.11
 description: Kubernetes Operational View - read-only system dashboard for multiple
   K8s clusters


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
