### PR TITLE
[stable/kube2iam] add apiVersion

### DIFF
--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: kube2iam
-version: 0.11.0
+version: 1.0.0
 appVersion: 0.10.4
 description: Provide IAM credentials to pods based on annotations.
 keywords:


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
