### PR TITLE
[stable/kubernetes-dashboard] add apiVersion

### DIFF
--- a/stable/kubernetes-dashboard/Chart.yaml
+++ b/stable/kubernetes-dashboard/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: kubernetes-dashboard
-version: 1.5.1
+version: 1.5.2
 appVersion: 1.10.1
 description: General-purpose web UI for Kubernetes clusters
 keywords:


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
