### PR TITLE
[stable/locust] add apiVersion

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,7 @@
+apiVersion: v1
 name: locust
 description: A modern load testing framework
-version: 0.4.0
+version: 1.0.0
 appVersion: 0.9.0
 maintainers:
   - name: so0k


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
