### PR TITLE
[stable/mcrouter] add apiVersion

### DIFF
--- a/stable/mcrouter/Chart.yaml
+++ b/stable/mcrouter/Chart.yaml
@@ -1,6 +1,7 @@
+apiVersion: v1
 name: mcrouter
 home: https://github.com/facebook/mcrouter
-version: 0.1.1
+version: 1.0.0
 appVersion: 0.36.0
 description: Mcrouter is a memcached protocol router for scaling memcached deployments.
 sources:


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
