### PR TITLE
[stable/memcached] add apiVersion

### DIFF
--- a/stable/memcached/Chart.yaml
+++ b/stable/memcached/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: memcached
-version: 2.7.1
+version: 2.7.2
 appVersion: 1.5.12
 description: Free & open source, high-performance, distributed memory object caching
   system.


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
