### PR TITLE
[stable/minecraft] add apiVersion

### DIFF
--- a/stable/minecraft/Chart.yaml
+++ b/stable/minecraft/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: minecraft
-version: 0.3.2
+version: 1.0.0
 appVersion: 1.13.1
 home: https://minecraft.net/
 description: Minecraft server

--- a/stable/minecraft/ci/test-values.yaml
+++ b/stable/minecraft/ci/test-values.yaml
@@ -1,3 +1,3 @@
 # This must be overridden, since we can't accept this for the user.
-  minecraftServer.eula: "TRUE"
-#fix in place and rebased
+minecraftServer.eula: "TRUE"
+# fix in place and rebased


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
