### PR TITLE
[stable/nextcloud] add apiVersion

### DIFF
--- a/stable/nextcloud/Chart.yaml
+++ b/stable/nextcloud/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: nextcloud
-version: 1.0.2
+version: 1.0.3
 appVersion: 15.0.2
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
