### PR TITLE
[stable/node-problem-detector] add apiVersion

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: node-problem-detector
-version: "1.4.0"
+version: "1.4.1"
 appVersion: v0.6.1
 home: https://github.com/kubernetes/node-problem-detector
 description: Installs the node-problem-detector daemonset for monitoring extra attributes on nodes


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
