### PR TITLE
[stable/prisma] add apiVersion

### DIFF
--- a/stable/prisma/Chart.yaml
+++ b/stable/prisma/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: prisma
-version: 1.2.0
+version: 1.2.1
 appVersion: 1.29.1
 kubeVersion: "^1.8.0-0"
 description: Prisma turns your database into a realtime GraphQL API


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
