### PR TITLE
[stable/prometheus] add apiVersion

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: prometheus
-version: 8.11.1
+version: 8.11.2
 appVersion: 2.9.2
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
