### PR TITLE
[stable/redis-ha] add apiVersion

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 name: redis-ha
 home: http://redis.io/
 engine: gotpl
@@ -5,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.4.1
+version: 3.4.2
 appVersion: 5.0.3
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
