### PR TITLE
[stable/rethinkdb] add apiVersion

### DIFF
--- a/stable/rethinkdb/Chart.yaml
+++ b/stable/rethinkdb/Chart.yaml
@@ -1,6 +1,7 @@
+apiVersion: v1
 name: rethinkdb
 description: The open-source database for the realtime web
-version: 0.2.0
+version: 1.0.0
 appVersion: 0.1.0
 keywords:
 - rethinkdb


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
