### PR TITLE
[stable/satisfy] add apiVersion

### DIFF
--- a/stable/satisfy/Chart.yaml
+++ b/stable/satisfy/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: satisfy
-version: 0.1.2
+version: 1.0.0
 appVersion: "3.0.4"
 description: Composer repo hosting with Satisfy
 home: https://github.com/anapsix/docker-satisfy


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
