### PR TITLE
[stable/sematext-docker-agent] add apiVersion

### DIFF
--- a/stable/sematext-docker-agent/Chart.yaml
+++ b/stable/sematext-docker-agent/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: sematext-docker-agent
-version: 0.2.0
+version: 1.0.0
 appVersion: 1.31.53
 description: Sematext Docker Agent
 keywords:


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
