### PR TITLE
[stable/sonatype-nexus] add apiVersion

### DIFF
--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: sonatype-nexus
-version: 1.18.0
+version: 1.18.1
 appVersion: 3.15.2-01
 description: Sonatype Nexus is an open source repository manager
 keywords:


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
