### PR TITLE
[stable/spark-history-server] add apiVersion

### DIFF
--- a/stable/spark-history-server/Chart.yaml
+++ b/stable/spark-history-server/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: spark-history-server
-version: 0.5.0
+version: 1.0.0
 appVersion: 2.4.0
 description: A Helm chart for Spark History Server
 home: https://spark.apache.org


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
