### PR TITLE
[stable/spartakus] add apiVersion

### DIFF
--- a/stable/spartakus/Chart.yaml
+++ b/stable/spartakus/Chart.yaml
@@ -7,6 +7,6 @@ description: Collect information about Kubernetes clusters to help improve the p
 sources:
   - https://github.com/kubernetes-incubator/spartakus
 maintainers:
-  - name: Michael Goodness
+  - name: mgoodness
     email: mgoodness@gmail.com
 engine: gotpl

--- a/stable/spartakus/Chart.yaml
+++ b/stable/spartakus/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: spartakus
-version: 1.1.5
+version: 1.1.6
 appVersion: 1.0.0
 home: https://www.shdlr.com
 description: Collect information about Kubernetes clusters to help improve the project.


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
