### PR TITLE
[stable/spotify-docker-gc] add apiVersion

### DIFF
--- a/stable/spotify-docker-gc/Chart.yaml
+++ b/stable/spotify-docker-gc/Chart.yaml
@@ -1,6 +1,7 @@
+apiVersion: v1
 name: spotify-docker-gc
 home: https://github.com/spotify/docker-gc
-version: 0.3.0
+version: 1.0.0
 appVersion: latest
 description: A simple Docker container and image garbage collection script.
 sources:


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
