### PR TITLE
[stable/sumokube] add apiVersion

### DIFF
--- a/stable/sumokube/Chart.yaml
+++ b/stable/sumokube/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
 sources:
 - https://github.com/SumoLogic/sumologic-collector-docker
 maintainers:
-- name: Jason DuMars
+- name: jdumars
   email: jdumars+github@gmail.com
-- name: Sean Knox
+- name: seanknox
   email: knoxville+github@gmail.com

--- a/stable/sumokube/Chart.yaml
+++ b/stable/sumokube/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: sumokube
-version: 0.1.4
+version: 1.0.0
 appVersion: latest
 home: https://www.sumologic.com/
 description: Sumologic Log Collector


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
