### PR TITLE
[stable/sumologic-fluentd] add apiVersion

### DIFF
--- a/stable/sumologic-fluentd/Chart.yaml
+++ b/stable/sumologic-fluentd/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: sumologic-fluentd
-version: 0.12.0
+version: 1.0.0
 appVersion: 2.3.0
 description: Sumologic Log Collector
 keywords:


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
