### PR TITLE
[stable/sysdig] add apiVersion

### DIFF
--- a/stable/sysdig/Chart.yaml
+++ b/stable/sysdig/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: sysdig
-version: 1.4.6
+version: 1.4.7
 appVersion: 0.89.5
 description: Sysdig Monitor and Secure agent
 keywords:


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
