### PR TITLE
[stable/tensorflow-serving] add apiVersion

### DIFF
--- a/stable/tensorflow-serving/Chart.yaml
+++ b/stable/tensorflow-serving/Chart.yaml
@@ -1,6 +1,7 @@
+apiVersion: v1
 name: tensorflow-serving
 home: https://github.com/kubernetes/charts
-version: 0.1.2
+version: 1.0.0
 appVersion: 1.14.0
 description: TensorFlow Serving is an open-source software library for serving machine learning models.
 sources:


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
