### PR TITLE
[stable/weave-scope] add apiVersion

### DIFF
--- a/stable/weave-scope/Chart.yaml
+++ b/stable/weave-scope/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: weave-scope
-version: 0.11.1
+version: 1.0.0
 appVersion: 1.10.1
 description: A Helm chart for the Weave Scope cluster visualizer.
 keywords:


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
