### PR TITLE
[stable/kube-state-metrics]: Use the recommended apiGroup versions in kube-state-metrics

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - metric
 - monitoring
 - prometheus
-version: 1.5.0
+version: 1.6.0
 appVersion: 1.6.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:
@@ -13,3 +13,5 @@ sources:
 maintainers:
 - name: fiunchinho
   email: jose@armesto.net
+- name: tariq1890
+  email: tariq.ibrahim@mulesoft.com

--- a/stable/kube-state-metrics/OWNERS
+++ b/stable/kube-state-metrics/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- fiunchinho
+- tariq1890
+reviewers:
+- fiunchinho
+- tariq1890

--- a/stable/kube-state-metrics/templates/deployment.yaml
+++ b/stable/kube-state-metrics/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kube-state-metrics.fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "kube-state-metrics.name" . }}
   replicas: {{ .Values.replicas }}
   template:
     metadata:

--- a/stable/kube-state-metrics/templates/podsecuritypolicy.yaml
+++ b/stable/kube-state-metrics/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podSecurityPolicy.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "kube-state-metrics.fullname" . }}


### PR DESCRIPTION
This PR ensures the k8s deployments and podsecuritypolicies use the recommended apiGroups.