### PR TITLE
Handle priorityClassName for incubator/fluentd-cloudwatch.

### DIFF
--- a/incubator/fluentd-cloudwatch/Chart.yaml
+++ b/incubator/fluentd-cloudwatch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-cloudwatch
-version: 0.9.0
+version: 0.9.1
 appVersion: v1.3.3-debian-cloudwatch-1.0
 description: A Fluentd CloudWatch Helm chart for Kubernetes.
 home: https://www.fluentd.org/

--- a/incubator/fluentd-cloudwatch/README.md
+++ b/incubator/fluentd-cloudwatch/README.md
@@ -71,6 +71,7 @@ The following table lists the configurable parameters of the Fluentd Cloudwatch 
 | `updateStrategy`             | Define daemonset update strategy                                          | `OnDelete`                            |
 | `nodeSelector`               | Node labels for pod assignment                                            | `{}`                                  |
 | `affinity`                   | Node affinity for pod assignment                                          | `{}`                                  |
+| `priorityClassName`          | Set priority class for daemon set                                         | `nil`                                 |
 
 If using fluentd-kubernetes-daemonset v0.12.43-cloudwatch, the container runs as user fluentd. To be able to write pos files to the host system, you'll need to run fluentd as root. Add the following extraVars value to run as root.
 

--- a/incubator/fluentd-cloudwatch/templates/daemonset.yaml
+++ b/incubator/fluentd-cloudwatch/templates/daemonset.yaml
@@ -71,6 +71,9 @@ spec:
           readOnly: true
         - name: config
           mountPath: /fluentd/etc
+{{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+{{- end }}
       terminationGracePeriodSeconds: 30
       volumes:
       - name: varlog

--- a/incubator/fluentd-cloudwatch/values.yaml
+++ b/incubator/fluentd-cloudwatch/values.yaml
@@ -50,6 +50,11 @@ podSecurityContext: {}
 
 podAnnotations: {}
 
+# Pod priority
+# Sets PriorityClassName if defined.
+#
+# priorityClassName: "my-priority-class"
+
 awsRegion: us-east-1
 awsRole:
 awsAccessKeyId:


### PR DESCRIPTION
#### What this PR does / why we need it:

Handle priorityClassName when deploying fluentd daemonset.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] title of the PR contains starts with chart name e.g. `[stable/chart]`
