### PR TITLE
[incubator/etcd] add apiVersion

### DIFF
--- a/incubator/etcd/Chart.yaml
+++ b/incubator/etcd/Chart.yaml
@@ -1,6 +1,7 @@
+apiVersion: v1
 name: etcd
 home: https://github.com/coreos/etcd
-version: 0.6.2
+version: 0.6.3
 appVersion: 2.2.5
 description: Distributed reliable key-value store for the most critical data of a
   distributed system.


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
