### PR TITLE
[incubator/mysqlha] add apiVersion

### DIFF
--- a/incubator/mysqlha/Chart.yaml
+++ b/incubator/mysqlha/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: mysqlha
-version: 0.5.0
+version: 0.5.1
 appVersion: 5.7.13
 description: MySQL cluster with a single master and zero or more slave replicas
 keywords:


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
