### PR TITLE
[incubator/raw] add apiVersion

### DIFF
--- a/incubator/raw/Chart.yaml
+++ b/incubator/raw/Chart.yaml
@@ -1,6 +1,7 @@
+apiVersion: v1
 name: raw
 home: https://github.com/helm/charts/blob/master/incubator/raw
-version: 0.2.1
+version: 0.2.2
 appVersion: 0.2.1
 description: A place for all the Kubernetes resources which don't already have a home.
 maintainers:


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
