### PR TITLE
[incubator/sparkoperator] add apiVersion

### DIFF
--- a/incubator/sparkoperator/Chart.yaml
+++ b/incubator/sparkoperator/Chart.yaml
@@ -1,6 +1,7 @@
+apiVersion: v1
 name: sparkoperator
 description: A Helm chart for Spark on Kubernetes operator
-version: 0.2.2
+version: 0.2.3
 appVersion: v2.4.0-v1beta1-0.8.2
 kubeVersion: ">=1.8.0-0"
 keywords:


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
