### PR TITLE
[incubator/tensorflow-inception] add apiVersion

### DIFF
--- a/incubator/tensorflow-inception/Chart.yaml
+++ b/incubator/tensorflow-inception/Chart.yaml
@@ -1,6 +1,7 @@
+apiVersion: v1
 name: tensorflow-inception
 home: https://github.com/kubernetes/charts
-version: 0.4.0
+version: 0.4.1
 appVersion: 1.4.0
 description: Open source software library for numerical computation using data flow graphs.
 icon: https://camo.githubusercontent.com/ee91ac3c9f5ad840ebf70b54284498fe0e6ddb92/68747470733a2f2f7777772e74656e736f72666c6f772e6f72672f696d616765732f74665f6c6f676f5f7472616e73702e706e67

--- a/incubator/tensorflow-inception/README.md
+++ b/incubator/tensorflow-inception/README.md
@@ -28,7 +28,7 @@ The following table lists the configurable parameters of the TensorFlow inceptio
 | Parameter               | Description                        | Default                                                    |
 | ----------------------- | ---------------------------------- | ---------------------------------------------------------- |
 | `image.repository`          | Container image name               | `quay.io/thomasjungblut/tfs-inception`                              |
-| `image.tag`       | Container image tag                | `tfs-1.8.0-gpu`                                                          |
+| `image.tag`       | Container image tag                | `tfs-1.8.0-cpu`                                                          |
 | `replicas`       | k8s deployment replicas            | `1`                                                               |
 | `component`      | k8s selector key                   | `tensorflow-inception`                                            |
 | `resources`      | Set the resource to be allocated and allowed for the Pods                   | `{}`                                            |
@@ -36,6 +36,8 @@ The following table lists the configurable parameters of the TensorFlow inceptio
 | `containerPort`  | Container listening port           | `9090`                                                            |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+> **Note**: For the GPU version, use `image.tag=tfs-1.8.0-gpu`.
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 

--- a/incubator/tensorflow-inception/values.yaml
+++ b/incubator/tensorflow-inception/values.yaml
@@ -10,7 +10,7 @@ component: "tensorflow-inception"
 replicas: 1
 image:
   repository: "quay.io/thomasjungblut/tfs-inception"
-  tag: "tfs-1.8.0-gpu"
+  tag: "tfs-1.8.0-cpu"
   pullPolicy: "IfNotPresent"
 
 env:


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
