### PR TITLE
[incubator/zookeeper] add apiVersion

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,6 +1,7 @@
+apiVersion: v1
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 1.3.0
+version: 1.3.1
 appVersion: 3.4.10
 description: Centralized service for maintaining configuration information, naming,
   providing distributed synchronization, and providing group services.


### PR DESCRIPTION
Adding the `apiVersion` for `chart.yaml`

to fix the issue: https://github.com/helm/charts/issues/13763

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
