### PR TITLE
[stable/postgresql] Fix NetworkPolicy in replicated mode

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 4.2.1
+version: 4.2.2
 appVersion: 10.8.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/networkpolicy.yaml
+++ b/stable/postgresql/templates/networkpolicy.yaml
@@ -22,6 +22,11 @@ spec:
       - podSelector:
           matchLabels:
             {{ template "postgresql.fullname" . }}-client: "true"
+      - podSelector:
+          matchLabels:
+            app: {{ template "postgresql.name" . }}
+            release: {{ .Release.Name | quote }}
+            role: slave
     {{- end }}
     # Allow prometheus scrapes
     - ports:


### PR DESCRIPTION
#### What this PR does / why we need it:

With replication enabled and a network policy that prevents external
communication, i.e.

```yaml
replication:
  enabled: true
networkPolicy:
  enabled: true
  allowExternal: false
```

the slave pods are not allowed to connect to the master, which causes
them to enter into a crash loop.

This commit expands the ingress policy to allow communication from the
slaves to the master on port 5432.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`