### PR TITLE
[stable/jenkins] [JENKINS-57484] Use the new API Token features

### DIFF
--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -75,6 +75,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.podLabels`                | Custom Pod labels                    | Not set                                   |
 | `master.adminUser`                | Admin username (and password) created as a secret if useSecurity is true | `admin` |
 | `master.adminPassword`            | Admin password (and user) created as a secret if useSecurity is true | Random value |
+| `master.adminInitialApiToken`     | Admin initial fixed API Token as a secret if useSecurity is true | None created |
 | `master.jenkinsAdminEmail`        | Email address for the administrator of the Jenkins instance | Not set            |
 | `master.resources`                | Resources allocation (Requests and Limits) | `{requests: {cpu: 50m, memory: 256Mi}, limits: {cpu: 2000m, memory: 4096Mi}}`|
 | `master.initContainerEnv`         | Environment variables for Init Container                                 | Not set |

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -284,15 +284,30 @@ data:
   init{{ $key }}.groovy: |-
 {{ $val | indent 4 }}
 {{- end }}
+{{- if .Values.master.adminInitialApiToken }}
+  init-add-api-token-to-admin.groovy: |-
+    import jenkins.security.ApiTokenProperty
+    import hudson.model.User
+    /*
+     * If you are using this script, it is strongly recommended to use this fixed token 
+     * to generate a new one (purely random) and then revoke the other. 
+     */
+    User u = User.get('{{ .Values.master.adminUser | default "admin" }}')
+    ApiTokenProperty t = u.getProperty(ApiTokenProperty.class)
+    if (t.metaClass.respondsTo(t, 'addFixedNewToken', String, String) {
+      t.addFixedNewToken('token-generated-by-chart', '{{ .Values.master.adminInitialApiToken }}')
+      u.save()
+    } else {
+      throw new Exception("If you want to use the 'master.adminInitialApiToken' parameter, please update Jenkins to TODO")
+    }
+{{- end }}
 {{- if .Values.master.JCasC.enabled }}
   {{- if .Values.master.sidecars.configAutoReload.enabled }}
   init-add-ssh-key-to-admin.groovy: |-
     import jenkins.security.*
     import hudson.model.User
-    import jenkins.security.ApiTokenProperty
     import jenkins.model.Jenkins
     User u = User.get("{{ .Values.master.adminUser | default "admin" }}")
-    ApiTokenProperty t = u.getProperty(ApiTokenProperty.class)
     String sshKeyString = new File('/var/jenkins_home/key.pub').text
     keys_param = new org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl(sshKeyString)
     u.addProperty(keys_param)

--- a/stable/jenkins/templates/secret.yaml
+++ b/stable/jenkins/templates/secret.yaml
@@ -24,4 +24,7 @@ data:
   {{ end -}}
   {{ end -}}
   jenkins-admin-user: {{ .Values.master.adminUser | b64enc | quote }}
+  {{ if .Values.master.adminInitialApiToken -}}
+  jenkins-admin-initial-api-token: {{ .Values.master.adminInitialApiToken | b64enc | quote }}
+  {{ end -}}
 {{- end }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -44,6 +44,11 @@ master:
   adminUser: "admin"
   # adminPassword: <defaults to random>
   # adminSshKey: <defaults to auto-generated>
+  # If you want to have an initial API Token for the admin user, please provide here a value such that
+  # the first two characters are the hash version, "11" currently and then 32 hex characters (0-9a-f)
+  # the full value will be the plain text value of the API Token that could be used to access REST Api of Jenkins
+  # It is strongly recommended to use this fixed token to generate a new one (purely random) and then revoke the other. 
+  # adminInitialApiToken: 110123456789abcdef0123456789abcdef 
   # If CasC auto-reload is enabled, an SSH (RSA) keypair is needed.  Can either provide your own, or leave unconfigured to allow a random key to be auto-generated.
   # If you supply your own, it is recommended that the values file that contains your key not be committed to source control in an unencrypted format
   rollingUpdate: {}


### PR DESCRIPTION
Use the new API Token features proposed in []() to provide more authentication options.

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

- Use the recent addition to the API Token system in Jenkins to provide a new option when creating the chart, to have a fixed API Token configured and put in the secret.

#### Which issue this PR fixes
- n/a

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
