### PR TITLE
stable/openvpn Add namespace to command in notes

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 3.12.3
+version: 3.12.4
 appVersion: 1.1.0
 maintainers:
 - name: jfelten

--- a/stable/openvpn/templates/NOTES.txt
+++ b/stable/openvpn/templates/NOTES.txt
@@ -4,11 +4,11 @@ Please be aware that certificate generation is variable and may take some time (
 
 Check pod status with the command:
 
-  POD_NAME=$(kubectl get pods --namespace "{{ .Release.Namespace }}" -l app=openvpn -o jsonpath='{ .items[0].metadata.name }') && kubectl logs $POD_NAME --follow
+  POD_NAME=$(kubectl get pods --namespace "{{ .Release.Namespace }}" -l app=openvpn -o jsonpath='{ .items[0].metadata.name }') && kubectl --namespace "{{ .Release.Namespace }}" logs $POD_NAME --follow
 
 LoadBalancer ingress creation can take some time as well. Check service status with the command:
 
-  kubectl get svc
+  kubectl --namespace "{{ .Release.Namespace }}" get svc
 {{ if and (eq "NodePort" .Values.service.type) (hasKey .Values.service "nodePort") }}
 You set the service type to NodePort, port {{ .Values.service.nodePort }} will be used on each node.
 {{ end }}


### PR DESCRIPTION
Add `--namespace={{ .Release.Namespace }}` to commands in openvpn chart notes

# What this PR does / why we need it:
The command fails if the namespace isn't in the default kubectl context
Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`

