### PR TITLE
[stable/jenkins] Fix: healthProbe timeouts mapping to initial delay

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.1.20
+version: 1.1.21
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -89,13 +89,13 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.targetPort`               | k8s target port                      | `8080`                                    |
 | `master.nodePort`                 | k8s node port                        | Not set                                   |
 | `master.healthProbes`             | Enable k8s liveness and readiness probes    | `true`                             |
-| `master.healthProbesLivenessTimeout`  | Set the timeout for the liveness probe  | `120`                              |
-| `master.healthProbesReadinessTimeout` | Set the timeout for the readiness probe | `60`                               |
-| `master.healthProbeLivenessPeriodSeconds` | Set how often (in seconds) to perform the liveness probe | `30`         |
-| `master.healthProbeReadinessPeriodSeconds` | Set how often (in seconds) to perform the readiness probe | `30`         |
+| `master.healthProbesLivenessTimeout`  | Set the timeout for the liveness probe  | `5`                              |
+| `master.healthProbesReadinessTimeout` | Set the timeout for the readiness probe | `5`                               |
+| `master.healthProbeLivenessPeriodSeconds` | Set how often (in seconds) to perform the liveness probe | `10`         |
+| `master.healthProbeReadinessPeriodSeconds` | Set how often (in seconds) to perform the readiness probe | `10`         |
 | `master.healthProbeLivenessFailureThreshold` | Set the failure threshold for the liveness probe | `5`               |
 | `master.healthProbeReadinessFailureThreshold` | Set the failure threshold for the readiness probe | `3`               |
-| `master.healthProbeLivenessInitialDelay` | Set the initial delay for the liveness probe | `120`               |
+| `master.healthProbeLivenessInitialDelay` | Set the initial delay for the liveness probe | `90`               |
 | `master.healthProbeReadinessInitialDelay` | Set the initial delay for the readiness probe | `60`               |
 | `master.slaveListenerPort`        | Listening port for agents            | `50000`                                   |
 | `master.slaveHostPort`            | Host port to listen for agents            | Not set                              |

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -88,11 +88,15 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.servicePort`              | k8s service port                     | `8080`                                    |
 | `master.targetPort`               | k8s target port                      | `8080`                                    |
 | `master.nodePort`                 | k8s node port                        | Not set                                   |
-| `master.healthProbes`             | Enable k8s liveness and readiness probes    | `true`                             |
-| `master.healthProbesLivenessTimeout`  | Set the timeout for the liveness probe  | `120`                              |
-| `master.healthProbesReadinessTimeout` | Set the timeout for the readiness probe | `60`                               |
-| `master.healthProbeReadinessPeriodSeconds` | Set how often (in seconds) to perform the liveness probe | `10`         |
-| `master.healthProbeLivenessFailureThreshold` | Set the failure threshold for the liveness probe | `12`               |
+| `master.healthProbes.enabled`             | Enable k8s liveness and readiness probes    | `true`                             |
+| `master.healthProbes.liveness.initialDelay`  | Set the initial delay for the liveness probe  | `120`                              |
+| `master.healthProbes.liveness.timeout`  | Set the timeout for the liveness probe  | `20`                              |
+| `master.master.healthProbes.liveness.period` | Set how often (in seconds) to perform the liveness probe | `30`         |
+| `master.healthProbes.liveness.failureThreshold` | Set the failure threshold for the liveness probe | `12`               |
+| `master.healthProbes.readiness.initialDelay` | Set the initial delay for the readiness probe | `60`                               |
+| `master.healthProbes.readiness.timeout` | Set the timeout for the readiness probe | `20`                               |
+| `master.healthProbes.readiness.period` | Set how often (in seconds) to perform the readiness probe | `30`                               |
+| `master.healthProbes.readiness.failureThreshold` | Set the failure threshold for the readiness probe | `3`                               |
 | `master.slaveListenerPort`        | Listening port for agents            | `50000`                                   |
 | `master.slaveHostPort`            | Host port to listen for agents            | Not set                              |
 | `master.slaveKubernetesNamespace` | Namespace in which the Kubernetes agents should be launched  | Not set           |

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -88,15 +88,15 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.servicePort`              | k8s service port                     | `8080`                                    |
 | `master.targetPort`               | k8s target port                      | `8080`                                    |
 | `master.nodePort`                 | k8s node port                        | Not set                                   |
-| `master.healthProbes.enabled`             | Enable k8s liveness and readiness probes    | `true`                             |
-| `master.healthProbes.liveness.initialDelay`  | Set the initial delay for the liveness probe  | `120`                              |
-| `master.healthProbes.liveness.timeout`  | Set the timeout for the liveness probe  | `20`                              |
-| `master.master.healthProbes.liveness.period` | Set how often (in seconds) to perform the liveness probe | `30`         |
-| `master.healthProbes.liveness.failureThreshold` | Set the failure threshold for the liveness probe | `12`               |
-| `master.healthProbes.readiness.initialDelay` | Set the initial delay for the readiness probe | `60`                               |
-| `master.healthProbes.readiness.timeout` | Set the timeout for the readiness probe | `20`                               |
-| `master.healthProbes.readiness.period` | Set how often (in seconds) to perform the readiness probe | `30`                               |
-| `master.healthProbes.readiness.failureThreshold` | Set the failure threshold for the readiness probe | `3`                               |
+| `master.healthProbes`             | Enable k8s liveness and readiness probes    | `true`                             |
+| `master.healthProbesLivenessTimeout`  | Set the timeout for the liveness probe  | `120`                              |
+| `master.healthProbesReadinessTimeout` | Set the timeout for the readiness probe | `60`                               |
+| `master.healthProbeLivenessPeriodSeconds` | Set how often (in seconds) to perform the liveness probe | `30`         |
+| `master.healthProbeReadinessPeriodSeconds` | Set how often (in seconds) to perform the readiness probe | `30`         |
+| `master.healthProbeLivenessFailureThreshold` | Set the failure threshold for the liveness probe | `5`               |
+| `master.healthProbeReadinessFailureThreshold` | Set the failure threshold for the readiness probe | `3`               |
+| `master.healthProbeLivenessInitialDelay` | Set the initial delay for the liveness probe | `120`               |
+| `master.healthProbeReadinessInitialDelay` | Set the initial delay for the readiness probe | `60`               |
 | `master.slaveListenerPort`        | Listening port for agents            | `50000`                                   |
 | `master.slaveHostPort`            | Host port to listen for agents            | Not set                              |
 | `master.slaveKubernetesNamespace` | Namespace in which the Kubernetes agents should be launched  | Not set           |

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -211,26 +211,18 @@ spec:
             httpGet:
               path: "{{ default "" .Values.master.jenkinsUriPrefix }}/login"
               port: http
-            {{- if .Values.master.healthProbeLivenessInitialDelay }}
             initialDelaySeconds: {{ .Values.master.healthProbeLivenessInitialDelay }}
-            {{- end }}
-            {{- if .Values.master.healthProbeLivenessPeriodSeconds }}
             periodSeconds: {{ .Values.master.healthProbeLivenessPeriodSeconds }}
-            {{- end }}
             timeoutSeconds: {{ .Values.master.healthProbesLivenessTimeout }}
             failureThreshold: {{ .Values.master.healthProbeLivenessFailureThreshold }}
           readinessProbe:
             httpGet:
               path: "{{ default "" .Values.master.jenkinsUriPrefix }}/login"
               port: http
-            {{- if .Values.master.healthProbeReadinessInitialDelay }}
             initialDelaySeconds: {{ .Values.master.healthProbeReadinessInitialDelay }}
-            {{- end }}
             periodSeconds: {{ .Values.master.healthProbeReadinessPeriodSeconds }}
             timeoutSeconds: {{ .Values.master.healthProbesReadinessTimeout }}
-            {{- if .Values.master.healthProbeReadinessFailureThreshold }}
             failureThreshold: {{ .Values.master.healthProbeReadinessFailureThreshold }}
-            {{- end }}
 {{- end }}
 
           resources:

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -206,20 +206,23 @@ spec:
             - containerPort: {{ $port.port }}
               name: {{ $port.name }}
 {{- end }}
-{{- if .Values.master.healthProbes }}
+{{- if .Values.master.healthProbes.enabled }}
           livenessProbe:
             httpGet:
               path: "{{ default "" .Values.master.jenkinsUriPrefix }}/login"
               port: http
-            initialDelaySeconds: {{ .Values.master.healthProbesLivenessTimeout }}
-            timeoutSeconds: 5
-            failureThreshold: {{ .Values.master.healthProbeLivenessFailureThreshold }}
+            initialDelaySeconds: {{ .Values.master.healthProbes.liveness.initialDelay }}
+            periodSeconds: {{ .Values.master.healthProbes.liveness.period }}
+            timeoutSeconds: {{ .Values.master.healthProbes.liveness.timeout }}
+            failureThreshold: {{ .Values.master.healthProbes.liveness.failureThreshold }}
           readinessProbe:
             httpGet:
               path: "{{ default "" .Values.master.jenkinsUriPrefix }}/login"
               port: http
-            initialDelaySeconds: {{ .Values.master.healthProbesReadinessTimeout }}
-            periodSeconds: {{ .Values.master.healthProbeReadinessPeriodSeconds }}
+            initialDelaySeconds: {{ .Values.master.healthProbes.readiness.initialDelay }}
+            periodSeconds: {{ .Values.master.healthProbes.readiness.period }}
+            timeoutSeconds: {{ .Values.master.healthProbes.readiness.timeout }}
+            failureThreshold: {{ .Values.master.healthProbes.readiness.failureThreshold }}
 {{- end }}
 
           resources:

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -206,23 +206,31 @@ spec:
             - containerPort: {{ $port.port }}
               name: {{ $port.name }}
 {{- end }}
-{{- if .Values.master.healthProbes.enabled }}
+{{- if .Values.master.healthProbes }}
           livenessProbe:
             httpGet:
               path: "{{ default "" .Values.master.jenkinsUriPrefix }}/login"
               port: http
-            initialDelaySeconds: {{ .Values.master.healthProbes.liveness.initialDelay }}
-            periodSeconds: {{ .Values.master.healthProbes.liveness.period }}
-            timeoutSeconds: {{ .Values.master.healthProbes.liveness.timeout }}
-            failureThreshold: {{ .Values.master.healthProbes.liveness.failureThreshold }}
+            {{- if .Values.master.healthProbeLivenessInitialDelay }}
+            initialDelaySeconds: {{ .Values.master.healthProbeLivenessInitialDelay }}
+            {{- end }}
+            {{- if .Values.master.healthProbeLivenessPeriodSeconds }}
+            periodSeconds: {{ .Values.master.healthProbeLivenessPeriodSeconds }}
+            {{- end }}
+            timeoutSeconds: {{ .Values.master.healthProbesLivenessTimeout }}
+            failureThreshold: {{ .Values.master.healthProbeLivenessFailureThreshold }}
           readinessProbe:
             httpGet:
               path: "{{ default "" .Values.master.jenkinsUriPrefix }}/login"
               port: http
-            initialDelaySeconds: {{ .Values.master.healthProbes.readiness.initialDelay }}
-            periodSeconds: {{ .Values.master.healthProbes.readiness.period }}
-            timeoutSeconds: {{ .Values.master.healthProbes.readiness.timeout }}
-            failureThreshold: {{ .Values.master.healthProbes.readiness.failureThreshold }}
+            {{- if .Values.master.healthProbeReadinessInitialDelay }}
+            initialDelaySeconds: {{ .Values.master.healthProbeReadinessInitialDelay }}
+            {{- end }}
+            periodSeconds: {{ .Values.master.healthProbeReadinessPeriodSeconds }}
+            timeoutSeconds: {{ .Values.master.healthProbesReadinessTimeout }}
+            {{- if .Values.master.healthProbeReadinessFailureThreshold }}
+            failureThreshold: {{ .Values.master.healthProbeReadinessFailureThreshold }}
+            {{- end }}
 {{- end }}
 
           resources:

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -97,13 +97,13 @@ master:
   # Enable Kubernetes Liveness and Readiness Probes
   # ~ 2 minutes to allow Jenkins to restart when upgrading plugins. Set ReadinessTimeout to be shorter than LivenessTimeout.
   healthProbes: true
-  healthProbesLivenessTimeout: 20
-  healthProbesReadinessTimeout: 20
-  healthProbeLivenessPeriodSeconds: 30
-  healthProbeReadinessPeriodSeconds: 30
+  healthProbesLivenessTimeout: 5
+  healthProbesReadinessTimeout: 5
+  healthProbeLivenessPeriodSeconds: 10
+  healthProbeReadinessPeriodSeconds: 10
   healthProbeLivenessFailureThreshold: 5
   healthProbeReadinessFailureThreshold: 3
-  healthProbeLivenessInitialDelay: 120
+  healthProbeLivenessInitialDelay: 90
   healthProbeReadinessInitialDelay: 60
   slaveListenerPort: 50000
   slaveHostPort:

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -96,18 +96,15 @@ master:
   # nodePort: <to set explicitly, choose port between 30000-32767
   # Enable Kubernetes Liveness and Readiness Probes
   # ~ 2 minutes to allow Jenkins to restart when upgrading plugins. Set ReadinessTimeout to be shorter than LivenessTimeout.
-  healthProbes:
-    enabled: true
-    liveness:
-      initialDelay: 120
-      period: 30
-      timeout: 20
-      failureThreshold: 12
-    readiness:
-      initialDelay: 60
-      period: 30
-      timeout: 20
-      failureThreshold: 3
+  healthProbes: true
+  healthProbesLivenessTimeout: 20
+  healthProbesReadinessTimeout: 20
+  healthProbeLivenessPeriodSeconds: 30
+  healthProbeReadinessPeriodSeconds: 30
+  healthProbeLivenessFailureThreshold: 5
+  healthProbeReadinessFailureThreshold: 3
+  healthProbeLivenessInitialDelay: 120
+  healthProbeReadinessInitialDelay: 60
   slaveListenerPort: 50000
   slaveHostPort:
   disabledAgentProtocols:

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -96,11 +96,18 @@ master:
   # nodePort: <to set explicitly, choose port between 30000-32767
   # Enable Kubernetes Liveness and Readiness Probes
   # ~ 2 minutes to allow Jenkins to restart when upgrading plugins. Set ReadinessTimeout to be shorter than LivenessTimeout.
-  healthProbes: true
-  healthProbesLivenessTimeout: 90
-  healthProbesReadinessTimeout: 60
-  healthProbeReadinessPeriodSeconds: 10
-  healthProbeLivenessFailureThreshold: 12
+  healthProbes:
+    enabled: true
+    liveness:
+      initialDelay: 120
+      period: 30
+      timeout: 20
+      failureThreshold: 12
+    readiness:
+      initialDelay: 60
+      period: 30
+      timeout: 20
+      failureThreshold: 3
   slaveListenerPort: 50000
   slaveHostPort:
   disabledAgentProtocols:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
`.Values.master.healthProbesLivenessTimeout` and `.Values.master.healthProbesReadinessTimeout` are rendered as the respective initial delays. Refactored the `healthProbes` section

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
