### PR TITLE
[stable/cockroachdb]: Add more OWNERS to cockroachdb chart

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 2.1.6
+version: 2.1.7
 appVersion: 19.1.0
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png
@@ -9,4 +9,10 @@ sources:
 - https://github.com/cockroachdb/cockroach
 maintainers:
 - name: a-robinson
-  email: alex@cockroachlabs.com
+  email: alexdwanerobinson@gmail.com
+- name: DuskEagle
+  email: Joel.A.Kenny@gmail.com
+- name: joshimhoff
+  email: joshimhoff13@gmail.com
+- name: keith-mcclellan
+  email: keith.mcclellan@gmail.com

--- a/stable/cockroachdb/OWNERS
+++ b/stable/cockroachdb/OWNERS
@@ -1,4 +1,10 @@
 approvers:
 - a-robinson
+- DuskEagle
+- joshimhoff
+- keith-mcclellan
 reviewers:
 - a-robinson
+- DuskEagle
+- joshimhoff
+- keith-mcclellan


### PR DESCRIPTION
These three all have good knowledge of CockroachDB and experience
running it in production on Kubernetes.

#### What this PR does / why we need it:
Add more OWNERS to cockroachdb chart to address #13867

#### Which issue this PR fixes
  - contributes to #13867

#### Special notes for your reviewer:
I don't think I have the necessary permissions to add them as collaborators on the repo. Can whoever approves this do so?

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
