### PR TITLE
[stable/logstash] Add init container

### DIFF
--- a/stable/logstash/Chart.yaml
+++ b/stable/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 1.10.0
+version: 1.11.0
 appVersion: 6.7.0
 sources:
 - https://www.docker.elastic.co

--- a/stable/logstash/README.md
+++ b/stable/logstash/README.md
@@ -75,6 +75,7 @@ The following table lists the configurable parameters of the chart and its defau
 | `podDisruptionBudget`           | Pod disruption budget                              | `maxUnavailable: 1`                              |
 | `updateStrategy`                | Update strategy                                    | `type: RollingUpdate`                            |
 | `image.repository`              | Container image name                               | `docker.elastic.co/logstash/logstash-oss`        |
+| `initContainers`           | Specify Init Containers (see example in vaules.yaml)                             | `{}`                                             |
 | `image.tag`                     | Container image tag                                | `6.7.0`                                          |
 | `image.pullPolicy`              | Container image pull policy                        | `IfNotPresent`                                   |
 | `service.type`                  | Service type (ClusterIP, NodePort or LoadBalancer) | `ClusterIP`                                      |

--- a/stable/logstash/templates/statefulset.yaml
+++ b/stable/logstash/templates/statefulset.yaml
@@ -46,6 +46,13 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}
       {{- end }}
+{{- if .Values.initContainers }}
+      initContainers:
+{{- range $key, $value := .Values.initContainers }}
+        - name: {{ $key }}
+{{ toYaml $value | indent 10 }}
+{{- end }}
+{{- end }}
       containers:
 
         ## logstash

--- a/stable/logstash/values.yaml
+++ b/stable/logstash/values.yaml
@@ -8,6 +8,16 @@ updateStrategy:
 
 terminationGracePeriodSeconds: 30
 
+# Add your own init container. Example shown below.
+initContainers: {}
+#   vault-init:  # <- will be used as container name
+#     image: "busybox:1.30.1"
+#     imagePullPolicy: "IfNotPresent"
+#     command: ['/vault-helper.sh']
+#     volumeMounts:
+#       - mountPath: /vault-volume
+#         name: vault-volume
+
 image:
   repository: docker.elastic.co/logstash/logstash-oss
   tag: 6.7.0


### PR DESCRIPTION
#### What this PR does / why we need it:
Allow for adding init containers to the the Stateful Set. This can be used to grabbing secrets/credentials from an init container as an environment variables. A specific use case is using Hashicorp Vault to grab or create AWS IAM credentials on-demand.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
