### PR TITLE
[stable/spinnaker] Move default profile settings from values to the template

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.8.2
+version: 1.9.0
 appVersion: 1.12.5
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/configmap/additional-profile-configmaps.yaml
+++ b/stable/spinnaker/templates/configmap/additional-profile-configmaps.yaml
@@ -10,6 +10,12 @@ Render profiles for each service by merging predefined defaults with values pass
 */}}
 {{- $profiles := dict "gate-local.yml" "" -}}
 
+{{- /* Defaults: Disable S3 versioning on Front50 if Minio storage is used */}}
+{{- /* https://www.spinnaker.io/setup/install/storage/minio/#editing-your-storage-settings */}}
+{{- if .Values.minio.enabled -}}
+{{- $_ := set $profiles "front50-local.yml" (dict "spinnaker" (dict "s3" (dict "versioning" false))) -}}
+{{- end -}}
+
 {{- /* Defaults: Add special settings for gate if GCE or ALB ingress is used */}}
 {{- /* https://github.com/spinnaker/spinnaker/issues/1630#issuecomment-467359999 */}}
 {{- if index $.Values.ingress "annotations" -}}

--- a/stable/spinnaker/templates/configmap/additional-profile-configmaps.yaml
+++ b/stable/spinnaker/templates/configmap/additional-profile-configmaps.yaml
@@ -1,15 +1,40 @@
-{{ if  .Values.halyard.additionalProfileConfigMaps.create -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "spinnaker.fullname" . }}-additional-profile-config-maps
   labels:
 {{ include "spinnaker.standard-labels" . | indent 4 }}
+{{/*
+Render profiles for each service by merging predefined defaults with values passed by
+.Values.halyard.additionalProfileConfigMaps.data
+*/}}
+{{- $profiles := dict "gate-local.yml" "" -}}
+
+{{- /* Defaults: Add special settings for gate if GCE or ALB ingress is used */}}
+{{- /* https://github.com/spinnaker/spinnaker/issues/1630#issuecomment-467359999 */}}
+{{- if index $.Values.ingress "annotations" -}}
+{{- if eq (index $.Values.ingress.annotations "kubernetes.io/ingress.class" | default "") "gce" "alb" }}
+{{- $tomcatProxySettings := dict -}}
+{{- $_ := set $tomcatProxySettings "protocolHeader" "X-Forwarded-Proto" -}}
+{{- $_ := set $tomcatProxySettings "remoteIpHeader" "X-Forwarded-For" -}}
+{{- $_ := set $tomcatProxySettings "internalProxies" ".*" -}}
+{{- $_ := set $tomcatProxySettings "httpsServerPort" "X-Forwarded-Port" -}}
+{{- $_ := set $profiles "gate-local.yml" (dict "server" (dict "tomcat" $tomcatProxySettings)) -}}
+{{- end -}}
+{{- end -}}
+
+{{- /* Merge dictionaries with passed values */}}
+{{- $customProfilesEnabled := .Values.halyard.additionalProfileConfigMaps.create | default true -}}
+{{- if and $customProfilesEnabled .Values.halyard.additionalProfileConfigMaps.data -}}
+{{- $_ := mergeOverwrite $profiles .Values.halyard.additionalProfileConfigMaps.data -}}
+{{- end -}}
+
+{{- /* Convert the content of profiles to string unless it's already a string */}}
+{{- range $filename, $content := $profiles -}}
+{{- if not (typeIs "string" $content) -}}
+{{- $_ := set $profiles $filename ($content | toYaml) -}}
+{{- end -}}
+{{- end -}}
+
 data:
-{{- if  and .Values.halyard.additionalProfileConfigMaps.create .Values.halyard.additionalProfileConfigMaps.data }}
-{{- range $index, $content := .Values.halyard.additionalProfileConfigMaps.data }}
-  {{ $index }}: |-
-{{ $content | indent 4 }}
-{{- end }}
-{{- end }}
-{{- end }}
+{{ $profiles | toYaml | indent 2 }}

--- a/stable/spinnaker/templates/configmap/halyard-init-script.yaml
+++ b/stable/spinnaker/templates/configmap/halyard-init-script.yaml
@@ -16,11 +16,9 @@ data:
     mkdir -p /tmp/spinnaker/.hal/default/service-settings
     cp /tmp/service-settings/* /tmp/spinnaker/.hal/default/service-settings/
 
-    {{- if .Values.halyard.additionalProfileConfigMaps.create }}
     rm -rf /tmp/spinnaker/.hal/default/profiles
     mkdir -p /tmp/spinnaker/.hal/default/profiles
     cp /tmp/additionalProfileConfigMaps/* /tmp/spinnaker/.hal/default/profiles/
-    {{- end }}
 
     {{- if hasKey .Values.halyard "additionalInitScript" }}
     # additionalInitScript

--- a/stable/spinnaker/templates/statefulsets/halyard.yaml
+++ b/stable/spinnaker/templates/statefulsets/halyard.yaml
@@ -42,10 +42,8 @@ spec:
           mountPath: /tmp/service-settings
         - name: halyard-home
           mountPath: /tmp/spinnaker
-        {{- if .Values.halyard.additionalProfileConfigMaps.create }}
         - name: additional-profile-config-maps
           mountPath: /tmp/additionalProfileConfigMaps
-        {{- end }}
         - name: halyard-initscript
           mountPath: /tmp/initscript
       volumes:
@@ -89,11 +87,9 @@ spec:
         configMap:
           name: {{ template "spinnaker.fullname" . }}-additional-config-maps
       {{- end }}
-      {{- if .Values.halyard.additionalProfileConfigMaps.create }}
       - name: additional-profile-config-maps
         configMap:
           name: {{ template "spinnaker.fullname" . }}-additional-profile-config-maps
-      {{- end }}
       - name: halyard-config
         emptyDir: {}
       - name: service-settings

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -20,21 +20,21 @@ halyard:
   additionalConfigMaps:
     create: false
     data: {}
+
   additionalProfileConfigMaps:
-    create: false
-    data:
-    ## if you're running spinnaker behind a reverse proxy such as a GCE ingress
-    ## you may need the following profile settings for the gate profile.
-    ## see https://github.com/spinnaker/spinnaker/issues/1630
-    ## otherwise its harmless and will likely become default behavior in the future
-    ## According to the linked github issue.
-      gate-local.yml: |-
-        server:
-          tomcat:
-            protocolHeader: X-Forwarded-Proto
-            remoteIpHeader: X-Forwarded-For
-            internalProxies: .*
-            httpsServerPort: X-Forwarded-Port
+    data: {}
+      ## if you're running spinnaker behind a reverse proxy such as a GCE ingress
+      ## you may need the following profile settings for the gate profile.
+      ## see https://github.com/spinnaker/spinnaker/issues/1630
+      ## otherwise its harmless and will likely become default behavior in the future
+      ## According to the linked github issue.
+      # gate-local.yml:
+      #   server:
+      #     tomcat:
+      #       protocolHeader: X-Forwarded-Proto
+      #       remoteIpHeader: X-Forwarded-For
+      #       internalProxies: .*
+      #       httpsServerPort: X-Forwarded-Port
 
   ## Uncomment if you want to add extra commands to the init script
   ## run by the init container before halyard is started.


### PR DESCRIPTION
#### What this PR does / why we need it:

Now `templates/configmap/additional-profile-configmaps.yaml` template has advanced logic with conditions and dict merging, which brings us the following:

### 1. Move default profile settings from values to the template.
Default values for `gate-local.yml` profile (introduced in https://github.com/helm/charts/pull/10771) will be injected automatically if `gce` or `alb` ingress controller is used. 
So, there will be no need for some users to set `halyard.additionalProfileConfigMaps` to true to get it working. Also, other users won't have to explicitly unset `halyard.additionalProfileConfigMaps.data.gate-local\.yml` if they don't use `gce` or `alb` ingress.

### 2. Disable S3 versioning if Minio is used
Minio is the local S3-compatible storage engine, which is enabled in `stable/spinnaker` by default  (as an alternative to AWS S3). However, it doesn't support versioning, which makes the front50 microservice failing to start. 
So the versioning should be disabled according to Spinnaker docs:
https://www.spinnaker.io/setup/install/storage/minio/#editing-your-storage-settings

### 3. Changes in `halyard.additionalProfileConfigMaps.data` map
- I removed `halyard.additionalProfileConfigMaps.create` key from `values.yaml` because now this ConfigMap will always be created and mounted, in order to get the default settings (p.1) available.
- I also changed the expected type of values in `halyard.additionalProfileConfigMaps.data` map. Now it could be not only a string, but a dict (`map[string]interface{}`) too, so users can override any of the fields defined by default, for example:

```yaml
# overrides-values.yml
halyard:
  additionalProfileConfigMaps:
    data:
      front50-local.yml:  # it's a map, no "|-" here
        foo: bar
        spinnaker:
          s3:
            endpoint: OVERRIDEN_VALUE
```
will lead to this content of the ConfigMap:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  # ...
data:
  front50-local.yml: |
    foo: bar
    spinnaker:
      s3:
        endpoint: OVERRIDEN_VALUE
        versioning: false
```

#### Special notes for your reviewer:

Despite all the changes, this PR saves full backward compatibility. If the user has set `halyard.additionalProfileConfigMaps.create` to `true` and defined any profiles in `halyard.additionalProfileConfigMaps.data`, these profiles will be always respected instead of the defaults generated by the template conditions (if they overlap).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
