### PR TITLE
[stable/chaoskube] add a servicemonitor resource for Prometheus operator

### DIFF
--- a/stable/chaoskube/Chart.yaml
+++ b/stable/chaoskube/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: chaoskube
-version: 2.0.0
+version: 3.0.0
 appVersion: 0.13.0
 description: Chaoskube periodically kills random pods in your Kubernetes cluster.
 icon: https://raw.githubusercontent.com/linki/chaoskube/master/chaoskube.png

--- a/stable/chaoskube/README.md
+++ b/stable/chaoskube/README.md
@@ -37,34 +37,39 @@ If you're sure you want to use it run `helm` with:
 $ helm install stable/chaoskube --set dryRun=false
 ```
 
-| Parameter                 | Description                                         | Default                          |
-|---------------------------|-----------------------------------------------------|----------------------------------|
-| `name`                    | container name                                      | chaoskube                        |
-| `image`                   | docker image                                        | quay.io/linki/chaoskube          |
-| `imageTag`                | docker image tag                                    | v0.11.0                          |
-| `replicas`                | number of replicas to run                           | 1                                |
-| `interval`                | interval between pod terminations                   | 10m                              |
-| `labels`                  | label selector to filter pods by                    | "" (matches everything)          |
-| `annotations`             | annotation selector to filter pods by               | "" (matches everything)          |
-| `namespaces`              | namespace selector to filter pods by                | "" (all namespaces)              |
-| `dryRun`                  | don't kill pods, only log what would have been done | true                             |
-| `logFormat`               | Options to choose log format(i.e. "text" or "json") | "text"                           |
-| `debug`                   | Enable debug logging mode, for detailed logs        | false                            |
-| `timezone`                | Set timezone for running actions (Optional)         | "" (UTC)                         |
-| `excludedWeekdays`        | Set Days of the Week to avoid actions (Optional)    | "" (Don't skip any weekdays)     |
-| `excludedTimesOfDay`      | Set Time Range to avoid actions (Optional)          | "" (Don't skip any times of day) |
-| `excludedDaysOfYear`      | Set Days of the Year to avoid actions (Optional)    | "" (Don't skip any days)         |
-| `priorityClassName`       | priorityClassName                                   | `nil`                            |
-| `rbac.create`             | create rbac service account and roles               | false                            |
-| `rbac.serviceAccountName` | name of serviceAccount to use when create is false  | default                          |
-| `resources`               | CPU/Memory resource requests/limits                 | `{}`                             |
-| `nodeSelector`            | Node labels for pod assignment                      | `{}`                             |
-| `tolerations`             | Toleration labels for pod assignment                | `[]`                             |
-| `affinity`                | Affinity settings for pod assignment                | `{}`                             |
-| `minimumAge`              | Set minimum pod age to filter pod by                | `0s`                             |
-| `podAnnotations`          | Annotations for the chaoskube pod                   | `{}`                             |
-| `gracePeriod`             | grace period to give pods when terminating them     | `-1s` (pod decides)              |
-| `metricsAddress`          | Listening address for metrics handler               | `:8080`                          |
+| Parameter                                 | Description                                                                           | Default                          |
+|-------------------------------------------|---------------------------------------------------------------------------------------|----------------------------------|
+| `name`                                    | container name                                                                        | chaoskube                        |
+| `image`                                   | docker image                                                                          | quay.io/linki/chaoskube          |
+| `imageTag`                                | docker image tag                                                                      | v0.11.0                          |
+| `replicas`                                | number of replicas to run                                                             | 1                                |
+| `interval`                                | interval between pod terminations                                                     | 10m                              |
+| `labels`                                  | label selector to filter pods by                                                      | "" (matches everything)          |
+| `annotations`                             | annotation selector to filter pods by                                                 | "" (matches everything)          |
+| `namespaces`                              | namespace selector to filter pods by                                                  | "" (all namespaces)              |
+| `dryRun`                                  | don't kill pods, only log what would have been done                                   | true                             |
+| `logFormat`                               | Options to choose log format(i.e. "text" or "json")                                   | "text"                           |
+| `debug`                                   | Enable debug logging mode, for detailed logs                                          | false                            |
+| `timezone`                                | Set timezone for running actions (Optional)                                           | "" (UTC)                         |
+| `excludedWeekdays`                        | Set Days of the Week to avoid actions (Optional)                                      | "" (Don't skip any weekdays)     |
+| `excludedTimesOfDay`                      | Set Time Range to avoid actions (Optional)                                            | "" (Don't skip any times of day) |
+| `excludedDaysOfYear`                      | Set Days of the Year to avoid actions (Optional)                                      | "" (Don't skip any days)         |
+| `priorityClassName`                       | priorityClassName                                                                     | `nil`                            |
+| `rbac.create`                             | create rbac service account and roles                                                 | false                            |
+| `rbac.serviceAccountName`                 | name of serviceAccount to use when create is false                                    | default                          |
+| `resources`                               | CPU/Memory resource requests/limits                                                   | `{}`                             |
+| `nodeSelector`                            | Node labels for pod assignment                                                        | `{}`                             |
+| `tolerations`                             | Toleration labels for pod assignment                                                  | `[]`                             |
+| `affinity`                                | Affinity settings for pod assignment                                                  | `{}`                             |
+| `minimumAge`                              | Set minimum pod age to filter pod by                                                  | `0s`                             |
+| `podAnnotations`                          | Annotations for the chaoskube pod                                                     | `{}`                             |
+| `gracePeriod`                             | grace period to give pods when terminating them                                       | `-1s` (pod decides)              |
+| `metrics.enabled`                         | Enable metrics handler                                                                | `false`                          |
+| `metrics.port`                            | Listening port for metrics handler                                                    | `8080`                           |
+| `metrics.service.type`                    | Metrics service type                                                                  | `ClusterIP`                      |
+| `metrics.service.port`                    | Metrics service port                                                                  | `8080`                           |
+| `metrics.serviceMonitor.enabled`          | Set this to `true` to create ServiceMonitor for Prometheus operator                   | `false`                          |
+| `metrics.serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`                             |
 
 Setting label and namespaces selectors from the shell can be tricky but is possible (example with zsh):
 

--- a/stable/chaoskube/templates/deployment.yaml
+++ b/stable/chaoskube/templates/deployment.yaml
@@ -46,7 +46,16 @@ spec:
             {{- end }}
             - --minimum-age={{ .Values.minimumAge }}
             - --grace-period={{ .Values.gracePeriod }}
-            - --metrics-address={{ .Values.metricsAddress }}
+          {{- if .Values.metrics.enabled }}
+            - --metrics-address=:{{ .Values.metrics.port }}
+          {{- else }}
+            - --metrics-address=
+          {{- end }}
+          {{- if .Values.metrics.enabled }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           securityContext:

--- a/stable/chaoskube/templates/service.yaml
+++ b/stable/chaoskube/templates/service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chaoskube.fullname" . }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+spec:
+  type: {{ .Values.metrics.service.type }}
+  ports:
+    - port: {{ .Values.metrics.service.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    app.kubernetes.io/name: {{ include "chaoskube.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/stable/chaoskube/templates/servicemonitor.yaml
+++ b/stable/chaoskube/templates/servicemonitor.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "chaoskube.fullname" . }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      interval: 30s
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "chaoskube.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/stable/chaoskube/values.yaml
+++ b/stable/chaoskube/values.yaml
@@ -49,8 +49,26 @@ minimumAge: 0s
 # grace period to give pods when terminating them (negative: pod decides)
 gracePeriod: -1s
 
-# Listening address for metrics handler
-metricsAddress: :8080
+metrics:
+  # Enable metrics handler
+  enabled: false
+
+  # Listening port for metrics handler
+  port: 8080
+
+  service:
+    # Metrics service type
+    type: ClusterIP
+
+    # Metrics service port
+    port: 8080
+
+  serviceMonitor:
+    # Set this to `true` to create ServiceMonitor for Prometheus operator
+    enabled: false
+
+    # Additional labels that can be used so ServiceMonitor will be discovered by Prometheus
+    additionalLabels: {}
 
 priorityClassName: ""
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Add a servicemonitor resource for Prometheus operator.

Also refactor the way metrics is enabled, so user can configure the metrics port and not the metrics address. This is a breaking change.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
