### PR TITLE
[stable/prometheus-mongodb-exporter] Add MONGODB_URI env variable secret

### DIFF
--- a/stable/prometheus-mongodb-exporter/Chart.yaml
+++ b/stable/prometheus-mongodb-exporter/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 name: prometheus-mongodb-exporter
 sources:
 - https://github.com/percona/mongodb_exporter
-version: 2.0.1
+version: 2.1.0

--- a/stable/prometheus-mongodb-exporter/README.md
+++ b/stable/prometheus-mongodb-exporter/README.md
@@ -42,7 +42,6 @@ podAnnotations:
 | `image.tag` | MongoDB Exporter image tag | `0.7.0` |
 | `imagePullSecrets` | List of container registry secrets | `[]` |
 | `mongodb.uri` | The required [URI](https://docs.mongodb.com/manual/reference/connection-string) to connect to MongoDB | `` |
-| `secret.mongodbUri` | [URI](https://docs.mongodb.com/manual/reference/connection-string) to connect to MongoDB | `` |
 | `nameOverride` | Override the application name  | `` |
 | `nodeSelector` | Node labels for pod assignment | `{}` |
 | `podAnnotations` | Annotations to be added to all pods | `{}` |

--- a/stable/prometheus-mongodb-exporter/README.md
+++ b/stable/prometheus-mongodb-exporter/README.md
@@ -16,7 +16,7 @@ This command deploys the MongoDB Exporter with the default configuration. The [c
 ## Using the Chart
 
 To use the chart, ensure the `mongodb.uri` is populated with a valid [MongoDB URI](https://docs.mongodb.com/manual/reference/connection-string).
-If the MongoDB server requires authentication, credentials should be populated in the connection string as well. The MongoDB Exporter supports 
+If the MongoDB server requires authentication, credentials should be populated in the connection string as well. The MongoDB Exporter supports
 connecting to either a MongoDB replica set member, shard, or standalone instance.
 
 The chart comes with a ServiceMonitor for use with the [Prometheus Operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator).
@@ -42,6 +42,7 @@ podAnnotations:
 | `image.tag` | MongoDB Exporter image tag | `0.7.0` |
 | `imagePullSecrets` | List of container registry secrets | `[]` |
 | `mongodb.uri` | The required [URI](https://docs.mongodb.com/manual/reference/connection-string) to connect to MongoDB | `` |
+| `secret.mongodbUri` | [URI](https://docs.mongodb.com/manual/reference/connection-string) to connect to MongoDB | `` |
 | `nameOverride` | Override the application name  | `` |
 | `nodeSelector` | Node labels for pod assignment | `{}` |
 | `podAnnotations` | Annotations to be added to all pods | `{}` |

--- a/stable/prometheus-mongodb-exporter/templates/deployment.yaml
+++ b/stable/prometheus-mongodb-exporter/templates/deployment.yaml
@@ -25,16 +25,13 @@ spec:
     spec:
       containers:
       - name: mongodb-exporter
-        {{- if .Values.secret.mongodbUri }}
         env:
           - name: MONGODB_URI
             valueFrom:
               secretKeyRef:
                 name: {{ include "prometheus-mongodb-exporter.fullname" . }}
                 key: mongodb-uri
-        {{- end }}
         {{- if .Values.env }}
-        env:
         {{- range $key, $value := .Values.env }}
           - name: "{{ $key }}"
             value: "{{ $value }}"
@@ -43,9 +40,6 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
-        {{- if (not .Values.secret.mongodbUri) }}
-        - --mongodb.uri={{ required "A MongoDB URI is required" .Values.mongodb.uri }}
-        {{- end }}
         - --web.listen-address={{ printf ":%s" .Values.port }}
         {{- toYaml .Values.extraArgs | nindent 8 }}
         ports:

--- a/stable/prometheus-mongodb-exporter/templates/deployment.yaml
+++ b/stable/prometheus-mongodb-exporter/templates/deployment.yaml
@@ -25,6 +25,14 @@ spec:
     spec:
       containers:
       - name: mongodb-exporter
+        {{- if .Values.secret.mongodbUri }}
+        env:
+          - name: MONGODB_URI
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "prometheus-mongodb-exporter.fullname" . }}
+                key: mongodb-uri
+        {{- end }}
         {{- if .Values.env }}
         env:
         {{- range $key, $value := .Values.env }}
@@ -35,7 +43,9 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
+        {{- if (not .Values.secret.mongodbUri) }}
         - --mongodb.uri={{ required "A MongoDB URI is required" .Values.mongodb.uri }}
+        {{- end }}
         - --web.listen-address={{ printf ":%s" .Values.port }}
         {{- toYaml .Values.extraArgs | nindent 8 }}
         ports:

--- a/stable/prometheus-mongodb-exporter/templates/secret.yaml
+++ b/stable/prometheus-mongodb-exporter/templates/secret.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.secret.mongodbUri }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,5 +9,4 @@ metadata:
     helm.sh/chart: {{ include "prometheus-mongodb-exporter.chart" . }}
 type: Opaque
 data:
-  mongodb-uri: {{ .Values.secret.mongodbUri| b64enc }}
-{{- end }}
+  mongodb-uri: {{ required "A MongoDB URI is required" .Values.mongodb.uri | b64enc }}

--- a/stable/prometheus-mongodb-exporter/templates/secret.yaml
+++ b/stable/prometheus-mongodb-exporter/templates/secret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.secret.mongodbUri }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "prometheus-mongodb-exporter.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "prometheus-mongodb-exporter.chart" . }}
+type: Opaque
+data:
+  mongodb-uri: {{ .Values.secret.mongodbUri| b64enc }}
+{{- end }}

--- a/stable/prometheus-mongodb-exporter/values.yaml
+++ b/stable/prometheus-mongodb-exporter/values.yaml
@@ -27,9 +27,6 @@ livenessProbe:
 mongodb:
   uri:
 
-secret:
-  mongodbUri: ""
-
 nameOverride: ""
 
 nodeSelector: {}

--- a/stable/prometheus-mongodb-exporter/values.yaml
+++ b/stable/prometheus-mongodb-exporter/values.yaml
@@ -27,6 +27,9 @@ livenessProbe:
 mongodb:
   uri:
 
+secret:
+  mongodbUri: ""
+
 nameOverride: ""
 
 nodeSelector: {}


### PR DESCRIPTION
Signed-off-by: Dagenais, Philippe <pdagenais@nuglif.com>

#### What this PR does / why we need it:
This add the possibility to use a environment variable for the mongodb URI connection string.
Uses a secret that define the MONGODB_URI environment variable.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`
