### PR TITLE
[stable/fluent-bit] add section to add custom labels to the metrics service

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.0.3
+version: 2.0.4
 appVersion: 1.1.0
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -124,6 +124,7 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `affinity`                         | Expressions for affinity                   | `NULL`                                            |
 | `metrics.enabled`                  | Specifies whether a service for metrics should be exposed | `false`                            |
 | `metrics.service.annotations`      | Optional metrics service annotations       | `NULL`                                            |
+| `metrics.service.labels`           | Additional labels for the fluent-bit metrics service definition, specified as a map.                                                    | None                                              |
 | `metrics.service.port`             | Port on where metrics should be exposed    | `2020`                                            |
 | `metrics.service.type`             | Service type for metrics                   | `ClusterIP`                                       |
 | `trackOffsets`                     | Specify whether to track the file offsets for tailing docker logs. This allows fluent-bit to pick up where it left after pod restarts but requires access to a `hostPath` | `false` |

--- a/stable/fluent-bit/templates/service.yaml
+++ b/stable/fluent-bit/templates/service.yaml
@@ -12,6 +12,11 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  {{- if .Values.metrics.service }}
+  {{- range $key, $value := .Values.metrics.service.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.metrics.service.type}}
   sessionAffinity: None

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -1,4 +1,4 @@
-# Minikube stores its logs in a separate directory.
+  # Minikube stores its logs in a separate directory.
 # enable if started in minikube.
 on_minikube: false
 
@@ -19,6 +19,8 @@ fullnameOverride: ""
 metrics:
   enabled: false
   service:
+    # labels:
+    #   key: value
     annotations: {}
     # In order for Prometheus to consume metrics automatically use the following annotations:
     # prometheus.io/path: "/api/v1/metrics/prometheus"


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR allows to add custom labels to the fluent-bit metrics service

#### Special notes for your reviewer:
When creating a generic service monitor to scrape metrics from a certain label, we need to be able to define the service labels as done in other charts, e.g. traefik.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
