### PR TITLE
[stable/graylog] Fix multiple TCP NotePort support

### DIFF
--- a/stable/graylog/templates/tcp-service.yaml
+++ b/stable/graylog/templates/tcp-service.yaml
@@ -21,12 +21,10 @@ spec:
       port: {{ .port }}
       protocol: TCP
       targetPort: {{ .port }}
+    {{- if .nodePort }}
+      nodePort:  {{ .nodePort }}
+    {{- end }}
   {{- end }}
-{{- if contains "NodePort" .Values.graylog.input.tcp.service.type }}
-  {{- if .Values.graylog.input.tcp.service.nodePort }}
-      nodePort:  {{ .Values.graylog.input.tcp.service.nodePort }}
-  {{- end }}
-{{- end }}
 {{- if .Values.graylog.input.tcp.service.externalIPs }}
   externalIPs:
 {{ toYaml .Values.graylog.input.tcp.service.externalIPs | indent 4 }}


### PR DESCRIPTION
- fixes #14007
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
