### PR TITLE
[stable/datadog] fixes indent

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.30.5
+version: 1.30.6
 appVersion: 6.10.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/service.yaml
+++ b/stable/datadog/templates/service.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service | quote }}
   {{- if .Values.deployment.service.annotations }}
   annotations:
-  {{ toYaml .Values.deployment.service.annotations | indent 4 }}
+{{ toYaml .Values.deployment.service.annotations | indent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.deployment.service.type }}


### PR DESCRIPTION
#### What this PR does / why we need it:

fixes indent.
When using `toYaml` and `indent`, YAML is broken if an indent is inserted at the beginning of the line.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
