### PR TITLE
[stable/rabbitmq] optionally skip set max file descriptor limit (#14020)

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 5.6.0
+version: 5.7.0
 appVersion: 3.7.15
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -67,6 +67,7 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `rabbitmq.clustering.address_type`   | Switch clustering mode                           | `ip` or `hostname`                                      |
 | `rabbitmq.clustering.k8s_domain`     | Customize internal k8s cluster domain            | `cluster.local`                                         |
 | `rabbitmq.logs`                      | Value for the RABBITMQ_LOGS environment variable | `-`                                                     |
+| `rabbitmq.setUlimitNofiles`          | Specify if max file descriptor limit should be set | `true`                                                |
 | `rabbitmq.ulimitNofiles`             | Max File Descriptor limit                        | `65536`                                                 |
 | `rabbitmq.maxAvailableSchedulers`    | RabbitMQ maximum available scheduler threads     | `2`                                                     |
 | `rabbitmq.onlineSchedulers`          | RabbitMQ online scheduler threads                | `1`                                                     |

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -86,7 +86,9 @@ spec:
             #copy the mounted configuration to both places
             cp  /opt/bitnami/rabbitmq/conf/* /opt/bitnami/rabbitmq/etc/rabbitmq
             # Apply resources limits
+            {{- if .Values.rabbitmq.setUlimitNofiles }}
             ulimit -n "${RABBITMQ_ULIMIT_NOFILES}"
+            {{- end }}
             #replace the default password that is generated
             sed -i "s/CHANGEME/$RABBITMQ_PASSWORD/g" /opt/bitnami/rabbitmq/etc/rabbitmq/rabbitmq.conf
             #api check for probes

--- a/stable/rabbitmq/values-production.yaml
+++ b/stable/rabbitmq/values-production.yaml
@@ -81,6 +81,7 @@ rabbitmq:
   ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
   ## ref: https://www.rabbitmq.com/install-debian.html#kernel-resource-limits
   ##
+  setUlimitNofiles: true
   ulimitNofiles: '65536'
 
   ## RabbitMQ maximum available scheduler threads and online scheduler threads

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -80,6 +80,7 @@ rabbitmq:
   ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
   ## ref: https://www.rabbitmq.com/install-debian.html#kernel-resource-limits
   ##
+  setUlimitNofiles: true
   ulimitNofiles: '65536'
 
   ## RabbitMQ maximum available scheduler threads and online scheduler threads


### PR DESCRIPTION
"ulimit -n" is not allowed in AWS EC2. The max file descriptor limit has to be set differently. Therefore there should be an option to not call ulimit command during the startup of the container, otherwise it fails in AWS EC2. This commit adds an option to disable ulimit.

Signed-off-by: Michal Artazov <michal@artazov.cz>

#### What this PR does / why we need it:
Skips `ulimit -n` command during container startup, which fails in AWS EC2.

#### Which issue this PR fixes
  - fixes #14020 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
