### PR TITLE
[stable/sematext-agent] SC-4770 Remove region info from Helm chart

### DIFF
--- a/stable/sematext-agent/Chart.yaml
+++ b/stable/sematext-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.0"
-version: 1.0.6
+version: 1.0.7
 description: Helm chart for deploying Sematext Agent to Kubernetes
 keywords:
   - sematext

--- a/stable/sematext-agent/templates/configmap-agent.yaml
+++ b/stable/sematext-agent/templates/configmap-agent.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  API_SERVER_PORT: "{{ .Values.agent.service.port }}"
+  REGION: {{ .Values.region | quote }}
   {{- range $key, $val := .Values.agent.config }}
   {{ $key }}: {{ $val | quote }}
   {{- end }}
@@ -16,12 +16,5 @@ data:
   SERVER_BASE_URL: {{ default "" .Values.customUrl.serverBaseUrl | quote }}
   EVENTS_RECEIVER_URL: {{ default "" .Values.customUrl.eventsRecieverUrl | quote }}
   LOGS_RECEIVER_URL: {{ default "" .Values.customUrl.logsReceiverUrl | quote }}
-  {{- else if eq .Values.region "EU" }}
-  SERVER_BASE_URL: "https://spm-receiver.eu.sematext.com"
-  EVENTS_RECEIVER_URL: "https://event-receiver.eu.sematext.com"
-  LOGS_RECEIVER_URL: "https://logsene-receiver.eu.sematext.com"
-  {{- else if eq .Values.region "US" }}
-  SERVER_BASE_URL: "https://spm-receiver.sematext.com"
-  EVENTS_RECEIVER_URL: "https://event-receiver.sematext.com"
-  LOGS_RECEIVER_URL: "https://logsene-receiver.sematext.com"
   {{- end }}
+  API_SERVER_PORT: "{{ .Values.agent.service.port }}"


### PR DESCRIPTION
The region info is backed into the image and it is redundant in the helm chart.