### PR TITLE
[stable/chaoskube] Update docker image to v0.14.0

### DIFF
--- a/stable/chaoskube/Chart.yaml
+++ b/stable/chaoskube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: chaoskube
-version: 3.0.0
-appVersion: 0.13.0
+version: 3.1.0
+appVersion: 0.14.0
 description: Chaoskube periodically kills random pods in your Kubernetes cluster.
 icon: https://raw.githubusercontent.com/linki/chaoskube/master/chaoskube.png
 home: https://github.com/linki/chaoskube

--- a/stable/chaoskube/templates/deployment.yaml
+++ b/stable/chaoskube/templates/deployment.yaml
@@ -34,6 +34,12 @@ spec:
             {{- if not .Values.dryRun }}
             - --no-dry-run
             {{- end }}
+            {{- if .Values.includedPodNames }}
+            - --included-pod-names={{ .Values.includedPodNames }}
+            {{- end }}
+            {{- if .Values.excludedPodNames }}
+            - --excluded-pod-names={{ .Values.excludedPodNames }}
+            {{- end }}
             - --excluded-weekdays={{ .Values.excludedWeekdays }}
             - --excluded-times-of-day={{ .Values.excludedTimesOfDay }}
             - --excluded-days-of-year={{ .Values.excludedDaysOfYear }}

--- a/stable/chaoskube/values.yaml
+++ b/stable/chaoskube/values.yaml
@@ -5,7 +5,7 @@ name: chaoskube
 image: quay.io/linki/chaoskube
 
 # docker image tag
-imageTag: v0.13.0
+imageTag: v0.14.0
 
 # number of replicas to run
 replicas: 1
@@ -27,6 +27,12 @@ dryRun: true
 
 # Enable debug logging
 debug: false
+
+# regular expression pattern for pod names to include (all included by default)
+includedPodNames:
+
+# regular expression pattern for pod names to exclude (none excluded by default)
+excludedPodNames:
 
 # Set values for exempting specific week days from Chaoskube Actions
 excludedWeekdays:


### PR DESCRIPTION
Updates to `chaoskube` to the latest version and allows using the new flags.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
