### PR TITLE
[stable/magento] Disable Elasticsearch by default

### DIFF
--- a/stable/magento/Chart.yaml
+++ b/stable/magento/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: magento
-version: 5.0.0
+version: 5.0.1
 appVersion: 2.3.1
 description: A feature-rich flexible e-commerce solution. It includes transaction options, multi-store functionality, loyalty programs, product categorization and shopper filtering, promotion rules, and more.
 keywords:

--- a/stable/magento/README.md
+++ b/stable/magento/README.md
@@ -90,7 +90,11 @@ The following table lists the configurable parameters of the Magento chart and t
 | `mariadb.db.name`                    | Database name to create                                                              | `bitnami_magento`                                            |
 | `mariadb.db.user`                    | Database user to create                                                              | `bn_magento`                                                 |
 | `mariadb.db.password`                | Password for the database                                                            | _random 10 character long alphanumeric string_               |
-| `elasticsearch.enabled`              | Whether to use the Elasticsearch chart as search engine for magento                  | `true`                                                       |
+| `elasticsearch.enabled`              | Use the Elasticsearch chart as search engine                                         | `false`                                                      |
+| `elasticsearch.cluster.env`          | Cluster environment variables                                                        | `{MINIMUM_MASTER_NODES: "2"}`                                |
+| `elasticsearch.client.replicas`      | Client node replicas (deployment)                                                    | `1`                                                          |
+| `elasticsearch.master.replicas`      | Master node replicas (deployment)                                                    | `2`                                                          |
+| `elasticsearch.data.replicas`        | Data node replicas (statefulset)                                                     | `1`                                                          |
 | `service.type`                       | Kubernetes Service type                                                              | `LoadBalancer`                                               |
 | `service.port`                       | Service HTTP port                                                                    | `80`                                                         |
 | `service.httpsPort`                  | Service HTTPS port                                                                   | `443`                                                        |
@@ -130,6 +134,11 @@ The following table lists the configurable parameters of the Magento chart and t
 | `metrics.resources`                  | Exporter resource requests/limit                                                     | {}                                                           |
 
 The above parameters map to the env variables defined in [bitnami/magento](http://github.com/bitnami/bitnami-docker-magento). For more information please refer to the [bitnami/magento](http://github.com/bitnami/bitnami-docker-magento) image documentation.
+
+> **Note:**\
+>
+> Setting `elasticsearch.enabled` to true will launch four more nodes by default. Use it with caution.
+
 
 > **Note**:
 >
@@ -173,7 +182,7 @@ The [Bitnami Magento](https://github.com/bitnami/bitnami-docker-magento) image s
 
 ### To 5.0.0
 
-Manual intervention is needed in order to configure Elasticsearch 6 as Magento search engine after upgrading to 5.0.0.
+Manual intervention is needed if configuring Elasticsearch 6 as Magento search engine is desired.
 
 [Follow the Magento documentation](https://devdocs.magento.com/guides/v2.3/config-guide/elasticsearch/configure-magento.html) in order to configure Elasticsearch, setting **Search Engine** to **Elasticsearch 6.0+**. If using the Elasticsearch server included in this chart, `hostname` and `port` can be obtained with the following commands:
 

--- a/stable/magento/values.yaml
+++ b/stable/magento/values.yaml
@@ -163,7 +163,23 @@ mariadb:
 elasticsearch:
   ## Whether to deploy a elasticsearch server to use as magento's search engine
   ## To use an external server set this to false and configure the externalElasticsearch parameters
-  enabled: true
+  enabled: false
+
+  cluster:
+    env:
+      # IMPORTANT: https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#minimum_master_nodes
+      # To prevent data loss, it is vital to configure the discovery.zen.minimum_master_nodes setting so that each master-eligible
+      # node knows the minimum number of master-eligible nodes that must be visible in order to form a cluster.
+      MINIMUM_MASTER_NODES: "2"
+
+  client:
+    replicas: 1
+
+  master:
+    replicas: 2
+
+  data:
+    replicas: 1
 
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer


### PR DESCRIPTION
Signed-off-by: Alejandro Moreno <amoreno@bitnami.com>

#### What this PR does / why we need it:

Disables Elasticsearch by default as the dependency uses too much resources.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
