### PR TITLE
[stable/parse] Fix template "parse.chart" being not defined

### DIFF
--- a/stable/parse/templates/dashboard-deployment.yaml
+++ b/stable/parse/templates/dashboard-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "parse.fullname" . }}-dashboard
   labels:
     app: {{ template "parse.name" . }}
-    chart: {{ template "parse.chart" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     component: "dashboard"


### PR DESCRIPTION
Fixing a small bug not making the template being generated.

#### What this PR does / why we need it:
It fixes an error when generating the template:
> Error: render error in "parse/templates/ingress.yaml": template: parse/templates/ingress.yaml:20:19: executing "parse/templates/ingress.yaml" at <.Values.ingress.dashbard.hosts>: nil pointer evaluating interface {}.hosts

#### Special notes for your reviewer:
There's no big changes, I just modified a var's name
