### PR TITLE
[stable/dex] run jobs as nobody instead of root

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 1.2.1
+version: 1.2.2
 appVersion: 2.16.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 1.2.2
+version: 1.3.0
 appVersion: 2.16.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/templates/job-grpc-certs.yaml
+++ b/stable/dex/templates/job-grpc-certs.yaml
@@ -31,12 +31,19 @@ spec:
         release: "{{ .Release.Name }}"
         component: "job"
     spec:
+      securityContext:
+        runAsUser: 65534
+        fsGroup: 65534
       serviceAccountName: {{ template "dex.serviceAccountName" . }}
       restartPolicy: OnFailure
       containers:
       - name: main
         image: "{{ .Values.certs.image }}:{{ .Values.certs.imageTag }}"
         imagePullPolicy: {{ .Values.certs.imagePullPolicy }}
+        env:
+        - name: HOME
+          value: /tmp
+        workingDir: /tmp
         command:
         - /bin/bash
         - -exc

--- a/stable/dex/templates/job-grpc-certs.yaml
+++ b/stable/dex/templates/job-grpc-certs.yaml
@@ -31,9 +31,11 @@ spec:
         release: "{{ .Release.Name }}"
         component: "job"
     spec:
+      {{- if .Values.certs.securityContext.enabled }}
       securityContext:
-        runAsUser: 65534
-        fsGroup: 65534
+        runAsUser: {{ .Values.certs.securityContext.runAsUser }}
+        fsGroup: {{ .Values.certs.securityContext.fsGroup }}
+      {{- end }}
       serviceAccountName: {{ template "dex.serviceAccountName" . }}
       restartPolicy: OnFailure
       containers:

--- a/stable/dex/templates/job-web-certs.yaml
+++ b/stable/dex/templates/job-web-certs.yaml
@@ -28,12 +28,19 @@ spec:
         release: "{{ .Release.Name }}"
         component: "job"
     spec:
+      securityContext:
+        runAsUser: 65534
+        fsGroup: 65534
       serviceAccountName: {{ template "dex.serviceAccountName" . }}
       restartPolicy: OnFailure
       containers:
       - name: main
         image: "{{ .Values.certs.image }}:{{ .Values.certs.imageTag }}"
         imagePullPolicy: {{ .Values.certs.imagePullPolicy }}
+        env:
+        - name: HOME
+          value: /tmp
+        workingDir: /tmp
         command:
         - /bin/bash
         - -exc

--- a/stable/dex/templates/job-web-certs.yaml
+++ b/stable/dex/templates/job-web-certs.yaml
@@ -28,9 +28,11 @@ spec:
         release: "{{ .Release.Name }}"
         component: "job"
     spec:
+      {{- if .Values.certs.securityContext.enabled }}
       securityContext:
-        runAsUser: 65534
-        fsGroup: 65534
+        runAsUser: {{ .Values.certs.securityContext.runAsUser }}
+        fsGroup: {{ .Values.certs.securityContext.fsGroup }}
+      {{- end }}
       serviceAccountName: {{ template "dex.serviceAccountName" . }}
       restartPolicy: OnFailure
       containers:

--- a/stable/dex/values.yaml
+++ b/stable/dex/values.yaml
@@ -52,6 +52,10 @@ extraVolumes: []
 extraVolumeMounts: []
 
 certs:
+  securityContext:
+    enabled: true
+    runAsUser: 65534
+    fsGroup: 65534
   image: gcr.io/google_containers/kubernetes-dashboard-init-amd64
   imageTag: "v1.0.0"
   imagePullPolicy: "IfNotPresent"


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
When running on a cluster with podsecuritypolicies enabled, the ssl-creation jobs fail because they're being run as root. I'm just switching to user nobody and set the current dir to /tmp to generate the certs.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
