### PR TITLE
[incubator/schema-registry] allow custom service labels

### DIFF
--- a/incubator/schema-registry/Chart.yaml
+++ b/incubator/schema-registry/Chart.yaml
@@ -1,6 +1,6 @@
 name: schema-registry
 home: https://docs.confluent.io/current/schema-registry/docs/index.html
-version: 1.1.3
+version: 1.1.4
 appVersion: 5.0.1
 keywords:
   - confluent

--- a/incubator/schema-registry/README.md
+++ b/incubator/schema-registry/README.md
@@ -78,6 +78,7 @@ The following table lists the configurable parameters of the SchemaRegistry char
 | `sasl.scram.zookeeperClientPassword` | the sasl scram password to use to authenticate to zookeeper | `zookeeper-password` |
 | `resources` | CPU/Memory resource requests/limits | `{}` |
 | `servicePort` | The port on which the SchemaRegistry server will be exposed. | `8081` |
+| `service.labels` | Additional labels for the service | `{}` |
 | `overrideGroupId` | Group ID defaults to using Release Name so each release is its own Schema Registry worker group, it can be overridden | `{- .Release.Name -}}` |
 | `kafkaStore.overrideBootstrapServers` | Defaults to Kafka Servers in the same release, it can be overridden in case there was a separate release for Kafka Deploy | `{{- printf "PLAINTEXT://%s-kafka-headless:9092" .Release.Name }}`
 | `kafka.enabled` | If `true`, install Kafka/Zookeeper alongside the `SchemaRegistry`. This is intended for testing and argument-less helm installs of this chart only and should not be used in Production. | `true` |

--- a/incubator/schema-registry/templates/service.yaml
+++ b/incubator/schema-registry/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
 spec:
   ports:
     - name: schema-registry

--- a/incubator/schema-registry/values.yaml
+++ b/incubator/schema-registry/values.yaml
@@ -37,6 +37,11 @@ resources: {}
 ## The port on which the SchemaRegistry will be available and serving requests
 servicePort: 8081
 
+## Provides schema registry service settings
+service:
+  ## Any additional labels to add to the service
+  labels: {}
+
 ## If `Kafka.Enabled` is `false`, kafkaStore.overrideBootstrapServers must be provided for Master Election.
 ## You can list load balanced service endpoint, or list of all brokers (which is hard in K8s).  e.g.:
 ## overrideBootstrapServers: "PLAINTEXT://dozing-prawn-kafka-headless:9092"


### PR DESCRIPTION
Signed-off-by: S.Cavallo <smcavallo@hotmail.com>

#### What this PR does / why we need it:
Allows further customization of schema-registry service

#### Which issue this PR fixes
n/a

#### Special notes for your reviewer:
This follows the same exact pattern used in the ingress template with ingress.labels

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X ] Chart Version bumped
- [X ] Variables are documented in the README.md
- [X ] Title of the PR starts with chart name (e.g. `[stable/chart]`)
