### PR TITLE
[stable/prometheus-operator] allow adding targetLabels to servicemonitors

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 5.10.1
+version: 5.10.2
 appVersion: 0.29.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/ci/test-values.yaml
+++ b/stable/prometheus-operator/ci/test-values.yaml
@@ -1439,6 +1439,10 @@ prometheus:
     ##
     # jobLabel: ""
 
+    ## labels to transfer from the kubernetes service to the target
+    ##
+    # targetLabels: ""
+
     ## Label selector for services to which this ServiceMonitor applies
     ##
     # selector: {}

--- a/stable/prometheus-operator/templates/prometheus/servicemonitors.yaml
+++ b/stable/prometheus-operator/templates/prometheus/servicemonitors.yaml
@@ -25,5 +25,9 @@ items:
     {{- end }}
       selector:
 {{ toYaml .selector | indent 8 }}
+    {{- if .targetLabels }}
+      targetLabels:
+{{ toYaml .targetLabels | indent 8 }}
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -1439,6 +1439,10 @@ prometheus:
     ##
     # jobLabel: ""
 
+    ## labels to transfer from the kubernetes service to the target
+    ##
+    # targetLabels: ""
+
     ## Label selector for services to which this ServiceMonitor applies
     ##
     # selector: {}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Allows targetLabels to be set on ServiceMonitor resources created via prometheusSpec.additionalServiceMonitors


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)