### PR TITLE
[stable/spinnaker] Fix default deck settings

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.10.1
+version: 1.10.2
 appVersion: 1.12.5
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/configmap/service-settings.yaml
+++ b/stable/spinnaker/templates/configmap/service-settings.yaml
@@ -26,7 +26,7 @@ Render settings for each service by merging predefined defaults with values pass
 
 {{/* Defaults: deck service */}}
 {{- $deckDefaults := dict -}}
-{{- $_ := set $deckDefaults "API_HOST" "http://spin-gate:8084" -}}
+{{- $_ := set $deckDefaults "env" (dict "API_HOST" "http://spin-gate:8084") -}}
 {{- if .Values.ingress.enabled -}}
 {{- $_ := set $deckDefaults "kubernetes" (dict "useExecHealthCheck" false "serviceType" "NodePort") -}}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR fixes the regression introduced in https://github.com/helm/charts/pull/13049  (really sorry about this)

`"API_HOST"` env variable should be nested in `"env"` map

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
