### PR TITLE
[stable/instana-agent] Add mount "/run" for the Instana Agent

### DIFF
--- a/stable/instana-agent/Chart.yaml
+++ b/stable/instana-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: instana-agent
-version: 1.0.7
+version: 1.0.8
 appVersion: 1.0
 description: Instana Agent for Kubernetes
 home: https://www.instana.com/

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -92,10 +92,12 @@ spec:
             - name: dev
               mountPath: /dev
             - name: run
+              mountPath: /run
+            - name: var-run
               mountPath: /var/run
             - name: sys
               mountPath: /sys
-            - name: log
+            - name: var-log
               mountPath: /var/log
             - name: machine-id
               mountPath: /etc/machine-id
@@ -147,11 +149,14 @@ spec:
             path: /dev
         - name: run
           hostPath:
+            path: /run
+        - name: var-run
+          hostPath:
             path: /var/run
         - name: sys
           hostPath:
             path: /sys
-        - name: log
+        - name: var-log
           hostPath:
             path: /var/log
         - name: machine-id


### PR DESCRIPTION
To work with ContainerD, the Instana Agent needs an additional mount at
`/run`. Renamed the `/var/run` mount and `/var/log` as well for
consistency.

Signed-off-by: Miel Donkers <miel.donkers@instana.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
