### PR TITLE
[incubator/haproxy-ingress] Fix ingressClass typo in README.md

### DIFF
--- a/incubator/haproxy-ingress/Chart.yaml
+++ b/incubator/haproxy-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: haproxy-ingress
-version: 0.0.13
+version: 0.0.14
 appVersion: 0.7.1
 home: https://github.com/jcmoraisjr/haproxy-ingress
 description: Ingress controller implementation for haproxy loadbalancer.

--- a/incubator/haproxy-ingress/README.md
+++ b/incubator/haproxy-ingress/README.md
@@ -48,7 +48,7 @@ Parameter | Description | Default
 `controller.extraEnv` | extra environment variables for the haproxy-ingress-controller | `{}`
 `controller.template` | custom template for haproxy-ingress-controller | `{}`
 `controller.defaultBackendService` | backend service if defualtBackend.enabled==false | `""`
-`controller.ingressClass` | name of the ingress class to route through this controller | `happroxy`
+`controller.ingressClass` | name of the ingress class to route through this controller | `haproxy`
 `controller.healthzPort` | The haproxy health check (monitoring) port | `10253`
 `controller.livenessProbe.path` | The liveness probe path | `/healthz`
 `controller.livenessProbe.port` | The livneness probe port | `10253`
@@ -87,10 +87,10 @@ Parameter | Description | Default
 `controller.minAvailable` | PodDisruptionBudget minimum available controller pods | `1`
 `controller.resources` | controller container resource requests & limits | `{}`
 `controller.autoscaling.enabled` | enabling controller horizontal pod autoscaling (when `controller.kind` is `Deployment`) | `false`
-`controller.autoscaling.minReplicas` | minimum number of replicas | 
-`controller.autoscaling.maxReplicas` | maximum number of replicas | 
-`controller.autoscaling.targetCPUUtilizationPercentage` | target cpu utilization | 
-`controller.autoscaling.targetMemoryUtilizationPercentage` | target memory utilization | 
+`controller.autoscaling.minReplicas` | minimum number of replicas |
+`controller.autoscaling.maxReplicas` | maximum number of replicas |
+`controller.autoscaling.targetCPUUtilizationPercentage` | target cpu utilization |
+`controller.autoscaling.targetMemoryUtilizationPercentage` | target memory utilization |
 `controller.autoscaling.customMetrics` | Extra custom metrics to add to the HPA | `[]`
 `controller.tolerations` | to control scheduling to servers with taints | `[]`
 `controller.affinity` | to control scheduling | `{}`
@@ -144,7 +144,7 @@ Parameter | Description | Default
 `defaultBackend.podLabels` | Labels for the default backend pod | `{}`
 `defaultBackend.replicaCount` | the number of replicas to deploy (when `controller.kind` is `Deployment`) | `1`
 `defaultBackend.minAvailable` | PodDisruptionBudget minimum available default backend pods | `1`
-`defaultBackend.resources` | default backend pod resources | _see defaults below_ 
+`defaultBackend.resources` | default backend pod resources | _see defaults below_
 `defaultBackend.resources.limits.cpu` | default backend cpu resources limit | `10m`
 `defaultBackend.resources.limits.memory` | default backend memory resources limit | `20Mi`
 `defaultBackend.service.name` | name of default backend service to create | `ingress-default-backend`


### PR DESCRIPTION
#### What this PR does / why we need it:
A small typo has been fixed in the README. Also some trailing whitespace was removed.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
