### PR TITLE
[stable/traefik] quote timeout configs in configmap

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.69.1
+version: 1.69.2
 appVersion: 1.7.12
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -389,22 +389,22 @@ data:
     {{- if .Values.timeouts.responding }}
     [respondingTimeouts]
       {{- if .Values.timeouts.responding.readTimeout }}
-      readTimeout = {{ .Values.timeouts.responding.readTimeout }}
+      readTimeout = {{ .Values.timeouts.responding.readTimeout | quote }}
       {{- end }}
       {{- if .Values.timeouts.responding.writeTimeout }}
-      writeTimeout = {{ .Values.timeouts.responding.writeTimeout }}
+      writeTimeout = {{ .Values.timeouts.responding.writeTimeout | quote }}
       {{- end }}
       {{- if .Values.timeouts.responding.idleTimeout }}
-      idleTimeout = {{ .Values.timeouts.responding.idleTimeout }}
+      idleTimeout = {{ .Values.timeouts.responding.idleTimeout | quote }}
       {{- end }}
     {{- end }}
     {{- if .Values.timeouts.forwarding }}
     [forwardingTimeouts]
       {{- if .Values.timeouts.forwarding.dialTimeout }}
-      dialTimeout = {{ .Values.timeouts.forwarding.dialTimeout }}
+      dialTimeout = {{ .Values.timeouts.forwarding.dialTimeout | quote }}
       {{- end }}
       {{- if .Values.timeouts.forwarding.responseHeaderTimeout }}
-      responseHeaderTimeout = {{ .Values.timeouts.forwarding.responseHeaderTimeout }}
+      responseHeaderTimeout = {{ .Values.timeouts.forwarding.responseHeaderTimeout | quote }}
       {{- end }}
     {{- end }}
     {{- end }}


### PR DESCRIPTION
In order to prevent:
```
Error reading TOML config file /config/traefik.toml
: Near line 78 (last key parsed 'forwardingTimeouts'): expected a
top-level item to end with a newline, comment, or EOF, but got 's'
instead
```

fixes #14093

Signed-off-by: Alwin Mark <a.mark@crowdfox.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
