### PR TITLE
[incubator/sentry-kubernetes] Allow using existing secrets

### DIFF
--- a/incubator/sentry-kubernetes/Chart.yaml
+++ b/incubator/sentry-kubernetes/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for sentry-kubernetes (https://github.com/getsentry/sentry-kubernetes)
 name: sentry-kubernetes
-version: 0.2.0
+version: 0.2.1
 appVersion: latest
 icon: https://sentry-brand.storage.googleapis.com/sentry-glyph-white.png
 home: https://github.com/getsentry/sentry-kubernetes

--- a/incubator/sentry-kubernetes/README.md
+++ b/incubator/sentry-kubernetes/README.md
@@ -15,6 +15,7 @@ The following table lists the configurable parameters of the sentry-kubernetes c
 | Parameter               | Description                                                                                                                 | Default                       |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
 | `sentry.dsn`            | Sentry dsn                                                                                                                  | Empty                         |
+| `existingSecret`        | Existing secret to read DSN from                                                                                           | Empty                         |
 | `sentry.environment`    | Sentry environment                                                                                                          | Empty                         |
 | `sentry.release`        | Sentry release                                                                                                              | Empty                         |
 | `sentry.logLevel`       | Sentry log level                                                                                                            | Empty                         |

--- a/incubator/sentry-kubernetes/templates/_helpers.tpl
+++ b/incubator/sentry-kubernetes/templates/_helpers.tpl
@@ -52,3 +52,24 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Get the DSN
+*/}}
+{{- define "sentry-kubernetes.secretName" -}}
+{{- if .Values.existingSecret -}}
+    {{- printf "%s" .Values.existingSecret -}}
+{{- else -}}
+    {{- printf "%s" (include "sentry-kubernetes.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if a secret object should be created
+*/}}
+{{- define "sentry-kubernetes.createSecret" -}}
+{{- if .Values.existingSecret -}}
+{{- else -}}
+    {{- true -}}
+{{- end -}}
+{{- end -}}

--- a/incubator/sentry-kubernetes/templates/deployment.yaml
+++ b/incubator/sentry-kubernetes/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
         checksum/secrets: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         app: {{ template "sentry-kubernetes.name" . }}
-        release: {{.Release.Name }}    
+        release: {{.Release.Name }}
     spec:
       containers:
       - name: {{ .Chart.Name }}
@@ -24,14 +24,14 @@ spec:
           - name: DSN
             valueFrom:
               secretKeyRef:
-                name: {{ template "sentry-kubernetes.fullname" . }}
+                name: {{ template "sentry-kubernetes.secretName" . }}
                 key: sentry.dsn
           {{ if .Values.sentry.environment }}
           - name: ENVIRONMENT
             value: {{ .Values.sentry.environment }}
           {{ end }}
           {{ if .Values.sentry.release }}
-          - name: RELEASE 
+          - name: RELEASE
             value: {{ .Values.sentry.release }}
           {{ end }}
           {{ if .Values.sentry.logLevel }}

--- a/incubator/sentry-kubernetes/templates/secret.yaml
+++ b/incubator/sentry-kubernetes/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if (include "sentry-kubernetes.createSecret" .) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,3 +7,4 @@ metadata:
 type: Opaque
 data:
   sentry.dsn: {{ .Values.sentry.dsn | b64enc | quote }}
+{{- end -}}

--- a/incubator/sentry-kubernetes/values.yaml
+++ b/incubator/sentry-kubernetes/values.yaml
@@ -3,6 +3,8 @@
 sentry:
   dsn: <change-me>
   logLevel: ~
+# Sentry DSN config using an existing secret:
+# existingSecret:
 image:
   repository: getsentry/sentry-kubernetes
   tag: latest


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR extends the sentry-kubernetes chart to allow the usage of existing secrets. This allows the usage of tools like sealed-secrets to provide the Sentry DSN in a secure way.

#### Special notes for your reviewer:

Greetings from Barcelona!

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
