### PR TITLE
[stable/elasticsearch] Allow elasticsearch client to be headless or specify an IP

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.27.2
+version: 1.27.3
 appVersion: 6.7.0
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/stable/elasticsearch/README.md
+++ b/stable/elasticsearch/README.md
@@ -86,7 +86,8 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `client.tolerations`                 | Client tolerations                                                  | `[]`                                                |
 | `client.serviceAnnotations`          | Client Service annotations                                          | `{}`                                                |
 | `client.serviceType`                 | Client service type                                                 | `ClusterIP`                                         |
-| `client.httpNodePort`                | Client service HTTP NodePort port number. Has no effect if client.serviceType is not `NodePort`.   | `nil`                                         |
+| `client.clusterIP`                   | Client ClusterIP setting. Allows for headless or specific IP         | `None`                                              |
+| `client.httpNodePort`                | Client service HTTP NodePort port number. Has no effect if client.serviceType is not `NodePort`.   | `nil`                |
 | `client.loadBalancerIP`              | Client loadBalancerIP                                               | `{}`                                                |
 | `client.loadBalancerSourceRanges`    | Client loadBalancerSourceRanges                                     | `{}`                                                |
 | `client.antiAffinity`                | Client anti-affinity policy                                         | `soft`                                              |
@@ -144,7 +145,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `data.nodeAffinity`                  | Data node affinity policy                                           | `{}`                                                |
 | `data.podManagementPolicy`           | Data pod creation strategy                                          | `OrderedReady`                                      |
 | `data.updateStrategy`                | Data node update strategy policy                                    | `{type: "onDelete"}`                                |
-| `sysctlInitContainer.enabled`        | If true, the sysctl init container is enabled (does not stop extraInitContainers from running) | `true`                                              |
+| `sysctlInitContainer.enabled`        | If true, the sysctl init container is enabled (does not stop extraInitContainers from running) | `true`                   |
 | `extraInitContainers`                | Additional init container passed through the tpl                    | ``                                                  |
 | `podSecurityPolicy.annotations`      | Specify pod annotations in the pod security policy                  | `{}`                                              |
 | `podSecurityPolicy.enabled`          | Specify if a pod security policy must be created                    | `false`                                             |

--- a/stable/elasticsearch/templates/client-svc.yaml
+++ b/stable/elasticsearch/templates/client-svc.yaml
@@ -31,6 +31,9 @@ spec:
     component: "{{ .Values.client.name }}"
     release: {{ .Release.Name }}
   type: {{ .Values.client.serviceType }}
+{{- if .Values.client.clusterIP }}
+  clusterIP: "{{ .Values.client.clusterIP }}"
+{{- end }}
 {{- if .Values.client.loadBalancerIP }}
   loadBalancerIP: "{{ .Values.client.loadBalancerIP }}"
 {{- end }}

--- a/stable/elasticsearch/values.yaml
+++ b/stable/elasticsearch/values.yaml
@@ -79,6 +79,9 @@ client:
   name: client
   replicas: 2
   serviceType: ClusterIP
+  ## If set it will either set to None the client service will be headless
+  # if set to a specific IP it will use that IP from the kube-proxy pool
+  clusterIP: "None"
   ## If coupled with serviceType = "NodePort", this will set a specific nodePort to the client HTTP port
   # httpNodePort: 30920
   loadBalancerIP: {}


### PR DESCRIPTION
Signed-off-by: Boris Kurktchiev <boris@diamanti.com>

#### What this PR does / why we need it:
Adds the ability for the elasticsearch client pool to be setup as a headless service for those instances where a Kubernetes cluster does not use kube-proxy as its CNI

#### Special notes for your reviewer:
@simonswine @icereval @rendhalver @desaintmartin

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
