### PR TITLE
[incubator/kafka] use latest version of zookeeper chart

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.15.3
+version: 0.15.4
 appVersion: 5.0.1
 keywords:
 - kafka

--- a/incubator/kafka/requirements.lock
+++ b/incubator/kafka/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: zookeeper
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  version: 1.2.0
-digest: sha256:48de211cbffc0b7df9995edc4fd5d693e8bbc94e684aa83c11e6f94803f0e8b9
-generated: 2018-11-26T17:47:36.893674-05:00
+  version: 1.3.1
+digest: sha256:c21214b1f44972d0c120e73c9ff4af5f420a1e6c5c387e0ef440a181c45f053e
+generated: 2019-05-23T15:54:57.740788654-04:00

--- a/incubator/kafka/requirements.yaml
+++ b/incubator/kafka/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: zookeeper
-  version: 1.2.0
+  version: 1.3.1
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
   condition: zookeeper.enabled
 


### PR DESCRIPTION
Signed-off-by: S.Cavallo <smcavallo@hotmail.com>

#### What this PR does / why we need it:

use latest version of zookeeper chart
1.2.0 -> 1.3.1

Revision Changes are below:
1.2.1 ->  https://github.com/helm/charts/commit/48503bacd1fb53edea643cc771b578c0c499ce9f#diff-0f9aa47eda1d12ca8dc821213a08d4c6
1.2.2 -> https://github.com/helm/charts/commit/2e5aa98d0e74a77b81f4485a0e0296afa029b074#diff-0f9aa47eda1d12ca8dc821213a08d4c6
1.3.0 -> https://github.com/helm/charts/commit/a79301082b1bd94b86ecd1dccaad9b24c9287f36#diff-0f9aa47eda1d12ca8dc821213a08d4c6
1.3.1 -> https://github.com/helm/charts/commit/5fbd2cbe7163b14d33778c33539270c6975de50d#diff-0f9aa47eda1d12ca8dc821213a08d4c6

#### Which issue this PR fixes
zookeeper fixes and enhancements
 - fixes secrets
 - fixes headless port
 - adds ability to use custom zk images

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X ] Chart Version bumped
- [X ] Variables are documented in the README.md
- [X ] Title of the PR starts with chart name (e.g. `[stable/chart]`)
