### PR TITLE
[incubator/vault] Fix liveness & readiness probes

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.18.7
+version: 0.18.8
 appVersion: 1.0.1
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -62,8 +62,8 @@ spec:
               {{- if .Values.vault.liveness.aliveIfSealed -}}sealedcode=204&{{- end }}
             port: {{ .Values.service.port }}
             scheme: {{ if .Values.vault.config.listener.tcp.tls_disable -}}HTTP{{- else -}}HTTPS{{- end }}
-            initialDelaySeconds: {{ .Values.vault.liveness.initialDelaySeconds }}
-            periodSeconds: {{ .Values.vault.liveness.periodSeconds }}
+          initialDelaySeconds: {{ .Values.vault.liveness.initialDelaySeconds }}
+          periodSeconds: {{ .Values.vault.liveness.periodSeconds }}
         readinessProbe:
           # Ready depends on preference
           httpGet:
@@ -73,8 +73,8 @@ spec:
               {{- if .Values.vault.readiness.readyIfUninitialized -}}uninitcode=204&{{- end }}
             port: {{ .Values.service.port }}
             scheme: {{ if .Values.vault.config.listener.tcp.tls_disable -}}HTTP{{- else -}}HTTPS{{- end }}
-            initialDelaySeconds: {{ .Values.vault.readiness.initialDelaySeconds }}
-            periodSeconds: {{ .Values.vault.readiness.periodSeconds }}
+          initialDelaySeconds: {{ .Values.vault.readiness.initialDelaySeconds }}
+          periodSeconds: {{ .Values.vault.readiness.periodSeconds }}
         securityContext:
           readOnlyRootFilesystem: true
           capabilities:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This fixes the default liveness and readiness probes. 
They were broken via: https://github.com/helm/charts/commit/1cd1614c5951ed68af7fb4de270376916c284ce5#diff-faec2cdc117dcf149b68f933ea781116
which added initialDelaySeconds and periodSeconds. These are is not a properties of httpGet, but are rather properties of livenessProbe or readinessProbe: http://kubernetes.io/docs/user-guide/liveness/

#### Special notes for your reviewer:
Before:

```
$ helm install --name vault \
        incubator/vault \
        --set vault.dev=true \
        --set vault.config.storage.consul.address="consul-consul:8500",vault.config.storage.consul.path="vault" \
        --namespace vault-project
Error: validation failed: error validating "": error validating data: [ValidationError(Deployment.spec.template.spec.containers[0].livenessProbe.httpGet): unknown field "initialDelaySeconds" in io.k8s.api.core.v1.HTTPGetAction, ValidationError(Deployment.spec.template.spec.containers[0].livenessProbe.httpGet): unknown field "periodSeconds" in io.k8s.api.core.v1.HTTPGetAction, ValidationError(Deployment.spec.template.spec.containers[0].readinessProbe.httpGet): unknown field "initialDelaySeconds" in io.k8s.api.core.v1.HTTPGetAction, ValidationError(Deployment.spec.template.spec.containers[0].readinessProbe.httpGet): unknown field "periodSeconds" in io.k8s.api.core.v1.HTTPGetAction]
```

After (via local chart):
```
$ helm install --name vault \
    ./vault \
    --set vault.dev=true 
    --set vault.config.storage.consul.address="consul- consul:8500",vault.config.storage.consul.path="vault" \
    --namespace vault-project
NAME:   vault
LAST DEPLOYED: Thu May 23 15:29:52 2019
NAMESPACE: vault-project
STATUS: DEPLOYED

RESOURCES:
==> v1/ConfigMap
NAME                     DATA  AGE
vault-vault-config  1     0s

==> v1/Pod(related)
NAME                               READY  STATUS             RESTARTS  AGE
vault-vault-6d869dc487-2gzw6  0/1    ContainerCreating  0         0s
vault-vault-6d869dc487-b9d6z  0/1    ContainerCreating  0         0s
vault-vault-6d869dc487-m6svr  0/1    ContainerCreating  0         0s

==> v1/Service
NAME              TYPE       CLUSTER-IP    EXTERNAL-IP  PORT(S)   AGE
vault-vault  ClusterIP  10.98.13.227  <none>       8200/TCP  0s

==> v1beta1/Deployment
NAME              READY  UP-TO-DATE  AVAILABLE  AGE
vault-vault  0/3    3           0          0s

==> v1beta1/PodDisruptionBudget
NAME              MIN AVAILABLE  MAX UNAVAILABLE  ALLOWED DISRUPTIONS  AGE
vault-vault  N/A            1                0                    0s


NOTES:
1. Get the application URL by running these commands:
  export POD_NAME=$(kubectl get pods --namespace vault-project -l "app=vault" -o jsonpath="{.items[0].metadata.name}")
  echo "Use http://127.0.0.1:8200 as the Vault address after forwarding."
  kubectl port-forward --namespace vault-project  $POD_NAME 8200:8200
```
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
