### PR TITLE
[stable/helm-exporter] Add OWNERS to helmignore

### DIFF
--- a/stable/helm-exporter/.helmignore
+++ b/stable/helm-exporter/.helmignore
@@ -19,3 +19,5 @@
 .project
 .idea/
 *.tmproj
+
+OWNERS

--- a/stable/helm-exporter/Chart.yaml
+++ b/stable/helm-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.4.0"
 description: Exports helm release stats to prometheus
 name: helm-exporter
-version: 0.2.3
+version: 0.2.4
 home: https://github.com/sstarcher/helm-exporter
 sources:
 - https://github.com/sstarcher/helm-exporter


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds OWNERS to `.helmignore` for stable/helm-exporter chart

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
