### PR TITLE
[stable/velero] Add volumeSnapshotLocation config parameters for GCP

### DIFF
--- a/stable/velero/Chart.yaml
+++ b/stable/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.0
 description: A Helm chart for velero
 name: velero
-version: 2.0.1
+version: 2.0.2
 home: https://github.com/heptio/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/stable/velero/README.md
+++ b/stable/velero/README.md
@@ -80,6 +80,8 @@ Parameter | Description | Default
 `configuration.volumeSnapshotLocation.config.region` | The cloud provider region (AWS only) | ``
 `configuration.volumeSnapshotLocation.config.apitimeout` | The API timeout (`azure` only) |
 `configuration.volumeSnapshotLocation.config.resourceGroup` | The name of the resource group where volume snapshots should be stored, if different from the cluster’s resource group. (Azure only) |
+`configuration.volumeSnapshotLocation.config.project` | The project ID where snapshots should be stored, if different than the project that your IAM account is in. (GCP only) |
+`configuration.volumeSnapshotLocation.config.snapshotLocation` | The location where the snapshots will be stored. (GCP only) |
 `credentials.existingSecret` | If specified and `useSecret` is `true`, uses an existing secret with this name instead of creating one | ``
 `credentials.useSecret` | Whether a secret should be used. Set this to `false` when using `kube2iam` | `true`
 `credentials.secretContents` | Contents for the credentials secret | `{}`

--- a/stable/velero/templates/volumesnapshotlocation.yaml
+++ b/stable/velero/templates/volumesnapshotlocation.yaml
@@ -22,6 +22,12 @@ spec:
   {{- with .resourceGroup }}
     resourceGroup: {{ . }}
   {{- end }}
+  {{- with .snapshotLocation }}
+    snapshotLocation: {{ . }}
+  {{- end}}
+  {{- with .project }}
+    project: {{ . }}
+  {{- end}}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/velero/values.yaml
+++ b/stable/velero/values.yaml
@@ -93,6 +93,9 @@ configuration:
     config: {}
   #    region:
   #    apitimeout:
+  #    resourceGroup:
+  #    snapshotLocation:
+  #    project:
 
   # These are server-level settings passed as CLI flags to the `velero server` command. Velero
   # uses default values if they're not passed in, so they only need to be explicitly specified


### PR DESCRIPTION
Signed-off-by: Cyrill Troxler <cyrill@nine.ch>

#### What this PR does / why we need it:
This adds two parameters to the `volumeSnapshotLocation` config for GCP that have been recently added to Velero: https://velero.io/docs/v1.0.0/api-types/volumesnapshotlocation/#gcp

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
