### PR TITLE
[stable/kibana] Set hosts as env var only

### DIFF
--- a/stable/kibana/Chart.yaml
+++ b/stable/kibana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kibana
-version: 3.0.0
+version: 3.1.0
 appVersion: 6.7.0
 description: Kibana is an open source data visualization plugin for Elasticsearch
 icon: https://raw.githubusercontent.com/elastic/kibana/master/src/ui/public/icons/kibana-color.svg

--- a/stable/kibana/Chart.yaml
+++ b/stable/kibana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kibana
-version: 3.1.0
+version: 3.0.1
 appVersion: 6.7.0
 description: Kibana is an open source data visualization plugin for Elasticsearch
 icon: https://raw.githubusercontent.com/elastic/kibana/master/src/ui/public/icons/kibana-color.svg

--- a/stable/kibana/README.md
+++ b/stable/kibana/README.md
@@ -141,7 +141,7 @@ $ helm install stable/kibana --name my-release -f values.yaml
 
 ## Upgrading
 
-### To 3.1.0
+### To 3.0.1
 
 Elasticsearch url/hosts now only managed via ENV_VAR by default. There is no longer a default value within `.Values.files.kibana.yml`.
 

--- a/stable/kibana/README.md
+++ b/stable/kibana/README.md
@@ -141,6 +141,10 @@ $ helm install stable/kibana --name my-release -f values.yaml
 
 ## Upgrading
 
+### To 3.1.0
+
+Elasticsearch url/hosts now only managed via ENV_VAR by default. There is no longer a default value within `.Values.files.kibana.yml`.
+
 ### To 2.3.0
 
 The default value of `elasticsearch.url` (for kibana < 6.6) has been removed in favor of `elasticsearch.hosts` (for kibana >= 6.6).

--- a/stable/kibana/values.yaml
+++ b/stable/kibana/values.yaml
@@ -10,12 +10,12 @@ testFramework:
 commandline:
   args: []
 
-env: {}
+env:
   ## All Kibana configuration options are adjustable via env vars.
   ## To adjust a config option to an env var uppercase + replace `.` with `_`
   ## Ref: https://www.elastic.co/guide/en/kibana/current/settings.html
   ## For kibana < 6.6, use ELASTICSEARCH_URL instead
-  # ELASTICSEARCH_HOSTS: http://elasticsearch-client:9200
+  ELASTICSEARCH_HOSTS: http://elasticsearch-client:9200
   # SERVER_PORT: 5601
   # LOGGING_VERBOSE: "true"
   # SERVER_DEFAULTROUTE: "/app/kibana"
@@ -25,8 +25,6 @@ files:
     ## Default Kibana configuration from kibana-docker.
     server.name: kibana
     server.host: "0"
-    ## For kibana < 6.6, use elasticsearch.url instead
-    elasticsearch.hosts: http://elasticsearch:9200
 
     ## Custom config properties below
     ## Ref: https://www.elastic.co/guide/en/kibana/current/settings.html


### PR DESCRIPTION
Signed-off-by: Naseem <naseemkullah@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

setting `elasticsearch.hosts` by default in `kibana.yml` causes issues if pinning kibana to version < 6.6

This was brought up here https://github.com/helm/charts/issues/14062#issue-447128407

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #14062

#### Special notes for your reviewer:

cc @monotek @desaintmartin @Towmeykaw @mjrepo2

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
