### PR TITLE
[stable/kong] Add proxy.externalTrafficPolicy to the configuration

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.11.1
+version: 0.11.2
 appVersion: 1.1

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -82,6 +82,7 @@ and their default values.
 | proxy.loadBalancerSourceRanges | Limit proxy access to CIDRs if set and service type is `LoadBalancer`            | `[]`                |
 | proxy.loadBalancerIP           | To reuse an existing ingress static IP for the admin service                     |                     |
 | proxy.externalIPs              | IPs for which nodes in the cluster will also accept traffic for the proxy        | `[]`                |
+| proxy.externalTrafficPolicy    | k8s service's externalTrafficPolicy. Options: Cluster, Local                     |                     |
 | proxy.ingress.enabled          | Enable ingress resource creation (works with proxy.type=ClusterIP)               | `false`             |
 | proxy.ingress.tls              | Name of secret resource, containing TLS secret                                   |                     |
 | proxy.ingress.hosts            | List of ingress hosts.                                                           | `[]`                |

--- a/stable/kong/templates/service-kong-proxy.yaml
+++ b/stable/kong/templates/service-kong-proxy.yaml
@@ -47,6 +47,10 @@ spec:
   {{- end }}
     protocol: TCP
   {{- end }}
+  {{- if .Values.proxy.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.proxy.externalTrafficPolicy }}
+  {{- end }}
+
   selector:
     app: {{ template "kong.name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
Add proxy.externalTrafficPolicy to the configuration to allow configuring externalTrafficPolicy on kong-proxy SVC

Signed-off-by: Benoît Ngô <ngobenoit@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR add the configuration proxy.externalTrafficPolicy to allow configuring externalTrafficPolicy on kong-proxy SVC.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ X ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ X ] Chart Version bumped
- [ X ] Variables are documented in the README.md
- [ X ] Title of the PR starts with chart name (e.g. `[stable/chart]`)
