### PR TITLE
[stable/jenkins] Support servicemonitor and alerting rules

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.1.21
+version: 1.1.22
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -145,6 +145,12 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.jenkinsUriPrefix`         | Root Uri Jenkins will be served on   | Not set                                   |
 | `master.customInitContainers`     | Custom init-container specification in raw-yaml format | Not set                 |
 | `master.lifecycle`                | Lifecycle specification for master-container | Not set                           |
+| `master.prometheus.enabled`       | Enables prometheus service monitor | `false`                                     |
+| `master.prometheus.serviceMonitorAdditionalLabels` | Additional labels to add to the service monitor object | `{}`                       |
+| `master.prometheus.scrapeInterval` | How often prometheus should scrape metrics | `60s`                              |
+| `master.prometheus.scrapeEndpoint` | The endpoint prometheus should get metrics from | `/prometheus`                 |
+| `master.prometheus.alertingrules` | Array of prometheus alerting rules | `[]`                                        |
+| `master.prometheus.alertingRulesAdditionalLabels` | Additional labels to add to the prometheus rule object     | `{}`                                   |
 | `master.priorityClassName`        | The name of a `priorityClass` to apply to the master pod | Not set               |
 | `networkPolicy.enabled`           | Enable creation of NetworkPolicy resources. | `false`                            |
 | `networkPolicy.apiVersion`        | NetworkPolicy ApiVersion             | `networking.k8s.io/v1`                    |

--- a/stable/jenkins/templates/jenkins-master-alerting-rules.yaml
+++ b/stable/jenkins/templates/jenkins-master-alerting-rules.yaml
@@ -9,6 +9,7 @@ metadata:
     "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
     "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
+    "app.kubernetes.io/component": "{{ .Values.master.componentName }}"
     {{- range $key, $val := .Values.master.prometheus.alertingRulesAdditionalLabels }}
     {{ $key }}: {{ $val | quote }}
     {{- end}}

--- a/stable/jenkins/templates/jenkins-master-alerting-rules.yaml
+++ b/stable/jenkins/templates/jenkins-master-alerting-rules.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.master.prometheus.enabled .Values.master.prometheus.alertingrules }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "jenkins.fullname" . }}
+  labels:
+    "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
+    "app.kubernetes.io/instance": "{{ .Release.Name }}"
+    {{- range $key, $val := .Values.master.prometheus.alertingRulesAdditionalLabels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end}}
+spec:
+  groups:
+{{ toYaml .Values.master.prometheus.alertingrules | indent 2 }}
+{{- end }}

--- a/stable/jenkins/templates/jenkins-master-servicemonitor.yaml
+++ b/stable/jenkins/templates/jenkins-master-servicemonitor.yaml
@@ -28,4 +28,5 @@ spec:
       "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
       "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
       "app.kubernetes.io/instance": "{{ .Release.Name }}"
+      "app.kubernetes.io/component": "{{ .Values.master.componentName }}"
 {{- end }}

--- a/stable/jenkins/templates/jenkins-master-servicemonitor.yaml
+++ b/stable/jenkins/templates/jenkins-master-servicemonitor.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.master.prometheus.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+
+metadata:
+  name: {{ template "jenkins.fullname" . }}
+  labels:
+    "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
+    "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    "app.kubernetes.io/managed-by": "{{ .Release.Service }}"
+    "app.kubernetes.io/instance": "{{ .Release.Name }}"
+    "app.kubernetes.io/component": "{{ .Values.master.componentName }}"
+    {{- range $key, $val := .Values.master.prometheus.serviceMonitorAdditionalLabels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end}}
+
+spec:
+  endpoints:
+  - interval: {{ .Values.master.prometheus.scrapeInterval }}
+    port: http
+    path: {{ .Values.master.prometheus.scrapeEndpoint }}
+  jobLabel: {{ template "jenkins.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - "{{ $.Release.Namespace }}"
+  selector:
+    matchLabels:
+      "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
+      "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      "app.kubernetes.io/instance": "{{ .Release.Name }}"
+{{- end }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -310,6 +310,23 @@ master:
   #   hostnames:
   #     - other.local
 
+  # Expose Prometheus metrics
+  prometheus:
+    # If enabled, add the prometheus plugin to the list of plugins to install
+    # https://plugins.jenkins.io/prometheus
+    enabled: false
+    # Additional labels to add to the ServiceMonitor object
+    serviceMonitorAdditionalLabels: {}
+    scrapeInterval: 60s
+    # This is the default endpoint used by the prometheus plugin
+    scrapeEndpoint: /prometheus
+    # Additional labels to add to the PrometheusRule object
+    alertingRulesAdditionalLabels: {}
+    # An array of prometheus alerting rules
+    # See here: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+    # The `groups` root object is added by default, simply add the rule entries
+    alertingrules: []
+
 agent:
   enabled: true
   image: "jenkins/jnlp-slave"


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Adds support for adding Prometheus service monitor and alerting rules

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
