### PR TITLE
[stable/rocketchat] Add Affinities, podAntiAffinity and PodDisruptionBudget

### DIFF
--- a/stable/rocketchat/Chart.yaml
+++ b/stable/rocketchat/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rocketchat
-version: 1.1.2
+version: 1.1.3
 appVersion: 1.0.3
 description: Prepare to take off with the ultimate chat platform, experience the next level of team communications
 keywords:

--- a/stable/rocketchat/README.md
+++ b/stable/rocketchat/README.md
@@ -53,6 +53,10 @@ Parameter | Description | Default
 `smtp.host` | Hostname of the SMTP server | `""`
 `smtp.port` | Port of the SMTP server | `587`
 `extraEnv` | Extra environment variables for Rocket.Chat. Used with `tpl` function, so this needs to be a string | `""`
+`podAntiAffinity` | Pod anti-affinity can prevent the scheduler from placing RocketChat replicas on the same node. The default value "soft" means that the scheduler should *prefer* to not schedule two replica pods onto the same node but no guarantee is provided. The value "hard" means that the scheduler is *required* to not schedule two replica pods onto the same node. The value "" will disable pod anti-affinity so that no anti-affinity rules will be configured. | `""` |
+`podAntiAffinityTopologyKey` | If anti-affinity is enabled sets the topologyKey to use for anti-affinity. This can be changed to, for example `failure-domain.beta.kubernetes.io/zone`| `kubernetes.io/hostname` |
+| `affinity` | Assign custom affinity rules to the RocketChat instance https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ | `{}` |
+`minAvailable` | Minimum number / percentage of pods that should remain scheduled | `1` |
 `externalMongodbUrl` | MongoDB URL if using an externally provisioned MongoDB | `""`
 `externalMongodbOplogUrl` | MongoDB OpLog URL if using an externally provisioned MongoDB. Required if `externalMongodbUrl` is set | `""`
 `mongodb.enabled` | Enable or disable MongoDB dependency. Refer to the [stable/mongodb docs](https://github.com/helm/charts/tree/master/stable/mongodb#configuration) for more information | `true`

--- a/stable/rocketchat/templates/deployment.yaml
+++ b/stable/rocketchat/templates/deployment.yaml
@@ -89,3 +89,27 @@ spec:
       {{- else }}
         emptyDir: {}
       {{- end }}
+{{- if or .Values.podAntiAffinity .Values.affinity }}
+      affinity:
+{{- if .Values.affinity }}
+{{ toYaml .Values.affinity | indent 4 }}
+{{- end }}
+{{- if eq .Values.podAntiAffinity "hard" }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: {{ .Values.podAntiAffinityTopologyKey }}
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: {{ include "rocketchat.name" . }}
+{{- else if eq .Values.podAntiAffinity "soft" }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: {{ .Values.podAntiAffinityTopologyKey }}
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: {{ include "rocketchat.name" . }}
+                  app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+{{- end }}

--- a/stable/rocketchat/templates/poddisruptionbudget.yaml
+++ b/stable/rocketchat/templates/poddisruptionbudget.yaml
@@ -1,0 +1,17 @@
+{{- if gt .Values.replicaCount 1.0 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "rocketchat.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  name: {{ template "rocketchat.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "rocketchat.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  minAvailable: {{ .Values.minAvailable }}
+{{- end }}

--- a/stable/rocketchat/values.yaml
+++ b/stable/rocketchat/values.yaml
@@ -11,6 +11,7 @@ image:
 # host:
 
 replicaCount: 1
+minAvailable: 1
 
 smtp:
   enabled: false
@@ -25,6 +26,32 @@ extraEnv:  # |
   #   value: '{"ssl": "true"}'
   # - name: MONGO_OPLOG_URL
   #   value: mongodb://oploguser:password@rocket-1:27017/local&replicaSet=rs0
+
+## Pod anti-affinity can prevent the scheduler from placing RocketChat replicas on the same node.
+## The default value "soft" means that the scheduler should *prefer* to not schedule two replica pods onto the same node but no guarantee is provided.
+## The value "hard" means that the scheduler is *required* to not schedule two replica pods onto the same node.
+## The value "" will disable pod anti-affinity so that no anti-affinity rules will be configured.
+##
+podAntiAffinity: ""
+
+## If anti-affinity is enabled sets the topologyKey to use for anti-affinity.
+## This can be changed to, for example, failure-domain.beta.kubernetes.io/zone
+##
+podAntiAffinityTopologyKey: kubernetes.io/hostname
+
+## Assign custom affinity rules to the RocketChat instance
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+##
+affinity: {}
+# nodeAffinity:
+#   requiredDuringSchedulingIgnoredDuringExecution:
+#     nodeSelectorTerms:
+#     - matchExpressions:
+#       - key: kubernetes.io/e2e-az-name
+#         operator: In
+#         values:
+#         - e2e-az1
+#         - e2e-az2
 
 ## MongoDB URL if using an externally provisioned MongoDB
 externalMongodbUrl:  # mongodb://user:password@localhost:27017/rocketchat


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

* RocketChat makes it possible to set a replica count > 1. When running with multiple replicas, it should be possible to:
  * Make sure they are running on different nodes (Affinities)
  * Prevent node evictions to trigger service outages (PodDisruptionBudget)

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### How to test

* Affinities
```yaml
# values.yaml:
podAntiAffinity: hard
```

```sh
kubectl scale deployments -l app.kubernetes.io/name=rocketchat --replicas=$HIGHER_THAN_NODE_COUNT
```
It should have multiple pods pending with and `kubectl describe pod` on the pending pods should tell something like `0/3 nodes are available: 3 node(s) didn't match pod affinity/anti-affinity, 3 node(s) didn't match pod anti-affinity rules.`

* PodDisruptionBudget
```yaml
replicaCount: 3
```

```sh
kubectl describe poddisruptionbudgets.policy

Status:
    Allowed disruptions:  2
    Current:              3
    Desired:              1
    Total:                3
```

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
