### PR TITLE
[stable/sentry] Fix sentry icon

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 1.3.7
+version: 1.3.8
 appVersion: 9.0
 keywords:
   - debugging
@@ -9,7 +9,7 @@ keywords:
 sources:
   - https://github.com/getsentry/sentry
 home: https://sentry.io/
-icon: https://sentry.io/_static/getsentry/images/branding/png/sentry-glyph-black.png
+icon: https://sentry-brand.storage.googleapis.com/sentry-glyph-black.png
 maintainers:
   - name: rothgar
     email: justin@linux.com


### PR DESCRIPTION
The sentry icon is currently broken. See https://hub.helm.sh/charts?q=sentry

Fix icon based on https://sentry.io/branding/
This PR updates the URL to use a supported link that is not likely to get broken (see https://sentry.io/branding/)


<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] title of the PR contains starts with chart name e.g. `[stable/chart]`