### PR TITLE
[stable/mongodb-replicaset] Add quotes around annotation values while rendering StatefulSet

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.9.4
+version: 3.9.5
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -341,7 +341,7 @@ spec:
         name: datadir
         annotations:
         {{- range $key, $value := .Values.persistentVolume.annotations }}
-          {{ $key }}: {{ $value }}
+          {{ $key }}: "{{ $value }}"
         {{- end }}
       spec:
         accessModes:


### PR DESCRIPTION
Proposed fix for https://github.com/helm/charts/issues/14139. Very simple patch adding quotes to annotation values. If left unquoted, numbers are misrepresented as integers by the api server and `helm install` fails.