### PR TITLE
[stable/traefik] Added traefik service monitor

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.75.1
+version: 1.76.0
 appVersion: 1.7.12
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -204,6 +204,11 @@ The following table lists the configurable parameters of the Traefik chart and t
 | `metrics.prometheus.enabled`           | Whether to enable the `/metrics` endpoint for metric collection by Prometheus.                                               | `false`                                           |
 | `metrics.prometheus.restrictAccess`    | Whether to limit access to the metrics port (8080) to the dashboard service. When `false`, it is accessible on the main Traefik service as well. | `false`                       |
 | `metrics.prometheus.buckets`           | A list of response times (in seconds) - for each list element, Traefik will report all response times less than the element. | `[0.1,0.3,1.2,5]`                                 |
+| `metrics.prometheus.serviceMonitor.enabled` | Set this to `true` to create ServiceMonitor for Prometheus operator
+                     | `false`                                           |
+| `metrics.prometheus.serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus                          | `{}`                                              |
+| `metrics.prometheus.serviceMonitor.namespace` | namespace where servicemonitor resource should be created
+                     | `the same namespace as traefik`                   |
 | `metrics.datadog.enabled`              | Whether to enable pushing metrics to Datadog.                                                                                | `false`                                           |
 | `metrics.datadog.address`              | Datadog host in the format <hostname>:<port>                                                                                 | `localhost:8125`                                  |
 | `metrics.datadog.pushInterval`         | How often to push metrics to Datadog.                                                                                        | `10s`                                             |

--- a/stable/traefik/templates/service-monitor.yaml
+++ b/stable/traefik/templates/service-monitor.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.metrics.prometheus.enabled .Values.metrics.prometheus.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "traefik.fullname" . }}
+  {{- if .Values.metrics.prometheus.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.prometheus.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: {{ template "traefik.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    {{- if .Values.metrics.prometheus.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.metrics.prometheus.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      interval: 30s
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "traefik.name" . }}
+      release: "{{ .Release.Name }}"
+{{- end }}

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -408,6 +408,10 @@ metrics:
     ## it to the dashboard service only
     restrictAccess: false
     # buckets: [0.1,0.3,1.2,5]
+    serviceMonitor:
+      enabled: false
+      namespace: ""
+      additionalLabels: {}
   datadog:
     enabled: false
     # address: localhost:8125


### PR DESCRIPTION
Added a traefik service monitor for Prometheus Operator.
Following similar pattern to nginx-ingress controller.

Signed-off-by: John Dewey <john@dewey.ws>

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
