### PR TITLE
[stable/locust] fix locust workers cannot find master

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: locust
 description: A modern load testing framework
-version: 1.1.0
+version: 1.1.1
 appVersion: 0.9.0
 maintainers:
   - name: so0k

--- a/stable/locust/templates/worker-deploy.yaml
+++ b/stable/locust/templates/worker-deploy.yaml
@@ -42,7 +42,7 @@ spec:
         - name: LOCUST_MASTER
           value: {{ template "locust.master-svc" . }}
         - name: LOCUST_MASTER_WEB
-          value: "{{ .Values.service.internalPort }}"
+          value: "{{ .Values.service.externalPort }}"
         - name: TARGET_HOST
           value: {{ index .Values.master.config "target-host" | quote }}
         resources:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
- This PR make worker pods access to master via `service.externalPort`.
- In previous implementation, locust workers couldn't find master if `service.externalPort` != `service.internalPort` because workers used `service.internalPort` .
    - `service.externalPort` is a service port for a master pod.
    - `service.internalPort` is a service targetPort and containerPort for a master pod.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
