### PR TITLE
[stable/prometheus-node-exporter] Fix extraArgs type

### DIFF
--- a/stable/prometheus-node-exporter/Chart.yaml
+++ b/stable/prometheus-node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.18.0"
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 1.5.0
+version: 1.5.1
 home: https://github.com/prometheus/node_exporter/
 sources:
 - https://github.com/prometheus/node_exporter/

--- a/stable/prometheus-node-exporter/values.yaml
+++ b/stable/prometheus-node-exporter/values.yaml
@@ -86,7 +86,7 @@ tolerations:
 
 ## Additional container arguments
 ##
-extraArgs: {}
+extraArgs: []
 #   - --collector.diskstats.ignored-devices=^(ram|loop|fd|(h|s|v)d[a-z]|nvme\\d+n\\d+p)\\d+$
 
 ## Additional mounts from the host


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
  - fixes #14147

#### Special notes for your reviewer:
Readme.md already specifies this as a list, but it default to dict. This behavious is causing prometheus-operator installation to fail (it assumes list, as defined in readme)
