### PR TITLE
[stable/ambassador]: allow get,list,watch on CRDs

### DIFF
--- a/stable/ambassador/Chart.yaml
+++ b/stable/ambassador/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.70.1
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 2.6.1
+version: 2.6.2
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/stable/ambassador/templates/rbac.yaml
+++ b/stable/ambassador/templates/rbac.yaml
@@ -23,6 +23,9 @@ rules:
   - apiGroups: [ "getambassador.io" ]
     resources: [ "*" ]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [ "apiextensions.k8s.io" ]
+    resources: [ "customresourcedefinitions" ]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- if .Values.rbac.namespaced }}


### PR DESCRIPTION
@Flydiverny @kflynn @nbkrause 


#### What this PR does / why we need it:
Currently, with chart version 2.6.1, ambassador can't see the CRDs it created (a new check was added with 2.6.1, this was not done before). As a consequence, ambassador disabled CRD support entirely.
Working with the CRDs itself works, but the new check needs get/list permission on CRDs in general. This PR adds this required permission

There was an official patch for ambassador reference YAMLs, but it didnt make it into the Chart it seems. Look here: https://github.com/datawire/ambassador/commit/c0ccd8ecd56f8d03a509d46fbbd0a2c8c5f53b43

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
