### PR TITLE
[stable/nginx-ingress] Remove stats dependency from metrics

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.6.13
+version: 1.6.14
 appVersion: 0.24.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -113,7 +113,7 @@ Parameter | Description | Default
 `controller.readinessProbe.successThreshold` | Minimum consecutive successes for the probe to be considered successful after having failed. | 1
 `controller.readinessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded. | 3
 `controller.readinessProbe.port` | The port number that the readiness probe will listen on. | 10254
-`controller.stats.enabled` | if `true`, enable "vts-status" page | `false`
+`controller.stats.enabled` | if `true`, enable status page | `false`
 `controller.stats.service.annotations` | annotations for controller stats service | `{}`
 `controller.stats.service.clusterIP` | internal controller stats cluster service IP | `""`
 `controller.stats.service.omitClusterIP` | To omit the `clusterIP` from the stats service | `false`
@@ -121,7 +121,7 @@ Parameter | Description | Default
 `controller.stats.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `controller.stats.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 `controller.stats.service.type` | type of controller stats service to create | `ClusterIP`
-`controller.metrics.enabled` | if `true`, enable Prometheus metrics (`controller.stats.enabled` must be `true` as well) | `false`
+`controller.metrics.enabled` | if `true`, enable Prometheus metrics | `false`
 `controller.metrics.service.annotations` | annotations for Prometheus metrics service | `{}`
 `controller.metrics.service.clusterIP` | cluster IP address to assign to service | `""`
 `controller.metrics.service.omitClusterIP` | To omit the `clusterIP` from the metrics service | `false`
@@ -196,11 +196,10 @@ else it would make it impossible to evacuate a node. See [gh issue #7127](https:
 
 ## Prometheus Metrics
 
-The Nginx ingress controller can export Prometheus metrics. In order for this to work, the VTS dashboard must be enabled as well.
+The Nginx ingress controller can export Prometheus metrics.
 
 ```console
 $ helm install stable/nginx-ingress --name my-release \
-    --set controller.stats.enabled=true \
     --set controller.metrics.enabled=true
 ```
 

--- a/stable/nginx-ingress/templates/controller-configmap.yaml
+++ b/stable/nginx-ingress/templates/controller-configmap.yaml
@@ -9,7 +9,6 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.controller.fullname" . }}
 data:
-  enable-vts-status: "{{ .Values.controller.stats.enabled }}"
 {{- if .Values.controller.headers }}
   proxy-set-headers: {{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-custom-headers
 {{- end }}

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -134,11 +134,11 @@ spec:
               {{- if .Values.controller.daemonset.useHostPort }}
               hostPort: {{ .Values.controller.daemonset.hostPorts.stats }}
               {{- end }}
-            {{- if .Values.controller.metrics.enabled }}
+          {{- end }}
+          {{- if .Values.controller.metrics.enabled }}
             - name: metrics
               containerPort: 10254
               protocol: TCP
-            {{- end }}
           {{- end }}
           {{- range $key, $value := .Values.tcp }}
             - name: "{{ $key }}-tcp"

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -126,11 +126,11 @@ spec:
             - name: stats
               containerPort: 18080
               protocol: TCP
-            {{- if .Values.controller.metrics.enabled }}
+          {{- end }}
+          {{- if .Values.controller.metrics.enabled }}
             - name: metrics
               containerPort: 10254
               protocol: TCP
-            {{- end }}
           {{- end }}
           {{- range $key, $value := .Values.tcp }}
             - name: "{{ $key }}-tcp"

--- a/stable/nginx-ingress/templates/controller-metrics-service.yaml
+++ b/stable/nginx-ingress/templates/controller-metrics-service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.controller.stats.enabled .Values.controller.metrics.enabled }}
+{{- if .Values.controller.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/stable/nginx-ingress/templates/controller-servicemonitor.yaml
+++ b/stable/nginx-ingress/templates/controller-servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.metrics.enabled .Values.controller.metrics.serviceMonitor.enabled }}
+{{- if and .Values.controller.metrics.enabled .Values.controller.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/stable/nginx-ingress/templates/controller-servicemonitor.yaml
+++ b/stable/nginx-ingress/templates/controller-servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.controller.stats.enabled .Values.controller.metrics.enabled .Values.controller.metrics.serviceMonitor.enabled }}
+{{- if .Values.controller.metrics.enabled .Values.controller.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -267,8 +267,7 @@ controller:
       servicePort: 18080
       type: ClusterIP
 
-  ## If controller.stats.enabled = true and controller.metrics.enabled = true, Prometheus metrics will be exported
-  ##
+  
   metrics:
     enabled: false
 

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -267,7 +267,7 @@ controller:
       servicePort: 18080
       type: ClusterIP
 
-  
+
   metrics:
     enabled: false
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
VTS has been removed from nginx-ingress since June 2018 and now we have only a simple stats page at port 18080:
https://github.com/kubernetes/ingress-nginx/pull/2643/files

Now Prometheus metrics are exported directly without VTS

This PR remove stats dependency from metrics and remove the vts configmap option.

#### Which issue this PR fixes
No issue ATM

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
