### PR TITLE
[stable/prometheus] Fixed type for allowedHostPaths

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 8.11.4
+version: 8.11.5
 appVersion: 2.9.2
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/node-exporter-podsecuritypolicy.yaml
+++ b/stable/prometheus/templates/node-exporter-podsecuritypolicy.yaml
@@ -19,7 +19,7 @@ spec:
     - 'configMap'
     - 'hostPath'
     - 'secret'
-  AllowedHostPaths:
+  allowedHostPaths:
     - pathPrefix: /proc
       readOnly: true
     - pathPrefix: /sys


### PR DESCRIPTION
Signed-off-by: Florian Buchmeier <b.florian.86@gmail.com>

#### What this PR does / why we need it:

Typo in node-exporter pod security policy template. Should read `allowedHostPaths` instead of `AllowedHostPaths`

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
