### PR TITLE
[stable/openebs]: remove pre-install hook from secret and update labels

### DIFF
--- a/stable/openebs/Chart.yaml
+++ b/stable/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.9.1
+version: 0.9.2
 name: openebs
 appVersion: 0.9.0
 description: Containerized Storage for Containers

--- a/stable/openebs/README.md
+++ b/stable/openebs/README.md
@@ -65,6 +65,7 @@ The following table lists the configurable parameters of the OpenEBS chart and t
 | `ndm.sparse.count`                      | Number of sparse files to be created          | `1`                                       |
 | `ndm.filters.excludeVendors`            | Exclude devices with specified vendor         | `CLOUDBYT,OpenEBS`                        |
 | `ndm.filters.excludePaths`              | Exclude devices with specified path patterns  | `loop,fd0,sr0,/dev/ram,/dev/dm-,/dev/md`  |
+| `ndm.filters.includePaths`              | Include devices with specified path patterns  | `""`                                      |
 | `jiva.image`                            | Image for Jiva                                | `quay.io/openebs/jiva`                    |
 | `jiva.imageTag`                         | Image Tag for Jiva                            | `0.9.0`                                   |
 | `jiva.replicas`                         | Number of Jiva Replicas                       | `3`                                       |

--- a/stable/openebs/templates/cm-node-disk-manager.yaml
+++ b/stable/openebs/templates/cm-node-disk-manager.yaml
@@ -38,6 +38,6 @@ data:
       - key: path-filter
         name: path filter
         state: true
-        include: ""
+        include: "{{ .Values.ndm.filters.includePaths }}"
         exclude: "{{ .Values.ndm.filters.excludePaths }}"
 ---

--- a/stable/openebs/templates/daemonset-ndm.yaml
+++ b/stable/openebs/templates/daemonset-ndm.yaml
@@ -8,7 +8,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: ndm
-    openebs.io/component-name: ndm
 spec:
   updateStrategy:
     type: "RollingUpdate"
@@ -23,6 +22,8 @@ spec:
         app: {{ template "openebs.name" . }}
         release: {{ .Release.Name }}
         component: ndm
+        openebs.io/component-name: ndm
+        name: openebs-ndm
         openebs.io/version: {{ .Values.release.version }}
     spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}

--- a/stable/openebs/templates/deployment-admission-server.yaml
+++ b/stable/openebs/templates/deployment-admission-server.yaml
@@ -8,8 +8,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: admission-webhook
-    name: admission-webhook
-    openebs.io/component-name: maya-apiserver
 spec:
   replicas: {{ .Values.webhook.replicas }}
   selector:
@@ -19,7 +17,9 @@ spec:
     metadata:
       labels:
         app: admission-webhook
+        name: admission-webhook
         openebs.io/version: {{ .Values.release.version }}
+        openebs.io/component-name: admission-webhook
     spec:
 {{- if .Values.webhook.nodeSelector }}
       nodeSelector:

--- a/stable/openebs/templates/deployment-local-provisioner.yaml
+++ b/stable/openebs/templates/deployment-local-provisioner.yaml
@@ -8,7 +8,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: localpv-provisioner
-    openebs.io/component-name: openebs-localpv-provisioner
 spec:
   replicas: {{ .Values.provisioner.replicas }}
   selector:
@@ -21,7 +20,9 @@ spec:
         app: {{ template "openebs.name" . }}
         release: {{ .Release.Name }}
         component: localpv-provisioner
+        name: openebs-localpv-provisioner
         openebs.io/version: {{ .Values.release.version }}
+        openebs.io/component-name: openebs-localpv-provisioner
     spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}
       containers:

--- a/stable/openebs/templates/deployment-maya-apiserver.yaml
+++ b/stable/openebs/templates/deployment-maya-apiserver.yaml
@@ -9,7 +9,6 @@ metadata:
     heritage: {{ .Release.Service }}
     component: apiserver
     name: maya-apiserver
-    openebs.io/component-name: maya-apiserver
 spec:
   replicas: {{ .Values.apiserver.replicas }}
   selector:
@@ -23,6 +22,7 @@ spec:
         release: {{ .Release.Name }}
         component: apiserver
         name: maya-apiserver
+        openebs.io/component-name: maya-apiserver
         openebs.io/version: {{ .Values.release.version }}
     spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}

--- a/stable/openebs/templates/deployment-maya-provisioner.yaml
+++ b/stable/openebs/templates/deployment-maya-provisioner.yaml
@@ -8,7 +8,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: provisioner
-    openebs.io/component-name: openebs-provisioner
 spec:
   replicas: {{ .Values.provisioner.replicas }}
   selector:
@@ -21,6 +20,8 @@ spec:
         app: {{ template "openebs.name" . }}
         release: {{ .Release.Name }}
         component: provisioner
+        name: openebs-provisioner
+        openebs.io/component-name: openebs-provisioner
         openebs.io/version: {{ .Values.release.version }}
     spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}

--- a/stable/openebs/templates/deployment-maya-snapshot-operator.yaml
+++ b/stable/openebs/templates/deployment-maya-snapshot-operator.yaml
@@ -8,7 +8,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: snapshot-operator
-    openebs.io/component-name: openebs-snapshot-operator
 spec:
   replicas: {{ .Values.snapshotOperator.replicas }}
   selector:
@@ -23,7 +22,9 @@ spec:
         app: {{ template "openebs.name" . }}
         release: {{ .Release.Name }}
         component: snapshot-operator
+        name: openebs-snapshot-operator
         openebs.io/version: {{ .Values.release.version }}
+        openebs.io/component-name: openebs-snapshot-operator
     spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}
       containers:

--- a/stable/openebs/templates/validationwebhook.yaml
+++ b/stable/openebs/templates/validationwebhook.yaml
@@ -42,13 +42,6 @@ metadata:
     chart: {{ template "openebs.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  # Helm hook annotations in order to ensure that the certs
-  # will only be generated on chart install. This will
-  # prevent overriding the certs anytime we upgrade the chart’s
-  # released instance.
-  annotations:
-    "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 type: Opaque
 data:
 {{- if .Values.webhook.generateTLS }}

--- a/stable/openebs/values.yaml
+++ b/stable/openebs/values.yaml
@@ -80,6 +80,7 @@ ndm:
     count: "1"
   filters:
     excludeVendors: "CLOUDBYT,OpenEBS"
+    includePaths: ""
     excludePaths: "loop,fd0,sr0,/dev/ram,/dev/dm-,/dev/md"
   nodeSelector: {}
   healthCheck:


### PR DESCRIPTION

#### What this PR does / why we need it:

- Updated README
- Updated chart version
- Updated values.yaml
- Update pod labels for deployments

###Why we need this change:

`pre-install` hook: Executes after templates are rendered, but before any resources are created in Kubernetes.
This hook has been added to the secret , will only be generated on chart install,
 to prevent overriding the certs anytime we upgrade the chart’s released instance.

Thus `pre-install hook` prevents the secret creation if someone uses the older version of charts and upgraded to new version.

Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
