### PR TITLE
[stable/kafka-manager] use service.port for addClusters.sh during bootstrap

### DIFF
--- a/stable/kafka-manager/Chart.yaml
+++ b/stable/kafka-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka-manager
-version: 2.1.4
+version: 2.1.5
 appVersion: 1.3.3.22
 kubeVersion: "^1.8.0-0"
 description: A tool for managing Apache Kafka.

--- a/stable/kafka-manager/templates/configmap.yaml
+++ b/stable/kafka-manager/templates/configmap.yaml
@@ -14,7 +14,7 @@ data:
     #!/bin/bash
     set -e
     {{- range $cluster := .Values.clusters }}
-    {{ printf "curl http://%s:%d/clusters -X POST -f " (include "kafka-manager.fullname" $) (int64 $.Values.service.port) -}}
+    {{ printf "curl http://%s:%v/clusters -X POST -f " (include "kafka-manager.fullname" $) $.Values.service.port -}}
     {{- printf "-d name=%v " (default "default" $cluster.name) -}}
     {{- printf "-d zkHosts=%v " (default (include "kafka-manager.zkHosts" $) $cluster.zkHosts) -}}
     {{- printf "-d kafkaVersion=%v " (default "1.0.0" $cluster.kafkaVersion) -}}

--- a/stable/kafka-manager/templates/configmap.yaml
+++ b/stable/kafka-manager/templates/configmap.yaml
@@ -14,7 +14,7 @@ data:
     #!/bin/bash
     set -e
     {{- range $cluster := .Values.clusters }}
-    {{ printf "curl http://%s:9000/clusters -X POST -f " (include "kafka-manager.fullname" $) -}}
+    {{ printf "curl http://%s:%d/clusters -X POST -f " (include "kafka-manager.fullname" $) (int64 $.Values.service.port) -}}
     {{- printf "-d name=%v " (default "default" $cluster.name) -}}
     {{- printf "-d zkHosts=%v " (default (include "kafka-manager.zkHosts" $) $cluster.zkHosts) -}}
     {{- printf "-d kafkaVersion=%v " (default "1.0.0" $cluster.kafkaVersion) -}}


### PR DESCRIPTION
#### What this PR does / why we need it:
The service port number used to connect to kafka-manager during the bootstrap phase for configuring the Kafka clusters was hardcoded to 9000. With this change, the `service.port` value is used instead. This allows to change the service port number without breaking the bootstrapping.

#### Which issue this PR fixes
fixes #13615

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
