### PR TITLE
[stable/logstash]: add podManagementPolicy in statefulset

### DIFF
--- a/stable/logstash/Chart.yaml
+++ b/stable/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 1.11.0
+version: 1.12.0
 appVersion: 6.7.0
 sources:
 - https://www.docker.elastic.co

--- a/stable/logstash/README.md
+++ b/stable/logstash/README.md
@@ -100,6 +100,7 @@ The following table lists the configurable parameters of the chart and its defau
 | `podLabels`                     | Pod labels                                         | `{}`                                             |
 | `extraEnv`                      | Extra pod environment variables                    | `[]`                                             |
 | `extraInitContainers`           | Add additional initContainers                      | `[]`                                             |
+| `podManagementPolicy`          | podManagementPolicy of the StatefulSet              | `OrderedReady`                                   |
 | `livenessProbe`                 | Liveness probe settings for logstash container     | (see `values.yaml`)                              |
 | `readinessProbe`                | Readiness probe settings for logstash container    | (see `values.yaml`)                              |
 | `persistence.enabled`           | Enable persistence                                 | `true`                                           |

--- a/stable/logstash/templates/statefulset.yaml
+++ b/stable/logstash/templates/statefulset.yaml
@@ -10,6 +10,7 @@ metadata:
 spec:
   serviceName: {{ template "logstash.fullname" . }}
   replicas: {{ .Values.replicaCount }}
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
   selector:
     matchLabels:
       app: {{ template "logstash.name" . }}

--- a/stable/logstash/values.yaml
+++ b/stable/logstash/values.yaml
@@ -125,6 +125,8 @@ extraInitContainers: []
   #     - echo
   #     - hello
 
+podManagementPolicy: OrderedReady
+ # can be OrderReady or Parallel
 livenessProbe:
   httpGet:
     path: /


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR add in logstash the `Podmanagementpolicy` in the statefulset (can be `OrderedReady` or `Parallel`). `OrderedReady` is still the default value.
By default StatefulSet start pod once by once and wait for the previous one to be ready before starting the next one. It can be long to deploy. 


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/chart]`)
