### PR TITLE
[stable/datadog]add  mount log path

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.30.7
+version: 1.30.8
 appVersion: 6.10.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -218,6 +218,16 @@ spec:
           - name: pointerdir
             mountPath: /opt/datadog-agent/run
           {{- end }}
+          {{- if (and (.Values.datadog.logsEnabled) (.Values.datadog.logsConfigContainerCollectAll)) }}
+          - name: logpodpath
+            mountPath: /var/log/pods
+            readOnly: true
+          {{- if .Values.datadog.containerLogsPath }}
+          - name: logcontainerpath
+            mountPath: {{ .Values.datadog.containerLogsPath | quote }}
+            readOnly: true
+          {{- end }}
+          {{- end }}
           {{- if .Values.datadog.processAgentEnabled }}
           - name: passwd
             mountPath: /etc/passwd
@@ -273,6 +283,16 @@ spec:
         - hostPath:
             path: {{ default "/var/lib/datadog-agent/logs" .Values.datadog.logsPointerHostPath | quote }}
           name: pointerdir
+        {{- end }}
+        {{- if (and (.Values.datadog.logsEnabled) (.Values.datadog.logsConfigContainerCollectAll)) }}
+        - hostPath:
+            path: /var/log/pods
+          name: logpodpath
+        {{- if .Values.datadog.containerLogsPath }}
+        - hostPath:
+            path: {{ .Values.datadog.containerLogsPath | quote }}
+          name: logcontainerpath
+        {{- end }}  
         {{- end }}
         {{- if .Values.datadog.processAgentEnabled }}
         - hostPath:

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -174,6 +174,14 @@ datadog:
   #
   # logsConfigContainerCollectAll: false
 
+  ## @param containerLogsPath - string - optional - default: /var/lib/docker/containers
+  ## This to allow log collection from container log path. Set to a different path if not
+  ## using docker runtime.
+  ## ref: https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile#create-manifest
+  #
+  containerLogsPath: /var/lib/docker/containers
+
+
   ## @param apmEnabled - boolean - optional - default: false
   ## Enable this to enable APM and tracing, on port 8126
   ## ref: https://github.com/DataDog/docker-dd-agent#tracing-from-the-host


### PR DESCRIPTION
#### What this PR does / why we need it:
To mount the log directory for log collection when running datadog agent daemonset.

#### Which issue this PR fixes
NO

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
