### PR TITLE
[stable/velero] Render `extraEnvVars` even when not using credentials

### DIFF
--- a/stable/velero/Chart.yaml
+++ b/stable/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.0
 description: A Helm chart for velero
 name: velero
-version: 2.0.2
+version: 2.0.3
 home: https://github.com/heptio/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/stable/velero/templates/deployment.yaml
+++ b/stable/velero/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
             - name: scratch
               mountPath: /scratch
         {{- end }}
-          {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp") .Values.configuration.extraEnvVars) }}
+          {{- if (or (and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp"))) .Values.configuration.extraEnvVars) }}
           env:
           {{- end }}
           {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp")) }}

--- a/stable/velero/templates/deployment.yaml
+++ b/stable/velero/templates/deployment.yaml
@@ -78,22 +78,26 @@ spec:
               mountPath: /credentials
             - name: scratch
               mountPath: /scratch
+        {{- end }}
+          {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp") .Values.configuration.extraEnvVars) }}
           env:
-          {{- if eq $provider "aws" }}
-            - name: AWS_SHARED_CREDENTIALS_FILE
-          {{- else }}
-            - name: GOOGLE_APPLICATION_CREDENTIALS
           {{- end }}
+          {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp")) }}
+            {{- if eq $provider "aws" }}
+            - name: AWS_SHARED_CREDENTIALS_FILE
+            {{- else }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+            {{- end }}
               value: /credentials/cloud
             - name: VELERO_SCRATCH_DIR
               value: /scratch
-          {{ with .Values.configuration.extraEnvVars }}
+          {{- end }}
+          {{- with .Values.configuration.extraEnvVars }}
           {{- range $key, $value := . }}
             - name: {{ default "none" $key }}
               value: {{ default "none" $value }}
           {{- end }}
           {{- end }}
-        {{- end }}
 {{- if .Values.initContainers }}
       initContainers:
         {{- toYaml .Values.initContainers | nindent 8 }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
currently the logic in the deployment template does not render extraEnvVars if the credentials are not used
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #14130

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)