### PR TITLE
[stable/datadog] Fix process agent enable flag

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.30.7
+version: 1.30.8
 appVersion: 6.10.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/stable/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -47,7 +47,7 @@ spec:
           - {name: DD_EXTRA_CONFIG_PROVIDERS, value: "clusterchecks"}
           # Remove unused features
           - {name: DD_APM_ENABLED, value: "false"}
-          - {name: DD_PROCESS_AGENT_ENABLED, value: "false"}
+          - {name: DD_PROCESS_AGENT_ENABLED, value: "disabled"}
           - {name: DD_LOGS_ENABLED, value: "false"}
           # Safely run alongside the daemonset
           - {name: DD_ENABLE_METADATA_COLLECTION, value: "false"}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -180,12 +180,12 @@ datadog:
   #
   # apmEnabled: false
 
-  ## @param processAgentEnabled - boolean - optional - default: false
-  ## Enable this to activate live process monitoring.
+  ## @param processAgentEnabled - string - optional - default: disabled
+  ## Enable this (to true) to activate live process monitoring.
   ## Note: /etc/passwd is automatically mounted to allow username resolution.
   ## ref: https://docs.datadoghq.com/graphing/infrastructure/process/#kubernetes-daemonset
   #
-  # processAgentEnabled: false
+  # processAgentEnabled: disabled
 
   ## @param env - list of object - optional
   ## The dd-agent supports many environment variables


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

When using datadog agent image > 6.11.0  `DD_PROCESS_AGENT_ENABLED=false` doesn't work anymore you have to use `DD_PROCESS_AGENT_ENABLED=disabled` which also works with older verions

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
