### PR TITLE
[stable/anchore-engine] Fix simplequeue deployment template

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: anchore-engine
-version: 1.0.3
+version: 1.0.4
 appVersion: 0.4.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/simplequeue_deployment.yaml
+++ b/stable/anchore-engine/templates/simplequeue_deployment.yaml
@@ -22,7 +22,7 @@ spec:
         component: {{ $component }}
       {{- with .Values.anchoreSimpleQueue.annotations }}
       annotations:
-        {{ toYaml .Values.anchoreSimpleQueue.annotations | nindent 8 | trim }}
+        {{ toYaml . | nindent 8 | trim }}
       {{- end }}
     spec:
       containers:


### PR DESCRIPTION
#### What this PR does / why we need it:
This fix the error we get when settings annotations for the simplequeue deployment.

```
Error: render error in "anchore-engine/templates/simplequeue_deployment.yaml": template: anchore-engine/templates/simplequeue_deployment.yaml:25:25: executing "anchore-engine/templates/simplequeue_deployment.yaml" at <.Values.anchoreSimpl...>: can't evaluate field anchoreSimpleQueue in type interface {}
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
