### PR TITLE
[stable/airflow]: pass through annotations to service-web and service-flower

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 2.8.2
+version: 2.8.3
 appVersion: 1.10.2
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -295,7 +295,9 @@ The following table lists the configurable parameters of the Airflow chart and t
 | Parameter                                | Description                                             | Default                   |
 |------------------------------------------|---------------------------------------------------------|---------------------------|
 | `airflow.fernetKey`                      | Ferney key (see `values.yaml` for example)              | (auto generated)          |
-| `airflow.service.type`                   | services type                                           | `ClusterIP`               |
+| `airflow.service.type`                   | service type for Airflow UI                             | `ClusterIP`               |
+| `airflow.service.annotations`            | (optional) service annotations for Airflow UI           | `{}`                      |
+| `airflow.service.externalPort`           | (optional) external port for Airflow UI                 | `8080`                    |
 | `airflow.executor`                       | the executor to run                                     | `Celery`                  |
 | `airflow.initRetryLoop`                  | max number of retries during container init             |                           |
 | `airflow.image.repository`               | Airflow docker image                                    | `puckel/docker-airflow`   |
@@ -313,6 +315,9 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `airflow.extraVolumeMounts`              | additional volumeMounts to the main container in scheduler, worker & web pods | `[]`|
 | `airflow.extraVolumes`                   | additional volumes for the scheduler, worker & web pods | `[]`                      |
 | `flower.resources`                       | custom resource configuration for flower pod            | `{}`                      |
+| `flower.service.type`                    | service type for Flower UI                              | `ClusterIP`               |
+| `flower.service.annotations`             | (optional) service annotations for Flower UI            | `{}`                      |
+| `flower.service.externalPort`            | (optional) external port for Flower UI                  | `5555`                    |
 | `web.resources`                          | custom resource configuration for web pod               | `{}`                      |
 | `web.initialStartupDelay`                | amount of time webserver pod should sleep before initializing webserver             | `60`  |
 | `web.initialDelaySeconds`                | initial delay on livenessprobe before checking if webserver is available    | `360` |
@@ -392,3 +397,5 @@ Full and up-to-date documentation can be found in the comments of the `values.ya
 ### To 2.0.0
 The parameter `workers.pod.annotations` has been renamed to `workers.podAnnotations`.  If using a
 custom values file, rename this parameter.
+### To 2.8.3+
+The parameter `airflow.service.type` no longer applies to the Flower service, but the default of `ClusterIP` has been maintained.  If using a custom values file and have changed the service type, also specify `flower.service.type`.

--- a/stable/airflow/templates/service-flower.yaml
+++ b/stable/airflow/templates/service-flower.yaml
@@ -9,8 +9,12 @@ metadata:
     chart: {{ template "airflow.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+  {{- if .Values.flower.service.annotations }}
+{{ toYaml .Values.flower.service.annotations | trim | indent 4 }}
+  {{- end }}
 spec:
-  type: {{ .Values.airflow.service.type }}
+  type: {{ .Values.flower.service.type | default "ClusterIP" }}
   selector:
     app: {{ template "airflow.name" . }}
     component: flower
@@ -18,5 +22,6 @@ spec:
   ports:
     - name: flower
       protocol: TCP
-      port: 5555
+      port: {{ .Values.flower.service.externalPort | default 5555 }}
+      targetPort: 5555
 {{- end }}

--- a/stable/airflow/templates/service-web.yaml
+++ b/stable/airflow/templates/service-web.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: {{ template "airflow.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+  {{- if .Values.airflow.service.annotations }}
+{{ toYaml .Values.airflow.service.annotations | trim | indent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.airflow.service.type }}
   selector:
@@ -17,4 +21,5 @@ spec:
   ports:
     - name: web
       protocol: TCP
-      port: 8080
+      port: {{ .Values.airflow.service.externalPort | default 8080 }}
+      targetPort: 8080

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -59,7 +59,9 @@ airflow:
   ## fernetKey: ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD
   fernetKey: ""
   service:
+    annotations: {}
     type: ClusterIP
+    externalPort: 8080
   ##
   ## The executor to use.
   ##
@@ -194,6 +196,10 @@ flower:
     # requests:
     #   cpu: "100m"
     #   memory: "128Mi"
+  service:
+    annotations: {}
+    type: ClusterIP
+    externalPort: 5555
 
 web:
   resources: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

Passes through annotations for the web and flower services from the values file. This change enables various scenarios: can use K8s External DNS; can configure AWS ELBs; and can setup SSL certs on those ELBs. Also allows the external port for the services to be configured via the values file.

The change also decouples service-web and service-flower configuration into separate sections of the values file, so that we can have e.g. the Airflow UI on a public load balancer but Flower on a private one. The defaults are maintained for Flower and a note is added to documentation for those that changed the Flower service's type.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
