### PR TITLE
[stable/spinnaker] Fix the default value for gate-local.yml profile

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.11.0
+version: 1.11.1
 appVersion: 1.12.5
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/configmap/additional-profile-configmaps.yaml
+++ b/stable/spinnaker/templates/configmap/additional-profile-configmaps.yaml
@@ -8,7 +8,7 @@ metadata:
 Render profiles for each service by merging predefined defaults with values passed by
 .Values.halyard.additionalProfileConfigMaps.data
 */}}
-{{- $profiles := dict "gate-local.yml" "" -}}
+{{- $profiles := dict "gate-local.yml" dict -}}
 
 {{- /* Defaults: Disable S3 versioning on Front50 if Minio storage is used */}}
 {{- /* https://www.spinnaker.io/setup/install/storage/minio/#editing-your-storage-settings */}}


### PR DESCRIPTION
This PR fixes an issue introduced in https://github.com/helm/charts/pull/13918.

#### What this PR does / why we need it:

By default the ConfigMap for additional profiles has this content: `"gate-local.yml": ""`. It was done just to avoid having an empty data in the ConfigMap, which will lead to the error of mounting it to the Pod.

However, en empty string `""` prevents `mergeOverwrite` function to merge it with customized values. It needs to be replaced with an empty dict instead. See the example below:


##### Before this PR:

```yaml
## ==> custom-values.yaml
halyard:
# ...
  additionalProfileConfigMaps:
    create: true
    data:
      gate-local.yml:
        redis:
          configuration:
            secure: true

## <== Actual ConfigMap content.  Empty string is not what's expected!
kind: ConfigMap
# ...
data:
  gate-local.yml: ""
```

##### After this PR:

```yaml
## ==> custom-values.yaml

halyard:
# ...
  additionalProfileConfigMaps:
    create: true
    data:
      gate-local.yml:
        redis:
          configuration:
            secure: true

## <== Actual ConfigMap content. Values are merged as expected
kind: ConfigMap
# ...
data:
  gate-local.yml: |
    redis:
      configuration:
        secure: true
```

It also works if values are passed as a string, not dict:

```yaml
## ==> custom-values.yaml
halyard:
# ...
  additionalProfileConfigMaps:
    create: true
    data:
      gate-local.yml: |   # Now this is a multi-line string
        redis:
          configuration:
            secure: true

## <== Actual ConfigMap content. Values are merged as expected
kind: ConfigMap
# ...
data:
  gate-local.yml: |
    redis:
      configuration:
        secure: true
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
