### PR TITLE
[stable/wordpress] Change regex looking for rolling tags

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 5.9.7
+version: 5.9.8
 appVersion: 5.2.1
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/templates/NOTES.txt
+++ b/stable/wordpress/templates/NOTES.txt
@@ -38,7 +38,7 @@
   echo Username: {{ .Values.wordpressUsername }}
   echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "wordpress.fullname" . }} -o jsonpath="{.data.wordpress-password}" | base64 --decode)
 
-{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | regexFind "-r\\d+$")) }}
+{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
 
 WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
 +info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix tag interpreted as float instead of string and support _sha256_ as an immutable tag

#### Which issue this PR fixes
  - Fixes https://github.com/helm/charts/pull/14199#issuecomment-496883321

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
