### PR TITLE
[stable/phpmyadmin] Change regex looking for rolling tags

### DIFF
--- a/stable/phpmyadmin/Chart.yaml
+++ b/stable/phpmyadmin/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: phpmyadmin
-version: 2.2.1
+version: 2.2.2
 appVersion: 4.8.5
 description: phpMyAdmin is an mysql administration frontend
 keywords:

--- a/stable/phpmyadmin/templates/NOTES.txt
+++ b/stable/phpmyadmin/templates/NOTES.txt
@@ -50,7 +50,7 @@ $ helm upgrade {{.Release.Name}} stable/phpmyadmin --set db.host=mydb
 
 {{end}}
 
-{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | regexFind "-r\\d+$")) }}
+{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
 
 WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
 +info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix tag interpreted as float instead of string and support _sha256_ as an immutable tag

#### Which issue this PR fixes
  - Fixes https://github.com/helm/charts/pull/14199#issuecomment-496883321

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
