### PR TITLE
[stable/dokuwiki] Change regex looking for rolling tags

### DIFF
--- a/stable/dokuwiki/Chart.yaml
+++ b/stable/dokuwiki/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: dokuwiki
-version: 4.2.2
-appVersion: 0.20180422.201901061035
+version: 4.2.3
+appVersion: 0.201804.2.301901061035
 description: DokuWiki is a standards-compliant, simple to use wiki optimized for creating
   documentation. It is targeted at developer teams, workgroups, and small companies.
   All data is stored in plain text files, so no database is required.

--- a/stable/dokuwiki/Chart.yaml
+++ b/stable/dokuwiki/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: dokuwiki
 version: 4.2.3
-appVersion: 0.201804.2.301901061035
+appVersion: 0.20180422.201901061035
 description: DokuWiki is a standards-compliant, simple to use wiki optimized for creating
   documentation. It is targeted at developer teams, workgroups, and small companies.
   All data is stored in plain text files, so no database is required.

--- a/stable/dokuwiki/templates/NOTES.txt
+++ b/stable/dokuwiki/templates/NOTES.txt
@@ -43,7 +43,7 @@
   echo Username: {{ .Values.dokuwikiUsername }}
   echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "dokuwiki.fullname" . }} -o jsonpath="{.data.dokuwiki-password}" | base64 --decode)
 
-{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | regexFind "-r\\d+$")) }}
+{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
 
 WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
 +info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix tag interpreted as float instead of string and support _sha256_ as an immutable tag

#### Which issue this PR fixes
  - Fixes https://github.com/helm/charts/pull/14199#issuecomment-496883321

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
