### PR TITLE
[stable/coredns] allow zones to specify a nodeport

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: coredns
-version: 1.5.3
+version: 1.5.4
 appVersion: 1.5.0
 description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services
 keywords:

--- a/stable/coredns/templates/_helpers.tpl
+++ b/stable/coredns/templates/_helpers.tpl
@@ -29,6 +29,7 @@ Generate the list of ports automatically from the server definitions
     {{- range .Values.servers -}}
         {{/* Capture port to avoid scoping awkwardness */}}
         {{- $port := toString .port -}}
+        {{- $nodePort := toString (default 0 .nodePort) -}}
 
         {{/* If none of the server blocks has mentioned this port yet take note of it */}}
         {{- if not (hasKey $ports $port) -}}
@@ -36,6 +37,8 @@ Generate the list of ports automatically from the server definitions
         {{- end -}}
         {{/* Retrieve the inner dict that holds the protocols for a given port */}}
         {{- $innerdict := index $ports $port -}}
+        {{/* Set the nodeport on the inner dict */}}
+        {{- $innerdict := set $innerdict "nodePort" $nodePort -}}
 
         {{/*
         Look at each of the zones and check which protocol they serve
@@ -69,11 +72,23 @@ Generate the list of ports automatically from the server definitions
 
     {{/* Write out the ports according to the info collected above */}}
     {{- range $port, $innerdict := $ports -}}
+        {{- $portsOutput := list -}}
         {{- if index $innerdict "isudp" -}}
-            {{- printf "- {port: %v, protocol: UDP, name: udp-%s}\n" $port $port -}}
+            {{- $portOutput := dict "port" ($port | int) "protocol" "UDP" "name" (printf "udp-%s" $port) -}}
+            {{- if ne (index $innerdict "nodePort") "0" -}}
+                {{- $_ := set $portOutput "nodePort" ((index $innerdict "nodePort") | int ) -}}
+            {{- end -}}
+            {{- $portsOutput = append $portsOutput $portOutput -}}
         {{- end -}}
         {{- if index $innerdict "istcp" -}}
-            {{- printf "- {port: %v, protocol: TCP, name: tcp-%s}\n" $port $port -}}
+            {{- $portOutput := dict "port" ($port | int) "protocol" "TCP" "name" (printf "tcp-%s" $port) -}}
+            {{- if ne (index $innerdict "nodePort") "0" -}}
+                {{- $_ := set $portOutput "nodePort" ((index $innerdict "nodePort") | int ) -}}
+            {{- end -}}
+            {{- $portsOutput = append $portsOutput $portOutput -}}
+        {{- end -}}
+        {{- range $index, $portOutput := $portsOutput -}}
+            {{- printf "- %v\n" (toJson $portOutput) -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -72,6 +72,7 @@ servers:
 #     scheme: tls://       # optional, defaults to "" (which equals "dns://" in CoreDNS)
 #   - zone: foo.bar.
 #     scheme: dns://
+#     nodePort: 31053      # optional, sets the node port that should be exposed
 #     use_tcp: true        # set this parameter to optionally expose the port on tcp as well as udp for the DNS protocol
 #                          # Note that this will not work if you are also exposing tls or grpc on the same server
 #   port: 12345            # optional, defaults to "" (which equals 53 in CoreDNS)


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

allow zones to specify a nodeport

This is a redo of #12089 to be compatible with the latest changes

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
