### PR TITLE
[stable/prometheus-node-exporter] add scrapeTimeout for the service monitor

### DIFF
--- a/stable/prometheus-node-exporter/Chart.yaml
+++ b/stable/prometheus-node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.18.0"
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 1.5.0
+version: 1.5.1
 home: https://github.com/prometheus/node_exporter/
 sources:
 - https://github.com/prometheus/node_exporter/

--- a/stable/prometheus-node-exporter/README.md
+++ b/stable/prometheus-node-exporter/README.md
@@ -65,6 +65,7 @@ The following table lists the configurable parameters of the Node Exporter chart
 | `prometheus.monitor.enabled` | Set this to `true` to create ServiceMonitor for Prometheus operator | `false` | |
 | `prometheus.monitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}` | |
 | `prometheus.monitor.namespace` | namespace where servicemonitor resource should be created | `the same namespace as prometheus node exporter` | |
+| `prometheus.monitor.scrapeTimeout` | Timeout after which the scrape is ended | `10s` | |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-node-exporter/templates/monitor.yaml
+++ b/stable/prometheus-node-exporter/templates/monitor.yaml
@@ -14,4 +14,7 @@ spec:
       release: {{ .Release.Name }}
   endpoints:
     - port: metrics
+      {{- if .Values.prometheus.monitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.prometheus.monitor.scrapeTimeout }}
+      {{- end }}
 {{- end }}

--- a/stable/prometheus-node-exporter/values.yaml
+++ b/stable/prometheus-node-exporter/values.yaml
@@ -20,6 +20,8 @@ prometheus:
     additionalLabels: {}
     namespace: ""
 
+    scrapeTimeout: 10s
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

The scrape time should be configurable, when node _exporter has more things to scrape this can take longer.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
