### PR TITLE
[stable/elastic-stack] Fix install command

### DIFF
--- a/stable/elastic-stack/README.md
+++ b/stable/elastic-stack/README.md
@@ -20,7 +20,7 @@ This chart will do the following:
 To install the chart with the release name `my-release`:
 
 ```bash
-$ helm install --name my-release stable/elastic-stack
+$ RELEASE_NAME=my-release helm install --set kibana.env.ELASTICSEARCH_URL=http://${RELEASE_NAME}-elasticsearch-client:9200 --name ${RELEASE_NAME} stable/elastic-stack
 ```
 
 ## Deleting the Charts


### PR DESCRIPTION
@rendhalver @jar361 @christian-roggia @cpanato 

#### What this PR does / why we need it:

The default command did not work since kibana would not be able to connect to the elasticsearch client.

Until a permanent fix is found for #11037 this temporary workaround gets the stack running.

#### Which issue this PR fixes

Temporary workaround for #11037

#### Special notes for your reviewer:

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
