### PR TITLE
[stable/Janusgraph] Allow env variables in template

### DIFF
--- a/stable/janusgraph/Chart.yaml
+++ b/stable/janusgraph/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: Open source, scalable graph database.
 name: janusgraph
-version: 0.2.0
+version: 0.2.1
 home: http://janusgraph.org
 icon: https://raw.githubusercontent.com/JanusGraph/janusgraph/master/janusgraph.png
 sources:

--- a/stable/janusgraph/templates/deployment.yaml
+++ b/stable/janusgraph/templates/deployment.yaml
@@ -23,6 +23,12 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.extraEnvs }}
+          env:
+              {{- with .Values.extraEnvs }}
+                {{- toYaml . | trim | nindent 12 -}}
+              {{- end }}
+          {{- end }}
           ports:
             - containerPort: 8182
               protocol: TCP

--- a/stable/janusgraph/values.yaml
+++ b/stable/janusgraph/values.yaml
@@ -15,6 +15,8 @@ replicaCount: 1
 ## set any pod specific resource requests here
 resources: {}
 
+extraEnvs: {}
+
 service:
   type: ClusterIP  # Change to LoadBalancer if you plan to access JanusGraph outside k8s cluster
   port: 8182


### PR DESCRIPTION
#### What this PR does / why we need it:
Allow additional environment variables in the template, for example if one wants to use an official Janusgraph docker image.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
