### PR TITLE
[stable/wordpress] Remove apache and/or php volume

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 5.9.8
+version: 5.10.0
 appVersion: 5.2.1
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/templates/deployment.yaml
+++ b/stable/wordpress/templates/deployment.yaml
@@ -153,15 +153,9 @@ spec:
           {{- end }}
 {{ toYaml .Values.readinessProbe | indent 10 }}
         volumeMounts:
-        - mountPath: /bitnami/apache
-          name: wordpress-data
-          subPath: apache
         - mountPath: /bitnami/wordpress
           name: wordpress-data
           subPath: wordpress
-        - mountPath: /bitnami/php
-          name: wordpress-data
-          subPath: php
         {{- if and .Values.allowOverrideNone .Values.customHTAccessCM}}
         - mountPath: /opt/bitnami/wordpress/wordpress-htaccess.conf
           name: custom-htaccess

--- a/stable/wordpress/values-production.yaml
+++ b/stable/wordpress/values-production.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/wordpress
-  tag: 5.2.1-debian-9-r1
+  tag: 5.2.1-debian-9-r9
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/wordpress
-  tag: 5.2.1-debian-9-r1
+  tag: 5.2.1-debian-9-r9
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

The Apache and PHP configuration volumes (_/bitnami/apache_ and _/bitnami/php_) has been deprecated, and support for this feature will be dropped in the near future. Until then, the container will enable the Apache/PHP configuration from that volume if it exists. By default, and if the configuration volume does not exist, the configuration files will be regenerated each time the container is created. Users wanting to apply custom Apache/PHP configuration files are advised to mount a volume for the configuration at _/opt/bitnami/apache/conf_ or _/opt/bitnami/php/conf_, or mount specific configuration files individually.

You can find more info in the container README: https://github.com/bitnami/bitnami-docker-wordpress/blob/master/README.md#notable-changes

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
