### PR TITLE
[stable/suitecrm] Remove apache and/or php volume

### DIFF
--- a/stable/suitecrm/Chart.yaml
+++ b/stable/suitecrm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: suitecrm
-version: 5.3.5
+version: 5.4.0
 appVersion: 7.11.4
 description: SuiteCRM is a completely open source enterprise-grade Customer Relationship Management (CRM) application. SuiteCRM is a software fork of the popular customer relationship management (CRM) system SugarCRM.
 keywords:

--- a/stable/suitecrm/README.md
+++ b/stable/suitecrm/README.md
@@ -154,7 +154,7 @@ Bitnami will release a new chart updating its containers if a new version of the
 
 ## Persistence
 
-The [Bitnami SuiteCRM](https://github.com/bitnami/bitnami-docker-suitecrm) image stores the SuiteCRM data and configurations at the `/bitnami/suitecrm` and `/bitnami/apache` paths of the container.
+The [Bitnami SuiteCRM](https://github.com/bitnami/bitnami-docker-suitecrm) image stores the SuiteCRM data and configurations at the `/bitnami/suitecrm` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Configuration](#configuration) section to configure the PVC or to disable persistence.

--- a/stable/suitecrm/templates/deployment.yaml
+++ b/stable/suitecrm/templates/deployment.yaml
@@ -126,9 +126,6 @@ spec:
         - name: suitecrm-data
           mountPath: /bitnami/suitecrm
           subPath: suitecrm
-        - name: suitecrm-data
-          mountPath: /bitnami/apache
-          subPath: apache
 {{- if .Values.metrics.enabled }}
       - name: metrics
         image: {{ template "suitecrm.metrics.image" . }}

--- a/stable/suitecrm/values.yaml
+++ b/stable/suitecrm/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/suitecrm
-  tag: 7.11.4-debian-9-r18
+  tag: 7.11.4-debian-9-r21
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

The Apache configuration volume (_/bitnami/apache_) has been deprecated, and support for this feature will be dropped in the near future. Until then, the container will enable the Apache configuration from that volume if it exists. By default, and if the configuration volume does not exist, the configuration files will be regenerated each time the container is created. Users wanting to apply custom Apache configuration files are advised to mount a volume for the configuration at _/opt/bitnami/apache/conf_, or mount specific configuration files individually.

You can find more info in the container README: https://github.com/bitnami/bitnami-docker-suitecrm/blob/master/README.md#notable-changes

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
