### PR TITLE
[stable/prestashop] Remove apache and/or php volume

### DIFF
--- a/stable/prestashop/Chart.yaml
+++ b/stable/prestashop/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prestashop
-version: 6.5.3
+version: 6.6.0
 appVersion: 1.7.5-2
 description: A popular open source ecommerce solution. Professional tools are easily accessible to increase online sales including instant guest checkout, abandoned cart reminders and automated Email marketing.
 keywords:

--- a/stable/prestashop/README.md
+++ b/stable/prestashop/README.md
@@ -101,7 +101,7 @@ The following table lists the configurable parameters of the PrestaShop chart an
 | `sessionAffinity`                     | Configures the session affinity                                                              | `None`                                                       |
 | `persistence.enabled`                 | Enable persistence using PVC                                                                 | `true`                                                       |
 | `persistence.storageClass`            | PVC Storage Class for PrestaShop volume                                                      | `nil` (uses alpha storage class annotation)                  |
-| `persistence.existingClaim`           | An Existing PVC name for Apache volume                                                       | `nil` (uses alpha storage class annotation)                  |
+| `persistence.existingClaim`           | An Existing PVC name for PrestaShop volume                                                   | `nil` (uses alpha storage class annotation)                  |
 | `persistence.accessMode`              | PVC Access Mode for PrestaShop volume                                                        | `ReadWriteOnce`                                              |
 | `persistence.size`                    | PVC Storage Request for PrestaShop volume                                                    | `8Gi`                                                        |
 | `resources`                           | CPU/Memory resource requests/limits                                                          | Memory: `512Mi`, CPU: `300m`                                 |
@@ -167,7 +167,7 @@ Bitnami will release a new chart updating its containers if a new version of the
 
 ## Persistence
 
-The [Bitnami PrestaShop](https://github.com/bitnami/bitnami-docker-prestashop) image stores the PrestaShop data and configurations at the `/bitnami/prestashop` and `/bitnami/apache` paths of the container.
+The [Bitnami PrestaShop](https://github.com/bitnami/bitnami-docker-prestashop) image stores the PrestaShop data and configurations at the `/bitnami/prestashop` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Configuration](#configuration) section to configure the PVC or to disable persistence.

--- a/stable/prestashop/templates/deployment.yaml
+++ b/stable/prestashop/templates/deployment.yaml
@@ -157,9 +157,6 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
-        - mountPath: /bitnami/apache
-          name: prestashop-data
-          subPath: apache
         - mountPath: /bitnami/prestashop
           name: prestashop-data
           subPath: prestashop

--- a/stable/prestashop/values.yaml
+++ b/stable/prestashop/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/prestashop
-  tag: 1.7.5-2-debian-9-r9
+  tag: 1.7.5-2-debian-9-r12
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

The Apache configuration volume (_/bitnami/apache_) has been deprecated, and support for this feature will be dropped in the near future. Until then, the container will enable the Apache configuration from that volume if it exists. By default, and if the configuration volume does not exist, the configuration files will be regenerated each time the container is created. Users wanting to apply custom Apache configuration files are advised to mount a volume for the configuration at _/opt/bitnami/apache/conf_, or mount specific configuration files individually.

You can find more info in the container README: https://github.com/bitnami/bitnami-docker-prestashop/blob/master/README.md#notable-changes

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
