### PR TITLE
[stable/k8s-spot-rescheduler] Added podAnnotations option.

### DIFF
--- a/stable/k8s-spot-rescheduler/Chart.yaml
+++ b/stable/k8s-spot-rescheduler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.2.0"
 description: A k8s-spot-rescheduler Helm chart for Kubernetes
 name: k8s-spot-rescheduler
-version: 0.4.0
+version: 0.4.1
 keywords:
   - spot
   - rescheduler

--- a/stable/k8s-spot-rescheduler/templates/deployment.yaml
+++ b/stable/k8s-spot-rescheduler/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
       labels:
         app: {{ template "k8s-spot-rescheduler.name" . }}
         release: {{ .Release.Name }}
+{{- with .Values.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
       serviceAccountName: {{ template "k8s-spot-rescheduler.serviceAccountName" . }}
       containers:

--- a/stable/k8s-spot-rescheduler/values.yaml
+++ b/stable/k8s-spot-rescheduler/values.yaml
@@ -3,6 +3,8 @@
 # Declare variables to be passed into your templates.
 replicaCount: 1
 
+podAnnotations: {}
+
 podDisruptionBudget: {}
   # maxUnavailable: 1
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Added `podAnnotations` so that Prometheus metrics can be exported.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
