### PR TITLE
[stable/elasticsearch-exporter] add namespace metadata

### DIFF
--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 1.2.0
+version: 1.2.1
 appVersion: 1.0.2
 home: https://github.com/justwatchcom/elasticsearch_exporter
 sources:

--- a/stable/elasticsearch-exporter/templates/cert-secret.yaml
+++ b/stable/elasticsearch-exporter/templates/cert-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "elasticsearch-exporter.fullname" . }}-cert
+  namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ template "elasticsearch-exporter.chart" . }}
     app: {{ template "elasticsearch-exporter.name" . }}

--- a/stable/elasticsearch-exporter/templates/deployment.yaml
+++ b/stable/elasticsearch-exporter/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: {{ template "elasticsearch-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ template "elasticsearch-exporter.chart" . }}
     app: {{ template "elasticsearch-exporter.name" . }}

--- a/stable/elasticsearch-exporter/templates/service.yaml
+++ b/stable/elasticsearch-exporter/templates/service.yaml
@@ -2,6 +2,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ template "elasticsearch-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ template "elasticsearch-exporter.chart" . }}
     app: {{ template "elasticsearch-exporter.name" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

this is needed for when helm is used purely as a templating tool,
since helm template does not add the namespace
helm/helm#3553

Signed-off-by: Sergey Nuzhdin <ipaq.lw@gmail.com>

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
