### PR TITLE
[stable/prometheus-snmp-exporter] add namespace metadata

### DIFF
--- a/stable/prometheus-snmp-exporter/Chart.yaml
+++ b/stable/prometheus-snmp-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
-version: 0.0.2
+version: 0.0.3
 appVersion: 0.14.0
 home: https://github.com/prometheus/snmp_exporter
 sources:

--- a/stable/prometheus-snmp-exporter/templates/configmap.yaml
+++ b/stable/prometheus-snmp-exporter/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "prometheus-snmp-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "prometheus-snmp-exporter.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/prometheus-snmp-exporter/templates/deployment.yaml
+++ b/stable/prometheus-snmp-exporter/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "prometheus-snmp-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "prometheus-snmp-exporter.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/prometheus-snmp-exporter/templates/ingress.yaml
+++ b/stable/prometheus-snmp-exporter/templates/ingress.yaml
@@ -5,6 +5,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "prometheus-snmp-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "prometheus-snmp-exporter.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/prometheus-snmp-exporter/templates/role.yaml
+++ b/stable/prometheus-snmp-exporter/templates/role.yaml
@@ -3,6 +3,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "prometheus-snmp-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "prometheus-snmp-exporter.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/prometheus-snmp-exporter/templates/rolebinding.yaml
+++ b/stable/prometheus-snmp-exporter/templates/rolebinding.yaml
@@ -3,6 +3,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "prometheus-snmp-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "prometheus-snmp-exporter.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/prometheus-snmp-exporter/templates/service.yaml
+++ b/stable/prometheus-snmp-exporter/templates/service.yaml
@@ -2,6 +2,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ template "prometheus-snmp-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/stable/prometheus-snmp-exporter/templates/serviceaccount.yaml
+++ b/stable/prometheus-snmp-exporter/templates/serviceaccount.yaml
@@ -8,4 +8,5 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "prometheus-snmp-exporter.chart" . }}
   name: {{ template "prometheus-snmp-exporter.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

this is needed for when helm is used purely as a templating tool,
since helm template does not add the namespace
helm/helm#3553

Signed-off-by: Sergey Nuzhdin <ipaq.lw@gmail.com>

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
