### PR TITLE
[stable/stolon] add namespace metadata

### DIFF
--- a/stable/stolon/Chart.yaml
+++ b/stable/stolon/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stolon
-version: 1.1.1
+version: 1.1.2
 appVersion: 0.13.0
 description: Stolon - PostgreSQL cloud native High Availability.
 home: https://github.com/sorintlab/stolon

--- a/stable/stolon/templates/configmap.yaml
+++ b/stable/stolon/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "stolon.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}

--- a/stable/stolon/templates/hooks/create-cluster-job.yaml
+++ b/stable/stolon/templates/hooks/create-cluster-job.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "stolon.fullname" . }}-create-cluster
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}

--- a/stable/stolon/templates/hooks/update-cluster-spec-job.yaml
+++ b/stable/stolon/templates/hooks/update-cluster-spec-job.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "stolon.fullname" . }}-update-cluster-spec
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}

--- a/stable/stolon/templates/keeper-headless-service.yaml
+++ b/stable/stolon/templates/keeper-headless-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "stolon.fullname" . }}-keeper-headless
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}

--- a/stable/stolon/templates/keeper-pdb.yaml
+++ b/stable/stolon/templates/keeper-pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "stolon.fullname" . }}-keeper
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}

--- a/stable/stolon/templates/keeper-statefulset.yaml
+++ b/stable/stolon/templates/keeper-statefulset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1beta2
 kind: StatefulSet
 metadata:
   name: {{ template "stolon.fullname" . }}-keeper
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}

--- a/stable/stolon/templates/proxy-deployment.yaml
+++ b/stable/stolon/templates/proxy-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: {{ template "stolon.fullname" . }}-proxy
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}

--- a/stable/stolon/templates/proxy-pdb.yaml
+++ b/stable/stolon/templates/proxy-pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "stolon.fullname" . }}-proxy
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}

--- a/stable/stolon/templates/proxy-service.yaml
+++ b/stable/stolon/templates/proxy-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "stolon.fullname" . }}-proxy
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}

--- a/stable/stolon/templates/role.yaml
+++ b/stable/stolon/templates/role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: {{ template "stolon.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}

--- a/stable/stolon/templates/rolebinding.yaml
+++ b/stable/stolon/templates/rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: {{ template "stolon.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}

--- a/stable/stolon/templates/secret.yaml
+++ b/stable/stolon/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "stolon.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}

--- a/stable/stolon/templates/sentinel-deployment.yaml
+++ b/stable/stolon/templates/sentinel-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: {{ template "stolon.fullname" . }}-sentinel
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}

--- a/stable/stolon/templates/sentinel-pdb.yaml
+++ b/stable/stolon/templates/sentinel-pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "stolon.fullname" . }}-sentinel
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}

--- a/stable/stolon/templates/serviceaccount.yaml
+++ b/stable/stolon/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "stolon.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

this is needed for when helm is used purely as a templating tool,
since helm template does not add the namespace
helm/helm#3553

Signed-off-by: Sergey Nuzhdin <ipaq.lw@gmail.com>

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
