### PR TITLE
[stable/kafka-pubsub-emulator] Introduce chart for Google Cloud Platform Pub/Sub Emulator for Kafka

### DIFF
--- a/stable/kafka-pubsub-emulator/.helmignore
+++ b/stable/kafka-pubsub-emulator/.helmignore
@@ -1,0 +1,28 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+# sources and build files
+src
+demo
+go
+target
+*pom.xml
+checkstyle.xml

--- a/stable/kafka-pubsub-emulator/Chart.yaml
+++ b/stable/kafka-pubsub-emulator/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+appVersion: "0.1.0"
+description: A Helm chart for the GCP Kafka PubSub Emulator
+home: https://github.com/GoogleCloudPlatform/kafka-pubsub-emulator
+keywords:
+  - google cloud platform
+  - kafka
+  - kafka-pubsub-emulator
+  - messaging
+  - pubsub
+  - queue
+name: kafka-pubsub-emulator
+maintainers:
+  - name: riccardomc
+sources:
+  - https://github.com/GoogleCloudPlatform/kafka-pubsub-emulator
+version: 0.2.0

--- a/stable/kafka-pubsub-emulator/Chart.yaml
+++ b/stable/kafka-pubsub-emulator/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
   - name: riccardomc
 sources:
   - https://github.com/GoogleCloudPlatform/kafka-pubsub-emulator
-version: 0.2.0
+version: 0.3.0

--- a/stable/kafka-pubsub-emulator/README.md
+++ b/stable/kafka-pubsub-emulator/README.md
@@ -17,7 +17,9 @@ This chart will create:
 
 3. A [ConfigMap](https://kubernetes.io/docs/tutorials/configuration/) that holds the Server configuration for the Pub/Sub Emulator for Kafka that will be mounted by the Pods in the StatefulSet above
 
-4. A [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that holds the projects layout (topics and subscriptions) configuration used by the Pub/Sub Emulator for Kafka. 
+4. A [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that holds the projects layout (topics and subscriptions) configuration used by the Pub/Sub Emulator for Kafka
+
+4. A [Kafka](https://github.com/helm/charts/tree/master/incubator/kafka) cluster (optional, enabled by default)
 
 ### Installation
 
@@ -26,17 +28,6 @@ helm install --name emulator stable/kafka-pubsub-emulator
 ```
 
 ### Configuration
-
-You can provide the configuration of the Pub/Sub Emulator for Kafka using the `emulatorConfig` key in `values.yaml`. Refer to the [Configuration Options](https://github.com/GoogleCloudPlatform/kafka-pubsub-emulator#configuration-options) section in the original repository for details.
-
-You will need to specify at least your Kafka Bootstrap Servers, for example:
-
-```shell
-helm install --name emulator \
-    --set server.kafka.bootstrapServers[0]='kafka1:9092' \
-    --set server.kafka.bootstrapServers[1]='kafka2:9092' \
-    --set server.kafka.bootstrapServers[2]='kafka3:9092' \
-```
 
 |Parameter|Description|Default|
 | - | - | - |
@@ -50,11 +41,19 @@ helm install --name emulator \
 | `ingress.path` | Path within the url structure | `/`
 | `ingress.tls ` | TLS configuration | `[]`
 | `livenessProbe.tcpSocket.port`| Liveness probe target port | `8080`
-| `livenessProbe.initialDelaySeconds`| Liveness probe initial delay | `5`
+| `kafka.enabled`| Define wether to install a Kafka cluster as part of the
+release | `true`
 | `readinessProbe.tcpSocket.port`| readiness probe target port | `8080`
 | `readinessProbe.initialDelaySeconds`| readiness probe initial delay | `5`
 | `server.port` | Port for the Emulator to listen on | `8080`
-| `server.kafka.bootstrapServers` | Kafka bootstrap servers | `[]`
+| `server.kafka.bootstrapServers` | Kafka bootstrap servers, if empty and
+`kafka.enabled` is true it will be generated based on release name | `""`
+| `server.kafka.consumerProperties.maxPollRecords` | `max.poll.records` value for each consumer | `1000`
+| `server.kafka.consumersPerSubscription` | Number of consumers per subscription | `4`
+| `server.kafka.producerExecutors` | Number of Kafka producer executors | `4`
+| `server.kafka.producerProperties.lingerMs` | `linger.ms` value for each producer | `200`
+| `server.kafka.producerProperties.batchSize` | `batch.size` value for each producer | `1000`
+| `server.kafka.producerProperties.bufferMemory` | `buffer.memory` value for each producer | `32000000`
 | `pubsub.projects` | Initial PubSub projects configuration | [Default PubSub Configuration](#markdown-header-default-pubsub-configuration)
 
 #### Default PubSub Configuration

--- a/stable/kafka-pubsub-emulator/README.md
+++ b/stable/kafka-pubsub-emulator/README.md
@@ -1,0 +1,87 @@
+# Pub/Sub Emulator for Kafka
+
+This chart packages the [Pub/Sub Emulator for Kafka](https://github.com/GoogleCloudPlatform/kafka-pubsub-emulator) which implements an emulation layer on top of an existing [Kafka](https://kafka.apache.org/) cluster.
+
+## Prerequisites
+
+* Kubernetes 1.4+ with Beta APIs enabled
+* A Kafka cluster
+
+## Chart Details
+
+This chart will create:
+
+1. A [StatefulSet](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) with a single replica running the Pub/Sub Emulator for Kafka
+
+2. A [Service](https://kubernetes.io/docs/concepts/services-networking/service/) exposing the Pub/Sub Emulator for Kafka
+
+3. A [ConfigMap](https://kubernetes.io/docs/tutorials/configuration/) that holds the Server configuration for the Pub/Sub Emulator for Kafka that will be mounted by the Pods in the StatefulSet above
+
+4. A [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that holds the projects layout (topics and subscriptions) configuration used by the Pub/Sub Emulator for Kafka. 
+
+### Installation
+
+```shell
+helm install --name emulator stable/kafka-pubsub-emulator<Paste>
+```
+
+### Configuration
+
+You can provide the configuration of the Pub/Sub Emulator for Kafka using the `emulatorConfig` key in `values.yaml`. Refer to the [Configuration Options](https://github.com/GoogleCloudPlatform/kafka-pubsub-emulator#configuration-options) section in the original repository for details.
+
+You will need to specify at least your Kafka Bootstrap Servers, for example:
+
+```shell
+helm install --name emulator \
+    --set server.kafka.bootstrapServers[0]='kafka1:9092' \
+    --set server.kafka.bootstrapServers[1]='kafka2:9092' \
+    --set server.kafka.bootstrapServers[2]='kafka3:9092' \
+```
+
+|Parameter|Description|Default|
+| - | - | - |
+| `image.repository` | Image repository | `us.gcr.io/kafka-pubsub-emulator/kafka-pubsub-emulator`
+| `image.tag` | Image tag | `0.1.0`
+| `service.type` | Service type | `LoadBalancer`
+| `service.port` | Service port | `80`
+| `ingress.enabled` | Enable ingress controller resource | `false`
+| `ingress.annotations` | Annotations for the ingress record | `[]`
+| `ingress.hosts` | Hostname to Pub/Sub Emulator for Kafka installation | `[emulator.local]`
+| `ingress.path` | Path within the url structure | `/`
+| `ingress.tls ` | TLS configuration | `[]`
+| `livenessProbe.tcpSocket.port`| Liveness probe target port | `8080`
+| `livenessProbe.initialDelaySeconds`| Liveness probe initial delay | `5`
+| `readinessProbe.tcpSocket.port`| readiness probe target port | `8080`
+| `readinessProbe.initialDelaySeconds`| readiness probe initial delay | `5`
+| `server.port` | Port for the Emulator to listen on | `8080`
+| `server.kafka.bootstrapServers` | Kafka bootstrap servers | `[]`
+| `pubsub.projects` | Initial PubSub projects configuration | [Default PubSub Configuration](#markdown-header-default-pubsub-configuration)
+
+#### Default PubSub Configuration
+The following project layout configuration is generated when the PubSub emulator is first started:
+
+```yaml
+projects:
+  - name: default
+    topics:
+      - name: topic1
+        kafkaTopic: topic1
+        subscriptions:
+          - name: subscription-topic1
+            ackDeadlineSeconds: 10
+```
+
+Since the PubSub emulator writes back changes to the project layout that happen at runtime (e.g. via `createTopic` or `createSubscription`) this configuration is applied only when the PubSub emulator is started the first time and no previous configuration exists.
+
+## Use the Emulator
+
+According to Google Cloud Pub/Sub
+[documentation](https://cloud.google.com/pubsub/docs/emulator), [Google Cloud Client Libraries](https://cloud.google.com/pubsub/docs/reference/libraries#gcloud-libraries) support using a Pub/Sub emulator by setting the `PUBSUB_EMULATOR_HOST` environment variable, for example, on Linux:
+
+```shell
+export PUBSUB_EMULATOR_HOST=$SERVICE_IP:$SERVICE_PORT
+./my_pubsub_application
+```
+
+Where `$SERVICE_IP` and `$SERVICE_PORT` depend on the way you expose the
+service outside of your Kubernetes cluster.

--- a/stable/kafka-pubsub-emulator/README.md
+++ b/stable/kafka-pubsub-emulator/README.md
@@ -22,7 +22,7 @@ This chart will create:
 ### Installation
 
 ```shell
-helm install --name emulator stable/kafka-pubsub-emulator<Paste>
+helm install --name emulator stable/kafka-pubsub-emulator
 ```
 
 ### Configuration

--- a/stable/kafka-pubsub-emulator/requirements.lock
+++ b/stable/kafka-pubsub-emulator/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kafka
-  repository: http://storage.googleapis.com/kubernetes-charts-incubator
+  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
   version: 0.15.5
-digest: sha256:751df642aae5629e628b0867137766f46087c6c7f62659a7e8c8b66597955700
-generated: "2019-06-04T16:45:16.612939649+01:00"
+digest: sha256:390b38e604cc1fa84e14520411e91432ac29a1ff00d8dd86523ee421fd2986e2
+generated: "2019-06-04T18:18:03.198303576+01:00"

--- a/stable/kafka-pubsub-emulator/requirements.lock
+++ b/stable/kafka-pubsub-emulator/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: kafka
+  repository: http://storage.googleapis.com/kubernetes-charts-incubator
+  version: 0.15.5
+digest: sha256:751df642aae5629e628b0867137766f46087c6c7f62659a7e8c8b66597955700
+generated: "2019-06-04T16:45:16.612939649+01:00"

--- a/stable/kafka-pubsub-emulator/requirements.yaml
+++ b/stable/kafka-pubsub-emulator/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+  - name: kafka
+    version: 0.15.5
+    repository: http://storage.googleapis.com/kubernetes-charts-incubator
+    condition: kafka.enabled

--- a/stable/kafka-pubsub-emulator/requirements.yaml
+++ b/stable/kafka-pubsub-emulator/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: kafka
     version: 0.15.5
-    repository: http://storage.googleapis.com/kubernetes-charts-incubator
+    repository: https://kubernetes-charts-incubator.storage.googleapis.com/
     condition: kafka.enabled

--- a/stable/kafka-pubsub-emulator/templates/NOTES.txt
+++ b/stable/kafka-pubsub-emulator/templates/NOTES.txt
@@ -20,7 +20,7 @@
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "kafka-pubsub-emulator.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export PUBSUB_EMULATOR_HOST=127.0.0.1:8080
-  kubectl port-forward $POD_NAME 8080:80
+  kubectl port-forward $POD_NAME -- 8080:{{ .Values.server.port }}
 
 2. Google Pub/Sub Client libraries will automatically use the address in
 the PUBSUB_EMULATOR_HOST environment variable.

--- a/stable/kafka-pubsub-emulator/templates/NOTES.txt
+++ b/stable/kafka-pubsub-emulator/templates/NOTES.txt
@@ -1,0 +1,28 @@
+1. Set the PUBSUB_EMULATOR_HOST environment variable:
+
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "kafka-pubsub-emulator.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  export PUBSUB_EMULATOR_HOST=$NODE_IP:$NODE_PORT
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ include "kafka-pubsub-emulator.fullname" . }}'
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "kafka-pubsub-emulator.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  export PUBSUB_EMULATOR_HOST=$SERVICE_IP:{{ .Values.service.port }}
+
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "kafka-pubsub-emulator.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export PUBSUB_EMULATOR_HOST=127.0.0.1:8080
+  kubectl port-forward $POD_NAME 8080:80
+
+2. Google Pub/Sub Client libraries will automatically use the address in
+the PUBSUB_EMULATOR_HOST environment variable.
+
+{{- end }}

--- a/stable/kafka-pubsub-emulator/templates/_helpers.tpl
+++ b/stable/kafka-pubsub-emulator/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "kafka-pubsub-emulator.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create bootsrapServers: if using kafka child chart build based on release name
+*/}}
+{{- define "kafka-pubsub-emulator.bootstrapServers" -}}
+{{- if .Values.server.kafka.bootstrapServers -}}
+    {{ toJson .Values.server.kafka.bootstrapServers }}
+{{- else -}}
+    {{- printf "[ \"RELEASE-kafka-0.RELEASE-kafka-headless:9092\", \"RELEASE-kafka-1.RELEASE-kafka-headless:9092\", \"RELEASE-kafka-2.RELEASE-kafka-headless:9092\" ]" | replace "RELEASE" .Release.Name -}}
+{{- end -}}
+{{- end -}}

--- a/stable/kafka-pubsub-emulator/templates/_helpers.tpl
+++ b/stable/kafka-pubsub-emulator/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kafka-pubsub-emulator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kafka-pubsub-emulator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kafka-pubsub-emulator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/kafka-pubsub-emulator/templates/configmap.yaml
+++ b/stable/kafka-pubsub-emulator/templates/configmap.yaml
@@ -9,5 +9,20 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
-  config.json: |
-{{ toPrettyJson .Values.server | indent 4 }}
+  config.json: |-
+    {
+      "port": {{ .Values.server.port }},
+      "kafka": {
+        "bootstrapServers": {{ template "kafka-pubsub-emulator.bootstrapServers" . }},
+        "producerExecutors": {{ .Values.server.kafka.producerExecutors }},
+        "producerProperties": {
+          "linger.ms": {{ .Values.server.kafka.producerProperties.lingerMs }},
+          "batch.size": {{ .Values.server.kafka.producerProperties.batchSize }},
+          "buffer.memory": {{ .Values.server.kafka.producerProperties.bufferMemory }}
+        },
+        "consumerProperties": {
+          "max.poll.records": {{ .Values.server.kafka.consumerProperties.maxPollRecords }}
+        },
+        "consumersPerSubscription": {{ .Values.server.kafka.consumersPerSubscription }}
+      }
+    }

--- a/stable/kafka-pubsub-emulator/templates/configmap.yaml
+++ b/stable/kafka-pubsub-emulator/templates/configmap.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kafka-pubsub-emulator.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "kafka-pubsub-emulator.name" . }}
+    helm.sh/chart: {{ include "kafka-pubsub-emulator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  config.json: |
+{{ toPrettyJson .Values.server | indent 4 }}

--- a/stable/kafka-pubsub-emulator/templates/ingress.yaml
+++ b/stable/kafka-pubsub-emulator/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "kafka-pubsub-emulator.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "kafka-pubsub-emulator.name" . }}
+    helm.sh/chart: {{ include "kafka-pubsub-emulator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/stable/kafka-pubsub-emulator/templates/service.yaml
+++ b/stable/kafka-pubsub-emulator/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kafka-pubsub-emulator.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "kafka-pubsub-emulator.name" . }}
+    helm.sh/chart: {{ include "kafka-pubsub-emulator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "kafka-pubsub-emulator.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/kafka-pubsub-emulator/templates/statefulset.yaml
+++ b/stable/kafka-pubsub-emulator/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "kafka-pubsub-emulator.fullname" . }}

--- a/stable/kafka-pubsub-emulator/templates/statefulset.yaml
+++ b/stable/kafka-pubsub-emulator/templates/statefulset.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1beta2
+kind: StatefulSet
+metadata:
+  name: {{ include "kafka-pubsub-emulator.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "kafka-pubsub-emulator.name" . }}
+    helm.sh/chart: {{ include "kafka-pubsub-emulator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "kafka-pubsub-emulator.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "kafka-pubsub-emulator.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      initContainers:
+        - name: config-init
+          image: busybox
+          command:
+            - sh
+            - '-c'
+            - |
+              set -xe
+
+              DESTINATION=/run/pubsub/pubsub.json
+              mkdir -p $(dirname ${DESTINATION})
+
+              if [ ! -f ${DESTINATION} ] ; then
+              cat << 'EOF' > ${DESTINATION}
+{{ toPrettyJson .Values.pubsub | indent 14 }}
+              EOF
+              fi
+
+              cat ${DESTINATION}
+          volumeMounts:
+            - name: persistent-config-volume
+              mountPath: /run/pubsub
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["-c", "/etc/config/config.json", "-p", "/run/pubsub/pubsub.json"]
+          volumeMounts:
+            - name: persistent-config-volume
+              mountPath: /run/pubsub
+            - name: config-volume
+              mountPath: /etc/config
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+{{ toYaml . | indent 12 }}
+          {{- end}}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+{{ toYaml . | indent 12 }}
+          {{- end}}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ include "kafka-pubsub-emulator.fullname" . }}
+  volumeClaimTemplates:
+    - metadata:
+        name: persistent-config-volume
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 1Gi

--- a/stable/kafka-pubsub-emulator/templates/statefulset.yaml
+++ b/stable/kafka-pubsub-emulator/templates/statefulset.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  serviceName: {{ include "kafka-pubsub-emulator.fullname" . }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "kafka-pubsub-emulator.name" . }}

--- a/stable/kafka-pubsub-emulator/values.yaml
+++ b/stable/kafka-pubsub-emulator/values.yaml
@@ -13,7 +13,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 service:
-  type: LoadBalancer
+  type: ClusterIP
   port: 80
 
 ingress:

--- a/stable/kafka-pubsub-emulator/values.yaml
+++ b/stable/kafka-pubsub-emulator/values.yaml
@@ -58,19 +58,30 @@ tolerations: []
 affinity: {}
 
 #
+# Kafka Cluster
+#
+kafka:
+  # Define whether a kafka cluster should be installed as part of this release
+  enabled: true
+
+#
 # Kafka Pub/Sub Emulator Server configuration
 #
 server:
   port: 8080
   kafka:
-    bootstrapServers: []
+    # if empty and kafka.enabled is true then bootstrapServers will be
+    # generated based on the release name
+    bootstrapServers:
     producerExecutors: 4
     producerProperties:
-      linger.ms: 200
-      batch.size: 10000
-      buffer.memory: 32000000
+      lingerMs: 200
+      batchSize: 10000
+      # note: we're passing large numbers as string because of:
+      # https://github.com/helm/helm/issues/1707
+      bufferMemory: "32000000"
     consumerProperties:
-      max.poll.records: 1000
+      maxPollRecords: 1000
     consumersPerSubscription: 4
 
 #

--- a/stable/kafka-pubsub-emulator/values.yaml
+++ b/stable/kafka-pubsub-emulator/values.yaml
@@ -1,0 +1,92 @@
+# Default values for kafka-pubsub-emulator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: us.gcr.io/kafka-pubsub-emulator/kafka-pubsub-emulator
+  tag: 0.1.0
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: LoadBalancer
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - emulator.local
+  tls: []
+  #  - secretName: emulator-tls
+  #    hosts:
+  #      - emulator.local
+
+livenessProbe:
+  tcpSocket:
+    port: http
+  initialDelaySeconds: 5
+
+readinessProbe:
+  tcpSocket:
+    port: http
+  initialDelaySeconds: 5
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+#
+# Kafka Pub/Sub Emulator Server configuration
+#
+server:
+  port: 8080
+  kafka:
+    bootstrapServers: []
+    producerExecutors: 4
+    producerProperties:
+      linger.ms: 200
+      batch.size: 10000
+      buffer.memory: 32000000
+    consumerProperties:
+      max.poll.records: 1000
+    consumersPerSubscription: 4
+
+#
+# Kafka Pub/Sub Emulator Project layout configuration
+#
+# NOTE: this configuration is written to a pubsub.json file in the persistentvolume when the
+# emulator pod is started. If an existing configuration file is present in the persistentvolume
+# it will *not* be overwritten. This is done in order to not lose the changed written at runtime
+# by the emulator.
+#
+pubsub:
+  projects:
+    - name: default
+      topics:
+        - name: topic1
+          kafkaTopic: topic1
+          subscriptions:
+            - name: subscription-topic1
+              ackDeadlineSeconds: 10


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR introduces an Helm Chart for [Google Cloud Platform Pub/Sub Emulator for Kafka](https://github.com/GoogleCloudPlatform/kafka-pubsub-emulator). See the project GitHub page for additional details.

#### Special notes for your reviewer:

Please notice that in the past I opened a similar PR (https://github.com/helm/charts/pull/9784) that is now stale. This is an updated version of that chart that reflect important changes in the upstream project.

#### Checklist

- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
