### PR TITLE
[stable/prometheus-operator]: remove etcd alerts triggering false positives

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -10,7 +10,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 5.11.0
+version: 5.12.0
 appVersion: 0.30.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/templates/prometheus/rules/etcd.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/etcd.yaml
@@ -41,28 +41,6 @@ spec:
       for: 15m
       labels:
         severity: warning
-    - alert: etcdHighNumberOfFailedGRPCRequests
-      annotations:
-        message: 'etcd cluster "{{`{{ $labels.job }}`}}": {{`{{ $value }}`}}% of requests for {{`{{ $labels.grpc_method }}`}} failed on etcd instance {{`{{ $labels.instance }}`}}.'
-      expr: |-
-        100 * sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code!="OK"}[5m])) BY (job, instance, grpc_service, grpc_method)
-          /
-        sum(rate(grpc_server_handled_total{job=~".*etcd.*"}[5m])) BY (job, instance, grpc_service, grpc_method)
-          > 1
-      for: 10m
-      labels:
-        severity: warning
-    - alert: etcdHighNumberOfFailedGRPCRequests
-      annotations:
-        message: 'etcd cluster "{{`{{ $labels.job }}`}}": {{`{{ $value }}`}}% of requests for {{`{{ $labels.grpc_method }}`}} failed on etcd instance {{`{{ $labels.instance }}`}}.'
-      expr: |-
-        100 * sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code!="OK"}[5m])) BY (job, instance, grpc_service, grpc_method)
-          /
-        sum(rate(grpc_server_handled_total{job=~".*etcd.*"}[5m])) BY (job, instance, grpc_service, grpc_method)
-          > 5
-      for: 5m
-      labels:
-        severity: critical
     - alert: etcdGRPCRequestsSlow
       annotations:
         message: 'etcd cluster "{{`{{ $labels.job }}`}}": gRPC requests to {{`{{ $labels.grpc_method }}`}} are taking {{`{{ $value }}`}}s on etcd instance {{`{{ $labels.instance }}`}}.'


### PR DESCRIPTION

#### What this PR does / why we need it:

This PR removes etcd gRPC calls failed alerts. These alerts are firing constantly due to some issues around how to etcd increases its metrics. See etcd-io/etcd#10289

#### Which issue this PR fixes

Once etcd metrics are enabled and scrapped by Prometheus, false positives are triggering from these alerts. This has been detected on Openshift as well as on a vanilla Kubernetes installation. See https://github.com/openshift/cluster-monitoring-operator/pull/340


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
