### PR TITLE
[stable/airflow]: align log path directories

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 2.8.5
+version: 2.8.6
 appVersion: 1.10.2
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/templates/configmap-env.yaml
+++ b/stable/airflow/templates/configmap-env.yaml
@@ -29,6 +29,8 @@ data:
   AIRFLOW__CELERY__WORKER_CONCURRENCY: "{{ .Values.workers.celery.instances }}"
   AIRFLOW__CORE__DAGS_FOLDER: "{{ .Values.dags.path }}"
   AIRFLOW__CORE__BASE_LOG_FOLDER: "{{ .Values.logs.path }}"
+  AIRFLOW__CORE__DAG_PROCESSOR_MANAGER_LOG_LOCATION: "{{ printf "%s/%s" .Values.logs.path "dag_processor_manager/dag_processor_manager.log" }}"
+  AIRFLOW__SCHEDULER__CHILD_PROCESS_LOG_DIRECTORY: "{{ printf "%s/%s" .Values.logs.path "scheduler" }}"
   AIRFLOW__WEBSERVER__BASE_URL: "http://localhost:8080{{ .Values.ingress.web.path }}"
   # Disabling XCom pickling for forward compatibility
   AIRFLOW__CODE__ENABLE_XCOM_PICKLING: "false"


### PR DESCRIPTION
#### What this PR does / why we need it:

When changing the `logs.path` value away from the default, the scheduler and DAG processor manager logs were still being written to the default path. This PR adds missing config overrides for `scheduler.child_process_log_directory` and `core.dag_processor_manager_log_location` to make sure all logs are written to the same base location. It means that when using persistent storage, all of the logs are maintained and avoids an incorrect symlink being created from the *new* log path to the *default* one.

The logging paths configuration options can be seen in [airflow_local_settings.py](https://github.com/apache/airflow/blob/1.10.2/airflow/config_templates/airflow_local_settings.py#L40) so I'm confident that this gets them all.

#### Checklist

- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
