### PR TITLE
[incubator/kafka] Fix hard coded headless port

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.15.5
+version: 0.15.6
 appVersion: 5.0.1
 keywords:
 - kafka

--- a/incubator/kafka/templates/NOTES.txt
+++ b/incubator/kafka/templates/NOTES.txt
@@ -27,12 +27,12 @@ To create a new topic:
 
 To listen for messages on a topic:
 
-  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- /opt/kafka/bin/kafka-console-consumer.sh --bootstrap-server {{ include "kafka.fullname" . }}:9092 --topic test1 --from-beginning
+  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- /opt/kafka/bin/kafka-console-consumer.sh --bootstrap-server {{ include "kafka.fullname" . }}:{{ .Values.headless.port }} --topic test1 --from-beginning
 
 To stop the listener session above press: Ctrl+C
 
 To start an interactive message producer session:
-  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- /opt/kafka/bin/kafka-console-producer.sh --broker-list {{ include "kafka.fullname" . }}-headless:9092 --topic test1
+  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- /opt/kafka/bin/kafka-console-producer.sh --broker-list {{ include "kafka.fullname" . }}-headless:{{ .Values.headless.port }} --topic test1
 
 To create a message in the above session, simply type the message and press "enter"
 To end the producer session try: Ctrl+C

--- a/incubator/kafka/templates/configmap-config.yaml
+++ b/incubator/kafka/templates/configmap-config.yaml
@@ -19,7 +19,7 @@ data:
       echo "Waiting for Zookeeper..."
       sleep 20
     done
-    until nc -z {{ template "kafka.fullname" . }} 9092 || (( retries++ >= 6 ))
+    until nc -z {{ template "kafka.fullname" . }} {{ .Values.headless.port }} || (( retries++ >= 6 ))
     do
       echo "Waiting for Kafka..."
       sleep 20

--- a/incubator/kafka/templates/deployment-kafka-exporter.yaml
+++ b/incubator/kafka/templates/deployment-kafka-exporter.yaml
@@ -29,7 +29,7 @@ spec:
       - image: "{{ .Values.prometheus.kafka.image }}:{{ .Values.prometheus.kafka.imageTag }}"
         name: kafka-exporter
         args:
-          - --kafka.server={{ template "kafka.fullname" . }}:9092
+          - --kafka.server={{ template "kafka.fullname" . }}:{{ .Values.headless.port }}
           - --web.listen-address=:{{ .Values.prometheus.kafka.port }}
         ports:
           - containerPort: {{ .Values.prometheus.kafka.port }}

--- a/incubator/kafka/templates/service-brokers.yaml
+++ b/incubator/kafka/templates/service-brokers.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   ports:
   - name: broker
-    port: 9092
+    port: {{ .Values.headless.port }}
     targetPort: kafka
 {{- if and .Values.prometheus.jmx.enabled .Values.prometheus.operator.enabled }}
   - name: jmx-exporter

--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -113,7 +113,7 @@ spec:
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         ports:
-        - containerPort: 9092
+        - containerPort: {{ .Values.headless.port }}
           name: kafka
         {{- if .Values.external.enabled }}
           {{- $replicas := .Values.replicas | int }}
@@ -195,7 +195,7 @@ spec:
           {{- if eq .Values.external.type "LoadBalancer" }}
           export LOAD_BALANCER_IP=$(echo '{{ .Values.external.loadBalancerIP }}' | tr -d '[]' | cut -d ' ' -f "$(($KAFKA_BROKER_ID + 1))") && \
           {{- end }}
-          export KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://${POD_NAME}.{{ include "kafka.fullname" . }}-headless.${POD_NAMESPACE}:9092{{ if kindIs "string" $advertisedListenersOverride }}{{ printf ",%s" $advertisedListenersOverride }}{{ end }} && \
+          export KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://${POD_NAME}.{{ include "kafka.fullname" . }}-headless.${POD_NAMESPACE}:{{ .Values.headless.port }}{{ if kindIs "string" $advertisedListenersOverride }}{{ printf ",%s" $advertisedListenersOverride }}{{ end }} && \
           exec /etc/confluent/docker/run
         volumeMounts:
         - name: datadir

--- a/incubator/kafka/templates/tests/test_topic_create_consume_produce.yaml
+++ b/incubator/kafka/templates/tests/test_topic_create_consume_produce.yaml
@@ -17,7 +17,7 @@ spec:
       # Create a message
       MESSAGE="`date -u`" && \
       # Produce a test message to the topic
-      echo "$MESSAGE" | kafka-console-producer --broker-list {{ include "kafka.fullname" . }}:9092 --topic helm-test-topic-create-consume-produce && \
+      echo "$MESSAGE" | kafka-console-producer --broker-list {{ include "kafka.fullname" . }}:{{ .Values.headless.port }} --topic helm-test-topic-create-consume-produce && \
       # Consume a test message from the topic
-      kafka-console-consumer --bootstrap-server {{ include "kafka.fullname" . }}-headless:9092 --topic helm-test-topic-create-consume-produce --from-beginning --timeout-ms 2000 --max-messages 1 | grep "$MESSAGE"
+      kafka-console-consumer --bootstrap-server {{ include "kafka.fullname" . }}-headless:{{ .Values.headless.port }} --topic helm-test-topic-create-consume-produce --from-beginning --timeout-ms 2000 --max-messages 1 | grep "$MESSAGE"
   restartPolicy: Never


### PR DESCRIPTION
#### What this PR does / why we need it:

9092 is currently the hard coded port for the headless service, should be configurable with a variable


#### Special notes for your reviewer:
This is the same as issue #14288  :) hoping everything is signed off properly now!

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
