### PR TITLE
[incubator/vault] Add RBAC to vault.

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.18.11
+version: 0.18.12
 appVersion: 1.1.2
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -80,6 +80,7 @@ The following table lists the configurable parameters of the Vault chart and the
 | `podLabels`                       | Extra labels for pods                    | `{}`                                |
 | `serviceAccount.create`           | Specifies whether a ServiceAccount should be created | `false`                 |
 | `serviceAccount.name`             | The name of the ServiceAccount to create | Generated from fullname template    |
+| `rbac.enabled`                    | Specifies whether RBAC should be enabled | `false`                             |
 | `consulAgent.join`                | If set, start start a consul agent       | `nil`                               |
 | `consulAgent.repository`          | Container image for consul agent         | `consul`                            |
 | `consulAgent.tag`                 | Container image tag for consul agent     | `1.4.0`                             |

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -79,11 +79,8 @@ The following table lists the configurable parameters of the Vault chart and the
 | `minReadySeconds`                 | Minimum number of seconds that newly created replicas must be ready without any containers crashing | `0`                                |
 | `podLabels`                       | Extra labels for pods                    | `{}`                                |
 | `serviceAccount.create`           | Specifies whether a ServiceAccount should be created | `false`                 |
-<<<<<<< HEAD
 | `serviceAccount.name`             | The name of the ServiceAccount to create | Generated from fullname template    |
-=======
->>>>>>> Add RBAC to vault.
-| `rbac.enabled`                    | Specifies whether RBAC should be enabled | `false`                             |
+| `rbac.create`                     | Specifies whether RBAC should be created | `true`                              |
 | `consulAgent.join`                | If set, start start a consul agent       | `nil`                               |
 | `consulAgent.repository`          | Container image for consul agent         | `consul`                            |
 | `consulAgent.tag`                 | Container image tag for consul agent     | `1.4.0`                             |

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -78,7 +78,7 @@ The following table lists the configurable parameters of the Vault chart and the
 | `priorityClassName`               | Priority class name for pods             | `""`                                |
 | `minReadySeconds`                 | Minimum number of seconds that newly created replicas must be ready without any containers crashing | `0`                                |
 | `podLabels`                       | Extra labels for pods                    | `{}`                                |
-| `serviceAccount.create`           | Specifies whether a ServiceAccount should be created | `false`                 |
+| `serviceAccount.create`           | Specifies whether a ServiceAccount should be created | `true`                 |
 | `serviceAccount.name`             | The name of the ServiceAccount to create | Generated from fullname template    |
 | `rbac.create`                     | Specifies whether RBAC should be created | `true`                              |
 | `consulAgent.join`                | If set, start start a consul agent       | `nil`                               |

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -79,7 +79,10 @@ The following table lists the configurable parameters of the Vault chart and the
 | `minReadySeconds`                 | Minimum number of seconds that newly created replicas must be ready without any containers crashing | `0`                                |
 | `podLabels`                       | Extra labels for pods                    | `{}`                                |
 | `serviceAccount.create`           | Specifies whether a ServiceAccount should be created | `false`                 |
+<<<<<<< HEAD
 | `serviceAccount.name`             | The name of the ServiceAccount to create | Generated from fullname template    |
+=======
+>>>>>>> Add RBAC to vault.
 | `rbac.enabled`                    | Specifies whether RBAC should be enabled | `false`                             |
 | `consulAgent.join`                | If set, start start a consul agent       | `nil`                               |
 | `consulAgent.repository`          | Container image for consul agent         | `consul`                            |

--- a/incubator/vault/templates/role.yaml
+++ b/incubator/vault/templates/role.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "vault.serviceAccountName" . }}
+  labels:
+    app: {{ template "vault.name" . }}
+    chart: {{ template "vault.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: {{ template "vault.serviceAccountName" . }}
+  namespace: default
+{{- end -}}

--- a/incubator/vault/templates/role.yaml
+++ b/incubator/vault/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.enabled -}}
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -242,4 +242,4 @@ vault:
 
 rbac:
    ## Enable RBAC
-  enabled: false
+  create: true

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -239,3 +239,7 @@ vault:
       #   bucket: ""
       #   # Use a custom secret to mount this file.
       #   credentials_file: ""
+
+rbac:
+   ## Enable RBAC
+  enabled: false

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -144,7 +144,7 @@ minReadySeconds: 0
 serviceAccount:
   ## Specifies whether a ServiceAccount should be created
   ##
-  create: false
+  create: true
   ## The name of the ServiceAccount to use.
   ## If not set and create is true, a name is generated using the fullname template
   name:


### PR DESCRIPTION
Signed-off-by: Aravind Valkodai <Aravind.Valkodai@qlik.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Adding RBAC for vault. RBAC is need for enabling `Kubernetes Auth Method` in Vault. (https://www.vaultproject.io/docs/auth/kubernetes.html) for more details.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x ] Variables are documented in the README.md
- [x ] Title of the PR starts with chart name (e.g. `[stable/chart]`)
