### PR TITLE
[stable/velero] optionally deploy restic daemonset as privileged pods

### DIFF
--- a/stable/velero/Chart.yaml
+++ b/stable/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.0
 description: A Helm chart for velero
 name: velero
-version: 2.0.4
+version: 2.0.5
 home: https://github.com/heptio/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/stable/velero/README.md
+++ b/stable/velero/README.md
@@ -92,7 +92,7 @@ Parameter | Description | Default
 `metrics.serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`
 `schedules` | A dict of schedules | `{}`
 `restic.podVolumePath` | Location of pod volumes on the host | `/var/lib/kubelet/pods`
-
+`restic.privileged` | Whether restic should run as a privileged pod. Only necessary in special cases (SELinux) | `false`
 
 ## How to
 ```

--- a/stable/velero/templates/restic-daemonset.yaml
+++ b/stable/velero/templates/restic-daemonset.yaml
@@ -89,6 +89,8 @@ spec:
             - name: AWS_SHARED_CREDENTIALS_FILE
               value: /credentials/cloud
             {{- end }}
+          securityContext:
+            privileged: {{ .Values.restic.privileged }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/stable/velero/values.yaml
+++ b/stable/velero/values.yaml
@@ -154,6 +154,7 @@ deployRestic: false
 
 restic:
   podVolumePath: /var/lib/kubelet/pods
+  privileged: false
 
 # Backup schedules to create.
 # Eg:


### PR DESCRIPTION
Signed-off-by: Mathias Merscher <Mathias.Merscher@dg-i.net>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it

Under certain circumstances (e.g. when running with SELinux) the restic daemonset needs to run as privileged pods. This change makes this configurable.

#### Special notes for your reviewer

Could lead to merge conflicts with #14378. Let me know if I should rebase one of the PRs.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
