### PR TITLE
stable/airflow: fix wrong scheduler key in scheduler.resources

### DIFF
--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -178,8 +178,7 @@ airflow:
   #   emptyDir: {}
 
 scheduler:
-  resources:
-    scheduler: {}
+  resources: {}
     # limits:
     #   cpu: "1000m"
     #   memory: "1Gi"


### PR DESCRIPTION
#### What this PR does / why we need it:

Remove dangling `scheduler` key in `scheduler.resources` in airflow's `values.yaml`.