### PR TITLE
[stable/instana] Bump leadership-elector to 0.5.4

### DIFF
--- a/stable/instana-agent/Chart.yaml
+++ b/stable/instana-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: instana-agent
-version: 1.0.9
+version: 1.0.10
 appVersion: 1.0
 description: Instana Agent for Kubernetes
 home: https://www.instana.com/
@@ -20,3 +20,5 @@ maintainers:
     email: miel.donkers@instana.com
   - name: dlbock
     email: dahlia.bock@instana.com
+  - name: nfisher
+    email: nathan.fisher@instana.com

--- a/stable/instana-agent/OWNERS
+++ b/stable/instana-agent/OWNERS
@@ -5,6 +5,7 @@ approvers:
 - fstab
 - mdonkers
 - dlbock
+- nfisher
 reviewers:
 - jbrisbin
 - wiggzz
@@ -12,3 +13,4 @@ reviewers:
 - fstab
 - mdonkers
 - dlbock
+- nfisher

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -122,13 +122,17 @@ spec:
           ports:
             - containerPort: 42699
         - name: {{ template "instana-agent.name" . }}-leader-elector
-          image: instana/leader-elector:0.5.1
+          image: instana/leader-elector:0.5.4
           env:
             - name: INSTANA_AGENT_POD_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-          args: ["--election=instana", "--http=localhost:{{ default 42655 .Values.agent.leaderElectorPort }}", "--id=$(INSTANA_AGENT_POD_NAME)"]
+          command:
+            - "/app/server"
+            - "--election=instana"
+            - "--http=localhost:{{ default 42655 .Values.agent.leaderElectorPort }}"
+            - "--id=$(INSTANA_AGENT_POD_NAME)"
           resources:
             requests:
               cpu: 0.1


### PR DESCRIPTION
#### What this PR does / why we need it:

Updated leader-elector to 0.5.4 which uses a distroless image to reduce the number of ongoing vulnerabilities to 3 Debian stretch libraries:

- [glibc](https://security-tracker.debian.org/tracker/source-package/glibc)
- [openssl](https://security-tracker.debian.org/tracker/source-package/openssl)
- [busybox](https://security-tracker.debian.org/tracker/source-package/busybox)

#### Special notes for your reviewer:

- Chart installed and verified in minikube.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)