### PR TITLE
docs(stable/concourse): update instructions to generate secrets

### DIFF
--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -255,13 +255,14 @@ cd concourse-secrets
 # - web key pair,
 # - worker key pair, and
 # - the session signing token.
-#
-ssh-keygen -t rsa -f host-key  -N ''
+# Generate these keys using the concourse binary to ensure they are compatible
+
+concourse generate-key -t ssh -f ./host-key
 mv host-key.pub host-key-pub
-ssh-keygen -t rsa -f worker-key  -N ''
+concourse generate-key -t ssh -f ./worker-key
 mv worker-key.pub worker-key-pub
-ssh-keygen -t rsa -f session-signing-key  -N ''
-rm session-signing-key.pub
+concourse generate-key -t rsa -f ./session-signing-key
+
 printf "%s:%s" "concourse" "$(openssl rand -base64 24)" > local-users
 ```
 


### PR DESCRIPTION
The readme advises to use `ssh-keygen -t rsa -f host-key  -N ''` to generate keys for concourse. However, some ssh-keygen implementations will generate keys that make concourse crash with ugly SIGSEGV errors. 

This has already been reported upstream: https://github.com/concourse/concourse/issues/2779

I propose changing the instructions to match the [official docs](https://concourse-ci.org/concourse-generate-key.html), slightly adapted for filenames
