### PR TITLE
stable/nextcloud: create db-secrets also for external DB

### DIFF
--- a/stable/nextcloud/Chart.yaml
+++ b/stable/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nextcloud
-version: 1.2.1
+version: 1.2.2
 appVersion: 16.0.1
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/nextcloud/templates/db-secret.yaml
+++ b/stable/nextcloud/templates/db-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.mariadb.enabled }}
+{{- if or .Values.mariadb.enabled .Values.externalDatabase.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/nextcloud/templates/db-secret.yaml
+++ b/stable/nextcloud/templates/db-secret.yaml
@@ -10,6 +10,11 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
+  {{- if .Values.mariadb.enabled }}
   db-password: {{ default "" .Values.mariadb.db.password | b64enc | quote }}
   db-username: {{ default "" .Values.mariadb.db.user | b64enc | quote }}
+  {{- else }}
+  db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
+  db-username: {{ default "" .Values.externalDatabase.user | b64enc | quote }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Lennart Jern <lennart.jern@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
The db-secret was only created for mariadb, not for external databases even though the deployment expects this. This PR allows the deployment to work also with external databases.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
