### PR TITLE
[stable/prometheus-adapter] conditionally register external metrics API (#13716)

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 1.0.2
+version: 1.0.3
 appVersion: v0.5.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/ci/external-rules-values.yaml
+++ b/stable/prometheus-adapter/ci/external-rules-values.yaml
@@ -1,0 +1,9 @@
+rules:
+  external:
+  - seriesQuery: '{__name__=~"^some_metric_count$"}'
+    resources:
+      template: <<.Resource>>
+    name:
+      matches: ""
+      as: "my_custom_metric"
+    metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)

--- a/stable/prometheus-adapter/templates/external-metrics-apiservice.yaml
+++ b/stable/prometheus-adapter/templates/external-metrics-apiservice.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rules.external }}
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
 metadata:
@@ -19,3 +20,4 @@ spec:
   insecureSkipTLSVerify: {{ if .Values.tls.enable }}false{{ else }}true{{ end }}
   groupPriorityMinimum: 100
   versionPriority: 100
+{{- end -}}

--- a/stable/prometheus-adapter/templates/external-metrics-cluster-role.yaml
+++ b/stable/prometheus-adapter/templates/external-metrics-cluster-role.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.rbac.create -}}
-{{- if .Values.rules.external }}
+{{- if and .Values.rbac.create .Values.rules.external -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -18,5 +17,4 @@ rules:
   - list
   - get
   - watch
-{{- end -}}
 {{- end -}}

--- a/stable/prometheus-adapter/templates/external-metrics-cluster-role.yaml
+++ b/stable/prometheus-adapter/templates/external-metrics-cluster-role.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.rbac.create -}}
+{{- if .Values.rules.external }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -17,4 +18,5 @@ rules:
   - list
   - get
   - watch
+{{- end -}}
 {{- end -}}

--- a/stable/prometheus-adapter/templates/hpa-external-metrics-cluster-role-binding.yaml
+++ b/stable/prometheus-adapter/templates/hpa-external-metrics-cluster-role-binding.yaml
@@ -1,5 +1,5 @@
-
 {{- if .Values.rbac.create -}}
+{{- if .Values.rules.external }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -17,4 +17,5 @@ subjects:
 - kind: ServiceAccount
   name: horizontal-pod-autoscaler
   namespace: kube-system
+{{- end -}}
 {{- end -}}

--- a/stable/prometheus-adapter/templates/hpa-external-metrics-cluster-role-binding.yaml
+++ b/stable/prometheus-adapter/templates/hpa-external-metrics-cluster-role-binding.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.rbac.create -}}
-{{- if .Values.rules.external }}
+{{- if and .Values.rbac.create .Values.rules.external -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -17,5 +16,4 @@ subjects:
 - kind: ServiceAccount
   name: horizontal-pod-autoscaler
   namespace: kube-system
-{{- end -}}
 {{- end -}}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

The prometheus-adapter will NOT serve external metrics API if `externalRules` section is not specified. See this code: https://github.com/DirectXMan12/k8s-prometheus-adapter/blob/v0.5.0/cmd/adapter/adapter.go#L177

In that case, we cannot bindly register the external metrics API. Otherwise, we might see issues described in #13716. This patch fixed the issue by conditionally register the external metrics API.

#### Which issue this PR fixes

  - fixes #13716

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
