### PR TITLE
[stable/seq] Version change to GA and add baseURI setting

### DIFF
--- a/stable/seq/Chart.yaml
+++ b/stable/seq/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: seq
-version: 1.0.0
-appVersion: 5.0.832-pre
+version: 1.0.1
+appVersion: 5
 description: Seq is the easiest way for development teams to capture, search and visualize structured log events! This page will walk you through the very quick setup process.
 keywords:
 - seq

--- a/stable/seq/README.md
+++ b/stable/seq/README.md
@@ -46,9 +46,10 @@ The following table lists the configurable parameters of the Seq chart and their
 |           Parameter           |                Description                        |           Default            |
 |-------------------------------|-------------------------------------------------- |------------------------------|
 | `image.repository`         | Image repository                    | `datalust/seq`                                          |
-| `image.tag`                | Seq image tag. Possible values listed [here](https://hub.docker.com/r/datalust/seq/tags/).| `5.0.832-pre`|
+| `image.tag`                | Seq image tag. Possible values listed [here](https://hub.docker.com/r/datalust/seq/tags/).| `5`|
 | `image.pullPolicy`         | Image pull policy                   | `IfNotPresent`                                          |
-| `acceptEULA`               | Accept EULA                         | `Y`                                                 |
+| `acceptEULA`               | Accept EULA                         | `Y`                                                     |
+| `baseURI`                  | Base URL for ingress/AAD (see values.yaml)|                                                   |
 | `service.type`             | Kubernetes service type             | `ClusterIP`                                             |
 | `service.port`             | Kubernetes port where service is exposed| `5341`                                              |
 | `persistence.enabled`      | Use persistent volume to store data | `true`                                                  |

--- a/stable/seq/templates/deployment.yaml
+++ b/stable/seq/templates/deployment.yaml
@@ -25,6 +25,10 @@ spec:
           env:
             - name: "ACCEPT_EULA"
               value: "{{ .Values.acceptEULA }}"
+{{- if .Values.baseURI }}
+            - name: "BASE_URI"
+              value: "{{ .Values.baseURI }}"
+{{- end }}
           ports:
             - name: ingestion
               containerPort: 5341

--- a/stable/seq/values.yaml
+++ b/stable/seq/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: datalust/seq
-  tag: 5.0.832-pre
+  tag: 5
   pullPolicy: IfNotPresent
 
 # By passing the value Y in the ACCEPT_EULA environment variable,
@@ -12,6 +12,13 @@ image:
 # Seq End User License Agreement applicable to the Seq Docker image
 # that you intend to use.
 acceptEULA: "Y"
+
+# Set this URL if you enable ingress and/or AAD authentication.
+# Without this URL set to include HTTPS, SEQ will try to set a login redirect
+# URL with HTTP instead of HTTPS and AAD's registration requires HTTPS.
+# The result is that you'll get an error during login:
+#   AADSTS50011: The reply url specified in the request does not match the reply urls configured for the application
+# baseURI: https://my.public.url/
 
 service:
   type: ClusterIP


### PR DESCRIPTION
    - Bump SEQ to GA 5.0 image tag
    - Add setting for BASE_URI - Needed for Ingress and Azure Active Directory Authentication

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Bumps SEQ image tag to GA version (5).  Adds environment variable setting for [BASE_URI](https://docs.datalust.co/docs/getting-started-with-docker#section-environment-variables) which is needed to support Ingress and Azure AD.  Without overriding and specifying HTTPS in the URL, SEQ will give a login redirect URL with HTTP and AAD only supports login redirects to HTTPS

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
