### PR TITLE
[stabled/elasticsearch-exporter] add custom labels to the service and set service http port name

### DIFF
--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 1.2.0
+version: 1.3.0
 appVersion: 1.0.2
 home: https://github.com/justwatchcom/elasticsearch_exporter
 sources:

--- a/stable/elasticsearch-exporter/README.md
+++ b/stable/elasticsearch-exporter/README.md
@@ -56,8 +56,9 @@ Parameter | Description | Default
 `podAnnotations` | Pod annotations | `{}` |
 `service.type` | type of service to create | `ClusterIP`
 `service.httpPort` | port for the http service | `9108`
+`service.metricsPort.name` | name for the http service | `http`
 `service.annotations` | Annotations on the http service | `{}`
-`service.labels` | Additional labels for the service definition | `{}` 
+`service.labels` | Additional labels for the service definition | `{}`
 `es.uri` | address of the Elasticsearch node to connect to | `localhost:9200`
 `es.all` | if `true`, query stats for all nodes in the cluster, rather than just the node we connect to | `true`
 `es.indices` | if true, query stats for all indices in the cluster | `true`

--- a/stable/elasticsearch-exporter/README.md
+++ b/stable/elasticsearch-exporter/README.md
@@ -57,6 +57,7 @@ Parameter | Description | Default
 `service.type` | type of service to create | `ClusterIP`
 `service.httpPort` | port for the http service | `9108`
 `service.annotations` | Annotations on the http service | `{}`
+`service.labels` | Additional labels for the service definition | `{}` 
 `es.uri` | address of the Elasticsearch node to connect to | `localhost:9200`
 `es.all` | if `true`, query stats for all nodes in the cluster, rather than just the node we connect to | `true`
 `es.indices` | if true, query stats for all indices in the cluster | `true`

--- a/stable/elasticsearch-exporter/templates/service.yaml
+++ b/stable/elasticsearch-exporter/templates/service.yaml
@@ -7,6 +7,11 @@ metadata:
     app: {{ template "elasticsearch-exporter.name" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    {{- if .Values.service.labels }}
+    {{- range $key, $value := .Values.service.labels }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}
@@ -14,7 +19,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - name: http
+    - name: port
       port: {{ .Values.service.httpPort }}
       protocol: TCP
   selector:

--- a/stable/elasticsearch-exporter/templates/service.yaml
+++ b/stable/elasticsearch-exporter/templates/service.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - name: port
+    - name: {{ .Values.service.metricsPort.name }}
       port: {{ .Values.service.httpPort }}
       protocol: TCP
   selector:

--- a/stable/elasticsearch-exporter/templates/servicemonitor.yaml
+++ b/stable/elasticsearch-exporter/templates/servicemonitor.yaml
@@ -22,7 +22,7 @@ spec:
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
     {{- end }}
     honorLabels: true
-    port: http
+    port: {{ .Values.service.metricsPort.name }}
     path: {{ .Values.web.path }}
     scheme: {{ .Values.serviceMonitor.scheme }}
   jobLabel: "{{ .Release.Name }}"

--- a/stable/elasticsearch-exporter/values.yaml
+++ b/stable/elasticsearch-exporter/values.yaml
@@ -31,6 +31,7 @@ service:
   type: ClusterIP
   httpPort: 9108
   annotations: {}
+  labels: {}
 
 es:
   ## Address (host and port) of the Elasticsearch node we should connect to.

--- a/stable/elasticsearch-exporter/values.yaml
+++ b/stable/elasticsearch-exporter/values.yaml
@@ -30,6 +30,8 @@ podAnnotations: {}
 service:
   type: ClusterIP
   httpPort: 9108
+  metricsPort:
+    name: http
   annotations: {}
   labels: {}
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Add custom labels to the elasticsearch-exporter service.
Rename the elasticsearch-exporter service http port which expose metrics to a more standardized name such as `metrics`.  The default value remains as before `port`.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
