### PR TITLE
[stable/kiam] added whitelist argument in agent-daemonset.yaml

### DIFF
--- a/stable/kiam/Chart.yaml
+++ b/stable/kiam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kiam
-version: 2.4.0
+version: 2.4.1
 appVersion: 3.2
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/stable/kiam/README.md
+++ b/stable/kiam/README.md
@@ -98,6 +98,7 @@ Parameter | Description | Default
 `agent.image.tag` | Agent image tag | `v3.2`
 `agent.image.pullPolicy` | Agent image pull policy | `IfNotPresent`
 `agent.dnsPolicy` | Agent pod DNS policy | `ClusterFirstWithHostNet`
+`agent.whiteListRouteRegexp` | Agent pod whitelist metadata API path argument regex  | `{}`
 `agent.extraArgs` | Additional agent container arguments | `{}`
 `agent.extraEnv` | Additional agent container environment variables | `{}`
 `agent.extraHostPathMounts` | Additional agent container hostPath mounts | `[]`

--- a/stable/kiam/templates/agent-daemonset.yaml
+++ b/stable/kiam/templates/agent-daemonset.yaml
@@ -94,6 +94,9 @@ spec:
             - --prometheus-listen-addr=0.0.0.0:{{ .Values.agent.prometheus.port }}
             - --prometheus-sync-interval={{ .Values.agent.prometheus.syncInterval }}
             {{- end }}
+            {{- if .Values.agent.whiteListRouteRegexp }}
+            - --whitelist-route-regexp={{ .Values.agent.whiteListRouteRegexp }}
+            {{- end }}
             - --gateway-timeout-creation={{ .Values.agent.gatewayTimeoutCreation }}
           {{- range $key, $value := .Values.agent.extraArgs }}
             {{- if $value }}

--- a/stable/kiam/values.yaml
+++ b/stable/kiam/values.yaml
@@ -14,6 +14,11 @@ agent:
     tag: v3.2
     pullPolicy: IfNotPresent
 
+  ## agent whitelist of proxy routes matching this reg-ex
+  ##
+  # whiteListRouteRegexp:
+
+
   ## Logging settings
   ##
   log:


### PR DESCRIPTION
Signed-off by: Pravar Agrawal pravarag@gmail.com

#### What this PR does / why we need it:
- Makes it possible to specify whitelist arguments for allowing other AWS metadata API paths which are currently blocked by default
- Update the README.md
- Bump the version

https://github.com/uswitch/kiam/blob/a7456b01a22ea60adcf7dda861953af64efc3478/cmd/kiam/agent.go#L49

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
