### PR TITLE
[stable/metrics-server] Use nindent for metrics-server service labels

### DIFF
--- a/stable/metrics-server/Chart.yaml
+++ b/stable/metrics-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.3.2
 description: Metrics Server is a cluster-wide aggregator of resource usage data.
 name: metrics-server
-version: 2.8.0
+version: 2.8.1
 keywords:
 - metrics-server
 home: https://github.com/kubernetes-incubator/metrics-server

--- a/stable/metrics-server/templates/metric-server-service.yaml
+++ b/stable/metrics-server/templates/metric-server-service.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     {{- with .Values.service.labels }}
-    {{ toYaml . | indent 4}}
+    {{ toYaml . | nindent 4}}
     {{- end }}
   annotations:
     {{- toYaml .Values.service.annotations | nindent 4 }}


### PR DESCRIPTION
`indent` produces incorrectly-formatted YAML when inserting labels specified in a values file into the metric-server-service template, e.g.:

```yaml
metadata:
  name: release-name-metrics-server
  labels:
    app: metrics-server
    chart: metrics-server-2.8.0
    release: release-name
    heritage: Tiller
        kubernetes.io/cluster-service: "true"
    kubernetes.io/name: metrics-server

  annotations:
    {}
```

Using `nindent` instead produces the intended output without the extra indentation on the values-specified labels.

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
