### PR TITLE
[stable/metricbeat] Fix 'secrets.yaml' to make `ExtraSecrets`work.

### DIFF
--- a/stable/metricbeat/Chart.yaml
+++ b/stable/metricbeat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart to collect Kubernetes logs with metricbeat
 icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.svg
 name: metricbeat
-version: 1.6.2
+version: 1.6.3
 appVersion: 6.7.0
 home: https://www.elastic.co/products/beats/metricbeat
 sources:

--- a/stable/metricbeat/templates/secret.yaml
+++ b/stable/metricbeat/templates/secret.yaml
@@ -72,8 +72,8 @@ kind: Secret
 metadata:
   name: {{ $secret.name }}
   labels:
-    app: {{ default $.Chart.Name $.Values.nameOverride | trunc 63 | trimSuffix "-" }}
-    chart: {{ printf "%s-%s" $.Chart.Name $.Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+    app: {{ template "metricbeat.name" $ }}
+    chart: {{ template "metricbeat.chart" $ }}
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
 type: Opaque

--- a/stable/metricbeat/templates/secret.yaml
+++ b/stable/metricbeat/templates/secret.yaml
@@ -72,8 +72,8 @@ kind: Secret
 metadata:
   name: {{ $secret.name }}
   labels:
-    app: {{ template "metricbeat.name" . }}
-    chart: {{ template "metricbeat.chart" . }}
+    app: {{ default $.Chart.Name $.Values.nameOverride | trunc 63 | trimSuffix "-" }}
+    chart: {{ printf "%s-%s" $.Chart.Name $.Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
 type: Opaque

--- a/stable/metricbeat/values.yaml
+++ b/stable/metricbeat/values.yaml
@@ -139,10 +139,11 @@ extraVolumeMounts: []
   #   readOnly: true
 extraSecrets: []
   # - name: ca-cert
-  #   data: |-
-  #     -----BEGIN CERTIFICATE-----
-  #     ...
-  #     -----END CERTIFICATE-----
+  #   data:
+  #     ca.pem: |-
+  #       -----BEGIN CERTIFICATE-----
+  #       ...
+  #       -----END CERTIFICATE-----
   # - name: userdata
   #   data:
   #     id: userid


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This is related to [PR #14084](https://github.com/helm/charts/pull/14084).
I forgot that an access with `.Values` didn't work in `range` function so that I have to fix it.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
