### PR TITLE
[stable/postgresql] Ensure intContainer creates the data directory.

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 5.2.1
+version: 5.2.2
 appVersion: 11.3.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/statefulset-slaves.yaml
+++ b/stable/postgresql/templates/statefulset-slaves.yaml
@@ -70,11 +70,9 @@ spec:
           - sh
           - -c
           - |
+            mkdir -p {{ .Values.persistence.mountPath }}/data && chmod 0700 {{ .Values.persistence.mountPath }}/data
             find {{ .Values.persistence.mountPath }} -mindepth 1 -maxdepth 1 -not -name ".snapshot" | \
               xargs chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}
-            if [ -d {{ .Values.persistence.mountPath }}/data ]; then
-              chmod  0700 {{ .Values.persistence.mountPath }}/data;
-            fi
         securityContext:
           runAsUser: {{ .Values.volumePermissions.securityContext.runAsUser }}
         volumeMounts:

--- a/stable/postgresql/templates/statefulset-slaves.yaml
+++ b/stable/postgresql/templates/statefulset-slaves.yaml
@@ -70,7 +70,7 @@ spec:
           - sh
           - -c
           - |
-            mkdir -p {{ .Values.persistence.mountPath }}/data && chmod 0700 {{ .Values.persistence.mountPath }}/data
+            mkdir -m 700 -p {{ .Values.persistence.mountPath }}/data
             find {{ .Values.persistence.mountPath }} -mindepth 1 -maxdepth 1 -not -name ".snapshot" | \
               xargs chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}
         securityContext:

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -74,7 +74,7 @@ spec:
           - sh
           - -c
           - |
-            mkdir -p {{ .Values.persistence.mountPath }}/data && chmod 0700 {{ .Values.persistence.mountPath }}/data
+            mkdir -m 700 -p {{ .Values.persistence.mountPath }}/data
             find {{ .Values.persistence.mountPath }} -mindepth 1 -maxdepth 1 -not -name ".snapshot" | \
               xargs chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}
         securityContext:

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -74,11 +74,9 @@ spec:
           - sh
           - -c
           - |
+            mkdir -p {{ .Values.persistence.mountPath }}/data && chmod 0700 {{ .Values.persistence.mountPath }}/data
             find {{ .Values.persistence.mountPath }} -mindepth 1 -maxdepth 1 -not -name ".snapshot" | \
               xargs chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}
-            if [ -d {{ .Values.persistence.mountPath }}/data ]; then
-              chmod  0700 {{ .Values.persistence.mountPath }}/data;
-            fi
         securityContext:
           runAsUser: {{ .Values.volumePermissions.securityContext.runAsUser }}
         volumeMounts:

--- a/stable/postgresql/values-production.yaml
+++ b/stable/postgresql/values-production.yaml
@@ -14,7 +14,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/postgresql
-  tag: 11.3.0-debian-9-r26
+  tag: 11.3.0-debian-9-r27
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/stable/postgresql/values-production.yaml
+++ b/stable/postgresql/values-production.yaml
@@ -14,7 +14,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/postgresql
-  tag: 11.3.0-debian-9-r17
+  tag: 11.3.0-debian-9-r26
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -14,7 +14,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/postgresql
-  tag: 11.3.0-debian-9-r26
+  tag: 11.3.0-debian-9-r27
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -14,7 +14,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/postgresql
-  tag: 11.3.0-debian-9-r17
+  tag: 11.3.0-debian-9-r26
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR ensures the initContainer used to prepare the right permissions in the volume used to persist data are correct. To do so, it ensure the "data" directory exists so the PostgreSQL container doesn't face the error below:

```
 04:12:56.72 INFO  ==> pg_hba.conf file not detected. Generating it...
mkdir: cannot create directory ‘/bitnami/postgresql/data’: Permission denied
 04:12:56.73 INFO  ==> Stopping PostgreSQL...
```

#### Which issue this PR fixes

  - fixes https://github.com/helm/charts/issues/14390

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
