### PR TITLE
[stable/chaoskube] Fixed service account definition for RBAC (#14405).

### DIFF
--- a/stable/chaoskube/Chart.yaml
+++ b/stable/chaoskube/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: chaoskube
-version: 3.1.1
+version: 3.1.2
 appVersion: 0.14.0
 description: Chaoskube periodically kills random pods in your Kubernetes cluster.
 icon: https://raw.githubusercontent.com/linki/chaoskube/master/chaoskube.png

--- a/stable/chaoskube/README.md
+++ b/stable/chaoskube/README.md
@@ -56,7 +56,7 @@ $ helm install stable/chaoskube --set dryRun=false
 | `excludedDaysOfYear`                      | Set Days of the Year to avoid actions (Optional)                                      | "" (Don't skip any days)         |
 | `priorityClassName`                       | priorityClassName                                                                     | `nil`                            |
 | `rbac.create`                             | create rbac service account and roles                                                 | false                            |
-| `rbac.serviceAccountName`                 | name of serviceAccount to use when create is false                                    | default                          |
+| `rbac.serviceAccountName`                 | name of serviceAccount to use                                                         | default                          |
 | `resources`                               | CPU/Memory resource requests/limits                                                   | `{}`                             |
 | `nodeSelector`                            | Node labels for pod assignment                                                        | `{}`                             |
 | `tolerations`                             | Toleration labels for pod assignment                                                  | `[]`                             |

--- a/stable/chaoskube/templates/clusterrole.yaml
+++ b/stable/chaoskube/templates/clusterrole.yaml
@@ -4,7 +4,7 @@ kind: ClusterRole
 metadata:
   labels:
 {{ include "labels.standard" . | indent 4 }}
-  name: {{ printf "%s-%s" .Release.Name .Values.name }}
+  name: {{ template "chaoskube.fullname" . }}
 rules:
   - apiGroups: [""]
     resources: ["pods"]

--- a/stable/chaoskube/templates/clusterrolebinding.yaml
+++ b/stable/chaoskube/templates/clusterrolebinding.yaml
@@ -4,13 +4,13 @@ kind: ClusterRoleBinding
 metadata:
   labels:
 {{ include "labels.standard" . | indent 4 }}
-  name: {{ printf "%s-%s" .Release.Name .Values.name }}
+  name: {{ template "chaoskube.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ printf "%s-%s" .Release.Name .Values.name }}
+  name: {{ template "chaoskube.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ printf "%s-%s" .Release.Name .Values.name }}
+    name: "{{ .Values.rbac.serviceAccountName }}"
     namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/stable/chaoskube/templates/deployment.yaml
+++ b/stable/chaoskube/templates/deployment.yaml
@@ -73,7 +73,9 @@ spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
 {{- end }}
-      serviceAccountName: {{ if .Values.rbac.create }}{{ printf "%s-%s" .Release.Name .Values.name }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+{{- if .Values.rbac.create }}
+      serviceAccountName: "{{ .Values.rbac.serviceAccountName }}"
+{{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/stable/chaoskube/templates/serviceaccount.yaml
+++ b/stable/chaoskube/templates/serviceaccount.yaml
@@ -4,5 +4,5 @@ kind: ServiceAccount
 metadata:
   labels:
 {{ include "labels.standard" . | indent 4 }}
-  name: {{ printf "%s-%s" .Release.Name .Values.name }}
+  name: "{{ .Values.rbac.serviceAccountName }}"
 {{- end -}}

--- a/stable/chaoskube/values.yaml
+++ b/stable/chaoskube/values.yaml
@@ -81,8 +81,6 @@ priorityClassName: ""
 # create service account with permission to list and kill pods
 rbac:
   create: false
-
-  # only used when create is false
   serviceAccountName: default
 
 resources: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixed service account definition for RBAC.

#### Which issue this PR fixes

  - fixes #14405 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
