### PR TITLE
[stable/oauth2-proxy] Add openshift compatiblity for oauth2-proxy

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 0.12.2
+version: 0.13.0
 apiVersion: v1
 appVersion: 3.1.0
 home: http://www.videntity.com/

--- a/stable/oauth2-proxy/README.md
+++ b/stable/oauth2-proxy/README.md
@@ -22,6 +22,16 @@ $ helm install stable/oauth2-proxy --name my-release
 
 The command deploys oauth2-proxy on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
+## Installing on openshift
+
+To install the chart on openshift, you will have to use a different image than
+the vanilla one: openshift/oauth-proxy .
+Sources available here : https://github.com/openshift/oauth-proxy
+
+You will also have to set the isOpenshift value to true.
+
+The installation procedure is then the same as kubernetes.
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `my-release` deployment:
@@ -38,6 +48,7 @@ The following table lists the configurable parameters of the oauth2-proxy chart 
 
 Parameter | Description | Default
 --- | --- | ---
+`isOpenshift`| Is this going to be deployed on openshift ? | `false`
 `affinity` | node/pod affinities | None
 `authenticatedEmailsFile.enabled` | Enables authorize individual email addresses | `false`
 `authenticatedEmailsFile.template` | Name of the configmap that is handled outside of that chart | `""`

--- a/stable/oauth2-proxy/templates/_helpers.tpl
+++ b/stable/oauth2-proxy/templates/_helpers.tpl
@@ -32,6 +32,14 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Create client-id for openshift
+*/}}
+{{- define "oauth2-proxy.openshift.clientId" -}}
+{{- printf "%s" (include "oauth2-proxy.fullname" .) | b64enc | quote -}}
+{{- end -}}
+
+
+{{/*
 Get the secret name.
 */}}
 {{- define "oauth2-proxy.secretName" -}}

--- a/stable/oauth2-proxy/templates/deployment.yaml
+++ b/stable/oauth2-proxy/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
 {{ toYaml .Values.podLabels | indent 8 }}
       {{- end }}
     spec:
+    {{- if .Values.isOpenshift }}
+      serviceAccountName: {{ template "oauth2-proxy.fullname" . }}
+    {{- end }}
     {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
     {{- end }}
@@ -39,6 +42,10 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
           - --http-address=0.0.0.0:4180
+          - --openshift-service-account={{ template "oauth2-proxy.fullname" . }}
+        {{- if .Values.htpasswd.enabled }}
+          - --htpasswd-file=/htpasswd/htpasswd
+        {{- end}}
         {{- range $key, $value := .Values.extraArgs }}
           {{- if $value }}
           - --{{ $key }}={{ $value }}
@@ -62,6 +69,7 @@ spec:
           - --google-service-account-json=/google/service-account.json
         {{- end }}
         {{- end }}
+        {{- if not .Values.isOpenshift }}
         env:
         - name: OAUTH2_PROXY_CLIENT_ID
           valueFrom:
@@ -78,6 +86,7 @@ spec:
             secretKeyRef:
               name:  {{ template "oauth2-proxy.secretName" . }}
               key: cookie-secret
+        {{- end }}
         ports:
           - containerPort: 4180
             name: http
@@ -103,6 +112,14 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
+{{- if .Values.isOpenshift }}
+        - mountPath: /etc/tls/private
+          name: {{ template "oauth2-proxy.fullname" . }}-tls
+{{- end}}
+{{- if .Values.htpasswd.enabled }}
+        - name: htpasswd
+          mountPath: /htpasswd
+{{- end }}
 {{- with .Values.config.google }}
 {{- if and .adminEmail (or .serviceAccountJson .existingSecret) }}
         - name: google-secret
@@ -120,6 +137,16 @@ spec:
           readOnly: true
 {{- end }}
       volumes:
+{{ if .Values.isOpenshift }}
+      - name: {{ template "oauth2-proxy.fullname" . }}-tls
+        secret:
+          secretName: {{ template "oauth2-proxy.fullname" . }}-tls
+{{- end}}
+{{- if .Values.htpasswd.enabled }}
+      - name: htpasswd
+        secret:
+          secretName: {{ template "oauth2-proxy.fullname" . }}-htpasswd
+{{- end }}
 {{- with .Values.config.google }}
 {{- if and .adminEmail (or .serviceAccountJson .existingSecret) }}
       - name: google-secret

--- a/stable/oauth2-proxy/templates/htpasswd.yaml
+++ b/stable/oauth2-proxy/templates/htpasswd.yaml
@@ -1,0 +1,9 @@
+{{ if .Values.htpasswd.enabled }}
+apiVersion: v1
+data:
+  htpasswd: {{ .Values.htpasswd.htpasswd }}
+kind: Secret
+metadata:
+  name: {{ template "oauth2-proxy.fullname" . }}-htpasswd
+type: Opaque
+{{- end -}}

--- a/stable/oauth2-proxy/templates/secret.yaml
+++ b/stable/oauth2-proxy/templates/secret.yaml
@@ -12,5 +12,9 @@ type: Opaque
 data:
   cookie-secret: {{ .Values.config.cookieSecret | b64enc | quote }}
   client-secret: {{ .Values.config.clientSecret | b64enc | quote }}
+{{- if .Values.isOpenshift }}
+  client-id: {{ template "oauth2-proxy.openshift.clientId" . }}
+{{- else }}
   client-id: {{ .Values.config.clientID | b64enc | quote }}
+{{- end -}}
 {{- end -}}

--- a/stable/oauth2-proxy/templates/service.yaml
+++ b/stable/oauth2-proxy/templates/service.yaml
@@ -7,9 +7,14 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   name: {{ template "oauth2-proxy.fullname" . }}
-{{- if .Values.service.annotations }}
+{{- if or .Values.service.annotations .Values.isOpenshift }}
   annotations:
+{{- end }}
+{{- if  .Values.service.annotations }}
 {{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+{{- if .Values.isOpenshift }}
+    service.alpha.openshift.io/serving-cert-secret-name: {{ template "oauth2-proxy.fullname" . }}-tls
 {{- end }}
 spec:
 {{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}

--- a/stable/oauth2-proxy/templates/serviceAcccount.yaml
+++ b/stable/oauth2-proxy/templates/serviceAcccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.isOpenshift }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "oauth2-proxy.fullname" . }}
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"{{ template "oauth2-proxy.fullname" . }}"}}'
+{{- end }}

--- a/stable/oauth2-proxy/values.yaml
+++ b/stable/oauth2-proxy/values.yaml
@@ -1,4 +1,10 @@
+htpasswd:
+  enabled: false
+  # Content of the htpasswd file, as described here :
+  # https://github.com/pusher/oauth2_proxy/blob/master/contrib/oauth2_proxy.cfg.example#L58
+  # htpasswd: ""
 # Oauth client configuration specifics
+isOpenshift: false
 config:
   # OAuth client ID
   clientID: "XXXXXXX"


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR allows somebody using openshift to deploy this chart. 
I however do not know if you allows openshift PRs on this repo.
It uses the openshift oauth-proxy available here : 
https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

#### Special notes for your reviewer:
This should run flawlessly on any kubernetes installation as there is no changes on this part. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
