### PR TITLE
[stable/home-assistant] remove probes from optional configuration containers

### DIFF
--- a/stable/home-assistant/Chart.yaml
+++ b/stable/home-assistant/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.92.2
+appVersion: 0.93.2
 description: Home Assistant
 name: home-assistant
-version: 0.9.1
+version: 0.9.2
 keywords:
 - home-assistant
 - hass

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -112,14 +112,6 @@ spec:
             - name: configurator
               containerPort: {{ .Values.configurator.service.port }}
               protocol: TCP
-          livenessProbe:
-            tcpSocket:
-              port: configurator
-            initialDelaySeconds: 30
-          readinessProbe:
-            tcpSocket:
-              port: configurator
-            initialDelaySeconds: 15
           env:
             {{- if .Values.configurator.hassApiPassword }}
             - name: HC_HASS_API_PASSWORD
@@ -197,14 +189,6 @@ spec:
             - name: vscode
               containerPort: {{ .Values.vscode.service.port }}
               protocol: TCP
-          livenessProbe:
-            tcpSocket:
-              port: vscode
-            initialDelaySeconds: 30
-          readinessProbe:
-            tcpSocket:
-              port: vscode
-            initialDelaySeconds: 15
           env:
             {{- if .Values.vscode.password }}
             - name: PASSWORD

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: homeassistant/home-assistant
-  tag: 0.92.1
+  tag: 0.93.2
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
#### What this PR does / why we need it:

The extra optional configuration containers (configurator and vscode-server) can cause issues with the main home-assistant when they fail their liveness probes.  If they are misbehaving or otherwise not responding quickly enough, kubernetes will restart the entire pod which disrupts home-assistant operation.

We should not allow a configuration container to disrupt home-assistant and therefore the probes are being removed from those containers in this PR.

... also bumping home-assistant to the latest version

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
