### PR TITLE
[stable/sonarqube] Allow use of custom cacerts

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -6,7 +6,7 @@ appVersion: 7.7
 keywords:
   - coverage
   - security
-  - cod
+  - code
   - quality
 home: https://www.sonarqube.org/
 icon: https://www.sonarqube.org/assets/logo-31ad3115b1b4b120f3d1efd63e6b13ac9f1f89437f0cf6881cc4d8b5603a52b4.svg

--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 1.0.5
+version: 1.1.0
 appVersion: 7.7
 keywords:
   - coverage
   - security
-  - code
+  - cod
   - quality
 home: https://www.sonarqube.org/
 icon: https://www.sonarqube.org/assets/logo-31ad3115b1b4b120f3d1efd63e6b13ac9f1f89437f0cf6881cc4d8b5603a52b4.svg

--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -10,9 +10,9 @@ This chart bootstraps a SonarQube instance with a PostgreSQL database.
 
 - Kubernetes 1.6+
 
-## Installing the chart:
+## Installing the chart
 
-To install the chart :
+To install the chart:
 
 ```bash
 $ helm install stable/sonarqube
@@ -62,6 +62,8 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `persistence.accessMode`                    | Volumes access mode to be set             | `ReadWriteOnce`                            |
 | `persistence.size`                          | Size of the volume                        | None                                     |
 | `sonarProperties`                           | Custom `sonar.properties` file            | None                                       |
+| `customCerts.enabled`                       | Use `customCerts.secretName`              | false                                      |
+| `customCerts.secretName`                    | Name of the secret which conatins your `cacerts` | false                                      |
 | `sonarSecretKey`                            | Name of existing secret used for settings encryption | None                            |
 | `database.type`                             | Set to "mysql" to use mysql database       | `postgresql`|
 | `postgresql.enabled`                        | Set to `false` to use external server / mysql database     | `true`                                     |
@@ -90,7 +92,37 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `plugins.deleteDefaultPlugins`              | Remove default plugins and use plugins.install list | `[]`                             |
 | `podLabels`                                 | Map of labels to add to the pods          | `{}`                                       |
 
-
 You can also configure values for the PostgreSQL / MySQL database via the Postgresql [README.md](https://github.com/kubernetes/charts/blob/master/stable/postgresql/README.md) / MySQL [README.md](https://github.com/kubernetes/charts/blob/master/stable/mysql/README.md)
 
 For overriding variables see: [Customizing the chart](https://docs.helm.sh/using_helm/#customizing-the-chart-before-installing)
+
+### Use custom `cacerts`
+
+In environments with air-gapped setup, especially with internal tooling (repos) and self-signed certificates it is required to provide an adequate `cacerts` which overrides the default one:
+
+1. Create a yaml file `cacerts.yaml` with a secret that contanins the `cacerts`
+
+   ```yaml
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: my-cacerts
+   data:
+     cacerts: |
+       xxxxxxxxxxxxxxxxxxxxxxx
+   ```
+
+2. Upload your `cacerts.yaml` to a secret with the key you specify in `secretName` in the cluster you are installing Sonarqube to.
+
+   ```shell
+   $ kubectl apply -f cacerts.yaml
+   ```
+
+3. Set the following values of the chart:
+
+   ```yaml
+   customCerts:
+      ## Enable to override the default cacerts with your own one
+      enabled: false
+      secretName: my-cacerts
+   ```

--- a/stable/sonarqube/templates/deployment.yaml
+++ b/stable/sonarqube/templates/deployment.yaml
@@ -126,6 +126,11 @@ spec:
             - mountPath: /opt/sonarqube/secret/
               name: secret
             {{- end }}
+            {{- if .Values.customCerts.enabled }}
+            - mountPath: /etc/ssl/certs/java/cacerts
+              subPath: cacerts
+              name: cacerts
+            {{- end }}
             - mountPath: /opt/sonarqube/data
               name: sonarqube
               subPath: data
@@ -178,6 +183,14 @@ spec:
           items:
           - key: sonar-secret.txt
             path: sonar-secret.txt
+      {{- end }}
+      {{- if .Values.customCerts.enabled }}
+      - name: cacerts
+        secret:
+          secretName: {{ .Values.customCerts.secretName }}
+          items:
+          - key: cacerts
+            path: cacerts
       {{- end }}
       - name: install-plugins
         configMap:

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -143,6 +143,11 @@ plugins:
 # The 'sonar.secretKeyPath' property will be set automatically.
 # sonarSecretKey: "settings-encryption-secret"
 
+customCerts:
+  ## Enable to override the default cacerts with your own one
+  enabled: false
+  secretName: my-cacerts
+
 ## Configuration value to select database type
 ## Option to use "postgresql" or "mysql" database type, by default "postgresql" is chosen
 ## Set the "enable" field to true of the database type you select (if you want to use internal database) and false of the one you don't select


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

In environments with air-gapped setup, especially with internal tooling (repos) and self-signed certificates it is required to provide an adequate cacerts which overrides the default one:

#### Which issue this PR fixes
none

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
