### PR TITLE
[stable/kuberhealthy] Various chart fixes

### DIFF
--- a/stable/kuberhealthy/Chart.yaml
+++ b/stable/kuberhealthy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.0.2"
 home: https://comcast.github.io/kuberhealthy/
 description: The official Helm chart for Kuberhealthy.
 name: kuberhealthy
-version: 1.2.5
+version: 1.3.0
 maintainers:
   - name: integrii
     email: eric.greer@comcast.com

--- a/stable/kuberhealthy/templates/_helpers.tpl
+++ b/stable/kuberhealthy/templates/_helpers.tpl
@@ -7,6 +7,31 @@ Setup a chart name
 {{- end -}}
 
 {{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kuberhealthy.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kuberhealthy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Return the appropriate apiVersion for RBAC APIs.
 */}}
 {{- define "rbac.apiVersion" -}}

--- a/stable/kuberhealthy/templates/clusterrole.yaml
+++ b/stable/kuberhealthy/templates/clusterrole.yaml
@@ -1,7 +1,12 @@
 apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
-  name: {{ template "kuberhealthy.name" . }}
+  name: {{ template "kuberhealthy.fullname" . }}
+  labels:
+    app: {{ template "kuberhealthy.name" . }}
+    chart: {{ template "kuberhealthy.chart" .  }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
 rules:
   - apiGroups:
     - ""

--- a/stable/kuberhealthy/templates/clusterrolebinding.yaml
+++ b/stable/kuberhealthy/templates/clusterrolebinding.yaml
@@ -2,7 +2,12 @@
 apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "kuberhealthy.name" . }}
+  name: {{ template "kuberhealthy.fullname" . }}
+  labels:
+    app: {{ template "kuberhealthy.name" . }}
+    chart: {{ template "kuberhealthy.chart" .  }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/stable/kuberhealthy/templates/deployment.yaml
+++ b/stable/kuberhealthy/templates/deployment.yaml
@@ -20,6 +20,12 @@ spec:
       labels:
         app: {{ template "kuberhealthy.name" . }}
         release: {{ .Release.Name }}
+    {{- if .Values.podAnnotations }}
+      annotations:
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/stable/kuberhealthy/templates/deployment.yaml
+++ b/stable/kuberhealthy/templates/deployment.yaml
@@ -1,97 +1,67 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "kuberhealthy.name" . }}
+  name: {{ include "kuberhealthy.fullname" . }}
   labels:
     app: {{ template "kuberhealthy.name" . }}
     chart: {{ .Chart.Name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.deployment.replicas }}
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       app: {{ template "kuberhealthy.name" . }}
+      chart: {{ .Chart.Name }}
       release: {{ .Release.Name }}
-  strategy:
-    rollingUpdate:
-      maxSurge: {{ .Values.deployment.maxSurge }}
-      maxUnavailable: {{ .Values.deployment.maxUnavailable }}
-    type: RollingUpdate
+      heritage: {{ .Release.Service }}
   template:
     metadata:
-      {{- if .Values.deployment.podAnnotations }}
-      annotations:
-      {{- range $key, $value := .Values.deployment.podAnnotations }}
-        {{ $key }}: {{ $value | quote }}
-      {{- end }}
-      {{- end }}
-      {{- if .Values.prometheus.enabled -}}
-      {{- if .Values.prometheus.enableScraping -}}
-      {{- if not .Values.deployment.podAnnotations }}
-      annotations:
-      {{- end}}
-        prometheus.io/scrape: "true"
-        prometheus.io/path: "/metrics"
-        prometheus.io/port: "8080"
-      {{- end }}
-      {{- end }}
       labels:
         app: {{ template "kuberhealthy.name" . }}
-        chart: {{ .Chart.Name }}
         release: {{ .Release.Name }}
-        heritage: {{ .Release.Service }}
     spec:
-      serviceAccountName: kuberhealthy
-      automountServiceAccountToken: true
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       containers:
-      - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-        command: {{ .Values.deployment.command }}
-        {{- if .Values.deployment.args }}
-        args:
-{{ toYaml .Values.deployment.args | nindent 8 }}
-        {{- end }}
-        ports:
-        - containerPort: 8080
-          name: http
-        securityContext:
-        {{- toYaml .Values.securityContext | nindent 10 -}}
-        imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
-        livenessProbe:
-          failureThreshold: 3
-          initialDelaySeconds: 2
-          periodSeconds: 4
-          successThreshold: 1
-          tcpSocket:
-            port: 8080
-          timeoutSeconds: 1
-        name:  {{ template "kuberhealthy.name" . }}
-        env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-        readinessProbe:
-          failureThreshold: 3
-          initialDelaySeconds: 2
-          periodSeconds: 4
-          successThreshold: 1
-          tcpSocket:
-            port: 8080
-          timeoutSeconds: 1
-        resources:
-          requests:
-            cpu: {{ .Values.resources.requests.cpu }}
-            memory: {{ .Values.resources.requests.memory }}
-      restartPolicy: Always
-      terminationGracePeriodSeconds: 310
-{{- if .Values.tolerations.master }}
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/app/kuberhealthy"]
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
       tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
-{{- end -}}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/stable/kuberhealthy/templates/deployment.yaml
+++ b/stable/kuberhealthy/templates/deployment.yaml
@@ -12,9 +12,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "kuberhealthy.name" . }}
-      chart: {{ .Chart.Name }}
       release: {{ .Release.Name }}
-      heritage: {{ .Release.Service }}
   template:
     metadata:
       labels:

--- a/stable/kuberhealthy/templates/deployment.yaml
+++ b/stable/kuberhealthy/templates/deployment.yaml
@@ -31,6 +31,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/kuberhealthy/templates/poddisruptionbudget.yaml
+++ b/stable/kuberhealthy/templates/poddisruptionbudget.yaml
@@ -1,7 +1,12 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name:  {{ template "kuberhealthy.name" . }}-pdb
+  name:  {{ template "kuberhealthy.fullname" . }}-pdb
+  labels:
+    app: {{ template "kuberhealthy.name" . }}
+    chart: {{ template "kuberhealthy.chart" .  }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
 spec:
   minAvailable: 1
   selector:

--- a/stable/kuberhealthy/templates/role.yaml
+++ b/stable/kuberhealthy/templates/role.yaml
@@ -1,7 +1,12 @@
 apiVersion: {{ template "rbac.apiVersion" . }}
 kind: Role
 metadata:
-  name: {{ template "kuberhealthy.name" . }}
+  name: {{ template "kuberhealthy.fullname" . }}
+  labels:
+    app: {{ template "kuberhealthy.name" . }}
+    chart: {{ template "kuberhealthy.chart" .  }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
 rules:
   - apiGroups:
     - apps

--- a/stable/kuberhealthy/templates/rolebinding.yaml
+++ b/stable/kuberhealthy/templates/rolebinding.yaml
@@ -1,7 +1,12 @@
 apiVersion: {{ template "rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
-  name: {{ template "kuberhealthy.name" . }}
+  name: {{ template "kuberhealthy.fullname" . }}
+  labels:
+    app: {{ template "kuberhealthy.name" . }}
+    chart: {{ template "kuberhealthy.chart" .  }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/stable/kuberhealthy/templates/service.yaml
+++ b/stable/kuberhealthy/templates/service.yaml
@@ -3,8 +3,10 @@ kind: Service
 metadata:
   labels:
     app: {{ template "kuberhealthy.name" . }}
+    chart: {{ .Chart.Name }}
     release: {{ .Release.Name }}
-  name: {{ template "kuberhealthy.name" . }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "kuberhealthy.fullname" . }}
   {{- if .Values.service.annotations }}
   annotations:
   {{- range $key, $value := .Values.service.annotations }}
@@ -16,6 +18,7 @@ spec:
   ports:
   - port: {{ .Values.service.externalPort }}
     name: http
+    protocol: TCP
     targetPort: http
   selector:
     app: {{ template "kuberhealthy.name" . }}

--- a/stable/kuberhealthy/templates/serviceaccount.yaml
+++ b/stable/kuberhealthy/templates/serviceaccount.yaml
@@ -1,4 +1,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "kuberhealthy.name" . }}
+  name: {{ template "kuberhealthy.fullname" . }}
+  labels:
+    app: {{ template "kuberhealthy.name" . }}
+    chart: {{ template "kuberhealthy.chart" .  }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"

--- a/stable/kuberhealthy/values.yaml
+++ b/stable/kuberhealthy/values.yaml
@@ -21,6 +21,8 @@ resources:
     cpu: 400m
     memory: 200Mi
 
+podAnnotations: {}
+
 tolerations: {}
 
 replicaCount: 2

--- a/stable/kuberhealthy/values.yaml
+++ b/stable/kuberhealthy/values.yaml
@@ -31,7 +31,6 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 999
   fsGroup: 999
-  allowPrivilegeEscalation: false
 
 # Please remember that changing the service type to LoadBalancer
 # will expose Kuberhealthy to the internet, which could cause

--- a/stable/kuberhealthy/values.yaml
+++ b/stable/kuberhealthy/values.yaml
@@ -21,22 +21,10 @@ resources:
     cpu: 400m
     memory: 200Mi
 
-tolerations:
-  # change to true to tolerate and deploy to masters
-  master: false
+tolerations: {}
 
-deployment:
-  replicas: 2
-  maxSurge: 0
-  maxUnavailable: 1
-  imagePullPolicy: IfNotPresent
-  podAnnotations: {}
-  command:
-  - /app/kuberhealthy
-  # use this to override location of the test-image, see: https://github.com/Comcast/kuberhealthy/blob/master/docs/FLAGS.md
-  # args:
-  # - -dsPauseContainerImageOverride
-  # - your-repo/google_containers/pause:0.8.0
+replicaCount: 2
+
 securityContext:
   runAsNonRoot: true
   runAsUser: 999


### PR DESCRIPTION
#### What this PR does / why we need it:

With Helm 2.14, kuberhealthy fails with:

```
kuberhealthy: &status.statusError{Code:2, Message:\"error validating \\\"\\\": error validating data: [ValidationError(Deployment.spec.template.spec.containers[0].securityContext): unknown field \\\"fsGroup\\\" in io.k8s.api.core.v1.SecurityContext, ValidationError(Deployment.spec.template.spec.containers[0].securityContext): unknown field \\\"imagePullPolicy\\\" in io.k8s.api.core.v1.SecurityContext]\", Details:[]*any.Any(nil), XXX_NoUnkeyedLiteral:struct {}{}, XXX_unrecognized:[]uint8(nil), XXX_sizecache:0}"
```

This branch fixes this and makes the `deployment.yaml` file much more readable too.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
