### PR TITLE
[stable/fluent-bit] Load elasticsearch credentials from an existing secret

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.0.5
+version: 2.0.6
 appVersion: 1.1.2
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -48,6 +48,9 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `backend.es.replace_dots`     | Enable/Disable Replace_Dots option. | `On` |
 | `backend.es.http_user`        | Optional username credential for Elastic X-Pack access. | `` |
 | `backend.es.http_passwd:`     | Password for user defined in HTTP_User. | `` |
+| `backend.es.http_passwd_secret:`  | Secret for the elastic search user password. | `NULL`
+| `backend.es.http_passwd_secret.name:` | Secret name | ``
+| `backend.es.http_passwd_secret.key:` | Secret key for the password | ``
 | `backend.es.tls`              | Enable or disable TLS support | `off` |
 | `backend.es.tls_verify`       | Force certificate validation  | `on` |
 | `backend.es.tls_ca`           | TLS CA certificate for the Elastic instance (in PEM format). Specify if tls: on. | `` |

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -106,7 +106,11 @@ data:
 {{- end }}
 {{- if .Values.backend.es.http_user }}
         HTTP_User {{ .Values.backend.es.http_user }}
+{{- if .Values.backend.es.http_passwd }}
         HTTP_Passwd {{ .Values.backend.es.http_passwd }}
+{{ else }}
+        HTTP_Passwd ${HTTP_PASSWORD}
+{{ end }}
 {{- end }}
 {{if eq .Values.backend.es.tls "on" }}
         tls {{ .Values.backend.es.tls }}

--- a/stable/fluent-bit/templates/daemonset.yaml
+++ b/stable/fluent-bit/templates/daemonset.yaml
@@ -39,7 +39,20 @@ spec:
         image: "{{ .Values.image.fluent_bit.repository }}:{{ .Values.image.fluent_bit.tag }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         env:
+{{- if .Values.backend.es.http_passwd_secret.name }}
+{{ with .Values.backend.es.http_passwd_secret }}
+          - name: HTTP_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .name }}
+                key: {{ .key }}
+{{ end }}
+{{- if .Values.env }}
 {{ toYaml .Values.env | indent 10 }}
+{{ end }}
+{{- else }}
+{{ toYaml .Values.env | indent 10 }}
+{{ end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
 {{- if or .Values.metrics.enabled .Values.extraPorts }}

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -58,6 +58,12 @@ backend:
     http_user:
     # Password for user defined in HTTP_User
     http_passwd:
+    # Password secret for user defined in HTTP_User
+    http_passwd_secret:
+      # Secret name
+      name:
+      # Secret key for the password
+      key:
     # Optional TLS encryption to ElasticSearch instance
     tls: "off"
     tls_verify: "on"


### PR DESCRIPTION

Signed-off-by: Gean Palacios <nullbyte16@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR allows to load elasticsearch credentials from a known kubernetes secret.

#### Special notes for your reviewer:
Allowing to set the elasticsearch http password in a secret avoids having to commit sensitive data if a scm is being used for collaborative work.
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
