### PR TITLE
[stable/atlantis] missing required field "serviceName" in io.k8s.api.apps.v1.StatefulSetSpec

### DIFF
--- a/stable/atlantis/Chart.yaml
+++ b/stable/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.7.1"
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 3.5.3
+version: 3.5.4
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/stable/atlantis/templates/statefulset.yaml
+++ b/stable/atlantis/templates/statefulset.yaml
@@ -15,7 +15,7 @@ metadata:
 {{ toYaml . | indent 4 }}
   {{- end }}
 spec:
-  serviceName: “{{ template atlantis.fullname” . }}”
+  serviceName: {{ template "atlantis.fullname" . }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:

--- a/stable/atlantis/templates/statefulset.yaml
+++ b/stable/atlantis/templates/statefulset.yaml
@@ -15,6 +15,7 @@ metadata:
 {{ toYaml . | indent 4 }}
   {{- end }}
 spec:
+  serviceName: “{{ template atlantis.fullname” . }}”
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:


### PR DESCRIPTION
#### What this PR does / why we need it:

fix: missing required field "serviceName" in io.k8s.api.apps.v1.StatefulSetSpec

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
