### PR TITLE
[stable/sonatype-nexus] Fix ingress when proxy service is renamed

### DIFF
--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 1.18.3
+version: 1.18.4
 appVersion: 3.15.2-01
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/templates/ingress.yaml
+++ b/stable/sonatype-nexus/templates/ingress.yaml
@@ -16,7 +16,11 @@ spec:
       http:
         paths:
           - backend:
+            {{- if .Values.nexusProxy.svcName }}
+              serviceName: {{ .Values.nexusProxy.svcName }}
+            {{- else }}
               serviceName: {{ template "nexus.fullname" . }}
+            {{- end }}
               servicePort: {{ .Values.nexusProxy.port }}
             path: {{ .Values.ingress.path }}
   {{- end }}
@@ -25,7 +29,11 @@ spec:
       http:
         paths:
           - backend:
+            {{- if .Values.nexusProxy.svcName }}
+              serviceName: {{ .Values.nexusProxy.svcName }}
+            {{- else }}
               serviceName: {{ template "nexus.fullname" . }}
+            {{- end }}
               servicePort: {{ .Values.nexusProxy.port }}
             path: {{ .Values.ingress.path }}
   {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Currently, when renaming the proxy service, the ingress doesn't map the right service, and
that cannot be changed.
When renaming the proxy service, ingress should map the new name instead
of the default one.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
