### PR TITLE
[stable/fluentd] add Prometheus metrics

### DIFF
--- a/stable/fluentd/Chart.yaml
+++ b/stable/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Fluentd Elasticsearch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd
-version: 1.9.1
+version: 1.10.0
 appVersion: v2.4.0
 home: https://www.fluentd.org/
 sources:

--- a/stable/fluentd/README.md
+++ b/stable/fluentd/README.md
@@ -66,6 +66,13 @@ Parameter | Description | Default
 `persistence.enabled` | Enable buffer persistence | `false`
 `persistence.accessMode` | Access mode for buffer persistence | `ReadWriteOnce`
 `persistence.size` | Volume size for buffer persistence | `10Gi`
+`metrics.enabled`                         | Set this to `true` to enable Prometheus metrics HTTP endpoint                         | `false`
+`metrics.service.port``                   | Prometheus metrics HTTP endpoint port                                                 | `24231`
+`metrics.serviceMonitor.enabled`          | Set this to `true` to create ServiceMonitor for Prometheus operator                   | `false`
+`metrics.serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`
+`metrics.serviceMonitor.namespace`        | Optional namespace in which to create ServiceMonitor                                  | `nil`
+`metrics.serviceMonitor.interval`         | Scrape interval. If not set, the Prometheus default scrape interval is used           | `nil`
+`metrics.serviceMonitor.scrapeTimeout`    | Scrape timeout. If not set, the Prometheus default scrape timeout is used             | `nil`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/fluentd/README.md
+++ b/stable/fluentd/README.md
@@ -67,7 +67,7 @@ Parameter | Description | Default
 `persistence.accessMode` | Access mode for buffer persistence | `ReadWriteOnce`
 `persistence.size` | Volume size for buffer persistence | `10Gi`
 `metrics.enabled`                         | Set this to `true` to enable Prometheus metrics HTTP endpoint                         | `false`
-`metrics.service.port``                   | Prometheus metrics HTTP endpoint port                                                 | `24231`
+`metrics.service.port`                    | Prometheus metrics HTTP endpoint port                                                 | `24231`
 `metrics.serviceMonitor.enabled`          | Set this to `true` to create ServiceMonitor for Prometheus operator                   | `false`
 `metrics.serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`
 `metrics.serviceMonitor.namespace`        | Optional namespace in which to create ServiceMonitor                                  | `nil`

--- a/stable/fluentd/templates/configmap.yaml
+++ b/stable/fluentd/templates/configmap.yaml
@@ -12,3 +12,18 @@ data:
   {{ $key }}: |-
 {{ $value | indent 4 }}
 {{- end }}
+{{- if .Values.metrics.enabled }}
+  metrics.conf: |
+    <source>
+      @type prometheus
+      port {{ .Values.metrics.service.port }}
+    </source>
+
+    <source>
+      @type prometheus_monitor
+    </source>
+
+    <source>
+      @type prometheus_output_monitor
+    </source>
+{{- end }}

--- a/stable/fluentd/templates/deployment.yaml
+++ b/stable/fluentd/templates/deployment.yaml
@@ -66,6 +66,11 @@ spec:
             containerPort: {{ $port.containerPort }}
             protocol: {{ $port.protocol }}
 {{- end }}
+{{- if .Values.metrics.enabled }}
+          - name: metrics
+            containerPort: {{ .Values.metrics.service.port }}
+            protocol: TCP
+{{- end }}
           - name: http-input
             containerPort: 9880
             protocol: TCP

--- a/stable/fluentd/templates/service.yaml
+++ b/stable/fluentd/templates/service.yaml
@@ -19,6 +19,12 @@ spec:
   {{ if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
       nodePort: {{ .Values.service.nodePort }}
   {{ end }}
+  {{- if .Values.metrics.enabled }}
+    - name: metrics
+      port: {{ .Values.metrics.service.port }}
+      targetPort: metrics
+      protocol: TCP
+  {{- end }}
   selector:
     app: {{ template "fluentd.name" . }}
     release: {{ .Release.Name }}

--- a/stable/fluentd/templates/servicemonitor.yaml
+++ b/stable/fluentd/templates/servicemonitor.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "fluentd.fullname" . }}
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "fluentd.name" . }}
+    chart: {{ template "fluentd.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ include "fluentd.name" . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/stable/fluentd/values.yaml
+++ b/stable/fluentd/values.yaml
@@ -37,6 +37,17 @@ service:
       protocol: TCP
       containerPort: 24220
 
+metrics:
+  enabled: false
+  service:
+    port: 24231
+  serviceMonitor:
+    enabled: false
+    additionalLabels: {}
+    # namespace: monitoring
+    # interval: 30s
+    # scrapeTimeout: 10s
+
 annotations: {}
 #  prometheus.io/scrape: "true"
 #  prometheus.io/port: "24231"


### PR DESCRIPTION
#### What this PR does / why we need it:

Add Prometheus metrics by configuring fluent-plugin-prometheus. This plugin is yet present in the default image.

Also add a ServiceMonitor resource for Prometheus Operator.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
