### PR TITLE
[stable/prometheus-operator] Add optional additionalPrometheusRulesMap

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -11,7 +11,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 5.13.0
+version: 5.13.1
 appVersion: 0.30.1
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -118,7 +118,8 @@ The following tables list the configurable parameters of the prometheus-operator
 | `defaultRules.rules.prometheus` | Create Prometheus  default rules| `true` |
 | `defaultRules.labels` | Labels for default rules for monitoring the cluster | `{}` |
 | `defaultRules.annotations` | Annotations for default rules for monitoring the cluster | `{}` |
-| `additionalPrometheusRules` | List of `prometheusRule` objects to create. See https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusrulespec. | `[]` |
+| `additionalPrometheusRules` | *DEPRECATED* Will be removed in a future release.  Please use **additionalPrometheusRulesMap** instead.  List of `prometheusRule` objects to create. See https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusrulespec. | `[]` |
+| `additionalPrometheusRulesMap` | Map of `prometheusRule` objects to create with the key used as the name of the rule spec. If defined, this will take precedence over `additionalPrometheusRules`. See https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusrulespec. | `nil` |
 | `global.rbac.create` | Create RBAC resources | `true` |
 | `global.rbac.pspEnabled` | Create pod security policy resources | `true` |
 | `global.imagePullSecrets` | Reference to one or more secrets to be used when pulling images | `[]` |

--- a/stable/prometheus-operator/templates/prometheus/additionalPrometheusRules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/additionalPrometheusRules.yaml
@@ -1,7 +1,24 @@
-{{- if .Values.additionalPrometheusRules }}
+{{- if or .Values.additionalPrometheusRules .Values.additionalPrometheusRulesMap}}
 apiVersion: v1
 kind: List
 items:
+{{- if .Values.additionalPrometheusRulesMap }}
+{{- range $prometheusRuleName, $prometheusRule := .Values.additionalPrometheusRulesMap }}
+  - apiVersion: {{ printf "%s/v1" ($.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
+    kind: PrometheusRule
+    metadata:
+      name: {{ template "prometheus-operator.name" $ }}-{{ $prometheusRuleName }}
+      labels:
+        app: {{ template "prometheus-operator.name" $ }}
+{{ include "prometheus-operator.labels" $ | indent 8 }}
+    {{- if $prometheusRule.additionalLabels }}
+{{ toYaml $prometheusRule.additionalLabels | indent 8 }}
+    {{- end }}
+    spec:
+      groups:
+{{ toYaml $prometheusRule.groups| indent 8 }}
+{{- end }}
+{{- else }}
 {{- range .Values.additionalPrometheusRules }}
   - apiVersion: {{ printf "%s/v1" ($.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
     kind: PrometheusRule
@@ -16,5 +33,6 @@ items:
     spec:
       groups:
 {{ toYaml .groups| indent 8 }}
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds a reference to `additionalPrometheusRulesMap` in `templates/prometheus/additionalPrometheusRules.yaml`  The template now has the following behavior in regards to this new value.
* `additionalPrometheusRulesMap` is `nil` by default, which results in no change to the current behavior of the chart.  This is done to avoid breaking current deployments/dependencies.
* If `additionalPrometheusRulesMap` is defined, it will override any value specified by `additionalPrometheusRules`
* The objects contained within `additionalPrometheusRulesMap` follow the same spec as those within `additionalPrometheusRules`, but use the top level key as the name of the rule spec

By using a map instead of a list one gains the following benefits:
* Can merge data across multiple values files.  Useful for defining different rules/thresholds for different environments while having a common base set.
* Enforces uniqueness of rule names to prevent conflicts in object definitions.

#### Which issue this PR fixes
* N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)