### PR TITLE
[stable/prometheus-adapter] add new resourceRules in values

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 1.0.4
+version: 1.1.0
 appVersion: v0.5.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/README.md
+++ b/stable/prometheus-adapter/README.md
@@ -20,6 +20,70 @@ This command deploys the prometheus adapter with the default configuration. The 
 
 To use the chart, ensure the `prometheus.url` and `prometheus.port` are configured with the correct Prometheus service endpoint. Additionally, the chart comes with a set of default rules out of the box but they may pull in too many metrics or not map them correctly for your needs. Therefore, it is recommended to populate `rules.custom` with a list of rules (see the [config document](https://github.com/DirectXMan12/k8s-prometheus-adapter/blob/master/docs/config.md) for the proper format). Finally, to configure your Horizontal Pod Autoscaler to use the custom metric, see the custom metrics section of the [HPA walkthrough](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics).
 
+The Prometheus Adapter can serve three different [metrics APIs](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-metrics-apis):
+
+* `/apis/custom.metrics.k8s.io/v1beta1`  
+Can be enabled using values file as such:
+```
+rules:
+  custom:
+  - seriesQuery: '{__name__=~"^some_metric_count$"}'
+    resources:
+      template: <<.Resource>>
+    name:
+      matches: ""
+      as: "my_custom_metric"
+    metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+```
+
+* `/apis/external.metrics.k8s.io/v1beta1`  
+Can be enabled using values file as such:
+```
+rules:
+  external:
+  - seriesQuery: '{__name__=~"^some_metric_count$"}'
+    resources:
+      template: <<.Resource>>
+    name:
+      matches: ""
+      as: "my_external_metric"
+    metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+```
+
+* `/apis/metrics.k8s.io/v1beta1`  
+Can be enabled using values file as such, using the configuration below will allow you to use pod CPU and Memory utilization for [Horizontal Pod Autoscalers](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/), as well as the `kubectl top` command:
+```
+rules:
+  resource:
+    cpu:
+      containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>)
+      nodeQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, id='/'}[1m])) by (<<.GroupBy>>)
+      resources:
+        overrides:
+          instance:
+            resource: node
+          namespace:
+            resource: namespace
+          pod_name:
+            resource: pod
+      containerLabel: container_name
+    memory:
+      containerQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+      nodeQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>,id='/'}) by (<<.GroupBy>>)
+      resources:
+        overrides:
+          instance:
+            resource: node
+          namespace:
+            resource: namespace
+          pod_name:
+            resource: pod
+      containerLabel: container_name
+    window: 1m
+```
+
+**NOTE:** setting a value for `resource:` will also deploy the `v1beta1.metrics.k8s.io` `APIService`, providing the same functionality as the [metrics-server](https://github.com/helm/charts/tree/master/stable/metrics-server), and as such it is not possible to deploy both in the same cluster.  
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `my-release` deployment:
@@ -52,6 +116,7 @@ The following table lists the configurable parameters of the Prometheus Adapter 
 | `rules.custom`                  | A list of custom configmap rules                                                | `[]`                                        |
 | `rules.existing`                | The name of an existing configMap with rules. Overrides default, custom and external. | ``                                    |
 | `rules.external`                | A list of custom rules for external metrics API                                 | `[]`                                        |
+| `rules.resource`                | `resourceRules` to set in configmap rules                                       | `{}`                                        |
 | `service.annotations`           | Annotations to add to the service                                               | `{}`                                        |
 | `service.port`                  | Service port to expose                                                          | `443`                                       |
 | `service.type`                  | Type of service to create                                                       | `ClusterIP`                                 |

--- a/stable/prometheus-adapter/README.md
+++ b/stable/prometheus-adapter/README.md
@@ -56,8 +56,8 @@ Can be enabled using values file as such, using the configuration below will all
 rules:
   resource:
     cpu:
-      containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>)
-      nodeQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, id='/'}[1m])) by (<<.GroupBy>>)
+      containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>}[3m])) by (<<.GroupBy>>)
+      nodeQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, id='/'}[3m])) by (<<.GroupBy>>)
       resources:
         overrides:
           instance:
@@ -79,7 +79,7 @@ rules:
           pod_name:
             resource: pod
       containerLabel: container_name
-    window: 1m
+    window: 3m
 ```
 
 **NOTE:** setting a value for `resource:` will also deploy the `v1beta1.metrics.k8s.io` `APIService`, providing the same functionality as the [metrics-server](https://github.com/helm/charts/tree/master/stable/metrics-server), and as such it is not possible to deploy both in the same cluster.  

--- a/stable/prometheus-adapter/templates/NOTES.txt
+++ b/stable/prometheus-adapter/templates/NOTES.txt
@@ -1,5 +1,9 @@
 {{ template "k8s-prometheus-adapter.fullname" .  }} has been deployed.
-In a few minutes you should be able to list metrics using the following command:
-
+In a few minutes you should be able to list metrics using the following command(s):
+{{ if .Values.rules.resource }}
+  kubectl get --raw /apis/metrics.k8s.io/v1beta1
+{{- end }}
   kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1
-
+{{ if .Values.rules.external }}
+  kubectl get --raw /apis/external.metrics.k8s.io/v1beta1
+{{- end }}

--- a/stable/prometheus-adapter/templates/custom-metrics-configmap.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-configmap.yaml
@@ -86,4 +86,8 @@ data:
     externalRules:
 {{ toYaml .Values.rules.external | indent 4 }}
 {{- end -}}
+{{- if .Values.rules.resource }}
+    resourceRules:
+{{ toYaml .Values.rules.resource | indent 6 }}
+{{- end -}}
 {{- end -}}

--- a/stable/prometheus-adapter/templates/resource-metrics-apiservice.yaml
+++ b/stable/prometheus-adapter/templates/resource-metrics-apiservice.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.rules.resource}}
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  labels:
+    app: {{ template "k8s-prometheus-adapter.name" . }}
+    chart: {{ template "k8s-prometheus-adapter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: v1beta1.metrics.k8s.io
+spec:
+  service:
+    name: {{ template "k8s-prometheus-adapter.fullname" . }}
+    namespace: {{ .Release.Namespace | quote }}
+  {{ if .Values.tls.enable -}}
+  caBundle: {{ b64enc .Values.tls.ca }}
+  {{- end }}
+  group: metrics.k8s.io
+  version: v1beta1
+  insecureSkipTLSVerify: {{ if .Values.tls.enable }}false{{ else }}true{{ end }}
+  groupPriorityMinimum: 100
+  versionPriority: 100
+{{- end -}}

--- a/stable/prometheus-adapter/templates/resource-metrics-cluster-role-binding.yaml
+++ b/stable/prometheus-adapter/templates/resource-metrics-cluster-role-binding.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.rbac.create .Values.rules.resource -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "k8s-prometheus-adapter.name" . }}
+    chart: {{ template "k8s-prometheus-adapter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "k8s-prometheus-adapter.name" . }}-hpa-controller-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "k8s-prometheus-adapter.name" . }}-metrics
+subjects:
+- kind: ServiceAccount
+  name: {{ template "k8s-prometheus-adapter.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- end -}}

--- a/stable/prometheus-adapter/templates/resource-metrics-cluster-role.yaml
+++ b/stable/prometheus-adapter/templates/resource-metrics-cluster-role.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.rbac.create .Values.rules.resource -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "k8s-prometheus-adapter.name" . }}
+    chart: {{ template "k8s-prometheus-adapter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "k8s-prometheus-adapter.name" . }}-metrics
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - nodes/stats
+  verbs:
+  - get
+  - list
+  - watch
+{{- end -}}

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -49,7 +49,7 @@ rules:
 #     as: "my_custom_metric"
 #   metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
   # Mounts a configMap with pre-generated rules for use. Overrides the
-  # default, custom and external entries
+  # default, custom, external and resource entries
   existing:
   external: []
 # - seriesQuery: '{__name__=~"^some_metric_count$"}'
@@ -57,8 +57,34 @@ rules:
 #     template: <<.Resource>>
 #   name:
 #     matches: ""
-#     as: "my_custom_metric"
+#     as: "my_external_metric"
 #   metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+  resource: {}
+#   cpu:
+#     containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>)
+#     nodeQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, id='/'}[1m])) by (<<.GroupBy>>)
+#     resources:
+#       overrides:
+#         instance:
+#           resource: node
+#         namespace:
+#           resource: namespace
+#         pod_name:
+#           resource: pod
+#     containerLabel: container_name
+#   memory:
+#     containerQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+#     nodeQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>,id='/'}) by (<<.GroupBy>>)
+#     resources:
+#       overrides:
+#         instance:
+#           resource: node
+#         namespace:
+#           resource: namespace
+#         pod_name:
+#           resource: pod
+#     containerLabel: container_name
+#   window: 1m
 
 service:
   annotations: {}

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -61,8 +61,8 @@ rules:
 #   metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
   resource: {}
 #   cpu:
-#     containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>)
-#     nodeQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, id='/'}[1m])) by (<<.GroupBy>>)
+#     containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>}[3m])) by (<<.GroupBy>>)
+#     nodeQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, id='/'}[3m])) by (<<.GroupBy>>)
 #     resources:
 #       overrides:
 #         instance:
@@ -84,7 +84,7 @@ rules:
 #         pod_name:
 #           resource: pod
 #     containerLabel: container_name
-#   window: 1m
+#   window: 3m
 
 service:
   annotations: {}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  -  Enables adding [resourceRules](https://github.com/DirectXMan12/k8s-prometheus-adapter/blob/680e404250fcb08b6c2c48ed1cbd04f49b7b0d3d/pkg/config/config.go#L13) to the configMap

Tested by setting the values from the [project's deploy example](https://github.com/DirectXMan12/k8s-prometheus-adapter/blob/680e404250fcb08b6c2c48ed1cbd04f49b7b0d3d/deploy/manifests/custom-metrics-config-map.yaml#L73) and then the usage example for [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/).

~* Also modified `hpa-external-metrics-cluster-role-binding.yaml` ServiceAccount, I could not figure out why it was hardcoded to `horizontal-pod-autoscaler` but let me know it it is correct and I will revert.~


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
