### PR TITLE
[stable/kong] add Kong Enterprise support

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.11.2
+version: 0.12.2
 appVersion: 1.1

--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.12.2
+version: 0.12.0
 appVersion: 1.1

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -28,6 +28,16 @@ To install the chart with the release name `my-release`:
 $ helm install --name my-release stable/kong
 ```
 
+If using Kong Enterprise, several additional steps are necessary before
+installing the chart. At minimum, you must:
+* Create a [license secret](#license).
+* Set `enterprise.enabled: true` in values.yaml.
+* Update values.yaml to use a Kong Enterprise image. If needed, follow the
+instructions in values.yaml to add a registry pull secret.
+
+Reading through [the full list of Enterprise considerations](#kong-enterprise-specific-parameters)
+is recommended.
+
 > **Tip**: List all releases using `helm list`
 
 ## Uninstalling the Chart
@@ -176,6 +186,143 @@ $ helm install stable/kong --name my-release -f values.yaml
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+### Kong Enterprise-specific parameters
+
+Kong Enterprise requires some additional configuration not needed when using
+Kong OSS. Some of the more important configuration is grouped in sections
+under the `.enterprise` key in values.yaml, though most enterprise-specific
+configuration can be placed under the `.env` key.
+
+To use Kong Enterprise, change your image to a Kong Enterprise image and set
+`.enterprise.enabled: true` in values.yaml to render Enterprise sections of the
+templates. Review the sections below for other settings you should consider
+configuring before installing the chart.
+
+#### Service location hints
+
+Kong Enterprise add two GUIs, Kong Manager and the Kong Developer Portal, that
+must know where other Kong services (namely the admin and files APIs) can be
+accessed in order to function properly. Kong's default behavior for attempting
+to locate these absent configuration is unlikely to work in common Kubernetes
+environments. Because of this, you should set each of `admin_gui_url`,
+`admin_api_uri`, `proxy_url`, `portal_api_url`, `portal_gui_host`, and
+`portal_gui_protocol` under the `.env` key in values.yaml to locations where
+each of their respective services can be accessed to ensure that Kong services
+can locate one another and properly set CORS headers. See the [Property Reference documentation](https://docs.konghq.com/enterprise/0.35-x/property-reference/)
+for more details on these settings.
+
+#### License
+
+All Kong Enterprise deployments require a license. If you do not have a copy
+of yours, please contact Kong Support. Once you have it, you will need to
+store it in a Secret. Save your secret in a file named `license` (no extension)
+and then create and inspect your secret:
+
+```
+$ kubectl create secret generic kong-enterprise-license --from-file=./license
+$ kubectl get secret kong-enterprise-license -o yaml
+apiVersion: v1
+data:
+  license: eyJsaWNlbnNlIjp7InNpZ25hdHVyZSI6IkhFWSBJIFNFRSBZT1UgUEVFS0lORyBJTlNJREUgTVkgQkFTRTY0IEVYQU1QTEUiLCJwYXlsb2FkIjp7ImN1c3RvbWVyIjoiV0VMTCBUT08gQkFEIiwibGljZW5zZV9jcmVhdGlvbl9kYXRlIjoiMjAxOC0wNi0wNSIsInByb2R1Y3Rfc3Vic2NyaXB0aW9uIjoiVEhFUkVTIE5PVEhJTkcgSEVSRSIsImFkbWluX3NlYXRzIjoiNSIsInN1cHBvcnRfcGxhbiI6IkZha2UiLCJsaWNlbnNlX2V4cGlyYXRpb25fZGF0ZSI6IjIwMjAtMjAtMjAiLCJsaWNlbnNlX2tleSI6IlRTT0kgWkhJViJ9LCJ2ZXJzaW9uIjoxfX0K
+kind: Secret
+metadata:
+  creationTimestamp: "2019-05-17T21:45:16Z"
+  name: kong-enterprise-license
+  namespace: default
+  resourceVersion: "48695485"
+  selfLink: /api/v1/namespaces/default/secrets/kong-enterprise-license
+  uid: 0f2e8903-78ed-11e9-b1a6-42010a8a02ec
+type: Opaque
+```
+Set the secret name in values.yaml, in the `.enterprise.license_secret` key.
+
+#### RBAC
+
+Note that you can create a default RBAC superuser when initially setting up an
+environment, by setting the `KONG_PASSWORD` environment variable on the initial
+migration Job's Pod. This will create a `kong_admin` admin whose token and
+basic-auth password match the value of `KONG_PASSWORD`
+
+Using RBAC within Kubernetes environments requires providing Kubernetes an RBAC
+user for its readiness and liveness checks. We recommend creating a user that
+has permission to read `/status` and nothing else. For example, with RBAC still
+disabled:
+
+```
+$ curl -sX POST http://admin.kong.example/rbac/users --data name=statuschecker --data user_token=REPLACE_WITH_SOME_TOKEN
+{"user_token_ident":"45239","user_token":"$2b$09$cL.xbvRQCzE35A0osl8VTej7u0BgJOIgpTVjxpwZ1U8.jNdMwyQRW","id":"fe8824dc-09a7-4b68-b5e6-541e4b9b4ced","name":"statuschecker","enabled":true,"comment":null,"created_at":1558131229}
+
+$ curl -sX POST http://admin.kong.example/rbac/roles --data name=read-status
+{"comment":null,"created_at":1558131353,"id":"e32507a5-e636-40b2-88c0-090042db7d79","name":"read-status","is_default":false}
+
+$ curl -sX POST http://admin.kong.example/rbac/roles/read-status/endpoints --data endpoint="/status" --data actions=read
+{"endpoint":"\/status","created_at":1558131423,"workspace":"default","actions":["read"],"negative":false,"role":{"id":"e32507a5-e636-40b2-88c0-090042db7d79"}}
+
+$ curl -sX POST http://admin.kong.example/rbac/users/statuschecker/roles --data roles=read-status
+{"roles":[{"created_at":1558131353,"id":"e32507a5-e636-40b2-88c0-090042db7d79","name":"read-status"}],"user":{"user_token_ident":"45239","user_token":"$2b$09$cL.xbvRQCzE35A0osl8VTej7u0BgJOIgpTVjxpwZ1U8.jNdMwyQRW","id":"fe8824dc-09a7-4b68-b5e6-541e4b9b4ced","name":"statuschecker","comment":null,"enabled":true,"created_at":1558131229}}
+```
+Probes will then need to include that user's token, e.g. for the readinessProbe:
+
+```
+readinessProbe:
+  httpGet:
+    path: "/status"
+    port: admin
+    scheme: HTTP
+    httpHeaders:
+      - name: Kong-Admin-Token
+        value: REPLACE_WITH_SOME_TOKEN
+    ...
+```
+
+Note that RBAC is **NOT** currently enabled on the admin API container for the
+controller Pod when the ingress controller is enabled. This admin API container
+is not exposed outside the Pod, so only the controller can interact with it. We
+intend to add RBAC to this container in the future after updating the controller
+to add support for storing its RBAC token in a Secret, as currently it would
+need to be stored in plaintext. RBAC is still enforced on the admin API of the
+main deployment when using the ingress controller, as that admin API *is*
+accessible outside the Pod.
+
+#### Sessions
+
+Login sessions for Kong Manager and the Developer Portal make use of [the Kong
+Sessions plugin](https://docs.konghq.com/enterprise/0.35-x/kong-manager/authentication/sessions/).
+Their configuration must be stored in Secrets, as it contains an HMAC key.
+If using either RBAC or the Portal, create a Secret with `admin_gui_session_conf`
+and `portal_session_conf` keys.
+
+```
+$ cat admin_gui_session_conf
+{"cookie_name":"admin_session","cookie_samesite":"off","secret":"admin-secret-CHANGEME","cookie_secure":true,"storage":"kong"}
+$ cat portal_session_conf
+{"cookie_name":"portal_session","cookie_samesite":"off","secret":"portal-secret-CHANGEME","cookie_secure":true,"storage":"kong"}
+$ kubectl create secret generic kong-session-config --from-file=admin_gui_session_conf --from-file=portal_session_conf
+secret/kong-session-config created
+```
+The exact plugin settings may vary in your environment. The `secret` should
+always be changed for both configurations.
+
+After creating your secret, set its name in values.yaml, in the
+`.enterprise.rbac.session_conf_secret` and
+`.enterprise.rbac.session_conf_secret` keys.
+
+#### Email/SMTP
+
+Email is used to send invitations for [Kong Admins](https://docs.konghq.com/enterprise/enterprise/0.35-x/kong-manager/networking/email/)
+and [Developers](https://docs.konghq.com/enterprise/enterprise/0.35-x/developer-portal/configuration/smtp/).
+
+Email invitations rely on setting a number of SMTP settings at once. For
+convenience, these are grouped under the `.enterprise.smtp` key in values.yaml.
+Setting `.enterprise.smtp.disabled: true` will set `KONG_SMTP_MOCK=on` and
+allow Admin/Developer invites to proceed without sending email. Note, however,
+that these have limited functionality without sending email.
+
+If your SMTP server requires authentication, you should the `username` and
+`smtp_password_secret` keys under `.enterprise.smtp.auth`.
+`smtp_password_secret` must be a Secret containing an `smtp_password` key whose
+value is your SMTP password.
 
 ### Kong Ingress Controller
 

--- a/stable/kong/templates/_helpers.tpl
+++ b/stable/kong/templates/_helpers.tpl
@@ -53,13 +53,68 @@ Create the KONG_PROXY_LISTEN value string
 {{- end }}
 
 {{/*
+Create the KONG_ADMIN_GUI_LISTEN value string
+*/}}
+{{- define "kong.kongManagerListenValue" -}}
+
+{{- if and .Values.manager.http.enabled .Values.manager.tls.enabled -}}
+   0.0.0.0:{{ .Values.manager.http.containerPort }},0.0.0.0:{{ .Values.manager.tls.containerPort }} ssl
+{{- else -}}
+{{- if .Values.manager.http.enabled -}}
+   0.0.0.0:{{ .Values.manager.http.containerPort }}
+{{- end -}}
+{{- if .Values.manager.tls.enabled -}}
+   0.0.0.0:{{ .Values.manager.tls.containerPort }} ssl
+{{- end -}}
+{{- end -}}
+
+{{- end }}
+
+{{/*
+Create the KONG_PORTAL_GUI_LISTEN value string
+*/}}
+{{- define "kong.kongPortalListenValue" -}}
+
+{{- if and .Values.portal.http.enabled .Values.portal.tls.enabled -}}
+   0.0.0.0:{{ .Values.portal.http.containerPort }},0.0.0.0:{{ .Values.portal.tls.containerPort }} ssl
+{{- else -}}
+{{- if .Values.portal.http.enabled -}}
+   0.0.0.0:{{ .Values.portal.http.containerPort }}
+{{- end -}}
+{{- if .Values.portal.tls.enabled -}}
+   0.0.0.0:{{ .Values.portal.tls.containerPort }} ssl
+{{- end -}}
+{{- end -}}
+
+{{- end }}
+
+{{/*
+Create the KONG_PORTAL_API_LISTEN value string
+*/}}
+{{- define "kong.kongPortalApiListenValue" -}}
+
+{{- if and .Values.portalapi.http.enabled .Values.portalapi.tls.enabled -}}
+   0.0.0.0:{{ .Values.portalapi.http.containerPort }},0.0.0.0:{{ .Values.portalapi.tls.containerPort }} ssl
+{{- else -}}
+{{- if .Values.portalapi.http.enabled -}}
+   0.0.0.0:{{ .Values.portalapi.http.containerPort }}
+{{- end -}}
+{{- if .Values.portalapi.tls.enabled -}}
+   0.0.0.0:{{ .Values.portalapi.tls.containerPort }} ssl
+{{- end -}}
+{{- end -}}
+
+{{- end }}
+
+{{/*
 Create the ingress servicePort value string
 */}}
+
 {{- define "kong.ingress.servicePort" -}}
-{{- if .Values.proxy.tls.enabled -}}
-   {{ .Values.proxy.tls.servicePort }}
+{{- if .tls.enabled -}}
+   {{ .tls.servicePort }}
 {{- else -}}
-   {{ .Values.proxy.http.servicePort }}
+   {{ .http.servicePort }}
 {{- end -}}
 {{- end -}}
 
@@ -81,6 +136,9 @@ Create the ingress servicePort value string
   image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
   imagePullPolicy: {{ .Values.image.pullPolicy }}
   env:
+  {{- if .Values.enterprise.enabled }}
+  {{- include "kong.license" . | nindent 2 }}
+  {{- end }}
   {{- if .Values.postgresql.enabled }}
   - name: KONG_PG_HOST
     value: {{ template "kong.postgresql.fullname" . }}
@@ -150,4 +208,15 @@ Create the ingress servicePort value string
     timeoutSeconds: 1
   resources:
 {{ toYaml .Values.ingressController.resources | indent 10 }}
+{{- end -}}
+
+{{/*
+Retrieve Kong Enterprise license from a secret and make it available in env vars
+*/}}
+{{- define "kong.license" -}}
+- name: KONG_LICENSE_DATA
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.enterprise.license_secret }}
+      key: license
 {{- end -}}

--- a/stable/kong/templates/controller-deployment.yaml
+++ b/stable/kong/templates/controller-deployment.yaml
@@ -43,6 +43,24 @@ spec:
         env:
         - name: KONG_PROXY_LISTEN
           value: 'off'
+        {{- if .Values.enterprise.enabled }}
+        {{- if .Values.enterprise.rbac.enabled }}
+        # TODO: uncomment this once we have a means of securely providing the
+        # controller its token using a secret.
+        #- name: KONG_ENFORCE_RBAC
+        #  value: "on"
+        {{- end }}
+        # the controller admin API should not receive requests to create admins or developers
+        # never enable SMTP on it as such
+        {{- if .Values.enterprise.smtp.enabled }}
+        - name: KONG_SMTP_MOCK
+          value: "on"
+        {{- else }}
+        - name: KONG_SMTP_MOCK
+          value: "on"
+        {{- end }}
+        {{- include "kong.license" . | nindent 8 }}
+        {{- end }}
         {{- include "kong.env" .  | indent 8 }}
         {{- if .Values.admin.useTLS }}
         - name: KONG_ADMIN_LISTEN

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -60,8 +60,81 @@ spec:
         - name: KONG_PROXY_LISTEN
           value: {{ template "kong.kongProxyListenValue" . }}
         {{- end }}
+        {{- if and (not .Values.env.admin_gui_listen) (.Values.enterprise.enabled) }}
+        - name: KONG_ADMIN_GUI_LISTEN
+          value: {{ template "kong.kongManagerListenValue" . }}
+        {{- end }}
+        {{- if and (not .Values.env.portal_gui_listen) (.Values.enterprise.enabled) (.Values.enterprise.portal.enabled) }}
+        - name: KONG_PORTAL_GUI_LISTEN
+          value: {{ template "kong.kongPortalListenValue" . }}
+        {{- end }}
+        {{- if and (not .Values.env.portal_api_listen) (.Values.enterprise.enabled) (.Values.enterprise.portal.enabled) }}
+        - name: KONG_PORTAL_API_LISTEN
+          value: {{ template "kong.kongPortalApiListenValue" . }}
+        {{- end }}
         - name: KONG_NGINX_DAEMON
           value: "off"
+        {{- if .Values.enterprise.enabled }}
+        {{- if .Values.enterprise.vitals.enabled }}
+        - name: KONG_VITALS
+          value: "on"
+        {{- end }}
+        {{- if .Values.enterprise.portal.enabled }}
+        - name: KONG_PORTAL
+          value: "on"
+        {{- if .Values.enterprise.portal.portal_auth }}
+        - name: KONG_PORTAL_AUTH
+          value: {{ .Values.enterprise.portal.portal_auth }}
+        - name: KONG_PORTAL_SESSION_CONF
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.enterprise.portal.session_conf_secret }}
+              key: portal_session_conf
+        {{- end }}
+        {{- end }}
+        {{- if .Values.enterprise.rbac.enabled }}
+        - name: KONG_ENFORCE_RBAC
+          value: "on"
+        - name: KONG_ADMIN_GUI_AUTH
+          value: {{ .Values.enterprise.rbac.admin_gui_auth | default "basic-auth" }}
+        - name: KONG_ADMIN_GUI_AUTH_CONF
+          value: {{ toJson .Values.enterprise.rbac.admin_gui_auth_conf | default "" }}
+        - name: KONG_ADMIN_GUI_SESSION_CONF
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.enterprise.rbac.session_conf_secret }}
+              key: admin_gui_session_conf
+        {{- end }}
+        {{- if .Values.enterprise.smtp.enabled }}
+        - name: KONG_PORTAL_EMAILS_FROM
+          value: {{ .Values.enterprise.smtp.portal_emails_from }}
+        - name: KONG_PORTAL_EMAILS_REPLY_TO
+          value: {{ .Values.enterprise.smtp.portal_emails_reply_to }}
+        - name: KONG_ADMIN_EMAILS_FROM
+          value: {{ .Values.enterprise.smtp.admin_emails_from }}
+        - name: KONG_ADMIN_EMAILS_REPLY_TO
+          value: {{ .Values.enterprise.smtp.admin_emails_reply_to }}
+        - name: KONG_SMTP_HOST
+          value: {{ .Values.enterprise.smtp.smtp_host }}
+        - name: KONG_SMTP_PORT
+          value: {{ .Values.enterprise.smtp.smtp_port }}
+        - name: KONG_SMTP_STARTTLS
+          value: {{ .Values.enterprise.smtp.smtp_starttls }}
+        {{- if .Values.enterprise.smtp.auth.smtp_username }}
+        - name: KONG_SMTP_USERNAME
+          value: {{ .Values.enterprise.smtp.auth.smtp_username }}
+        - name: KONG_SMTP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.enterprise.smtp.auth.smtp_password }}
+              key: smtp_password
+        {{- end }}
+        {{- else }}
+        - name: KONG_SMTP_MOCK
+          value: "on"
+        {{- end }}
+        {{- include "kong.license" . | nindent 8 }}
+        {{- end }}
         {{- include "kong.env" .  | indent 8 }}
         {{- if .Values.postgresql.enabled }}
         - name: KONG_PG_HOST
@@ -100,6 +173,56 @@ spec:
           hostPort: {{ .Values.proxy.tls.hostPort }}
           {{- end}}
           protocol: TCP
+        {{- end }}
+        {{- if .Values.enterprise.enabled }}
+        {{- if .Values.manager.http.enabled }}
+        - name: manager
+          containerPort: {{ .Values.manager.http.containerPort }}
+          {{- if .Values.manager.http.hostPort }}
+          hostPort: {{ .Values.manager.http.hostPort }}
+          {{- end}}
+          protocol: TCP
+        {{- end }}
+        {{- if .Values.manager.tls.enabled }}
+        - name: manager-tls
+          containerPort: {{ .Values.manager.tls.containerPort }}
+          {{- if .Values.manager.tls.hostPort }}
+          hostPort: {{ .Values.manager.tls.hostPort }}
+          {{- end}}
+          protocol: TCP
+        {{- end }}
+        {{- if .Values.portal.http.enabled }}
+        - name: portal
+          containerPort: {{ .Values.portal.http.containerPort }}
+          {{- if .Values.portal.http.hostPort }}
+          hostPort: {{ .Values.portal.http.hostPort }}
+          {{- end}}
+          protocol: TCP
+        {{- end }}
+        {{- if .Values.portal.tls.enabled }}
+        - name: portal-tls
+          containerPort: {{ .Values.portal.tls.containerPort }}
+          {{- if .Values.portal.tls.hostPort }}
+          hostPort: {{ .Values.portal.tls.hostPort }}
+          {{- end}}
+          protocol: TCP
+        {{- end }}
+        {{- if .Values.portalapi.http.enabled }}
+        - name: portalapi
+          containerPort: {{ .Values.portalapi.http.containerPort }}
+          {{- if .Values.portalapi.http.hostPort }}
+          hostPort: {{ .Values.portalapi.http.hostPort }}
+          {{- end}}
+          protocol: TCP
+        {{- end }}
+        {{- if .Values.portalapi.tls.enabled }}
+        - name: portalapi-tls
+          containerPort: {{ .Values.portalapi.tls.containerPort }}
+          {{- if .Values.portalapi.tls.hostPort }}
+          hostPort: {{ .Values.portalapi.tls.hostPort }}
+          {{- end}}
+          protocol: TCP
+        {{- end }}
         {{- end }}
         readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 10 }}

--- a/stable/kong/templates/ingress-manager.yaml
+++ b/stable/kong/templates/ingress-manager.yaml
@@ -1,33 +1,35 @@
-{{- if .Values.proxy.ingress.enabled -}}
+{{- if .Values.enterprise.enabled }}
+{{- if .Values.manager.ingress.enabled -}}
 {{- $serviceName := include "kong.fullname" . -}}
-{{- $servicePort := include "kong.ingress.servicePort" .Values.proxy -}}
-{{- $path := .Values.proxy.ingress.path -}}
+{{- $servicePort := include "kong.ingress.servicePort" .Values.manager -}}
+{{- $path := .Values.manager.ingress.path -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "kong.fullname" . }}-proxy
+  name: {{ template "kong.fullname" . }}-manager
   labels:
     app: {{ template "kong.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-    {{- range $key, $value := .Values.proxy.ingress.annotations }}
+    {{- range $key, $value := .Values.manager.ingress.annotations }}
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
   rules:
-    {{- range $host := .Values.proxy.ingress.hosts }}
+    {{- range $host := .Values.manager.ingress.hosts }}
     - host: {{ $host }}
       http:
         paths:
           - path: {{ $path }}
             backend:
-              serviceName: {{ $serviceName }}-proxy
+              serviceName: {{ $serviceName }}-manager
               servicePort: {{ $servicePort }}
     {{- end -}}
-  {{- if .Values.proxy.ingress.tls }}
+  {{- if .Values.manager.ingress.tls }}
   tls:
-{{ toYaml .Values.proxy.ingress.tls | indent 4 }}
+{{ toYaml .Values.manager.ingress.tls | indent 4 }}
   {{- end -}}
+{{- end -}}
 {{- end -}}

--- a/stable/kong/templates/ingress-portal-api.yaml
+++ b/stable/kong/templates/ingress-portal-api.yaml
@@ -1,33 +1,35 @@
-{{- if .Values.proxy.ingress.enabled -}}
+{{- if .Values.enterprise.enabled }}
+{{- if .Values.portalapi.ingress.enabled -}}
 {{- $serviceName := include "kong.fullname" . -}}
-{{- $servicePort := include "kong.ingress.servicePort" .Values.proxy -}}
-{{- $path := .Values.proxy.ingress.path -}}
+{{- $servicePort := include "kong.ingress.servicePort" .Values.portalapi -}}
+{{- $path := .Values.portalapi.ingress.path -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "kong.fullname" . }}-proxy
+  name: {{ template "kong.fullname" . }}-portalapi
   labels:
     app: {{ template "kong.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-    {{- range $key, $value := .Values.proxy.ingress.annotations }}
+    {{- range $key, $value := .Values.portalapi.ingress.annotations }}
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
   rules:
-    {{- range $host := .Values.proxy.ingress.hosts }}
+    {{- range $host := .Values.portalapi.ingress.hosts }}
     - host: {{ $host }}
       http:
         paths:
           - path: {{ $path }}
             backend:
-              serviceName: {{ $serviceName }}-proxy
+              serviceName: {{ $serviceName }}-portalapi
               servicePort: {{ $servicePort }}
     {{- end -}}
-  {{- if .Values.proxy.ingress.tls }}
+  {{- if .Values.portalapi.ingress.tls }}
   tls:
-{{ toYaml .Values.proxy.ingress.tls | indent 4 }}
+{{ toYaml .Values.portalapi.ingress.tls | indent 4 }}
   {{- end -}}
+{{- end -}}
 {{- end -}}

--- a/stable/kong/templates/ingress-portal.yaml
+++ b/stable/kong/templates/ingress-portal.yaml
@@ -1,33 +1,35 @@
-{{- if .Values.proxy.ingress.enabled -}}
+{{- if .Values.enterprise.enabled }}
+{{- if .Values.portal.ingress.enabled -}}
 {{- $serviceName := include "kong.fullname" . -}}
-{{- $servicePort := include "kong.ingress.servicePort" .Values.proxy -}}
-{{- $path := .Values.proxy.ingress.path -}}
+{{- $servicePort := include "kong.ingress.servicePort" .Values.portal -}}
+{{- $path := .Values.portal.ingress.path -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "kong.fullname" . }}-proxy
+  name: {{ template "kong.fullname" . }}-portal
   labels:
     app: {{ template "kong.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-    {{- range $key, $value := .Values.proxy.ingress.annotations }}
+    {{- range $key, $value := .Values.portal.ingress.annotations }}
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
   rules:
-    {{- range $host := .Values.proxy.ingress.hosts }}
+    {{- range $host := .Values.portal.ingress.hosts }}
     - host: {{ $host }}
       http:
         paths:
           - path: {{ $path }}
             backend:
-              serviceName: {{ $serviceName }}-proxy
+              serviceName: {{ $serviceName }}-portal
               servicePort: {{ $servicePort }}
     {{- end -}}
-  {{- if .Values.proxy.ingress.tls }}
+  {{- if .Values.portal.ingress.tls }}
   tls:
-{{ toYaml .Values.proxy.ingress.tls | indent 4 }}
+{{ toYaml .Values.portal.ingress.tls | indent 4 }}
   {{- end -}}
+{{- end -}}
 {{- end -}}

--- a/stable/kong/templates/migrations-post-upgrade.yaml
+++ b/stable/kong/templates/migrations-post-upgrade.yaml
@@ -52,6 +52,9 @@ spec:
         env:
         - name: KONG_NGINX_DAEMON
           value: "off"
+        {{- if .Values.enterprise.enabled }}
+        {{- include "kong.license" . | nindent 8 }}
+        {{- end }}
         {{- include "kong.env" .  | indent 8 }}
         {{- if .Values.postgresql.enabled }}
         - name: KONG_PG_HOST

--- a/stable/kong/templates/migrations-pre-upgrade.yaml
+++ b/stable/kong/templates/migrations-pre-upgrade.yaml
@@ -52,6 +52,9 @@ spec:
         env:
         - name: KONG_NGINX_DAEMON
           value: "off"
+        {{- if .Values.enterprise.enabled }}
+        {{- include "kong.license" . | nindent 8 }}
+        {{- end }}
         {{- include "kong.env" .  | indent 8 }}
         {{- if .Values.postgresql.enabled }}
         - name: KONG_PG_HOST

--- a/stable/kong/templates/migrations.yaml
+++ b/stable/kong/templates/migrations.yaml
@@ -47,6 +47,9 @@ spec:
         env:
         - name: KONG_NGINX_DAEMON
           value: "off"
+        {{- if .Values.enterprise.enabled }}
+        {{- include "kong.license" . | nindent 8 }}
+        {{- end }}
         {{- include "kong.env" .  | indent 8 }}
         {{- if .Values.postgresql.enabled }}
         - name: KONG_PG_HOST

--- a/stable/kong/templates/service-kong-manager.yaml
+++ b/stable/kong/templates/service-kong-manager.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.enterprise.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kong.fullname" . }}-manager
+  annotations:
+    {{- range $key, $value := .Values.manager.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  labels:
+    app: {{ template "kong.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: {{ .Values.manager.type }}
+  {{- if eq .Values.manager.type "LoadBalancer" }}
+  {{- if .Values.manager.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.manager.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.manager.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range $cidr := .Values.manager.loadBalancerSourceRanges }}
+  - {{ $cidr }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  externalIPs:
+  {{- range $ip := .Values.manager.externalIPs }}
+  - {{ $ip }}
+  {{- end }}
+  ports:
+  {{- if .Values.manager.http.enabled }}
+  - name: kong-manager
+    port: {{ .Values.manager.http.servicePort }}
+    targetPort: {{ .Values.manager.http.containerPort }}
+  {{- if (and (eq .Values.manager.type "NodePort") (not (empty .Values.manager.http.nodePort))) }}
+    nodePort: {{ .Values.manager.http.nodePort }}
+  {{- end }}
+    protocol: TCP
+  {{- end }}
+  {{- if or .Values.manager.tls.enabled }}
+  - name: kong-manager-tls
+    port: {{ .Values.manager.tls.servicePort }}
+    targetPort: {{ .Values.manager.tls.containerPort }}
+  {{- if (and (eq .Values.manager.type "NodePort") (not (empty .Values.manager.tls.nodePort))) }}
+    nodePort: {{ .Values.manager.tls.nodePort }}
+  {{- end }}
+    protocol: TCP
+  {{- end }}
+
+
+  selector:
+    app: {{ template "kong.name" . }}
+    release: {{ .Release.Name }}
+    component: app
+{{- end -}}

--- a/stable/kong/templates/service-kong-portal-api.yaml
+++ b/stable/kong/templates/service-kong-portal-api.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.enterprise.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kong.fullname" . }}-portalapi
+  annotations:
+    {{- range $key, $value := .Values.portalapi.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  labels:
+    app: {{ template "kong.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: {{ .Values.portalapi.type }}
+  {{- if eq .Values.portalapi.type "LoadBalancer" }}
+  {{- if .Values.portalapi.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.portalapi.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.portalapi.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range $cidr := .Values.portalapi.loadBalancerSourceRanges }}
+  - {{ $cidr }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  externalIPs:
+  {{- range $ip := .Values.portalapi.externalIPs }}
+  - {{ $ip }}
+  {{- end }}
+  ports:
+  {{- if .Values.portalapi.http.enabled }}
+  - name: kong-portalapi
+    port: {{ .Values.portalapi.http.servicePort }}
+    targetPort: {{ .Values.portalapi.http.containerPort }}
+  {{- if (and (eq .Values.portalapi.type "NodePort") (not (empty .Values.portalapi.http.nodePort))) }}
+    nodePort: {{ .Values.portalapi.http.nodePort }}
+  {{- end }}
+    protocol: TCP
+  {{- end }}
+  {{- if or .Values.portalapi.tls.enabled }}
+  - name: kong-portalapi-tls
+    port: {{ .Values.portalapi.tls.servicePort }}
+    targetPort: {{ .Values.portalapi.tls.containerPort }}
+  {{- if (and (eq .Values.portalapi.type "NodePort") (not (empty .Values.portalapi.tls.nodePort))) }}
+    nodePort: {{ .Values.portalapi.tls.nodePort }}
+  {{- end }}
+    protocol: TCP
+  {{- end }}
+
+
+  selector:
+    app: {{ template "kong.name" . }}
+    release: {{ .Release.Name }}
+    component: app
+{{- end -}}

--- a/stable/kong/templates/service-kong-portal.yaml
+++ b/stable/kong/templates/service-kong-portal.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.enterprise.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kong.fullname" . }}-portal
+  annotations:
+    {{- range $key, $value := .Values.portal.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  labels:
+    app: {{ template "kong.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: {{ .Values.portal.type }}
+  {{- if eq .Values.portal.type "LoadBalancer" }}
+  {{- if .Values.portal.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.portal.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.portal.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range $cidr := .Values.portal.loadBalancerSourceRanges }}
+  - {{ $cidr }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  externalIPs:
+  {{- range $ip := .Values.portal.externalIPs }}
+  - {{ $ip }}
+  {{- end }}
+  ports:
+  {{- if .Values.portal.http.enabled }}
+  - name: kong-portal
+    port: {{ .Values.portal.http.servicePort }}
+    targetPort: {{ .Values.portal.http.containerPort }}
+  {{- if (and (eq .Values.portal.type "NodePort") (not (empty .Values.portal.http.nodePort))) }}
+    nodePort: {{ .Values.portal.http.nodePort }}
+  {{- end }}
+    protocol: TCP
+  {{- end }}
+  {{- if or .Values.portal.tls.enabled }}
+  - name: kong-portal-tls
+    port: {{ .Values.portal.tls.servicePort }}
+    targetPort: {{ .Values.portal.tls.containerPort }}
+  {{- if (and (eq .Values.portal.type "NodePort") (not (empty .Values.portal.tls.nodePort))) }}
+    nodePort: {{ .Values.portal.tls.nodePort }}
+  {{- end }}
+    protocol: TCP
+  {{- end }}
+
+
+  selector:
+    app: {{ template "kong.name" . }}
+    release: {{ .Release.Name }}
+    component: app
+{{- end -}}

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -229,7 +229,7 @@ enterprise:
     # The key value must be a secret configuration, following the example at https://docs.konghq.com/enterprise/0.35-x/kong-manager/authentication/sessions/
     session_conf_secret: you-must-create-an-rbac-session-conf-secret
     # Set to the appropriate plugin config JSON if not using basic-auth
-    #admin_gui_auth_conf: ''
+    # admin_gui_auth_conf: ''
   smtp:
     enabled: false
     portal_emails_from: none@example.com
@@ -239,13 +239,13 @@ enterprise:
     smtp_admin_emails: none@example.com
     smtp_host: smtp.example.com
     smtp_port: 587
-    smtp_starttls: on
+    smtp_starttls: true
     auth:
       # If your SMTP server does not require authentication, this section can
       # be left as-is. If smtp_username is set to anything other than an empty
       # string, you must create a Secret with an smtp_password key containing
       # your SMTP password and specify its name here.
-      smtp_username: '' # e.g. postmaster@example.com
+      smtp_username: ''  # e.g. postmaster@example.com
       smtp_password_secret: you-must-create-an-smtp-password
 
 # Set runMigrations to run Kong migrations

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -3,10 +3,12 @@
 
 image:
   repository: kong
+  # repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
   tag: 1.1
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
+  ## If using the official Kong Enterprise registry above, you MUST provide a secret.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   ##
   # pullSecrets:
@@ -83,6 +85,169 @@ proxy:
 
   externalIPs: []
 
+manager:
+  # If you want to specify annotations for the Manager service, uncomment the following
+  # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+  annotations: {}
+  #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+
+  # HTTP plain-text traffic
+  http:
+    enabled: true
+    servicePort: 8002
+    containerPort: 8002
+    # Set a nodePort which is available if service type is NodePort
+    # nodePort: 32080
+
+  tls:
+    enabled: true
+    servicePort: 8445
+    containerPort: 8445
+    # Set a nodePort which is available if service type is NodePort
+    # nodePort: 32443
+
+  type: NodePort
+
+  # Kong proxy ingress settings.
+  ingress:
+    # Enable/disable exposure using ingress.
+    enabled: false
+    # TLS secret name.
+    # tls: kong-proxy.example.com-tls
+    # Array of ingress hosts.
+    hosts: []
+    # Map of ingress annotations.
+    annotations: {}
+    # Ingress path.
+    path: /
+
+  externalIPs: []
+
+portal:
+  # If you want to specify annotations for the Portal service, uncomment the following
+  # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+  annotations: {}
+  #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+
+  # HTTP plain-text traffic
+  http:
+    enabled: true
+    servicePort: 8003
+    containerPort: 8003
+    # Set a nodePort which is available if service type is NodePort
+    # nodePort: 32080
+
+  tls:
+    enabled: true
+    servicePort: 8446
+    containerPort: 8446
+    # Set a nodePort which is available if service type is NodePort
+    # nodePort: 32443
+
+  type: NodePort
+
+  # Kong proxy ingress settings.
+  ingress:
+    # Enable/disable exposure using ingress.
+    enabled: false
+    # TLS secret name.
+    # tls: kong-proxy.example.com-tls
+    # Array of ingress hosts.
+    hosts: []
+    # Map of ingress annotations.
+    annotations: {}
+    # Ingress path.
+    path: /
+
+  externalIPs: []
+
+portalapi:
+  # If you want to specify annotations for the Portal API service, uncomment the following
+  # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+  annotations: {}
+  #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+
+  # HTTP plain-text traffic
+  http:
+    enabled: true
+    servicePort: 8004
+    containerPort: 8004
+    # Set a nodePort which is available if service type is NodePort
+    # nodePort: 32080
+
+  tls:
+    enabled: true
+    servicePort: 8447
+    containerPort: 8447
+    # Set a nodePort which is available if service type is NodePort
+    # nodePort: 32443
+
+  type: NodePort
+
+  # Kong proxy ingress settings.
+  ingress:
+    # Enable/disable exposure using ingress.
+    enabled: false
+    # TLS secret name.
+    # tls: kong-proxy.example.com-tls
+    # Array of ingress hosts.
+    hosts: []
+    # Map of ingress annotations.
+    annotations: {}
+    # Ingress path.
+    path: /
+
+  externalIPs: []
+
+# Toggle Kong Enterprise features on or off
+# RBAC and SMTP configuration have additional options that must all be set together
+# Other settings should be added to the "env" settings below
+enterprise:
+  enabled: false
+  # Kong Enterprise license secret name
+  # This secret must contain a single 'license' key, containing your base64-encoded license data
+  # The license secret is required for all Kong Enterprise deployments
+  license_secret: you-must-create-a-kong-license-secret
+  # Session configuration secret
+  # The session conf secret is required if using RBAC or the Portal
+  vitals:
+    enabled: true
+  portal:
+    enabled: false
+    # portal_auth here sets the default authentication mechanism for the Portal
+    # FIXME This can be changed per-workspace, but must currently default to
+    # basic-auth to work around limitations with session configuration
+    portal_auth: basic-auth
+    # If the Portal is enabled and any workspace's Portal uses authentication,
+    # this Secret must contain an portal_session_conf key
+    # The key value must be a secret configuration, following the example at https://docs.konghq.com/enterprise/0.35-x/kong-manager/authentication/sessions/
+    session_conf_secret: you-must-create-a-portal-session-conf-secret
+  rbac:
+    enabled: false
+    admin_gui_auth: basic-auth
+    # If RBAC is enabled, this Secret must contain an admin_gui_session_conf key
+    # The key value must be a secret configuration, following the example at https://docs.konghq.com/enterprise/0.35-x/kong-manager/authentication/sessions/
+    session_conf_secret: you-must-create-an-rbac-session-conf-secret
+    # Set to the appropriate plugin config JSON if not using basic-auth
+    #admin_gui_auth_conf: ''
+  smtp:
+    enabled: false
+    portal_emails_from: none@example.com
+    portal_emails_reply_to: none@example.com
+    admin_emails_from: none@example.com
+    admin_emails_reply_to: none@example.com
+    smtp_admin_emails: none@example.com
+    smtp_host: smtp.example.com
+    smtp_port: 587
+    smtp_starttls: on
+    auth:
+      # If your SMTP server does not require authentication, this section can
+      # be left as-is. If smtp_username is set to anything other than an empty
+      # string, you must create a Secret with an smtp_password key containing
+      # your SMTP password and specify its name here.
+      smtp_username: '' # e.g. postmaster@example.com
+      smtp_password_secret: you-must-create-an-smtp-password
+
 # Set runMigrations to run Kong migrations
 runMigrations: true
 
@@ -92,8 +257,12 @@ env:
   database: postgres
   proxy_access_log: /dev/stdout
   admin_access_log: /dev/stdout
+  admin_gui_access_log: /dev/stdout
+  portal_api_access_log: /dev/stdout
   proxy_error_log: /dev/stderr
   admin_error_log: /dev/stderr
+  admin_gui_error_log: /dev/stderr
+  portal_api_error_log: /dev/stderr
 
 # If you want to specify resources, uncomment the following
 # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
@@ -106,6 +275,7 @@ resources: {}
   #  memory: 128Mi
 
 # readinessProbe for Kong pods
+# If using Kong Enterprise with RBAC, you must add a Kong-Admin-Token header
 readinessProbe:
   httpGet:
     path: "/status"
@@ -118,6 +288,7 @@ readinessProbe:
   failureThreshold: 5
 
 # livenessProbe for Kong pods
+# If using Kong Enterprise with RBAC, you must add a Kong-Admin-Token header
 livenessProbe:
   httpGet:
     path: "/status"


### PR DESCRIPTION
Signed-off-by: Travis Raines <traines@konghq.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Adds support for Kong Enterprise and toggling the chart between a Kong open source deployment (default) or Kong Enterprise deployment. 

#### Special notes for your reviewer:
@hbagdi and @shashiranjan84 for review. This PR is pre-squashed; https://github.com/rainest/charts/tree/kong-enterprise has additional history and https://github.com/Kong/charts/pull/1 has some prior discussion.

These additions are designed to support Kong Enterprise 0.35+. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)