### PR TITLE
[stable/k8s-spot-rescheduler] Adding priority class support 🔺

### DIFF
--- a/stable/k8s-spot-rescheduler/Chart.yaml
+++ b/stable/k8s-spot-rescheduler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.2.0"
 description: A k8s-spot-rescheduler Helm chart for Kubernetes
 name: k8s-spot-rescheduler
-version: 0.4.1
+version: 0.4.2
 keywords:
   - spot
   - rescheduler

--- a/stable/k8s-spot-rescheduler/README.md
+++ b/stable/k8s-spot-rescheduler/README.md
@@ -26,3 +26,7 @@ helm install \
 ## Configuration
 
 Add the parameters to `cmdOptions` which you want to use. Here is [the full list of available options](https://github.com/pusher/k8s-spot-rescheduler#flags).
+
+| Parameter                          | Description                                                                                                                | Default                                            |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `priorityClassName`                | priorityClassName                                                                                                          | `""`    

--- a/stable/k8s-spot-rescheduler/templates/deployment.yaml
+++ b/stable/k8s-spot-rescheduler/templates/deployment.yaml
@@ -24,6 +24,9 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ template "k8s-spot-rescheduler.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/k8s-spot-rescheduler/values.yaml
+++ b/stable/k8s-spot-rescheduler/values.yaml
@@ -59,3 +59,8 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+
+# Leverage a PriorityClass to ensure your pods survive resource shortages
+# ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+# PriorityClass: system-cluster-critical
+priorityClassName: ""


### PR DESCRIPTION
Summoning @komljen per the PR template. Thanks for taking the time to review this, it's much appreciated!

####Special notes for your reviewer:
I installed this change on an EKS cluster and the priority class appeared as expected.

#### What this PR does / why we need it:
Adding `priorityClassName` support for k8s-spot-rescheduler.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
