### PR TITLE
[stable/postgresql] Make readiness probe compatible for most postgresql images

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 5.3.1
+version: 5.3.2
 appVersion: 11.3.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/_helpers.tpl
+++ b/stable/postgresql/templates/_helpers.tpl
@@ -295,3 +295,22 @@ imagePullSecrets:
 {{- end }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Get the readiness probe command
+*/}}
+{{- define "postgresql.readinessProbeCommand" -}}
+{{- if contains "bitnami/" .Values.image.repository }}
+  {{- if (include "postgresql.database" .) }}
+    - pg_isready -U {{ include "postgresql.username" . | quote }} -d {{ (include "postgresql.database" .) | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }} && [ -f /opt/bitnami/postgresql/tmp/.initialized ]
+  {{- else }}
+    - pg_isready -U {{ include "postgresql.username" . | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }} && [ -f /opt/bitnami/postgresql/tmp/.initialized ]
+  {{- end }}
+{{- else -}}
+  {{- if (include "postgresql.database" .) }}
+    - pg_isready -U {{ include "postgresql.username" . | quote }} -d {{ (include "postgresql.database" .) | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
+  {{- else }}
+    - pg_isready -U {{ include "postgresql.username" . | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
+  {{- end }}
+{{- end -}}
+{{- end -}}

--- a/stable/postgresql/templates/_helpers.tpl
+++ b/stable/postgresql/templates/_helpers.tpl
@@ -300,17 +300,13 @@ imagePullSecrets:
 Get the readiness probe command
 */}}
 {{- define "postgresql.readinessProbeCommand" -}}
+- |
+{{- if (include "postgresql.database" .) }}
+  pg_isready -U {{ include "postgresql.username" . | quote }} -d {{ (include "postgresql.database" .) | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
+{{- else }}
+  pg_isready -U {{ include "postgresql.username" . | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
+{{- end }}
 {{- if contains "bitnami/" .Values.image.repository }}
-  {{- if (include "postgresql.database" .) }}
-    - pg_isready -U {{ include "postgresql.username" . | quote }} -d {{ (include "postgresql.database" .) | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }} && [ -f /opt/bitnami/postgresql/tmp/.initialized ]
-  {{- else }}
-    - pg_isready -U {{ include "postgresql.username" . | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }} && [ -f /opt/bitnami/postgresql/tmp/.initialized ]
-  {{- end }}
-{{- else -}}
-  {{- if (include "postgresql.database" .) }}
-    - pg_isready -U {{ include "postgresql.username" . | quote }} -d {{ (include "postgresql.database" .) | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
-  {{- else }}
-    - pg_isready -U {{ include "postgresql.username" . | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
-  {{- end }}
+  [ -f /opt/bitnami/postgresql/tmp/.initialized ]
 {{- end -}}
 {{- end -}}

--- a/stable/postgresql/templates/statefulset-slaves.yaml
+++ b/stable/postgresql/templates/statefulset-slaves.yaml
@@ -155,7 +155,7 @@ spec:
             command:
             - sh
             - -c
-            {{- include "postgresql.readinessProbeCommand" . | indent 8 }}
+            {{- include "postgresql.readinessProbeCommand" . | nindent 12 }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/stable/postgresql/templates/statefulset-slaves.yaml
+++ b/stable/postgresql/templates/statefulset-slaves.yaml
@@ -155,11 +155,7 @@ spec:
             command:
             - sh
             - -c
-           {{- if (include "postgresql.database" .) }}
-            - pg_isready -U {{ include "postgresql.username" . | quote }} -d {{ (include "postgresql.database" .) | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }} && [ -f /opt/bitnami/postgresql/tmp/.initialized ]
-           {{- else }}
-            - pg_isready -U {{ include "postgresql.username" . | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }} && [ -f /opt/bitnami/postgresql/tmp/.initialized ]
-           {{- end }}
+            {{- include "postgresql.readinessProbeCommand" . | indent 8 }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -180,7 +180,7 @@ spec:
             command:
             - sh
             - -c
-            {{- include "postgresql.readinessProbeCommand" . | indent 8 }}
+            {{- include "postgresql.readinessProbeCommand" . | nindent 12 }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -180,11 +180,7 @@ spec:
             command:
             - sh
             - -c
-           {{- if (include "postgresql.database" .) }}
-            - pg_isready -U {{ include "postgresql.username" . | quote }} -d {{ (include "postgresql.database" .) | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }} && [ -f /opt/bitnami/postgresql/tmp/.initialized ]
-           {{- else }}
-            - pg_isready -U {{ include "postgresql.username" . | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }} && [ -f /opt/bitnami/postgresql/tmp/.initialized ]
-           {{- end }}
+            {{- include "postgresql.readinessProbeCommand" . | indent 8 }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}


### PR DESCRIPTION
Signed-off-by: tompizmor <tompizmor@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
In this previous PR (https://github.com/helm/charts/pull/14370) I improved the readinessProbe to fix this issue (https://github.com/helm/charts/issues/10627). However, that breaks the readiness probes when the image used is not the Bitnami one. 

In this PR I have created a helper function to get the proper readiness probe command according to the image used.

Rendered readiness probe for bitnami image

```
        readinessProbe:
          exec:
            command:
            - sh
            - -c
            - |
              pg_isready -U "postgres" -d "tomasdb" -h 127.0.0.1 -p 5432
              [ -f /opt/bitnami/postgresql/tmp/.initialized ]
```

Rendered readiness probe for non-bitnami image

```
        readinessProbe:
          exec:
            command:
            - sh
            - -c
            - |
              pg_isready -U "postgres" -d "tomasdb" -h 127.0.0.1 -p 5432
```

#### Which issue this PR fixes
  - fixes #14495

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
