### PR TITLE
[stable/prometheus-redis-exporter] Support image pullSecrets

### DIFF
--- a/stable/prometheus-redis-exporter/Chart.yaml
+++ b/stable/prometheus-redis-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.28.0
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 1.0.2
+version: 1.0.3
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/stable/prometheus-redis-exporter/README.md
+++ b/stable/prometheus-redis-exporter/README.md
@@ -46,6 +46,7 @@ The following table lists the configurable parameters and their default values.
 | `image.repository`     | prometheus-redis-exporter image repository          | `oliver006/redis_exporter`|
 | `image.tag`            | prometheus-redis-exporter image tag                 | `v0.28.0`                 |
 | `image.pullPolicy`     | image pull policy                                   | `IfNotPresent`            |
+| `image.pullSecrets`    | image pull secrets                                  | {}                        |
 | `extraArgs`            | extra arguments for the binary; possible values [here](https://github.com/oliver006/redis_exporter#flags)| {}
 | `env`                  | additional environment variables in YAML format. Can be used to pass credentials as env variables (via secret) as per the image readme [here](https://github.com/oliver006/redis_exporter#environment-variables) | {} |
 | `resources`            | cpu/memory resource requests/limits                 | {}                        |

--- a/stable/prometheus-redis-exporter/templates/deployment.yaml
+++ b/stable/prometheus-redis-exporter/templates/deployment.yaml
@@ -22,6 +22,12 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ template "prometheus-redis-exporter.serviceAccountName" . }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end}}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
@acondrat 

#### What this PR does / why we need it:
Without this, you couldn't pull redis exporter image from private repos.

#### Special notes for your reviewer:
<3

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
