### PR TITLE
[stable/karma] validation error fix

### DIFF
--- a/stable/karma/Chart.yaml
+++ b/stable/karma/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/prymitive/karma
 sources:
   - https://hub.docker.com/r/lmierzwa/karma/
   - https://github.com/prymitive/karma
-version: 1.1.15
+version: 1.1.16
 maintainers:
 - name: davidkarlsen
   email: david@davidkarlsen.com

--- a/stable/karma/templates/deployment.yaml
+++ b/stable/karma/templates/deployment.yaml
@@ -44,14 +44,14 @@ spec:
             httpGet:
               path: {{ .Values.livenessProbe.path }}
               port: http
-              initialDelaySeconds: {{ .Values.livenessProbe.delay }}
-              periodSeconds: {{ .Values.livenessProbe.period }}
+            initialDelaySeconds: {{ .Values.livenessProbe.delay }}
+            periodSeconds: {{ .Values.livenessProbe.period }}
           readinessProbe:
             httpGet:
               path: {{ .Values.livenessProbe.path }}
               port: http
-              initialDelaySeconds: {{ .Values.livenessProbe.delay }}
-              periodSeconds: {{ .Values.livenessProbe.period }}
+            initialDelaySeconds: {{ .Values.livenessProbe.delay }}
+            periodSeconds: {{ .Values.livenessProbe.period }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           {{- if .Values.configMap.enabled }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
this change fix the validation error on livenessProbe and readinessProbe definitions

#### Which issue this PR fixes
helm install command returns:

Error: validation failed: error validating "": error validating data: [ValidationError(Deployment.spec.template.spec.containers[0].livenessProbe.httpGet): unknown field "initialDelaySeconds" in io.k8s.api.core.v1.HTTPGetAction, ValidationError(Deployment.spec.template.spec.containers[0].livenessProbe.httpGet): unknown field "periodSeconds" in io.k8s.api.core.v1.HTTPGetAction, ValidationError(Deployment.spec.template.spec.containers[0].readinessProbe.httpGet): unknown field "initialDelaySeconds" in io.k8s.api.core.v1.HTTPGetAction, ValidationError(Deployment.spec.template.spec.containers[0].readinessProbe.httpGet): unknown field "periodSeconds" in io.k8s.api.core.v1.HTTPGetAction] 

#### Special notes for your reviewer:
none.
@davidkarlsen @prymitive

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
