### PR TITLE
[stable/external-dns] Add configmap/secret checksum to pod annotation

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -3,7 +3,7 @@ description: |
   Configure external DNS servers (AWS Route53, Google CloudDNS and others)
   for Kubernetes Ingresses and Services
 name: external-dns
-version: 1.7.9
+version: 1.7.10
 appVersion: 0.5.14
 home: https://github.com/kubernetes-incubator/external-dns
 sources:

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -11,6 +11,12 @@ spec:
       annotations: {{ toYaml .Values.podAnnotations | nindent 8}}
     {{- end }}
       labels: {{ include "external-dns.labels" . | indent 8 }}
+    {{- if or (and .Values.aws.secretKey .Values.aws.accessKey) .Values.cloudflare.apiKey .Values.digitalocean.apiToken (and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword) .Values.rfc2136.tsigSecret .Values.extraEnv .Values.google.serviceAccountKey }}
+      checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+    {{- end }}
+    {{- if and (eq .Values.provider "designate") .Values.designate.customCA.enabled }}
+      checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    {{- end }}
     spec:
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
Add checksum annotation to the pod in order to force restart on secret/configmap change.