### PR TITLE
[stable/prometheus-nats-exporter] upgrade to official image

### DIFF
--- a/stable/prometheus-nats-exporter/Chart.yaml
+++ b/stable/prometheus-nats-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.17.0"
+appVersion: "0.3.0"
 description: A Helm chart for prometheus-nats-exporter
 name: prometheus-nats-exporter
-version: 1.0.1
+version: 2.0.0
 home: https://github.com/nats-io/prometheus-nats-exporter
 sources:
   - https://github.com/nats-io/prometheus-nats-exporter

--- a/stable/prometheus-nats-exporter/README.md
+++ b/stable/prometheus-nats-exporter/README.md
@@ -17,7 +17,7 @@ This chart bootstraps a prometheus [NATS exporter](https://github.com/nats-io/pr
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install --name my-release incubator/prometheus-nats-exporter
+$ helm install --name my-release stable/prometheus-nats-exporter
 ```
 
 The command deploys NATS exporter on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -38,12 +38,12 @@ The following table lists the configurable parameters of the postgres Exporter c
 
 | Parameter                       | Description                                | Default                                                    |
 | ------------------------------- | ------------------------------------------ | ---------------------------------------------------------- |
-| `image`                         | Image                                      | `appcelerator/prometheus-nats-exporter`                    |
-| `imageTag`                      | Image tag                                  | `0.17.0`                                                   |
+| `image`                         | Image                                      | `synadia/prometheus-nats-exporter`                         |
+| `imageTag`                      | Image tag                                  | `0.3.0`                                                    |
 | `imagePullPolicy`               | Image pull policy                          | `IfNotPresent`                                             |
 | `service.type`                  | Service type                               | `ClusterIP`                                                |
 | `service.port`                  | The service port                           | `80`                                                       |
-| `service.targetPort`            | The target port of the container           | `8222`                                                     |
+| `service.targetPort`            | The target port of the container           | `7777`                                                     |
 | `resources`                     |                                            | `{}`                                                       |
 | `config.nats.service`           | NATS monitoring [service name](https://github.com/helm/charts/blob/master/stable/nats/templates/monitoring-svc.yaml)| `nats-nats-monitoring`|
 | `config.nats.namespace`         | Namespace in which NATS deployed           | `default`                                                  |
@@ -60,7 +60,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 $ helm install --name my-release \
   --set config.nats.service=nats-production-nats-monitoring  \
-    incubator/prometheus-nats-exporter
+    stable/prometheus-nats-exporter
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,

--- a/stable/prometheus-nats-exporter/README.md
+++ b/stable/prometheus-nats-exporter/README.md
@@ -36,35 +36,43 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the postgres Exporter chart and their default values.
 
-| Parameter                       | Description                                | Default                                                    |
-| ------------------------------- | ------------------------------------------ | ---------------------------------------------------------- |
-| `image`                         | Image                                      | `synadia/prometheus-nats-exporter`                         |
-| `imageTag`                      | Image tag                                  | `0.3.0`                                                    |
-| `imagePullPolicy`               | Image pull policy                          | `IfNotPresent`                                             |
-| `service.type`                  | Service type                               | `ClusterIP`                                                |
-| `service.port`                  | The service port                           | `80`                                                       |
-| `service.targetPort`            | The target port of the container           | `7777`                                                     |
-| `resources`                     |                                            | `{}`                                                       |
-| `config.nats.service`           | NATS monitoring [service name](https://github.com/helm/charts/blob/master/stable/nats/templates/monitoring-svc.yaml)| `nats-nats-monitoring`|
-| `config.nats.namespace`         | Namespace in which NATS deployed           | `default`                                                  |
-| `config.nats.port`              | NATS monitoring service port               | `8222`                                                     |
-| `tolerations`                   | Add tolerations                            | `[]`                                                       |
-| `nodeSelector`                  | node labels for pod assignment             | `{}`                                                       |
-| `affinity`                      |     node/pod affinities                    | `{}`                                                       |
-| `annotations`                   | Deployment annotations                     | `{}`                                                       |
-| `extraContainers`               | Additional sidecar containers              | `""`                                                       |
-| `extraVolumes`                  | Additional volumes for use in extraContainers | `""`                                                    |
+| Parameter                       | Description                                   | Default                                                    |
+| ------------------------------- | --------------------------------------------- | ---------------------------------------------------------- |
+| `image`                         | Image                                         | `synadia/prometheus-nats-exporter`                         |
+| `imageTag`                      | Image tag                                     | `0.3.0`                                                    |
+| `imagePullPolicy`               | Image pull policy                             | `IfNotPresent`                                             |
+| `service.type`                  | Service type                                  | `ClusterIP`                                                |
+| `service.port`                  | The service port                              | `80`                                                       |
+| `service.targetPort`            | The target port of the container              | `7777`                                                     |
+| `resources`                     |                                               | `{}`                                                       |
+| `config.nats.service`            | NATS monitoring [service name][svc-name]      | `nats-nats-monitoring`                                     |
+| `config.nats.namespace`          | Namespace in which NATS deployed              | `default`                                                  |
+| `config.nats.port`               | NATS monitoring service port                  | `8222`                                                     |
+| `config.metrics.varz`            | NATS varz metrics                             | `true`                                                     |
+| `config.metrics.channelz`        | NATS channelz metrics                         | `true`                                                     |
+| `config.metrics.connz`           | NATS connz metrics                            | `true`                                                     |
+| `config.metrics.routez`          | NATS routez metrics                           | `true`                                                     |
+| `config.metrics.serverz`         | NATS serverz metrics                          | `true`                                                     |
+| `config.metrics.subz`            | NATS subz metrics                             | `true`                                                     |
+| `tolerations`                   | Add tolerations                               | `[]`                                                       |
+| `nodeSelector`                  | node labels for pod assignment                | `{}`                                                       |
+| `affinity`                       | node/pod affinities                            | `{}`                                                       |
+| `annotations`                   | Deployment annotations                        | `{}`                                                       |
+| `extraContainers`               | Additional sidecar containers                 | `""`                                                       |
+| `extraVolumes`                  | Additional volumes for use in extraContainers | `""`                                                       |
+
+[svc-name]: https://github.com/helm/charts/blob/master/stable/nats/templates/monitoring-svc.yaml
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-$ helm install --name my-release \
-  --set config.nats.service=nats-production-nats-monitoring  \
-    stable/prometheus-nats-exporter
+$ helm install --name my-release stable/prometheus-nats-exporter \
+  --set config.nats.service=nats-production-nats-monitoring \
+  --set config.metrics.subz=false
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-$ helm install --name my-release -f values.yaml stable/prometheus-nats-exporter
+$ helm install --name my-release stable/prometheus-nats-exporter -f values.yaml
 ```

--- a/stable/prometheus-nats-exporter/templates/NOTES.txt
+++ b/stable/prometheus-nats-exporter/templates/NOTES.txt
@@ -9,7 +9,7 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "prometheus-nats-exporter.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "prometheus-nats-exporter.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "prometheus-nats-exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:{{ .Values.service.targetPort }}/metrics to use your application"
+  kubectl port-forward $POD_NAME {{ .Values.service.targetPort }}:{{ .Values.service.targetPort }}
 {{- end }}

--- a/stable/prometheus-nats-exporter/templates/deployment.yaml
+++ b/stable/prometheus-nats-exporter/templates/deployment.yaml
@@ -28,12 +28,24 @@ spec:
           args:
             - "-port"
             - "{{ .Values.service.targetPort }}"
+            {{- if .Values.config.metrics.varz }}
             - "-varz"
+            {{- end }}
+            {{- if .Values.config.metrics.channelz }}
             - "-channelz"
+            {{- end }}
+            {{- if .Values.config.metrics.connz }}
             - "-connz"
+            {{- end }}
+            {{- if .Values.config.metrics.routez }}
             - "-routez"
+            {{- end }}
+            {{- if .Values.config.metrics.serverz }}
             - "-serverz"
+            {{- end }}
+            {{- if .Values.config.metrics.subz }}
             - "-subz"
+            {{- end }}
             - "http://{{ .Values.config.nats.service }}.{{ .Values.config.nats.namespace }}.svc.cluster.local:{{ .Values.config.nats.port }}"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/stable/prometheus-nats-exporter/templates/deployment.yaml
+++ b/stable/prometheus-nats-exporter/templates/deployment.yaml
@@ -29,6 +29,11 @@ spec:
             - "-port"
             - "{{ .Values.service.targetPort }}"
             - "-varz"
+            - "-channelz"
+            - "-connz"
+            - "-routez"
+            - "-serverz"
+            - "-subz"
             - "http://{{ .Values.config.nats.service }}.{{ .Values.config.nats.namespace }}.svc.cluster.local:{{ .Values.config.nats.port }}"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/stable/prometheus-nats-exporter/values.yaml
+++ b/stable/prometheus-nats-exporter/values.yaml
@@ -5,14 +5,14 @@
 replicaCount: 1
 
 image:
-  repository: appcelerator/prometheus-nats-exporter
-  tag: 0.17.0
+  repository: synadia/prometheus-nats-exporter
+  tag: 0.3.0
   pullPolicy: IfNotPresent
 
 service:
   type: ClusterIP
   port: 80
-  targetPort: 8222
+  targetPort: 7777
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/stable/prometheus-nats-exporter/values.yaml
+++ b/stable/prometheus-nats-exporter/values.yaml
@@ -31,6 +31,13 @@ config:
     service: nats-nats-monitoring
     namespace: default
     port: 8222
+  metrics:
+    varz: true
+    channelz: true
+    connz: true
+    routez: true
+    serverz: true
+    subz: true
 
 nodeSelector: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

- Upgrades the chart to use the official docker image from https://github.com/nats-io/prometheus-nats-exporter/releases
- fixed post install notes
- fixed some small things in the README
- added the other params to the deployment in order to export all metrics (should we made this optional eventually?)

#### Which issue this PR fixes
none.

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
