### PR TITLE
[incubator/kafka] Adding zookeeper fullnameOverride

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.15.5
+version: 0.15.6
 appVersion: 5.0.1
 keywords:
 - kafka

--- a/incubator/kafka/templates/_helpers.tpl
+++ b/incubator/kafka/templates/_helpers.tpl
@@ -29,8 +29,12 @@ Create a default fully qualified zookeeper name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "kafka.zookeeper.fullname" -}}
+{{- if .Values.zookeeper.fullnameOverride -}}
+{{- .Values.zookeeper.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default "zookeeper" .Values.zookeeper.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently when you add a zookeeper `fullnameOverride` in your values for kafka, zookeeper will use the updated name, but kafka will still attempt to connect via `.Release.Name`-zookeeper.
This PR makes it so it should connect the overridden zookeeper name.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
