### PR TITLE
[stable/elasticsearch] Rolling update statefulsets and deployment on configmap change

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.28.0
+version: 1.28.1
 appVersion: 6.7.0
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/stable/elasticsearch/ci/updatestrategy-values.yaml
+++ b/stable/elasticsearch/ci/updatestrategy-values.yaml
@@ -1,0 +1,7 @@
+data:
+  updateStrategy:
+    type: RollingUpdate
+
+master:
+  updateStrategy:
+    type: RollingUpdate

--- a/stable/elasticsearch/templates/client-deployment.yaml
+++ b/stable/elasticsearch/templates/client-deployment.yaml
@@ -16,8 +16,9 @@ spec:
         app: {{ template "elasticsearch.name" . }}
         component: "{{ .Values.client.name }}"
         release: {{ .Release.Name }}
-        {{- if .Values.client.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.client.podAnnotations }}
 {{ toYaml .Values.client.podAnnotations | indent 8 }}
         {{- end }}
     spec:

--- a/stable/elasticsearch/templates/data-statefulset.yaml
+++ b/stable/elasticsearch/templates/data-statefulset.yaml
@@ -18,10 +18,15 @@ spec:
         component: "{{ .Values.data.name }}"
         release: {{ .Release.Name }}
         role: data
-        {{- if .Values.data.podAnnotations }}
+{{- if or .Values.data.podAnnotations (eq .Values.data.updateStrategy.type "RollingUpdate") }}
       annotations:
+      {{- if .Values.data.podAnnotations }}
 {{ toYaml .Values.data.podAnnotations | indent 8 }}
-        {{- end }}
+      {{- end }}
+      {{- if eq .Values.data.updateStrategy.type "RollingUpdate" }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- end }}
+{{- end }}
     spec:
       {{- if .Values.schedulerName }}
       schedulerName: "{{ .Values.schedulerName }}"

--- a/stable/elasticsearch/templates/master-statefulset.yaml
+++ b/stable/elasticsearch/templates/master-statefulset.yaml
@@ -18,7 +18,6 @@ spec:
         component: "{{ .Values.master.name }}"
         release: {{ .Release.Name }}
         role: master
-        {{- if .Values.master.podAnnotations }}
 {{- if or .Values.master.podAnnotations (eq .Values.master.updateStrategy.type "RollingUpdate") }}
       annotations:
       {{- if .Values.master.podAnnotations }}

--- a/stable/elasticsearch/templates/master-statefulset.yaml
+++ b/stable/elasticsearch/templates/master-statefulset.yaml
@@ -19,9 +19,15 @@ spec:
         release: {{ .Release.Name }}
         role: master
         {{- if .Values.master.podAnnotations }}
+{{- if or .Values.master.podAnnotations (eq .Values.master.updateStrategy.type "RollingUpdate") }}
       annotations:
+      {{- if .Values.master.podAnnotations }}
 {{ toYaml .Values.master.podAnnotations | indent 8 }}
-        {{- end }}
+      {{- end }}
+      {{- if eq .Values.master.updateStrategy.type "RollingUpdate" }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- end }}
+{{- end }}
     spec:
       {{- if .Values.schedulerName }}
       schedulerName: "{{ .Values.schedulerName }}"


### PR DESCRIPTION
#### What this PR does / why we need it:
Currently data and master StatefulSets, and client deployment ignore updates of the ConfigMap.
This PR suggest performing the rolling update for clients and if updateStrategy.type of data or master nodes are set to RollingUpdate.

#### Special notes for your reviewer:
This PR repeats https://github.com/helm/charts/pull/11490, @desaintmartin could you please have a look?

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
