### PR TITLE
[stable/rabbitmq] Update image to new bash container 

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 5.9.2
+version: 6.0.0
 appVersion: 3.7.15
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -208,6 +208,10 @@ $ helm install --set persistence.existingClaim=PVC_NAME rabbitmq
 
 ## Upgrading
 
+### To 6.0.0
+
+This new version updates the RabbitMQ image to a [new version based on bash instead of node.js](https://github.com/bitnami/bitnami-docker-rabbitmq#3715-r18-3715-ol-7-r19). However, since this Chart overwrites the container's command, the changes to the container shouldn't affect the Chart. To upgrade, it may be needed to enable the `fastBoot` option, as it is already the case from upgrading from 5.X to 5.Y.  
+
 ### To 5.0.0
 
 This major release changes the clustering method from `ip` to `hostname`.

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -159,12 +159,8 @@ spec:
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
         {{- end }}
         env:
-        {{- if .Values.image.debug}}
-          - name: BASH_DEBUG
-            value: "1"
-          - name: NAMI_DEBUG
-            value: "1"
-        {{- end }}
+          - name: BITNAMI_DEBUG
+            value: {{ ternary "true" "false" .Values.image.debug | quote }}
           - name: MY_POD_IP
             valueFrom:
               fieldRef:

--- a/stable/rabbitmq/values-production.yaml
+++ b/stable/rabbitmq/values-production.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 3.7.15-debian-9-r8
+  tag: 3.7.15-debian-9-r18
 
   ## set to true if you would like to see extra information on logs
   ## it turns BASH and NAMI debugging in minideb

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 3.7.15-debian-9-r8
+  tag: 3.7.15-debian-9-r18
 
   ## set to true if you would like to see extra information on logs
   ## it turns BASH and NAMI debugging in minideb


### PR DESCRIPTION
Signed-off-by: Alejandro Moreno <amoreno@bitnami.com>

#### What this PR does / why we need it:
Updates the container to use the new container with bash logic.

#### Special notes for your reviewer:
As the chart has its own logic in a custom command, the changes to the underlying image shouldn't affect the chart. To upgrade, it maybe needed to use the `forceBoot` option, but as far as I know that is also the case with the current version.

This is a copy #14529.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
