### PR TITLE
[stable/kibana] Fixed Kibana used as a subchart

### DIFF
--- a/stable/kibana/Chart.yaml
+++ b/stable/kibana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kibana
-version: 3.0.0
+version: 3.1.0
 appVersion: 6.7.0
 description: Kibana is an open source data visualization plugin for Elasticsearch
 icon: https://raw.githubusercontent.com/elastic/kibana/master/src/ui/public/icons/kibana-color.svg

--- a/stable/kibana/README.md
+++ b/stable/kibana/README.md
@@ -41,8 +41,8 @@ The following table lists the configurable parameters of the kibana chart and th
 | Parameter                                  | Description                                                            | Default                               |
 | ------------------------------------------ | ---------------------------------------------------------------------- | ------------------------------------- |
 | `affinity`                                 | node/pod affinities                                                    | None                                  |
-| `env`                                      | Environment variables to configure Kibana                              | `{}`                                  |
-| `files`                                    | Kibana configuration files                                             | None                                  |
+| `env`                                      | Environment variables to configure Kibana to be passed to the `tpl` function   | `{}`                                  |
+| `files`                                    | Kibana configuration files to be passed to the `tpl` function          | None                                  |
 | `livenessProbe.enabled`                    | livenessProbe to be enabled?                                           | `false`                               |
 | `livenessProbe.path`                       | path for livenessProbe                                                 | `/status`                             |
 | `livenessProbe.initialDelaySeconds`        | number of seconds                                                      | 30                                    |

--- a/stable/kibana/templates/configmap.yaml
+++ b/stable/kibana/templates/configmap.yaml
@@ -9,6 +9,8 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
 {{- range $key, $value := .Values.files }}
-  {{ $key }}: |
-{{ toYaml $value | default "{}" | indent 4 }}
+{{- if $value }}
+    {{ $key }}: |
+    {{ tpl (toYaml $value | default "{}" | indent 4) $ }}
+{{- end}}
 {{- end -}}

--- a/stable/kibana/templates/deployment.yaml
+++ b/stable/kibana/templates/deployment.yaml
@@ -53,8 +53,8 @@ spec:
 {{- end }}
         env:
         {{- range $key, $value := .Values.env }}
-        - name: "{{ $key }}"
-          value: "{{ $value }}"
+        - name: {{ $key | quote }}
+          value: {{ tpl $value $ | quote }}
         {{- end }}
         volumeMounts:
         - name: {{ template "kibana.fullname" . }}-dashboards
@@ -108,8 +108,8 @@ spec:
             done
         env:
         {{- range $key, $value := .Values.env }}
-        - name: "{{ $key }}"
-          value: "{{ $value }}"
+        - name: {{ $key | quote }}
+          value: {{ tpl $value $ | quote }}
         {{- end }}
         volumeMounts:
         - name: plugins
@@ -137,8 +137,8 @@ spec:
         {{- end }}
         env:
         {{- range $key, $value := .Values.env }}
-        - name: "{{ $key }}"
-          value: "{{ $value }}"
+        - name: {{ $key | quote }}
+          value: {{ tpl $value $ | quote }}
         {{- end }}
 {{- if (not .Values.authProxyEnabled) }}
         ports:

--- a/stable/kibana/values.yaml
+++ b/stable/kibana/values.yaml
@@ -15,6 +15,8 @@ env: {}
   ## To adjust a config option to an env var uppercase + replace `.` with `_`
   ## Ref: https://www.elastic.co/guide/en/kibana/current/settings.html
   ## For kibana < 6.6, use ELASTICSEARCH_URL instead
+  ## Environment variables values accept template variables
+  ## (e.g. ELASTICSEARCH_HOSTS: http://{{ .Release.Name }}-elasticsearch-client:9200)
   # ELASTICSEARCH_HOSTS: http://elasticsearch-client:9200
   # SERVER_PORT: 5601
   # LOGGING_VERBOSE: "true"


### PR DESCRIPTION
Support the use of templates for the env vars and file mapping so that charts using kibana as a subcharts can set the name of the elasticsearch instance via template
    
Signed-off-by: Laurent Goderre <laurent.goderre@gmail.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
