### PR TITLE
[stable/reloader] Bump Version to v0.0.29

### DIFF
--- a/stable/reloader/Chart.yaml
+++ b/stable/reloader/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: reloader
 description: Reloader chart that runs on kubernetes
-version: 1.0.3
+version: 1.1.0
 appVersion: "v0.0.29"
 keywords:
   - Reloader

--- a/stable/reloader/Chart.yaml
+++ b/stable/reloader/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: reloader
 description: Reloader chart that runs on kubernetes
-version: 1.0.2
-appVersion: "v0.0.25"
+version: 1.0.3
+appVersion: "v0.0.29"
 keywords:
   - Reloader
   - kubernetes

--- a/stable/reloader/README.md
+++ b/stable/reloader/README.md
@@ -88,7 +88,7 @@ Update the `values.yaml` and set the following properties
 | rbac.labels          | Additional labels for rbac                                               | `{}`                        | `{}`                        |
 | serviceAccount.create          | Option to create serviceAccount                                               | `true`                        | `true`                        |
 | serviceAccount.name          | Name of serviceAccount                                               | `reloader`                        | `reloader`                        |
-
+| custom_annotations          | Optional flags to pass to the Reloader entrypoint           | `{}`          | `{}`          |
 ## Deploying to Kubernetes
 
 You can deploy Reloader by following methods:

--- a/stable/reloader/README.md
+++ b/stable/reloader/README.md
@@ -79,7 +79,7 @@ Update the `values.yaml` and set the following properties
 | deployment.annotations          | Annotations for deployment                                                | `{}`                        | `{}`                        |
 | deployment.labels          | Labels for deployment                                                | `provider`                        | `provider`                        |
 | deployment.image.name          | Image name for reloader                                                | `stakater/reloader`                        | `stakater/reloader`                        |
-| deployment.image.tag          | Image tag for reloader                                                | `v0.0.25`                        | `v0.0.25`                        |
+| deployment.image.tag          | Image tag for reloader                                                | `v0.0.29`                        | `v0.0.29`                        |
 | deployment.image.pullPolicy          | Image pull policy for reloader                                                | `IfNotPresent`                        | `IfNotPresent`                        |
 | deployment.env.open          | Additional key value pair as environment variables                                                | `STORAGE: local`                        | ``                        |
 | deployment.env.secret          | Additional Key value pair as environment variables. It gets the values based on keys from default reloader secret if any                                               | `BASIC_AUTH_USER: test`                        | ``                        |

--- a/stable/reloader/templates/deployment.yaml
+++ b/stable/reloader/templates/deployment.yaml
@@ -72,4 +72,19 @@ spec:
         image: "{{ .Values.reloader.deployment.image.name }}:{{ .Values.reloader.deployment.image.tag }}"
         imagePullPolicy: {{ .Values.reloader.deployment.image.pullPolicy }}
         name: {{ template "reloader-name" . }}
+      {{- if .Values.reloader.custom_annotations }}
+        args:
+          {{- if .Values.reloader.custom_annotations.configmap }}
+          - "--configmap-annotation"
+          - "{{ .Values.reloader.custom_annotations.configmap }}"
+          {{- end }}
+          {{- if .Values.reloader.custom_annotations.secret }}
+          - "--secret-annotation"
+          - "{{ .Values.reloader.custom_annotations.secret }}"
+          {{- end }}
+          {{- if .Values.reloader.custom_annotations.auto }}
+          - "--auto-annotation"
+          - "{{ .Values.reloader.custom_annotations.auto }}"
+          {{- end }}
+        {{- end }}
       serviceAccountName: {{ template "serviceAccountName" . }}

--- a/stable/reloader/values.yaml
+++ b/stable/reloader/values.yaml
@@ -18,7 +18,6 @@ reloader:
       secret:
       # field supports Key value pair as environment variables. It gets the values from other fields of pod.
       field:
-
   rbac:
     enabled: true
     labels: {}
@@ -30,3 +29,9 @@ reloader:
     # The name of the ServiceAccount to use.
     # If not set and create is true, a name is generated using the fullname template
     name: reloader
+  # Optional flags to pass to the Reloader entrypoint
+  # Example:
+  #   custom_annotations:
+  #     configmap: "my.company.com/configmap"
+  #     secret: "my.company.com/secret"
+  custom_annotations: {}

--- a/stable/reloader/values.yaml
+++ b/stable/reloader/values.yaml
@@ -8,7 +8,7 @@ reloader:
       group: com.stakater.platform
     image:
       name: stakater/reloader
-      tag: "v0.0.25"
+      tag: "v0.0.29"
       pullPolicy: IfNotPresent
     # Support for extra environment variables.
     env:


### PR DESCRIPTION
Update app version in README.md, Chart.yaml and in the values.yaml

Signed-off-by: James Ritter <jamesritter15@gmail.com>

#### What this PR does / why we need it:
Update the default tag to use the latest Reloader image

#### Which issue this PR fixes
  - fixes #14573

#### Special notes for your reviewer:
Is support for the stable/reloader chart going to be dropped for the chart in https://github.com/stakater/Reloader?

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
