### PR TITLE
[stable/airflow] Add livenessPath config to airflow web deployment

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 2.8.7
+version: 2.8.8
 appVersion: 1.10.2
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -351,6 +351,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `ingress.web.host`                       | hostname for the webserver ui                           | ""                        |
 | `ingress.web.path`                       | path of the werbserver ui (read `values.yaml`)          | ``                        |
 | `ingress.web.annotations`                | annotations for the web ui ingress                      | `{}`                      |
+| `ingress.web.livenessPath`               | path to the web liveness probe                          | `{{ ingress.web.path }}/health` |
 | `ingress.web.tls.enabled`                | enables TLS termination at the ingress                  | `false`                   |
 | `ingress.web.tls.secretName`             | name of the secret containing the TLS certificate & key | ``                        |
 | `ingress.flower.host`                    | hostname for the flower ui                              | ""                        |

--- a/stable/airflow/templates/deployments-web.yaml
+++ b/stable/airflow/templates/deployments-web.yaml
@@ -141,7 +141,11 @@ spec:
           {{- end }}
           livenessProbe:
             httpGet:
+              {{- if .Values.ingress.web.livenessPath }}
+              path: "{{ .Values.ingress.web.livenessPath }}"
+              {{- else }}
               path: "{{ .Values.ingress.web.path }}/health"
+              {{- end }}
               port: web
             ## Keep 6 minutes the delay to allow clean wait of postgres and redis containers
             initialDelaySeconds: {{ .Values.web.initialDelaySeconds }}

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -286,6 +286,10 @@ ingress:
       ## Example for Traefik:
       # traefik.frontend.rule.type: PathPrefix
       # kubernetes.io/ingress.class: traefik
+    ##
+    ## Configure the web liveness path.
+    ## Defaults to the templated value `{{ ingress.web.path }}/health`
+    livenessPath:
     tls:
       ## Set to "true" to enable TLS termination at the ingress
       enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR allows for setting a custom `livenessPath` in the `airflow-web-deployment` template.

This is needed when the `ingress.web.path` path that contain metadata that should _not_ be included in the `livenessPath`, such as when using `rewrite-target` rules with the `nginx-ingress` controller.

Example config:

```
ingress:
  enabled: true
  web:
    path: /airflow(/|$)(.*)
    host: <HOST>
    annotations:
      kubernetes.io/ingress.class: nginx
      nginx.ingress.kubernetes.io/rewrite-target: /airflow/$2
    livenessPath: "/airflow/health"
```

Prior to this change the liveness path in the deployment appears as `path: /airflow(/|$)(.*)/health` and the liveness probe continuously fails with log messages like this:
`10.186.0.60 - - [06/Jun/2019:16:50:45 +0000] "GET /airflow%28/%7C$%29%28.%2A%29/health HTTP/1.1" 404 38 "-" "kube-probe/1.11"`

#### Special notes for your reviewer:

N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)

Signed-off-by: Kevin Pullin <kevin.pullin@gmail.com>