### PR TITLE
[incubator/cassandra] add matchLabels config value

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cassandra
-version: 0.13.0
+version: 0.14.0
 appVersion: 3.11.3
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/README.md
+++ b/incubator/cassandra/README.md
@@ -131,6 +131,8 @@ The following table lists the configurable parameters of the Cassandra chart and
 | `podManagementPolicy`                | podManagementPolicy of the StatefulSet          | `OrderedReady`                                             |
 | `podDisruptionBudget`                | Pod distruption budget                          | `{}`                                                       |
 | `podAnnotations`                     | pod annotations for the StatefulSet             | `{}`                                                       |
+| `podLabels`                       | pod labels for the StatefulSet                     | `{}`                                                       |
+| `matchLabels`                     | matchLabels for the StatefulSet                    | `{}`                                                       |
 | `updateStrategy.type`                | UpdateStrategy of the StatefulSet               | `OnDelete`                                                 |
 | `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated        | `90`                                                       |
 | `livenessProbe.periodSeconds`        | How often to perform the probe                  | `30`                                                       |

--- a/incubator/cassandra/templates/statefulset.yaml
+++ b/incubator/cassandra/templates/statefulset.yaml
@@ -12,6 +12,9 @@ spec:
     matchLabels:
       app: {{ template "cassandra.name" . }}
       release: {{ .Release.Name }}
+{{- if .Values.matchLabels }}
+{{ toYaml .Values.podLabels | indent 6 }}
+{{- end }}
   serviceName: {{ template "cassandra.fullname" . }}
   replicas: {{ .Values.config.cluster_size }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -114,6 +114,10 @@ podAnnotations: {}
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
+## Additional pod labels to match
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ku
+podLabels: {}
+
 ## Additional pod-level settings
 podSettings:
   # Change this to give pods more time to properly leave the cluster when not using persistent storage.


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows adding additional `matchLabels` to the cassandra chart. This is useful because of this bug in how k8s handles labels on `VolumeClaimTemplates` (which is now fixed): https://github.com/kubernetes/kubernetes/pull/74941

Kubernetes overwrites the supplied `metadata.labels` on the `VolumeClaimTemplate` with the `matchLabels` from the statefulset. This is useful for legacy k8s installations that need to pass label validation via an admission controller.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
