### PR TITLE
[stable/mysqldump]: add MYSQL_PORT to test script in configmap

### DIFF
--- a/stable/mysqldump/Chart.yaml
+++ b/stable/mysqldump/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.4.1
 description: A Helm chart to help backup MySQL databases using mysqldump
 name: mysqldump
-version: 2.4.1
+version: 2.4.2
 keywords:
 - mysql
 - mysqldump

--- a/stable/mysqldump/templates/configmap.yaml
+++ b/stable/mysqldump/templates/configmap.yaml
@@ -36,7 +36,7 @@ data:
     TIMESTAMP="$(date +%Y%m%d%H%M%S)"
 
     echo "test mysql connection"
-    if [ -z "$(mysql -h ${MYSQL_HOST} -u ${MYSQL_USERNAME}{{ if .Values.mysql.password }} -p${MYSQL_PASSWORD}{{ end }} -B -N -e 'SHOW DATABASES;')" ]; then
+    if [ -z "$(mysql -h ${MYSQL_HOST} -P ${MYSQL_PORT} -u ${MYSQL_USERNAME}{{ if .Values.mysql.password }} -p${MYSQL_PASSWORD}{{ end }} -B -N -e 'SHOW DATABASES;')" ]; then
       echo "mysql connection failed! exiting..."
       exit 1
     fi


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes an issue where the test script used to check if mysql is available can't connect because it doesn't specify the port in the connection

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
