### PR TITLE
[stable/mongodb] Expose metrics port on 'primary' svc

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 5.19.0
+version: 5.19.1
 appVersion: 4.0.10
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/templates/headless-svc-rs.yaml
+++ b/stable/mongodb/templates/headless-svc-rs.yaml
@@ -9,8 +9,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.service.annotations }}
-  annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
+  annotations: {{ toYaml .Values.service.annotations | nindent 4 }}
 {{- end }}
 spec:
   type: ClusterIP
@@ -18,11 +17,6 @@ spec:
   ports:
   - name: mongodb
     port: {{ .Values.service.port }}
-{{- if .Values.metrics.enabled }}
-  - name: metrics
-    port: 9216
-    targetPort: metrics
-{{- end }}
   selector:
     app: {{ template "mongodb.name" . }}
     release: {{ .Release.Name }}

--- a/stable/mongodb/templates/svc-primary-rs.yaml
+++ b/stable/mongodb/templates/svc-primary-rs.yaml
@@ -9,8 +9,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.service.annotations }}
-  annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
+  annotations: {{ toYaml .Values.service.annotations | nindent 4 }}
 {{- end }}
 spec:
   type: {{ .Values.service.type }}
@@ -21,16 +20,19 @@ spec:
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
   {{- if .Values.service.externalIPs }}
-  externalIPs:
-  {{ toYaml .Values.service.externalIPs | indent 4 }}
+  externalIPs: {{ toYaml .Values.service.externalIPs | nindent 4 }}
   {{- end }}
-
   ports:
   - name: mongodb
     port: 27017
     targetPort: mongodb
 {{- if .Values.service.nodePort }}
     nodePort: {{ .Values.service.nodePort }}
+{{- end }}
+{{- if .Values.metrics.enabled }}
+  - name: metrics
+    port: 9216
+    targetPort: metrics
 {{- end }}
   selector:
     app: {{ template "mongodb.name" . }}

--- a/stable/mongodb/templates/svc-standalone.yaml
+++ b/stable/mongodb/templates/svc-standalone.yaml
@@ -9,8 +9,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.service.annotations }}
-  annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
+  annotations: {{ toYaml .Values.service.annotations | nindent 4 }}
 {{- end }}
 spec:
   type: {{ .Values.service.type }}
@@ -21,10 +20,8 @@ spec:
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
   {{- if .Values.service.externalIPs }}
-  externalIPs:
-  {{ toYaml .Values.service.externalIPs | indent 4 }}
+  externalIPs: {{ toYaml .Values.service.externalIPs | nindent 4 }}
   {{- end }}
-
   ports:
   - name: mongodb
     port: 27017


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

We're exposing the 'metrics' port in the `headless-svc.yaml` where it's not necessary while we're not exposing it in the `primary-svc.yaml`. This PR addresses this issue.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
