### PR TITLE
[stable/datadog]Remove `logs_collect_all` condition for mounting containers log directories

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.30.8
+version: 1.30.9
 appVersion: 6.10.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -218,7 +218,7 @@ spec:
           - name: pointerdir
             mountPath: /opt/datadog-agent/run
           {{- end }}
-          {{- if (and (.Values.datadog.logsEnabled) (.Values.datadog.logsConfigContainerCollectAll)) }}
+          {{- if .Values.datadog.logsEnabled }}
           - name: logpodpath
             mountPath: /var/log/pods
             readOnly: true
@@ -284,7 +284,7 @@ spec:
             path: {{ default "/var/lib/datadog-agent/logs" .Values.datadog.logsPointerHostPath | quote }}
           name: pointerdir
         {{- end }}
-        {{- if (and (.Values.datadog.logsEnabled) (.Values.datadog.logsConfigContainerCollectAll)) }}
+        {{- if .Values.datadog.logsEnabled }}
         - hostPath:
             path: /var/log/pods
           name: logpodpath


### PR DESCRIPTION
#### What this PR does / why we need it:
Update condition for mounting containers logs directories in datadog daemonset.yaml file.
#### Which issue this PR fixes

#### Special notes for your reviewer:
When user set autodiscovery annotation, the condition `collect_all` is not required to be true to mount these directories.
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
