### PR TITLE
Prometheus operator enhancements

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -11,7 +11,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 5.12.5
+version: 5.13.0
 appVersion: 0.30.1
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -275,6 +275,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `alertmanager.service.loadBalancerIP` |  Alertmanager Loadbalancer IP | `""` |
 | `alertmanager.service.loadBalancerSourceRanges` | Alertmanager Load Balancer Source Ranges | `[]` |
 | `alertmanager.config` | Provide YAML to configure Alertmanager. See https://prometheus.io/docs/alerting/configuration/#configuration-file. The default provided works to suppress the Watchdog alert from `defaultRules.create` | `{"global":{"resolve_timeout":"5m"},"route":{"group_by":["job"],"group_wait":"30s","group_interval":"5m","repeat_interval":"12h","receiver":"null","routes":[{"match":{"alertname":"Watchdog"},"receiver":"null"}]},"receivers":[{"name":"null"}]}` |
+| `alertmanager.tplConfig` | Pass the Alertmanager configuration directives through Helm's templating engine. If the Alertmanager configuration contains Alertmanager templates, they'll need to be properly escaped so that they are not interpreted by Helm | `false` |
 | `alertmanager.alertmanagerSpec.podMetadata` | Standard object’s metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata Metadata Labels and Annotations gets propagated to the prometheus pods. | `{}` |
 | `alertmanager.alertmanagerSpec.image.tag` | Tag of Alertmanager container image to be deployed. | `v0.17.0` |
 | `alertmanager.alertmanagerSpec.image.repository` | Base image that is used to deploy pods, without tag. | `quay.io/prometheus/alertmanager` |

--- a/stable/prometheus-operator/templates/alertmanager/secret.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/secret.yaml
@@ -7,7 +7,11 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-alertmanager
 {{ include "prometheus-operator.labels" . | indent 4 }}
 data:
+{{- if .Values.alertmanager.tplConfig }}
+  alertmanager.yaml: {{ tpl (toYaml .Values.alertmanager.config) . | b64enc | quote }}
+{{- else }}
   alertmanager.yaml: {{ toYaml .Values.alertmanager.config | b64enc | quote }}
+{{- end}}
 {{- range $key, $val := .Values.alertmanager.templateFiles }}
   {{ $key }}: {{ $val | b64enc | quote }}
 {{- end }}

--- a/stable/prometheus-operator/templates/alertmanager/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/servicemonitor.yaml
@@ -22,7 +22,7 @@ spec:
     path: "{{ trimSuffix "/" .Values.alertmanager.alertmanagerSpec.routePrefix }}/metrics"
 {{- if .Values.alertmanager.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml .Values.alertmanager.serviceMonitor.metricRelabelings | indent 6 }}
+{{ tpl (toYaml .Values.alertmanager.serviceMonitor.metricRelabelings | indent 6) . }}
 {{- end }}
 {{- if .Values.alertmanager.serviceMonitor.relabelings }}
     relabelings:

--- a/stable/prometheus-operator/templates/exporters/core-dns/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/core-dns/servicemonitor.yaml
@@ -23,7 +23,7 @@ spec:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
 {{- if .Values.coreDns.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml .Values.coreDns.serviceMonitor.metricRelabelings | indent 4 }}
+{{ tpl (toYaml .Values.coreDns.serviceMonitor.metricRelabelings | indent 4) . }}
 {{- end }}
 {{- if .Values.coreDns.serviceMonitor.relabelings }}
     relabelings:

--- a/stable/prometheus-operator/templates/exporters/kube-api-server/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-api-server/servicemonitor.yaml
@@ -16,7 +16,7 @@ spec:
     scheme: https
 {{- if .Values.kubeApiServer.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml .Values.kubeApiServer.serviceMonitor.metricRelabelings | indent 6 }}
+{{ tpl (toYaml .Values.kubeApiServer.serviceMonitor.metricRelabelings | indent 6) . }}
 {{- end }}
 {{- if .Values.kubeApiServer.relabelings }}
     relabelings:

--- a/stable/prometheus-operator/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -28,7 +28,7 @@ spec:
     {{- end }}
 {{- if .Values.kubeControllerManager.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml .Values.kubeControllerManager.serviceMonitor.metricRelabelings | indent 4 }}
+{{ tpl (toYaml .Values.kubeControllerManager.serviceMonitor.metricRelabelings | indent 4) . }}
 {{- end }}
 {{- if .Values.kubeControllerManager.serviceMonitor.relabelings }}
     relabelings:

--- a/stable/prometheus-operator/templates/exporters/kube-dns/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-dns/servicemonitor.yaml
@@ -28,7 +28,7 @@ spec:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
 {{- if .Values.kubeDns.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml .Values.kubeDns.serviceMonitor.metricRelabelings | indent 4 }}
+{{ tpl (toYaml .Values.kubeDns.serviceMonitor.metricRelabelings | indent 4) . }}
 {{- end }}
 {{- if .Values.kubeDns.serviceMonitor.relabelings }}
     relabelings:

--- a/stable/prometheus-operator/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -40,7 +40,7 @@ spec:
     {{- end }}
 {{- if .Values.kubeEtcd.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml .Values.kubeEtcd.serviceMonitor.metricRelabelings | indent 4 }}
+{{ tpl (toYaml .Values.kubeEtcd.serviceMonitor.metricRelabelings | indent 4) . }}
 {{- end }}
 {{- if .Values.kubeEtcd.serviceMonitor.relabelings }}
     relabelings:

--- a/stable/prometheus-operator/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -28,7 +28,7 @@ spec:
     {{- end}}
 {{- if .Values.kubeScheduler.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml .Values.kubeScheduler.serviceMonitor.metricRelabelings | indent 4 }}
+{{ tpl (toYaml .Values.kubeScheduler.serviceMonitor.metricRelabelings | indent 4) . }}
 {{- end }}
 {{- if .Values.kubeScheduler.serviceMonitor.relabelings }}
     relabelings:

--- a/stable/prometheus-operator/templates/exporters/kube-state-metrics/serviceMonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-state-metrics/serviceMonitor.yaml
@@ -16,7 +16,7 @@ spec:
     honorLabels: true
 {{- if .Values.kubeStateMetrics.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml .Values.kubeStateMetrics.serviceMonitor.metricRelabelings | indent 4 }}
+{{ tpl (toYaml .Values.kubeStateMetrics.serviceMonitor.metricRelabelings | indent 4) . }}
 {{- end }}
 {{- if .Values.kubeStateMetrics.serviceMonitor.relabelings }}
     relabelings:

--- a/stable/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
@@ -21,7 +21,7 @@ spec:
     honorLabels: true
 {{- if .Values.kubelet.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml .Values.kubelet.serviceMonitor.metricRelabelings | indent 4 }}
+{{ tpl (toYaml .Values.kubelet.serviceMonitor.metricRelabelings | indent 4) . }}
 {{- end }}
 {{- if .Values.kubelet.serviceMonitor.relabelings }}
     relabelings:
@@ -40,7 +40,7 @@ spec:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
 {{- if .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings }}
     metricRelabelings:
-{{ toYaml .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings | indent 4 }}
+{{ tpl (toYaml .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings | indent 4) . }}
 {{- end }}
 {{- if .Values.kubelet.serviceMonitor.cAdvisorRelabelings }}
     relabelings:
@@ -54,7 +54,7 @@ spec:
     honorLabels: true
 {{- if .Values.kubelet.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml .Values.kubelet.serviceMonitor.metricRelabelings | indent 4 }}
+{{ tpl (toYaml .Values.kubelet.serviceMonitor.metricRelabelings | indent 4) . }}
 {{- end }}
 {{- if .Values.kubelet.serviceMonitor.relabelings }}
     relabelings:
@@ -68,7 +68,7 @@ spec:
     honorLabels: true
 {{- if .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings }}
     metricRelabelings:
-{{ toYaml .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings | indent 4 }}
+{{ tpl (toYaml .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings | indent 4) . }}
 {{- end }}
 {{- if .Values.kubelet.serviceMonitor.cAdvisorRelabelings }}
     relabelings:

--- a/stable/prometheus-operator/templates/exporters/node-exporter/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/node-exporter/servicemonitor.yaml
@@ -19,7 +19,7 @@ spec:
     {{- end }}
 {{- if .Values.nodeExporter.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml .Values.nodeExporter.serviceMonitor.metricRelabelings | indent 4 }}
+{{ tpl (toYaml .Values.nodeExporter.serviceMonitor.metricRelabelings | indent 4) . }}
 {{- end }}
 {{- if .Values.nodeExporter.serviceMonitor.relabelings }}
     relabelings:

--- a/stable/prometheus-operator/templates/grafana/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/grafana/servicemonitor.yaml
@@ -22,7 +22,7 @@ spec:
     path: "/metrics"
 {{- if .Values.grafana.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml .Values.grafana.serviceMonitor.metricRelabelings | indent 6 }}
+{{ tpl (toYaml .Values.grafana.serviceMonitor.metricRelabelings | indent 6) . }}
 {{- end }}
 {{- if .Values.grafana.serviceMonitor.relabelings }}
     relabelings:

--- a/stable/prometheus-operator/templates/prometheus-operator/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/servicemonitor.yaml
@@ -15,7 +15,7 @@ spec:
     {{- end }}
 {{- if .Values.prometheusOperator.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml .Values.prometheusOperator.serviceMonitor.metricRelabelings | indent 6 }}
+{{ tpl (toYaml .Values.prometheusOperator.serviceMonitor.metricRelabelings | indent 6) . }}
 {{- end }}
 {{- if .Values.prometheusOperator.serviceMonitor.relabelings }}
     relabelings:

--- a/stable/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/stable/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -11,13 +11,15 @@ spec:
     alertmanagers:
 {{- if .Values.prometheus.prometheusSpec.alertingEndpoints }}
 {{ toYaml .Values.prometheus.prometheusSpec.alertingEndpoints | indent 6 }}
-{{- else }}
+{{- else if .Values.alertmanager.enabled }}
       - namespace: {{ .Release.Namespace }}
         name: {{ template "prometheus-operator.fullname" . }}-alertmanager
         port: web
         {{- if .Values.alertmanager.alertmanagerSpec.routePrefix }}
         pathPrefix: "{{ .Values.alertmanager.alertmanagerSpec.routePrefix }}"
         {{- end }}
+{{- else }}
+      []
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.image }}
   baseImage: {{ .Values.prometheus.prometheusSpec.image.repository }}

--- a/stable/prometheus-operator/templates/prometheus/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/prometheus/servicemonitor.yaml
@@ -22,7 +22,7 @@ spec:
     path: "{{ trimSuffix "/" .Values.prometheus.prometheusSpec.routePrefix }}/metrics"
 {{- if .Values.prometheus.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml .Values.prometheus.serviceMonitor.metricRelabelings | indent 6 }}
+{{ tpl (toYaml .Values.prometheus.serviceMonitor.metricRelabelings | indent 6) . }}
 {{- end }}
 {{- if .Values.prometheus.serviceMonitor.relabelings }}
     relabelings:

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -110,6 +110,16 @@ alertmanager:
     receivers:
     - name: 'null'
 
+  ## Pass the Alertmanager configuration directives through Helm's templating
+  ## engine. If the Alertmanager configuration contains Alertmanager templates,
+  ## they'll need to be properly escaped so that they are not interpreted by
+  ## Helm
+  ## ref: https://helm.sh/docs/developing_charts/#using-the-tpl-function
+  ##      https://prometheus.io/docs/alerting/configuration/#%3Ctmpl_string%3E
+  ##      https://prometheus.io/docs/alerting/notifications/
+  ##      https://prometheus.io/docs/alerting/notification_examples/
+  tplConfig: false
+
   ## Alertmanager template files to format alerts
   ## ref: https://prometheus.io/docs/alerting/notifications/
   ##      https://prometheus.io/docs/alerting/notification_examples/


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

_This PR follows up on the discussion in https://github.com/helm/charts/pull/13064_

This PR does two things

1. Allow values used for metric relabeling configurations to support template strings. This is useful so that consumers of the chart can pass template strings as values to do things such as only keep metrics for the current namespace as follows:
```
    kubelet:
      serviceMonitor:
        metricRelabelings:
        - sourceLabels:
          - namespace
          regex: '{{ .Release.Namespace }}'
          action: keep
        cAdvisorMetricRelabelings:
        - sourceLabels:
          - namespace
          regex: '{{ .Release.Namespace }}'
          action: keep
```

2. It also makes a minor change that disables the default AlertManager connection when `.Values.alertmanager.enabled` has been set to `false`

#### Special notes for your reviewer:

Our organization has only used the template string functionality for metric relabeling configurations on the kube-state-metrics and kubelet exporters, but I've provided the functionality for all exporters here for consistency. If you think that's not a good idea, please let me know. Similarly, let me know if this behavior should be extended to relabeling configurations as well. I'm more than happy to make either change

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
