### PR TITLE
[incubator/schema-registry] Add support for prometheus jmx exporter &…

### DIFF
--- a/incubator/schema-registry/Chart.yaml
+++ b/incubator/schema-registry/Chart.yaml
@@ -1,6 +1,6 @@
 name: schema-registry
 home: https://docs.confluent.io/current/schema-registry/docs/index.html
-version: 1.1.4
+version: 1.1.5
 appVersion: 5.0.1
 keywords:
   - confluent

--- a/incubator/schema-registry/README.md
+++ b/incubator/schema-registry/README.md
@@ -101,7 +101,7 @@ The following table lists the configurable parameters of the SchemaRegistry char
 | `jmx.port` | set JMX port | `5555` |
 | `prometheus.jmx.enabled` | Enable Prometheus JMX Exporter | `false` |
 | `prometheus.jmx.image` | Set Prometheus JMX Exporter image | `solsson/kafka-prometheus-jmx-exporter@sha256` |
-| `prometheus.jmx.` | Set Prometheus JMX Exporter image tag | `6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143` |
-| `prometheus.jmx.` | Set Prometheus JMX Exporter port | `5556` |
-| `prometheus.jmx.` | Set Prometheus JMX Exporter resource requests & limits | `{}` |
+| `prometheus.jmx.imageTag` | Set Prometheus JMX Exporter image tag | `6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143` |
+| `prometheus.jmx.port` | Set Prometheus JMX Exporter port | `5556` |
+| `prometheus.jmx.resources` | Set Prometheus JMX Exporter resource requests & limits | `{}` |
 | `secrets` | Pass any secrets to the pods.The secret will be mounted to a specific path if required | `[]` |

--- a/incubator/schema-registry/README.md
+++ b/incubator/schema-registry/README.md
@@ -66,6 +66,7 @@ The following table lists the configurable parameters of the SchemaRegistry char
 | `imagePullPolicy` | Image Pull Policy | `IfNotPresent` |
 | `replicaCount` | The number of `SchemaRegistry` Pods in the Deployment | `1` |
 | `configurationOverrides` | `SchemaRegistry` [configuration setting](https://github.com/confluentinc/schema-registry/blob/master/docs/config.rst#configuration-options) overrides in the dictionary format `setting.name: value` | `{}` |
+| `podAnnotations` | Pod annotations. | ` ` |
 | `kafkaOpts` | Additional Java arguments to pass to Kafka. | ` ` |
 | `sasl.configPath` | where to store config for sasl configurations | `/etc/kafka-config` |
 | `sasl.scram.enabled` | whether sasl-scam is enabled | `false` |
@@ -98,4 +99,9 @@ The following table lists the configurable parameters of the SchemaRegistry char
 | `external.nodePort` | set Nodeport (valid range depends on CLoud Provider) | `""` |
 | `jmx.enabled` | Enable JMX? | `true` |
 | `jmx.port` | set JMX port | `5555` |
+| `prometheus.jmx.enabled` | Enable Prometheus JMX Exporter | `false` |
+| `prometheus.jmx.image` | Set Prometheus JMX Exporter image | `solsson/kafka-prometheus-jmx-exporter@sha256` |
+| `prometheus.jmx.` | Set Prometheus JMX Exporter image tag | `6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143` |
+| `prometheus.jmx.` | Set Prometheus JMX Exporter port | `5556` |
+| `prometheus.jmx.` | Set Prometheus JMX Exporter resource requests & limits | `{}` |
 | `secrets` | Pass any secrets to the pods.The secret will be mounted to a specific path if required | `[]` |

--- a/incubator/schema-registry/templates/deployment.yaml
+++ b/incubator/schema-registry/templates/deployment.yaml
@@ -14,6 +14,16 @@ spec:
       labels:
         app: {{ template "schema-registry.name" . }}
         release: {{ .Release.Name }}
+      {{- if or .Values.podAnnotations .Values.prometheus.jmx.enabled }}
+      annotations:
+      {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- if .Values.prometheus.jmx.enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .Values.prometheus.jmx.port | quote }}
+      {{- end }}
+      {{- end }}
     spec:
     {{- if .Values.sasl.scram.enabled }}
       initContainers:
@@ -58,6 +68,27 @@ spec:
           mountPath: {{ .Values.sasl.configPath | quote }}
     {{- end }}
       containers:
+        {{- if .Values.prometheus.jmx.enabled }}
+        - name: prometheus-jmx-exporter
+          image: "{{ .Values.prometheus.jmx.image }}:{{ .Values.prometheus.jmx.imageTag }}"
+          command:
+          - java
+          - -XX:+UnlockExperimentalVMOptions
+          - -XX:+UseCGroupMemoryLimitForHeap
+          - -XX:MaxRAMFraction=1
+          - -XshowSettings:vm
+          - -jar
+          - jmx_prometheus_httpserver.jar
+          - {{ .Values.prometheus.jmx.port | quote }}
+          - /etc/jmx-schema-registry/jmx-schema-registry-prometheus.yml
+          ports:
+          - containerPort: {{ .Values.prometheus.jmx.port }}
+          resources:
+{{ toYaml .Values.prometheus.jmx.resources | indent 12 }}
+          volumeMounts:
+          - name: jmx-config
+            mountPath: /etc/jmx-schema-registry
+        {{- end }}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -158,6 +189,11 @@ spec:
       - name: jaastemplate
         configMap:
           name: {{ template "schema-registry.fullname" . }}
+      {{- end }}
+      {{- if .Values.prometheus.jmx.enabled }}
+      - name: jmx-config
+        configMap:
+          name: {{ template "schema-registry.fullname" . }}-jmx-configmap
       {{- end }}
       {{- range .Values.secrets }}
       - name: {{ include "schema-registry.fullname" $ }}-{{ .name }}

--- a/incubator/schema-registry/templates/jmx-configmap.yaml
+++ b/incubator/schema-registry/templates/jmx-configmap.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.prometheus.jmx.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "schema-registry.fullname" . }}-jmx-configmap
+  labels:
+    app: {{ template "schema-registry.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  jmx-schema-registry-prometheus.yml: |+
+    jmxUrl: service:jmx:rmi:///jndi/rmi://localhost:{{ .Values.jmx.port }}/jmxrmi
+    lowercaseOutputName: true
+    lowercaseOutputLabelNames: true
+    ssl: false
+    rules:
+    - pattern : 'kafka.schema.registry<type=jetty-metrics>([^:]+):'
+      name: "kafka_schema_registry_jetty_metrics_$1"
+    - pattern : 'kafka.schema.registry<type=master-slave-role>([^:]+):'
+      name: "kafka_schema_registry_master_slave_role"
+    - pattern : 'kafka.schema.registry<type=jersey-metrics>([^:]+):'
+      name: "kafka_schema_registry_jersey_metrics_$1"
+{{- end }}

--- a/incubator/schema-registry/values.yaml
+++ b/incubator/schema-registry/values.yaml
@@ -21,6 +21,9 @@ configurationOverrides: {}
   ## The default master.eligiblity is true
   # master.eligibility: false
 
+## Custom pod annotations
+podAnnotations: {}
+
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ## Confluent has production deployment guidelines here:
@@ -134,6 +137,24 @@ external:
 jmx:
   enabled: true
   port: 5555
+
+## Prometheus Exporter Configuration
+## ref: https://prometheus.io/docs/instrumenting/exporters/
+prometheus:
+  ## JMX Exporter Configuration
+  ## ref: https://github.com/prometheus/jmx_exporter
+  jmx:
+    enabled: false
+    image: solsson/kafka-prometheus-jmx-exporter@sha256
+    imageTag: 6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
+    port: 5556
+    resources: {}
+      # limits:
+      #  cpu: 100m
+      #  memory: 128Mi
+      # requests:
+      #  cpu: 100m
+      #  memory: 128Mi
 
 ## Pass any secrets to the pods. The secrets will be mounted to a specfic path
 ## OR presented as Environment Variables. Environment variable names are


### PR DESCRIPTION
… pod annotations

Signed-off-by: chris-vest <hotdogsandfrenchfries@gmail.com>

#### What this PR does / why we need it:

Support for:
1. Pod annotations
2. Prometheus JMX exporter
3. Configuration of JMX exporter via configMap

#### Which issue this PR fixes

None, but will be useful for anyone using Prometheus & Schema Registry in the same cluster.

#### Special notes for your reviewer:

Hope this is useful to the community. Apologies if it's poor form to submit this unsolicited!

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
