### PR TITLE
[stable/spring-cloud-data-flow] Add field to specify db scheme

### DIFF
--- a/stable/spring-cloud-data-flow/Chart.yaml
+++ b/stable/spring-cloud-data-flow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Toolkit for building data processing pipelines.
 name: spring-cloud-data-flow
-version: 2.2.0
+version: 2.2.1
 appVersion: 2.0.2.RELEASE
 home: http://cloud.spring.io/spring-cloud-dataflow/
 sources:

--- a/stable/spring-cloud-data-flow/README.md
+++ b/stable/spring-cloud-data-flow/README.md
@@ -137,6 +137,7 @@ The following tables list the configurable parameters and their default values.
 | Parameter           | Description                    | Default                   |
 | ------------------- | ------------------------------ | ------------------------- |
 | database.driver     | Database driver                | nil
+| database.scheme     | Database scheme                | nil
 | database.host       | Database host                  | nil
 | database.port       | Database port                  | nil
 | database.user       | Database user                  | scdf

--- a/stable/spring-cloud-data-flow/templates/_helpers.tpl
+++ b/stable/spring-cloud-data-flow/templates/_helpers.tpl
@@ -49,6 +49,14 @@ Create the name of the service account to use
   {{- end -}}
 {{- end -}}
 
+{{- define "scdf.database.scheme" -}}
+  {{- if .Values.mysql.enabled -}}
+    {{- printf "mysql" -}}
+  {{- else -}}
+    {{- .Values.database.scheme -}}
+  {{- end -}}
+{{- end -}}
+
 {{- define "scdf.database.host" -}}
   {{- if .Values.mysql.enabled -}}
     {{- printf "${%s_MYSQL_SERVICE_HOST}" (include "scdf.envrelease" . ) -}}

--- a/stable/spring-cloud-data-flow/templates/server-config.yaml
+++ b/stable/spring-cloud-data-flow/templates/server-config.yaml
@@ -22,7 +22,7 @@ data:
                       memory: {{ .Values.deployer.resourceLimits.memory }}
                       cpu: {{ .Values.deployer.resourceLimits.cpu }}
       datasource:
-        url: 'jdbc:mysql://{{ template "scdf.database.host" . }}:{{ template "scdf.database.port" . }}/{{ template "scdf.database.dataflow" . }}'
+        url: 'jdbc:{{ template "scdf.database.scheme" . }}://{{ template "scdf.database.host" . }}:{{ template "scdf.database.port" . }}/{{ template "scdf.database.dataflow" . }}'
         driverClassName: {{ template "scdf.database.driver" . }}
         username: {{ template "scdf.database.user" . }}
         password: {{ template "scdf.database.password" . }}

--- a/stable/spring-cloud-data-flow/templates/skipper-config.yaml
+++ b/stable/spring-cloud-data-flow/templates/skipper-config.yaml
@@ -29,7 +29,7 @@ data:
                     readinessProbeDelay: {{ .Values.deployer.readinessProbe.initialDelaySeconds }}
                     livenessProbeDelay: {{ .Values.deployer.livenessProbe.initialDelaySeconds }}
       datasource:
-        url: 'jdbc:mysql://{{ template "scdf.database.host" . }}:{{ template "scdf.database.port" . }}/{{ template "scdf.database.skipper" . }}'
+        url: 'jdbc:{{ template "scdf.database.scheme" . }}://{{ template "scdf.database.host" . }}:{{ template "scdf.database.port" . }}/{{ template "scdf.database.skipper" . }}'
         driverClassName: {{ template "scdf.database.driver" . }}
         username: {{ template "scdf.database.user" . }}
         password: {{ template "scdf.database.password" . }}

--- a/stable/spring-cloud-data-flow/values.yaml
+++ b/stable/spring-cloud-data-flow/values.yaml
@@ -81,6 +81,7 @@ mysql:
 ## you must specify the following database details
 database:
   driver:
+  scheme:
   host:
   port:
   user: scdf


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Database scheme is hardcoded in config map, preventing usage of other db types unless changes are made in config map after deployment. This is a bug.

Thus, this fix allows this to be specified in during deployment in values.yaml.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
