### PR TITLE
[incubator/solr] run solr container with uid 8983

### DIFF
--- a/incubator/solr/Chart.yaml
+++ b/incubator/solr/Chart.yaml
@@ -2,7 +2,7 @@
 
 apiVersion: "v1"
 name: "solr"
-version: "1.0.1"
+version: "1.0.2"
 appVersion: "7.6.0"
 description: "A helm chart to install Apache Solr: http://lucene.apache.org/solr/"
 keywords:

--- a/incubator/solr/templates/statefulset.yaml
+++ b/incubator/solr/templates/statefulset.yaml
@@ -28,6 +28,7 @@ spec:
     spec:
       securityContext:
         fsGroup: 8983
+        runAsUser: 8983
       affinity:
 {{ tpl (toYaml .Values.affinity) .  | indent 8 }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}


### PR DESCRIPTION
Signed-off-by: Joe Cai <joey.cai@gmail.com>

#### What this PR does / why we need it:
This fixes the following error while running solr pods from minikube 
```
$ kubectl -n backend logs solr-0
Starting Solr 7.6.0
WARNING: Starting Solr as the root user is a security risk and not considered best practice. Exiting.
         Please consult the Reference Guide. To override this check, start with argument '-force'
```
Note that 8983 is the hard-coded uid for the user `solr` for the solr image.

#### Special notes for your reviewer:
@ian-thebridge-lucidworks review please. thanks!

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
