### PR TITLE
[stable/nextcloud] Bump mariadb dep, add probes config to README

### DIFF
--- a/stable/nextcloud/Chart.yaml
+++ b/stable/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nextcloud
-version: 1.1.1
+version: 1.2.0
 appVersion: 16.0.1
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/nextcloud/README.md
+++ b/stable/nextcloud/README.md
@@ -45,50 +45,62 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the nextcloud chart and their default values.
 
-|              Parameter              |                Description                |                   Default                               |
-|-------------------------------------|-------------------------------------------|-------------------------------------------------------- |
-| `image.repository`                  | nextcloud Image name                       | `nextcloud`                                      |
-| `image.tag`                         | nextcloud Image tag                        | `{VERSION}`                                             |
-| `image.pullPolicy`                  | Image pull policy                         | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
-| `image.pullSecrets`                 | Specify image pull secrets                | `nil`                                                   |
-| `ingress.enabled`                   | Enable use of ingress controllers         | `false`                                                 |
-| `ingress.servicePort`               | Ingress' backend servicePort              | `http`                                                  |
-| `ingress.annotations`               | An array of service annotations           | `nil`                                                   |
-| `ingress.tls`                       | Ingress TLS configuration                 | `[]`                                                    |
-| `nextcloud.host`                     | nextcloud host to create application URLs  | `nextcloud.kube.home`                                                   |
-| `nextcloud.username`                 | User of the application                   | `admin`                                                  |
-| `nextcloud.password`                 | Application password                      | `changeme`                                    |
-| `nextcloud.update`                  | trigger nextcloud update if custom command is used         | `0`                                    |
-| `nextcloud.datadir`                 | nextcloud data dir location               | `/var/www/html/data`                                    |
-| `nextcloud.tableprefix`             | nextcloud db table prefix                 | `''`                                                    |
-| `nextcloud.smtp.host`               | SMTP hostname                             | `nil`                                                   |
-| `nextcloud.smtp.secure`             | SMTP connection `ssl` or empty            | `''`                                                    |
-| `nextcloud.smtp.port`               | Optional SMTP port                        | `nil`                                                   |
-| `nextcloud.smtp.authtype`           | SMTP authentication method                | `LOGIN`                                                 |
-| `nextcloud.smtp.name`               | SMTP username                             | `''`                                                    |
-| `nextcloud.smtp.password`           | SMTP password                             | `''`                                                    |
-| `nextcloud.mail.fromaddress`        | nextcloud mail send from field            | `nil`                                                   |
-| `nextcloud.mail.domain`             | nextcloud mail domain                     | `nil`                                                   |
-| `internalDatabase.enabled`         | Whether to use internal sqlite database    | `true`                                      |
-| `internalDatabase.database`         | Name of the existing database             | `nextcloud`                                      |
-| `externalDatabase.enabled`          | Whether to use external database          | `false`                                                   |
-| `externalDatabase.host`             | Host of the external database             | `nil`                                                   |
-| `externalDatabase.database`         | Name of the existing database             | `nextcloud`                                      |
-| `externalDatabase.user`             | Existing username in the external db      | `nextcloud`                                           |
-| `externalDatabase.password`         | Password for the above username           | `nil`                                                   |
-| `mariadb.enabled`                   | Whether to use the MariaDB chart          | `false`                                                  |
-| `mariadb.db.name`           | Database name to create                   | `nextcloud`                                      |
-| `mariadb.db.password`           | Password for the database                 | `changeme`                                                   |
-| `mariadb.db.user`               | Database user to create                   | `nextcloud`                                           |
-| `mariadb.rootUser.password`       | MariaDB admin password                    | `nil`                                                   |
-| `service.type`                      | Kubernetes Service type                   | `ClusterIp`                                          |
-| `service.loadBalancerIP`            | LoadBalancerIp for service type LoadBalancer                   | `nil`                                          |
-| `persistence.enabled`     | Enable persistence using PVC              | `false`                                                  |
-| `persistence.storageClass` | PVC Storage Class for nextcloud volume     | `nil` (uses alpha storage class annotation)             |
-| `persistence.existingClaim`| An Existing PVC name for nextcloud volume  | `nil` (uses alpha storage class annotation)             |
-| `persistence.accessMode`   | PVC Access Mode for nextcloud volume       | `ReadWriteOnce`                                         |
-| `persistence.size`         | PVC Storage Request for nextcloud volume   | `8Gi`                                                   |
-| `resources`                         | CPU/Memory resource requests/limits       | `{}`                 |
+|              Parameter              |                   Description                 |                         Default                         |
+|-------------------------------------|-----------------------------------------------|-------------------------------------------------------- |
+| `image.repository`                  | nextcloud Image name                          | `nextcloud`                                             |
+| `image.tag`                         | nextcloud Image tag                           | `{VERSION}`                                             |
+| `image.pullPolicy`                  | Image pull policy                             | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
+| `image.pullSecrets`                 | Specify image pull secrets                    | `nil`                                                   |
+| `ingress.enabled`                   | Enable use of ingress controllers             | `false`                                                 |
+| `ingress.servicePort`               | Ingress' backend servicePort                  | `http`                                                  |
+| `ingress.annotations`               | An array of service annotations               | `nil`                                                   |
+| `ingress.tls`                       | Ingress TLS configuration                     | `[]`                                                    |
+| `nextcloud.host`                    | nextcloud host to create application URLs     | `nextcloud.kube.home`                                   |
+| `nextcloud.username`                | User of the application                       | `admin`                                                 |
+| `nextcloud.password`                | Application password                          | `changeme`                                              |
+| `nextcloud.update`                  | Trigger update if custom command is used      | `0`                                                     |
+| `nextcloud.datadir`                 | nextcloud data dir location                   | `/var/www/html/data`                                    |
+| `nextcloud.tableprefix`             | nextcloud db table prefix                     | `''`                                                    |
+| `nextcloud.smtp.host`               | SMTP hostname                                 | `nil`                                                   |
+| `nextcloud.smtp.secure`             | SMTP connection `ssl` or empty                | `''`                                                    |
+| `nextcloud.smtp.port`               | Optional SMTP port                            | `nil`                                                   |
+| `nextcloud.smtp.authtype`           | SMTP authentication method                    | `LOGIN`                                                 |
+| `nextcloud.smtp.name`               | SMTP username                                 | `''`                                                    |
+| `nextcloud.smtp.password`           | SMTP password                                 | `''`                                                    |
+| `nextcloud.mail.fromaddress`        | nextcloud mail send from field                | `nil`                                                   |
+| `nextcloud.mail.domain`             | nextcloud mail domain                         | `nil`                                                   |
+| `internalDatabase.enabled`          | Whether to use internal sqlite database       | `true`                                                  |
+| `internalDatabase.database`         | Name of the existing database                 | `nextcloud`                                             |
+| `externalDatabase.enabled`          | Whether to use external database              | `false`                                                 |
+| `externalDatabase.host`             | Host of the external database                 | `nil`                                                   |
+| `externalDatabase.database`         | Name of the existing database                 | `nextcloud`                                             |
+| `externalDatabase.user`             | Existing username in the external db          | `nextcloud`                                             |
+| `externalDatabase.password`         | Password for the above username               | `nil`                                                   |
+| `mariadb.enabled`                   | Whether to use the MariaDB chart              | `false`                                                 |
+| `mariadb.db.name`                   | Database name to create                       | `nextcloud`                                             |
+| `mariadb.db.password`               | Password for the database                     | `changeme`                                              |
+| `mariadb.db.user`                   | Database user to create                       | `nextcloud`                                             |
+| `mariadb.rootUser.password`         | MariaDB admin password                        | `nil`                                                   |
+| `service.type`                      | Kubernetes Service type                       | `ClusterIp`                                             |
+| `service.loadBalancerIP`            | LoadBalancerIp for service type LoadBalancer  | `nil`                                                   |
+| `persistence.enabled`               | Enable persistence using PVC                  | `false`                                                 |
+| `persistence.storageClass`          | PVC Storage Class for nextcloud volume        | `nil` (uses alpha storage class annotation)             |
+| `persistence.existingClaim`         | An Existing PVC name for nextcloud volume     | `nil` (uses alpha storage class annotation)             |
+| `persistence.accessMode`            | PVC Access Mode for nextcloud volume          | `ReadWriteOnce`                                         |
+| `persistence.size`                  | PVC Storage Request for nextcloud volume      | `8Gi`                                                   |
+| `resources`                         | CPU/Memory resource requests/limits           | `{}`                                                    |
+| `livenessProbe.enabled`             | Turn on and off liveness probe                | `true`                                                  |
+| `livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated      | `30`                                                    |
+| `livenessProbe.periodSeconds`       | How often to perform the probe                | `15`                                                    |
+| `livenessProbe.timeoutSeconds`      | When the probe times out                      | `5`                                                     |
+| `livenessProbe.failureThreshold`    | Minimum consecutive failures for the probe    | `3`                                                     |
+| `livenessProbe.successThreshold`    | Minimum consecutive successes for the probe   | `1`                                                     |
+| `readinessProbe.enabled`            | Turn on and off readiness probe               | `true`                                                  |
+| `readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated     | `30`                                                    |
+| `readinessProbe.periodSeconds`      | How often to perform the probe                | `15`                                                    |
+| `readinessProbe.timeoutSeconds`     | When the probe times out                      | `5`                                                     |
+| `readinessProbe.failureThreshold`   | Minimum consecutive failures for the probe    | `3`                                                     |
+| `readinessProbe.successThreshold`   | Minimum consecutive successes for the probe   | `1`                                                     |
 
 > **Note**:
 >

--- a/stable/nextcloud/requirements.lock
+++ b/stable/nextcloud/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.5.0
-digest: sha256:66e8bec50806f6576f4954c145d45b44a55975cad4f10b3bdd6cc4e208055bca
-generated: 2019-01-26T18:57:18.847326+01:00
+  version: 6.4.1
+digest: sha256:699d8d25a15a33030a5df3f516affefc45c79c7a59f4adc1057b854826fa2b51
+generated: "2019-06-09T02:08:45.597815913+02:00"

--- a/stable/nextcloud/requirements.yaml
+++ b/stable/nextcloud/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
-  version: ~5.5.0
+  version: ~6.4.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: mariadb.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:
Upgrading to the latest version of `stable/mariadb` dependency chart and keeping README in sync with recently added probes conf. Further, aligned values in README for easier readability (hence why `size/L` but recommend you to review in rich diff mode).

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
