### PR TITLE
[stable/openvpn] allow setting up ta.key and overriding cipher.

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 3.12.6
+version: 3.13.0
 appVersion: 1.1.0
 maintainers:
 - name: jfelten

--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 3.12.5
+version: 3.12.6
 appVersion: 1.1.0
 maintainers:
 - name: jfelten

--- a/stable/openvpn/README.md
+++ b/stable/openvpn/README.md
@@ -101,6 +101,8 @@ Parameter | Description | Default
 `openvpn.dhcpOptionDomain`     | Push a `dhcp-option DOMAIN` config                                   | `true`
 `openvpn.conf`                 | Arbitrary lines appended to the end of the server configuration file | `nil`
 `openvpn.redirectGateway`      | Redirect all client traffic through VPN                              | `true`
+`openvpn.taKey`                | Use/generate a ta.key file for hardening security                    | `false`
+`openvpn.cipher`               | Override the default cipher                                          | `nil` (OpenVPN default)
 `nodeSelector`                 | Node labels for pod assignment                                       | `{}`
 
 This chart has been engineered to use kube-dns and route all network traffic to kubernetes pods and services,
@@ -120,7 +122,7 @@ Certificates can be passed in secret, which name is specified in *openvpn.keysto
 Create secret as follows:
 
 ```bash
-kubectl create secret generic openvpn-keystore-secret --from-file=./server.key --from-file=./ca.crt --from-file=./server.crt --from-file=./dh.pem
+kubectl create secret generic openvpn-keystore-secret --from-file=./server.key --from-file=./ca.crt --from-file=./server.crt --from-file=./dh.pem [--from-file=./ta.key]
 ```
 
 You can deploy temporary openvpn chart, create secret from generated certificates, and then re-deploy openvpn, providing the secret.
@@ -130,3 +132,7 @@ Certificates can be found in openvpn pod in the following files:
  `/etc/openvpn/certs/pki/ca.crt`
  `/etc/openvpn/certs/pki/issued/server.crt`
  `/etc/openvpn/certs/pki/dh.pem`
+
+And optionally (see openvpn.taKey setting):
+
+ `/etc/openvpn/certs/pki/ta.key`

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -25,6 +25,9 @@ data:
       ./easyrsa gen-crl
       cp ${EASY_RSA_LOC}/pki/crl.pem ${EASY_RSA_LOC}/crl.pem # Note: the pki/ directory is inaccessible after openvpn drops privileges, so we cp crl.pem to ${EASY_RSA_LOC} to allow CRL updates without a restart
       chmod 644 ${EASY_RSA_LOC}/crl.pem
+      {{- if .Values.openvpn.taKey }}
+      openvpn --genkey --secret ${EASY_RSA_LOC}/pki/ta.key
+      {{- end }}
     fi
 
 
@@ -39,6 +42,9 @@ data:
       nobind
       dev tun
       remote ${MY_IP_ADDR} {{ .Values.service.externalPort }} {{ .Values.openvpn.OVPN_PROTO }}
+      {{- if .Values.openvpn.cipher }}
+      cipher {{ .Values.openvpn.cipher }}
+      {{- end }}
       {{- if .Values.openvpn.redirectGateway }}
       redirect-gateway def1
       {{- end }}
@@ -51,6 +57,12 @@ data:
       <ca>
       `cat ${EASY_RSA_LOC}/pki/ca.crt`
       </ca>
+      {{- if .Values.openvpn.taKey }}
+      <tls-auth>
+      `cat ${EASY_RSA_LOC}/pki/ta.key`
+      </tls-auth>
+      key-direction 1
+      {{- end }}
       EOF
       cat pki/$1.ovpn
 
@@ -134,7 +146,13 @@ data:
       ca /etc/openvpn/certs/pki/ca.crt
       cert /etc/openvpn/certs/pki/issued/server.crt
       dh /etc/openvpn/certs/pki/dh.pem
+{{ if .Values.openvpn.taKey }}
+      tls-auth /etc/openvpn/certs/pki/ta.key 0
+{{ end }}
 
+{{ if .Values.openvpn.cipher }}
+      cipher {{ .Values.openvpn.cipher }}
+{{ end }}
       key-direction 0
       keepalive 10 60
       persist-key

--- a/stable/openvpn/templates/openvpn-deployment.yaml
+++ b/stable/openvpn/templates/openvpn-deployment.yaml
@@ -79,6 +79,10 @@ spec:
             path: "pki/issued/server.crt"
           - key: "dh.pem"
             path: "pki/dh.pem"
+          {{- if .Values.openvpn.taKey }}
+          - key: "ta.key"
+            path: "pki/ta.key"
+          {{- end }}
         {{- else }}
         emptyDir: {}
         {{- end -}}

--- a/stable/openvpn/values.yaml
+++ b/stable/openvpn/values.yaml
@@ -81,6 +81,10 @@ openvpn:
   dhcpOptionDomain: true
   # Redirect all client traffic through VPN
   redirectGateway: true
+  # Use/generate a ta.key (https://openvpn.net/community-resources/hardening-openvpn-security/)
+  taKey: false
+  # Override default cipher
+  # cipher: AES-256-CBC
   # Arbitrary lines appended to the end of the server configuration file
   # conf: |
   #  max-clients 100


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR allows you to override the default OpenVPN cipher and generate client certificates using the same cipher.
It also allows you to set up / use an optional ta.key, generate client certificates with that and take it from the secret if available.

Both these changes have to do with hardening OpenVPN security (https://openvpn.net/community-resources/hardening-openvpn-security/).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
