### PR TITLE
[stable/jaeger-operator] Change operator role to a cluster role

### DIFF
--- a/stable/jaeger-operator/Chart.yaml
+++ b/stable/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.8.0
+version: 2.9.0
 appVersion: 1.13.1
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/stable/jaeger-operator/README.md
+++ b/stable/jaeger-operator/README.md
@@ -49,6 +49,7 @@ The following table lists the configurable parameters of the jaeger-operator cha
 | `rbac.create`           | All required roles and rolebindings will be created                                                         | `true`                          |
 | `serviceAccount.create` | Service account to use                                                                                      | `true`                          |
 | `rbac.pspEnabled`       | Pod security policy for pod will be created and included in rbac role                                       | `false`                         |
+| `rbac.clusterRole`      | ClusterRole will be used by operator ServiceAccount                                                         | `false`                         |
 | `serviceAccount.name`   | Service account name to use. If not set and create is true, a name is generated using the fullname template | ``                              |
 | `resources`             | K8s pod resorces                                                                                            | `None`                          |
 | `nodeSelector`          | Node labels for pod assignment                                                                              | `{}`                            |

--- a/stable/jaeger-operator/templates/deployment.yaml
+++ b/stable/jaeger-operator/templates/deployment.yaml
@@ -33,9 +33,13 @@ spec:
           args: ["start"]
           env:
             - name: WATCH_NAMESPACE
+              {{- if .Values.rbac.clusterRole }}
+              value: ""
+              {{- else }}
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+              {{- end }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/stable/jaeger-operator/templates/role-binding.yaml
+++ b/stable/jaeger-operator/templates/role-binding.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create }}
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: {{ if .Values.rbac.clusterRole }}Cluster{{ end }}RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "jaeger-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
@@ -11,7 +11,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
   name: {{ include "jaeger-operator.serviceAccountName" . }}
 roleRef:
-  kind: Role
+  kind: {{ if .Values.rbac.clusterRole }}Cluster{{ end }}Role
   name: {{ include "jaeger-operator.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/stable/jaeger-operator/templates/role.yaml
+++ b/stable/jaeger-operator/templates/role.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create }}
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: {{ if .Values.rbac.clusterRole }}Cluster{{ end }}Role
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "jaeger-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}

--- a/stable/jaeger-operator/values.yaml
+++ b/stable/jaeger-operator/values.yaml
@@ -10,6 +10,7 @@ rbac:
   # Specifies whether RBAC resources should be created
   create: true
   pspEnabled: false
+  clusterRole: false
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows jaeger operator to act on jaeger crds defined in any namespace.

#### Special notes for your reviewer:
- ClusterRole was taken from https://github.com/jaegertracing/jaeger-operator/blob/master/deploy/role.yaml
- ClusterRoleBinding was taken from https://github.com/jaegertracing/jaeger-operator/blob/master/deploy/role_binding.yaml

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
