### PR TITLE
[stable/sematext-agent] Updates to auto discovery configuration file in sematext agent

### DIFF
--- a/stable/sematext-agent/Chart.yaml
+++ b/stable/sematext-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.0"
-version: 1.0.8
+version: 1.0.9
 description: Helm chart for deploying Sematext Agent to Kubernetes
 keywords:
   - sematext

--- a/stable/sematext-agent/files/autodisco.yml
+++ b/stable/sematext-agent/files/autodisco.yml
@@ -75,7 +75,7 @@ couchbase:
     - 8094
     - 11210
   labels:
-    COUCHBASE_HOSTPORT: "{{ .IP }}:8093"
+    COUCHBASE_HOST_PORT: "{{ .IP }}:8093"
     COUCHBASE_QUERY_HOSTPORT: "{{ .IP }}:8093"
     COUCHBASE_BASICAUTH_USERNAME:
     COUCHBASE_BASICAUTH_PASSWORD:
@@ -101,7 +101,7 @@ flink:
     - 6121
     - 6122
   lables:
-    FLINK_HOSTPORT: "{{ .IP }}:8081"
+    FLINK_HOST_PORT: "{{ .IP }}:8081"
 
 haproxy:
   process: haproxy
@@ -142,7 +142,7 @@ nats:
     - 8222
     - 6222
   labels:
-    NATS_SERVER_HOSTPORT: "{{ .IP }}:8222"
+    NATS_SERVER_HOST_PORT: "{{ .IP }}:8222"
 
 nginx:
   process: nginx
@@ -163,8 +163,8 @@ postgresql:
   ports:
     - 5432
   labels:
-    POSTGRESQL_DB_HOST_PORT: 5432
-    POSTGRESQL_DB_DATABASE: pg_stat_user_tables
+    POSTGRESQL_HOST_PORT: 5432
+    POSTGRESQL_DB_NAME: pg_stat_user_tables
     POSTGRESQL_DB_USER:
     POSTGRESQL_DB_PASSWORD:
 
@@ -176,7 +176,7 @@ rabbitmq:
     - 5671
     - 15672
   labels:
-    RABBITMQ_API_URL: "http://{{ .IP }}:15672"
+    RABBITMQ_HOST_PORT: "http://{{ .IP }}:15672"
     RABBITMQ_BASICAUTH_USERNAME:
     RABBITMQ_BASICAUTH_PASSWORD:
 


### PR DESCRIPTION
The PR updates the variable names in the autodiscovery configuration file of sematext agent chart, based on recent changes in App Agent repo

@komljen 

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
