### PR TITLE
[stable/elasticsearch] remove cpu limit from default values

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.28.2
+version: 1.28.3
 appVersion: 6.7.0
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/stable/elasticsearch/values.yaml
+++ b/stable/elasticsearch/values.yaml
@@ -132,8 +132,8 @@ client:
     #   cpu: "25m"
     #   memory: "128Mi"
   resources:
-    limits:
-      cpu: "1"
+    # limits:
+      # cpu: "1"
       # memory: "1024Mi"
     requests:
       cpu: "25m"
@@ -190,8 +190,8 @@ master:
     #   cpu: "25m"
     #   memory: "128Mi"
   resources:
-    limits:
-      cpu: "1"
+    # limits:
+      # cpu: "1"
       # memory: "1024Mi"
     requests:
       cpu: "25m"
@@ -238,8 +238,8 @@ data:
     #   cpu: "25m"
     #   memory: "128Mi"
   resources:
-    limits:
-      cpu: "1"
+    # limits:
+      # cpu: "1"
       # memory: "2048Mi"
     requests:
       cpu: "25m"


### PR DESCRIPTION
Signed-off-by: Artur Gadelshin <a.gadelshin@melsoft-games.com>

#### What this PR does / why we need it:

cpu limits work in unexpected way causing cpu throttling according to https://github.com/kubernetes/kubernetes/issues/51135

also, default value in docs is already '{}'

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
