### PR TITLE
[stable/consul] Fix ingress service name

### DIFF
--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: consul
 home: https://github.com/hashicorp/consul
-version: 3.6.2
+version: 3.6.3
 appVersion: 1.0.0
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/stable/consul/templates/consul-ingress.yaml
+++ b/stable/consul/templates/consul-ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.uiIngress.enabled -}}
 {{- $releaseName := .Release.Name -}}
 {{- $servicePort := .Values.HttpPort -}}
-{{- $serviceName := printf "%s-%s" (include "consul.fullname" .) "ui" -}}
+{{- $serviceName := include "consul.fullname" . -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:


### PR DESCRIPTION
This change fixes the service name in the ingress backend configuration.

The name of the headless service is set with `"{{ template "consul.fullname" . }}"` which the the ingress expects the service name to be suffixed with `-ui`, causing the ingress to fail. Removing the suffix will solve the problem.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
