### PR TITLE
[stable/postgresql] Allow templating of extra env vars

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 5.3.5
+version: 5.3.6
 appVersion: 11.3.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -166,7 +166,7 @@ The following tables lists the configurable parameters of the PostgreSQL chart a
 | `metrics.readinessProbe.timeoutSeconds`       | When the probe times out                                                                                               | 5                                                           |
 | `metrics.readinessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.                             | 6                                                           |
 | `metrics.readinessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed                            | 1                                                           |
-| `extraEnv`                                    | Any extra environment variables you would like to pass on to the pod                                                   | `{}`                                                        |
+| `extraEnv`                                    | Any extra environment variables you would like to pass on to the pod. The value is evaluated as a template.            | `{}`                                                        |
 | `updateStrategy`                              | Update strategy policy                                                                                                 | `{type: "RollingUpdate"}`                                   |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -153,7 +153,7 @@ spec:
           value: {{ (include "postgresql.database" .) | quote }}
         {{- end }}
 {{- if .Values.extraEnv }}
-{{ toYaml .Values.extraEnv | indent 8 }}
+{{ tpl (toYaml .Values.extraEnv) $ | indent 8 }}
 {{- end }}
         ports:
         - name: postgresql


### PR DESCRIPTION
#### What this PR does / why we need it:

This runs extraEnvs through tpl so that they can refer to release specific
environment variables that are obtained from secrets or configmaps.
Otherwise, it is not possible to pass env vars as follows, and must use
a hardcoded keyref.
```
  extraEnv:
    - name: MY_CUSTOM_PARAM
      valueFrom:
        secretKeyRef:
          name: "{{ .Release.Name }}-my-var"
          key: my-custom-key
```

#### Which issue this PR fixes
This is a workaround for issue: https://github.com/helm/helm/issues/2492
and follows similar solutions used elsewhere:
https://github.com/helm/charts/issues/10342

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
