### PR TITLE
[stable/neo4j]  Add the bolt protocol on port 7687 to the Service

### DIFF
--- a/stable/neo4j/Chart.yaml
+++ b/stable/neo4j/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: neo4j
 home: https://www.neo4j.com
-version: 1.0.0
+version: 1.1.0
 appVersion: 3.4.5
 description: Neo4j is the world's leading graph database
 icon: http://info.neo4j.com/rs/773-GON-065/images/neo4j_logo.png

--- a/stable/neo4j/templates/core-dns.yaml
+++ b/stable/neo4j/templates/core-dns.yaml
@@ -11,8 +11,12 @@ metadata:
 spec:
   clusterIP: None
   ports:
-    - port: 7474
+    - name: http
+      port: 7474
       targetPort: 7474
+    - name: bolt
+      port: 7687
+      targetPort: 7687
   selector:
     app: {{ template "neo4j.name" . }}
     release: {{ .Release.Name | quote }}


### PR DESCRIPTION

#### What this PR does / why we need it:
This PR adds the ability to communicate with Neo4j over the Bolt protocol on port 7687. Transmission over Bolt is significantly faster than over HTTP. See this blog post for a deeper dive on Bolt vs HTTP.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes  #6737

#### Special notes for your reviewer:
The ports should really be configurable, but this is the first step, which matches the existing setup for the HTTP port 7474.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
