### PR TITLE
[stable/prometheus-redis-exporter] Change redisAddress to a list

### DIFF
--- a/stable/prometheus-redis-exporter/Chart.yaml
+++ b/stable/prometheus-redis-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.28.0
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 1.1.0
+version: 2.0.0
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/stable/prometheus-redis-exporter/README.md
+++ b/stable/prometheus-redis-exporter/README.md
@@ -54,7 +54,7 @@ The following table lists the configurable parameters and their default values.
 | `service.port`         | service external port                               | `9121`                    |
 | `service.annotations`  | Custom annotations for service                      | `{}`                      |
 | `service.labels`       | Additional custom labels for the service            | `{}`                      |
-| `redisAddress`         | address of one or more redis nodes, comma separated | `redis://myredis:6379`    |
+| `redisAddress`         | A list of addresses of one or more redis nodes      | `redis://myredis:6379`    |
 | `annotations`          | pod annotations for easier discovery                | {}                        |
 | `rbac.create`           | Specifies whether RBAC resources should be created.| `true` |
 | `rbac.pspEnabled`       | Specifies whether a PodSecurityPolicy should be created.| `true` |

--- a/stable/prometheus-redis-exporter/templates/deployment.yaml
+++ b/stable/prometheus-redis-exporter/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
               containerPort: 9121
           env:
             - name: REDIS_ADDR
-              value: {{ .Values.redisAddress }}
+              value: {{ join "," .Values.redisAddress }}
 {{- if .Values.env }}
 {{ toYaml .Values.env | indent 12 }}
 {{- end }}

--- a/stable/prometheus-redis-exporter/values.yaml
+++ b/stable/prometheus-redis-exporter/values.yaml
@@ -32,7 +32,8 @@ service:
     # prometheus.io/port: "9121"
     # prometheus.io/scrape: "true"
 resources: {}
-redisAddress: redis://myredis:6379
+redisAddress:
+  - redis://myredis:6379
 annotations: {}
 #  prometheus.io/path: /metrics
 #  prometheus.io/port: "9121"


### PR DESCRIPTION
#### What this PR does / why we need it:
- Make redisAddress value a list instead of comma serparated string

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
