### PR TITLE
[stable/nginx-ingress] Remove invalid empty configmap

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.6.16
+version: 1.6.17
 appVersion: 0.24.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/controller-configmap.yaml
+++ b/stable/nginx-ingress/templates/controller-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.controller.headers .Values.controller.config }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,4 +15,5 @@ data:
 {{- end }}
 {{- if .Values.controller.config }}
 {{ toYaml .Values.controller.config | indent 2 }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
When neither headers nor config are set, the configmap contains a "null" data section. Remove it to allow strict schema checking (e.g. using kubeval).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
