### PR TITLE
[stable/prometheus-mysql-exporter] Fix invalid YAML with non-boolean collectors

### DIFF
--- a/stable/prometheus-mysql-exporter/Chart.yaml
+++ b/stable/prometheus-mysql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 0.3.2
+version: 0.3.3
 home: https://github.com/prometheus/mysqld_exporter
 appVersion: v0.11.0
 sources:

--- a/stable/prometheus-mysql-exporter/templates/deployment.yaml
+++ b/stable/prometheus-mysql-exporter/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
 {{- else if and (typeIs "bool" $element) (not $element) }}
 {{ printf "--no-collect.%s" $index | quote | indent 12 }},
 {{- else }}
-{{ printf "--collect.%s" $index | quote | indent 12 }}, {{ $element | quote }}
+{{ printf "--collect.%s" $index | quote | indent 12 }}, {{ $element | quote }},
 {{- end }}
 {{- end }}
           ]


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes the omission of a trailing comma when non-boolean values to the collectors parameter are supplied.

#### Which issue this PR fixes
  - fixes #14700

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
