### PR TITLE
[stable/prometheus-couchdb-exporter] Run with couchdb username and password

### DIFF
--- a/stable/prometheus-couchdb-exporter/Chart.yaml
+++ b/stable/prometheus-couchdb-exporter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart to export the metrics from couchdb in Prometheus format.
 name: prometheus-couchdb-exporter
 home: https://github.com/gesellix/couchdb-prometheus-exporter
-version: 0.1.0
+version: 0.1.1
 keywords:
 - couchdb-exporter
 sources:

--- a/stable/prometheus-couchdb-exporter/README.md
+++ b/stable/prometheus-couchdb-exporter/README.md
@@ -59,6 +59,8 @@ The following table lists the configurable parameters and their default values.
 | `affinity`             | affinity settings for proxy pod assignments         | {}                                      |
 | `couchdb.uri`          | address of the couchdb                              | `http://couchdb.default.svc:5984`       |
 | `couchdb.databases`    | comma separated databases to monitor                | `_all_dbs`                              |
+| `couchdb.username`     | username for couchdb                                |                                         |
+| `couchdb.password`     | password for couchdb                                |                                         |
 
 
 For more information please refer to the [couchdb-prometheus-exporter]https://github.com/gesellix/couchdb-prometheus-exporter) documentation.

--- a/stable/prometheus-couchdb-exporter/templates/deployment.yaml
+++ b/stable/prometheus-couchdb-exporter/templates/deployment.yaml
@@ -24,11 +24,18 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["/couchdb-prometheus-exporter",
-                    "-telemetry.address=0.0.0.0:9984",
-                    "-logtostderr",
-                    "-couchdb.uri={{ .Values.couchdb.uri }}",
-                    "-databases={{ .Values.couchdb.databases }}"]
+          command:
+            - "/couchdb-prometheus-exporter"
+            - "-telemetry.address=0.0.0.0:9984"
+            - "-logtostderr"
+            - "-couchdb.uri={{ .Values.couchdb.uri }}"
+            - "-databases={{ .Values.couchdb.databases }}"
+          {{- if .Values.couchdb.username }}
+            - "-couchdb.username={{ .Values.couchdb.username }}"
+          {{- end }}
+          {{- if .Values.couchdb.password }}
+            - "-couchdb.password={{ .Values.couchdb.password }}"
+          {{- end }}
           ports:
             - name: http
               containerPort: 9984


### PR DESCRIPTION
@gkarthiks please review

Signed-off-by: Nacef LABIDI <nacef.labidi@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Allows prometheus exporter to connect to couchdb with username and password. Currently, couchdb.username and couchdb.password are present in values.yaml but are not passed to deployment.yaml

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
