### PR TITLE
[stable/ghost] Fix targetPort when using ClusterIP

### DIFF
--- a/stable/ghost/templates/svc.yaml
+++ b/stable/ghost/templates/svc.yaml
@@ -23,7 +23,11 @@ spec:
   ports:
     - name: http
       port: {{ .Values.service.port }}
+      {{- if (and (eq .Values.service.type "ClusterIP"))}}
+      targetPort: 2368
+      {{- else }}
       targetPort: http
+      {{- end }}
       {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePorts.http)))}}
       nodePort: {{ .Values.service.nodePorts.http }}
       {{- end }}


### PR DESCRIPTION
Related issue: https://github.com/helm/charts/issues/11470

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

The ghost chart currently does not work when using ClusterIP. This seems to happen because the targetPort is set to http while the containerPort is set to 2368. Matching these ports made it work on my machine... :)

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #11470

#### Special notes for your reviewer:
This could probably be handled with a variable in values.yaml, however I like to keep the changes small. Feel free to implement this better.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
