### PR TITLE
[stable/prometheus-mysql-exporter] feat: store MySQL password in a k8s Secret

### DIFF
--- a/stable/prometheus-mysql-exporter/Chart.yaml
+++ b/stable/prometheus-mysql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 0.3.4
+version: 0.4.0
 home: https://github.com/prometheus/mysqld_exporter
 appVersion: v0.11.0
 sources:

--- a/stable/prometheus-mysql-exporter/templates/deployment.yaml
+++ b/stable/prometheus-mysql-exporter/templates/deployment.yaml
@@ -48,9 +48,9 @@ spec:
 {{- end }}
           ]
 {{- end }}
-          env:
-            - name: DATA_SOURCE_NAME
-              value: "{{ .Values.mysql.user }}:{{ .Values.mysql.pass }}@{{ if .Values.mysql.protocol }}{{ .Values.mysql.protocol }}{{ end }}({{ .Values.mysql.host }}:{{ .Values.mysql.port }})/{{ if .Values.mysql.db }}{{ .Values.mysql.db }}{{ end }}{{ if .Values.mysql.param }}?{{ .Values.mysql.param }}{{ end }}"
+          envFrom:
+            - secretRef:
+                name: {{ template "prometheus-mysql-exporter.fullname" . }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/stable/prometheus-mysql-exporter/templates/secret-env.yaml
+++ b/stable/prometheus-mysql-exporter/templates/secret-env.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "prometheus-mysql-exporter.fullname" . }}
+type: Opaque
+stringData:
+  DATA_SOURCE_NAME: "{{ .Values.mysql.user }}:{{ .Values.mysql.pass }}@{{ if .Values.mysql.protocol }}{{ .Values.mysql.protocol }}{{ end }}({{ .Values.mysql.host }}:{{ .Values.mysql.port }})/{{ if .Values.mysql.db }}{{ .Values.mysql.db }}{{ end }}{{ if .Values.mysql.param }}?{{ .Values.mysql.param }}{{ end }}"


### PR DESCRIPTION
The DATA_SOURCE_NAME environment variable contains a secret key for
authenticating to th MySQL instance (.Values.mysql.pass). This secret
should be stored in a K8s Secret object rather than directly on the
Deployment. Kubernetes RBAC requires more elevated permissions for
viewing Secret data than for viewing Deployment configuration.

Signed-off-by: Thomas Lovett <tklovett@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This is required by organizations that have strict RBAC policies for viewing secrets vs viewing deployment configuration.

#### Which issue this PR fixes
I didn't open one.

#### Special notes for your reviewer:
/cc @Juanchimienti @monotek 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped (yes, but it will conflict with #14600 )
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
