### PR TITLE
[stable/parse] Change tags/pullPolicy in values and/or README

### DIFF
--- a/stable/parse/Chart.yaml
+++ b/stable/parse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: parse
-version: 6.2.9
+version: 6.2.10
 appVersion: 3.4.0
 description: Parse is a platform that enables users to add a scalable and powerful backend to launch a full-featured app for iOS, Android, JavaScript, Windows, Unity, and more.
 keywords:

--- a/stable/parse/README.md
+++ b/stable/parse/README.md
@@ -57,7 +57,7 @@ The following table lists the configurable parameters of the Parse chart and the
 | `server.image.registry`               | Parse image registry                     | `docker.io`                                             |
 | `server.image.repository`             | Parse image name                         | `bitnami/parse`                                         |
 | `server.image.tag`                    | Parse image tag                          | `{TAG_NAME}`                                            |
-| `server.image.pullPolicy`             | Image pull policy                        | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
+| `server.image.pullPolicy`             | Image pull policy                        | `IfNotPresent`                                          |
 | `server.image.pullSecrets`            | Specify docker-registry secret names as an array               | `[]` (does not add image pull secrets to deployed pods) |
 | `server.securityContext.enabled`      | Enable security context for Parse Server | `true`                                                  |
 | `server.securityContext.fsGroup`      | Group ID for Parse Server container      | `1001`                                                  |
@@ -71,7 +71,7 @@ The following table lists the configurable parameters of the Parse chart and the
 | `dashboard.image.registry`            | Dashboard image registry                 | `docker.io`                                             |
 | `dashboard.image.repository`          | Dashboard image name                     | `bitnami/parse-dashboard`                               |
 | `dashboard.image.tag`                 | Dashboard image tag                      | `{TAG_NAME}`                                            |
-| `dashboard.image.pullPolicy`          | Image pull policy                        | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
+| `dashboard.image.pullPolicy`          | Image pull policy                        | `IfNotPresent`                                          |
 | `dashboard.securityContext.enabled`   | Enable security context for Dashboard    | `true`                                                  |
 | `dashboard.securityContext.fsGroup`   | Group ID for Dashboard container         | `1001`                                                  |
 | `dashboard.securityContext.runAsUser` | User ID for Dashboard container          | `1001`                                                  |


### PR DESCRIPTION
#### What this PR does / why we need it:

According to the [official docs](http://kubernetes.io/docs/user-guide/images/#pre-pulling-images), the `pullPolicy` should be set by defaults to 'Always' if the image tag is _latest_, else set to 'IfNotPresent'.

Bitnami images used rolling tags in the past so it had the sense to use 'Always', but at this moment all the images (except some metrics-exporter or init-containers) are using an immutable tag. I checked that all the immutable tags have 'IfNotPresent' as `pullPolicy` (also the opposite: _latest_ have 'Always'), documenting it in the README and changing the _values.yaml_ if needed.

Other charts were fixed as part of other PRs.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
