### PR TITLE
[stable/orangehrm] Change tags/pullPolicy in values and/or README

### DIFF
--- a/stable/orangehrm/Chart.yaml
+++ b/stable/orangehrm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: orangehrm
-version: 4.4.2
+version: 4.4.3
 appVersion: 4.3.1-0
 description: OrangeHRM is a free HR management system that offers a wealth of modules
   to suit the needs of your business.

--- a/stable/orangehrm/README.md
+++ b/stable/orangehrm/README.md
@@ -54,7 +54,7 @@ The following table lists the configurable parameters of the OrangeHRM chart and
 | `image.registry`                     | OrangeHRM image registry                 | `docker.io`                                             |
 | `image.repository`                   | OrangeHRM Image name                     | `bitnami/orangehrm`                                     |
 | `image.tag`                          | OrangeHRM Image tag                      | `{TAG_NAME}`                                            |
-| `image.pullPolicy`                   | Image pull policy                        | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
+| `image.pullPolicy`                   | Image pull policy                        | `IfNotPresent`                                          |
 | `image.pullSecrets`                  | Specify docker-registry secret names as an array               | `[]` (does not add image pull secrets to deployed pods) |
 | `orangehrmUsername`                  | User of the application                  | `user`                                                  |
 | `orangehrmPassword`                  | Application password                     | _random 10 character long alphanumeric string_          |


### PR DESCRIPTION
#### What this PR does / why we need it:

According to the [official docs](http://kubernetes.io/docs/user-guide/images/#pre-pulling-images), the `pullPolicy` should be set by defaults to 'Always' if the image tag is _latest_, else set to 'IfNotPresent'.

Bitnami images used rolling tags in the past so it had the sense to use 'Always', but at this moment all the images (except some metrics-exporter or init-containers) are using an immutable tag. I checked that all the immutable tags have 'IfNotPresent' as `pullPolicy` (also the opposite: _latest_ have 'Always'), documenting it in the README and changing the _values.yaml_ if needed.

Other charts were fixed as part of other PRs.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
