### PR TITLE
[stable/percona] Fixed value names

### DIFF
--- a/stable/percona/Chart.yaml
+++ b/stable/percona/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: percona
-version: 1.1.0
+version: 1.1.1
 appVersion: 5.7.17
 description: free, fully compatible, enhanced, open source drop-in replacement for
   MySQL

--- a/stable/percona/README.md
+++ b/stable/percona/README.md
@@ -51,10 +51,10 @@ The following table lists the configurable parameters of the Percona chart and t
 | `image`                    | `percona` image.                   | Percona official image on Docker Hub                       |
 | `imageTag`                 | `percona` image tag.                 | Most recent release                                        |
 | `imagePullPolicy`          | Image pull policy                  | `IfNotPresent`                                             |
-| `perconaRootPassword`        | Password for the `root` user.      | `nil`                                                      |
-| `perconaUser`                | Username of new user to create.    | `nil`                                                      |
-| `perconaPassword`            | Password for the new user.         | `nil`                                                      |
-| `perconaDatabase`            | Name for new database to create.   | `nil`                                                      |
+| `mysqlRootPassword`        | Password for the `root` user.      | `nil`                                                      |
+| `mysqlUser`                | Username of new user to create.    | `nil`                                                      |
+| `mysqlPassword`            | Password for the new user.         | `nil`                                                      |
+| `mysqlDatabase`            | Name for new database to create.   | `nil`                                                      |
 | `schedulerName`            | Name of the k8s scheduler (other than default)  | `nil`                                         |
 | `persistence.enabled`      | Create a volume to store data      | false                                                       |
 | `persistence.size`         | Size of persistent volume claim    | 8Gi RW                                                     |


### PR DESCRIPTION
There was a mistake in the readme defining values prefixed with percona. Those are not valid and not used within the values.yaml. Default is mysql-prefix.

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
