### PR TITLE
[stable/k8s-event-logger] Adding new chart to log k8s events

### DIFF
--- a/stable/k8s-event-logger/.helmignore
+++ b/stable/k8s-event-logger/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/k8s-event-logger/Chart.yaml
+++ b/stable/k8s-event-logger/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.1"
+appVersion: "1.3"
 version: "1.0"
 description: A tool to log k8s events to stdout in JSON
 home: https://github.com/max-rocket-internet/k8s-event-logger

--- a/stable/k8s-event-logger/Chart.yaml
+++ b/stable/k8s-event-logger/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+appVersion: "1.1"
+version: 1.0
+description: A tool to log k8s events to stdout in JSON
+home: https://github.com/max-rocket-internet/k8s-event-logger
+name: k8s-event-logger
+maintainers:
+- name: max-rocket-internet
+  email: max.williams@deliveryhero.com
+- name: mmingorance-dh
+  email: miguel.mingorance@deliveryhero.com
+engine: gotpl
+icon: https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png
+keywords:
+- events
+- logging
+- Auditing
+sources:
+- https://github.com/max-rocket-internet/k8s-event-logger

--- a/stable/k8s-event-logger/Chart.yaml
+++ b/stable/k8s-event-logger/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.1"
-version: 1.0
+version: "1.0"
 description: A tool to log k8s events to stdout in JSON
 home: https://github.com/max-rocket-internet/k8s-event-logger
 name: k8s-event-logger

--- a/stable/k8s-event-logger/OWNERS
+++ b/stable/k8s-event-logger/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- max-rocket-internet
+- mmingorance-dh
+reviewers:
+- max-rocket-internet
+- mmingorance-dh

--- a/stable/k8s-event-logger/README.md
+++ b/stable/k8s-event-logger/README.md
@@ -1,0 +1,61 @@
+# k8s-event-logger
+
+This chart runs a pod that simply watches Kubernetes Events and logs them to stdout in JSON to be collected and stored by your logging solution, e.g. [fluentd](https://github.com/helm/charts/tree/master/stable/fluentd) or [fluent-bit](https://github.com/helm/charts/tree/master/stable/fluent-bit).
+
+https://github.com/max-rocket-internet/k8s-event-logger
+
+Events in Kubernetes log very important information. If are trying to understand what happened in the past then these events show clearly what your Kubernetes cluster was thinking and doing. Some examples:
+
+- Pod events like failed probes, crashes, scheduling related information like `TriggeredScaleUp` or `FailedScheduling`
+- HorizontalPodAutoscaler events like scaling up and down
+- Deployment events like scaling in and out of ReplicaSets
+- Ingress events like create and update
+
+The problem is that these events are simply API objects in Kubernetes and are only stored for about 1 hour. Without some way of storing these events, debugging a problem in the past very tricky.
+
+## Prerequisites
+
+- Kubernetes 1.8+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release` and default configuration:
+
+```shell
+$ helm install --name my-release stable/k8s-event-logger
+```
+
+## Uninstalling the Chart
+
+To delete the chart:
+
+```shell
+$ helm delete my-release
+```
+
+## Configuration
+
+The following table lists the configurable parameters for this chart and their default values.
+
+| Parameter                | Description                          | Default                                                |
+| -------------------------|--------------------------------------|--------------------------------------------------------|
+| `resources`              | Resources for the overprovision pods | `{}`                                                   |
+| `image.repository`       | Image repository                     | `tools4k8s/k8s-event-logger`                           |
+| `image.tag`              | Image tag                            | `1.2`                                                  |
+| `image.pullPolicy`       | Container pull policy                | `IfNotPresent`                                         |
+| `affinity`               | Map of node/pod affinities           | `{}`                                                   |
+| `nodeSelector`           | Node labels for pod assignment       | `{}`                                                   |
+| `annotations`            | Optional deployment annotations      | `{}`                                                   |
+| `fullnameOverride`       | Override the fullname of the chart   | `nil`                                                  |
+| `nameOverride`           | Override the name of the chart       | `nil`                                                  |
+| `tolerations`            | Optional deployment tolerations      | `[]`                                                   |
+| `podLabels`              | Additional labels to use for pods    | `{}`                                                   |
+| `env.KUBERNETES_API_URL` | URL of the k8s API in your cluster   | `https://172.20.0.1:443`                               |
+| `env.CA_FILE`            | Path to the service account CA file  | `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` |
+| `podLabels`              | Additional labels to use for pods    | `{}`                                                   |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
+
+```shell
+$ helm install --name my-release stable/k8s-event-logger --values values.yaml
+```

--- a/stable/k8s-event-logger/README.md
+++ b/stable/k8s-event-logger/README.md
@@ -15,7 +15,7 @@ The problem is that these events are simply API objects in Kubernetes and are on
 
 ## Prerequisites
 
-- Kubernetes 1.8+
+- Kubernetes 1.8+ with RBAC enabled
 
 ## Installing the Chart
 

--- a/stable/k8s-event-logger/templates/NOTES.txt
+++ b/stable/k8s-event-logger/templates/NOTES.txt
@@ -1,0 +1,3 @@
+To verify that the k8s-event-logger pod has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ template "k8s-event-logger.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"

--- a/stable/k8s-event-logger/templates/_helpers.tpl
+++ b/stable/k8s-event-logger/templates/_helpers.tpl
@@ -1,0 +1,46 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "k8s-event-logger.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "k8s-event-logger.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "k8s-event-logger.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{/*
+Common labels
+*/}}
+{{- define "k8s-event-logger.labels" -}}
+app.kubernetes.io/name: {{ include "k8s-event-logger.name" . }}
+helm.sh/chart: {{ include "k8s-event-logger.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/stable/k8s-event-logger/templates/clusterrole.yaml
+++ b/stable/k8s-event-logger/templates/clusterrole.yaml
@@ -1,0 +1,13 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ include "k8s-event-logger.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "k8s-event-logger.name" . }}
+    helm.sh/chart: {{ include "k8s-event-logger.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]

--- a/stable/k8s-event-logger/templates/clusterrolebinding.yaml
+++ b/stable/k8s-event-logger/templates/clusterrolebinding.yaml
@@ -1,0 +1,17 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "k8s-event-logger.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "k8s-event-logger.name" . }}
+    helm.sh/chart: {{ include "k8s-event-logger.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "k8s-event-logger.fullname" . }}
+subjects:
+- namespace: {{ .Release.Namespace }}
+  kind: ServiceAccount
+  name: {{ include "k8s-event-logger.fullname" . }}

--- a/stable/k8s-event-logger/templates/deployment.yaml
+++ b/stable/k8s-event-logger/templates/deployment.yaml
@@ -28,6 +28,9 @@ spec:
         - name: app
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
           env:
 {{- range $key, $value := .Values.env }}
           - name: {{ $key }}

--- a/stable/k8s-event-logger/templates/deployment.yaml
+++ b/stable/k8s-event-logger/templates/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "k8s-event-logger.fullname" . }}
+  labels:
+{{ include "k8s-event-logger.labels" . | indent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "k8s-event-logger.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "k8s-event-logger.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "k8s-event-logger.fullname" . }}
+      containers:
+        - name: app
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+{{- range $key, $value := .Values.env }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+{{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/stable/k8s-event-logger/templates/serviceaccount.yaml
+++ b/stable/k8s-event-logger/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{ include "k8s-event-logger.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "k8s-event-logger.name" . }}
+    helm.sh/chart: {{ include "k8s-event-logger.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/stable/k8s-event-logger/values.yaml
+++ b/stable/k8s-event-logger/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: tools4k8s/k8s-event-logger
-  tag: "1.3"
+  tag: "1.4"
   pullPolicy: IfNotPresent
 
 resources:

--- a/stable/k8s-event-logger/values.yaml
+++ b/stable/k8s-event-logger/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: tools4k8s/k8s-event-logger
-  tag: "1.2"
+  tag: "1.3"
   pullPolicy: IfNotPresent
 
 resources:

--- a/stable/k8s-event-logger/values.yaml
+++ b/stable/k8s-event-logger/values.yaml
@@ -1,0 +1,24 @@
+image:
+  repository: tools4k8s/k8s-event-logger
+  tag: "1.2"
+  pullPolicy: IfNotPresent
+
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi
+
+env:
+  KUBERNETES_API_URL: https://172.20.0.1:443
+  CA_FILE: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+nodeSelector: {}
+tolerations: []
+affinity: {}
+podLabels: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

Adding a new chart that logs k8s events to stdout in JSON.

This chart runs a pod that simply watches Kubernetes Events and logs them to stdout in JSON to be collected and stored by your logging solution, e.g. [stable/fluentd](https://github.com/helm/charts/tree/master/stable/fluentd) or [stable/fluent-bit](https://github.com/helm/charts/tree/master/stable/fluent-bit).

Other tools exist for persisting Kubernetes Events, such as Sysdig, Datadog or Google's [event-exporter](https://github.com/GoogleCloudPlatform/k8s-stackdriver/tree/master/event-exporter) but this tool is open and will work with any logging solution.

Events in Kubernetes log very important information. If are trying to understand what happened in the past then these events show clearly what your Kubernetes cluster was thinking and doing. Some examples:

- Pod events like failed probes, crashes, scheduling related information like `TriggeredScaleUp` or `FailedScheduling`
- HorizontalPodAutoscaler events like scaling up and down
- Deployment events like scaling in and out of ReplicaSets
- Ingress events like create and update

The problem is that these events are simply API objects in Kubernetes and are only stored for about 1 hour. Without some way of storing these events, debugging a problem in the past very tricky.

Source code: https://github.com/max-rocket-internet/k8s-event-logger

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
