### PR TITLE
[incubator/vault] Added enterprise functionality

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.18.11
+version: 0.19.0
 appVersion: 1.1.2
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -53,6 +53,7 @@ The following table lists the configurable parameters of the Vault chart and the
 | `image.repository`                | Container image to use                   | `vault`                             |
 | `image.tag`                       | Container image tag to deploy            | `.Chart.appVersion`                            |
 | `vault.dev`                       | Use Vault in dev mode                    | true (set to false in production)   |
+| `vault.enterprise`                | Enables health checks for Vault Enterprise endpoints | false (set to true if using vault enterprise) |
 | `vault.extraEnv`                  | Extra env vars for Vault pods            | `{}`                                |
 | `vault.extraContainers`           | Sidecar containers to add to the vault pod | `{}`                              |
 | `vault.extraInitContainers`       | Init containers to be added to the vault pod | `{}`                            |
@@ -165,3 +166,12 @@ vault:
       mountPath: /vault/tls
       readOnly: true
 ```
+
+## Vault Enterprise
+Vault Enterprise comes with additional features that aren't available in open source vault. Disaster recovery replication, performance standby and performance replication. Enterprise vault servers have different health statuses when compared to their open source counterparts. Refer to the [vault documentation](https://www.vaultproject.io/api/system/health.html) for all health statuses.
+
+### Requirements
+In order to use the enterprise features of this chart, an image with the Vault Enterprise binary is required. Be sure that the binary version matches the version of the base Vault image.
+
+### Vault Disaster Recovery Replication
+Vault DR replication requires that the primary and DR cluster have connectivity to each other. It is also important to note that replication happens via port 8201.

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -63,9 +63,14 @@ spec:
         livenessProbe:
           # Alive if Vault is successfully responding to requests
           httpGet:
+          {{- if .Values.vault.enterprise }}
+            path: /v1/sys/health?performancestandbycode=204&
+          {{- else }}
             path: /v1/sys/health?standbyok=true&
+          {{- end -}}
               {{- if .Values.vault.liveness.aliveIfUninitialized -}}uninitcode=204&{{- end }}
               {{- if .Values.vault.liveness.aliveIfSealed -}}sealedcode=204&{{- end }}
+              {{- if .Values.vault.liveness.drEnabled -}}drsecondarycode=204&{{- end }}
             port: {{ .Values.service.port }}
             scheme: {{ if .Values.vault.config.listener.tcp.tls_disable -}}HTTP{{- else -}}HTTPS{{- end }}
           initialDelaySeconds: {{ .Values.vault.liveness.initialDelaySeconds }}
@@ -74,9 +79,14 @@ spec:
           # Ready depends on preference
           httpGet:
             path: /v1/sys/health?
-              {{- if .Values.vault.readiness.readyIfSealed -}}sealedcode=204&{{- end }}
+            {{- if .Values.vault.enterprise -}}
+              {{- if .Values.vault.readiness.readyIfStandby -}}performancestandbycode=204&{{- end }}
+            {{- else -}}
               {{- if .Values.vault.readiness.readyIfStandby -}}standbycode=204&{{- end }}
+            {{- end -}}
+              {{- if .Values.vault.readiness.readyIfSealed -}}sealedcode=204&{{- end }}
               {{- if .Values.vault.readiness.readyIfUninitialized -}}uninitcode=204&{{- end }}
+              {{- if .Values.vault.readiness.drEnabled -}}drsecondarycode=204&{{- end }}
             port: {{ .Values.service.port }}
             scheme: {{ if .Values.vault.config.listener.tcp.tls_disable -}}HTTP{{- else -}}HTTPS{{- end }}
           initialDelaySeconds: {{ .Values.vault.readiness.initialDelaySeconds }}

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -155,6 +155,8 @@ vault:
   # https://www.vaultproject.io/intro/getting-started/dev-server.html for more
   # information.
   dev: true
+  # Set if using Vault enterprise
+  enterprise: false
   # Configure additional environment variables for the Vault containers
   extraEnv: []
   #   - name: VAULT_API_ADDR
@@ -194,11 +196,15 @@ vault:
   #   secret:
   #     secretName: some-secret
   liveness:
+    # DR requires Vault enterprise
+    drEnabled: false
     aliveIfUninitialized: true
     aliveIfSealed: true
     initialDelaySeconds: 30
     periodSeconds: 10
   readiness:
+    # DR requires Vault enterprise
+    drEnabled: false
     readyIfSealed: false
     readyIfStandby: true
     readyIfUninitialized: true


### PR DESCRIPTION
Signed-off-by: Matthew Ramirez <matthewxprogramming@gmail.com>

#### What this PR does / why we need it:
Currently, the incubator/vault helm chart doesn't support Vault Enterprise deployment.  I've added enterprise-specific liveness/readiness probe endpoints. 

Running this chart `helm` on `minikube` with the following configuration:
```
~ $ minikube version
minikube version: v1.1.0

~ $ kubectl version
Client Version: version.Info{Major:"1", Minor:"14", GitVersion:"v1.14.3", GitCommit:"5e53fd6bc17c0dec8434817e69b04a25d8ae0ff0", GitTreeState:"clean", BuildDate:"2019-06-07T09:57:54Z", GoVersion:"go1.12.5", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"14", GitVersion:"v1.14.2", GitCommit:"66049e3b21efe110454d67df4fa62b08ea79a19b", GitTreeState:"clean", BuildDate:"2019-05-16T16:14:56Z", GoVersion:"go1.12.5", Compiler:"gc", Platform:"linux/amd64"}

~ $ helm version
Client: &version.Version{SemVer:"v2.14.1", GitCommit:"5270352a09c7e8b6e8c9593002a73535276507c0", GitTreeState:"clean"}
Server: &version.Version{SemVer:"v2.14.1", GitCommit:"5270352a09c7e8b6e8c9593002a73535276507c0", GitTreeState:"clean"}
```

#### Special notes for your reviewer:
Testing of enterprise functionality will require an image with the enterprise binary.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
