### PR TITLE
[stable/minecraft] add extraEnv and forceReDownload options

### DIFF
--- a/stable/minecraft/Chart.yaml
+++ b/stable/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 1.0.1
+version: 1.0.2
 appVersion: 1.13.1
 home: https://minecraft.net/
 description: Minecraft server

--- a/stable/minecraft/templates/deployment.yaml
+++ b/stable/minecraft/templates/deployment.yaml
@@ -85,6 +85,10 @@ spec:
           value: {{ .Values.minecraftServer.enableCommandBlock | quote }}
         - name: FORCE_gameMode
           value: {{ .Values.minecraftServer.forcegameMode | quote }}
+        {{- if .Values.minecraftServer.forceReDownload }}
+        - name: FORCE_REDOWNLOAD
+          value: "TRUE"
+        {{- end }}
         - name: GENERATE_STRUCTURES
           value: {{ .Values.minecraftServer.generateStructures | quote }}
         - name: HARDCORE
@@ -147,6 +151,11 @@ spec:
           value: "true"
         - name: QUERY_PORT
           value: {{ .Values.minecraftServer.query.port }}
+        {{- end }}
+
+        {{- range $key, $value := .Values.extraEnv }}
+        - name: {{ $key }}
+          value: {{ $value }}
         {{- end }}
 
         ports:

--- a/stable/minecraft/values.yaml
+++ b/stable/minecraft/values.yaml
@@ -105,6 +105,8 @@ minecraftServer:
   worldSaveName: world
   # If set, this URL will be downloaded at startup and used as a starting point
   downloadWorldUrl:
+  # force re-download of server file
+  forceReDownload: false
   # If set, the modpack at this URL will be downloaded at startup
   downloadModpackUrl:
   # If true, old versions of downloaded mods will be replaced with new ones from downloadModpackUrl
@@ -125,6 +127,10 @@ minecraftServer:
     # If you enable this, your server will be "published" to Gamespy
     enabled: false
     port: 25565
+
+## Additional minecraft container environment variables
+##
+extraEnv: {}
 
 persistence:
   ## minecraft data Persistent Volume Storage Class


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR includes two enhancements to the minecraft chart:

1. A new values option, `forceReDownload`, if enabled will instruct the minecraft server container to automatically re-download the server file for each server type so that the files do not need to be manually removed first in order to force a version update.  See [#335](https://github.com/itzg/dockerfiles/pull/335) for more context and background
1. An added option to the values for setting any number of extra environment variables as needed. This can future-proof the chart for new env variables that get added to the base image.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
