### PR TITLE
[stable/k8s-spot-termination-handler] add support for setting securityContext

### DIFF
--- a/stable/k8s-spot-termination-handler/Chart.yaml
+++ b/stable/k8s-spot-termination-handler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.13.0-1"
+appVersion: "1.13.7-1"
 description: The K8s Spot Termination handler handles draining AWS Spot Instances in response to termination requests.
 name: k8s-spot-termination-handler
 version: 1.4.0

--- a/stable/k8s-spot-termination-handler/README.md
+++ b/stable/k8s-spot-termination-handler/README.md
@@ -40,6 +40,7 @@ Parameter | Description | Default
 `detachAsg` | if `true`, the spot termination handler will detect (standard) AutoScaling Group, and initiate detach when termination notice is detected. | `false`
 `gracePeriod` | Grace period for node draining | `120`
 `resources` | pod resource requests & limits | `{}`
+`securityContext` | pod securityContext | `{}`
 `nodeSelector` | node labels for pod assignment | `{}`
 `tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
 `affinity` | node/pod affinities (requires Kubernetes >=1.6) | `{}`

--- a/stable/k8s-spot-termination-handler/templates/daemonset.yaml
+++ b/stable/k8s-spot-termination-handler/templates/daemonset.yaml
@@ -82,3 +82,7 @@ spec:
     {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
     {{- end }}
+    {{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/stable/k8s-spot-termination-handler/values.yaml
+++ b/stable/k8s-spot-termination-handler/values.yaml
@@ -14,7 +14,7 @@ serviceAccount:
 
 image:
   repository: kubeaws/kube-spot-termination-notice-handler
-  tag: 1.13.0-1
+  tag: 1.13.7-1
   pullPolicy: IfNotPresent
 
 # Poll the metadata every pollInterval seconds for termination events:
@@ -74,3 +74,7 @@ podAnnotations: {}
 # Default value for Kubernetes v1.5 and before was "OnDelete".
 updateStrategy: RollingUpdate
 maxUnavailable: 1
+
+securityContext: {}
+  # runAsUser: 1000
+  # runAsGroup: 1000


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds support for setting `securityContext`, allowing the locking down of privileges, etc

Some minor version cleaning, and adding myself to the maintainers, given that I originated the first version of this chart. ;)


#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
