### PR TITLE
[stable/external-dns] Add support for PowerDNS provider

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.2.3
+version: 2.3.0
 appVersion: 0.5.15
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -95,6 +95,9 @@ The following table lists the configurable parameters of the external-dns chart 
 | `rfc2136.tsigKeyname`              | When using the rfc2136 provider, specify the tsig keyname to enable security (optional)                  | `"externaldns-key"`                                      |
 | `rfc2136.tsigSecretAlg`            | When using the rfc2136 provider, specify the tsig secret to enable security (optional)                   | `"hmac-sha256"`                                          |
 | `rfc2136.tsigAxfr`                 | When using the rfc2136 provider, enable AFXR to enable security (optional)                               | `true`                                                   |
+| `pdns.apiUrl`                      | When using the PowerDNS provider, specify the API URL of the server.                                                       | `""`                                               |
+| `pdns.apiPort`                     | When using the PowerDNS provider, specify the API port of the server.                                                      | `8081`                                             |
+| `pdns.apiKey`                      | When using the PowerDNS provider, specify the API key of the server.                                                       | `""`                                               |
 | `annotationFilter`                 | Filter sources managed by external-dns via annotation using label selector (optional)                    | `""`                                                     |
 | `domainFilters`                    | Limit possible target zones by domain suffixes (optional)                                                | `[]`                                                     |
 | `zoneIdFilters`                    | Limit possible target zones by zone id (optional)                                                        | `[]`                                                     |

--- a/stable/external-dns/templates/_helpers.tpl
+++ b/stable/external-dns/templates/_helpers.tpl
@@ -130,6 +130,8 @@ Compile all warnings into a single message, and call fail.
 {{- $messages := append $messages (include "external-dns.validateValues.aws" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.infoblox.gridHost" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.infoblox.wapiPassword" .) -}}
+{{- $messages := append $messages (include "external-dns.validateValues.pdns.apiUrl" .) -}}
+{{- $messages := append $messages (include "external-dns.validateValues.pdns.apiKey" .) -}}
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 
@@ -198,6 +200,30 @@ Validate values of External DNS:
 external-dns: infoblox.wapiPassword
     You must provide a WAPI password when provider="infoblox".
     Please set the wapiPassword parameter (--set infoblox.wapiPassword="xxxx")
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of External DNS:
+- must provide the PowerDNS API URL when provider is "pdns"
+*/}}
+{{- define "external-dns.validateValues.pdns.apiUrl" -}}
+{{- if and (eq .Values.provider "pdns") (not .Values.pdns.apiUrl) -}}
+external-dns: pdns.apiUrl
+    You must provide the the PowerDNS API URL when provider="pdns".
+    Please set the apiUrl parameter (--set pdns.apiUrl="xxxx")
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of External DNS:
+- must provide the PowerDNS API key when provider is "pdns"
+*/}}
+{{- define "external-dns.validateValues.pdns.apiKey" -}}
+{{- if and (eq .Values.provider "pdns") (not .Values.pdns.apiKey) -}}
+external-dns: pdns.apiKey
+    You must provide the the PowerDNS API key when provider="pdns".
+    Please set the apiKey parameter (--set pdns.apiKey="xxxx")
 {{- end -}}
 {{- end -}}
 

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -152,6 +152,11 @@ spec:
         - --rfc2136-insecure
           {{- end }}
         {{- end }}
+        # PowerDNS arguments
+        {{- if eq .Values.provider "pdns" }}
+        - --pdns-server={{ .Values.pdns.apiUrl }}:{{ .Values.pdns.apiPort }}
+        - --pdns-api-key=$(PDNS_API_KEY)
+        {{- end }}
         # Extra arguments
         {{- range $key, $value := .Values.extraArgs }}
           {{- if $value }}
@@ -235,6 +240,14 @@ spec:
         {{- if and (eq .Values.provider "designate") .Values.designate.customCA.enabled }}
         - name: OPENSTACK_CA_FILE
           value: {{ .Values.designate.customCA.mountPath }}/{{ .Values.designate.customCA.filename }}
+        {{- end }}
+        # PowerDNS environment variables
+        {{- if and (eq .Values.provider "pdns") .Values.pdns.apiKey }}
+        - name: PDNS_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "external-dns.fullname" . }}
+              key: pdns_api_key
         {{- end }}
         # Extra environment variables
         {{- $root := . -}}

--- a/stable/external-dns/templates/secret.yaml
+++ b/stable/external-dns/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.aws.assumeRoleArn (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey) .Values.cloudflare.apiKey .Values.digitalocean.apiToken .Values.google.serviceAccountKey (and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword) .Values.rfc2136.tsigSecret .Values.extraEnv }}
+{{- if or .Values.aws.assumeRoleArn (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey) .Values.cloudflare.apiKey .Values.digitalocean.apiToken .Values.google.serviceAccountKey (and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword) .Values.rfc2136.tsigSecret .Values.pdns.apiKey .Values.extraEnv }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -29,6 +29,9 @@ data:
   {{- end }}
   {{- if .Values.rfc2136.tsigSecret }}
   rfc2136_tsig_secret: {{ .Values.rfc2136.tsigSecret | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.pdns.apiKey }}
+  pdns_api_key: {{ .Values.pdns.apiKey | b64enc | quote }}
   {{- end }}
   {{- range $key, $value := .Values.extraEnv }}
   {{ $key }}: {{ $value | b64enc | quote }}

--- a/stable/external-dns/values-production.yaml
+++ b/stable/external-dns/values-production.yaml
@@ -159,6 +159,13 @@ rfc2136:
   tsigKeyname: externaldns-key
   tsigAxfr: true
 
+## PowerDNS configuration to be set via arguments/env. variables
+##
+pdns:
+  apiUrl: ""
+  apiPort: "8081"
+  apiKey: ""
+
 ## Limit possible target zones by domain suffixes (optional)
 ##
 domainFilters: []

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -159,6 +159,13 @@ rfc2136:
   tsigKeyname: externaldns-key
   tsigAxfr: true
 
+## PowerDNS configuration to be set via arguments/env. variables
+##
+pdns:
+  apiUrl: ""
+  apiPort: "8081"
+  apiKey: ""
+
 ## Limit possible target zones by domain suffixes (optional)
 ##
 domainFilters: []


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

ExternalDNS supports PowerDNS as a provider, but the external-dns chart does not have parameters to support this.  Modified chart to accept and render values for PowerDNS endpoint.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
