### PR TITLE
[stable/nextcloud] Adding cron for the background jobs

### DIFF
--- a/stable/nextcloud/Chart.yaml
+++ b/stable/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nextcloud
-version: 1.2.2
+version: 1.3.0
 appVersion: 16.0.1
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/nextcloud/README.md
+++ b/stable/nextcloud/README.md
@@ -82,6 +82,11 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `mariadb.db.password`               | Password for the database                     | `changeme`                                              |
 | `mariadb.db.user`                   | Database user to create                       | `nextcloud`                                             |
 | `mariadb.rootUser.password`         | MariaDB admin password                        | `nil`                                                   |
+| `cronjob.enabled`                   | Whether to enable/disable cronjob             | `false`                                                 |
+| `cronjob.schedule`                  | Schedule for the CronJob                      | `*/15 * * * *`                                          |
+| `cronjob.annotations`               | Annotations to add to the cronjob             | {}                                                      |
+| `cronjob.failedJobsHistoryLimit`    | Specify the number of failed Jobs to keep     | `5`                                                     |
+| `cronjob.successfulJobsHistoryLimit`| Specify the number of completed Jobs to keep  | `2`                                                     |
 | `service.type`                      | Kubernetes Service type                       | `ClusterIp`                                             |
 | `service.loadBalancerIP`            | LoadBalancerIp for service type LoadBalancer  | `nil`                                                   |
 | `persistence.enabled`               | Enable persistence using PVC                  | `false`                                                 |
@@ -141,3 +146,12 @@ The [Nextcloud](https://hub.docker.com/_/nextcloud/) image stores the nextcloud 
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Configuration](#configuration) section to enable persistence and configuration of the PVC.
+
+## Cronjob
+
+This chart can utilize Kubernetes `CronJob` resource to execute [background tasks](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/background_jobs_configuration.html).
+
+To use this functionality, set `cronjob.enabled` parameter to `true` and switch background mode to Webcron in your nextcloud settings page.
+See the [Configuration](#configuration) section for further configuration of the cronjob resource.
+
+> **Note**: For the cronjobs to work correctly, ingress must be also enabled (set `ingress.enabled` to `true`) and `nextcloud.host` has to be publicly resolvable.

--- a/stable/nextcloud/templates/cronjob.yaml
+++ b/stable/nextcloud/templates/cronjob.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.cronjob.enabled }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ template "nextcloud.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+{{ toYaml .Values.cronjob.annotations | indent 4 }}
+spec:
+  schedule: "{{ .Values.cronjob.schedule }}"
+  concurrencyPolicy: Forbid
+  {{- with .Values.cronjob.failedJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ . }}
+  {{- end }}
+  {{- with .Values.cronjob.successfulJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ . }}
+  {{- end }}
+  jobTemplate:
+    metadata:
+      labels:
+        app: {{ include "nextcloud.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+            app.kubernetes.io/managed-by: {{ .Release.Service }}
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: {{ .Chart.Name }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command: [ "curl" ]
+              args:
+                - "--fail"
+              {{- if .Values.ingress.tls }}
+                - "https://{{ .Values.nextcloud.host }}/cron.php"
+              {{- else }}
+                - "http://{{ .Values.nextcloud.host }}/cron.php"
+              {{- end }}
+              resources:
+{{ toYaml .Values.resources | indent 16 }}
+    {{- with .Values.nodeSelector }}
+          nodeSelector:
+{{ toYaml . | indent 12 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+          affinity:
+{{ toYaml . | indent 12 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+          tolerations:
+{{ toYaml . | indent 12 }}:
+    {{- end }}
+{{- end }}

--- a/stable/nextcloud/values.yaml
+++ b/stable/nextcloud/values.yaml
@@ -80,7 +80,6 @@ internalDatabase:
   enabled: true
   name: nextcloud
 
-
 ##
 ## External database configuration
 ##
@@ -119,11 +118,23 @@ mariadb:
     accessMode: ReadWriteOnce
     size: 8Gi
 
+## Cronjob to execute Nextcloud background tasks
+## ref: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#cron-jobs
+##
+cronjob:
+  enabled: false
+  # Every 15 minutes
+  # Note: Setting this to any any other value than 15 minutes might
+  #  cause issues with how nextcloud background jobs are executed
+  schedule: "*/15 * * * *"
+  annotations: {}
+  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 2
+
 service:
   type: ClusterIP
   port: 8080
   loadBalancerIP: nil
-
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
@@ -159,6 +170,9 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
+## Liveness and readiness probe values
+## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+##
 livenessProbe:
   enabled: true
   initialDelaySeconds: 30


### PR DESCRIPTION
#### What this PR does / why we need it:
Ajax mode is enabled by default on the nextcloud installation which is running on every page load. These changes give the possibility for the chart users to use k8s `CronJob` resource to execute `cron.php` script automatically over the web (webcron).

#### Further notes
Ideally, we should execute `cron.php` directly through the CLI with `php` but that would require setting up the volumes and env all over again in the `CronJob` template. I do not like the idea of copy-pasting those from `Deployment.yaml`. Maybe we should reconsider that later using a shared template. Something like `files/image-template.yaml` which will contain `volumeMounts` and `env` and then include it in both `Deployment` and `CronJob` templates? Suggestions are welcome.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
