### PR TITLE
[stable/prometheus-cloudwatch-exporter] Make container command configurable

### DIFF
--- a/stable/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/stable/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.4.6
+version: 0.4.7
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -48,42 +48,43 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Cloudwatch Exporter chart and their default values.
 
-|          Parameter          |                      Description                       |          Default           |
-| --------------------------- | ------------------------------------------------------ | -------------------------- |
-| `image.repository`          | Image                                                  | `prom/cloudwatch-exporter` |
-| `image.tag`                 | Image tag                                              | `cloudwatch_exporter-0.5.0`                   |
-| `image.pullPolicy`          | Image pull policy                                      | `IfNotPresent`             |
-| `service.type`              | Service type                                           | `ClusterIP`                |
-| `service.port`              | The service port                                       | `80`                       |
-| `service.portName`          | The name of the service port                           | `http`                     |
-| `service.annotations`       | Custom annotations for service                         | `{}`                       |
-| `service.labels`            | Additional custom labels for the service               | `{}`                       |
-| `resources`                 |                                                        | `{}`                       |
-| `aws.role`                  | AWS IAM Role To Use                                    |                            |
-| `aws.aws_access_key_id`     | AWS access key id                                      |                            |
-| `aws.aws_secret_access_key` | AWS secret access key                                  |                            |
-| `aws.secret.name` | The name of a pre-created secret in which AWS credentials are stored                                 |                            |
-| `aws.secret.includesSessionToken` |  Whether or not the pre-created secret contains an AWS STS session token                                  |                            |
-| `config`                    | Cloudwatch exporter configuration                      | `example configuration`    |
-| `rbac.create`               | If true, create & use RBAC resources                   | `false`                    |
-| `serviceAccount.create`     | Specifies whether a service account should be created. | `true`                     |
-| `serviceAccount.name`       | Name of the service account.                           |                            |
-| `tolerations`               | Add tolerations                                        | `[]`                       |
-| `nodeSelector`              | node labels for pod assignment                         | `{}`                       |
-| `affinity`                  | node/pod affinities                                    | `{}`                       |
-| `livenessProbe`             | Liveness probe settings                                |                            |
-| `readinessProbe`            | Readiness probe settings                               |                            |
-| `servicemonitor.enabled`    | Use servicemonitor from prometheus operator            | `false`                    |
-| `servicemonitor.namespace`  | Namespace thes Servicemonitor  is installed in         |                            |
-| `servicemonitor.interval`   | How frequently Prometheus should scrape                |                            |
-| `servicemonitor.telemetryPath` |  path to cloudwatch-exporter telemtery-path         |                            |
-| `servicemonitor.labels`     |   labels for the ServiceMonitor passed to Prometheus Operator      |  `{}`          |
-| `servicemonitor.timeout`     |  Timeout after which the scrape is ended              |                            |
-| `ingress.enabled`           | Enables Ingress                                        | `false`                    |
-| `ingress.annotations`       | Ingress annotations                                    | `{}`                       |
-| `ingress.labels`            | Custom labels                                          | `{}`                       |
-| `ingress.hosts`             | Ingress accepted hostnames                             | `[]`                       |
-| `ingress.tls`               | Ingress TLS configuration                              | `[]`                       |
+| Parameter                         | Description                                                             | Default                     |
+| --------------------------------- | ----------------------------------------------------------------------- | --------------------------- |
+| `image.repository`                | Image                                                                   | `prom/cloudwatch-exporter`  |
+| `image.tag`                       | Image tag                                                               | `cloudwatch_exporter-0.5.0` |
+| `image.pullPolicy`                | Image pull policy                                                       | `IfNotPresent`              |
+| `command`                         | Container entrypoint command                                            | `[]`                        |
+| `service.type`                    | Service type                                                            | `ClusterIP`                 |
+| `service.port`                    | The service port                                                        | `80`                        |
+| `service.portName`                | The name of the service port                                            | `http`                      |
+| `service.annotations`             | Custom annotations for service                                          | `{}`                        |
+| `service.labels`                  | Additional custom labels for the service                                | `{}`                        |
+| `resources`                       |                                                                         | `{}`                        |
+| `aws.role`                        | AWS IAM Role To Use                                                     |                             |
+| `aws.aws_access_key_id`           | AWS access key id                                                       |                             |
+| `aws.aws_secret_access_key`       | AWS secret access key                                                   |                             |
+| `aws.secret.name`                 | The name of a pre-created secret in which AWS credentials are stored    |                             |
+| `aws.secret.includesSessionToken` | Whether or not the pre-created secret contains an AWS STS session token |                             |
+| `config`                          | Cloudwatch exporter configuration                                       | `example configuration`     |
+| `rbac.create`                     | If true, create & use RBAC resources                                    | `false`                     |
+| `serviceAccount.create`           | Specifies whether a service account should be created.                  | `true`                      |
+| `serviceAccount.name`             | Name of the service account.                                            |                             |
+| `tolerations`                     | Add tolerations                                                         | `[]`                        |
+| `nodeSelector`                    | node labels for pod assignment                                          | `{}`                        |
+| `affinity`                        | node/pod affinities                                                     | `{}`                        |
+| `livenessProbe`                   | Liveness probe settings                                                 |                             |
+| `readinessProbe`                  | Readiness probe settings                                                |                             |
+| `servicemonitor.enabled`          | Use servicemonitor from prometheus operator                             | `false`                     |
+| `servicemonitor.namespace`        | Namespace thes Servicemonitor  is installed in                          |                             |
+| `servicemonitor.interval`         | How frequently Prometheus should scrape                                 |                             |
+| `servicemonitor.telemetryPath`    | path to cloudwatch-exporter telemtery-path                              |                             |
+| `servicemonitor.labels`           | labels for the ServiceMonitor passed to Prometheus Operator             | `{}`                        |
+| `servicemonitor.timeout`          | Timeout after which the scrape is ended                                 |                             |
+| `ingress.enabled`                 | Enables Ingress                                                         | `false`                     |
+| `ingress.annotations`             | Ingress annotations                                                     | `{}`                        |
+| `ingress.labels`                  | Custom labels                                                           | `{}`                        |
+| `ingress.hosts`                   | Ingress accepted hostnames                                              | `[]`                        |
+| `ingress.tls`                     | Ingress TLS configuration                                               | `[]`                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -60,6 +60,9 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.command }}
+          command: {{ toYaml .Values.command | nindent 12 -}}
+          {{- end }}
           ports:
             - name: container-port
               containerPort: 9106

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -9,6 +9,20 @@ image:
   tag: cloudwatch_exporter-0.5.0
   pullPolicy: IfNotPresent
 
+# Example proxy configuration:
+# command:
+#   - 'java'
+#   - '-Dhttp.proxyHost=proxy.example.com'
+#   - '-Dhttp.proxyPort=3128'
+#   - '-Dhttps.proxyHost=proxy.example.com'
+#   - '-Dhttps.proxyPort=3128'
+#   - '-jar'
+#   - '/cloudwatch_exporter.jar'
+#   - '9106'
+#   - '/config/config.yml'
+
+command: []
+
 service:
   type: ClusterIP
   port: 9106


### PR DESCRIPTION
#### What this PR does / why we need it:

Some use cases, e.g. configuring a proxy server, require modifying the container entrypoint command (see prometheus/cloudwatch_exporter#17, prometheus/cloudwatch_exporter#26 and prometheus/cloudwatch_exporter#131). This PR make the command optionally configurable, the default leaves the default Docker image entrypoint untouched.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
