### PR TITLE
[stable/sonarqube] "tls" expect an array not a hash

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 2.0.0
+version: 2.0.1
 appVersion: 7.7
 keywords:
   - coverage

--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -49,6 +49,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `ingress.labels`                            | Ingress additional labels                 | `{}`                                       |
 | `ingress.hosts[0].name`                     | Hostname to your SonarQube installation   | `sonar.organization.com`                   |
 | `ingress.hosts[0].path`                     | Path within the URL structure             | /                                          |
+| `ingress.tls`                               | Ingress secrets for TLS certificates      | `[]`                                       |
 | `livenessProbe.sonarWebContext`             | SonarQube web context for livenessProbe   | /                                          |
 | `readinessProbe.sonarWebContext`            | SonarQube web context for readinessProbe  | /                                          |
 | `service.type`                              | Kubernetes service type                   | `LoadBalancer`                             |

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -43,7 +43,7 @@ ingress:
   # labels:
   #  traffic-type: external
   #  traffic-type: internal
-  tls: {}
+  tls: []
   # Secrets must be manually created in the namespace.
   # - secretName: chart-example-tls
   #   hosts:


### PR DESCRIPTION
Signed-off-by: BESANCON Vincent <vincent.besancon@faurecia.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This fixes `tls` value. It expects to be an array, not a hash.

When using the sonarqube chart as a dependency of another chart (which is a stack for sonarqube + postgres), we are encountering the following error:

```
Warning: Merging destination map for chart 'sonarqube'. Cannot overwrite table item 'tls', with non table value: map[]
```

In our chart, we redefine the sonarqube's chart value `sonarqube.ingress.tls` like this:

```
sonarqube:
  ingress:
    tls:
      - secretName: sonarqube-dev-certificate
        hosts:
          - sonarqube-dev.app.corp
```

But the base chart (stable/sonarqube) is defining the `tls` key to an empty hash in `values.yaml`.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

:beer:

#### Checklist

- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
