### PR TITLE
[incubator/buzzfeed-sso] Make auth application ingress path configurable

### DIFF
--- a/incubator/buzzfeed-sso/Chart.yaml
+++ b/incubator/buzzfeed-sso/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Single sign-on for your Kubernetes services using Google OAuth
 name: buzzfeed-sso
-version: 0.0.6
+version: 0.0.7
 appVersion: 1.2.0
 home: https://github.com/buzzfeed/sso
 sources:

--- a/incubator/buzzfeed-sso/README.md
+++ b/incubator/buzzfeed-sso/README.md
@@ -66,6 +66,7 @@ Parameter | Description | Default
 `auth.service.type` | type of auth service to create | `ClusterIP`
 `auth.service.port` | port for the http auth service | `80`
 `auth.secret` | secrets to be generated randomly with `openssl rand -base64 32 | head -c 32`. | REQUIRED if `auth.customSecret` is not set
+`auth.ingressPath` | auth ingress path. | `/`
 `auth.tls` | tls configuration for central sso auth ingress. | `{}`
 `auth.customSecret` | the secret key to reuse (avoids secret creation via helm) | REQUIRED if `auth.secret` is not set
 `proxy.annotations` | extra annotations for proxy pods | `{}`

--- a/incubator/buzzfeed-sso/templates/ingress.yaml
+++ b/incubator/buzzfeed-sso/templates/ingress.yaml
@@ -48,7 +48,7 @@ spec:
     - host: {{ $authDomain }}
       http:
         paths:
-          - path: /
+          - path: /*
             backend:
               serviceName: {{ $fullName }}-auth
               servicePort: http

--- a/incubator/buzzfeed-sso/templates/ingress.yaml
+++ b/incubator/buzzfeed-sso/templates/ingress.yaml
@@ -48,7 +48,7 @@ spec:
     - host: {{ $authDomain }}
       http:
         paths:
-          - path: /*
+          - path: {{ .Values.auth.ingressPath }}
             backend:
               serviceName: {{ $fullName }}-auth
               servicePort: http

--- a/incubator/buzzfeed-sso/values.yaml
+++ b/incubator/buzzfeed-sso/values.yaml
@@ -27,6 +27,7 @@ auth:
     # cookieSecret: ''
   # # Or if you do not want to create the secret via helm
   # customSecret: my-sso-auth-secret
+  ingressPath: /
   tls: {}
     # secretName: sso-auth-tls-secret
 

--- a/incubator/buzzfeed-sso/values.yaml
+++ b/incubator/buzzfeed-sso/values.yaml
@@ -27,6 +27,9 @@ auth:
     # cookieSecret: ''
   # # Or if you do not want to create the secret via helm
   # customSecret: my-sso-auth-secret
+  # Auth application ingress path.
+  # For GKE and AWS ALB ingresses use "/*"
+  # For Nginx ingress use "/"
   ingressPath: /
   tls: {}
     # secretName: sso-auth-tls-secret


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
GKE ingress controller always injects an URL rule that points to the default backend to any created GCP HTTP LB. The injected URL rule has a path of `/*` which catches all URLs coming to an LB unless the "real" backend URL map entry has a path of `/*`.
The current auth application ingress config for the path results in an URL map config like bellow: 
<img width="677" alt="Screenshot 2019-06-16 at 11 38 06 AM" src="https://user-images.githubusercontent.com/16538065/59562363-e61a7d80-902b-11e9-84fc-3f696a4184b3.png">
First and second rules both points the default backend. The third one is the one created by this chart and as you can see the path match `/` only.

The same behavior can be seen for AWS ALB ingress controller. But for Nginx ingress controller the path `/` works just fine and `/*` doesn't.

#### Special notes for your reviewer:
@darioblanco in case you are using nginx-ingress, that would explain this comment from my previous PR : https://github.com/helm/charts/pull/14601#issuecomment-500753589

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
