### PR TITLE
[incubator/gogs] Fixed restarted pod by the livenessProbe

### DIFF
--- a/incubator/gogs/Chart.yaml
+++ b/incubator/gogs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: 'Gogs: Go Git Service'
 name: gogs
-version: 0.7.9
+version: 0.7.10
 appVersion: 0.11.86
 home: https://gogs.io/
 icon: https://gogs.io/img/favicon.ico

--- a/incubator/gogs/templates/deployment.yaml
+++ b/incubator/gogs/templates/deployment.yaml
@@ -42,12 +42,20 @@ spec:
           livenessProbe:
             initialDelaySeconds: 180
             httpGet:
+              {{- if .Values.service.gogs.serviceRequireSignInView }}
+              path: /user/login
+              {{- else }}
               path: /
+              {{- end }}
               port: 3000
           readinessProbe:
             initialDelaySeconds: 180
             httpGet:
+              {{- if .Values.service.gogs.serviceRequireSignInView }}
+              path: /user/login
+              {{- else }}
               path: /
+              {{- end }}
               port: 3000
           env:
             # https://github.com/gogits/gogs/tree/master/docker#container-options


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
When the variable service.gogs.serviceRequireSignInView=true the pod restarts because it is redirected from "/" to "/user/login" and the livenessProbe/readinessProbe considering a fail.
@obeyler

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped

Signed-off-by: André R. de Miranda andre@miranda.work