### PR TITLE
[stable/home-assistant] added zwave capabilities to kubernetes

### DIFF
--- a/stable/home-assistant/Chart.yaml
+++ b/stable/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.93.2
 description: Home Assistant
 name: home-assistant
-version: 0.9.2
+version: 0.9.3
 keywords:
 - home-assistant
 - hass

--- a/stable/home-assistant/README.md
+++ b/stable/home-assistant/README.md
@@ -63,6 +63,8 @@ The following tables lists the configurable parameters of the Home Assistant cha
 | `git.secret`                   | Git secret to use for git-sync | `git-creds` | 
 | `git.syncPath`                 | Git sync path | `/config` |
 | `git.keyPath`                  | Git ssh key path | `/root/.ssh` |
+| `zwave.enabled`                  | Enable zwave host device passthrough. Also enables privileged container mode. | `false` |
+| `zwave.device`                  | Device to passthrough to guest | `ttyACM0` |
 | `extraEnv`          | Extra ENV vars to pass to the home-assistant container | `{}` |
 | `extraEnvSecrets`   | Extra env vars to pass to the home-assistant container from k8s secrets - see `values.yaml` for an example | `{}` |
 | `configurator.enabled`     | Enable the optional [configuration UI](https://github.com/danielperna84/hass-configurator) | `false` |

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -89,6 +89,10 @@ spec:
           volumeMounts:
           - mountPath: /config
             name: config
+          {{- if .Values.zwave.enabled }}
+          - mountPath: /dev/ttyACM0
+            name: ttyacm
+          {{- end }}
           {{- if .Values.git.enabled }}
           - mountPath: {{ .Values.git.keyPath }}
             name: git-secret
@@ -104,6 +108,10 @@ spec:
           {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          {{- if .Values.zwave.enabled }}
+          securityContext:
+            privileged: true
+          {{- end }}
         {{- if .Values.configurator.enabled }}
         - name: configurator
           image: "{{ .Values.configurator.image.repository }}:{{ .Values.configurator.image.tag }}"
@@ -224,6 +232,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
+      {{- if .Values.zwave.enabled }}
+      - name: ttyacm
+        hostPath:
+          path: /dev/{{.Values.zwave.device}}
+      {{- end }}
       {{- if .Values.git.enabled }}
       - name: git-secret
         secret:

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -95,6 +95,10 @@ git:
   syncPath: /config
   keyPath: /root/.ssh
 
+zwave:
+  enabled: false
+  device: ttyACM0
+
 configurator:
   enabled: false
 


### PR DESCRIPTION
Signed-off-by: Ryan Holt <ryan@ryanholt.net>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it: Enables the passthrough of a zwave stick to Home-Assistant from the Kubernetes host

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
