### PR TITLE
[stable/stolon] Use custome names for stolon keeper in different namespace

### DIFF
--- a/stable/stolon/Chart.yaml
+++ b/stable/stolon/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stolon
-version: 1.1.1
+version: 1.1.2
 appVersion: 0.13.0
 description: Stolon - PostgreSQL cloud native High Availability.
 home: https://github.com/sorintlab/stolon

--- a/stable/stolon/README.md
+++ b/stable/stolon/README.md
@@ -25,6 +25,7 @@ Kubernetes is the default store backend. `consul`, `etcdv2` or `etcdv3` can also
 
 | Parameter                               | Description                                    | Default                                                      |
 | --------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------ |
+| `clusterName`                           | `stolon` cluster name                          | `nil`                                                |
 | `image.repository`                      | `stolon` image repository                      | `sorintlab/stolon`                                           |
 | `image.tag`                             | `stolon` image tag                             | `v0.13.0-pg10`                                               |
 | `image.pullPolicy`                      | `stolon` image pull policy                     | `IfNotPresent`                                               |

--- a/stable/stolon/README.md
+++ b/stable/stolon/README.md
@@ -57,6 +57,7 @@ Kubernetes is the default store backend. `consul`, `etcdv2` or `etcdv3` can also
 | `job.autoCreateCluster`                 | Set to `false` to force-disable auto-cluster-creation which may clear pre-existing postgres db data | `true`  |
 | `job.autoUpdateClusterSpec`             | Set to `false` to force-disable auto-cluster-spec-update | `true`                                             |
 | `clusterSpec`                           | Stolon cluster spec [reference](https://github.com/sorintlab/stolon/blob/master/doc/cluster_spec.md) | `{}`   |
+| `keeper.uid_prefix`                     | Keeper prefix name                             | `keeper`                                                     |
 | `keeper.replicaCount`                   | Number of keeper nodes                         | `2`                                                          |
 | `keeper.resources`                      | Keeper resource requests/limit                 | `{}`                                                         |
 | `keeper.priorityClassName`              | Keeper priorityClassName                       | `nil`                                                        |

--- a/stable/stolon/templates/_helpers.tpl
+++ b/stable/stolon/templates/_helpers.tpl
@@ -43,7 +43,7 @@ Create chart name and version as used by the chart label.
 
 {{- define "stolon.clusterName" -}}
 {{- if .Values.clusterName -}}
-    {{- .Values.clusterName | trunc 63 | trimSuffix "-"" -}}
+    {{- .Values.clusterName | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
     {{- template "stolon.fullname" . -}}
 {{- end -}}

--- a/stable/stolon/templates/_helpers.tpl
+++ b/stable/stolon/templates/_helpers.tpl
@@ -43,8 +43,8 @@ Create chart name and version as used by the chart label.
 
 {{- define "stolon.clusterName" -}}
 {{- if .Values.clusterName -}}
-  {{- .Values.clusterName | trunc 63 | trimSuffix "-"" -}}
+    {{- .Values.clusterName | trunc 63 | trimSuffix "-"" -}}
 {{- else -}}
-  {{- template "stolon.fullname" . -}}
+    {{- template "stolon.fullname" . -}}
 {{- end -}}
 {{- end -}}

--- a/stable/stolon/templates/_helpers.tpl
+++ b/stable/stolon/templates/_helpers.tpl
@@ -40,3 +40,11 @@ Create chart name and version as used by the chart label.
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{- define "stolon.clusterName" -}}
+{{- if .Values.clusterName -}}
+  {{- .Values.clusterName | trunc 63 | trimSuffix "-"" -}}
+{{- else -}}
+  {{- template "stolon.fullname" . -}}
+{{- end -}}
+{{- end -}}

--- a/stable/stolon/templates/configmap.yaml
+++ b/stable/stolon/templates/configmap.yaml
@@ -15,7 +15,7 @@ data:
 
     NODE_NAME=${HOSTNAME}
     IFS='-' read -ra ADDR <<< "$(hostname)"
-    STKEEPER_UID="keeper${ADDR[-1]}"
+    STKEEPER_UID="{{ .Values.keeper.uid_prefix }}${ADDR[-1]}"
 
     echo "keeper [${STKEEPER_UID}] is failing"
     stolonctl \

--- a/stable/stolon/templates/configmap.yaml
+++ b/stable/stolon/templates/configmap.yaml
@@ -19,7 +19,7 @@ data:
 
     echo "keeper [${STKEEPER_UID}] is failing"
     stolonctl \
-      --cluster-name={{ template "stolon.fullname" . }} \
+      --cluster-name={{ template "stolon.clusterName" . }} \
       --store-backend={{ .Values.store.backend }} \
       {{- if eq .Values.store.backend "kubernetes" }}
       --kube-resource-kind={{ .Values.store.kubeResourceKind }} \

--- a/stable/stolon/templates/hooks/create-cluster-job.yaml
+++ b/stable/stolon/templates/hooks/create-cluster-job.yaml
@@ -34,7 +34,7 @@ spec:
           command: ["/usr/local/bin/stolonctl"]
           args:
             - init
-            - --cluster-name={{ template "stolon.fullname" . }}
+            - --cluster-name={{ template "stolon.clusterName" . }}
             - --store-backend={{ .Values.store.backend }}
             {{- if eq .Values.store.backend "kubernetes" }}
             - --kube-resource-kind={{ .Values.store.kubeResourceKind }}

--- a/stable/stolon/templates/hooks/update-cluster-spec-job.yaml
+++ b/stable/stolon/templates/hooks/update-cluster-spec-job.yaml
@@ -34,7 +34,7 @@ spec:
           command: ["/usr/local/bin/stolonctl"]
           args:
             - update
-            - --cluster-name={{ template "stolon.fullname" . }}
+            - --cluster-name={{ template "stolon.clusterName" . }}
             - --store-backend={{ .Values.store.backend }}
             {{- if eq .Values.store.backend "kubernetes" }}
             - --kube-resource-kind={{ .Values.store.kubeResourceKind }}
@@ -44,4 +44,3 @@ spec:
             - -p
             - '{ {{- range $key, $value := .Values.clusterSpec }} {{ $key | quote }}: {{ if typeIs "string" $value }} {{ $value | quote }} {{ else }} {{ $value }} {{ end }}, {{- end }} "pgParameters": {{ toJson .Values.pgParameters }} }'
 {{ end }}
-

--- a/stable/stolon/templates/keeper-statefulset.yaml
+++ b/stable/stolon/templates/keeper-statefulset.yaml
@@ -42,7 +42,7 @@ spec:
             - |
               # Generate our keeper uid using the pod index
               IFS='-' read -ra ADDR <<< "$(hostname)"
-              export STKEEPER_UID="keeper${ADDR[-1]}"
+              export STKEEPER_UID="{{ .Values.keeper.uid_prefix }}${ADDR[-1]}"
               export POD_IP=$(hostname -i)
               export STKEEPER_PG_LISTEN_ADDRESS=$POD_IP
               export STOLON_DATA=/stolon-data

--- a/stable/stolon/values.yaml
+++ b/stable/stolon/values.yaml
@@ -1,3 +1,4 @@
+# clusterName: 
 image:
   repository: sorintlab/stolon
   tag: v0.13.0-pg10

--- a/stable/stolon/values.yaml
+++ b/stable/stolon/values.yaml
@@ -74,7 +74,7 @@ clusterSpec: {}
   # maxStandbys: 5
 
 keeper:
-  uid_prefix: "stolon"
+  uid_prefix: "keeper"
   replicaCount: 2
   annotations: {}
   resources: {}

--- a/stable/stolon/values.yaml
+++ b/stable/stolon/values.yaml
@@ -1,4 +1,4 @@
-# clusterName: 
+# clusterName:
 image:
   repository: sorintlab/stolon
   tag: v0.13.0-pg10

--- a/stable/stolon/values.yaml
+++ b/stable/stolon/values.yaml
@@ -74,6 +74,7 @@ clusterSpec: {}
   # maxStandbys: 5
 
 keeper:
+  uid_prefix: "stolon"
   replicaCount: 2
   annotations: {}
   resources: {}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
  - It help to create different UIDs for stolon keepers when you create two stolon clusters on one backend storage

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
