### PR TITLE
[stable/airflow] add option for airflow initdb

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 3.0.0
+version: 3.0.1
 appVersion: 1.10.2
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -348,6 +348,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `airflow.extraContainers`                | additional containers to run in the scheduler, worker & web pods | `[]`             |
 | `airflow.extraVolumeMounts`              | additional volumeMounts to the main container in scheduler, worker & web pods | `[]`|
 | `airflow.extraVolumes`                   | additional volumes for the scheduler, worker & web pods | `[]`                      |
+| `airflow.initdb`                         | run `airflow initdb` when starting the scheduler        | `true`                    |
 | `flower.resources`                       | custom resource configuration for flower pod            | `{}`                      |
 | `flower.service.type`                    | service type for Flower UI                              | `ClusterIP`               |
 | `flower.service.annotations`             | (optional) service annotations for Flower UI            | `{}`                      |

--- a/stable/airflow/templates/deployments-scheduler.yaml
+++ b/stable/airflow/templates/deployments-scheduler.yaml
@@ -134,8 +134,10 @@ spec:
               mkdir -p /usr/local/airflow/.local/bin &&
               export PATH=/usr/local/airflow/.local/bin:$PATH &&
               /usr/local/scripts/install-requirements.sh &&
+              {{- if .Values.airflow.initdb }}
               echo "executing initdb" &&
               airflow initdb &&
+              {{- end }}
             {{- if .Values.airflow.connections }}
               echo "adding connections" &&
               /usr/local/connections/add-connections.sh &&
@@ -156,8 +158,10 @@ spec:
               sleep 10 &&
               mkdir -p /usr/local/airflow/.local/bin &&
               export PATH=/usr/local/airflow/.local/bin:$PATH &&
+              {{- if .Values.airflow.initdb }}
               echo "executing initdb" &&
               airflow initdb &&
+              {{- end }}
             {{- if .Values.airflow.connections }}
               echo "adding connections" &&
               /usr/local/connections/add-connections.sh &&

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -92,9 +92,6 @@ airflow:
   schedulerDoPickle: true
   ##
   ## Number of replicas for web server.
-  ## For the moment, we recommend to leave this value to 1, since the webserver instance performs
-  ## the 'initdb' operation, starting more replicas will cause all the web containers to execute
-  ## it, which may cause unwanted issues on the database.
   webReplicas: 1
   ##
   ## Custom airflow configuration environment variables
@@ -156,6 +153,11 @@ airflow:
   ## Additional volumes for the Scheduler, Worker and Web pods.
   # - name: synchronised-dags
   #   emptyDir: {}
+
+  ##
+  ## Run initdb when the scheduler starts.
+  initdb: true
+
 
 scheduler:
   resources: {}


### PR DESCRIPTION
Signed-off-by: Marcin Szymanski <ms32035@gmail.com>

#### What this PR does / why we need it:

#### Which issue this PR fixes

Running `airflow initdb` on after the database was initialised recreates some example objects as connections, so it should be possible to disable it

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
