### PR TITLE
[stable/kibana] Enabling environment from secrets

### DIFF
--- a/stable/kibana/Chart.yaml
+++ b/stable/kibana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kibana
-version: 3.0.0
+version: 3.1.0
 appVersion: 6.7.0
 description: Kibana is an open source data visualization plugin for Elasticsearch
 icon: https://raw.githubusercontent.com/elastic/kibana/master/src/ui/public/icons/kibana-color.svg

--- a/stable/kibana/README.md
+++ b/stable/kibana/README.md
@@ -42,6 +42,9 @@ The following table lists the configurable parameters of the kibana chart and th
 | ------------------------------------------ | ---------------------------------------------------------------------- | ------------------------------------- |
 | `affinity`                                 | node/pod affinities                                                    | None                                  |
 | `env`                                      | Environment variables to configure Kibana                              | `{}`                                  |
+| `envFromSecrets`                           | Environment variables from secrets to the cronjob container            | {}                                    |
+| `envFromSecrets.*.from.secret`             | - `secretKeyRef.name` used for environment variable                    |                                       |
+| `envFromSecrets.*.from.key`                | - `secretKeyRef.key` used for environment variable                     |                                       |
 | `files`                                    | Kibana configuration files                                             | None                                  |
 | `livenessProbe.enabled`                    | livenessProbe to be enabled?                                           | `false`                               |
 | `livenessProbe.path`                       | path for livenessProbe                                                 | `/status`                             |

--- a/stable/kibana/templates/deployment.yaml
+++ b/stable/kibana/templates/deployment.yaml
@@ -142,11 +142,11 @@ spec:
         {{- end }}
 {{- if .Values.envFromSecrets }}
         {{- range $key,$value := .Values.envFromSecrets }}
-              - name: {{ $key | upper | quote}}
-                valueFrom:
-                  secretKeyRef:
-                    name: {{ $value.from.secret | quote}}
-                    key: {{ $value.from.key | quote}}
+        - name: {{ $key | upper | quote}}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $value.from.secret | quote}}
+              key: {{ $value.from.key | quote}}
         {{- end }}
 {{- end }}
 {{- if (not .Values.authProxyEnabled) }}

--- a/stable/kibana/templates/deployment.yaml
+++ b/stable/kibana/templates/deployment.yaml
@@ -140,6 +140,15 @@ spec:
         - name: "{{ $key }}"
           value: "{{ $value }}"
         {{- end }}
+{{- if .Values.envFromSecrets }}
+        {{- range $key,$value := .Values.envFromSecrets }}
+              - name: {{ $key | upper | quote}}
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $value.from.secret | quote}}
+                    key: {{ $value.from.key | quote}}
+        {{- end }}
+{{- end }}
 {{- if (not .Values.authProxyEnabled) }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR enables environment variables to be referenced from kubernetes secrets.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)

Signed-off-by: Endre Czirbesz <endre.czirbesz@rungway.com>
