### PR TITLE
[stable/mariadb] Add extraFlags property to MariaDB to set additional command line flags

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb
-version: 6.4.3
+version: 6.5.0
 appVersion: 10.3.15
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -82,6 +82,7 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `initdbScriptsConfigMap`                  | ConfigMap with the initdb scripts (Note: Overrides `initdbScripts`) | `nil`                                             |
 | `master.annotations[].key`                | key for the the annotation list item                |  `nil`                                                            |
 | `master.annotations[].value`              | value for the the annotation list item              |  `nil`                                                            |
+| `master.extraFlags`                       | MariaDB master additional command line flags        |  `nil`                                                            |
 | `master.affinity`                         | Master affinity (in addition to master.antiAffinity when set)  | `{}`                                                   |
 | `master.antiAffinity`                     | Master pod anti-affinity policy                     | `soft`                                                            |
 | `master.nodeSelector`                     | Master node labels for pod assignment               | `{}`                                                              |
@@ -116,6 +117,7 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `slave.replicas`                          | Desired number of slave replicas                    | `1`                                                               |
 | `slave.annotations[].key`                 | key for the the annotation list item                | `nil`                                                             |
 | `slave.annotations[].value`               | value for the the annotation list item              | `nil`                                                             |
+| `slave.extraFlags`                        | MariaDB slave additional command line flags         | `nil`                                                             |
 | `slave.affinity`                          | Slave affinity (in addition to slave.antiAffinity when set) | `{}`                                                      |
 | `slave.antiAffinity`                      | Slave pod anti-affinity policy                      | `soft`                                                            |
 | `slave.nodeSelector`                      | Slave node labels for pod assignment                | `{}`                                                              |

--- a/stable/mariadb/templates/master-statefulset.yaml
+++ b/stable/mariadb/templates/master-statefulset.yaml
@@ -98,6 +98,8 @@ spec:
         - name: BITNAMI_DEBUG
           value: "true"
         {{- end }}
+        - name: MARIADB_EXTRA_FLAGS
+          value: "{{ .Values.master.extraFlags }}"
         - name: MARIADB_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/stable/mariadb/templates/master-statefulset.yaml
+++ b/stable/mariadb/templates/master-statefulset.yaml
@@ -98,8 +98,10 @@ spec:
         - name: BITNAMI_DEBUG
           value: "true"
         {{- end }}
+        {{- if .Values.master.extraFlags }}
         - name: MARIADB_EXTRA_FLAGS
           value: "{{ .Values.master.extraFlags }}"
+        {{- end }}
         - name: MARIADB_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/stable/mariadb/templates/slave-statefulset.yaml
+++ b/stable/mariadb/templates/slave-statefulset.yaml
@@ -99,6 +99,8 @@ spec:
         - name: BITNAMI_DEBUG
           value: "true"
         {{- end }}
+        - name: MARIADB_EXTRA_FLAGS
+          value: "{{ .Values.slave.extraFlags }}"
         - name: MARIADB_REPLICATION_MODE
           value: "slave"
         - name: MARIADB_MASTER_HOST

--- a/stable/mariadb/templates/slave-statefulset.yaml
+++ b/stable/mariadb/templates/slave-statefulset.yaml
@@ -99,8 +99,10 @@ spec:
         - name: BITNAMI_DEBUG
           value: "true"
         {{- end }}
+        {{- if .Values.slave.extraFlags }}
         - name: MARIADB_EXTRA_FLAGS
           value: "{{ .Values.slave.extraFlags }}"
+        {{- end }}
         - name: MARIADB_REPLICATION_MODE
           value: "slave"
         - name: MARIADB_MASTER_HOST

--- a/stable/mariadb/values-production.yaml
+++ b/stable/mariadb/values-production.yaml
@@ -141,11 +141,9 @@ master:
   #     value: value1
 
   ## MariaDB additional command line flags
-  ##
   ## Can be used to specify command line flags, for example:
   ##
   ## extraFlags: "--max-connect-errors=1000 --max_connections=155"
-  extraFlags: ""
 
   ## Affinity for pod assignment
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
@@ -276,11 +274,9 @@ slave:
   #     value: value1
 
   ## MariaDB additional command line flags
-  ##
   ## Can be used to specify command line flags, for example:
   ##
   ## extraFlags: --max-connect-errors=1000 --max_connections=155"
-  extraFlags: ""
 
   ## Affinity for pod assignment
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity

--- a/stable/mariadb/values-production.yaml
+++ b/stable/mariadb/values-production.yaml
@@ -140,6 +140,13 @@ master:
   #   - key: key1
   #     value: value1
 
+  ## MariaDB additional command line flags
+  ##
+  ## Can be used to specify command line flags, for example:
+  ##
+  ## extraFlags: "--max-connect-errors=1000 --max_connections=155"
+  extraFlags: ""
+
   ## Affinity for pod assignment
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ##
@@ -267,6 +274,13 @@ slave:
   # annotations:
   #   - key: key1
   #     value: value1
+
+  ## MariaDB additional command line flags
+  ##
+  ## Can be used to specify command line flags, for example:
+  ##
+  ## extraFlags: --max-connect-errors=1000 --max_connections=155"
+  extraFlags: ""
 
   ## Affinity for pod assignment
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -141,11 +141,9 @@ master:
   #     value: value1
 
   ## MariaDB additional command line flags
-  ##
   ## Can be used to specify command line flags, for example:
   ##
   ## extraFlags: "--max-connect-errors=1000 --max_connections=155"
-  extraFlags: ""
 
   ## Affinity for pod assignment
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
@@ -276,11 +274,9 @@ slave:
   #     value: value1
 
   ## MariaDB additional command line flags
-  ##
   ## Can be used to specify command line flags, for example:
   ##
   ## extraFlags: "--max-connect-errors=1000 --max_connections=155"
-  extraFlags: ""
 
   ## Affinity for pod assignment
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -140,6 +140,13 @@ master:
   #   - key: key1
   #     value: value1
 
+  ## MariaDB additional command line flags
+  ##
+  ## Can be used to specify command line flags, for example:
+  ##
+  ## extraFlags: "--max-connect-errors=1000 --max_connections=155"
+  extraFlags: ""
+
   ## Affinity for pod assignment
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ##
@@ -267,6 +274,13 @@ slave:
   # annotations:
   #   - key: key1
   #     value: value1
+
+  ## MariaDB additional command line flags
+  ##
+  ## Can be used to specify command line flags, for example:
+  ##
+  ## extraFlags: "--max-connect-errors=1000 --max_connections=155"
+  extraFlags: ""
 
   ## Affinity for pod assignment
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
It allows setting extra configuration flags for MariaDB in case any other chart requires some specific configuration.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
