### PR TITLE
[stable/phabricator] Set extraFlags default value for MariaDB master node

### DIFF
--- a/stable/phabricator/Chart.yaml
+++ b/stable/phabricator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: phabricator
-version: 4.3.3
+version: 4.3.4
 appVersion: 2019.21.0
 description: Collection of open source web applications that help software companies build better software.
 keywords:

--- a/stable/phabricator/Chart.yaml
+++ b/stable/phabricator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: phabricator
-version: 4.3.4
+version: 5.0.0
 appVersion: 2019.21.0
 description: Collection of open source web applications that help software companies build better software.
 keywords:

--- a/stable/phabricator/requirements.lock
+++ b/stable/phabricator/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.11.3
-digest: sha256:e09c8ca7126923a30e39f442c3863b44684d4eb3f7b6dc869f0206da4463f416
-generated: 2019-06-10T03:49:39.586867315Z
+  version: 6.5.1
+digest: sha256:98f8faaf456130a5ab8958a3f87b17ea1eed6a40f39fdbf1ee50c3d295ede5ef
+generated: "2019-06-18T06:30:43.394329433Z"

--- a/stable/phabricator/requirements.yaml
+++ b/stable/phabricator/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 5.x.x
+  version: 6.x.x
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/phabricator/values.yaml
+++ b/stable/phabricator/values.yaml
@@ -93,6 +93,8 @@ mariadb:
   ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
   ##
   master:
+    ## Disable local_infile for MariaDB: https://secure.phabricator.com/T13238
+    extraFlags: "--local-infile=0"
     persistence:
       enabled: true
       ## mariadb data Persistent Volume Storage Class


### PR DESCRIPTION
Signed-off-by: Gonzalo Gomez <gonzalo@bitnami.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Set default `mariadb.master.extraFlags` value to remove a Phabricator warning related to MySQL.


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
