### PR TITLE
[stable/spark-history-server] Fix notes

### DIFF
--- a/stable/spark-history-server/Chart.yaml
+++ b/stable/spark-history-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: spark-history-server
-version: 1.0.0
+version: 1.0.1
 appVersion: 2.4.0
 description: A Helm chart for Spark History Server
 home: https://spark.apache.org

--- a/stable/spark-history-server/templates/NOTES.txt
+++ b/stable/spark-history-server/templates/NOTES.txt
@@ -13,6 +13,6 @@ Get the application URL by running the following commands. Note that the UI woul
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
     Note: If on OpenShift, change to the chart namespace before running the command below.'
-  kubectl port-forward $POD_NAME 8080:80
+  kubectl port-forward $POD_NAME 8080:18080
     Now visit http://127.0.0.1:8080 to use your application.'
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Maxime NANNAN <maxime.nannan@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
The NOTES displayed by helm are not providing the right port in `kubectl port-forward $POD_NAME 8080:80` command to access the `spark-history-server` when running it in `ClusterIP` mode. There is a mistake in the port number.
The command should be `kubectl port-forward $POD_NAME 8080:18080` because the `spark-server-history` is exposed on the port `18080`. 

#### Which issue this PR fixes
  - fixes #14881 

#### Special notes for your reviewer:
@yuchaoran2011 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
