### PR TITLE
[incubator/zookeeper] Setting maximum headless service name length

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 1.3.2
+version: 1.3.3
 appVersion: 3.4.10
 description: Centralized service for maintaining configuration information, naming,
   providing distributed synchronization, and providing group services.

--- a/incubator/zookeeper/templates/_helpers.tpl
+++ b/incubator/zookeeper/templates/_helpers.tpl
@@ -30,3 +30,17 @@ Create chart name and version as used by the chart label.
 {{- define "zookeeper.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+The name of the zookeeper headless service.
+*/}}
+{{- define "zookeeper.headless" -}}
+{{- printf "%s-headless" (include "zookeeper.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+The name of the zookeeper chroots job.
+*/}}
+{{- define "zookeeper.chroots" -}}
+{{- printf "%s-chroots" (include "zookeeper.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/zookeeper/templates/job-chroots.yaml
+++ b/incubator/zookeeper/templates/job-chroots.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "zookeeper.fullname" . }}-chroots
+  name: {{ template "zookeeper.chroots" . }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"

--- a/incubator/zookeeper/templates/service-headless.yaml
+++ b/incubator/zookeeper/templates/service-headless.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "zookeeper.fullname" . }}-headless
+  name: {{ template "zookeeper.headless" . }}
   labels:
     app: {{ template "zookeeper.name" . }}
     chart: {{ template "zookeeper.chart" . }}

--- a/incubator/zookeeper/templates/statefulset.yaml
+++ b/incubator/zookeeper/templates/statefulset.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
     component: server
 spec:
-  serviceName: {{ template "zookeeper.fullname" . }}-headless
+  serviceName: {{ template "zookeeper.headless" . }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:


### PR DESCRIPTION
#### What this PR does / why we need it:
Using a long fullnameOverride the headless service name can exceed the maximum of 63 allowed characters, because it is currently just appending `-headless` to the end of the fullname.

This pr trims the extra characters in order for the service to have a valid name.

#### Which issue this PR fixes
  - fixes #14771

#### Special notes for your reviewer:
If the fullnameOverride is greater than 63 characters on it's own, the normal service and the headless service will have the same name. Is that something we should protect against?

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
