### PR TITLE
[stable/jenkins] Update affinity for a backup cronjob

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.3.0
+version: 1.3.1
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/jenkins-backup-cronjob.yaml
+++ b/stable/jenkins/templates/jenkins-backup-cronjob.yaml
@@ -49,20 +49,22 @@ spec:
             resources:
 {{ toYaml . | indent 14 }}
           {{- end }}
-        affinity:
-          podAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                - key: "app.kubernetes.io/name"
-                  operator: In
-                  values:
-                  - "{{ template "jenkins.name" . }}"
-                - key: "app.kubernetes.io/instance"
-                  operator: In
-                  values:
-                  - "{{ .Release.Name }}"
-              topologyKey: "kubernetes.io/hostname"
+          affinity:
+            podAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  topologyKey: "kubernetes.io/hostname"
+                  labelSelector:
+                    matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                      - {{ template "jenkins.fullname" . }}
+                    - key: release
+                      operator: In
+                      values:
+                      - {{ .Release.Name }}
       {{- with .Values.tolerations }}
         tolerations:
 {{ toYaml . | indent 10 }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Current version not pass validation: 

```
UPGRADE FAILED
Error: error validating "": error validating data: ValidationError(CronJob.spec.jobTemplate.spec.template): unknown field "affinity" in io.k8s.api.core.v1.PodTemplateSpec
Error: UPGRADE FAILED: error validating "": error validating data: ValidationError(CronJob.spec.jobTemplate.spec.template): unknown field "affinity" in io.k8s.api.core.v1.PodTemplateSpec
```

#### Which issue this PR fixes
Fixes:
1) move affinity inside a pod spec
2) add podAffinityTerm and weight for preferred mode.

#### Special notes for your reviewer:

https://kubernetes.io/docs/concepts/configuration/assign-pod-node/

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
