### PR TITLE
[stable/rabbitmq-ha]  issue #14888

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.15
-version: 1.27.2
+version: 1.27.3
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/templates/service.yaml
+++ b/stable/rabbitmq-ha/templates/service.yaml
@@ -22,7 +22,7 @@ metadata:
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
 spec:
-{{- if ne .Values.service.type "NodePort" }}
+{{- if and (ne .Values.service.type "NodePort") (and (ne .Values.service.type "LoadBalancer") (eq .Values.service.clusterIP  "None")) }}
   clusterIP: "{{ .Values.service.clusterIP }}"
 {{- end }}
 {{- if .Values.service.externalIPs }}

--- a/stable/rabbitmq-ha/templates/service.yaml
+++ b/stable/rabbitmq-ha/templates/service.yaml
@@ -22,7 +22,7 @@ metadata:
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
 spec:
-{{- if and (ne .Values.service.type "NodePort") (and (ne .Values.service.type "LoadBalancer") (eq .Values.service.clusterIP  "None")) }}
+{{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}
   clusterIP: "{{ .Values.service.clusterIP }}"
 {{- end }}
 {{- if .Values.service.externalIPs }}


### PR DESCRIPTION
Allow for no ClusterIP to be set when using service type LoadBalancer.
Passing None results in an error but leaving the clusterIP unset works.

Signed-off-by: Steve Singer <ssinger@ca.afilias.info>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Add support for rabbitmq-ha LoadBalancer with no ClusterIP

#### Which issue this PR fixes


- Fixes #14888 

#### Special notes for your reviewer:

#### Checklist

- [X ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ X] Chart Version bumped
- [ X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
