### PR TITLE
[stable/grafana] Update grafana version to 6.2.4.

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: grafana
-version: 3.5.3
-appVersion: 6.2.3
+version: 3.5.4
+appVersion: 6.2.4
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -38,7 +38,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `securityContext`                         | Deployment securityContext                    | `{"runAsUser": 472, "fsGroup": 472}`                    |
 | `priorityClassName`                       | Name of Priority Class to assign pods         | `nil`                                                   |
 | `image.repository`                        | Image repository                              | `grafana/grafana`                                       |
-| `image.tag`                               | Image tag. (`Must be >= 5.0.0`)               | `6.2.3`                                                 |
+| `image.tag`                               | Image tag. (`Must be >= 5.0.0`)               | `6.2.4`                                                 |
 | `image.pullPolicy`                        | Image pull policy                             | `IfNotPresent`                                          |
 | `image.pullSecrets`                       | Image pull secrets                            | `{}`                                                    |
 | `service.type`                            | Kubernetes service type                       | `ClusterIP`                                             |

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -36,7 +36,7 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 6.2.3
+  tag: 6.2.4
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
@maorfr @zanhsieh @rtluckie 

#### What this PR does / why we need it:
Grafana 6.2.3 was removed from Docker after this issue was discovered: https://github.com/grafana/grafana/issues/17613

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
