### PR TITLE
[stable/datadog] Make name of dogstatsd socket configurable

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.31.2
+version: 1.31.3
 appVersion: 6.10.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -245,6 +245,7 @@ helm install --name <RELEASE_NAME> \
 | `datadog.useCriSocketVolume`             | Enable mounting the container runtime socket in Agent containers                          | `True`                                      |
 | `datadog.dogstatsdOriginDetection`       | Enable origin detection for container tagging                                             | `False`                                     |
 | `datadog.useDogStatsDSocketVolume`       | Enable dogstatsd over Unix Domain Socket                                                  | `False`                                     |
+| `datadog.dogStatsDSocketPath`            | Path to the DogStatsD socket                                                              | `/var/run/datadog/dsd.socket`               |
 | `datadog.volumes`                        | Additional volumes for the daemonset or deployment                                        | `nil`                                       |
 | `datadog.volumeMounts`                   | Additional volumeMounts for the daemonset or deployment                                   | `nil`                                       |
 | `datadog.podAnnotationsAsTags`           | Kubernetes Annotations to Datadog Tags mapping                                            | `nil`                                       |

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -245,7 +245,7 @@ helm install --name <RELEASE_NAME> \
 | `datadog.useCriSocketVolume`             | Enable mounting the container runtime socket in Agent containers                          | `True`                                      |
 | `datadog.dogstatsdOriginDetection`       | Enable origin detection for container tagging                                             | `False`                                     |
 | `datadog.useDogStatsDSocketVolume`       | Enable dogstatsd over Unix Domain Socket                                                  | `False`                                     |
-| `datadog.dogStatsDSocketPath`            | Path to the DogStatsD socket                                                              | `/var/run/datadog/dsd.socket`               |
+| `datadog.dogStatsDSocketPath`            | Custom path to the socket, has to be located in the `/var/run/datadog` folder path        | `/var/run/datadog/dsd.socket`               |
 | `datadog.volumes`                        | Additional volumes for the daemonset or deployment                                        | `nil`                                       |
 | `datadog.volumeMounts`                   | Additional volumeMounts for the daemonset or deployment                                   | `nil`                                       |
 | `datadog.podAnnotationsAsTags`           | Kubernetes Annotations to Datadog Tags mapping                                            | `nil`                                       |

--- a/stable/datadog/templates/container-agent.yaml
+++ b/stable/datadog/templates/container-agent.yaml
@@ -96,7 +96,7 @@
     {{- end }}
     {{- if .Values.datadog.useDogStatsDSocketVolume }}
     - name: DD_DOGSTATSD_SOCKET
-      value: "/var/run/datadog/dsd.socket"
+      value: {{ default "/var/run/datadog/dsd.socket" .Values.datadog.dogStatsDSocketPath | quote }}
     {{- end }}
     {{- if and .Values.clusterAgent.clusterChecks.enabled  (not .Values.clusterchecksDeployment.enabled) }}
     - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/stable/datadog/templates/container-agents.yaml
+++ b/stable/datadog/templates/container-agents.yaml
@@ -131,7 +131,7 @@
     {{- end }}
     {{- if .Values.datadog.useDogStatsDSocketVolume }}
     - name: DD_DOGSTATSD_SOCKET
-      value: "/var/run/datadog/dsd.socket"
+      value: {{ default "/var/run/datadog/dsd.socket" .Values.datadog.dogStatsDSocketPath | quote }}
     {{- end }}
     {{- if and .Values.clusterAgent.clusterChecks.enabled  (not .Values.clusterchecksDeployment.enabled) }}
     - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -94,7 +94,7 @@ spec:
           {{- end }}
           {{- if .Values.datadog.useDogStatsDSocketVolume }}
           - name: DD_DOGSTATSD_SOCKET
-            value: "/var/run/datadog/dsd.socket"
+            value: {{ default "/var/run/datadog/dsd.socket" .Values.datadog.dogStatsDSocketPath | quote }}
           {{- end }}
 {{- if .Values.datadog.env }}
 {{ toYaml .Values.datadog.env | indent 10 }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -252,6 +252,11 @@ datadog:
   #
   # criSocketPath: /var/run/containerd/containerd.sock
 
+  ## @param dogStatsDSocketPath - string - optional
+  ## Path to the DogStatsD socket
+  #
+  # dogStatsDSocketPath: /var/run/datadog/dsd.socket
+
   ## @param livenessProbe - object - optional
   ## Override the agent's liveness probe logic from the default:
   ## In case of issues with the probe, you can disable it with the


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Before https://github.com/helm/charts/pull/13088, I used `values.yaml` like this to enable DogStatsD via Unix domain socket:

```yaml
datadog:
  env:
    # To be be able to send metrics via unix domain socket
    - name: DD_DOGSTATSD_SOCKET
      value: /var/run/datadog/dogstatsd.socket
  volumes:
    - hostPath:
        path: /var/run/datadog/
      name: dsdsocket
  volumeMounts:
    - mountPath: /var/run/datadog
      name: dsdsocket
```

And with https://github.com/helm/charts/pull/13088, the path of Unix domain socket of DogStatsD is fixed as `/var/run/datadog/dsd.socket`.
It's different from which I used to specify with `DD_DOGSTATSD_SOCKET` (dogstatsd.socket).

Not to break existing applications referring dogstatsd.socket, I'd like to make it configurable.

#### Which issue this PR fixes

There is no issue for it.

#### Special notes for your reviewer:

Tested with `helm template`:

##### Case 1: Without `dogStatsDSocketPath`

Input:

```yaml
datadog:
  useDogStatsDSocketVolume: true
```

Output:

```
$ helm template ./stable/datadog -f values.yaml -n datadog | grep -C 1 socket
            - name: DD_DOGSTATSD_SOCKET
              value: "/var/run/datadog/dsd.socket"
...
```

#### Case 2: With `dogStatsDSocketPath`

Input:

```yaml
datadog:
  useDogStatsDSocketVolume: true
  dogStatsDSocketPath: /var/run/datadog/dogstatsd.socket
```

Output:

```
$ helm template ./stable/datadog -f values.yaml -n datadog | grep -C 1 socket
            - name: DD_DOGSTATSD_SOCKET
              value: "/var/run/datadog/dogstatsd.socket"
...
```

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
