### PR TITLE
[stable/drone] Fix extraContainers indentation

### DIFF
--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 2.0.2
+version: 2.0.3
 appVersion: 1.1.0
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/stable/drone/templates/deployment-server.yaml
+++ b/stable/drone/templates/deployment-server.yaml
@@ -117,7 +117,7 @@ spec:
         - name: data
           mountPath: /var/lib/drone
 {{- with .Values.server.extraContainers }}
-{{ tpl . $ | indent 10 }}
+{{ tpl . $ | indent 6 }}
 {{- end }}
       volumes:
       {{ if eq .Values.sourceControl.provider "bitbucketServer" -}}


### PR DESCRIPTION
Reverts indentation change from https://github.com/helm/charts/pull/14306
so that `extraContainers` can be overridden like this

```yaml
server:
  extraContainers: |
    - name: extra-container
      image: "docker.io/some/image:1.0"
      imagePullPolicy: IfNotPresent
```

If you run `helm template` with this configuration you will get a `container` section like this

```yaml
containers:
- name: server
  image: "docker.io/drone/drone:1.1.0"
  imagePullPolicy: IfNotPresent
<...>
- name: extra-container
  image: "docker.io/some/image:1.0"
  imagePullPolicy: IfNotPresent
```

This has the correct indentation, and deploys correctly.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
