### PR TITLE
[stable/rabbitmq] Added support for advanced.config file

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.1.0
+version: 6.1.1
 appVersion: 3.7.15
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -73,6 +73,7 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `rabbitmq.onlineSchedulers`          | RabbitMQ online scheduler threads                | `1`                                                     |
 | `rabbitmq.configuration`             | Required cluster configuration                   | See values.yaml                                         |
 | `rabbitmq.extraConfiguration`        | Extra configuration to add to rabbitmq.conf      | See values.yaml                                         |
+| `rabbitmq.advancedConfiguration`     | Extra configuration (in classic format) to add to advanced.config    | See values.yaml                                         |
 | `service.type`                       | Kubernetes Service type                          | `ClusterIP`                                             |
 | `service.port`                       | Amqp port                                        | `5672`                                                  |
 | `service.distPort`                   | Erlang distribution server port                  | `25672`                                                 |

--- a/stable/rabbitmq/templates/configuration.yaml
+++ b/stable/rabbitmq/templates/configuration.yaml
@@ -16,3 +16,7 @@ data:
     default_pass=CHANGEME
 {{ .Values.rabbitmq.configuration | indent 4 }}
 {{ .Values.rabbitmq.extraConfiguration | indent 4 }}
+{{ if .Values.rabbitmq.advancedConfiguration}}
+  advanced.config: |-
+{{ .Values.rabbitmq.advancedConfiguration | indent 4 }}
+{{ end }}   

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -263,6 +263,10 @@ spec:
             items:
             - key: rabbitmq.conf
               path: rabbitmq.conf
+        {{- if .Values.rabbitmq.advancedConfiguration}}
+            - key: advanced.config
+              path: advanced.config
+        {{- end }}      
             - key: enabled_plugins
               path: enabled_plugins
         {{- if .Values.rabbitmq.loadDefinition.enabled }}

--- a/stable/rabbitmq/values-production.yaml
+++ b/stable/rabbitmq/values-production.yaml
@@ -111,7 +111,7 @@ rabbitmq:
     secretName: load-definition
 
   ## Configuration file content: required cluster configuration
-  ## Do not override unless you know what you are doing. To add more configuration, use `extraConfiguration` instead
+  ## Do not override unless you know what you are doing. To add more configuration, use `extraConfiguration` of `advancedConfiguration` instead
   configuration: |-
     ## Clustering
     cluster_formation.peer_discovery_backend  = rabbit_peer_discovery_k8s
@@ -129,6 +129,10 @@ rabbitmq:
   extraConfiguration: |-
     #disk_free_limit.absolute = 50MB
     #management.load_definitions = /app/load_definition.json
+    
+  ## Configuration file content: advanced configuration
+  ## Use this as additional configuraton in classic config format (Erlang term configuration format) 
+  advancedConfiguration: |-
 
 ## Kubernetes service type
 service:

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -111,7 +111,7 @@ rabbitmq:
     secretName: load-definition
 
   ## Configuration file content: required cluster configuration
-  ## Do not override unless you know what you are doing. To add more configuration, use `extraConfiguration` instead
+  ## Do not override unless you know what you are doing. To add more configuration, use `extraConfiguration` of `advancedConfiguration` instead
   configuration: |-
     ## Clustering
     cluster_formation.peer_discovery_backend  = rabbit_peer_discovery_k8s
@@ -129,6 +129,11 @@ rabbitmq:
   extraConfiguration: |-
     #disk_free_limit.absolute = 50MB
     #management.load_definitions = /app/load_definition.json
+  
+  ## Configuration file content: advanced configuration
+  ## Use this as additional configuraton in classic config format (Erlang term configuration format) 
+  advancedConfiguration: |-
+  
 
 ## Kubernetes service type
 service:

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -129,11 +129,10 @@ rabbitmq:
   extraConfiguration: |-
     #disk_free_limit.absolute = 50MB
     #management.load_definitions = /app/load_definition.json
-  
+
   ## Configuration file content: advanced configuration
-  ## Use this as additional configuraton in classic config format (Erlang term configuration format) 
+  ## Use this as additional configuraton in classic config format (Erlang term configuration format)
   advancedConfiguration: |-
-  
 
 ## Kubernetes service type
 service:


### PR DESCRIPTION
Signed-off-by: Radek Hodain <radek.hodain@konicaminolta.cz>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
I added support for classic style configuration advanced.config (described here: https://www.rabbitmq.com/configure.html#config-file-formats), which can be placed next to the new style config file rabbitmq.conf and allows easily config eg. LDAP which is in the new style impossible.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
