### PR TITLE
[stable/prometheus-blackbox-exporter] Add support for imagePullSecrets

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 0.3.0
+version: 0.4.0
 appVersion: 0.14.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/README.md
+++ b/stable/prometheus-blackbox-exporter/README.md
@@ -56,6 +56,7 @@ The following table lists the configurable parameters of the Blackbox-Exporter c
 | `image.repository`                     | container image repository                        | `prom/blackbox-exporter`      |
 | `image.tag`                            | container image tag                               | `v0.14.0`                     |
 | `image.pullPolicy`                     | container image pull policy                       | `IfNotPresent`                |
+| `image.pullSecrets`                    | container image pull secrets                      | `[]`                          |
 | `ingress.annotations`                  | Ingress annotations                               | None                          |
 | `ingress.enabled`                      | Enables Ingress                                   | `false`                       |
 | `ingress.hosts`                        | Ingress accepted hostnames                        | None                          |

--- a/stable/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -38,6 +38,12 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 6 }}
     {{- end }}
+    {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
 
       restartPolicy: {{ .Values.restartPolicy }}
       containers:

--- a/stable/prometheus-blackbox-exporter/values.yaml
+++ b/stable/prometheus-blackbox-exporter/values.yaml
@@ -5,6 +5,13 @@ image:
   tag: v0.14.0
   pullPolicy: IfNotPresent
 
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistrKeySecretName
+
 nodeSelector: {}
 tolerations: []
 affinity: {}


### PR DESCRIPTION
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)

This PR adds support for using an image pull secret.