### PR TITLE
[stable/kibana] Add env variables evaluation as templates

### DIFF
--- a/stable/kibana/Chart.yaml
+++ b/stable/kibana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kibana
-version: 3.1.1
+version: 3.1.0
 appVersion: 6.7.0
 description: Kibana is an open source data visualization plugin for Elasticsearch
 icon: https://raw.githubusercontent.com/elastic/kibana/master/src/ui/public/icons/kibana-color.svg

--- a/stable/kibana/Chart.yaml
+++ b/stable/kibana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kibana
-version: 3.1.0
+version: 3.2.0
 appVersion: 6.7.0
 description: Kibana is an open source data visualization plugin for Elasticsearch
 icon: https://raw.githubusercontent.com/elastic/kibana/master/src/ui/public/icons/kibana-color.svg

--- a/stable/kibana/templates/deployment.yaml
+++ b/stable/kibana/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       initContainers:
 {{- if .Values.initContainers }}
 {{- range $key, $value := .Values.initContainers }}
-      - name: "{{ $key }}"
+      - name: {{ $key | quote }}
 {{ toYaml $value | indent 8 }}
 {{- end }}
 {{- end }}
@@ -53,8 +53,8 @@ spec:
 {{- end }}
         env:
         {{- range $key, $value := .Values.env }}
-        - name: "{{ $key }}"
-          value: "{{ $value }}"
+        - name: {{ $key | quote }}
+          value: {{ tpl $value | quote }}"
         {{- end }}
         volumeMounts:
         - name: {{ template "kibana.fullname" . }}-dashboards
@@ -108,8 +108,8 @@ spec:
             done
         env:
         {{- range $key, $value := .Values.env }}
-        - name: "{{ $key }}"
-          value: "{{ $value }}"
+        - name: {{ $key | quote }}
+          value: {{ tpl $value | quote }}"
         {{- end }}
         volumeMounts:
         - name: plugins
@@ -137,8 +137,8 @@ spec:
         {{- end }}
         env:
         {{- range $key, $value := .Values.env }}
-        - name: "{{ $key }}"
-          value: "{{ $value }}"
+        - name: {{ $key | quote }}
+          value: {{ tpl $value | quote }}"
         {{- end }}
 {{- if .Values.envFromSecrets }}
         {{- range $key,$value := .Values.envFromSecrets }}


### PR DESCRIPTION
Process environment variables as templates. Useful for passing endpoints from other services from 
parent chart.

Use case:
```yaml
kibana:
  env:
    ELASTICSEARCH_HOSTS: http://{{ .Release.Name }}-elasticsearch-client:9200

```

Fix:
- #6674
- #14445 
- #7114