### PR TITLE
[stable/elastic-stack] Fix elasticsearch URL

### DIFF
--- a/stable/elastic-stack/Chart.yaml
+++ b/stable/elastic-stack/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart for ELK
 home: https://www.elastic.co/products
 icon: https://www.elastic.co/assets/bltb35193323e8f1770/logo-elastic-stack-lt.svg
 name: elastic-stack
-version: 1.7.0
+version: 1.8.0
 appVersion: 6.0
 maintainers:
 - name: rendhalver

--- a/stable/elastic-stack/requirements.lock
+++ b/stable/elastic-stack/requirements.lock
@@ -1,22 +1,22 @@
 dependencies:
 - name: elasticsearch
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.25.0
+  version: 1.29.0
 - name: kibana
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 2.2.0
+  version: 3.2.1
 - name: filebeat
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 1.7.0
 - name: logstash
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.7.0
+  version: 1.13.0
 - name: fluentd
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.7.0
+  version: 1.10.0
 - name: fluent-bit
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.9.2
+  version: 1.10.3
 - name: fluentd-elasticsearch
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 2.0.7
@@ -25,9 +25,9 @@ dependencies:
   version: 0.1.2
 - name: elasticsearch-curator
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.4.0
+  version: 1.5.0
 - name: elasticsearch-exporter
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.2.0
-digest: sha256:107df51a0edf329067cb8a9a40b819ee301a8bc7c937b3f2e451f09170839c34
-generated: 2019-04-23T11:34:27.266960592+04:00
+  version: 1.4.1
+digest: sha256:21398a637cab285405e7a72c1f0ce3bc7c98ac41a9ccd125a27f7389503f4f7d
+generated: "2019-06-25T12:04:09.841215-07:00"

--- a/stable/elastic-stack/requirements.yaml
+++ b/stable/elastic-stack/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: elasticsearch.enabled
 - name: kibana
-  version: ^2.2.0
+  version: ^3.0.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: kibana.enabled
 - name: filebeat

--- a/stable/elastic-stack/values.yaml
+++ b/stable/elastic-stack/values.yaml
@@ -7,7 +7,7 @@ elasticsearch:
 kibana:
   enabled: true
   env:
-    ELASTICSEARCH_URL: http://http.default.svc.cluster.local:9200
+    ELASTICSEARCH_HOSTS: http://{{ .Release.Name }}-elasticsearch-client:9200
 
 logstash:
   enabled: true


### PR DESCRIPTION
- Update `ELASTICSEARCH_URL` to `ELASTICSEARCH_HOSTS`. `ELASTICSEARCH_URL` is deprecated for kibana `> 6.6`
- Set `ELASTICSEARCH_HOSTS` as a template
- Bump kibana chart version

This pull request is related to #14905 

Fix:
- #6674
- #14445 
- #7114

Edit:
Since `requirements.lock` strictly bind this chart to a specific dependency version, please wait until #14905 will be merged. Required changed are NOT in kibana upstream yet.

