### PR TITLE
[stable/logstash] Supporting secret references for environment vars

### DIFF
--- a/stable/logstash/Chart.yaml
+++ b/stable/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 2.1.0
+version: 2.2.0
 appVersion: 7.1.1
 sources:
 - https://www.docker.elastic.co

--- a/stable/logstash/README.md
+++ b/stable/logstash/README.md
@@ -100,6 +100,9 @@ The following table lists the configurable parameters of the chart and its defau
 | `podAnnotations`                | Pod annotations                                    | `{}`                                             |
 | `podLabels`                     | Pod labels                                         | `{}`                                             |
 | `extraEnv`                      | Extra pod environment variables                    | `[]`                                             |
+| `extraEnvSecrets`               | Environment variables from secrets to the cronjob container | {}                                      |
+| `extraEnvSecrets.*.from.secret` | - `secretKeyRef.name` used for environment variable         |                                         |
+| `extraEnvSecrets.*.from.key`    | - `secretKeyRef.key` used for environment variable          |                                         |
 | `extraInitContainers`           | Add additional initContainers                      | `[]`                                             |
 | `podManagementPolicy`           | podManagementPolicy of the StatefulSet             | `OrderedReady`                                   |
 | `livenessProbe`                 | Liveness probe settings for logstash container     | (see `values.yaml`)                              |

--- a/stable/logstash/templates/statefulset.yaml
+++ b/stable/logstash/templates/statefulset.yaml
@@ -92,6 +92,15 @@ spec:
           {{- if .Values.extraEnv }}
 {{ .Values.extraEnv | toYaml | indent 12 }}
           {{- end }}
+          {{- if .Values.extraEnvSecrets }}
+          {{- range $key,$value := .Values.extraEnvSecrets }}
+            - name: {{ $key | upper | quote}}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $value.from.secret | quote}}
+                  key: {{ $value.from.key | quote}}
+          {{- end }}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds support to use secrets in environment variables.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)

Signed-off-by: Endre Czirbesz <endre.czirbesz@rungway.com>
