### PR TITLE
[stable/cockroachdb] adds resources stanza to cockroach init pod

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 2.1.10
+version: 2.1.11
 appVersion: 19.1.2
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -167,7 +167,7 @@ The following table lists the configurable parameters of the CockroachDB chart a
 | ------------------------------ | ------------------------------------------------ | ----------------------------------------- |
 | `Name`                         | Chart name                                       | `cockroachdb`                             |
 | `Image`                        | Container image name                             | `cockroachdb/cockroach`                   |
-| `ImageTag`                     | Container image tag                              | `v19.1.2`                                  |
+| `ImageTag`                     | Container image tag                              | `v19.1.2`                                 |
 | `ImagePullPolicy`              | Container pull policy                            | `Always`                                  |
 | `Replicas`                     | k8s statefulset replicas                         | `3`                                       |
 | `MaxUnavailable`               | k8s PodDisruptionBudget parameter                | `1`                                       |
@@ -180,7 +180,8 @@ The following table lists the configurable parameters of the CockroachDB chart a
 | `ExternalHttpPort`             | CockroachDB HTTP port on service                 | `8080`                                    |
 | `HttpName`                     | Name given to the http service port              | `http`                                    |
 | `Resources`                    | Resource requests and limits                     | `{}`                                      |
-| `Storage`                      | Persistent volume size                           | `100Gi`                                     |
+| `InitPodResources`             | Resource requests and limits for the short-lived init pod | `{}`                             |
+| `Storage`                      | Persistent volume size                           | `100Gi`                                   |
 | `StorageClass`                 | Persistent volume class                          | `null`                                    |
 | `CacheSize`                    | Size of CockroachDB's in-memory cache            | `25%`                                     |
 | `MaxSQLMemory`                 | Max memory to use processing SQL queries         | `25%`                                     |

--- a/stable/cockroachdb/templates/cluster-init.yaml
+++ b/stable/cockroachdb/templates/cluster-init.yaml
@@ -48,6 +48,8 @@ spec:
       - name: cluster-init
         image: "{{ .Values.Image }}:{{ .Values.ImageTag }}"
         imagePullPolicy: "{{ .Values.ImagePullPolicy }}"
+        resources:
+{{ toYaml .Values.InitPodResources | indent 10 }}
 {{- if .Values.Secure.Enabled }}
         volumeMounts:
         - name: client-certs

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -29,6 +29,18 @@ Resources: {}
   # requests:
   #   cpu: "100m"
   #   memory: "512Mi"
+# The init pod runs at cluster creation to initialize CockroachDB. It finishes
+# quickly and doesn't continue to consume resources in the Kubernetes
+# cluster. Normally, you should leave this section commented out, but if your
+# Kubernetes cluster uses Resource Quotas and requires all pods to specify
+# resource requests or limits, you can set those here.
+InitPodResources: {}
+  # requests:
+  #   cpu: "10m"
+  #   memory: "128Mi"
+  # limits:
+  #   cpu: "10m"
+  #   memory: "128Mi"
 Storage: "100Gi"
 ## Persistent Volume Storage Class for database data
 ## If defined, storageClassName: <StorageClass>


### PR DESCRIPTION
Previously, this chart was not deployable in a Kubernetes namespace with
[Resource Quotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/)
enabled. A user could set resource limits on the CRDB pods, but not on the
short-lived pod that is part of the cockroachdb-init job. This adds an
additional resource configuration to that pod spec to allow this chart to be
deployed when Resource Quotas are enabled.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
