### PR TITLE
[stable/rabbitmq-ha] Add forceBoot

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.15
-version: 1.27.2
+version: 1.28.0
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:
@@ -18,4 +18,3 @@ sources:
 - https://github.com/docker-library/rabbitmq
 maintainers:
 - name: steven-sheehy
-  email: ssheehy@firescope.com

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -79,6 +79,7 @@ and their default values.
 | `definitions.bindings`                         | Pre-created bindings | `""` |
 | `definitions.policies`                         | HA policies to add to definitions.json | `""` |
 | `definitionsSource`                            | Use this key within an existing secret to reference the definitions specification | `"definitions.json"` |
+| `forceBoot`                                    | [Force](https://www.rabbitmq.com/rabbitmqctl.8.html#force_boot) the cluster to start even if it was shutdown in an unexpected order, preferring availability over integrity | `false` |
 | `image.pullPolicy`                             | Image pull policy                                                                                                                                                                                     | `IfNotPresent`   |
 | `image.repository`                             | RabbitMQ container image repository                                                                                                                                                                   | `rabbitmq`                                                 |
 | `image.tag`                                    | RabbitMQ container image tag                                                                                                                                                                          | `3.7.15-alpine`                                            |

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -44,10 +44,29 @@ spec:
 {{ toYaml .Values.securityContext | indent 10 }}
       serviceAccountName: {{ template "rabbitmq-ha.serviceAccountName" . }}
       initContainers:
-        - name: copy-rabbitmq-config
+        - name: bootstrap
           image: {{ .Values.busyboxImage.repository}}:{{ .Values.busyboxImage.tag}}
           imagePullPolicy: {{ .Values.busyboxImage.pullPolicy }}
-          command: ['sh', '-c', 'cp /configmap/* /etc/rabbitmq; rm -f /var/lib/rabbitmq/.erlang.cookie']
+          command: ['sh']
+          args:
+          - "-c"
+          - |
+            set -ex
+            cp /configmap/* /etc/rabbitmq
+            rm -f /var/lib/rabbitmq/.erlang.cookie
+            {{- if .Values.forceBoot }}
+            if [ -d "${RABBITMQ_MNESIA_DIR}" ]; then
+              touch "${RABBITMQ_MNESIA_DIR}/force_load"
+            fi
+            {{- end }}
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: RABBITMQ_MNESIA_DIR
+            value: /var/lib/rabbitmq/mnesia/rabbit@$(POD_NAME).{{ template "rabbitmq-ha.fullname" . }}-discovery.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
           resources:
 {{ toYaml .Values.initContainer.resources | indent 12 }}
           volumeMounts:

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -105,6 +105,8 @@ definitions:
 #      }
 #    }
 
+## Ref: https://www.rabbitmq.com/rabbitmqctl.8.html#force_boot
+forceBoot: false
 
 ## RabbitMQ default VirtualHost
 ## Ref: https://www.rabbitmq.com/vhosts.html


### PR DESCRIPTION
#### What this PR does / why we need it:
Similar to what was added for the rabbitmq chart in #14149, this adds a [`forceBoot`](https://www.rabbitmq.com/rabbitmqctl.8.html#force_boot) option. Force boot will ensure that clusters that are brought down in an unexpected order (or all at once) won't get the dreaded `Waiting for mnesia tables` error and restart repeatedly. By writing the `force_load` file, rabbitmq will ignore the shutdown order when starting up and prefer availability over integrity. By default it is disabled to be backwards compatible with the old approach.

#### Which issue this PR fixes
There have been various issues for this in the past, but none that are open.

#### Special notes for your reviewer:
I removed my email as I'm switching jobs and I would prefer not to be spammed anymore.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
