### PR TITLE
[incubator/couchdb] Promote CouchDB chart to stable

### DIFF
--- a/incubator/couchdb/Chart.yaml
+++ b/incubator/couchdb/Chart.yaml
@@ -1,15 +1,13 @@
 apiVersion: v1
 name: couchdb
-version: 1.2.2
+# The CouchDB chart has been promoted to stable and so the incubator
+# version is deprecated.
+deprecated: true
+version: 1.3.0
 appVersion: 2.3.1
-description: A database featuring seamless multi-master sync, that scales from
-  big data to mobile, with an intuitive HTTP/JSON API and designed for
-  reliability.
+description: DEPRECATED see stable version of chart
 home: https://couchdb.apache.org/
 sources:
   - https://github.com/apache/couchdb
   - https://github.com/kocolosk/couchdb-statefulset-assembler
-maintainers:
-  - name: kocolosk
-    email: kocolosk@apache.org
 icon: http://couchdb.apache.org/CouchDB-visual-identity/logo/CouchDB-couch-symbol.svg

--- a/incubator/couchdb/README.md
+++ b/incubator/couchdb/README.md
@@ -1,5 +1,8 @@
 # CouchDB
 
+This chart has been promoted to stable, so the version in the incubator is now
+deprecated.
+
 Apache CouchDB is a database featuring seamless multi-master sync, that scales
 from big data to mobile, with an intuitive HTTP/JSON API and designed for
 reliability.

--- a/incubator/couchdb/templates/NOTES.txt
+++ b/incubator/couchdb/templates/NOTES.txt
@@ -17,4 +17,5 @@ some required system databases:
     -u <adminUsername>
 {{- end }}
 
-Then it's time to relax.
+NOTE: This version of the CouchDB chart is deprecated; please use the one from
+the stable Helm repository instead of the incubator.

--- a/stable/couchdb/.helmignore
+++ b/stable/couchdb/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/couchdb/Chart.yaml
+++ b/stable/couchdb/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+name: couchdb
+version: 1.2.2
+appVersion: 2.3.1
+description: A database featuring seamless multi-master sync, that scales from
+  big data to mobile, with an intuitive HTTP/JSON API and designed for
+  reliability.
+home: https://couchdb.apache.org/
+sources:
+  - https://github.com/apache/couchdb
+  - https://github.com/kocolosk/couchdb-statefulset-assembler
+maintainers:
+  - name: kocolosk
+    email: kocolosk@apache.org
+icon: http://couchdb.apache.org/CouchDB-visual-identity/logo/CouchDB-couch-symbol.svg

--- a/stable/couchdb/Chart.yaml
+++ b/stable/couchdb/Chart.yaml
@@ -1,13 +1,17 @@
 apiVersion: v1
 name: couchdb
-version: 1.2.2
+version: 2.0.0
 appVersion: 2.3.1
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for
   reliability.
+keywords:
+  - couchdb
+  - database
+  - nosql
 home: https://couchdb.apache.org/
 sources:
-  - https://github.com/apache/couchdb
+  - https://github.com/apache/couchdb-docker
   - https://github.com/kocolosk/couchdb-statefulset-assembler
 maintainers:
   - name: kocolosk

--- a/stable/couchdb/README.md
+++ b/stable/couchdb/README.md
@@ -1,0 +1,136 @@
+# CouchDB
+
+Apache CouchDB is a database featuring seamless multi-master sync, that scales
+from big data to mobile, with an intuitive HTTP/JSON API and designed for
+reliability.
+
+This chart deploys a CouchDB cluster as a StatefulSet. It creates a ClusterIP
+Service in front of the Deployment for load balancing by default, but can also
+be configured to deploy other Service types or an Ingress Controller. The
+default persistence mechanism is simply the ephemeral local filesystem, but
+production deployments should set `persistentVolume.enabled` to `true` to attach
+storage volumes to each Pod in the Deployment.
+
+## TL;DR
+
+```bash
+$ helm install incubator/couchdb --set allowAdminParty=true
+```
+
+## Prerequisites
+
+- Kubernetes 1.8+ with Beta APIs enabled
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+$ helm install --name my-release incubator/couchdb
+```
+
+This will create a Secret containing the admin credentials for the cluster.
+Those credentials can be retrieved as follows:
+
+```bash
+$ kubectl get secret my-release-couchdb -o go-template='{{ .data.adminPassword }}' | base64 --decode
+```
+
+If you prefer to configure the admin credentials directly you can create a
+Secret containing `adminUsername`, `adminPassword` and `cookieAuthSecret` keys:
+
+```bash
+$  kubectl create secret generic my-release-couchdb --from-literal=adminUsername=foo --from-literal=adminPassword=bar --from-literal=cookieAuthSecret=baz
+```
+
+and then install the chart while overriding the `createAdminSecret` setting:
+
+```bash
+$ helm install --name my-release --set createAdminSecret=false incubator/couchdb
+```
+
+This Helm chart deploys CouchDB on the Kubernetes cluster in a default
+configuration. The [configuration](#configuration) section lists
+the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` Deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and
+deletes the release.
+
+## Upgrading an existing Release to a new major version
+
+A major chart version change (like v0.2.3 -> v1.0.0) indicates that there is an
+incompatible breaking change needing manual actions.
+
+### 1.0.0
+
+This version removes the `chart` and `heritage` labels from the
+`volumeClaimTemplates` which is immutable and prevents chart from being upgraded
+(see https://github.com/helm/charts/issues/7803 for details).
+
+In order to upgrade, delete the CouchDB StatefulSet before upgrading:
+
+```bash
+$ kubectl delete statefulsets --cascade=false my-release-couchdb
+```
+
+## Configuration
+
+The following table lists the most commonly configured parameters of the
+CouchDB chart and their default values:
+
+|           Parameter             |             Description                               |                Default                 |
+|---------------------------------|-------------------------------------------------------|----------------------------------------|
+| `clusterSize`                   | The initial number of nodes in the CouchDB cluster    | 3                                      |
+| `couchdbConfig`                 | Map allowing override elements of server .ini config  | chttpd.bind_address=any                |
+| `allowAdminParty`               | If enabled, start cluster without admin account       | false (requires creating a Secret)     |
+| `createAdminSecret`             | If enabled, create an admin account and cookie secret | true                                   |
+| `schedulerName`                 | Name of the k8s scheduler (other than default)        | `nil`                                  |
+| `erlangFlags`                   | Map of flags supplied to the underlying Erlang VM     | name: couchdb, setcookie: monster
+| `persistentVolume.enabled`      | Boolean determining whether to attach a PV to each node | false
+| `persistentVolume.size`         | If enabled, the size of the persistent volume to attach                          | 10Gi
+| `enableSearch`                  | Adds a sidecar for Lucene-powered text search         | false                                  |
+
+A variety of other parameters are also configurable. See the comments in the
+`values.yaml` file for further details:
+
+|           Parameter             |                Default                 |
+|---------------------------------|----------------------------------------|
+| `adminUsername`                 | admin                                  |
+| `adminPassword`                 | auto-generated                         |
+| `cookieAuthSecret`              | auto-generated                         |
+| `helperImage.repository`        | kocolosk/couchdb-statefulset-assembler |
+| `helperImage.tag`               | 1.2.0                                  |
+| `helperImage.pullPolicy`        | IfNotPresent                           |
+| `image.repository`              | couchdb                                |
+| `image.tag`                     | 2.3.0                                  |
+| `image.pullPolicy`              | IfNotPresent                           |
+| `searchImage.repository`        | kocolosk/couchdb-search                |
+| `searchImage.tag`               | 0.1.0                                  |
+| `searchImage.pullPolicy`        | IfNotPresent                           |
+| `initImage.repository`          | busybox                                |
+| `initImage.tag`                 | latest                                 |
+| `initImage.pullPolicy`          | Always                                 |
+| `ingress.enabled`               | false                                  |
+| `ingress.hosts`                 | chart-example.local                    |
+| `ingress.annotations`           |                                        |
+| `ingress.tls`                   |                                        |
+| `persistentVolume.accessModes`  | ReadWriteOnce                          |
+| `persistentVolume.storageClass` | Default for the Kube cluster           |
+| `podManagementPolicy`           | Parallel                               |
+| `affinity`                      |                                        |
+| `resources`                     |                                        |
+| `service.annotations`           |                                        |
+| `service.enabled`               | true                                   |
+| `service.type`                  | ClusterIP                              |
+| `service.externalPort`          | 5984                                   |

--- a/stable/couchdb/README.md
+++ b/stable/couchdb/README.md
@@ -14,7 +14,7 @@ storage volumes to each Pod in the Deployment.
 ## TL;DR
 
 ```bash
-$ helm install incubator/couchdb --set allowAdminParty=true
+$ helm install stable/couchdb --set allowAdminParty=true
 ```
 
 ## Prerequisites
@@ -26,8 +26,7 @@ $ helm install incubator/couchdb --set allowAdminParty=true
 To install the chart with the release name `my-release`:
 
 ```bash
-$ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
-$ helm install --name my-release incubator/couchdb
+$ helm install --name my-release stable/couchdb
 ```
 
 This will create a Secret containing the admin credentials for the cluster.
@@ -47,7 +46,7 @@ $  kubectl create secret generic my-release-couchdb --from-literal=adminUsername
 and then install the chart while overriding the `createAdminSecret` setting:
 
 ```bash
-$ helm install --name my-release --set createAdminSecret=false incubator/couchdb
+$ helm install --name my-release --set createAdminSecret=false stable/couchdb
 ```
 
 This Helm chart deploys CouchDB on the Kubernetes cluster in a default

--- a/stable/couchdb/templates/NOTES.txt
+++ b/stable/couchdb/templates/NOTES.txt
@@ -1,0 +1,20 @@
+Apache CouchDB is starting. Check the status of the Pods using:
+
+  kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "couchdb.name" . }},release={{ .Release.Name }}"
+
+Once all of the Pods are fully Ready, execute the following command to create
+some required system databases:
+
+  kubectl exec --namespace {{ .Release.Namespace }} {{ if not .Values.allowAdminParty }}-it {{ end }}{{ template "couchdb.fullname" . }}-0 -c couchdb -- \
+    curl -s \
+    http://127.0.0.1:5984/_cluster_setup \
+    -X POST \
+    -H "Content-Type: application/json" \
+{{- if .Values.allowAdminParty }}
+    -d '{"action": "finish_cluster"}'
+{{- else }}
+    -d '{"action": "finish_cluster"}' \
+    -u <adminUsername>
+{{- end }}
+
+Then it's time to relax.

--- a/stable/couchdb/templates/_helpers.tpl
+++ b/stable/couchdb/templates/_helpers.tpl
@@ -1,0 +1,44 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "couchdb.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "couchdb.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- printf "%s-%s" .Values.fullnameOverride .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+In the event that we create both a headless service and a traditional one,
+ensure that the latter gets a unique name.
+*/}}
+{{- define "couchdb.svcname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- printf "%s-svc-%s" .Values.fullnameOverride .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-svc-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a random string if the supplied key does not exist
+*/}}
+{{- define "couchdb.defaultsecret" -}}
+{{- if . -}}
+{{- . | b64enc | quote -}}
+{{- else -}}
+{{- randAlphaNum 20 | b64enc | quote -}}
+{{- end -}}
+{{- end -}}

--- a/stable/couchdb/templates/configmap.yaml
+++ b/stable/couchdb/templates/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "couchdb.fullname" . }}
+  labels:
+    app: {{ template "couchdb.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+data:
+  inifile: |
+    {{ range $section, $settings := .Values.couchdbConfig -}}
+    {{ printf "[%s]" $section }}
+    {{ range $key, $value := $settings -}}
+    {{ printf "%s = %s" $key ($value | toString) }}
+    {{ end }}
+    {{ end }}

--- a/stable/couchdb/templates/headless.yaml
+++ b/stable/couchdb/templates/headless.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "couchdb.fullname" . }}
+  labels:
+    app: {{ template "couchdb.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  clusterIP: None
+  ports:
+    - name: couchdb
+      port: 5984
+  selector:
+    app: {{ template "couchdb.name" . }}
+    release: {{ .Release.Name }}

--- a/stable/couchdb/templates/ingress.yaml
+++ b/stable/couchdb/templates/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "couchdb.fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "couchdb.fullname" . }}
+  labels:
+    app: {{ template "couchdb.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/stable/couchdb/templates/secrets.yaml
+++ b/stable/couchdb/templates/secrets.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.createAdminSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "couchdb.fullname" . }}
+  labels:
+    app: {{ template "couchdb.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  adminUsername: {{ template "couchdb.defaultsecret" .Values.adminUsername }}
+  adminPassword: {{ template "couchdb.defaultsecret" .Values.adminPassword }}
+  cookieAuthSecret: {{ template "couchdb.defaultsecret" .Values.cookieAuthSecret }}
+{{- end -}}

--- a/stable/couchdb/templates/service.yaml
+++ b/stable/couchdb/templates/service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "couchdb.svcname" . }}
+  labels:
+    app: {{ template "couchdb.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  ports:
+    - port: {{ .Values.service.externalPort }}
+      protocol: TCP
+      targetPort: 5984
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ template "couchdb.name" . }}
+    release: {{ .Release.Name }}
+{{- end -}}

--- a/stable/couchdb/templates/statefulset.yaml
+++ b/stable/couchdb/templates/statefulset.yaml
@@ -1,0 +1,161 @@
+apiVersion: apps/v1beta2
+kind: StatefulSet
+metadata:
+  name: {{ template "couchdb.fullname" . }}
+  labels:
+    app: {{ template "couchdb.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.clusterSize }}
+  serviceName: {{ template "couchdb.fullname" . }}
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
+  selector:
+    matchLabels:
+      app: {{ template "couchdb.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "couchdb.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      {{- if .Values.schedulerName }}
+      schedulerName: "{{ .Values.schedulerName }}"
+      {{- end }}
+      initContainers:
+        - name: init-copy
+          image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
+          imagePullPolicy: {{ .Values.initImage.pullPolicy }}
+          command: ['sh','-c','cp /tmp/chart.ini /default.d; ls -lrt /default.d;']
+          volumeMounts:
+          - name: config
+            mountPath: /tmp/
+          - name: config-storage
+            mountPath: /default.d
+      containers:
+        - name: couchdb
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: couchdb
+              containerPort: 5984
+            - name: epmd
+              containerPort: 4369
+            - containerPort: 9100
+          env:
+{{- if not .Values.allowAdminParty }}
+            - name: COUCHDB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "couchdb.fullname" . }}
+                  key: adminUsername
+            - name: COUCHDB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "couchdb.fullname" . }}
+                  key: adminPassword
+            - name: COUCHDB_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "couchdb.fullname" . }}
+                  key: cookieAuthSecret
+{{- end }}
+            - name: ERL_FLAGS
+              value: "{{ range $k, $v := .Values.erlangFlags }} -{{ $k }} {{ $v }} {{ end }}"
+          livenessProbe:
+{{- if .Values.couchdbConfig.chttpd.require_valid_user }}
+            exec:
+              command:
+                - sh
+                - -c
+                - curl -G --silent --fail -u ${COUCHDB_USER}:${COUCHDB_PASSWORD} http://localhost:5984/
+{{- else }}
+            httpGet:
+              path: /
+              port: 5984
+{{- end }}
+          readinessProbe:
+{{- if .Values.couchdbConfig.chttpd.require_valid_user }}
+            exec:
+              command:
+                - sh
+                - -c
+                - curl -G --silent --fail -u ${COUCHDB_USER}:${COUCHDB_PASSWORD} http://localhost:5984/_up
+{{- else }}
+            httpGet:
+              path: /_up
+              port: 5984
+{{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          volumeMounts:
+          - name: config-storage
+            mountPath: /opt/couchdb/etc/default.d
+          - name: database-storage
+            mountPath: /opt/couchdb/data
+        - name: couchdb-statefulset-assembler
+          image: "{{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}"
+          imagePullPolicy: {{ .Values.helperImage.pullPolicy }}
+{{- if not .Values.allowAdminParty }}
+          env:
+            - name: COUCHDB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "couchdb.fullname" . }}
+                  key: adminUsername
+            - name: COUCHDB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "couchdb.fullname" . }}
+                  key: adminPassword
+{{- end }}
+{{- if .Values.enableSearch }}
+        - name: clouseau
+          image: "{{ .Values.searchImage.repository }}:{{ .Values.searchImage.tag }}"
+          imagePullPolicy: {{ .Values.searchImage.pullPolicy }}
+{{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+      volumes:
+        - name: config-storage
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: {{ template "couchdb.fullname" . }}
+            items:
+              - key: inifile
+                path: chart.ini
+{{- if not .Values.persistentVolume.enabled }}
+        - name: database-storage
+          emptyDir: {}
+{{- else }}
+  volumeClaimTemplates:
+    - metadata:
+        name: database-storage
+        labels:
+          app: {{ template "couchdb.name" . }}
+          release: {{ .Release.Name }}
+      spec:
+        accessModes:
+        {{- range .Values.persistentVolume.accessModes }}
+          - {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistentVolume.size | quote }}
+      {{- if .Values.persistentVolume.storageClass }}
+      {{- if (eq "-" .Values.persistentVolume.storageClass) }}
+        storageClassName: ""
+      {{- else }}
+        storageClassName: "{{ .Values.persistentVolume.storageClass }}"
+      {{- end }}
+      {{- end }}
+{{- end }}

--- a/stable/couchdb/values.yaml
+++ b/stable/couchdb/values.yaml
@@ -1,0 +1,145 @@
+## clusterSize is the initial size of the CouchDB cluster.
+clusterSize: 3
+
+## If allowAdminParty is enabled the cluster will start up without any database
+## administrator account; i.e., all users will be granted administrative
+## access. Otherwise, the system will look for a Secret called
+## <ReleaseName>-couchdb containing `adminUsername`, `adminPassword` and
+## `cookieAuthSecret` keys. See the `createAdminSecret` flag.
+## ref: https://kubernetes.io/docs/concepts/configuration/secret/
+allowAdminParty: false
+
+## If createAdminSecret is enabled a Secret called <ReleaseName>-couchdb will
+## be created containing auto-generated credentials. Users who prefer to set
+## these values themselves have a couple of options:
+##
+## 1) The `adminUsername`, `adminPassword`, and `cookieAuthSecret` can be
+##    defined directly in the chart's values. Note that all of a chart's values
+##    are currently stored in plaintext in a ConfigMap in the tiller namespace.
+##
+## 2) This flag can be disabled and a Secret with the required keys can be
+##    created ahead of time.
+createAdminSecret: true
+
+adminUsername: admin
+# adminPassword: this_is_not_secure
+# cookieAuthSecret: neither_is_this
+
+## Use an alternate scheduler, e.g. "stork".
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+# schedulerName:
+
+## The storage volume used by each Pod in the StatefulSet. If a
+## persistentVolume is not enabled, the Pods will use `emptyDir` ephemeral
+## local storage. Setting the storageClass attribute to "-" disables dynamic
+## provisioning of Persistent Volumes; leaving it unset will invoke the default
+## provisioner.
+persistentVolume:
+  enabled: false
+  accessModes:
+    - ReadWriteOnce
+  size: 10Gi
+  # storageClass: "-"
+
+## The CouchDB image
+image:
+  repository: couchdb
+  tag: 2.3.1
+  pullPolicy: IfNotPresent
+
+## Sidecar that connects the individual Pods into a cluster
+helperImage:
+  repository: kocolosk/couchdb-statefulset-assembler
+  tag: 1.2.0
+  pullPolicy: IfNotPresent
+
+## Experimental integration with Lucene-powered fulltext search
+searchImage:
+  repository: kocolosk/couchdb-search
+  tag: 0.1.0
+  pullPolicy: IfNotPresent
+
+## Flip this to flag to include the Search container in each Pod
+enableSearch: false
+
+initImage:
+  repository: busybox
+  tag: latest
+  pullPolicy: Always
+
+## CouchDB is happy to spin up cluster nodes in parallel, but if you encounter
+## problems you can try setting podManagementPolicy to the StatefulSet default
+## `OrderedReady`
+podManagementPolicy: Parallel
+
+## To better tolerate Node failures, we can prevent Kubernetes scheduler from
+## assigning more than one Pod of CouchDB StatefulSet per Node using podAntiAffinity.
+affinity:
+  # podAntiAffinity:
+  #   requiredDuringSchedulingIgnoredDuringExecution:
+  #     - labelSelector:
+  #         matchExpressions:
+  #           - key: "app"
+  #             operator: In
+  #             values:
+  #             - couchdb
+  #       topologyKey: "kubernetes.io/hostname"
+
+## A StatefulSet requires a headless Service to establish the stable network
+## identities of the Pods, and that Service is created automatically by this
+## chart without any additional configuration. The Service block below refers
+## to a second Service that governs how clients connect to the CouchDB cluster.
+service:
+  # annotations:
+  enabled: true
+  type: ClusterIP
+  externalPort: 5984
+
+## An Ingress resource can provide name-based virtual hosting and TLS
+## termination among other things for CouchDB deployments which are accessed
+## from outside the Kubernetes cluster.
+## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: false
+  hosts:
+    - chart-example.local
+  annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+
+## Optional resource requests and limits for the CouchDB container
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+resources: {}
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # limits:
+  #  cpu: 56
+  #  memory: 256Gi
+
+## erlangFlags is a map that is passed to the Erlang VM as flags using the
+## ERL_FLAGS env. `name` and `setcookie` flags are minimally required to
+## establish connectivity between cluster nodes.
+## ref: http://erlang.org/doc/man/erl.html#init_flags
+erlangFlags:
+  name: couchdb
+  setcookie: monster
+
+## couchdbConfig will override default CouchDB configuration settings.
+## The contents of this map are reformatted into a .ini file laid down
+## by a ConfigMap object.
+## ref: http://docs.couchdb.org/en/latest/config/index.html
+couchdbConfig:
+  # cluster:
+  #   q: 8 # Create 8 shards for each database
+  chttpd:
+    bind_address: any
+    # chttpd.require_valid_user disables all the anonymous requests to the port
+    # 5984 when is set to true.
+    require_valid_user: false

--- a/stable/couchdb/values.yaml
+++ b/stable/couchdb/values.yaml
@@ -51,7 +51,7 @@ image:
 ## Sidecar that connects the individual Pods into a cluster
 helperImage:
   repository: kocolosk/couchdb-statefulset-assembler
-  tag: 1.2.0
+  tag: 2.0.0
   pullPolicy: IfNotPresent
 
 ## Experimental integration with Lucene-powered fulltext search


### PR DESCRIPTION
#### What this PR does / why we need it:

* Updates one container image default tag to clear out a few CVEs
* Adds some keywords
* Moves the chart to stable

#### Special notes for your reviewer:

I've run through the technical requirements and documentation requirements checklists and believe that the chart meets the large majority of the requirements. Some of the [labeling guidelines](https://github.com/helm/helm/blob/master/docs/chart_best_practices/labels.md) seem inconsistent with current practice for most stable charts and so I've stuck with what seems to be the _de facto_ standard.

The CouchDB chart has been baking in the incubator for a little over a year now and has seen a [healthy progression of fixes and enhancements](https://github.com/helm/charts/commits/master/incubator/couchdb). There's always more we can do, but I'm wondering if we can work out of `stable` now.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name