### PR TITLE
[stable/instana] configuration.yaml via values too

### DIFF
--- a/stable/instana-agent/Chart.yaml
+++ b/stable/instana-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: instana-agent
-version: 1.0.10
+version: 1.0.11
 appVersion: 1.0
 description: Instana Agent for Kubernetes
 home: https://www.instana.com/

--- a/stable/instana-agent/README.md
+++ b/stable/instana-agent/README.md
@@ -120,7 +120,27 @@ The following table lists the configurable parameters of the Instana chart and t
 | `rbac.create`                      | Whether RBAC resources should be created                                | `true`                                                                                                      |
 | `serviceAccount.create`            | Whether a ServiceAccount should be created                              | `true`                                                                                                      |
 | `serviceAccount.name`              | Name of the ServiceAccount to use                                       | `instana-agent`                                                                                             |
+| `configMap.configuration_yaml`     | Custom content for the configuration.yaml file                          | `# Sample configuration`                                                                                    |
 
 ### Agent
 
 There is a [config map](templates/configmap.yaml) which you can edit to configure the agent. This configuration will be used for all instana agents on all nodes.
+
+The value of configMap.configuration_yaml will be fed as a string. Your formatting must be correct as it will not be checked until after deployment.
+See the [docker configuration.yaml](https://github.com/instana/instana-agent-docker/blob/master/configuration.yaml) or contact the instana team for a more complete list of options.
+A sample is
+```
+configMap:
+  configuration_yaml: |
+    # Set tags
+    com.instana.plugin.host:
+      tags:
+        - Environment=Production
+    # Filter Secrets
+    com.instana.secrets:
+      matcher: 'contains-ignore-case' # 'contains-ignore-case', 'contains', 'regex'
+      list:
+        - 'key'
+        - 'password'
+        - 'secret'
+```

--- a/stable/instana-agent/templates/configmap.yaml
+++ b/stable/instana-agent/templates/configmap.yaml
@@ -6,6 +6,9 @@ metadata:
     {{- include "instana-agent.commonLabels" . | nindent 4 }}
 data:
   configuration.yaml: |
+{{- if .Values.configMap.configuration_yaml -}}
+{{ .Values.configMap.configuration_yaml | nindent 4 }}
+{{- end }}
     # Manual a-priori configuration. Configuration will be only used when the sensor
     # is actually installed by the agent.
     # The commented out example values represent example configuration and are not

--- a/stable/instana-agent/values.yaml
+++ b/stable/instana-agent/values.yaml
@@ -62,6 +62,11 @@ agent:
   # agent.proxyUseDNS sets the INSTANA_AGENT_PROXY_USE_DNS environment variable.
   # proxyUseDNS: null
 
+configMap:
+  # To add content to configuration.yaml either edit the config map, or paste it below
+  configuration_yaml: |
+    # Sample configuration
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows the `configuration.yaml` file via a values statement rather than editing the config map. Forking this chart just to add additional configuration options to the agent isn't as friendly as being able to put that into the values file 

@jbrisbin, @wiggzz, @JeroenSoeters, @fstab, @mdonkers, @dlbock, @nfisher : Please review.

#### Special notes for your reviewer:
I'll make Instana aware through standard support channels as well

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
