### PR TITLE
[stable/sentry] Add worker concurrency

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 1.5.5
+version: 1.5.6
 appVersion: 9.1.1
 keywords:
   - debugging

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -92,6 +92,7 @@ Parameter                          | Description                                
 `worker.schedulerName`             | Name of an alternate scheduler for worker                                                                  | `nil`
 `worker.affinity`                  | Affinity settings for worker pod assignment                                                                | `{}`
 `worker.tolerations`               | Toleration labels for worker pod assignment                                                                | `[]`
+`worker.concurrency`               | Celery worker concurrency                                                                                  | `nil`
 `user.create`                      | Create the default admin                                                                                   | `true`
 `user.email`                       | Username for default admin                                                                                 | `admin@sentry.local`
 `email.from_address`               | Email notifications are from                                                                               | `smtp`

--- a/stable/sentry/templates/workers-deployment.yaml
+++ b/stable/sentry/templates/workers-deployment.yaml
@@ -49,7 +49,13 @@ spec:
       - name: {{ .Chart.Name }}-workers
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        args: ["run", "worker"]
+        args:
+          - "run"
+          - "worker"
+          {{- if .Values.worker.concurrency }}
+          - "-c"
+          - "{{ .Values.worker.concurrency }}"
+          {{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         env:

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -68,6 +68,7 @@ worker:
   # schedulerName:
   # Optional extra labels for pod, i.e. redis-client: "true"
   # podLabels: []
+  # concurrency:
 
 # Admin user to create
 user:


### PR DESCRIPTION
#### What this PR does / why we need it:
This option allows to override default concurrency. Which is equal to [cpu_count](https://github.com/getsentry/sentry/blob/master/src/sentry/runner/commands/run.py#L198).

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
