### PR TITLE
[stable/concourse] properly cleanup btrfs subvolume and children

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 8.0.0
+version: 8.0.1
 appVersion: 5.3.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -51,12 +51,17 @@ spec:
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
           {{- end }}
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+          securityContext:
+            privileged: true
           command:
-            - /bin/sh
+            - /bin/bash
           args:
             - -ce
             - |-
-              rm -rf {{ .Values.concourse.worker.workDir }}/*
+              for v in $((btrfs subvolume list --sort=-ogen "{{ .Values.concourse.worker.workDir }}" || true) | awk '{print $9}'); do
+                (btrfs subvolume show "{{ .Values.concourse.worker.workDir }}/$v" && btrfs subvolume delete "{{ .Values.concourse.worker.workDir }}/$v") || true
+              done
+              rm -rf "{{ .Values.concourse.worker.workDir }}/*"
           volumeMounts:
             - name: concourse-work-dir
               mountPath: {{ .Values.concourse.worker.workDir | quote }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR is a follow up to https://github.com/helm/charts/pull/12398, having the `git rebase` already done.

More information about why it's needed can be found in the PR I mentioned above, but  the `tl;dr` is that a straight `rm -rf` doesn't work when what's there to be deleted is BTRFS subvolumes (rather than a plain sparse file - used when we don't have a "real" btrfs partition to use).

#### Which issue this PR fixes

  - fixes #13284

#### Special notes for your reviewer:

Please do not merge yet - I'll re-run the end-to-end tests that Concourse has first to ensure that we'll not be caught up with surprises 👍  

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
