### PR TITLE
[stable/concourse] updates pg subchart (0.13.1 -> 5.3.8)

### DIFF
--- a/stable/concourse/CHANGELOG.md
+++ b/stable/concourse/CHANGELOG.md
@@ -2,3 +2,7 @@
 
 - added the ability to create worker only and web-only deployments using `web.enabled` and `worker.enabled`
 - **[breaking]** worker and web secrets are now separated into 2 different templates, `worker-secrets.yaml` and `web-secrets.yaml`. Users bringing their own secrets will have to split them into 2 different k8s objects.
+
+# v7.0.0:
+
+- upgraded the PostgreSQL Chart (direct dependency of this Chart) from `0.13.1` to `5.3.8`. As various values (like `postgresUser`) changed (to, for instance, `postgresqlUsername`), a major dump was needed.

--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 6.5.0
+version: 7.0.0
 appVersion: 5.3.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -91,13 +91,13 @@ The following table lists the configurable parameters of the Concourse chart and
 | `persistence.worker.size` | Concourse Worker Persistent Volume Storage Size | `20Gi` |
 | `persistence.worker.storageClass` | Concourse Worker Persistent Volume Storage Class | `generic` |
 | `postgresql.enabled` | Enable PostgreSQL as a chart dependency | `true` |
-| `postgresql.persistence.accessMode` | Persistent Volume Access Mode | `ReadWriteOnce` |
+| `postgresql.persistence.accessModes` | Persistent Volume Access Mode | `["ReadWriteOnce"]` |
 | `postgresql.persistence.enabled` | Enable PostgreSQL persistence using Persistent Volume Claims | `true` |
 | `postgresql.persistence.size` | Persistent Volume Storage Size | `8Gi` |
 | `postgresql.persistence.storageClass` | Concourse data Persistent Volume Storage Class | `nil` |
-| `postgresql.postgresDatabase` | PostgreSQL Database to create | `concourse` |
-| `postgresql.postgresPassword` | PostgreSQL Password for the new user | `concourse` |
-| `postgresql.postgresUser` | PostgreSQL User to create | `concourse` |
+| `postgresql.postgresqlDatabase` | PostgreSQL Database to create | `concourse` |
+| `postgresql.postgresqlPassword` | PostgreSQL Password for the new user | `concourse` |
+| `postgresql.postgresqlUsername` | PostgreSQL User to create | `concourse` |
 | `rbac.apiVersion` | RBAC version | `v1beta1` |
 | `rbac.create` | Enables creation of RBAC resources | `true` |
 | `rbac.webServiceAccountName` | Name of the service account to use for web pods if `rbac.create` is `false` | `default` |
@@ -387,9 +387,9 @@ web:
 
 ### PostgreSQL
 
-By default, this chart uses a PostgreSQL database deployed as a chart dependency, with default values for username, password, and database name. These can be modified by setting the `postgresql.*` values.
+By default, this chart uses a PostgreSQL database deployed as a chart dependency (see the [PostgreSQL chart](https://github.com/helm/charts/blob/master/stable/postgresql/README.md)), with default values for username, password, and database name. These can be modified by setting the `postgresql.*` values.
 
-You can also bring your own PostgreSQL. To do so, set `postgresql.enabled` to false, and then configure Concourse's `postgres` values (`concourse.web.postgres.*`).
+You can also bring your own PostgreSQL. To do so, set `postgresql.enabled` to `false`, and then configure Concourse's `postgres` values (`concourse.web.postgres.*`).
 
 Note that some values get set in the form of secrets, like `postgresql-user`, `postgresql-password`, and others (see [templates/secrets.yaml](templates/secrets.yaml) for possible values and the [secrets section](#secrets) on this README for guidance on how to set those secrets).
 

--- a/stable/concourse/requirements.lock
+++ b/stable/concourse/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.13.1
-digest: sha256:65d358878e496ab1b51721a76e2af5b7fd3e6bb7630b1d402af67a17bf782bb4
-generated: 2018-05-31T16:11:40.655794088+01:00
+  version: 5.3.8
+digest: sha256:8beae180ba7a5ca551f75da9552e59cadbbfcce2d0e2edf6c8a93dcfacd0df10
+generated: "2019-06-20T13:43:23.321244-04:00"

--- a/stable/concourse/requirements.yaml
+++ b/stable/concourse/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: postgresql
-  version: 0.13.1
+  version: 5.3.8
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: postgresql.enabled

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -279,14 +279,14 @@ spec:
             - name: CONCOURSE_POSTGRES_HOST
               value: {{ template "concourse.postgresql.fullname" . }}
             - name: CONCOURSE_POSTGRES_USER
-              value: {{ .Values.postgresql.postgresUser | quote }}
+              value: {{ .Values.postgresql.postgresqlUsername | quote }}
             - name: CONCOURSE_POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "concourse.postgresql.fullname" . }}
-                  key: postgres-password
+                  key: postgresql-password
             - name: CONCOURSE_POSTGRES_DATABASE
-              value: {{ .Values.postgresql.postgresDatabase | quote }}
+              value: {{ .Values.postgresql.postgresqlDatabase | quote }}
             {{- else }}
             {{- if .Values.concourse.web.postgres.host }}
             - name: CONCOURSE_POSTGRES_HOST

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1669,25 +1669,30 @@ persistence:
 postgresql:
 
   ## Use the PostgreSQL chart dependency.
-  ## Set to false if bringing your own PostgreSQL, and set secret value postgresql-uri.
+  ##
+  ## Set to false if bringing your own PostgreSQL, and set the corresponding `secrets`
+  ## fields that correspond to the PostgreSQL variables that `concourse web` should use
+  ## to connect to.
+  ##
   ## Should be set to false if using the chart as a worker only deployment.
   ##
   enabled: true
 
   ### PostgreSQL User to create.
   ##
-  postgresUser: concourse
+  postgresqlUsername: concourse
 
   ## PostgreSQL Password for the new user.
   ## If not set, a random 10 characters password will be used.
   ##
-  postgresPassword: concourse
+  postgresqlPassword: concourse
 
   ## PostgreSQL Database to create.
   ##
-  postgresDatabase: concourse
+  postgresqlDatabase: concourse
 
-  ## Persistent Volume Storage configuration.
+  ## Persistent Volume Storage configuration for PostgreSQL.
+  ##
   ## Ref: https://kubernetes.io/docs/user-guide/persistent-volumes
   ##
   persistence:
@@ -1695,7 +1700,8 @@ postgresql:
     ##
     enabled: true
 
-    ## Concourse data Persistent Volume Storage Class.
+    ## Persistent Volume Storage Class to be used by PersistentVolumes created
+    ## for PostgreSQL.
     ##
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning
@@ -1707,7 +1713,8 @@ postgresql:
 
     ## Persistent Volume Access Mode.
     ##
-    accessMode: ReadWriteOnce
+    accessModes:
+      - ReadWriteOnce
 
     ## Persistent Volume Storage Size.
     ##


### PR DESCRIPTION
#### What this PR does / why we need it:


There's been a long time since the last upgrade that we did to the
subchart that Concourse optionally depends on.

With the upgrade, some values set in the `postgresql` chart changed. As
those are exposed in `concourse`'s `values` too (and we version our
Chart based on its public interface - values.yaml), this made it deserve
a major version bump.

For those users not making use of the subchart (or changing the default
values), no changes ar necessary.

For those who *are* configuring `postgresql.*` values - changes will
almost certainly be necessary.

#### Which issue this PR fixes

  - closes #11610

#### Special notes for your reviewer:

~~I'm still finishing running Concourse's e2e test suite, **PLEASE WAIT A BIT**.~~ All good 😁 (see https://gist.github.com/cirocosta/fbde7d341eee5cca0579d80cf08adc33) 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)