### PR TITLE
[stable/kiam] Add NET_ADMIN capability to agent pod to create iptables rule

### DIFF
--- a/stable/kiam/Chart.yaml
+++ b/stable/kiam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kiam
-version: 2.3.0
+version: 2.3.1
 appVersion: 3.2
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/stable/kiam/README.md
+++ b/stable/kiam/README.md
@@ -103,7 +103,7 @@ Parameter | Description | Default
 `agent.extraHostPathMounts` | Additional agent container hostPath mounts | `[]`
 `agent.gatewayTimeoutCreation` | Agent's timeout when creating the kiam gateway | `50ms`
 `agent.host.ip` | IP address of host | `$(HOST_IP)`
-`agent.host.iptables` | Add iptables rule | `false`
+`agent.host.iptables` | Add iptables rule (requires `NET_ADMIN` capability) | `false`
 `agent.host.interface` | Agent's host interface for proxying AWS metadata | `cali+`
 `agent.host.port` | Agent's listening port | `8181`
 `agent.log.jsonOutput` | Whether or not to output agent log in JSON format | `true`

--- a/stable/kiam/templates/agent-daemonset.yaml
+++ b/stable/kiam/templates/agent-daemonset.yaml
@@ -111,6 +111,12 @@ spec:
             - name: {{ $name }}
               value: {{ quote $value }}
           {{- end }}
+          {{- if .Values.agent.host.iptables }}
+          securityContext:
+            capabilities:
+              add:
+              - NET_ADMIN
+          {{- end }}
           volumeMounts:
             - mountPath: /etc/kiam/tls
               name: tls


### PR DESCRIPTION
When enabling `agent.host.iptables` to create the iptables rule, the agent pod crashes:
```
{
  "level":"fatal",
  "msg":"error configuring iptables:running [/sbin/iptables -t nat -C PREROUTING -p tcp -d 169.254.169.254 --dport 80 -j DNAT --to-destination 10.1.6.79:8181 -i cali+ --wait]: exit status 3: iptables v1.6.2: can't initialize iptables table `nat': Permission denied (you must be root)\nPerhaps iptables or your kernel needs to be upgraded.\n",
  "time":"2019-06-20T20:15:36Z"
}
```

Adding `NET_ADMIN` capability to the agent pod, when the value `agent.host.iptables` is set to true, allows the pod to create the iptables rule.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)