### PR TITLE
[stable/prometheus-rabbitmq-exporter] Added support for existing rabbitmq password secret

### DIFF
--- a/stable/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/stable/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 0.5.0
+version: 0.5.1
 appVersion: v0.29.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/stable/prometheus-rabbitmq-exporter/README.md
+++ b/stable/prometheus-rabbitmq-exporter/README.md
@@ -54,6 +54,7 @@ The following table lists the configurable parameters and their default values.
 | `rabbitmq.url`           | rabbitmq management url                                                | `http://myrabbit:15672`   |
 | `rabbitmq.user`          | rabbitmq user login                                                    | `guest`                   |
 | `rabbitmq.password`      | rabbitmq password login                                                | `guest`                   |
+| `rabbitmq.existingPasswordSecret` | existing secret name containing password key                  | `~`                       |
 | `rabbitmq.capabilities`  | comma-separated list of capabilities supported by the RabbitMQ server  | `bert,no_sort`            |
 | `rabbitmq.include_queues`| regex queue filter. just matching names are exported                   | `.*`                      |
 | `rabbitmq.skip_queues`   | regex, matching queue names are not exported                           | `^$`                      |
@@ -65,10 +66,10 @@ The following table lists the configurable parameters and their default values.
 | `rabbitmq.timeout`       | timeout in seconds for retrieving data from management plugin          | `30`                      |
 | `rabbitmq.max_queues`    | max number of queues before we drop metrics (disabled if set to 0)     | `0`                       |
 | `annotations`            | pod annotations for easier discovery                                   | {}                        |
-| `prometheus.monitor.enabled` | Set this to `true` to create ServiceMonitor for Prometheus operator | `false` | 
-| `prometheus.monitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | {} | 
-| `prometheus.monitor.interval` | Interval at which Prometheus Operator scrapes exporter | `15s` | 
-| `prometheus.monitor.namespace` | 	Selector to select which namespaces the Endpoints objects are discovered from. | [] | 
+| `prometheus.monitor.enabled` | Set this to `true` to create ServiceMonitor for Prometheus operator | `false` |
+| `prometheus.monitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | {} |
+| `prometheus.monitor.interval` | Interval at which Prometheus Operator scrapes exporter | `15s` |
+| `prometheus.monitor.namespace` | 	Selector to select which namespaces the Endpoints objects are discovered from. | [] |
 
 For more information please refer to the [rabbitmq_exporter](https://github.com/kbudde/rabbitmq_exporter) documentation.
 

--- a/stable/prometheus-rabbitmq-exporter/templates/deployment.yaml
+++ b/stable/prometheus-rabbitmq-exporter/templates/deployment.yaml
@@ -30,8 +30,16 @@ spec:
               value: "{{ .Values.rabbitmq.url }}"
             - name: RABBIT_USER
               value: "{{ .Values.rabbitmq.user }}"
+            {{- if .Values.rabbitmq.existingPasswordSecret }}
+            - name: RABBIT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name:  "{{ .Values.rabbitmq.existingPasswordSecret }}"
+                  key: password
+            {{- else }}
             - name: RABBIT_PASSWORD
               value: "{{ .Values.rabbitmq.password }}"
+            {{- end }}
             - name: PUBLISH_PORT
               value: "{{ .Values.service.internalPort }}"
             - name: LOG_LEVEL

--- a/stable/prometheus-rabbitmq-exporter/values.yaml
+++ b/stable/prometheus-rabbitmq-exporter/values.yaml
@@ -33,6 +33,8 @@ rabbitmq:
   url: http://myrabbit:15672
   user: guest
   password: guest
+  # If existingPasswordSecret is set then password is ignored
+  existingPasswordSecret: ~
   capabilities: bert,no_sort
   include_queues: ".*"
   include_vhost: ".*"


### PR DESCRIPTION
Signed-off-by: Jonny Ford <jonnyford1@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Adds support for getting the RabbitMQ password from an existing Kubernetes Secret.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
