### PR TITLE
[stable/prometheus-blackbox-exporter] Added existing config secret support

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 0.3.0
+version: 0.3.1
 appVersion: 0.14.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/README.md
+++ b/stable/prometheus-blackbox-exporter/README.md
@@ -44,6 +44,7 @@ The following table lists the configurable parameters of the Blackbox-Exporter c
 |               Parameter                |                    Description                    |            Default            |
 | -------------------------------------- | ------------------------------------------------- | ----------------------------- |
 | `config`                               | Prometheus blackbox configuration                 | {}                            |
+| `existingConfigSecret`                 | An existing Secret containing config              | ~
 | `secretConfig`                         | Whether to treat blackbox configuration as secret | `false`                       |
 | `configmapReload.name`                 | configmap-reload container name                   | `configmap-reload`            |
 | `configmapReload.image.repository`     | configmap-reload container image repository       | `jimmidyson/configmap-reload` |

--- a/stable/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -88,10 +88,15 @@ spec:
               readOnly: true
       volumes:
         - name: config
-{{- if .Values.secretConfig }}
+{{- if not .Values.existingConfigSecret }}
+  {{- if .Values.secretConfig }}
           secret:
             secretName: {{ template "prometheus-blackbox-exporter.fullname" . }}
-{{- else }}
+  {{- else }}
           configMap:
             name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+  {{- end }}
+{{- else }}
+          secret:
+            secretName: {{ .Values.existingConfigSecret }}
 {{- end }}

--- a/stable/prometheus-blackbox-exporter/values.yaml
+++ b/stable/prometheus-blackbox-exporter/values.yaml
@@ -9,16 +9,19 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
+# Set existingConfigSecret to load your config from an existing secret
+existingConfigSecret: ~
+# Set secretConfig to store the below config as a Secret
 secretConfig: false
-config:
-  modules:
-    http_2xx:
-      prober: http
-      timeout: 5s
-      http:
-        valid_http_versions: ["HTTP/1.1", "HTTP/2"]
-        no_follow_redirects: false
-        preferred_ip_protocol: "ip4"
+config: {}
+  # modules:
+  #   http_2xx:
+  #     prober: http
+  #     timeout: 5s
+  #     http:
+  #       valid_http_versions: ["HTTP/1.1", "HTTP/2"]
+  #       no_follow_redirects: false
+  #       preferred_ip_protocol: "ip4"
 
 resources: {}
   # limits:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Added support for getting config from an existing Kubernetes Secret.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
