### PR TITLE
[incubator/sparkoperator] Add missing namespaces for spark operator resources

### DIFF
--- a/incubator/sparkoperator/Chart.yaml
+++ b/incubator/sparkoperator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sparkoperator
 description: A Helm chart for Spark on Kubernetes operator
-version: 0.2.3
+version: 0.2.4
 appVersion: v2.4.0-v1beta1-0.8.2
 kubeVersion: ">=1.8.0-0"
 keywords:

--- a/incubator/sparkoperator/templates/crd-cleanup-job.yaml
+++ b/incubator/sparkoperator/templates/crd-cleanup-job.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "sparkoperator.fullname" . }}-crd-cleanup
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/incubator/sparkoperator/templates/spark-operator-deployment.yaml
+++ b/incubator/sparkoperator/templates/spark-operator-deployment.yaml
@@ -8,6 +8,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "sparkoperator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
     helm.sh/chart: {{ include "sparkoperator.chart" . }}

--- a/incubator/sparkoperator/templates/spark-operator-serviceaccount.yaml
+++ b/incubator/sparkoperator/templates/spark-operator-serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "sparkoperator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
     helm.sh/chart: {{ include "sparkoperator.chart" . }}

--- a/incubator/sparkoperator/templates/webhook-cleanup-job.yaml
+++ b/incubator/sparkoperator/templates/webhook-cleanup-job.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "sparkoperator.fullname" . }}-webhook-cleanup
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-delete, pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/incubator/sparkoperator/templates/webhook-init-job.yaml
+++ b/incubator/sparkoperator/templates/webhook-init-job.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "sparkoperator.fullname" . }}-init
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/incubator/sparkoperator/templates/webhook-service.yaml
+++ b/incubator/sparkoperator/templates/webhook-service.yaml
@@ -3,6 +3,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-webhook
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
     helm.sh/chart: {{ include "sparkoperator.chart" . }}


### PR DESCRIPTION
### What this PR does / why we need it:
The namespace is currently missing from the operator resources so an install leads to a crashlooping operator because the clusterrolebinding doesn't bind to the operator's service account.  Also the operator doesn't get installed in the namespace that you pass with the `--namespace` flag.

#### Which issue this PR fixes
n/a

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ x] Chart Version bumped
- [ x] Variables are documented in the README.md
- [ x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
