### PR TITLE
[stable/external-dns] Switch to use 'bitnami/external-dns' image

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 1.9.0
+version: 2.0.0
 appVersion: 0.5.14
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:
@@ -10,7 +10,9 @@ keywords:
 home: https://github.com/kubernetes-incubator/external-dns
 sources:
 - https://github.com/kubernetes-incubator/external-dns
+- https://github.com/bitnami/bitnami-docker-external-dns
 maintainers:
 - name: Bitnami
   email: containers@bitnami.com
 engine: gotpl
+icon: https://bitnami.com/assets/stacks/external-dns/img/external-dns-stack-110x117.png

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -5,7 +5,7 @@
 ## TL;DR;
 
 ```console
-$ helm install bitnami/external-dns
+$ helm install stable/external-dns
 ```
 
 ## Introduction
@@ -139,7 +139,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```console
 $ helm install --name my-release \
-  --set provider=aws bitnami/external-dns
+  --set provider=aws stable/external-dns
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
@@ -155,7 +155,7 @@ $ helm install --name my-release -f values.yaml stable/external-dns
 This chart includes a `values-production.yaml` file where you can find some parameters oriented to production configuration in comparison to the regular `values.yaml`.
 
 ```console
-$ helm install --name my-release -f ./values-production.yaml bitnami/external-dns
+$ helm install --name my-release -f ./values-production.yaml stable/external-dns
 ```
 
 - Desired number of ExternalDNS replicas:

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -1,14 +1,23 @@
 # external-dns
 
-## Chart Details
+[ExternalDNS](https://github.com/kubernetes-incubator/external-dns) is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 
-This chart will do the following:
+## TL;DR;
 
-* Create a deployment of [external-dns] within your Kubernetes Cluster.
+```console
+$ helm install bitnami/external-dns
+```
 
-Currently this uses the [Zalando] hosted container, if this is a concern follow the steps in the [external-dns] documentation to compile the binary and make a container. Where the chart pulls the image from is fully configurable.
+## Introduction
 
-> **Note**: If you want to use Chart version >1.1.0 with external-dns image <0.5.9 and use aws credentials, make sure to set `aws.credentialsPath: "/root/.aws"`
+This chart bootstraps a [ExternalDNS](https://github.com/bitnami/bitnami-docker-external-dns) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters. This chart has been tested to work with NGINX Ingress, cert-manager, fluentd and Prometheus on top of the [BKPR](https://kubeprod.io/).
+
+## Prerequisites
+
+- Kubernetes 1.8+ with Beta APIs enabled
+- PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart
 
@@ -18,90 +27,120 @@ To install the chart with the release name `my-release`:
 $ helm install --name my-release stable/external-dns
 ```
 
+The command deploys ExternalDNS on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
 ## Configuration
 
 The following table lists the configurable parameters of the external-dns chart and their default values.
 
+| Parameter                          | Description                                                                                              | Default                                                  |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `global.imageRegistry`             | Global Docker image registry                                                                             | `nil`                                                    |
+| `global.imagePullSecrets`          | Global Docker registry secret names as an array                                                          | `[]` (does not add image pull secrets to deployed pods)  |
+| `image.registry`                   | ExternalDNS image registry                                                                               | `docker.io`                                              |
+| `image.repository`                 | ExternalDNS Image name                                                                                   | `bitnami/external-dns`                                   |
+| `image.tag`                        | ExternalDNS Image tag                                                                                    | `{TAG_NAME}`                                             |
+| `image.pullPolicy`                 | ExternalDNS image pull policy                                                                            | `IfNotPresent`                                           |
+| `image.pullSecrets`                | Specify docker-registry secret names as an array                                                         | `[]` (does not add image pull secrets to deployed pods)  |
+| `sources`                          | K8s resources type to be observed for new DNS entries by ExternalDNS                                     | `[service, ingress]`                                     |
+| `provider`                         | DNS provider where the DNS records will be created (mandatory) (options: aws, azure, google, ...)        | `aws`                                                    |
+| `publishInternalServices`          | Whether to publish DNS records for ClusterIP services or not                                             | `false`                                                  |
+| `aws.credentials.accessKey`        | When using the AWS provider, set `aws_access_key_id` in the AWS credentials (optional)                                      | `""`                                                     |
+| `aws.credentials.secretKey`        | When using the AWS provider, set `aws_secret_access_key` in the AWS credentials (optional)                                      | `""`                                                     |
+| `aws.credentials.mountPath`        | When using the AWS provider, determine `mountPath` for `credentials` secret                              | `"/.aws"`                                                |
+| `aws.region`                       | When using the AWS provider, `AWS_DEFAULT_REGION` to set in the environment (optional)                   | `us-east-1`                                              |
+| `aws.zoneType`                     | When using the AWS provider, filter for zones of this type (optional, options: public, private)          | `""`                                                     |
+| `aws.assumeRoleArn`                | When using the AWS provider, assume role by specifying --aws-assume-role to the external-dns daemon      | `""`                                                     |
+| `aws.batchChangeSize`              | When using the AWS provider, set the maximum number of changes that will be applied in each batch        | `1000`                                                   |
+| `azure.secretName`                 | When using the Azure provider, set the secret containing the `azure.json` file                           | `""`                                                     |
+| `azure.resoureGroup`               | When using the Azure provider, set the Azure Resource Group                                              | `""`                                                     |
+| `cloudflare.apiKey`                | When using the Cloudflare provider, `CF_API_KEY` to set (optional)                                       | `""`                                                     |
+| `cloudflare.email`                 | When using the Cloudflare provider, `CF_API_EMAIL` to set (optional)                                     | `""`                                                     |
+| `cloudflare.proxied`               | When using the Cloudflare provider, enable the proxy feature (DDOS protection, CDN...) (optional)        | `true`                                                   |
+| `designate.customCA.enabled`       | When using the Designate provider, enable a custom CA (optional)                                         | false                                                    |
+| `designate.customCA.content`       | When using the Designate provider, set the content of the custom CA                                      | ""                                                       |
+| `designate.customCA.mountPath`     | When using the Designate provider, set the mountPath in which to mount the custom CA configuration       | "/config/designate"                                      |
+| `designate.customCA.filename`      | When using the Designate provider, set the custom CA configuration filename                              | "designate-ca.pem"                                       |
+| `digitalocean.apiToken`            | When using the DigitalOcean provider, `DO_TOKEN` to set (optional)                                       | `""`                                                     |
+| `google.project`                   | When using the Google provider, specify the Google project (required when provider=google)               | `""`                                                     |
+| `google.serviceAccountSecret`      | When using the Google provider, specify the existing secret which contains credentials.json (optional)   | `""`                                                     |
+| `google.serviceAccountKey`         | When using the Google provider, specify the service account key JSON file. (required when `google.serviceAccountSecret` is not provided. In this case a new secret will be created holding this service account | `""` |
+| `infoblox.gridHost`                | When using the Infoblox provider, specify the Infoblox Grid host (required when provider=infoblox)       | `""`                                                     |
+| `infoblox.wapiUsername`            | When using the Infoblox provider, specify the Infoblox WAPI username                                 | `"admin"`                                                |
+| `infoblox.wapiPassword`            | When using the Infoblox provider, specify the Infoblox WAPI password (required when provider=infoblox)   | `""`                                                     |
+| `infoblox.domainFilter`            | When using the Infoblox provider, specify the domain (optional)                                          | `""`                                                     |
+| `infoblox.noSslVerify`             | When using the Infoblox provider, disable SSL verification (optional)                                    | `false`                                                  |
+| `infoblox.wapiPort`                | When using the Infoblox provider, specify the Infoblox WAPI port (optional)                              | `""`                                                     |
+| `infoblox.wapiVersion`             | When using the Infoblox provider, specify the Infoblox WAPI version (optional)                           | `""`                                                     |
+| `infoblox.wapiConnectionPoolSize`  | When using the Infoblox provider, specify the Infoblox WAPI request connection pool size (optional)      | `""`                                                     |
+| `infoblox.wapiHttpTimeout`         | When using the Infoblox provider, specify the Infoblox WAPI request timeout in seconds (optional)        | `""`                                                     |
+| `rfc2136.host`                     | When using the rfc2136 provider, specify the RFC2136 host (required when provider=rfc2136)               | `""`                                                     |
+| `rfc2136.port`                     | When using the rfc2136 provider, specify the RFC2136 port (optional)                                     | `53`                                                     |
+| `rfc2136.zone`                     | When using the rfc2136 provider, specify the zone (required when provider=rfc2136)                       | `""`                                                     |
+| `rfc2136.tsigSecret`               | When using the rfc2136 provider, specify the tsig secret to enable security (optional)                   | `""`                                                     |
+| `rfc2136.tsigKeyname`              | When using the rfc2136 provider, specify the tsig keyname to enable security (optional)                  | `"externaldns-key"`                                      |
+| `rfc2136.tsigSecretAlg`            | When using the rfc2136 provider, specify the tsig secret to enable security (optional)                   | `"hmac-sha256"`                                          |
+| `rfc2136.tsigAxfr`                 | When using the rfc2136 provider, enable AFXR to enable security (optional)                               | `true`                                                   |
+| `annotationFilter`                 | Filter sources managed by external-dns via annotation using label selector (optional)                    | `""`                                                     |
+| `domainFilters`                    | Limit possible target zones by domain suffixes (optional)                                                | `[]`                                                     |
+| `zoneIdFilters`                    | Limit possible target zones by zone id (optional)                                                        | `[]`                                                     |
+| `crd.create`                       | If true, create CRD ressource                                                                            | `false`                                                  |
+| `crd.apiversion`                   | Sets the API version for the CRD to watch                                                                | `"`                                                      |
+| `crd.kind`                         | Sets the kind for the CRD to watch                                                                       | `"`                                                      |
+| `dryRun`                           | When enabled, prints DNS record changes rather than actually performing them (optional)                  | `false`                                                  |
+| `logLevel`                         | Verbosity of the logs (options: panic, debug, info, warn, error, fatal)                                  | `info`                                                   |
+| `interval`                         | Interval update period to use                                                                            | `1m`                                                     |
+| `istioIngressGateways`             | The fully-qualified name of the Istio ingress gateway services .                                         | `""`                                                     |
+| `policy`                           | Modify how DNS records are sychronized between sources and providers (options: sync, upsert-only )       | `upsert-only`                                            |
+| `registry`                         | Registry method to use (options: txt, noop)                                                              | `txt`                                                    |
+| `txtOwnerId`                       | When using the TXT registry, a name that identifies this instance of ExternalDNS (optional)              | `"default"`                                              |
+| `txtPrefix`                        | When using the TXT registry, a prefix for ownership records that avoids collision with CNAME entries (optional) | `""`                                              |
+| `extraArgs`                        | Extra arguments to be passed to external-dns                                                             | `{}`                                                     |
+| `extraEnv`                         | Extra environment variables to be passed to external-dns                                                 | `[]`                                                     |
+| `replicas`                         | Desired number of ExternalDNS replicas                                                                   | `1`                                                      |
+| `affinity`                         | Affinity for pod assignment (this value is evaluated as a template)                                                                              | `{}`                                                     |
+| `nodeSelector`                     | Node labels for pod assignment (this value is evaluated as a template)                                                                           | `{}`                                                     |
+| `tolerations`                      | Tolerations for pod assignment (this value is evaluated as a template)                                                                                | `[]`                                                     |
+| `podAnnotations`                   | Additional annotations to apply to the pod.                                                              | `{}`                                                     |
+| `podLabels`                        | Additional labels to be added to pods                                                                    | {}                                                       |
+| `priorityClassName`                | priorityClassName                                                                                        | `""`                                                     |
+| `service.type`                     | Kubernetes Service type                                                                                  | `ClusterIP`                                              |
+| `service.port`                     | ExternalDNS client port                                                                                  | `7979`                                                   |
+| `service.nodePort`                 | Port to bind to for NodePort service type (client port)                                                  | `nil`                                                    |
+| `service.clusterIP`                | IP address to assign to service                                                                          | `""`                                                     |
+| `service.externalIPs`              | Service external IP addresses                                                                            | `[]`                                                     |
+| `service.loadBalancerIP`           | IP address to assign to load balancer (if supported)                                                     | `""`                                                     |
+| `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)                                          | `[]`                                                     |
+| `service.annotations`              | Annotations to add to service                                                                            | `{}`                                                     |
+| `rbac.create`                      | Wether to create & use RBAC resources or not                                                             | `false`                                                  |
+| `rbac.serviceAccountName`          | ServiceAccount (ignored if rbac.create == true)                                                          | `default`                                                |
+| `rbac.apiVersion`                  | Version of the RBAC API                                                                                  | `v1beta1`                                                |
+| `securityContext.fsGroup`          | Group ID for the container                                                                               | `1001`                                                   |
+| `securityContext.runAsUser`        | User ID for the container                                                                                | `1001`                                                   |
+| `resources`                        | CPU/Memory resource requests/limits.                                                                     | `{}`                                                     |
+| `livenessProbe`                    | Deployment Liveness Probe                                                                                | See `values.yaml`                                        |
+| `readinessProbe`                   | Deployment Readiness Probe                                                                               | See `values.yaml`                                        |
+| `metrics.enabled`                  | Enable prometheus to access external-dns metrics endpoint                                                | `false`                                                  |
+| `metrics.podAnnotations`           | Annotations for enabling prometheus to access the metrics endpoint                                       | {`prometheus.io/scrape: "true",prometheus.io/port: "7979"`} |
 
-| Parameter                          | Description                                                                                                                                                                                                    | Default                                            |
-| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| `annotationFilter`                 | Filter sources managed by external-dns via annotation using label selector semantics (default: all sources) (optional).                                                                                        | `""`                                               |
-| `aws.accessKey`                    | set in `~/.aws/credentials` mounted through secret (optional).                                                                                                                                                 | `""`                                               |
-| `aws.assumeRoleArn`                | Assume role by specifying --aws-assume-role to the external-dns daemon.                                                                                                                                        | `""`                                               |
-| `aws.secretKey`                    | set in `~/.aws/credentials` mounted through secret (optional).                                                                                                                                                 | `""`                                               |
-| `aws.credentialsPath`              | determine `mountPath` for `credentials` secret, defaults to `nobody` USER  home path `/.aws` (optional).                                                                                                       | `"/.aws"`                                          |
-| `aws.region`                       | `AWS_DEFAULT_REGION` to set in the environment (optional).                                                                                                                                                     | `us-east-1`                                        |
-| `aws.roleArn`                      | If assume role credentials are used then is the role_arn (arn:aws:iam::....). Leave empty if not used.                                                                                                         | `""`                                               |
-| `aws.zoneType`                     | Filter for zones of this type (optional, options: public, private).                                                                                                                                            | `""`                                               |
-| `aws.batchChangeSize`              | When using the AWS provider, set the maximum number of changes that will be applied in each batch                                                                                                              | `1000`                                             |
-| `azure.secretName`                 | Set the secret created for the SP for azure, should contain an azure.json file                                                                                                                                 | `""`                                               |
-| `cloudflare.apiKey`                | `CF_API_KEY` to set in the environment (optional).                                                                                                                                                             | `""`                                               |
-| `cloudflare.email`                 | `CF_API_EMAIL` to set in the environment (optional).                                                                                                                                                           | `""`                                               |
-| `cloudflare.proxied`               | enable the proxy feature of Cloudflare (DDOS protection, CDN...) (optional).                                                                                                                                   | `true`                                             |
-| `designate.customCA.enabled`       | A switch to enable a custom CA for the Designate provider (optional)                                                                                                                                           | false                                              |
-| `designate.customCA.content`       | The content of the Designate provider's custom CA                                                                                                                                                              | ""                                                 |
-| `designate.customCA.directory`     | Directory in which to mount the Designate provider's custom CA                                                                                                                                                 | "/config/designate"                                |
-| `designate.customCA.filename`      | Filename of Designate provider's custom CA                                                                                                                                                                     | "designate-ca.pem"                                 |
-| `domainFilters`                    | Limit possible target zones by domain suffixes (optional).                                                                                                                                                     | `[]`                                               |
-| `digitalocean.apiToken`            | When using the DigitalOcean provider, sets `DO_TOKEN` in the environment (optional).                                                                                                                           | `""`                                               |
-| `dryRun`                           | When enabled, prints DNS record changes rather than actually performing them (optional).                                                                                                                       | `false`                                            |
-| `extraArgs`                        | Optional object of extra args, as `name`: `value` pairs. Where the name is the command line arg to external-dns.                                                                                               | `{}`                                               |
-| `extraEnv`                         | Optional array of extra environment variables. Supply a `name` property and either `value` of `valueFrom` for each.                                                                                            | `[]`                                               |
-| `google.project`                   | When using the Google provider, specify the Google project (required when provider=google).                                                                                                                    | `""`                                               |
-| `google.serviceAccountSecret`      | When using the Google provider, optionally specify the existing secret which contains credentials.json if necessary.                                                                                           | `""`                                               |
-| `google.serviceAccountKey`         | When using the Google provider, optionally specify the service account key JSON file. Must be provided when no existing secret is used, in this case a new secret will be created holding this service account | `""`                                               |
-| `image.name`                       | Container image name (Including repository name if not `hub.docker.com`).                                                                                                                                      | `registry.opensource.zalan.do/teapot/external-dns` |
-| `image.pullPolicy`                 | Container pull policy.                                                                                                                                                                                         | `IfNotPresent`                                     |
-| `image.tag`                        | Container image tag.                                                                                                                                                                                           | `v0.5.14`                                          |
-| `image.pullSecrets`                | Array of pull secret names                                                                                                                                                                                     | `[]`                                               |
-| `infoblox.gridHost`                | When using the Infoblox provider, specify the Infoblox Grid host.                                                                                                                                              | `""`                                               |
-| `infoblox.wapiUsername`            | When using the Infoblox provider, specify the Infoblox WAPI username.                                                                                                                                          | `""`                                               |
-| `infoblox.wapiPassword`            | When using the Infoblox provider, specify the Infoblox WAPI password.                                                                                                                                          | `""`                                               |
-| `infoblox.domainFilter`            | When using the Infoblox provider, optionally specify the domain.                                                                                                                                               | `""`                                               |
-| `infoblox.noSslVerify`             | When using the Infoblox provider, optionally disable SSL verification.                                                                                                                                         | `false`                                            |
-| `infoblox.wapiPort`                | When using the Infoblox provider, optionally specify the Infoblox WAPI port.                                                                                                                                   | `""`                                               |
-| `infoblox.wapiVersion`             | When using the Infoblox provider, optionally specify the Infoblox WAPI version.                                                                                                                                | `""`                                               |
-| `infoblox.wapiConnectionPoolSize`  | When using the Infoblox provider, optionally specify the Infoblox WAPI request connection pool size.                                                                                                           | `""`                                               |
-| `infoblox.wapiHttpTimeout`         | When using the Infoblox provider, optionally specify the Infoblox WAPI request timeout in seconds.                                                                                                             | `""`                                               |
-| `istioIngressGateways`             | The fully-qualified name of the Istio ingress gateway services .                                                                                                             | `""`                                               |
-| `rfc2136.host`                     | When using the rfc2136 provider, specify the RFC2136 host.                                                                                                                                                     | `""`                                               |
-| `rfc2136.port`                     | When using the rfc2136 provider, optionally specify the RFC2136 port.                                                                                                                                          | `53`                                               |
-| `rfc2136.zone`                     | When using the rfc2136 provider, specify the zone.                                                                                                                                                             | `""`                                               |
-| `rfc2136.tsigSecret`               | When using the rfc2136 provider, if you want to enable security, specify the tsig secret.                                                                                                                      | `""`                                               |
-| `rfc2136.tsigKeyname`              | When using the rfc2136 provider, if you want to enable security, specify the tsig keyname. If you want an insecure connection, disable this parameter.                                                         | `"externaldns-key"`                                |
-| `rfc2136.tsigSecretAlg`            | When using the rfc2136 provider, if you want to enable security, specify the tsig secret alg.                                                                                                                  | `"hmac-sha256"`                                    |
-| `rfc2136.tsigAxfr`                 | When using the rfc2136 provider, if you want to enable security, enable AFXR.                                                                                                                                  | `true`                                             |
-| `logLevel`                         | Verbosity of the logs (options: panic, debug, info, warn, error, fatal)                                                                                                                                        | `info`                                             |
-| `nodeSelector`                     | Node labels for pod assignment                                                                                                                                                                                 | `{}`                                               |
-| `podAnnotations`                   | Additional annotations to apply to the pod.                                                                                                                                                                    | `{}`                                               |
-| `policy`                           | Modify how DNS records are sychronized between sources and providers (options: sync, upsert-only ).                                                                                                            | `upsert-only`                                      |
-| `provider`                         | The DNS provider where the DNS records will be created (options: aws, google, azure, cloudflare, digitalocean, inmemory, rfc2136 ).                                                                            | `aws`                                              |
-| `publishInternalServices`          | Allow external-dns to publish DNS records for ClusterIP services (optional).                                                                                                                                   | `false`                                            |
-| `rbac.create`                      | If true, create & use RBAC resources                                                                                                                                                                           | `false`                                            |
-| `rbac.serviceAccountName`          | Existing ServiceAccount to use (ignored if rbac.create=true)                                                                                                                                                   | `default`                                          |
-| `interval`                         | Interval update period to use                                                                                                                                                                                  | `1m`                                               |
-| `registry`                         | Registry method to use (options: txt, noop)                                                                                                                                                                    | `txt`                                              |
-| `resources`                        | CPU/Memory resource requests/limits.                                                                                                                                                                           | `{}`                                               |
-| `securityContext`                  | Security options the pod should run with. [More info](https://kubernetes.io/docs/concepts/policy/security-context/)                                                                                            | `{}`                                               |
-| `priorityClassName`                | priorityClassName                                                                                                                                                                                              | `""`                                               |
-| `service.annotations`              | Annotations to add to service                                                                                                                                                                                  | `{}`                                               |
-| `service.clusterIP`                | IP address to assign to service                                                                                                                                                                                | `""`                                               |
-| `service.externalIPs`              | Service external IP addresses                                                                                                                                                                                  | `[]`                                               |
-| `service.loadBalancerIP`           | IP address to assign to load balancer (if supported)                                                                                                                                                           | `""`                                               |
-| `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)                                                                                                                                                | `[]`                                               |
-| `service.servicePort`              | Service port to expose                                                                                                                                                                                         | `7979`                                             |
-| `service.type`                     | Type of service to create                                                                                                                                                                                      | `ClusterIP`                                        |
-| `sources`                          | List of resource types to monitor, possible values are fake, service or ingress.                                                                                                                               | `[service, ingress]`                               |
-| `tolerations`                      | List of node taints to tolerate (requires Kubernetes >= 1.6)                                                                                                                                                   | `[]`                                               |
-| `affinity`                         | List of affinities (requires Kubernetes >=1.6)                                                                                                                                                                 | `{}`                                               |
-| `txtOwnerId`                       | When using the TXT registry, a name that identifies this instance of ExternalDNS (optional)                                                                                                                    | `"default"`                                        |
-| `txtPrefix`                        | When using the TXT registry, a prefix for ownership records that avoids collision with CNAME entries (optional)                                                                                                | `""`                                               |
-| `zoneIdFilters`                    | Limit possible target zones by zone id (optional)                                                                                                                                                              | `[]`                                               |
-| `crd.create`                       | If true, create CRD ressource                                                                                                                                                                                  | `false`                                            |
-| `crd.apiversion`                   | Sets the api version for the crd to watch                                                                                                                                                                      | `"`                                                |
-| `crd.kind`                         | Sets the kind for the crd to watch                                                                                                                                                                             | `"`                                                |
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+```console
+$ helm install --name my-release \
+  --set provider=aws bitnami/external-dns
+```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
@@ -111,35 +150,63 @@ $ helm install --name my-release -f values.yaml stable/external-dns
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
-## IAM Permissions
+### Production configuration
 
-```json
-{
- "Version": "2012-10-17",
- "Statement": [
-   {
-     "Effect": "Allow",
-     "Action": [
-       "route53:ChangeResourceRecordSets"
-     ],
-     "Resource": [
-       "arn:aws:route53:::hostedzone/*"
-     ]
-   },
-   {
-     "Effect": "Allow",
-     "Action": [
-       "route53:ListHostedZones",
-       "route53:ListResourceRecordSets"
-     ],
-     "Resource": [
-       "*"
-     ]
-   }
- ]
-}
+This chart includes a `values-production.yaml` file where you can find some parameters oriented to production configuration in comparison to the regular `values.yaml`.
+
+```console
+$ helm install --name my-release -f ./values-production.yaml bitnami/external-dns
 ```
 
-[external-dns]: https://github.com/kubernetes-incubator/external-dns
-[Zalando]: https://zalando.github.io/
-[getting-started]: https://github.com/kubernetes-incubator/external-dns/blob/master/README.md#getting-started
+- Desired number of ExternalDNS replicas:
+```diff
+- replicas: 1
++ replicas: 3
+```
+
+- Enable prometheus to access external-dns metrics endpoint:
+```diff
+- metrics.enabled: false
++ metrics.enabled: true
+```
+
+## Tutorials
+
+Find information about the requirements for each DNS provider on the link below:
+
+- [ExternalDNS Tutorials](https://github.com/kubernetes-incubator/external-dns/tree/master/docs/tutorials)
+
+For instance, to install ExternalDNS on AWS, you need to:
+
+- Provide the K8s worker node which runs the cluster autoscaler with a minimum IAM policy (check [IAM permissions docs](https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/aws.md#iam-permissions) for more information).
+- Setup a hosted zone on Route53 and annotate the Hosted Zone ID and its associated "nameservers" as described on [these docs](https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/aws.md#set-up-a-hosted-zone).
+- Install ExternalDNS chart using the command below:
+
+> Note: replace the placeholder HOSTED_ZONE_IDENTIFIER and HOSTED_ZONE_NAME, with your hosted zoned identifier and name, respectively.
+
+```bash
+$ helm install --name my-release \
+  --set provider=aws \
+  --set aws.zoneType=public \
+  --set txtOwnerId=HOSTED_ZONE_IDENTIFIER \
+  --set domainFilters[0]=HOSTED_ZONE_NAME \
+  stable/external-dns
+```
+
+### [Rolling VS Immutable tags](https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/)
+
+It is strongly recommended to use immutable tags in a production environment. This ensures your deployment does not change automatically if the same tag is updated with a different image.
+
+Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.
+
+## Upgrading
+
+### To 2.0.0
+
+Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
+Use the workaround below to upgrade from versions previous to 1.0.0. The following example assumes that the release name is `my-release`:
+
+```console
+$ kubectl delete deployment my-release-external-dns
+$ helm upgrade my-release stable/external-dns
+```

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -209,3 +209,13 @@ Use the workaround below to upgrade from versions previous to 1.0.0. The followi
 $ kubectl delete deployment my-release-external-dns
 $ helm upgrade my-release stable/external-dns
 ```
+
+Other mayor changes included in this major version are:
+
+- Default image changes from `registry.opensource.zalan.do/teapot/external-dns` to `bitnami/external-dns`.
+- The parameters below are renamed:
+  - `aws.secretKey` -> `aws.credentials.secretKey`
+  - `aws.accessKey` -> `aws.credentials.accessKey`
+  - `aws.credentialsPath` -> `aws.credentials.mountPath`
+  - `designate.customCA.directory` -> `designate.customCA.mountPath`
+- Support to Prometheus metrics is added.

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -17,7 +17,6 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 ## Prerequisites
 
 - Kubernetes 1.8+ with Beta APIs enabled
-- PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart
 

--- a/stable/external-dns/templates/NOTES.txt
+++ b/stable/external-dns/templates/NOTES.txt
@@ -1,3 +1,8 @@
+** Please be patient while the chart is being deployed **
+
 To verify that external-dns has started, run:
 
-  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "external-dns.name" . }},release={{ .Release.Name }}"
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ template "external-dns.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"
+
+{{ include "external-dns.validateValues" . }}
+{{ include "external-dns.checkRollingTags" . }}

--- a/stable/external-dns/templates/_helpers.tpl
+++ b/stable/external-dns/templates/_helpers.tpl
@@ -24,28 +24,201 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 {{- end -}}
 
-{{/* Generate basic labels */}}
-{{- define "external-dns.labels" }}
-app: {{ template "external-dns.name" . }}
-heritage: {{.Release.Service }}
-release: {{.Release.Name }}
-{{- if .Values.podLabels }}
-{{ toYaml .Values.podLabels }}
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "external-dns.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Helm required labels */}}
+{{- define "external-dns.labels" -}}
+app.kubernetes.io/name: {{ template "external-dns.name" . }}
+helm.sh/chart: {{ template "external-dns.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/* matchLabels */}}
+{{- define "external-dns.matchLabels" -}}
+app.kubernetes.io/name: {{ template "external-dns.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/* podAnnotations */}}
+{{- define "external-dns.podAnnotations" -}}
+{{- if .Values.podAnnotations }}
+{{- toYaml .Values.podAnnotations }}
 {{- end }}
+{{- if .Values.metrics.podAnnotations }}
+{{- toYaml .Values.metrics.podAnnotations }}
 {{- end }}
+{{- end -}}
+
+{{/*
+Return the proper External DNS image name
+*/}}
+{{- define "external-dns.image" -}}
+{{- $registryName := .Values.image.registry -}}
+{{- $repositoryName := .Values.image.repository -}}
+{{- $tag := .Values.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "external-dns.imagePullSecrets" -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
+Also, we can not use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- else if .Values.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- else if .Values.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- end -}}
 
 {{- define "external-dns.aws-credentials" }}
 [default]
-aws_access_key_id = {{ .Values.aws.accessKey }}
-aws_secret_access_key = {{ .Values.aws.secretKey }}
+aws_access_key_id = {{ .Values.aws.credentials.accessKey }}
+aws_secret_access_key = {{ .Values.aws.credentials.secretKey }}
 {{ end }}
-
 
 {{- define "external-dns.aws-config" }}
 [profile default]
-{{- if .Values.aws.roleArn }}
-role_arn = {{ .Values.aws.roleArn }}
-{{- end }}
+role_arn = {{ .Values.aws.assumeRoleArn }}
 region = {{ .Values.aws.region }}
 source_profile = default
 {{ end }}
+
+{{/*
+Compile all warnings into a single message, and call fail.
+*/}}
+{{- define "external-dns.validateValues" -}}
+{{- $messages := list -}}
+{{- $messages := append $messages (include "external-dns.validateValues.provider" .) -}}
+{{- $messages := append $messages (include "external-dns.validateValues.sources" .) -}}
+{{- $messages := append $messages (include "external-dns.validateValues.aws" .) -}}
+{{- $messages := append $messages (include "external-dns.validateValues.google" .) -}}
+{{- $messages := append $messages (include "external-dns.validateValues.infoblox.gridHost" .) -}}
+{{- $messages := append $messages (include "external-dns.validateValues.infoblox.wapiPassword" .) -}}
+{{- $messages := without $messages "" -}}
+{{- $message := join "\n" $messages -}}
+
+{{- if $message -}}
+{{-   printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of External DNS:
+- must set a provider
+*/}}
+{{- define "external-dns.validateValues.provider" -}}
+{{- if not .Values.provider -}}
+external-dns: provider
+    You must set a provider (options: aws, google, azure, cloudflare, ...)
+    Please set the provider parameter (--set provider="xxxx")
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of External DNS:
+- must provide sources to be observed for new DNS entries by ExternalDNS
+*/}}
+{{- define "external-dns.validateValues.sources" -}}
+{{- if empty .Values.sources -}}
+external-dns: sources
+    You must provide sources to be observed for new DNS entries by ExternalDNS
+    Please set the sources parameter (--set sources="xxxx")
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of External DNS:
+- The AWS Role to assume must follow ARN format when provider is "aws"
+*/}}
+{{- define "external-dns.validateValues.aws" -}}
+{{- if and (eq .Values.provider "aws") .Values.aws.assumeRoleArn -}}
+{{- if not (regexMatch "^arn:aws:iam::.*$" .Values.aws.assumeRoleArn) -}}
+external-dns: aws.assumeRoleArn
+    The AWS Role to assume must follow ARN format: `arn:aws:iam::123455567:role/external-dns`
+    Ref: https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
+    Please set a valid ARN (--set aws.assumeRoleARN="xxxx")
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of External DNS:
+- must provide a service account key when provider is "google"
+*/}}
+{{- define "external-dns.validateValues.google" -}}
+{{- if and (eq .Values.provider "google") (not .Values.google.serviceAccountSecret) (not .Values.google.serviceAccountKey) -}}
+external-dns: google.serviceAccountKey google.serviceAccountSecret
+    You must provide the service account key when provider="google".
+    Please set the service account key (--set google.serviceAccountKey="xxxx")
+    or reuse an existing secret (--set google.serviceAccountSecret="xxxx")
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of External DNS:
+- must provide the Grid Manager host when provider is "infoblox"
+*/}}
+{{- define "external-dns.validateValues.infoblox.gridHost" -}}
+{{- if and (eq .Values.provider "infoblox") (not .Values.infoblox.gridHost) -}}
+external-dns: infoblox.gridHost
+    You must provide the the Grid Manager host when provider="infoblox".
+    Please set the gridHost parameter (--set infoblox.gridHost="xxxx")
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of External DNS:
+- must provide a WAPI password when provider is "infoblox"
+*/}}
+{{- define "external-dns.validateValues.infoblox.wapiPassword" -}}
+{{- if and (eq .Values.provider "infoblox") (not .Values.infoblox.wapiPassword) -}}
+external-dns: infoblox.wapiPassword
+    You must provide a WAPI password when provider="infoblox".
+    Please set the wapiPassword parameter (--set infoblox.wapiPassword="xxxx")
+{{- end -}}
+{{- end -}}
+
+{{/* Check if there are rolling tags in the images */}}
+{{- define "external-dns.checkRollingTags" -}}
+{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
+WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
++info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
+{{- end }}
+{{- end -}}

--- a/stable/external-dns/templates/clusterrole.yaml
+++ b/stable/external-dns/templates/clusterrole.yaml
@@ -1,43 +1,42 @@
-{{- if .Values.rbac.create -}}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
 kind: ClusterRole
 metadata:
-  labels: {{ include "external-dns.labels" . | indent 4 }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   name: {{ template "external-dns.fullname" . }}
+  labels: {{ include "external-dns.labels" . | nindent 4 }}
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - services
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.istio.io
-    resources:
-      - gateways
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - externaldns.k8s.io
-    resources:
-      - dnsendpoints
-    verbs:
-      - get
-      - list
-      - watch
-{{- end -}}
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - externaldns.k8s.io
+  resources:
+  - dnsendpoints
+  verbs:
+  - get
+  - list
+  - watch  
+{{- end }}

--- a/stable/external-dns/templates/clusterrole.yaml
+++ b/stable/external-dns/templates/clusterrole.yaml
@@ -38,5 +38,5 @@ rules:
   verbs:
   - get
   - list
-  - watch  
+  - watch
 {{- end }}

--- a/stable/external-dns/templates/clusterrolebinding.yaml
+++ b/stable/external-dns/templates/clusterrolebinding.yaml
@@ -1,16 +1,15 @@
-{{- if .Values.rbac.create -}}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
 kind: ClusterRoleBinding
 metadata:
-  labels: {{ include "external-dns.labels" . | indent 4 }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   name: {{ template "external-dns.fullname" . }}
+  labels: {{ include "external-dns.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ template "external-dns.fullname" . }}
 subjects:
-  - kind: ServiceAccount
-    name: {{ template "external-dns.fullname" . }}
-    namespace: {{ .Release.Namespace }}
-{{- end -}}
+- kind: ServiceAccount
+  name: {{ template "external-dns.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/stable/external-dns/templates/configmap.yaml
+++ b/stable/external-dns/templates/configmap.yaml
@@ -3,8 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "external-dns.fullname" . }}
-  labels: {{ include "external-dns.labels" . | indent 4 }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  labels: {{ include "external-dns.labels" . | nindent 4 }}
 data:
   {{ .Values.designate.customCA.filename }}: |
 {{ .Values.designate.customCA.content | indent 4 }}

--- a/stable/external-dns/templates/crd.yaml
+++ b/stable/external-dns/templates/crd.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.crd.create }}
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -1,267 +1,325 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  labels: {{ include "external-dns.labels" . | indent 4 }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   name: {{ template "external-dns.fullname" . }}
+  labels: {{ include "external-dns.labels" . | nindent 4 }}
 spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels: {{ include "external-dns.matchLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- if .Values.podAnnotations }}
-      annotations: {{ toYaml .Values.podAnnotations | nindent 8}}
-    {{- end }}
-      labels: {{ include "external-dns.labels" . | indent 8 }}
-    {{- if or (and .Values.aws.secretKey .Values.aws.accessKey) .Values.cloudflare.apiKey .Values.digitalocean.apiToken (and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword) .Values.rfc2136.tsigSecret .Values.extraEnv .Values.google.serviceAccountKey }}
-      checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
-    {{- end }}
-    {{- if and (eq .Values.provider "designate") .Values.designate.customCA.enabled }}
-      checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-    {{- end }}
-    spec:
-      {{- if .Values.image.pullSecrets }}
-      imagePullSecrets:
-      {{- range $sec := .Values.image.pullSecrets }}
-        - name: {{$sec | quote }}
+      {{- if or .Values.podAnnotations .Values.metrics.enabled }}
+      annotations: {{ include "external-dns.podAnnotations" . | nindent 8 }}
       {{- end }}
-      {{- end }}
-      {{- if .Values.priorityClassName }}
-      priorityClassName: "{{ .Values.priorityClassName }}"
-      {{- end }}
-      containers:
-        - name: {{ template "external-dns.name" . }}
-          image: "{{.Values.image.name}}:{{ .Values.image.tag }}"
-          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
-          args:
-          {{- if .Values.logLevel }}
-            - --log-level={{ .Values.logLevel }}
-          {{- end }}
-          {{- if .Values.publishInternalServices }}
-            - --publish-internal-services
-          {{- end }}
-          {{- range .Values.domainFilters }}
-            - --domain-filter={{ . }}
-          {{- end }}
-          {{- range .Values.zoneIdFilters }}
-            - --zone-id-filter={{ . }}
-          {{- end }}
-            - --policy={{ .Values.policy }}
-            - --provider={{ .Values.provider }}
-            - --registry={{ .Values.registry }}
-            - --interval={{ .Values.interval }}
-          {{- if .Values.txtOwnerId }}
-            - --txt-owner-id={{ .Values.txtOwnerId }}
-          {{- end }}
-          {{- if .Values.txtPrefix }}
-            - --txt-prefix={{ .Values.txtPrefix }}
-          {{- end }}
-          {{- if .Values.annotationFilter }}
-            - --annotation-filter={{ .Values.annotationFilter }}
-          {{- end }}
-          {{- range .Values.sources }}
-            - --source={{ . }}
-          {{- end }}
-          {{- range .Values.istioIngressGateways }}
-            - --istio-ingress-gateway={{ . }}
-          {{- end }}
-          {{ if .Values.dryRun }}
-            - --dry-run
-          {{- end }}
-          {{ if .Values.aws.assumeRoleArn }}
-            - --aws-assume-role={{ .Values.aws.assumeRoleArn }}
-          {{- end }}
-          {{ if .Values.aws.batchChangeSize }}
-            - --aws-batch-change-size={{ .Values.aws.batchChangeSize }}
-          {{- end }}
-          {{- range $key, $value := .Values.extraArgs }}
-            {{- if $value }}
-            - --{{ $key }}={{ $value }}
-            {{- else }}
-            - --{{ $key }}
-            {{- end }}
-          {{- end }}
-          {{- if eq .Values.provider "cloudflare" }}
-            {{- if .Values.cloudflare.proxied }}
-            - --cloudflare-proxied
-            {{- end }}
-          {{- end }}
-          {{- if .Values.aws.zoneType }}
-            - --aws-zone-type={{ .Values.aws.zoneType }}
-          {{- end }}
-          {{- if .Values.google.project }}
-            - --google-project={{ .Values.google.project }}
-          {{- end }}
-          {{- if eq .Values.provider "infoblox" }}
-            - --infoblox-grid-host={{ .Values.infoblox.gridHost }}
-            {{- if .Values.infoblox.domainFilter }}
-            - --domain-filter={{ .Values.infoblox.domainFilter }}
-            {{- end }}
-            {{- if .Values.infoblox.wapiPort }}
-            - --infoblox-wapi-port={{ .Values.infoblox.wapiPort }}
-            {{- end }}
-            {{- if .Values.infoblox.wapiVersion }}
-            - --infoblox-wapi-version={{ .Values.infoblox.wapiVersion }}
-            {{- end }}
-            {{- if .Values.infoblox.noSslVerify }}
-            - --no-infoblox-ssl-verify
-            {{- else }}
-            - --infoblox-ssl-verify
-            {{- end }}
-          {{- end }}
-          {{- if eq .Values.provider "rfc2136" }}
-            - --rfc2136-host={{ required "rfc2136.host must be supplied for provider 'rfc2136'" .Values.rfc2136.host }}
-            - --rfc2136-port={{ .Values.rfc2136.port }}
-            - --rfc2136-zone={{ required "rfc2136.zone must be supplied for provider 'rfc2136'" .Values.rfc2136.zone }}
-            {{- if .Values.rfc2136.tsigKeyname }}
-            - --rfc2136-tsig-secret-alg={{ .Values.rfc2136.tsigSecretAlg }}
-            - --rfc2136-tsig-keyname={{ .Values.rfc2136.tsigKeyname }}
-              {{- if .Values.rfc2136.tsigAxfr }}
-            - --rfc2136-tsig-axfr
-              {{- end }}
-            {{- else }}
-            - --rfc2136-insecure
-            {{- end }}
-          {{- end }}
-          {{- if .Values.crd.create }}
-            - --source=crd
-            {{- if .Values.crd.apiversion }}
-            - --crd-source-apiversion={{ .Values.crd.apiversion }}
-            {{- end }}
-            {{- if .Values.crd.kind }}
-            - --crd-source-kind={{ .Values.crd.kind }}
-            {{- end }}
-          {{- end }}
-          volumeMounts:
-          {{- if or .Values.google.serviceAccountSecret .Values.google.serviceAccountKey }}
-          - name: google-service-account
-            mountPath: /etc/secrets/service-account/
-          {{- end}}
-          {{- if eq .Values.provider "azure" }}
-          - name: azure-config-file
-            {{- if not .Values.azure.secretName }}
-            mountPath: /etc/kubernetes/azure.json
-            {{- else }}
-            mountPath: /etc/kubernetes/
-            {{- end }}
-            readOnly: true
-          {{- end }}
-          {{- if (and .Values.aws.secretKey .Values.aws.accessKey) }}
-          - name: aws-credentials
-            mountPath: {{ .Values.aws.credentialsPath }}
-            readOnly: true
-          {{- end }}
-          {{- if and (eq .Values.provider "designate") .Values.designate.customCA.enabled }}
-          - name: designate-custom-ca
-            mountPath: {{ .Values.designate.customCA.directory }}
-            readOnly: true
-          {{- end }}
-          env:
-        {{- if or .Values.google.serviceAccountSecret .Values.google.serviceAccountKey }}
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/secrets/service-account/credentials.json
-        {{- end }}
-        {{- if or (eq .Values.provider "aws") (eq .Values.provider "aws-sd") }}
-        {{- if .Values.aws.region }}
-          - name: AWS_DEFAULT_REGION
-            value: {{ .Values.aws.region }}
-        {{- end }}
-        {{- end }}
-        {{- if and .Values.cloudflare.apiKey .Values.cloudflare.email }}
-          - name: CF_API_KEY
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "external-dns.fullname" . }}
-                key: cloudflare_api_key
-          - name: CF_API_EMAIL
-            value: "{{ .Values.cloudflare.email }}"
-        {{- end }}
-        {{- if .Values.digitalocean.apiToken }}
-          - name: DO_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "external-dns.fullname" . }}
-                key: digitalocean_api_token
-        {{- end }}
-        {{- if .Values.infoblox.wapiConnectionPoolSize }}
-          - name: EXTERNAL_DNS_INFOBLOX_HTTP_POOL_CONNECTIONS
-            value: "{{ .Values.infoblox.wapiConnectionPoolSize }}"
-        {{- end }}
-        {{- if .Values.infoblox.wapiHttpTimeout }}
-          - name: EXTERNAL_DNS_INFOBLOX_HTTP_REQUEST_TIMEOUT
-            value: "{{ .Values.infoblox.wapiHttpTimeout }}"
-        {{- end }}
-        {{- if and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword }}
-          - name: EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "external-dns.fullname" . }}
-                key: infoblox_wapi_username
-          - name: EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "external-dns.fullname" . }}
-                key: infoblox_wapi_password
-        {{- end }}
-        {{- if and .Values.rfc2136.tsigSecret }}
-          - name: EXTERNAL_DNS_RFC2136_TSIG_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "external-dns.fullname" . }}
-                key: rfc2136_tsig_secret
+      labels: {{ include "external-dns.labels" . | nindent 8 }}
+        {{- if or (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey) .Values.cloudflare.apiKey .Values.digitalocean.apiToken (and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword) .Values.rfc2136.tsigSecret .Values.extraEnv .Values.google.serviceAccountKey }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
         {{- if and (eq .Values.provider "designate") .Values.designate.customCA.enabled }}
-          - name: OPENSTACK_CA_FILE
-            value: {{ .Values.designate.customCA.directory }}/{{ .Values.designate.customCA.filename }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
-        {{- $root := . -}}
-        {{- range .Values.extraEnv }}
-          - name: {{ .name }}
-            valueFrom:
-          {{- if .valueFrom }}
-{{ toYaml .valueFrom | indent 14 }}
+    spec:
+{{- include "external-dns.imagePullSecrets" . | indent 6 }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- if .Values.rbac.create }}
+      serviceAccountName: {{ template "external-dns.fullname" . }}
+      {{- else }}
+      serviceAccountName: {{ .Values.rbac.serviceAccountName | quote }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      containers:
+      - name: external-dns
+        image: "{{ template "external-dns.image" . }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+        args:
+        # Generic arguments
+        {{- if .Values.logLevel }}
+        - --log-level={{ .Values.logLevel }}
+        {{- end }}
+        {{- if .Values.dryRun }}
+        - --dry-run
+        {{- end }}
+        {{- if .Values.publishInternalServices }}
+        - --publish-internal-services
+        {{- end }}
+        {{- range .Values.domainFilters }}
+        - --domain-filter={{ . }}
+        {{- end }}
+        {{- range .Values.zoneIdFilters }}
+        - --zone-id-filter={{ . }}
+        {{- end }}
+        - --policy={{ .Values.policy }}
+        - --provider={{ .Values.provider }}
+        - --registry={{ .Values.registry }}
+        - --interval={{ .Values.interval }}
+        {{- if eq .Values.registry "txt" }}
+        {{- if .Values.txtOwnerId }}
+        - --txt-owner-id={{ .Values.txtOwnerId }}
+        {{- end }}
+        {{- if .Values.txtPrefix }}
+        - --txt-prefix={{ .Values.txtPrefix }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.annotationFilter }}
+        - --annotation-filter={{ .Values.annotationFilter }}
+        {{- end }}
+        {{- if .Values.crd.create }}
+          {{- if .Values.crd.apiversion }}
+        - --crd-source-apiversion={{ .Values.crd.apiversion }}
+          {{- end }}
+          {{- if .Values.crd.kind }}
+        - --crd-source-kind={{ .Values.crd.kind }}
+          {{- end }}
+        {{- end }}        
+        {{- range $key, $value := .Values.extraArgs }}
+          {{- if $value }}
+        - --{{ $key }}={{ $value }}
           {{- else }}
-              secretKeyRef:
-                name: {{ template "external-dns.fullname" $root }}
-                key: {{ .name }}
+        - --{{ $key }}
           {{- end }}
         {{- end }}
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 7979
-          ports:
-            - containerPort: 7979
-        {{- if .Values.securityContext }}
-          securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
+        {{- range .Values.istioIngressGateways }}
+        - --istio-ingress-gateway={{ . }}
+        {{- end }}        
+        {{- range .Values.sources }}
+        - --source={{ . }}
         {{- end }}
+        # AWS arguments
+        {{- if or (eq .Values.provider "aws") (eq .Values.provider "aws-sd") }}
+        {{- if .Values.aws.zoneType }}
+        - --aws-zone-type={{ .Values.aws.zoneType }}
+        {{- end }}
+        {{- if .Values.aws.assumeRoleArn }}
+        - --aws-assume-role={{ .Values.aws.assumeRoleArn }}
+        {{- end }}
+        {{- if .Values.aws.batchChangeSize }}
+        - --aws-batch-change-size={{ .Values.aws.batchChangeSize }}
+        {{- end }}
+        {{- end }}
+        # Azure Arguments
+        {{- if eq .Values.provider "azure" }}
+        {{- if .Values.azure.resoureGroup }}
+        - --azure-resource-group={{ .Values.azure.resoureGroup }}
+        {{- end }}
+        {{- end }}
+        # Cloudflare arguments
+        {{- if eq .Values.provider "cloudflare" }}
+          {{- if .Values.cloudflare.proxied }}
+        - --cloudflare-proxied
+          {{- end }}
+        {{- end }}
+        # Google Arguments
+        {{- if eq .Values.provider "google" }}
+        - --google-project={{ .Values.google.project }}
+        {{- end }}
+        # Infloblox Arguments
+        {{- if eq .Values.provider "infoblox" }}
+        - --infoblox-grid-host={{ .Values.infoblox.gridHost }}
+          {{- if .Values.infoblox.domainFilter }}
+        - --domain-filter={{ .Values.infoblox.domainFilter }}
+          {{- end }}
+          {{- if .Values.infoblox.wapiPort }}
+        - --infoblox-wapi-port={{ .Values.infoblox.wapiPort }}
+          {{- end }}
+          {{- if .Values.infoblox.wapiVersion }}
+        - --infoblox-wapi-version={{ .Values.infoblox.wapiVersion }}
+          {{- end }}
+          {{- if .Values.infoblox.noSslVerify }}
+        - --no-infoblox-ssl-verify
+          {{- else }}
+        - --infoblox-ssl-verify
+          {{- end }}
+        {{- end }}
+        # RFC 2136 arguments
+        {{- if eq .Values.provider "rfc2136" }}
+        - --rfc2136-host={{ required "rfc2136.host must be supplied for provider 'rfc2136'" .Values.rfc2136.host }}
+        - --rfc2136-port={{ .Values.rfc2136.port }}
+        - --rfc2136-zone={{ required "rfc2136.zone must be supplied for provider 'rfc2136'" .Values.rfc2136.zone }}
+          {{- if .Values.rfc2136.tsigKeyname }}
+        - --rfc2136-tsig-secret-alg={{ .Values.rfc2136.tsigSecretAlg }}
+        - --rfc2136-tsig-keyname={{ .Values.rfc2136.tsigKeyname }}
+            {{- if .Values.rfc2136.tsigAxfr }}
+        - --rfc2136-tsig-axfr
+            {{- end }}
+          {{- else }}
+        - --rfc2136-insecure
+          {{- end }}
+        {{- end }}
+        # Extra arguments
+        {{- range $key, $value := .Values.extraArgs }}
+          {{- if $value }}
+        - --{{ $key }}={{ $value }}
+          {{- else }}
+        - --{{ $key }}
+          {{- end }}
+        {{- end }}
+        env:
+        # AWS environment variables
+        {{- if or (eq .Values.provider "aws") (eq .Values.provider "aws-sd") }}
+        {{- if .Values.aws.region }}
+        - name: AWS_DEFAULT_REGION
+          value: {{ .Values.aws.region }}
+        {{- end }}
+        {{- if .Values.aws.roleArn }}
+        - name: AWS_CONFIG_FILE
+          value: {{ .Values.aws.credentials.mountPath }}/config
+        {{- end }}
+        {{- if and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey }}
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: {{ .Values.aws.credentials.mountPath }}/credentials
+        {{- end }}
+        {{- end }}
+        # Cloudflare environment variables
+        {{- if eq .Values.provider "cloudflare" }}
+        - name: CF_API_KEY
+          valueFrom:
+            key: cloudflare_api_key
+        - name: CF_API_EMAIL
+            value: {{ .Values.cloudflare.email | quote }}
+        {{- end }}
+        # DigitalOcean environment variables
+        {{- if eq .Values.provider "digitalocean" }}
+        - name: DO_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "external-dns.fullname" . }}
+              key: digitalocean_api_token
+        {{- end }}
+        # Google environment variables
+        {{- if eq .Values.provider "google" }}
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/secrets/service-account/credentials.json
+        {{- end }}
+        # Infloblox environment variables
+        {{- if eq .Values.provider "infoblox" }}
+        {{- if .Values.infoblox.wapiConnectionPoolSize }}
+        - name: EXTERNAL_DNS_INFOBLOX_HTTP_POOL_CONNECTIONS
+          value: "{{ .Values.infoblox.wapiConnectionPoolSize }}"
+        {{- end }}
+        {{- if .Values.infoblox.wapiHttpTimeout }}
+        - name: EXTERNAL_DNS_INFOBLOX_HTTP_REQUEST_TIMEOUT
+          value: "{{ .Values.infoblox.wapiHttpTimeout }}"
+        {{- end }}
+        {{- if and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword }}
+        - name: EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "external-dns.fullname" . }}
+              key: infoblox_wapi_username
+        - name: EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "external-dns.fullname" . }}
+              key: infoblox_wapi_password
+        {{- end }}
+        {{- end }}
+        # RFC 2136 environment variables
+        {{- if and .Values.rfc2136.tsigSecret }}
+        - name: EXTERNAL_DNS_RFC2136_TSIG_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "external-dns.fullname" . }}
+              key: rfc2136_tsig_secret
+        {{- end }}
+        {{- if and (eq .Values.provider "designate") .Values.designate.customCA.enabled }}
+        - name: OPENSTACK_CA_FILE
+          value: {{ .Values.designate.customCA.mountPath }}/{{ .Values.designate.customCA.filename }}
+        {{- end }}
+        # Extra environment variables
+        {{- $root := . -}}
+        {{- range .Values.extraEnv }}
+        - name: {{ .name }}
+          valueFrom:
+            {{- if .valueFrom }}
+{{ toYaml .valueFrom | indent 12 }}
+            {{- else }}
+            secretKeyRef:
+              name: {{ template "external-dns.fullname" $root }}
+              key: {{ .name }}
+            {{- end }}
+        {{- end }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.service.port }}
+        readinessProbe: {{ toYaml .Values.readinessProbe | nindent 10 }}
+        livenessProbe: {{ toYaml .Values.livenessProbe | nindent 10 }}
         {{- if .Values.resources }}
-          resources: {{ toYaml .Values.resources | nindent 12 }}
+        resources: {{ toYaml .Values.resources | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        # AWS mountPath(s)
+        {{- if and (eq .Values.provider "aws") (or .Values.aws.assumeRoleArn (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey)) }}
+        - name: aws-credentials
+          mountPath: {{ .Values.aws.credentials.mountPath }}
+          readOnly: true
+        {{- end }}
+        # Azure mountPath(s)
+        {{- if eq .Values.provider "azure" }}
+        - name: azure-config-file
+          {{- if not .Values.azure.secretName }}
+          mountPath: /etc/kubernetes/azure.json
+          {{- else }}
+          mountPath: /etc/kubernetes/
+          {{- end }}
+          readOnly: true
+        {{- end }}
+        # Google mountPath(s)
+        {{- if eq .Values.provider "google" }}
+        - name: google-service-account
+          mountPath: /etc/secrets/service-account/
+        {{- end }}
+        # Designate mountPath(s)
+        {{- if and (eq .Values.provider "designate") .Values.designate.customCA.enabled }}
+        - name: designate-custom-ca
+          mountPath: {{ .Values.designate.customCA.mountPath }}
+          readOnly: true
         {{- end }}
       volumes:
-      {{- if .Values.google.serviceAccountSecret }}
-      - name: google-service-account
-        secret:
-          secretName: {{ .Values.google.serviceAccountSecret | quote }}
-      {{- else if .Values.google.serviceAccountKey }}
-      - name: google-service-account
-        secret:
-          secretName: {{ template "external-dns.fullname" . }}
-      {{- end}}
-      {{- if eq .Values.provider "azure" }}
-      - name: azure-config-file
-        {{- if (not .Values.azure.secretName)}}
-        hostPath:
-          path: /etc/kubernetes/azure.json
-          type: File
-        {{- else}}
-        secret:
-          secretName: {{.Values.azure.secretName}}
-        {{- end}}
-      {{- end }}
-      {{- if (and .Values.aws.secretKey .Values.aws.accessKey) }}
+      # AWS volume(s)
+      {{- if and (eq .Values.provider "aws") (or .Values.aws.assumeRoleArn (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey)) }}
       - name: aws-credentials
         secret:
           secretName: {{ template "external-dns.fullname" . }}
       {{- end }}
+      # Azure volume(s)
+      {{- if eq .Values.provider "azure" }}
+      - name: azure-config-file
+        {{- if (not .Values.azure.secretName) }}
+        hostPath:
+          path: /etc/kubernetes/azure.json
+          type: File
+        {{- else }}
+        secret:
+          secretName: {{ .Values.azure.secretName }}
+        {{- end }}
+      {{- end }}
+      # Google volume(s)
+      {{- if eq .Values.provider "google" }}
+      - name: google-service-account
+        secret:
+      {{- if .Values.google.serviceAccountSecret }}
+          secretName: {{ .Values.google.serviceAccountSecret | quote }}
+      {{- else }}
+          secretName: {{ template "external-dns.fullname" . }}
+      {{- end }}
+      {{- end }}
+      # Designate volume(s)
       {{- if and (eq .Values.provider "designate") .Values.designate.customCA.enabled }}
       - name: designate-custom-ca
         configMap:
@@ -270,13 +328,3 @@ spec:
           - key: {{ .Values.designate.customCA.filename }}
             path: {{ .Values.designate.customCA.filename }}
       {{- end }}
-    {{- if .Values.nodeSelector }}
-      nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}
-    {{- end }}
-    {{- if .Values.tolerations }}
-      tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
-    {{- end }}
-{{- if .Values.affinity }}
-      affinity: {{ toYaml .Values.affinity | nindent 8 }}
-    {{- end }}
-      serviceAccountName: {{ if .Values.rbac.create }}{{ template "external-dns.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}

--- a/stable/external-dns/templates/secret.yaml
+++ b/stable/external-dns/templates/secret.yaml
@@ -1,36 +1,36 @@
-{{- if or (and .Values.aws.secretKey .Values.aws.accessKey) .Values.cloudflare.apiKey .Values.digitalocean.apiToken (and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword) .Values.rfc2136.tsigSecret .Values.extraEnv .Values.google.serviceAccountKey -}}
+{{- if or .Values.aws.assumeRoleArn (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey) .Values.cloudflare.apiKey .Values.digitalocean.apiToken .Values.google.serviceAccountKey (and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword) .Values.rfc2136.tsigSecret .Values.extraEnv }}
 apiVersion: v1
 kind: Secret
 metadata:
-  labels: {{ include "external-dns.labels" . | indent 4 }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   name: {{ template "external-dns.fullname" . }}
+  labels: {{ include "external-dns.labels" . | nindent 4 }}
 type: Opaque
 data:
-{{- if eq .Values.provider "aws" }}
+  {{- if eq .Values.provider "aws" }}
+  {{- if and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey }}
   credentials: {{ include "external-dns.aws-credentials" . | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.aws.assumeRoleArn }}
   config: {{ include "external-dns.aws-config" . | b64enc | quote }}
-{{- end}}
-{{- if and (eq .Values.provider "google") .Values.google.serviceAccountKey }}
+  {{- end }}
+  {{- end }}
+  {{- if and (eq .Values.provider "google") .Values.google.serviceAccountKey }}
   credentials.json: {{ .Values.google.serviceAccountKey | b64enc | quote }}
-{{- end}}
-{{- if .Values.cloudflare.apiKey }}
+  {{- end }}
+  {{- if .Values.cloudflare.apiKey }}
   cloudflare_api_key: {{ .Values.cloudflare.apiKey | b64enc | quote }}
-{{- end }}
-{{- if .Values.digitalocean.apiToken }}
+  {{- end }}
+  {{- if .Values.digitalocean.apiToken }}
   digitalocean_api_token: {{ .Values.digitalocean.apiToken | b64enc | quote }}
-{{- end }}
-{{- if and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword }}
+  {{- end }}
+  {{- if and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword }}
   infoblox_wapi_username: {{ .Values.infoblox.wapiUsername | b64enc | quote }}
   infoblox_wapi_password: {{ .Values.infoblox.wapiPassword | b64enc | quote }}
-{{- end }}
-{{- if .Values.rfc2136.tsigSecret }}
-  rfc2136_tsig_secret: {{ .Values.rfc2136.tsigSecret | b64enc | quote }}
-{{- end }}
-
-{{- range .Values.extraEnv }}
-  {{- if .value }}
-  {{ .name }}: {{ .value | b64enc | quote }}
   {{- end }}
-{{- end }}
+  {{- if .Values.rfc2136.tsigSecret }}
+  rfc2136_tsig_secret: {{ .Values.rfc2136.tsigSecret | b64enc | quote }}
+  {{- end }}
+  {{- range $key, $value := .Values.extraEnv }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/stable/external-dns/templates/service.yaml
+++ b/stable/external-dns/templates/service.yaml
@@ -1,37 +1,31 @@
 apiVersion: v1
 kind: Service
 metadata:
-{{- if .Values.service.annotations }}
-  annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
-{{- end }}
-  labels:
-    app: {{ template "external-dns.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
   name: {{ template "external-dns.fullname" . }}
+  labels: {{ include "external-dns.labels" . | nindent 4 }}
+  {{- if .Values.service.annotations }}
+  annotations: {{ toYaml .Values.service.annotations | nindent 4 }}
+  {{- end }}
 spec:
-{{- if .Values.service.clusterIP }}
-  clusterIP: "{{ .Values.service.clusterIP }}"
-{{- end }}
-{{- if .Values.service.externalIPs }}
-  externalIPs:
-{{ toYaml .Values.service.externalIPs | indent 4 }}
-{{- end }}
-{{- if .Values.service.loadBalancerIP }}
-  loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
-{{- end }}
-{{- if .Values.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges:
-{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
-{{- end }}
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+  {{- if .Values.service.externalIPs }}
+  externalIPs: {{ toYaml .Values.service.externalIPs | nindent 4 }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
   ports:
-    - port: {{ .Values.service.servicePort }}
-      protocol: TCP
-      targetPort: 7979
-      name: http
-  selector:
-    app: {{ template "external-dns.name" . }}
-    release: {{ .Release.Name }}
-  type: "{{ .Values.service.type }}"
+  - name: http
+    port: {{ .Values.service.port }}
+    protocol: TCP
+    targetPort: http
+    {{- if and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort)) }}
+    nodePort: {{ .Values.service.nodePort  }}
+    {{- end }}
+  selector: {{ include "external-dns.matchLabels" . | nindent 6 }}
+  type: {{ .Values.service.type }}

--- a/stable/external-dns/templates/serviceaccount.yaml
+++ b/stable/external-dns/templates/serviceaccount.yaml
@@ -1,8 +1,7 @@
-{{- if .Values.rbac.create -}}
+{{- if .Values.rbac.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  labels: {{ include "external-dns.labels" . | indent 4 }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   name: {{ template "external-dns.fullname" . }}
+  labels: {{ include "external-dns.labels" . | nindent 4 }}
 {{- end }}

--- a/stable/external-dns/values-production.yaml
+++ b/stable/external-dns/values-production.yaml
@@ -26,6 +26,12 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## String to partially override external-dns.fullname template (will maintain the release name)
+# nameOverride:
+
+## String to fully override external-dns.fullname template
+# fullnameOverride:
+
 ## K8s resources type to be observed for new DNS entries by ExternalDNS
 ##
 sources:
@@ -222,6 +228,7 @@ priorityClassName: ""
 ## Installs the DNSEndpoint CRD
 ##
 crd:
+  create: false
   apiversion: ""
   kind: ""
 

--- a/stable/external-dns/values-production.yaml
+++ b/stable/external-dns/values-production.yaml
@@ -191,6 +191,10 @@ txtOwnerId: ""
 ## Prefix to create a TXT record with a name following the pattern prefix.<CNAME record>
 ##
 # txtPrefix: ""
+## Load balancer service to be used; ie: custom-istio-namespace/custom-istio-ingressgateway.
+## Omit to use the default (istio-system/istio-ingressgateway)
+##
+istioIngressGateways: []
 
 ## Extra Arguments to passed to external-dns
 ##

--- a/stable/external-dns/values-production.yaml
+++ b/stable/external-dns/values-production.yaml
@@ -37,7 +37,7 @@ image:
 sources:
 - service
 - ingress
-- crd
+# - crd
 
 ## DNS provider where the DNS records will be created. Available providers are:
 ## - aws, azure, cloudflare, designate, digitalocoean, google, infoblox, rfc2136

--- a/stable/external-dns/values-production.yaml
+++ b/stable/external-dns/values-production.yaml
@@ -185,10 +185,6 @@ txtOwnerId: ""
 ## Prefix to create a TXT record with a name following the pattern prefix.<CNAME record>
 ##
 # txtPrefix: ""
-## Load balancer service to be used; ie: custom-istio-namespace/custom-istio-ingressgateway.
-## Omit to use the default (istio-system/istio-ingressgateway)
-##
-istioIngressGateways: []
 
 ## Extra Arguments to passed to external-dns
 ##
@@ -199,7 +195,7 @@ extraEnv: {}
 
 ## Replica count
 ##
-replicas: 1
+replicas: 3
 
 ## Affinity for pod assignment (this value is evaluated as a template)
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
@@ -226,7 +222,6 @@ priorityClassName: ""
 ## Installs the DNSEndpoint CRD
 ##
 crd:
-  create: false  
   apiversion: ""
   kind: ""
 
@@ -320,6 +315,6 @@ readinessProbe:
 ## Prometheus Exporter / Metrics
 ##
 metrics:
-  enabled: false
+  enabled: true
   ## Metrics exporter pod Annotation and Labels
   ##

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -26,6 +26,12 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## String to partially override external-dns.fullname template (will maintain the release name)
+# nameOverride:
+
+## String to fully override external-dns.fullname template
+# fullnameOverride:
+
 ## K8s resources type to be observed for new DNS entries by ExternalDNS
 ##
 sources:
@@ -226,7 +232,7 @@ priorityClassName: ""
 ## Installs the DNSEndpoint CRD
 ##
 crd:
-  create: false  
+  create: false
   apiversion: ""
   kind: ""
 

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -37,7 +37,7 @@ image:
 sources:
 - service
 - ingress
-- crd
+# - crd
 
 ## DNS provider where the DNS records will be created. Available providers are:
 ## - aws, azure, cloudflare, designate, digitalocoean, google, infoblox, rfc2136


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

As a consequence of Bitnami maintaining this chart, this PR switches the default image to be used to `bitnami/external-dns` and it adapts the chart following the best practices applied to Bitnami charts.

#### Which issue this PR fixes

  - fixes https://github.com/helm/charts/issues/14861

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
