### PR TITLE
[stable/nginx-ingress] Add security context for default backend

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.6.18
+version: 1.6.19
 appVersion: 0.24.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -144,6 +144,7 @@ Parameter | Description | Default
 `defaultBackend.image.repository` | default backend container image repository | `k8s.gcr.io/defaultbackend-amd64`
 `defaultBackend.image.tag` | default backend container image tag | `1.5`
 `defaultBackend.image.pullPolicy` | default backend container image pull policy | `IfNotPresent`
+`defaultBackend.image.runAsUser` | User ID of the controller process. Value depends on the Linux distribution used inside of the container image. By default uses nobody user. | `65534`
 `defaultBackend.extraArgs` | Additional default backend container arguments | `{}`
 `defaultBackend.port` | Http port number | `8080`
 `defaultBackend.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
@@ -155,7 +156,7 @@ Parameter | Description | Default
 `defaultBackend.minAvailable` | minimum number of available default backend pods for PodDisruptionBudget | `1`
 `defaultBackend.resources` | default backend pod resource requests & limits | `{}`
 `defaultBackend.priorityClassName` | default backend  priorityClassName | `nil`
-`defaultBackend.podSecurityContext` | Security context policies to add to the default backend | `{ runAsUser: 65534 }`
+`defaultBackend.podSecurityContext` | Security context policies to add to the default backend | `{}`
 `defaultBackend.service.annotations` | annotations for default backend service | `{}`
 `defaultBackend.service.clusterIP` | internal default backend cluster service IP | `""`
 `defaultBackend.service.omitClusterIP` | To omit the `clusterIP` from the default backend service | `false`

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -155,6 +155,7 @@ Parameter | Description | Default
 `defaultBackend.minAvailable` | minimum number of available default backend pods for PodDisruptionBudget | `1`
 `defaultBackend.resources` | default backend pod resource requests & limits | `{}`
 `defaultBackend.priorityClassName` | default backend  priorityClassName | `nil`
+`defaultBackend.podSecurityContext` | Security context policies to add to the default backend | `{ runAsUser: 65534 }`
 `defaultBackend.service.annotations` | annotations for default backend service | `{}`
 `defaultBackend.service.clusterIP` | internal default backend cluster service IP | `""`
 `defaultBackend.service.omitClusterIP` | To omit the `clusterIP` from the default backend service | `false`

--- a/stable/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/stable/nginx-ingress/templates/default-backend-deployment.yaml
@@ -35,6 +35,10 @@ spec:
 {{- if .Values.defaultBackend.priorityClassName }}
       priorityClassName: "{{ .Values.defaultBackend.priorityClassName }}"
 {{- end }}
+      {{- if .Values.defaultBackend.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.defaultBackend.podSecurityContext | indent 8 }}
+      {{- end }}
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.defaultBackend.name }}
           image: "{{ .Values.defaultBackend.image.repository }}:{{ .Values.defaultBackend.image.tag }}"
@@ -60,7 +64,6 @@ spec:
               protocol: TCP
           resources:
 {{ toYaml .Values.defaultBackend.resources | indent 12 }}
-      serviceAccountName: {{ template "nginx-ingress.serviceAccountName" . }}
     {{- if .Values.defaultBackend.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.defaultBackend.nodeSelector | indent 8 }}

--- a/stable/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/stable/nginx-ingress/templates/default-backend-deployment.yaml
@@ -51,6 +51,8 @@ spec:
             - --{{ $key }}
             {{- end }}
           {{- end }}
+          securityContext:
+            runAsUser: {{ .Values.defaultBackend.image.runAsUser }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -316,6 +316,8 @@ defaultBackend:
     repository: k8s.gcr.io/defaultbackend-amd64
     tag: "1.5"
     pullPolicy: IfNotPresent
+    # nobody user -> uid 65534
+    runAsUser: 65534
 
   extraArgs: {}
 
@@ -336,8 +338,7 @@ defaultBackend:
   ## See https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/ for
   ## notes on enabling and using sysctls
   ##
-  podSecurityContext:
-    runAsUser: 65534
+  podSecurityContext: {}
 
   # labels to add to the pod container metadata
   podLabels: {}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -332,6 +332,13 @@ defaultBackend:
 
   affinity: {}
 
+  ## Security Context policies for controller pods
+  ## See https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/ for
+  ## notes on enabling and using sysctls
+  ##
+  podSecurityContext:
+    runAsUser: 65534
+
   # labels to add to the pod container metadata
   podLabels: {}
   #  key: value


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Add Security Context for defaultBackend pod, to start pods with no root user
Remove nginx-ingress sa for defaultBackend, pod doesn't need nginx-ingress controller rights

#### Which issue this PR fixes
  - fixes #14971 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
