### PR TITLE
 [stable/dex] Pod annotations Dex

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 1.4.0
+version: 1.5.0
 appVersion: 2.16.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/templates/deployment.yaml
+++ b/stable/dex/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
         release: "{{ .Release.Name }}"
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ template "dex.serviceAccountName" . }}
       nodeSelector:

--- a/stable/dex/values.yaml
+++ b/stable/dex/values.yaml
@@ -11,6 +11,8 @@ inMiniKube: false
 
 nodeSelector: {}
 
+podAnnotations: {}
+
 tolerations: []
   # - key: CriticalAddonsOnly
   #   operator: Exists


### PR DESCRIPTION
Signed-off-by: Rick Haan <rickhaan94@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Added the ability to configure your own pod annotations to the deployment of Dex. This can be useful when there is a need to configure your own, for example, to add Prometheus annotations as can be seen here:
``` yaml
podAnnotations:
  prometheus.io/path: "/metrics"
  prometheus.io/port: "5558"
  prometheus.io/scrape: "true"
```

#### Which issue this PR fixes
* None

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] ~~Variables are documented in the README.md~~ At the moment a `README.md` does not exist for this chart
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)