### PR TITLE
[Stable/Consul] Change UIIngress.TLS default value to List

### DIFF
--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: consul
 home: https://github.com/hashicorp/consul
-version: 3.6.3
+version: 3.6.4
 appVersion: 1.0.0
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/stable/consul/README.md
+++ b/stable/consul/README.md
@@ -59,7 +59,7 @@ The following table lists the configurable parameters of the consul chart and th
 | `uiIngress.annotations` | Associate annotations to the Ingress  | `{}`                                                       |
 | `uiIngress.labels`      | Associate labels to the Ingress       | `{}`                                                       |
 | `uiIngress.hosts`       | Associate hosts with the Ingress      | `[]`                                                       |
-| `uiIngress.tls`         | Associate TLS with the Ingress        | `{}`                                                       |
+| `uiIngress.tls`         | Associate TLS with the Ingress        | `[]`                                                       |
 | `uiService.enabled`     | Create dedicated Consul Web UI svc    | `true`                                                     |
 | `uiService.type`        | Dedicate Consul Web UI svc type       | `NodePort`                                                 |
 | `uiService.annotations` | Extra annotations for UI service      | `{}`                                                       |

--- a/stable/consul/values.yaml
+++ b/stable/consul/values.yaml
@@ -118,7 +118,7 @@ uiIngress:
   annotations: {}
   labels: {}
   hosts: []
-  tls: {}
+  tls: []
 
 ## Useful when ACLs are enabled
 acl:


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes the default values for UI-Ingress.TLS to be a list.  WIthout this, you get the following warning when deploying as a child chart and supplying an additional values file:

```
2019/06/21 14:05:06 Warning: Merging destination map for chart 'consul'. Cannot overwrite table item 'tls', with non table value: map[]
2019/06/21 14:05:06 Warning: Merging destination map for chart 'consul'. Cannot overwrite table item 'tls', with non table value: map[]
2019/06/21 14:05:06 Warning: Merging destination map for chart 'consul'. Cannot overwrite table item 'tls', with non table value: map[]
2019/06/21 14:05:06 Warning: Merging destination map for chart 'consul'. Cannot overwrite table item 'tls', with non table value: map[]
```

#### Which issue this PR fixes

None.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
