### PR TITLE
[stable/redis-ha] Improve liveness probe for large databases

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.5.1
+version: 3.5.2
 appVersion: 5.0.3
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/redis-ha-healthchecks.yaml
+++ b/stable/redis-ha/templates/redis-ha-healthchecks.yaml
@@ -39,3 +39,13 @@ data:
         echo "Server check failed with: $CHECK_SERVER"
         exit 1
     fi
+
+  liveness.sh: |
+    #!/bin/sh
+    set -eu
+    CHECK_SERVER="$(redis-cli -p "$1"{{ if .Values.auth }} -a "$AUTH"{{ end }} ping)"
+
+    if [ "$CHECK_SERVER" != "PONG" ] && [ "$CHECK_SERVER" != "LOADING Redis is loading the dataset in memory" ]; then
+        echo "Server check failed with: $CHECK_SERVER"
+        exit 1
+    fi

--- a/stable/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/stable/redis-ha/templates/redis-ha-statefulset.yaml
@@ -136,7 +136,7 @@ spec:
 {{- end }}
         livenessProbe:
           exec:
-            command: [ "sh", "/probes/readiness.sh", "{{ .Values.redis.port }}"]
+            command: [ "sh", "/probes/liveness.sh", "{{ .Values.redis.port }}"]
           initialDelaySeconds: 15
           periodSeconds: 5
         readinessProbe:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Improve liveness probe so that redis is not restarted while it is still loading its dataset into memory.

On larger databases this can take more than just the initial probe delay. During this time redis will not answer the ping command with pong, but with loading. Of course the container should not be marked as ready, but it also should not restart which results in redis never starting successfully.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
