### PR TITLE
[stable/sentry] Mount persistent volume into cron and worker

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 1.5.1
+version: 1.5.2
 appVersion: 9.1.1
 keywords:
   - debugging

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -125,6 +125,8 @@ Parameter                          | Description                                
 `persistence.storageClass`         | PVC Storage Class                                                                                          | `nil` (uses alpha storage class annotation)
 `persistence.accessMode`           | PVC Access Mode                                                                                            | `ReadWriteOnce`
 `persistence.size`                 | PVC Storage Request                                                                                        | `10Gi`
+`persistence.filestore_dir`        | The container path to mount the PVC to                                                                     | `/var/lib/sentry/files`
+`persistence.persistentWorkers`    | Mount the PVC to Sentry workers, enabling features such as private source maps                             | `false`
 `config.configYml`                 | Sentry config.yml file                                                                                     | ``
 `config.sentryConfPy`              | Sentry sentry.conf.py file                                                                                 | ``
 `metrics.enabled`                  | Start an exporter for sentry metrics                                                                       | `false`
@@ -179,3 +181,9 @@ Persistent Volume Claims are used to keep the data across deployments. This is k
 ## Ingress
 
 This chart provides support for Ingress resource. If you have an available Ingress Controller such as Nginx or Traefik you maybe want to set `ingress.enabled` to true and choose an `ingress.hostname` for the URL. Then, you should be able to access the installation using that address.
+
+## Persistence
+
+This chart is capable of mounting the sentry-data PV in the Sentry worker and cron pods. This feature is disabled by default, but is needed for some advanced features such as private sourcemaps.
+
+You may enable mounting of the sentry-data PV across worker and cron pods by changing `persistence.persistentWorkers` to `true`. If you plan on deploying Sentry containers across multiple nodes, you may need to change your PVC's access mode to `ReadWriteMany` and check that your PV supports mounting across multiple nodes.

--- a/stable/sentry/templates/cron-deployment.yaml
+++ b/stable/sentry/templates/cron-deployment.yaml
@@ -125,7 +125,7 @@ spec:
         configMap:
           name: {{ template "fullname" . }}
       - name: sentry-data
-      {{- if .Values.persistence.enabled }}
+      {{- if and (.Values.persistence.enabled) (.Values.persistence.persistentWorkers) }}
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim | default (include "fullname" .) }}
       {{- else }}

--- a/stable/sentry/templates/cron-deployment.yaml
+++ b/stable/sentry/templates/cron-deployment.yaml
@@ -116,9 +116,18 @@ spec:
         - mountPath: /etc/sentry
           name: config
           readOnly: true
+        - mountPath: {{ .Values.persistence.filestore_dir }}
+          name: sentry-data
         resources:
 {{ toYaml .Values.cron.resources | indent 12 }}
       volumes:
       - name: config
         configMap:
           name: {{ template "fullname" . }}
+      - name: sentry-data
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingClaim | default (include "fullname" .) }}
+      {{- else }}
+        emptyDir: {}
+      {{ end }}

--- a/stable/sentry/templates/workers-deployment.yaml
+++ b/stable/sentry/templates/workers-deployment.yaml
@@ -125,7 +125,7 @@ spec:
         configMap:
           name: {{ template "fullname" . }}
       - name: sentry-data
-      {{- if .Values.persistence.enabled }}
+      {{- if and (.Values.persistence.enabled) (.Values.persistence.persistentWorkers) }}
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim | default (include "fullname" .) }}
       {{- else }}

--- a/stable/sentry/templates/workers-deployment.yaml
+++ b/stable/sentry/templates/workers-deployment.yaml
@@ -116,9 +116,18 @@ spec:
         - mountPath: /etc/sentry
           name: config
           readOnly: true
+        - mountPath: {{ .Values.persistence.filestore_dir }}
+          name: sentry-data
         resources:
 {{ toYaml .Values.worker.resources | indent 12 }}
       volumes:
       - name: config
         configMap:
           name: {{ template "fullname" . }}
+      - name: sentry-data
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingClaim | default (include "fullname" .) }}
+      {{- else }}
+        emptyDir: {}
+      {{ end }}

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -133,6 +133,16 @@ persistence:
   # https://docs.sentry.io/server/filestore/
   filestore_dir: /var/lib/sentry/files
 
+  ## Whether to mount the persistent volume to the Sentry worker and
+  ## cron deployments. This setting needs to be enabled for some advanced
+  ## Sentry features, such as private source maps. If you disable this
+  ## setting, the Sentry workers will not have access to artifacts you upload
+  ## through the web deployment.
+  ## Please note that you may need to change your accessMode to ReadWriteMany
+  ## if you plan on having the web, worker and cron deployments run on
+  ## different nodes.
+  persistentWorkers: false
+
 ## Configure ingress resource that allow you to access the
 ## Sentry installation. Set up the URL
 ## ref: http://kubernetes.io/docs/user-guide/ingress/

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -114,6 +114,10 @@ service:
 ##
 persistence:
   enabled: true
+  ## The name of an existing pvc for persistence of database data
+  ## If undefined (the default) or set to null, a new pvc will be created
+  # existingClaim: sentry-data
+
   ## database data Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
#### What this PR does / why we need it:

Sentry workers need access to the sentry-data volume in order for some features, such as private source maps, to work. I have added it as a volume mount to the cron and worker deployment configs.

Sentry mounts the sentry-data volume to cron and worker as well in their own official [on-premise docker-compose configuration](https://github.com/getsentry/onpremise/blob/master/docker-compose.yml#L25).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
