### PR TITLE
[incubator/kafka] fix wrapper scripts in notes

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.16.0
+version: 0.16.1
 appVersion: 5.0.1
 keywords:
 - kafka

--- a/incubator/kafka/templates/NOTES.txt
+++ b/incubator/kafka/templates/NOTES.txt
@@ -19,20 +19,20 @@ You can connect to Kafka by running a simple pod in the K8s cluster like this wi
 Once you have the testclient pod above running, you can list all kafka
 topics with:
 
-  kubectl -n {{ .Release.Namespace }} exec testclient -- /opt/kafka/bin/kafka-topics.sh --zookeeper {{ .Release.Name }}-zookeeper:2181 --list
+  kubectl -n {{ .Release.Namespace }} exec testclient -- kafka-topics --zookeeper {{ .Release.Name }}-zookeeper:2181 --list
 
 To create a new topic:
 
-  kubectl -n {{ .Release.Namespace }} exec testclient -- /opt/kafka/bin/kafka-topics.sh --zookeeper {{ .Release.Name }}-zookeeper:2181 --topic test1 --create --partitions 1 --replication-factor 1
+  kubectl -n {{ .Release.Namespace }} exec testclient -- kafka-topics --zookeeper {{ .Release.Name }}-zookeeper:2181 --topic test1 --create --partitions 1 --replication-factor 1
 
 To listen for messages on a topic:
 
-  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- /opt/kafka/bin/kafka-console-consumer.sh --bootstrap-server {{ include "kafka.fullname" . }}:9092 --topic test1 --from-beginning
+  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- kafka-console-consumer --bootstrap-server {{ include "kafka.fullname" . }}:9092 --topic test1 --from-beginning
 
 To stop the listener session above press: Ctrl+C
 
 To start an interactive message producer session:
-  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- /opt/kafka/bin/kafka-console-producer.sh --broker-list {{ include "kafka.fullname" . }}-headless:9092 --topic test1
+  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- kafka-console-producer --broker-list {{ include "kafka.fullname" . }}-headless:9092 --topic test1
 
 To create a message in the above session, simply type the message and press "enter"
 To end the producer session try: Ctrl+C


### PR DESCRIPTION
#### What this PR does / why we need it:
The wrapper scripts (kafka-console-producer, kafka-console-consumer and kafka-topics) referenced in NOTES.txt seem to now be in /usr/bin of the confluentinc/cp-kafka:5.0.1 image.

Signed-off-by: Miiro Juuso <miiro.juuso@gmail.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
