### PR TITLE
[stable/sentry] Allow to put affinity for hooks pods

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 1.5.2
+version: 1.5.3
 appVersion: 9.1.1
 keywords:
   - debugging

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -145,6 +145,7 @@ Parameter                          | Description                                
 `metrics.serviceMonitor.namespace` | Optional namespace which Prometheus is running in                                                          | `nil`
 `metrics.serviceMonitor.interval`  | How frequently to scrape metrics (use by default, falling back to Prometheus' default)                     | `nil`
 `metrics.serviceMonitor.selector`  | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install | `{ prometheus: kube-prometheus }`
+`hooks.affinity`                   | Affinity settings for hooks pods                                                                           | `{}`
 
 Dependent charts can also have values overwritten. Preface values with postgresql. _or redis._
 

--- a/stable/sentry/templates/hooks/db-init.job.yaml
+++ b/stable/sentry/templates/hooks/db-init.job.yaml
@@ -25,6 +25,9 @@ spec:
 {{ toYaml .Values.worker.podLabels | indent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.hooks.affinity }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
       restartPolicy: Never
       {{- if .Values.image.imagePullSecrets }}
       imagePullSecrets:

--- a/stable/sentry/templates/hooks/user-create.job.yaml
+++ b/stable/sentry/templates/hooks/user-create.job.yaml
@@ -25,6 +25,9 @@ spec:
 {{ toYaml .Values.worker.podLabels | indent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.hooks.affinity }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
       restartPolicy: Never
       {{- if .Values.image.imagePullSecrets }}
       imagePullSecrets:

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -254,3 +254,6 @@ metrics:
     ## [Kube Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#exporters)
     selector:
       prometheus: kube-prometheus
+# Provide affinity for hooks if needed
+hooks:
+  affinity: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows user to set affinity for hooks pods, it's really usefull when using external DB and you have specific ACL set.


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
