### PR TITLE
[stable/external-dns] Add Bitnami team as maintainers.

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -10,7 +10,6 @@ keywords:
 home: https://github.com/kubernetes-incubator/external-dns
 sources:
 - https://github.com/kubernetes-incubator/external-dns
-engine: gotpl
 maintainers:
 - name: Bitnami
   email: containers@bitnami.com

--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,14 +1,17 @@
 apiVersion: v1
-description: |
-  Configure external DNS servers (AWS Route53, Google CloudDNS and others)
-  for Kubernetes Ingresses and Services
 name: external-dns
-version: 1.8.0
+version: 1.8.1
 appVersion: 0.5.14
+description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
+keywords:
+- external-dns
+- network
+- dns
 home: https://github.com/kubernetes-incubator/external-dns
 sources:
-  - https://github.com/kubernetes-incubator/external-dns
+- https://github.com/kubernetes-incubator/external-dns
 engine: gotpl
 maintainers:
-- name: rabadin
-  email: rabadin@cisco.com
+- name: Bitnami
+  email: containers@bitnami.com
+engine: gotpl

--- a/stable/external-dns/OWNERS
+++ b/stable/external-dns/OWNERS
@@ -1,0 +1,14 @@
+approvers:
+- prydonius
+- tompizmor
+- sameersbn
+- carrodher
+- javsalgar
+- juan131
+reviewers:
+- prydonius
+- tompizmor
+- sameersbn
+- carrodher
+- javsalgar
+- juan131


### PR DESCRIPTION
Signed-off-by: juan131 juan@bitnami.com

#### What this PR does / why we need it:

stable/external-dns currently lacks of maintainers. This PR adds Bitnami team (@carrodher @tompizmor @jsalmeron @juan131 @sameersbn @prydonius) as maintainers of the chart.

#### Which issue this PR fixes

- fixes #14861

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
