### PR TITLE
[stable/nextcloud] add redis feature

### DIFF
--- a/stable/nextcloud/Chart.yaml
+++ b/stable/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nextcloud
-version: 1.3.0
+version: 1.4.0
 appVersion: 16.0.1
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/nextcloud/README.md
+++ b/stable/nextcloud/README.md
@@ -82,6 +82,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `mariadb.db.password`               | Password for the database                     | `changeme`                                              |
 | `mariadb.db.user`                   | Database user to create                       | `nextcloud`                                             |
 | `mariadb.rootUser.password`         | MariaDB admin password                        | `nil`                                                   |
+| `redis.enabled`                     | Whether to install/use redis for locking      | `false`                                                 |
 | `cronjob.enabled`                   | Whether to enable/disable cronjob             | `false`                                                 |
 | `cronjob.schedule`                  | Schedule for the CronJob                      | `*/15 * * * *`                                          |
 | `cronjob.annotations`               | Annotations to add to the cronjob             | {}                                                      |

--- a/stable/nextcloud/requirements.lock
+++ b/stable/nextcloud/requirements.lock
@@ -1,6 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.4.1
-digest: sha256:699d8d25a15a33030a5df3f516affefc45c79c7a59f4adc1057b854826fa2b51
-generated: "2019-06-09T02:08:45.597815913+02:00"
+  version: 6.4.3
+- name: redis
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 8.0.12
+digest: sha256:538090f5752bbbec4dca0189ed8b6835ede0e2e39164e50320629510c603dc5d
+generated: "2019-06-24T19:41:25.184162+02:00"

--- a/stable/nextcloud/requirements.yaml
+++ b/stable/nextcloud/requirements.yaml
@@ -3,3 +3,7 @@ dependencies:
   version: ~6.4.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: mariadb.enabled
+- name: redis
+  version: ~8.0.12
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: redis.enabled

--- a/stable/nextcloud/templates/_helpers.tpl
+++ b/stable/nextcloud/templates/_helpers.tpl
@@ -32,6 +32,15 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+
+{{/*
+Create a default fully qualified redis app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "nextcloud.redis.fullname" -}}
+{{- printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/stable/nextcloud/templates/deployment.yaml
+++ b/stable/nextcloud/templates/deployment.yaml
@@ -112,6 +112,12 @@ spec:
               name: {{ template "nextcloud.fullname" . }}
               key: smtp-password
         {{- end }}
+        {{- if .Values.redis.enabled }}
+        - name: REDIS_HOST
+          value: {{ template "nextcloud.redis.fullname" . }}-master
+        - name: REDIS_HOST_PORT
+          value: {{ .Values.redis.redisPort | quote }}
+        {{- end }}
         ports:
         - name: http
           containerPort: 80

--- a/stable/nextcloud/values.yaml
+++ b/stable/nextcloud/values.yaml
@@ -118,6 +118,10 @@ mariadb:
     accessMode: ReadWriteOnce
     size: 8Gi
 
+redis:
+  enabled: false
+  usePassword: false
+
 ## Cronjob to execute Nextcloud background tasks
 ## ref: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#cron-jobs
 ##


### PR DESCRIPTION
#### What this PR does / why we need it:

* nextcloud docker image provides auto-configuration to use a redis server for file locking https://github.com/nextcloud/docker
* chart now is able to configure this

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
