### PR TITLE
[stable/ambassador] Support additional TCP ports in Ambassador

### DIFF
--- a/stable/ambassador/Chart.yaml
+++ b/stable/ambassador/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.72.0
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 2.9.1
+version: 2.10.0
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/stable/ambassador/Chart.yaml
+++ b/stable/ambassador/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.72.0
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 2.9.0
+version: 2.9.1
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/stable/ambassador/README.md
+++ b/stable/ambassador/README.md
@@ -103,6 +103,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `autoscaling.minReplica`           | If autoscaling enabled, this field sets minimum replica count                   | `2`                               |
 | `autoscaling.maxReplica`           | If autoscaling enabled, this field sets maximum replica count                   | `5`                               |
 | `autoscaling.metrics`              | If autoscaling enabled, configure hpa metrics                                   |                                   |
+| `additionalTCPPorts`               | List of additional TCP ports to be exposed by the container and service         | `[]`                              |
 
 **NOTE:** Make sure the configured `service.http.targetPort` and `service.https.targetPort` ports match your [Ambassador Module's](https://www.getambassador.io/reference/modules/#the-ambassador-module) `service_port` and `redirect_cleartext_from` configurations.
 

--- a/stable/ambassador/templates/deployment.yaml
+++ b/stable/ambassador/templates/deployment.yaml
@@ -100,6 +100,11 @@ spec:
             {{- end }}
             - name: admin
               containerPort: 8877
+          {{- range $key := .Values.additionalTCPPorts }}
+            - name: "{{ $key }}-tcp"
+              containerPort: {{ $key }}
+              protocol: TCP
+          {{- end }}
           env:
             - name: HOST_IP
               valueFrom:
@@ -201,4 +206,3 @@ spec:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       dnsPolicy: {{ .Values.dnsPolicy }}
       hostNetwork: {{ .Values.hostNetwork }}
-

--- a/stable/ambassador/templates/service.yaml
+++ b/stable/ambassador/templates/service.yaml
@@ -38,6 +38,12 @@ spec:
       nodePort: {{ toYaml . }}
       {{- end }}
     {{- end }}
+    {{- range $key := .Values.additionalTCPPorts }}
+    - name: "{{ $key }}-tcp"
+      port: {{ $key }}
+      protocol: TCP
+      targetPort: "{{ $key }}-tcp"
+    {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/ambassador/values.yaml
+++ b/stable/ambassador/values.yaml
@@ -109,6 +109,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+additionalTCPPorts: []
+
 initContainers: []
 
 volumes: []


### PR DESCRIPTION
#### What this PR does / why we need it:

This adds in the ability to have additional TCP Ports set in the service and container for ambassador. This is to support [TCPModules](https://www.getambassador.io/reference/tcpmappings/) as the new ports will need to be exposed on both if you want to reach them. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
