### PR TITLE
[stable/locust] enable secret volumes & envs

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: locust
 description: A modern load testing framework
-version: 1.1.0
+version: 1.1.1
 appVersion: 0.9.0
 maintainers:
   - name: so0k

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -35,8 +35,9 @@ helm install -n locust-nymph --set master.config.target-host=http://site.example
 | `service.nodePort`           | Port on cluster to expose master        | `0`                                                   |
 | `service.annotations`        | KV containing custom annotations        | `{}`                                                  |
 | `service.extraLabels`        | KV containing extra labels              | `{}`                                                  |
-| `extraVolumes`               | List of additional Volumes              | `[]`                                                  |
-| `extraVolumeMounts`          | List of additional Volume Mounts        | `[]`                                                  |
+| `extraVolumes`               | List of extra Volumes                   | `[]`                                                  |
+| `extraVolumeMounts`          | List of extra Volume Mounts             | `[]`                                                  |
+| `extraEnvs`                  | List of extra Environment Variables     | `[]`                                                  |
 | `master.config.target-host`  | locust target host                      | `http://site.example.com`                             |
 | `master.nodeSelector`        | k8s nodeselector                        | `{}`                                                  |
 | `master.tolerations`         | k8s tolerance                           | `{}`                                                  |

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -35,6 +35,8 @@ helm install -n locust-nymph --set master.config.target-host=http://site.example
 | `service.nodePort`           | Port on cluster to expose master        | `0`                                                   |
 | `service.annotations`        | KV containing custom annotations        | `{}`                                                  |
 | `service.extraLabels`        | KV containing extra labels              | `{}`                                                  |
+| `extraVolumes`               | List of additional Volumes              | `[]`                                                  |
+| `extraVolumeMounts`          | List of additional Volume Mounts        | `[]`                                                  |
 | `master.config.target-host`  | locust target host                      | `http://site.example.com`                             |
 | `master.nodeSelector`        | k8s nodeselector                        | `{}`                                                  |
 | `master.tolerations`         | k8s tolerance                           | `{}`                                                  |

--- a/stable/locust/templates/master-deploy.yaml
+++ b/stable/locust/templates/master-deploy.yaml
@@ -41,6 +41,9 @@ spec:
           value: "master"
         - name: LOCUST_SCRIPT
           value: {{ index .Values.worker.config "locust-script" | quote }}
+{{- if .Values.extraEnvs }}
+{{ toYaml .Values.extraEnvs | indent 8 }}
+{{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
           name: loc-master-web

--- a/stable/locust/templates/master-deploy.yaml
+++ b/stable/locust/templates/master-deploy.yaml
@@ -54,6 +54,9 @@ spec:
         volumeMounts:
           - name: locust-tasks
             mountPath: /locust-tasks/
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 10 }}
+{{- end }}
         livenessProbe:
           periodSeconds: 30
           httpGet:
@@ -68,6 +71,9 @@ spec:
       - name: "locust-tasks"
         configMap:
           name: {{ template "locust.worker-configmap" . }}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+{{- end }}
       restartPolicy: Always
 {{- with .Values.master.nodeSelector }}
       nodeSelector:

--- a/stable/locust/templates/worker-deploy.yaml
+++ b/stable/locust/templates/worker-deploy.yaml
@@ -32,6 +32,9 @@ spec:
         volumeMounts:
           - name: locust-tasks
             mountPath: /locust-tasks/
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 10 }}
+{{- end }}
         env:
         {{- range $key, $value :=  .Values.worker.config }}
         - name: {{ $key | upper | replace "-" "_" }}
@@ -52,6 +55,9 @@ spec:
         - name: "locust-tasks"
           configMap:
             name: {{ template "locust.worker-configmap" . }}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
+{{- end }}
 {{- with .Values.worker.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/stable/locust/templates/worker-deploy.yaml
+++ b/stable/locust/templates/worker-deploy.yaml
@@ -48,6 +48,9 @@ spec:
           value: "{{ .Values.service.internalPort }}"
         - name: TARGET_HOST
           value: {{ index .Values.master.config "target-host" | quote }}
+{{- if .Values.extraEnvs }}
+{{ toYaml .Values.extraEnvs | indent 8 }}
+{{- end }}
         resources:
 {{ toYaml .Values.worker.resources | indent 10 }}
       restartPolicy: Always

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -14,6 +14,21 @@ service:
   nodePort: 0
   annotations: {}
   extraLabels: {}
+
+# extra volumes and mounts for both worker and master pods
+extraVolumes: []
+# extraVolumes:
+# - name: mySecretVolume
+#   secret:
+#     secretName: mySecret
+# - name: myConfigMapVolume
+#   configMap:
+#     name: myConfigMap
+extraVolumeMounts: []
+# extraVolumeMounts:
+# - name: mySecretVolume
+#   mountPath: /locust/secrets/mySecretVolume/
+
 master:
   config:
     target-host: https://site.example.com

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -15,7 +15,7 @@ service:
   annotations: {}
   extraLabels: {}
 
-# extra volumes and mounts for both worker and master pods
+# extra volumes, volumeMounts and envs for both worker and master pods
 extraVolumes: []
 # extraVolumes:
 # - name: mySecretVolume
@@ -28,6 +28,15 @@ extraVolumeMounts: []
 # extraVolumeMounts:
 # - name: mySecretVolume
 #   mountPath: /locust/secrets/mySecretVolume/
+extraEnvs: []
+# extraEnvs:
+# - name: HELLO
+#   value: WORLD
+# - name: MY_SECRET
+#   valueFrom:
+#     secretKeyRef:
+#       name: mySecret
+#       key: mySecretKey
 
 master:
   config:


### PR DESCRIPTION
#### What this PR does / why we need it:

Add values to allow for additional volume mounts & envs which will enable users to mount secrets securely

#### Which issue this PR fixes


#### Special notes for your reviewer:

Pinging maintainers for rapid review as this is a simple addition:
@so0k 
@haugene 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
