### PR TITLE
[stable/dex] - Dex fix install

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 1.5.0
+version: 1.5.1
 appVersion: 2.16.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/OWNERS
+++ b/stable/dex/OWNERS
@@ -1,4 +1,6 @@
 approvers:
 - desaintmartin
+- sstarcher
 reviewers:
 - desaintmartin
+- sstarcher

--- a/stable/dex/templates/clusterrole.yaml
+++ b/stable/dex/templates/clusterrole.yaml
@@ -2,6 +2,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
   labels:
     app: {{ template "dex.name" . }}
     chart: {{ template "dex.chart" . }}

--- a/stable/dex/templates/clusterrolebinding.yaml
+++ b/stable/dex/templates/clusterrolebinding.yaml
@@ -2,6 +2,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
   labels:
     app: {{ template "dex.name" . }}
     chart: {{ template "dex.chart" . }}

--- a/stable/dex/templates/config-openssl.yaml
+++ b/stable/dex/templates/config-openssl.yaml
@@ -9,7 +9,7 @@ metadata:
     release: "{{ .Release.Name }}"
   name: {{ template "dex.fullname" . }}-openssl-config
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded
 data:

--- a/stable/dex/templates/deployment.yaml
+++ b/stable/dex/templates/deployment.yaml
@@ -59,7 +59,11 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         ports:
-{{ toYaml .Values.ports | indent 10 }}
+{{- range .Values.ports }}
+        - name: {{ .name }}
+          protocol: {{ .protocol }}
+          containerPort: {{ .containerPort }}
+{{- end }}
         env:
 {{ toYaml .Values.env | indent 10 }}
         volumeMounts:

--- a/stable/dex/templates/job-grpc-certs.yaml
+++ b/stable/dex/templates/job-grpc-certs.yaml
@@ -12,7 +12,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "2"
     "helm.sh/hook-delete-policy": hook-succeeded
   name: {{ $fullname }}-grpc-certs

--- a/stable/dex/templates/job-web-certs.yaml
+++ b/stable/dex/templates/job-web-certs.yaml
@@ -9,7 +9,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded
   name: {{ $fullname  }}-web-certs

--- a/stable/dex/templates/role.yaml
+++ b/stable/dex/templates/role.yaml
@@ -3,6 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
   labels:
     app: {{ template "dex.name" . }}
     chart: {{ template "dex.chart" . }}

--- a/stable/dex/templates/rolebinding.yaml
+++ b/stable/dex/templates/rolebinding.yaml
@@ -3,6 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
   labels:
     app: {{ template "dex.name" . }}
     chart: {{ template "dex.chart" . }}

--- a/stable/dex/templates/service.yaml
+++ b/stable/dex/templates/service.yaml
@@ -16,9 +16,9 @@ spec:
   sessionAffinity: None
   ports:
 {{- range .Values.ports }}
-  - name: {{ .name }} 
-    port: {{ .containerPort }}
-    targetPort: {{ .containerPort}}
+  - name: {{ .name }}
+    port: {{ .port | default .containerPort }}
+    targetPort: {{ .containerPort }}
 {{- if and (eq "NodePort" $.Values.service.type) (hasKey . "nodePort") }}
     nodePort: {{ .nodePort }}
 {{- end}}

--- a/stable/dex/templates/serviceaccount.yaml
+++ b/stable/dex/templates/serviceaccount.yaml
@@ -2,6 +2,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
   labels:
     app: {{ template "dex.name" . }}
     chart: {{ template "dex.chart" . }}

--- a/stable/dex/values.yaml
+++ b/stable/dex/values.yaml
@@ -35,9 +35,16 @@ ports:
   - name: http
     containerPort: 8080
     protocol: TCP
+  - name: https
+    containerPort: 8443
+    port: 443
+    protocol: TCP
 #   nodePort: 32080
   - name: grpc
     containerPort: 5000
+    protocol: TCP
+  - name: telemetry
+    containerPort: 5558
     protocol: TCP
 
 service:
@@ -128,13 +135,16 @@ config:
     level: debug
   web:
     http: 0.0.0.0:8080
-#   tlsCert: /etc/dex/tls/https/server/tls.crt
-#   tlsKey: /etc/dex/tls/https/server/tls.key
+    https: 0.0.0.0:8443
+    tlsCert: /etc/dex/tls/https/server/tls.crt
+    tlsKey: /etc/dex/tls/https/server/tls.key
   grpc:
     addr: 0.0.0.0:5000
     tlsCert: /etc/dex/tls/grpc/server/tls.crt
     tlsKey: /etc/dex/tls/grpc/server/tls.key
     tlsClientCA: /etc/dex/tls/grpc/ca/tls.crt
+  telemetry:
+    http: 0.0.0.0:5558
   connectors:
 #  - type: github
 #    id: github


### PR DESCRIPTION
In dex's current state it's fully non-functional.  The chart requires secrets to be created which the chart can do, but it's in a post-install hook which is never reachable as the deployment hangs for secrets.

This moves the hooks to pre-install along with creating the roles in the pre-install stage to ensure the jobs can run.  

By default SSL certs are created by HTTPS was not exposed this is no longer the case.