### PR TITLE
[stable/ambassador] Set annotations on Deployment/DaemonSet

### DIFF
--- a/stable/ambassador/Chart.yaml
+++ b/stable/ambassador/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.72.0
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 2.10.0
+version: 2.11.0
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/stable/ambassador/README.md
+++ b/stable/ambassador/README.md
@@ -50,7 +50,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `ambassadorConfig`                 | Config thats mounted to `/ambassador/ambassador-config`                         | `""`                              |
 | `crds.create`                      | If `true`, Creates CRD resources                                                | `true`                            |
 | `crds.keep`                        | If `true`, if the ambassador CRDs should be kept when the chart is deleted      | `true`                            |
-| `daemonSet`                        | If `true`, Create a daemonSet. By default Deployment controller will be created | `false`                           |
+| `daemonSet`                        | If `true`, Create a DaemonSet. By default Deployment controller will be created | `false`                           |
 | `hostNetwork`                      | If `true`, uses the host network, useful for on-premise setups                  | `false`                           |
 | `dnsPolicy`                        | Dns policy, when hostNetwork set to ClusterFirstWithHostNet                     | `ClusterFirst`                    |
 | `env`                              | Any additional environment variables for ambassador pods                        | `{}`                              |
@@ -61,8 +61,9 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `namespace.name`                   | Set the `AMBASSADOR_NAMESPACE` environment variable                             | `metadata.namespace`              |
 | `scope.singleNamespace`            | Set the `AMBASSADOR_SINGLE_NAMESPACE` environment variable                      | `false`                           |
 | `podAnnotations`                   | Additional annotations for ambassador pods                                      | `{}`                              |
+| `deploymentAnnotations`            | Additional annotations for ambassador DaemonSet/Deployment                      | `{}`                              |
 | `podLabels`                        | Additional labels for ambassador pods                                           |                                   |
-| `priorityClassName`                | The name of the priorityClass for the ambassador Daemonset/Deployment           | `""`                              |
+| `priorityClassName`                | The name of the priorityClass for the ambassador DaemonSet/Deployment           | `""`                              |
 | `prometheusExporter.enabled`       | Prometheus exporter side-car enabled                                            | `false`                           |
 | `prometheusExporter.pullPolicy`    | Image pull policy                                                               | `IfNotPresent`                    |
 | `prometheusExporter.repository`    | Prometheus exporter image                                                       | `prom/statsd-exporter`            |

--- a/stable/ambassador/templates/deployment.yaml
+++ b/stable/ambassador/templates/deployment.yaml
@@ -11,6 +11,10 @@ metadata:
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.deploymentAnnotations }}
+  annotations:
+      {{- toYaml .Values.deploymentAnnotations | nindent 4 }}
+    {{- end }}
 spec:
 {{- if not .Values.daemonSet }}
   replicas: {{ .Values.replicaCount }}

--- a/stable/ambassador/values.yaml
+++ b/stable/ambassador/values.yaml
@@ -1,3 +1,4 @@
+---
 # Default values for ambassador.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
@@ -124,6 +125,10 @@ podAnnotations:
   {}
   # prometheus.io/scrape: "true"
   # prometheus.io/port: "9102"
+
+deploymentAnnotations:
+  {}
+  # configmap.reloader.stakater.com/auto: "true"
 
 resources:
   {}


### PR DESCRIPTION
#### What this PR does / why we need it:

This is helpful for supporting [Reloader](https://github.com/stakater/Reloader)
to enable triggered rolling restarts of Ambassador Pods.

Signed-off-by: Steve Huff <shuff@vecna.org>

@Flydiverny @kflynn @nbkrause 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
