### PR TITLE
[incubator/kafka] limit Prometheus discovery to release namespace

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.16.1
+version: 0.16.2
 appVersion: 5.0.1
 keywords:
 - kafka

--- a/incubator/kafka/templates/servicemonitors.yaml
+++ b/incubator/kafka/templates/servicemonitors.yaml
@@ -18,7 +18,8 @@ spec:
     scrapeTimeout: {{ .Values.prometheus.jmx.scrapeTimeout }}
   {{- end }}
   namespaceSelector:
-    any: true
+    matchNames:
+      - {{ .Release.Namespace }}
 {{ end }}
 ---
 {{ if and .Values.prometheus.kafka.enabled .Values.prometheus.operator.enabled }}
@@ -41,5 +42,6 @@ spec:
     scrapeTimeout: {{ .Values.prometheus.kafka.scrapeTimeout }}
   {{- end }}
   namespaceSelector:
-    any: true
+    matchNames:
+      - {{ .Release.Namespace }}
 {{ end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Service monitor is configured to search for endpoints in all the cluster.

This PR limits the search in the namespace the chart is installed, no need to search in all namespaces.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
