### PR TITLE
[incubator/jaeger] ingress path for query-ui is using basePath now

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.12.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.10.4
+version: 0.10.5
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -186,6 +186,9 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `query.cmdlineParams`                    | Additional command line parameters  |  nil                                   |
 | `query.image`                            | Image for Jaeger Query UI           |  jaegertracing/jaeger-query            |
 | `query.ingress.enabled`                  | Allow external traffic access       |  false                                 |
+| `query.ingress.annotations`              | Configure annotations for Ingress   |  {}                                    |
+| `query.ingress.hosts`                    | Configure host for Ingress          |  nil                                   |
+| `query.ingress.tls`                      | Configure tls for Ingress           |  nil                                   |
 | `query.podAnnotations`                   | Annotations for Query pod           |  nil                                   |
 | `query.pullPolicy`                       | Query UI image pullPolicy           |  IfNotPresent                          |
 | `query.tolerations`                      | Node Tolerations                    | `[]`                                   |
@@ -193,7 +196,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `query.service.queryPort`                | External accessible port            |  80                                    |
 | `query.service.targetPort`               | Internal Query UI port              |  16686                                 |
 | `query.service.type`                     | Service type                        |  ClusterIP                             |
-| `query.basePath`                         | Base path of Query UI               |  /                                     |
+| `query.basePath`                         | Base path of Query UI, used for ingress as well (if it is enabled)   |  /    |
 | `schema.annotations`                     | Annotations for the schema job      |  nil                                   |
 | `schema.image`                           | Image to setup cassandra schema     |  jaegertracing/jaeger-cassandra-schema |
 | `schema.mode`                            | Schema mode (prod or test)          |  prod                                  |

--- a/incubator/jaeger/templates/query-ing.yaml
+++ b/incubator/jaeger/templates/query-ing.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.query.ingress.enabled -}}
 {{- $servicePort := .Values.query.service.queryPort -}}
+{{- $basePath := .Values.query.basePath -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -20,7 +21,7 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          - path: /
+          - path: {{ $basePath }}
             backend:
               serviceName: {{ template "jaeger.query.name" $ }}
               servicePort: {{ $servicePort }}


### PR DESCRIPTION
### What this PR does / why we need it:
Changing the basePath of the query ui was not reflected in the path configuration of the query ui ingress (if enabled). When I tried to run the query ui with basePath "/jaeger" the generated ingress pointed to "/" and I could not reach the ui.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
