### PR TITLE
[stable/prometheus-postgres-exporter] Allow specifying a securityContext

### DIFF
--- a/stable/prometheus-postgres-exporter/Chart.yaml
+++ b/stable/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.4.7"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 0.6.2
+version: 0.6.3
 home: https://github.com/wrouesnel/postgres_exporter
 sources:
 - https://github.com/wrouesnel/postgres_exporter

--- a/stable/prometheus-postgres-exporter/README.md
+++ b/stable/prometheus-postgres-exporter/README.md
@@ -62,6 +62,7 @@ The following table lists the configurable parameters of the postgres Exporter c
 | `podLabels`                      | Additional labels to add to each pod      | `{}` |
 | `extraContainers`                | Additional sidecar containers | `""` |
 | `extraVolumes`                   | Additional volumes for use in extraContainers | `""` |
+| `securityContext`                | Security options the pod should run with. [More info](https://kubernetes.io/docs/concepts/policy/security-context/) | `{}` |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/stable/prometheus-postgres-exporter/templates/deployment.yaml
@@ -76,6 +76,8 @@ spec:
 {{- with .Values.extraContainers }}
 {{ tpl . $ | indent 8 }}
 {{- end }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
      {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/stable/prometheus-postgres-exporter/values.yaml
+++ b/stable/prometheus-postgres-exporter/values.yaml
@@ -41,6 +41,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+securityContext: {}
+  # The securityContext this Pod should use. See https://kubernetes.io/docs/concepts/policy/security-context/ for more.
+  # runAsUser: 65534
+
 config:
   datasource:
     host:


### PR DESCRIPTION
Allow specifying a securityContext


#### What this PR does / why we need it:
This enables users running under restrictive PodSecurityPolicies to deploy the exporter running as a non-root container.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
