### PR TITLE
Change sed command for RABBITMQ Password

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.1.1
+version: 6.1.2
 appVersion: 3.7.15
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -93,7 +93,7 @@ spec:
             ulimit -n "${RABBITMQ_ULIMIT_NOFILES}"
             {{- end }}
             #replace the default password that is generated
-            sed -i "s/CHANGEME/$RABBITMQ_PASSWORD/g" /opt/bitnami/rabbitmq/etc/rabbitmq/rabbitmq.conf
+            sed -i "s|CHANGEME|$RABBITMQ_PASSWORD|g" /opt/bitnami/rabbitmq/etc/rabbitmq/rabbitmq.conf
             #api check for probes
             cat > /opt/bitnami/rabbitmq/sbin/rabbitmq-api-check <<EOF
             #!/bin/sh


### PR DESCRIPTION
Signed-off-by: Daniel Gordi <danial@gordi.ir>
#### What this PR does / why we need it:
I've changed the sed command from `sed 's/foo/bar/g'` to `sed 's|foo|bar|g` to supports slash and backslash in RABBITMQ Password.

#### Which issue this PR fixes

  - [fixes #15069](https://github.com/helm/charts/issues/15069)

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
