### PR TITLE
[stable/redis] Improve liveness probe for large databases

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 8.0.13
+version: 8.0.14
 appVersion: 5.0.5
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/health-configmap.yaml
+++ b/stable/redis/templates/health-configmap.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "redis.fullname" . }}-health
 data:
-  ping_local.sh: |-
+  ping_readiness_local.sh: |-
 {{- if .Values.usePasswordFile }}
     password_aux=`cat ${REDIS_PASSWORD_FILE}`
     export REDIS_PASSWORD=$password_aux
@@ -24,6 +24,25 @@ data:
         ping
     )
     if [ "$response" != "PONG" ]; then
+      echo "$response"
+      exit 1
+    fi
+  ping_liveness_local.sh: |-
+{{- if .Values.usePasswordFile }}
+    password_aux=`cat ${REDIS_PASSWORD_FILE}`
+    export REDIS_PASSWORD=$password_aux
+{{- end }}
+    response=$(
+      timeout -s 9 $1 \
+      redis-cli \
+{{- if .Values.usePassword }}
+        -a $REDIS_PASSWORD \
+{{- end }}
+        -h localhost \
+        -p $REDIS_PORT \
+        ping
+    )
+    if [ "$response" != "PONG" ] && [ "$response" != "LOADING Redis is loading the dataset in memory" ]; then
       echo "$response"
       exit 1
     fi
@@ -48,22 +67,22 @@ data:
       exit 1
     fi
   parse_sentinels.awk: |-
-    /ip/ {FOUND_IP=1} 
-    /port/ {FOUND_PORT=1} 
-    /runid/ {FOUND_RUNID=1} 
-    !/ip|port|runid/ { 
+    /ip/ {FOUND_IP=1}
+    /port/ {FOUND_PORT=1}
+    /runid/ {FOUND_RUNID=1}
+    !/ip|port|runid/ {
       if (FOUND_IP==1) {
         IP=$1; FOUND_IP=0;
-      } 
+      }
       else if (FOUND_PORT==1) {
-        PORT=$1; 
+        PORT=$1;
         FOUND_PORT=0;
       } else if (FOUND_RUNID==1) {
         printf "\nsentinel known-sentinel {{ .Values.sentinel.masterSet }} %s %s %s", IP, PORT, $0; FOUND_RUNID=0;
       }
     }
 {{- end }}
-  ping_master.sh: |-
+  ping_readiness_master.sh: |-
 {{- if .Values.usePasswordFile }}
     password_aux=`cat ${REDIS_MASTER_PASSWORD_FILE}`
     export REDIS_MASTER_PASSWORD=$password_aux
@@ -82,9 +101,34 @@ data:
       echo "$response"
       exit 1
     fi
-  ping_local_and_master.sh: |-
+  ping_liveness_master.sh: |-
+{{- if .Values.usePasswordFile }}
+    password_aux=`cat ${REDIS_MASTER_PASSWORD_FILE}`
+    export REDIS_MASTER_PASSWORD=$password_aux
+{{- end }}
+    response=$(
+      timeout -s 9 $1 \
+      redis-cli \
+{{- if .Values.usePassword }}
+        -a $REDIS_MASTER_PASSWORD \
+{{- end }}
+        -h $REDIS_MASTER_HOST \
+        -p $REDIS_MASTER_PORT_NUMBER \
+        ping
+    )
+    if [ "$response" != "PONG" ] && [ "$response" != "LOADING Redis is loading the dataset in memory" ]; then
+      echo "$response"
+      exit 1
+    fi
+  ping_readiness_local_and_master.sh: |-
     script_dir="$(dirname "$0")"
     exit_status=0
-    "$script_dir/ping_local.sh" $1 || exit_status=$?
-    "$script_dir/ping_master.sh" $1 || exit_status=$?
+    "$script_dir/ping_readiness_local.sh" $1 || exit_status=$?
+    "$script_dir/ping_readiness_master.sh" $1 || exit_status=$?
+    exit $exit_status
+  ping_liveness_local_and_master.sh: |-
+    script_dir="$(dirname "$0")"
+    exit_status=0
+    "$script_dir/ping_liveness_local.sh" $1 || exit_status=$?
+    "$script_dir/ping_liveness_master.sh" $1 || exit_status=$?
     exit $exit_status

--- a/stable/redis/templates/redis-master-statefulset.yaml
+++ b/stable/redis/templates/redis-master-statefulset.yaml
@@ -77,7 +77,7 @@ spec:
           fi
           if [[ ! -f /opt/bitnami/redis/etc/redis.conf ]];then
             cp /opt/bitnami/redis/mounted-etc/redis.conf /opt/bitnami/redis/etc/redis.conf
-          fi          
+          fi
           ARGS=("--port" "${REDIS_PORT}")
           {{- if .Values.usePassword }}
           ARGS+=("--requirepass" "${REDIS_PASSWORD}")
@@ -126,7 +126,7 @@ spec:
             command:
             - sh
             - -c
-            - /health/ping_local.sh {{ .Values.master.livenessProbe.timeoutSeconds }}
+            - /health/ping_liveness_local.sh {{ .Values.master.livenessProbe.timeoutSeconds }}
         {{- end }}
         {{- if .Values.master.readinessProbe.enabled}}
         readinessProbe:
@@ -139,7 +139,7 @@ spec:
             command:
             - sh
             - -c
-            - /health/ping_local.sh {{ .Values.master.livenessProbe.timeoutSeconds }}
+            - /health/ping_readiness_local.sh {{ .Values.master.livenessProbe.timeoutSeconds }}
         {{- end }}
         resources:
 {{ toYaml .Values.master.resources | indent 10 }}

--- a/stable/redis/templates/redis-slave-statefulset.yaml
+++ b/stable/redis/templates/redis-slave-statefulset.yaml
@@ -89,7 +89,7 @@ spec:
           fi
           if [[ ! -f /opt/bitnami/redis/etc/redis.conf ]];then
             cp /opt/bitnami/redis/mounted-etc/redis.conf /opt/bitnami/redis/etc/redis.conf
-          fi          
+          fi
           ARGS=("--port" "${REDIS_PORT}")
           ARGS+=("--slaveof" "${REDIS_MASTER_HOST}" "${REDIS_MASTER_PORT_NUMBER}")
           {{- if .Values.usePassword }}
@@ -151,9 +151,9 @@ spec:
             - sh
             - -c
             {{- if .Values.sentinel.enabled }}
-            - /health/ping_local.sh {{ .Values.slave.livenessProbe.timeoutSeconds }}
+            - /health/ping_liveness_local.sh {{ .Values.slave.livenessProbe.timeoutSeconds }}
             {{- else }}
-            - /health/ping_local_and_master.sh {{ .Values.slave.livenessProbe.timeoutSeconds }}
+            - /health/ping_liveness_local_and_master.sh {{ .Values.slave.livenessProbe.timeoutSeconds }}
             {{- end }}
         {{- end }}
 
@@ -169,9 +169,9 @@ spec:
             - sh
             - -c
             {{- if .Values.sentinel.enabled }}
-            - /health/ping_local.sh {{ .Values.slave.livenessProbe.timeoutSeconds }}
+            - /health/ping_readiness_local.sh {{ .Values.slave.livenessProbe.timeoutSeconds }}
             {{- else }}
-            - /health/ping_local_and_master.sh {{ .Values.slave.livenessProbe.timeoutSeconds }}
+            - /health/ping_readiness_local_and_master.sh {{ .Values.slave.livenessProbe.timeoutSeconds }}
             {{- end }}
         {{- end }}
         resources:


### PR DESCRIPTION
#### What this PR does / why we need it:
Improve liveness probe so that redis is not restarted while it is still loading its dataset into memory

On larger databases this can take more than just the initial probe delay. During this time redis will not answer the ping command with pong, but with loading. Of course the container should not be marked as ready, but it also should not restart which results in redis never starting successfully.

Signed-off-by: Bastian Hofmann <bashofmann@gmail.com>

#### Special notes for your reviewer:
See also similar PR for stable/redis-ha: https://github.com/helm/charts/pull/14999

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
