### PR TITLE
[stable/ambassador] Add app.kubernetes.io/part-of to ambassador

### DIFF
--- a/stable/ambassador/Chart.yaml
+++ b/stable/ambassador/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.72.0
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 2.11.0
+version: 2.12.0
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/stable/ambassador/templates/admin-service.yaml
+++ b/stable/ambassador/templates/admin-service.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   type: {{ .Values.adminService.type }}

--- a/stable/ambassador/templates/ambassador-pro-redis.yaml
+++ b/stable/ambassador/templates/ambassador-pro-redis.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "ambassador.fullname" . }}-pro-redis
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}-pro-redis
+    app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -23,6 +24,7 @@ metadata:
   name: {{ include "ambassador.fullname" . }}-pro-redis
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}-pro-redis
+    app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/stable/ambassador/templates/ambassador-pro-service.yaml
+++ b/stable/ambassador/templates/ambassador-pro-service.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     service: ambassador-pro
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/stable/ambassador/templates/config.yaml
+++ b/stable/ambassador/templates/config.yaml
@@ -5,6 +5,7 @@ metadata:
   name: '{{ include "ambassador.fullname" . }}-file-config'
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/stable/ambassador/templates/crds.yaml
+++ b/stable/ambassador/templates/crds.yaml
@@ -6,6 +6,7 @@ metadata:
   name: authservices.getambassador.io
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -32,13 +33,14 @@ metadata:
   name: consulresolvers.getambassador.io
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   {{ if .Values.crds.keep }}
   annotations:
     "helm.sh/resource-policy": keep
-  {{ end }}    
+  {{ end }}
 spec:
   group: getambassador.io
   version: v1
@@ -58,6 +60,7 @@ metadata:
   name: kubernetesendpointresolvers.getambassador.io
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -84,6 +87,7 @@ metadata:
   name: kubernetesserviceresolvers.getambassador.io
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -110,6 +114,7 @@ metadata:
   name: mappings.getambassador.io
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -136,6 +141,7 @@ metadata:
   name: modules.getambassador.io
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -158,6 +164,7 @@ metadata:
   name: ratelimitservices.getambassador.io
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -184,6 +191,7 @@ metadata:
   name: tcpmappings.getambassador.io
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -210,6 +218,7 @@ metadata:
   name: tlscontexts.getambassador.io
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/stable/ambassador/templates/deployment.yaml
+++ b/stable/ambassador/templates/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   name: {{ include "ambassador.fullname" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -27,6 +28,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: {{ include "ambassador.name" . }}
+        app.kubernetes.io/part-of: {{ .Release.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
       {{- if .Values.podLabels }}
         {{- toYaml .Values.podLabels | nindent 8 }}

--- a/stable/ambassador/templates/exporter-config.yaml
+++ b/stable/ambassador/templates/exporter-config.yaml
@@ -5,6 +5,7 @@ metadata:
   name: '{{ include "ambassador.fullname" . }}-exporter-config'
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/stable/ambassador/templates/hpa.yaml
+++ b/stable/ambassador/templates/hpa.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "ambassador.fullname" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/stable/ambassador/templates/rbac.yaml
+++ b/stable/ambassador/templates/rbac.yaml
@@ -9,6 +9,7 @@ metadata:
   name: {{ include "ambassador.fullname" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -39,6 +40,7 @@ metadata:
   name: {{ include "ambassador.fullname" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/stable/ambassador/templates/service.yaml
+++ b/stable/ambassador/templates/service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "ambassador.fullname" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/stable/ambassador/templates/serviceaccount.yaml
+++ b/stable/ambassador/templates/serviceaccount.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "ambassador.serviceAccountName" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}


### PR DESCRIPTION
What this PR does / why we need it:

Provides app.kubernetes.io/part-of to ambassador. See https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels
Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

[x] DCO signed
[x] Title of the PR starts with chart name (e.g. [stable/chart])
