### PR TITLE
[stable/redis] Add --no-auth-warning to health checks

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 8.0.14
+version: 8.0.15
 appVersion: 5.0.5
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/ci/redis-lib-values.yaml
+++ b/stable/redis/ci/redis-lib-values.yaml
@@ -4,7 +4,7 @@
 image:
   registry: docker.io
   repository: redis
-  tag: '4.0.11'
+  tag: '5.0.5'
 
 master:
   command: "redis-server"

--- a/stable/redis/templates/health-configmap.yaml
+++ b/stable/redis/templates/health-configmap.yaml
@@ -36,7 +36,7 @@ data:
       timeout -s 9 $1 \
       redis-cli \
 {{- if .Values.usePassword }}
-        -a $REDIS_PASSWORD \
+        -a $REDIS_PASSWORD --no-auth-warning \
 {{- end }}
         -h localhost \
         -p $REDIS_PORT \
@@ -110,7 +110,7 @@ data:
       timeout -s 9 $1 \
       redis-cli \
 {{- if .Values.usePassword }}
-        -a $REDIS_MASTER_PASSWORD \
+        -a $REDIS_MASTER_PASSWORD --no-auth-warning \
 {{- end }}
         -h $REDIS_MASTER_HOST \
         -p $REDIS_MASTER_PORT_NUMBER \

--- a/stable/redis/templates/health-configmap.yaml
+++ b/stable/redis/templates/health-configmap.yaml
@@ -17,7 +17,7 @@ data:
       timeout -s 9 $1 \
       redis-cli \
 {{- if .Values.usePassword }}
-        -a $REDIS_PASSWORD \
+        -a $REDIS_PASSWORD --no-auth-warning \
 {{- end }}
         -h localhost \
         -p $REDIS_PORT \
@@ -56,7 +56,7 @@ data:
       timeout -s 9 $1 \
       redis-cli \
 {{- if .Values.usePassword }}
-        -a $REDIS_PASSWORD \
+        -a $REDIS_PASSWORD --no-auth-warning \
 {{- end }}
         -h localhost \
         -p $REDIS_SENTINEL_PORT \
@@ -91,7 +91,7 @@ data:
       timeout -s 9 $1 \
       redis-cli \
 {{- if .Values.usePassword }}
-        -a $REDIS_MASTER_PASSWORD \
+        -a $REDIS_MASTER_PASSWORD --no-auth-warning \
 {{- end }}
         -h $REDIS_MASTER_HOST \
         -p $REDIS_MASTER_PORT_NUMBER \


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Health checks currently show the warning message
```Warning: Using a password with '-a' or '-u' option on the command line interface may not be safe``` which can be dismissed using the --no-auth-warning flag as mentioned in antirez/redis#5073

Continuation of #15062 
Chart version bumped to 8.0.14 pending #15082

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
