### PR TITLE
[stable/fluent-bit]: upgrade to Fluent Bit v1.2.0

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.0.6
-appVersion: 1.1.3
+version: 2.1.0
+appVersion: 1.2.0
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:
 - logging

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -97,6 +97,7 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `filter.kubeTag`                   | Optional top-level tag for matching in filter         | `kube`                                 |
 | `filter.kubeTagPrefix`             | Optional tag prefix used by Tail   | `kube.var.log.containers.`                                |
 | `filter.mergeJSONLog`              | If the log field content is a JSON string map, append the map fields as part of the log structure         | `true`                                 |
+| `filter.mergeLogKey`               | If set, append the processed log keys under a new root key specified by this variable. | log_processed |
 | `image.fluent_bit.repository`      | Image                                      | `fluent/fluent-bit`                               |
 | `image.fluent_bit.tag`             | Image tag                                  | `1.1.3`                                          |
 | `image.pullPolicy`                 | Image pull policy                          | `IfNotPresent`                                          |

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -60,6 +60,11 @@ data:
 {{- if .Values.filter.mergeJSONLog }}
         Merge_Log           On
 {{- end }}
+
+{{- if .Values.filter.mergeLogKey }}
+        Merge_Log_Key       {{ .Values.filter.mergeLogKey }}
+{{- end }}
+
 {{- if .Values.filter.enableParser }}
         K8S-Logging.Parser  On
 {{- end }}

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -5,7 +5,7 @@ on_minikube: false
 image:
   fluent_bit:
     repository: fluent/fluent-bit
-    tag: 1.1.3
+    tag: 1.2.0
   pullPolicy: Always
 
 testFramework:
@@ -233,6 +233,10 @@ filter:
 # If true, check to see if the log field content is a JSON string map, if so,
 # it append the map fields as part of the log structure.
   mergeJSONLog: true
+
+# If set, all unpacked keys from mergeJSONLog (Merge_Log) will be packed under
+# the key name specified on mergeLogKey (Merge_Log_Key)
+  mergeLogKey: log_processed
 
 # If true, enable the use of monitoring for a pod annotation of
 # fluentbit.io/parser: parser_name. parser_name must be the name


### PR DESCRIPTION
In addition to a version upgrade, this patch adds the new chart option
called 'mergeLogKey' that configure Merge_Log_Key inside the Kubernetes
filter.

Release notes: https://fluentbit.io/announcements/v1.2.0/

Signed-off-by: Eduardo Silva <eduardo@treasure-data.com>
