### PR TITLE
[stable/concourse] Removes annotation warning messages

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 8.0.1
+version: 8.0.2
 appVersion: 5.3.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1403,7 +1403,7 @@ web:
     ##   service.beta.kubernetes.io/aws-load-balancer-backend-port: "atc"
     ##   service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
     ##
-    annotations:
+    annotations: {}
 
     ## When using `web.service.type: LoadBalancer`, whitelist the load balancer to particular IPs
     ## Example:
@@ -1436,7 +1436,7 @@ web:
     ##   kubernetes.io/ingress.class: nginx
     ##   kubernetes.io/tls-acme: 'true'
     ##
-    annotations:
+    annotations: {}
 
     ## Hostnames.
     ## Must be provided if Ingress is enabled.


### PR DESCRIPTION
@cirocosta 
@william-tran 
@YoussB 

#### What this PR does / why we need it:
Removes warnings when annotations aren't used in values file.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
If you don't have anything for annotations it'll spit out a warning since it's expecting an object.  This just makes it an empty object.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
