### PR TITLE
[stable/rabbitmq] fix sed invocation to handle special characters

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.1.2
+version: 6.1.3
 appVersion: 3.7.15
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -93,7 +93,7 @@ spec:
             ulimit -n "${RABBITMQ_ULIMIT_NOFILES}"
             {{- end }}
             #replace the default password that is generated
-            sed -i "s|CHANGEME|$RABBITMQ_PASSWORD|g" /opt/bitnami/rabbitmq/etc/rabbitmq/rabbitmq.conf
+            sed -i "/CHANGEME/cdefault_pass=${RABBITMQ_PASSWORD//\\/\\\\}" /opt/bitnami/rabbitmq/etc/rabbitmq/rabbitmq.conf
             #api check for probes
             cat > /opt/bitnami/rabbitmq/sbin/rabbitmq-api-check <<EOF
             #!/bin/sh


### PR DESCRIPTION
Tested with `/\/\--||?+*`:

    $ kubectl create secret generic rabbitmq-secret --from-literal=rabbitmq-password='/\/\--||?+*'
    ...
    $ helm install --name my-release stable/rabbitmq --set rabbitmq.existingPasswordSecret=rabbitmq-secret --set persistence.storageClass=standard
    ...
    $ kubectl exec my-release-rabbitmq-0  -ti -- grep default_pass /opt/bitnami/rabbitmq/etc/rabbitmq/rabbitmq.conf
    default_pass=/\/\--||?+*

Resolves #15069.

Signed-off-by: Karoline Pauls <code@karolinepauls.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)