### PR TITLE
[stable/prometheus-operator] Fix prometheus operator on OpenShift 3.11

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -11,7 +11,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 5.14.0
+version: 5.15.0
 appVersion: 0.31.1
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/stable/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -106,6 +106,8 @@ spec:
 {{- if .Values.prometheus.prometheusSpec.securityContext }}
   securityContext:
 {{ toYaml .Values.prometheus.prometheusSpec.securityContext | indent 4 }}
+{{- else }}
+  securityContext: {}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.ruleNamespaceSelector }}
   ruleNamespaceSelector:


### PR DESCRIPTION

#### What this PR does / why we need it:

#### Which issue this PR fixes
    Currently there is no way to remove the `runAsUser` and `fsGroup`
    attributes of the `securityContext`. With this patch it, at least,
    allows you to set it to `{}`.
    This is require to start a `Prometheus` on OpenShift v3.11.

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
