### PR TITLE
Added double-quotes to label values in sidecar examples

### DIFF
--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -182,7 +182,7 @@ kind: ConfigMap
 metadata:
   name: sample-grafana-dashboard
   labels:
-     grafana_dashboard: 1
+     grafana_dashboard: "1"
 data:
   k8s-dashboard.json: |-
   [...]
@@ -199,7 +199,7 @@ kind: ConfigMap
 metadata:
   name: sample-grafana-datasource
   labels:
-     grafana_datasource: 1
+     grafana_datasource: "1"
 data:
   datasource.yaml: |-
     # config file version


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Sidecar configmap examples seems to have invalid syntax and cannot be applied. Label values must be strings.

When applying, I get:

```
Error from server (BadRequest): error when creating "configmap.yaml"
...Labels: ReadString: expects " or n, but found 1
```

Putting 1 in double-quotes works.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/chart]`)
