### PR TITLE
[stable/jaeger-operator] Extract common labels to _helpers.tpl

### DIFF
--- a/stable/jaeger-operator/Chart.yaml
+++ b/stable/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.7.1
+version: 2.7.2
 appVersion: 1.12.1
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/stable/jaeger-operator/templates/crd.yaml
+++ b/stable/jaeger-operator/templates/crd.yaml
@@ -8,10 +8,7 @@ metadata:
     "helm.sh/hook-delete-policy": "before-hook-creation"
 {{- end }}
   labels:
-    app.kubernetes.io/name: {{ include "jaeger-operator.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "jaeger-operator.chart" . }}
+{{ include "jaeger-operator.labels" . | indent 4 }}
 spec:
   group: jaegertracing.io
   names:

--- a/stable/jaeger-operator/templates/deployment.yaml
+++ b/stable/jaeger-operator/templates/deployment.yaml
@@ -3,10 +3,7 @@ kind: Deployment
 metadata:
   name: {{ include "jaeger-operator.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "jaeger-operator.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "jaeger-operator.chart" . }}
+{{ include "jaeger-operator.labels" . | indent 4 }}
 spec:
   replicas: 1
   selector:
@@ -17,10 +14,7 @@ spec:
     metadata:
       name: {{ include "jaeger-operator.fullname" . }}
       labels:
-        app.kubernetes.io/name: {{ include "jaeger-operator.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        helm.sh/chart: {{ include "jaeger-operator.chart" . }}
+{{ include "jaeger-operator.labels" . | indent 8 }}
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "jaeger-operator.serviceAccountName" . }}

--- a/stable/jaeger-operator/templates/role-binding.yaml
+++ b/stable/jaeger-operator/templates/role-binding.yaml
@@ -5,10 +5,7 @@ metadata:
   name: {{ include "jaeger-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "jaeger-operator.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "jaeger-operator.chart" . }}
+{{ include "jaeger-operator.labels" . | indent 4 }}
 subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}

--- a/stable/jaeger-operator/templates/role.yaml
+++ b/stable/jaeger-operator/templates/role.yaml
@@ -5,10 +5,7 @@ metadata:
   name: {{ include "jaeger-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "jaeger-operator.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "jaeger-operator.chart" . }}
+{{ include "jaeger-operator.labels" . | indent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/stable/jaeger-operator/templates/service-account.yaml
+++ b/stable/jaeger-operator/templates/service-account.yaml
@@ -5,8 +5,5 @@ metadata:
   name: {{ include "jaeger-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "jaeger-operator.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "jaeger-operator.chart" . }}
+{{ include "jaeger-operator.labels" . | indent 4 }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: mwieczorek <wieczorek-michal@wp.pl>

#### What this PR does / why we need it:

It's a follow-up of https://github.com/helm/charts/pull/13964.
It makes consistent use of common labels definition from _helper.tpl as it was introduced in the above PR.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
