### PR TITLE
[stable/datadog] Add priorityClassName to Cluster Agent deployment

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.31.3
+version: 1.31.4
 appVersion: 6.10.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -305,6 +305,7 @@ helm install --name <RELEASE_NAME> \
 | `clusterAgent.metricsProvider.enabled`   | Enable Datadog metrics as a source for HPA scaling                                        | `false`                                     |
 | `clusterAgent.clusterChecks.enabled`     | Enable Cluster Checks on both the Cluster Agent and the Agent daemonset                   | `false`                                     |
 | `clusterAgent.confd`                     | Additional check configurations (static and Autodiscovery)                                | `nil`                                       |
+| `clusterAgent.priorityClassName`         | Name of the priorityClass to apply to the Cluster Agent                                   | `nil`                                       |
 | `clusterAgent.resources.requests.cpu`    | CPU resource requests                                                                     | `200m`                                      |
 | `clusterAgent.resources.limits.cpu`      | CPU resource limits                                                                       | `200m`                                      |
 | `clusterAgent.resources.requests.memory` | Memory resource requests                                                                  | `256Mi`                                     |

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -33,6 +33,9 @@ spec:
             ]
           }]
     spec:
+      {{- if .Values.clusterAgent.priorityClassName }}
+      priorityClassName: "{{ .Values.clusterAgent.priorityClassName }}"
+      {{- end }}
       {{- if .Values.clusterAgent.image.pullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.clusterAgent.image.pullSecrets | indent 8 }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -346,6 +346,11 @@ clusterAgent:
 #      cpu: 200m
 #      memory: 256Mi
 
+  ## @param priorityclassName - string - optional
+  ## Name of the priorityClass to apply to the Cluster Agent
+
+  # priorityClassName: system-cluster-critical
+
   ## @param livenessProbe - object - optional
   ## Override the agent's liveness probe logic from the default:
   ## In case of issues with the probe, you can disable it with the


### PR DESCRIPTION
Signed-off-by: Peter Rifel <pgrifel@gmail.com>

#### What this PR does / why we need it:

Adds support for specifying the priority class on the Datadog cluster agent deployment

#### Which issue this PR fixes
- N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
