### PR TITLE
Added optional backendconfig resource for mercure

### DIFF
--- a/stable/mercure/Chart.yaml
+++ b/stable/mercure/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: The Mercure hub allows to push data updates using the Mercure protocol to web browsers and other HTTP clients in a convenient, fast, reliable and battery-efficient way
 name: mercure
-version: 1.0.5
+version: 1.0.6
 keywords:
 - mercure
 - hub

--- a/stable/mercure/templates/backend-config.yaml
+++ b/stable/mercure/templates/backend-config.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.backendConfig.enabled -}}
+apiVersion: cloud.google.com/v1beta1
+kind: BackendConfig
+metadata:
+  name: {{ include "mercure.fullname" . }}
+spec:
+  timeoutSec: {{ .Values.backendConfig.timeoutSec }}
+{{- end }}

--- a/stable/mercure/templates/service.yaml
+++ b/stable/mercure/templates/service.yaml
@@ -7,6 +7,10 @@ metadata:
     helm.sh/chart: {{ include "mercure.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- if .Values.backendConfig.enabled }}
+  annotations:
+    beta.cloud.google.com/backend-config: '{"default": "{{ include "mercure.fullname" . }}"}'
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/stable/mercure/values.yaml
+++ b/stable/mercure/values.yaml
@@ -42,6 +42,15 @@ ingress:
   #    hosts:
   #      - mercure.local
 
+# GCP load balancers by default terminate connections after 30 seconds. This can be changed by
+# enabling the following backendConfig and changing the `timeoutSec` property.
+# More info at: https://github.com/dunglas/mercure/issues/106 and
+# https://cloud.google.com/kubernetes-engine/docs/how-to/configure-backend-service
+backendConfig:
+  enabled: false
+  timeoutSec: 30
+
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
GCP load balancers by default terminate connections after 30 seconds. This can be changed by
adding a backendConfig resource and tweaking the `timeoutSec` property.
More info at: [https://github.com/dunglas/mercure/issues/106](https://github.com/dunglas/mercure/issues/106) and
https://cloud.google.com/kubernetes-engine/docs/how-to/configure-backend-service