### PR TITLE
[stable/redis] Collect metrics from sentinels when enabled

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 8.0.15
+version: 8.0.16
 appVersion: 5.0.5
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/metrics-deployment.yaml
+++ b/stable/redis/templates/metrics-deployment.yaml
@@ -53,10 +53,12 @@ spec:
         {{- end }}
         env:
         - name: REDIS_ADDR
-        {{- if .Values.cluster.enabled }}
+        {{- if and .Values.cluster.enabled .Values.sentinel.enabled }}
+          value: {{ printf "%s:%d" ( include "redis.fullname" . ) ( int .Values.sentinel.service.redisPort ) | quote }}
+        {{- else if .Values.cluster.enabled }}
           value: {{ printf "%s-master:%d,%s-slave:%d" ( include "redis.fullname" . ) ( int .Values.redisPort ) ( include "redis.fullname" . ) ( int .Values.redisPort ) | quote }}
         {{- else }}
-          value: {{ printf "%s-master:%d" (include "redis.fullname" . ) (int .Values.redisPort) | quote }}
+          value: {{ printf "%s-master:%d" ( include "redis.fullname" . ) (int .Values.redisPort) | quote }}
         {{- end }}
         - name: REDIS_ALIAS
           value: {{ template "redis.fullname" . }}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

When sentinel sidecar containers are used, the Redis metrics must be retrieved from Sentinel service instead of addressing the master/slave services.

#### Which issue this PR fixes

  - fixes https://github.com/helm/charts/issues/15145

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
