### PR TITLE
[incubator/couchdb] fix env vars for db container

### DIFF
--- a/incubator/couchdb/Chart.yaml
+++ b/incubator/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: couchdb
-version: 1.2.1
+version: 1.2.2
 appVersion: 2.3.1
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/incubator/couchdb/templates/statefulset.yaml
+++ b/incubator/couchdb/templates/statefulset.yaml
@@ -98,11 +98,6 @@ spec:
         - name: couchdb-statefulset-assembler
           image: "{{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}"
           imagePullPolicy: {{ .Values.helperImage.pullPolicy }}
-{{- if .Values.enableSearch }}
-        - name: clouseau
-          image: "{{ .Values.searchImage.repository }}:{{ .Values.searchImage.tag }}"
-          imagePullPolicy: {{ .Values.searchImage.pullPolicy }}
-{{- end }}
 {{- if not .Values.allowAdminParty }}
           env:
             - name: COUCHDB_USER
@@ -115,6 +110,11 @@ spec:
                 secretKeyRef:
                   name: {{ template "couchdb.fullname" . }}
                   key: adminPassword
+{{- end }}
+{{- if .Values.enableSearch }}
+        - name: clouseau
+          image: "{{ .Values.searchImage.repository }}:{{ .Values.searchImage.tag }}"
+          imagePullPolicy: {{ .Values.searchImage.pullPolicy }}
 {{- end }}
 {{- if .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Fixes environment variables not being set correctly for the
couchdb container when `.Values.enableSearch` is `false` (the
default).

The feature toggle for search excluded the search container from the
statefulset but did not exclude the associated environment variables.
The result of this was a duplicate `env` field for the `couchdb`
container which would override the correct `env` field; for example,
`ERL_FLAGS` would not be passed to the container.

This comment fixes the scoping of the `.Values.enableSearch` feature
toggle to include the `env` fields for the `clouseau` container.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
