### PR TITLE
[stable/couchdb] use seedlist to join cluster

### DIFF
--- a/stable/couchdb/Chart.yaml
+++ b/stable/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: couchdb
-version: 2.0.1
+version: 2.2.0
 appVersion: 2.3.1
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for
@@ -12,7 +12,6 @@ keywords:
 home: https://couchdb.apache.org/
 sources:
   - https://github.com/apache/couchdb-docker
-  - https://github.com/kocolosk/couchdb-statefulset-assembler
 maintainers:
   - name: kocolosk
     email: kocolosk@apache.org

--- a/stable/couchdb/README.md
+++ b/stable/couchdb/README.md
@@ -108,11 +108,8 @@ A variety of other parameters are also configurable. See the comments in the
 | `adminUsername`                 | admin                                  |
 | `adminPassword`                 | auto-generated                         |
 | `cookieAuthSecret`              | auto-generated                         |
-| `helperImage.repository`        | kocolosk/couchdb-statefulset-assembler |
-| `helperImage.tag`               | 1.2.0                                  |
-| `helperImage.pullPolicy`        | IfNotPresent                           |
 | `image.repository`              | couchdb                                |
-| `image.tag`                     | 2.3.0                                  |
+| `image.tag`                     | 2.3.1                                  |
 | `image.pullPolicy`              | IfNotPresent                           |
 | `searchImage.repository`        | kocolosk/couchdb-search                |
 | `searchImage.tag`               | 0.1.0                                  |
@@ -133,3 +130,4 @@ A variety of other parameters are also configurable. See the comments in the
 | `service.enabled`               | true                                   |
 | `service.type`                  | ClusterIP                              |
 | `service.externalPort`          | 5984                                   |
+| `dns.clusterDomainSuffix`       | cluster.local                          |

--- a/stable/couchdb/templates/_helpers.tpl
+++ b/stable/couchdb/templates/_helpers.tpl
@@ -42,3 +42,22 @@ Create a random string if the supplied key does not exist
 {{- randAlphaNum 20 | b64enc | quote -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Labels used to define Pods in the CouchDB statefulset
+*/}}
+{{- define "couchdb.ss.selector" -}}
+app: {{ template "couchdb.name" . }}
+release: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Generates a comma delimited list of nodes in the cluster
+*/}}
+{{- define "couchdb.seedlist" -}}
+{{- $nodeCount :=  min 5 .Values.clusterSize | int }}
+  {{- range $index0 := until $nodeCount -}}
+    {{- $index1 := $index0 | add1 -}}
+    {{ $.Values.erlangFlags.name }}@{{ template "couchdb.fullname" $ }}-{{ $index0 }}.{{ template "couchdb.fullname" $ }}.{{ $.Release.Namespace }}.svc.{{ $.Values.dns.clusterDomainSuffix }}{{ if ne $index1 $nodeCount }},{{ end }}
+  {{- end -}}
+{{- end -}}

--- a/stable/couchdb/templates/configmap.yaml
+++ b/stable/couchdb/templates/configmap.yaml
@@ -15,3 +15,7 @@ data:
     {{ printf "%s = %s" $key ($value | toString) }}
     {{ end }}
     {{ end }}
+
+  seedlistinifile: |
+    [cluster]
+    seedlist = {{ template "couchdb.seedlist" . }}

--- a/stable/couchdb/templates/headless.yaml
+++ b/stable/couchdb/templates/headless.yaml
@@ -9,9 +9,9 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
     - name: couchdb
       port: 5984
   selector:
-    app: {{ template "couchdb.name" . }}
-    release: {{ .Release.Name }}
+{{ include "couchdb.ss.selector" . | indent 4 }}

--- a/stable/couchdb/templates/service.yaml
+++ b/stable/couchdb/templates/service.yaml
@@ -19,6 +19,5 @@ spec:
       targetPort: 5984
   type: {{ .Values.service.type }}
   selector:
-    app: {{ template "couchdb.name" . }}
-    release: {{ .Release.Name }}
+{{ include "couchdb.ss.selector" . | indent 4 }}
 {{- end -}}

--- a/stable/couchdb/templates/statefulset.yaml
+++ b/stable/couchdb/templates/statefulset.yaml
@@ -13,13 +13,11 @@ spec:
   podManagementPolicy: {{ .Values.podManagementPolicy }}
   selector:
     matchLabels:
-      app: {{ template "couchdb.name" . }}
-      release: {{ .Release.Name }}
+{{ include "couchdb.ss.selector" . | indent 6 }}
   template:
     metadata:
       labels:
-        app: {{ template "couchdb.name" . }}
-        release: {{ .Release.Name }}
+{{ include "couchdb.ss.selector" . | indent 8 }}
     spec:
       {{- if .Values.schedulerName }}
       schedulerName: "{{ .Values.schedulerName }}"
@@ -28,7 +26,7 @@ spec:
         - name: init-copy
           image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
           imagePullPolicy: {{ .Values.initImage.pullPolicy }}
-          command: ['sh','-c','cp /tmp/chart.ini /default.d; ls -lrt /default.d;']
+          command: ['sh','-c','cp /tmp/chart.ini /default.d; cp /tmp/seedlist.ini /default.d; ls -lrt /default.d;']
           volumeMounts:
           - name: config
             mountPath: /tmp/
@@ -95,22 +93,6 @@ spec:
             mountPath: /opt/couchdb/etc/default.d
           - name: database-storage
             mountPath: /opt/couchdb/data
-        - name: couchdb-statefulset-assembler
-          image: "{{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}"
-          imagePullPolicy: {{ .Values.helperImage.pullPolicy }}
-{{- if not .Values.allowAdminParty }}
-          env:
-            - name: COUCHDB_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "couchdb.fullname" . }}
-                  key: adminUsername
-            - name: COUCHDB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "couchdb.fullname" . }}
-                  key: adminPassword
-{{- end }}
 {{- if .Values.enableSearch }}
         - name: clouseau
           image: "{{ .Values.searchImage.repository }}:{{ .Values.searchImage.tag }}"
@@ -136,6 +118,9 @@ spec:
             items:
               - key: inifile
                 path: chart.ini
+              - key: seedlistinifile
+                path: seedlist.ini
+
 {{- if not .Values.persistentVolume.enabled }}
         - name: database-storage
           emptyDir: {}

--- a/stable/couchdb/values.yaml
+++ b/stable/couchdb/values.yaml
@@ -48,12 +48,6 @@ image:
   tag: 2.3.1
   pullPolicy: IfNotPresent
 
-## Sidecar that connects the individual Pods into a cluster
-helperImage:
-  repository: kocolosk/couchdb-statefulset-assembler
-  tag: 2.0.0
-  pullPolicy: IfNotPresent
-
 ## Experimental integration with Lucene-powered fulltext search
 searchImage:
   repository: kocolosk/couchdb-search
@@ -143,3 +137,9 @@ couchdbConfig:
     # chttpd.require_valid_user disables all the anonymous requests to the port
     # 5984 when is set to true.
     require_valid_user: false
+
+
+# Kubernetes local cluster domain.
+# This is used to generate FQDNs for peers when joining the CouchDB cluster.
+dns:
+  clusterDomainSuffix: cluster.local


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Uses the [seedlist] feature in CouchDB 2.3.1 to join the nodes in the cluster. This removes the requirement for the statefulset-assembler sidecar. The first node in the statefulset is always used as the seed.

One slight niggle is that CouchDB will assume the seedlist contains fully qualified domain names, which can't be determined by Helm at install time. 

To address this, a new config value, `dns.clusterDomainSuffix` is added, which defaults to `cluster.local`. For now, users will need to modify this when using a non-default
domain suffix.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
