### PR TITLE
Add alerting config to chart

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 8.14.0
+version: 8.14.1
 appVersion: 2.11.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -245,6 +245,7 @@ Parameter | Description | Default
 `server.global.scrape_interval` | How frequently to scrape targets by default | `1m`
 `server.global.scrape_timeout` | How long until a scrape request times out | `10s`
 `server.global.evaluation_interval` | How frequently to evaluate rules | `1m`
+`server.alertRelabelConfig` | Alert relabel configs | ``
 `server.extraArgs` | Additional Prometheus server container arguments | `{}`
 `server.prefixURL` | The prefix slug at which the server can be accessed | ``
 `server.baseURL` | The external url at which the server can be accessed | ``
@@ -254,6 +255,7 @@ Parameter | Description | Default
 `server.extraSecretMounts` | Additional Prometheus server Secret mounts | `[]`
 `server.extraVolumeMounts` | Additional Prometheus server Volume mounts | `[]`
 `server.extraVolumes` | Additional Prometheus server Volumes | `[]`
+`server.extraAlertmanagerDiscoveryConfig` | Additional Prometheus server alertmanager discovery configs
 `server.configMapOverrideName` | Prometheus server ConfigMap override where full-name is `{{.Release.Name}}-{{.Values.server.configMapOverrideName}}` and setting this value will prevent the default server ConfigMap from being generated | `""`
 `server.ingress.enabled` | If true, Prometheus server Ingress will be created | `false`
 `server.ingress.annotations` | Prometheus server Ingress annotations | `[]`

--- a/stable/prometheus/templates/server-configmap.yaml
+++ b/stable/prometheus/templates/server-configmap.yaml
@@ -20,7 +20,14 @@ data:
 {{- end -}}
 {{- if $root.Values.alertmanager.enabled }}
     alerting:
+      {{- if $root.Values.server.alertRelabelConfig }}
+      alert_relabel_configs:
+      {{- $root.Values.server.alertRelabelConfig | nindent 6 -}}
+      {{- end }}
       alertmanagers:
+      {{- if $root.Values.server.extraAlertmanagerDiscoveryConfig }}
+      {{ $root.Values.server.extraAlertmanagerDiscoveryConfig | nindent 6 }}
+      {{- end }}
       - kubernetes_sd_configs:
           - role: pod
         tls_config:

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -581,6 +581,17 @@ server:
     ##
     evaluation_interval: 1m
 
+  ## Prometheus server alert relabeling config
+  ## must be a string so you have to add a | after alertRelabelConfig
+  ## Ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+  ##
+  alertRelabelConfig: ""
+
+  ## Prometheus server alertmanager discovery config
+  ## must be a string so you have to add a | after extraAlertmanagerDiscoveryConfig
+  ## Ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alertmanager_config
+  extraAlertmanagerDiscoveryConfig: ""
+
   ## Additional Prometheus server container arguments
   ##
   extraArgs: {}


### PR DESCRIPTION
…onfigs.

Signed-off-by: Johnathan Falk <johnathan.falk@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

@mgoodness @gianrubio 

#### What this PR does / why we need it:
Currently Prometheus' alerting configuration is statically set in the chart, this allows users to specify additional options. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #15185

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
