### PR TITLE
[incubator/haproxytech-haproxy-ingress] add haproxytech haproxy ingress controller

### DIFF
--- a/incubator/haproxytech-haproxy-ingress/.helmignore
+++ b/incubator/haproxytech-haproxy-ingress/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/incubator/haproxytech-haproxy-ingress/Chart.yaml
+++ b/incubator/haproxytech-haproxy-ingress/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+name: haproxytech-haproxy-ingress
+version: 0.0.1
+appVersion: "1.0.2"
+home: https://github.com/haproxytech/kubernetes-ingress
+description: The official haproxy 2.0 ingress controller
+icon: http://www.haproxy.org/img/HAProxyCommunityEdition_60px.png
+keywords:
+  - ingress
+  - haproxy
+sources:
+  - https://github.com/haproxytech/kubernetes-ingress
+maintainers:
+  - name: alectroemel
+    email: alec@mirusresearch.com

--- a/incubator/haproxytech-haproxy-ingress/OWNERS
+++ b/incubator/haproxytech-haproxy-ingress/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- alectroemel
+reviewers:
+- alectroemel

--- a/incubator/haproxytech-haproxy-ingress/README.md
+++ b/incubator/haproxytech-haproxy-ingress/README.md
@@ -1,0 +1,100 @@
+# haproxytech haproxy-ingress
+[haproxy-ingress](https://github.com/haproxytech/kubernetes-ingress/blob/ef1b5d404ead21b40352a1a453063dde3887283e/documentation/controller.md) is an Ingress Controller built by Haproxy Technologies as part of the v2.0 release. It uses ConfigMap and image arguments to configue the controller, along with ingress annotations to configure per-backend settings.
+
+## Introduction
+
+This chart bootstraps an haproxy-ingress deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+  - Kubernetes 1.8+ with Beta APIs enabled
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release incubator/haproxytech-haproxy-ingress
+```
+
+The command deploys haproxytech-haproxy-ingress on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete --purge my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the haproxtech-haproxy-ingress chart and their default values.
+
+Parameter | Description | Default
+--- | --- | ---
+`rbac.create` | If true, create & use RBAC resources | `true`
+`rbac.security.enable` | If true, and rbac.create is true, create & use PSP resources | `false`
+`serviceAccount.create` | If true, create serviceAccount | `true`
+`serviceAccount.name` | ServiceAccount to be used | ``
+`controller.name` | name of the controller component | `controller`
+`controller.image.repository` | controller container image repository | `haproxytech/kubernetes-ingress`
+`controller.image.tag` | controller container image tag | `1.0.2`
+`controller.image.pullPolicy` | controller container image pullPolicy | `IfNotPresent`
+`controller.ingressClass` | name of the ingress class to route through this controller | `haproxytech`
+`controller.extraArgs` | extra command line arguments for the ingress controller | `{}`
+`controller.extraEnv` | extra environment variables for the ingress controller | `{`}
+`controller.podLabels` | Labels for the haproxy-ingress-controller pod | `{}`
+`controller.defaultBackendService` | backend service if defualtBackend.enabled==false | `""`
+`controller.config` | additional controller [ConfigMap entries](https://github.com/haproxytech/kubernetes-ingress/blob/master/documentation/README.md) | `{}`
+`controller.service.loadBalancerIP` | external load balancer service IP | `""`
+`controller.metrics.resources` | prometheus-exporter container resource requests & limits |  `{}`
+`controller.livenessProbe.path` | The liveness probe path | `/healthz`
+`controller.livenessProbe.port` | The livneness probe port | `1042`
+`controller.livenessProbe.failureThreshold` | The livneness probe failure threshold | `3`
+`controller.livenessProbe.initialDelaySeconds` | The livneness probe initial delay (in seconds) | `10`
+`controller.livenessProbe.periodSeconds` | The livneness probe period (in seconds) | `10`
+`controller.livenessProbe.successThreshold` | The livneness probe success threshold | `1`
+`controller.livenessProbe.timeoutSeconds` | The livneness probe timeout (in seconds) | `1`
+`controller.readinessProbe.path` | The readiness probe path | `/healthz`
+`controller.readinessProbe.port` | The readiness probe port | `1042`
+`controller.readinessProbe.failureThreshold` | The readiness probe failure threshold | `3`
+`controller.readinessProbe.initialDelaySeconds` | The readiness probe initial delay (in seconds) | `10`
+`controller.readinessProbe.periodSeconds` | The readiness probe period (in seconds) | `10`
+`controller.readinessProbe.successThreshold` | The readiness probe success threshold | `1`
+`controller.readinessProbe.timeoutSeconds` | The readiness probe timeout (in seconds) | `1`
+`controller.tolerations` | to control scheduling to servers with taints | `[]`
+`controller.affinity` | to control scheduling | `{}`
+`controller.nodeSelector` | to control scheduling | `{}`
+`controller.service.annotations` | annotations for controller service | `{}`
+`controller.service.labels` | labels for controller service | `{}`
+`controller.service.clusterIP` | internal controller cluster service IP | `""`
+`controller.service.externalTrafficPolicy` | external traffic policy | `Cluster`
+`controller.service.externalIPs` | list of IP addresses at which the controller services are available | `[]`
+`controller.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
+`controller.service.loadBalancerSourceRanges` |  | `[]`
+`controller.service.type` | type of controller service to create | `LoadBalancer`
+`defaultBackend.enabled` | whether to use the default backend component | `true`
+`defaultBackend.name` | name of the default backend component | `default-backend`
+`defaultBackend.image.repository` | default backend container image repository | `gcr.io/google_containers/defaultbackend`
+`defaultBackend.image.tag` | default backend container image repository tag | `1.0`
+`defaultBackend.image.pullPolicy` | default backend container image pullPolicy | `IfNotPresent`
+`defaultBackend.tolerations` | to control scheduling to servers with taints | `[]`
+`defaultBackend.affinity` | to control scheduling | `{}`
+`defaultBackend.nodeSelector` | to control scheduling | `{}`
+`defaultBackend.podAnnotations` | Annotations for the default backend pod | `{}`
+`defaultBackend.podLabels` | Labels for the default backend pod | `{}`
+`defaultBackend.replicaCount` | the number of replicas to deploy (when `controller.kind` is `Deployment`) | `1`
+`defaultBackend.minAvailable` | PodDisruptionBudget minimum available default backend pods | `1`
+`defaultBackend.resources` | default backend pod resources | _see defaults below_
+`defaultBackend.resources.limits.cpu` | default backend cpu resources limit | `10m`
+`defaultBackend.resources.limits.memory` | default backend memory resources limit | `20Mi`
+`defaultBackend.service.name` | name of default backend service to create | `ingress-default-backend`
+`defaultBackend.service.annotations` | annotations for metrics service | `{}`
+`defaultBackend.service.clusterIP` | internal metrics cluster service IP | `""`
+`defaultBackend.service.externalIPs` | list of IP addresses at which the metrics service is available | `[]`
+`defaultBackend.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
+`defaultBackend.service.loadBalancerSourceRanges` |  | `[]`
+`defaultBackend.service.servicePort` | the port number exposed by the metrics service | `1936`
+`defaultBackend.service.type` | type of controller service to create | `ClusterIP`

--- a/incubator/haproxytech-haproxy-ingress/templates/NOTES.txt
+++ b/incubator/haproxytech-haproxy-ingress/templates/NOTES.txt
@@ -1,0 +1,45 @@
+The haproxytech-haproxt-ingress controller has been installed.
+
+{{- if contains "NodePort" .Values.controller.service.type }}
+Get the application URL by running these commands:
+
+{{- if (not (empty .Values.controller.service.nodePorts.http)) }}
+  export HTTP_NODE_PORT={{ .Values.controller.service.nodePorts.http }}
+{{- else }}
+  export HTTP_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[0].nodePort}" {{ template "haproxytech-ingress.fullname" . }})
+{{- end }}
+{{- if (not (empty .Values.controller.service.nodePorts.https)) }}
+  export HTTPS_NODE_PORT={{ .Values.controller.service.nodePorts.https }}
+{{- else }}
+  export HTTPS_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[1].nodePort}" {{ template "haproxytech-ingress.fullname" . }})
+{{- end }}
+  export NODE_IP=$(kubectl --namespace {{ .Release.Namespace }} get nodes -o jsonpath="{.items[0].status.addresses[1].address}")
+
+  echo "Visit http://$NODE_IP:$HTTP_NODE_PORT to access your application via HTTP."
+  echo "Visit https://$NODE_IP:$HTTPS_NODE_PORT to access your application via HTTPS."
+{{- else if contains "LoadBalancer" .Values.controller.service.type }}
+It may take a few minutes for the LoadBalancer IP to be available.
+You can watch the status by running 'kubectl --namespace {{ .Release.Namespace }} get services -o wide -w {{ template "haproxytech-ingress.fullname" . }}'
+{{- else if contains "ClusterIP"  .Values.controller.service.type }}
+Get the application URL by running these commands:
+  export POD_NAME=$(kubectl --namespace {{ .Release.Namespace }} get pods -o jsonpath="{.items[0].metadata.name}" -l "app={{ template "haproxytech-ingress.name" . }},component={{ .Values.controller.name }},release={{ .Release.Name }}")
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+  echo "Visit http://127.0.0.1:8080 to access your application."
+{{- end }}
+
+An example Ingress that makes use of the controller:
+
+  apiVersion: extensions/v1beta1
+  kind: Ingress
+  metadata:
+    name: example
+    namespace: foo
+  spec:
+    rules:
+      - host: www.example.com
+        http:
+          paths:
+            - backend:
+                serviceName: exampleService
+                servicePort: 80
+              path: /

--- a/incubator/haproxytech-haproxy-ingress/templates/_helpers.tpl
+++ b/incubator/haproxytech-haproxy-ingress/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.y
+*/}}
+{{- define "haproxytech-ingress.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "haproxytech-ingress.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "haproxytech-ingress.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified default backend name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "haproxytech-ingress.defaultBackend.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "haproxytech-ingress.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "haproxytech-ingress.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/incubator/haproxytech-haproxy-ingress/templates/cluster-role-binding.yaml
+++ b/incubator/haproxytech-haproxy-ingress/templates/cluster-role-binding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app: {{ template "haproxytech-ingress.name" . }}
+    chart: {{ template "haproxytech-ingress.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "haproxytech-ingress.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "haproxytech-ingress.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: haproxy-ingress-service-account
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/incubator/haproxytech-haproxy-ingress/templates/cluster-role.yaml
+++ b/incubator/haproxytech-haproxy-ingress/templates/cluster-role.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.rbac.create -}}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app: {{ template "haproxytech-ingress.name" . }}
+    chart: {{ template "haproxytech-ingress.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "haproxytech-ingress.fullname" . }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - nodes
+  - pods
+  - services
+  - namespaces
+  - events
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "extensions"
+  resources:
+  - ingresses
+  - ingresses/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+{{- end -}}

--- a/incubator/haproxytech-haproxy-ingress/templates/configmap.yaml
+++ b/incubator/haproxytech-haproxy-ingress/templates/configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.controller.config }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "haproxytech-ingress.name" . }}
+    chart: {{ template "haproxytech-ingress.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "haproxytech-ingress.fullname" . }}
+data:
+{{ toYaml .Values.controller.config | indent 2 -}}
+{{- end -}}

--- a/incubator/haproxytech-haproxy-ingress/templates/controller-deployment.yaml
+++ b/incubator/haproxytech-haproxy-ingress/templates/controller-deployment.yaml
@@ -5,13 +5,15 @@ metadata:
     app: {{ template "haproxytech-ingress.name" . }}
     chart: {{ template "haproxytech-ingress.chart" . }}
     release: {{ .Release.Name }}
+    component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
   name: {{ template "haproxytech-ingress.fullname" . }}
 spec:
-  replicas: {{ .Values.controller.replicas }}
+  replicas: {{ .Values.controller.replicaCount }}
   selector:
     matchLabels:
-      run: {{ template "haproxytech-ingress.fullname" . }}
+      app: {{ template "haproxytech-ingress.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:

--- a/incubator/haproxytech-haproxy-ingress/templates/controller-deployment.yaml
+++ b/incubator/haproxytech-haproxy-ingress/templates/controller-deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "haproxytech-ingress.name" . }}
+    chart: {{ template "haproxytech-ingress.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "haproxytech-ingress.fullname" . }}
+spec:
+  replicas: {{ .Values.controller.replicas }}
+  selector:
+    matchLabels:
+      run: {{ template "haproxytech-ingress.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "haproxytech-ingress.name" . }}
+        component: "{{ .Values.controller.name }}"
+        release: {{ .Release.Name }}
+        {{- if .Values.controller.podLabels }}
+{{ toYaml .Values.controller.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "haproxytech-ingress.fullname" . }}
+      containers:
+      - name: haproxy-ingress
+        image:  "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
+        imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
+        args:
+          - --default-ssl-certificate=default/tls-secret
+          {{- if .Values.controller.config }}
+          - --configmap={{ .Release.Namespace }}/{{ template "haproxytech-ingress.fullname" . }}
+          {{- end }}
+          - --ingress.class={{ .Values.controller.ingressClass }}
+          - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "haproxytech-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
+          {{- range $key, $value := .Values.controller.extraArgs }}
+            {{- if $value }}
+            - --{{ $key }}={{ $value }}
+            {{- else }}
+            - --{{ $key }}
+            {{- end }}
+          {{- end }}
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.controller.livenessProbe.path | quote }}
+            port: {{ .Values.controller.livenessProbe.port }}
+            scheme: HTTP
+          initialDelaySeconds: {{ .Values.controller.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.controller.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.controller.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.controller.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.controller.livenessProbe.failureThreshold }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.controller.readinessProbe.path | quote }}
+            port: {{ .Values.controller.readinessProbe.port }}
+            scheme: HTTP
+          initialDelaySeconds: {{ .Values.controller.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.controller.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.controller.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.controller.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.controller.readinessProbe.failureThreshold }}
+        ports:
+        - name: stat
+          containerPort: 1024
+        - name: http
+          containerPort: 80
+        - name: https
+          containerPort: 443
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        resources:
+{{ toYaml .Values.controller.resources | indent 10 }}
+{{- if .Values.controller.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.controller.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.controller.tolerations }}
+      tolerations:
+{{ toYaml .Values.controller.tolerations | indent 8 }}
+    {{- end }}
+    {{- if .Values.controller.affinity }}
+      affinity:
+{{ toYaml .Values.controller.affinity | indent 8 }}
+    {{- end }}

--- a/incubator/haproxytech-haproxy-ingress/templates/controller-service.yaml
+++ b/incubator/haproxytech-haproxy-ingress/templates/controller-service.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.controller.service.annotations }}
+  annotations:
+{{ toYaml .Values.controller.service.annotations | indent 4 }}
+{{- end }}
+  labels:
+{{- if .Values.controller.service.labels }}
+{{ toYaml .Values.controller.service.labels | indent 4 }}
+{{- end }}
+    app: {{ template "haproxytech-ingress.name" . }}
+    chart: {{ template "haproxytech-ingress.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "haproxytech-ingress.fullname" . }}
+spec:
+{{- if .Values.controller.service.clusterIP }}
+  clusterIP: "{{ .Values.controller.service.clusterIP }}"
+{{- end }}
+{{- if .Values.controller.service.externalTrafficPolicy }}
+  externalTrafficPolicy: "{{ .Values.controller.service.externalTrafficPolicy }}"
+{{- end }}
+{{- if .Values.controller.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.controller.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.controller.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.controller.service.loadBalancerIP }}"
+{{- end }}
+{{- if .Values.controller.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.controller.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+{{- if (.Values.controller.service.healthCheckNodePort) }}
+  healthCheckNodePort: {{ .Values.controller.service.healthCheckNodePort }}
+{{- end }}
+  selector:
+    run: {{ template "haproxytech-ingress.fullname" . }}
+    component: "{{ .Values.controller.name }}"
+    release: {{ .Release.Name }}
+  type: "{{ .Values.controller.service.type }}"
+  loadBalancerIP: {{ .Values.controller.service.loadBalancerIP }}
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  - name: stat
+    port: 1024
+    protocol: TCP
+    targetPort: 1024

--- a/incubator/haproxytech-haproxy-ingress/templates/controller-service.yaml
+++ b/incubator/haproxytech-haproxy-ingress/templates/controller-service.yaml
@@ -36,7 +36,7 @@ spec:
   healthCheckNodePort: {{ .Values.controller.service.healthCheckNodePort }}
 {{- end }}
   selector:
-    run: {{ template "haproxytech-ingress.fullname" . }}
+    app: {{ template "haproxytech-ingress.name" . }}
     component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
   type: "{{ .Values.controller.service.type }}"

--- a/incubator/haproxytech-haproxy-ingress/templates/default-backend-deployment.yaml
+++ b/incubator/haproxytech-haproxy-ingress/templates/default-backend-deployment.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.defaultBackend.enabled }}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "haproxytech-ingress.name" . }}
+    chart: {{ template "haproxytech-ingress.chart" . }}
+    component: "{{ .Values.defaultBackend.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "haproxytech-ingress.defaultBackend.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "haproxytech-ingress.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+    {{- if .Values.defaultBackend.podAnnotations }}
+      annotations:
+{{ toYaml .Values.defaultBackend.podAnnotations | indent 8 }}
+    {{- end }}
+      labels:
+        app: {{ template "haproxytech-ingress.name" . }}
+        component: "{{ .Values.defaultBackend.name }}"
+        release: {{ .Release.Name }}
+        {{- if .Values.defaultBackend.podLabels }}
+{{ toYaml .Values.defaultBackend.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      containers:
+        - name: {{ .Values.defaultBackend.name }}
+          image: "{{ .Values.defaultBackend.image.repository }}:{{ .Values.defaultBackend.image.tag }}"
+          imagePullPolicy: "{{ .Values.defaultBackend.image.pullPolicy }}"
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+{{ toYaml .Values.defaultBackend.resources | indent 12 }}
+    {{- if .Values.defaultBackend.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.defaultBackend.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.defaultBackend.tolerations }}
+      tolerations:
+{{ toYaml .Values.defaultBackend.tolerations | indent 8 }}
+    {{- end }}
+    {{- if .Values.defaultBackend.affinity }}
+      affinity:
+{{ toYaml .Values.defaultBackend.affinity | indent 8 }}
+    {{- end }}
+      terminationGracePeriodSeconds: 60
+{{- end }}

--- a/incubator/haproxytech-haproxy-ingress/templates/default-backend-deployment.yaml
+++ b/incubator/haproxytech-haproxy-ingress/templates/default-backend-deployment.yaml
@@ -28,6 +28,7 @@ spec:
 {{ toYaml .Values.defaultBackend.podLabels | indent 8 }}
         {{- end }}
     spec:
+      terminationGracePeriodSeconds: 60
       containers:
         - name: {{ .Values.defaultBackend.name }}
           image: "{{ .Values.defaultBackend.image.repository }}:{{ .Values.defaultBackend.image.tag }}"
@@ -50,5 +51,4 @@ spec:
       affinity:
 {{ toYaml .Values.defaultBackend.affinity | indent 8 }}
     {{- end }}
-      terminationGracePeriodSeconds: 60
-{{- end }}
+{{- end -}}

--- a/incubator/haproxytech-haproxy-ingress/templates/default-backend-service.yaml
+++ b/incubator/haproxytech-haproxy-ingress/templates/default-backend-service.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.defaultBackend.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.defaultBackend.service.annotations }}
+  annotations:
+{{ toYaml .Values.defaultBackend.service.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ template "haproxytech-ingress.name" . }}
+    chart: {{ template "haproxytech-ingress.chart" . }}
+    component: "{{ .Values.defaultBackend.name }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "haproxytech-ingress.defaultBackend.fullname" . }}
+spec:
+{{- if .Values.defaultBackend.service.clusterIP }}
+  clusterIP: "{{ .Values.defaultBackend.service.clusterIP }}"
+{{- end }}
+{{- if .Values.defaultBackend.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.defaultBackend.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.defaultBackend.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.defaultBackend.service.loadBalancerIP }}"
+{{- end }}
+{{- if .Values.defaultBackend.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.defaultBackend.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.defaultBackend.service.servicePort }}
+      protocol: TCP
+      targetPort: http
+  selector:
+    app: {{ template "haproxytech-ingress.name" . }}
+    component: "{{ .Values.defaultBackend.name }}"
+    release: {{ .Release.Name }}
+  type: "{{ .Values.defaultBackend.service.type }}"
+{{- end }}

--- a/incubator/haproxytech-haproxy-ingress/templates/service-account.yaml
+++ b/incubator/haproxytech-haproxy-ingress/templates/service-account.yaml
@@ -1,0 +1,11 @@
+{{- if or .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "haproxytech-ingress.name" . }}
+    chart: {{ template "haproxytech-ingress.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "haproxytech-ingress.serviceAccountName" . }}
+{{- end -}}

--- a/incubator/haproxytech-haproxy-ingress/values.yaml
+++ b/incubator/haproxytech-haproxy-ingress/values.yaml
@@ -1,0 +1,171 @@
+# Enable RBAC
+rbac:
+  create: true
+  security:
+    enable: false
+
+# Create ServiceAccount
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+controller:
+  name: controller
+  image:
+    repository: haproxytech/kubernetes-ingress
+    tag: "1.0.2"
+    pullPolicy: IfNotPresent
+
+  ## Name of the ingress class to route through this controller
+  ingressClass: haproxytech
+
+  ## Additional command line arguments to pass to haproxy-ingress-controller
+  ##
+  ## key:value, value can be null for a flag
+  extraArgs: {}
+
+  ## Additional environment variables to set
+  extraEnvs: []
+
+  # labels to add to the pod container metadata
+  podLabels: {}
+
+  ## Required only if defaultBackend.enabled = false
+  ## Must be <namespace>/<service_name>
+  ##
+  defaultBackendService: ""
+
+  # ConfigMap to configure ingress controller
+  config: {}
+    # check: "enabled"
+    # forwarded-for: "enabled"
+    # load-balance: "roundrobin"
+    # maxconn: "2000"
+    # nbthread: "1"
+    # rate-limit: "OFF"
+    # rate-limit-expire: "30m"
+    # rate-limit-interval: "10s"
+    # rate-limit-size: "100k"
+    # servers-increment: "42"
+    # servers-increment-max-disabled: "66"
+    # ssl-certificate: "default/tls-secret"
+    # ssl-numproc: "1"
+    # ssl-redirect: "ON"
+    # ssl-redirect-code: "302"
+    # timeout-http-request: "5s"
+    # timeout-connect: "5s"
+    # timeout-client: "50s"
+    # timeout-queue: "5s"
+    # timeout-server: "50s"
+    # timeout-tunnel: "1h"
+    # timeout-http-keep-alive: "1m"
+
+  service:
+    annotations: {}
+    labels: {}
+    clusterIP: ""
+
+    ## List of IP addresses at which the controller services are available
+    ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+    ##
+    externalIPs: []
+
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+
+    ## Set external traffic policy to: "Local" to preserve source IP on
+    ## providers supporting it
+    ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
+    externalTrafficPolicy: ""
+
+    healthCheckNodePort: 0
+    type: LoadBalancer
+
+  resources: {}
+
+  ## Liveness and readiness probe values
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    path: /healthz
+    port: 1042
+    failureThreshold: 3
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 1
+  readinessProbe:
+    path: /healthz
+    port: 1042
+    failureThreshold: 3
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 1
+
+# Default 404 backend
+defaultBackend:
+  ## If false, controller.defaultBackendService must be provided
+  enabled: true
+
+  name: default-backend
+  image:
+    repository: gcr.io/google_containers/defaultbackend
+    tag: "1.0"
+    pullPolicy: IfNotPresent
+
+  ## Node tolerations for server scheduling to nodes with taints
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  tolerations: []
+  #  - key: "key"
+  #    operator: "Equal|Exists"
+  #    value: "value"
+  #    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+  affinity: {}
+
+  ## Node labels for default backend pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Annotations to be added to default backend pods
+  ##
+  podAnnotations: {}
+
+  # labels to add to the pod container metadata
+  podLabels: {}
+  #  key: value
+
+  # Deployment
+  replicaCount: 1
+
+  # PodDisruptionBudget
+  minAvailable: 1
+
+  resources:
+    limits:
+      cpu: 10m
+      memory: 20Mi
+  # requests:
+  #   cpu: 10m
+  #   memory: 20Mi
+
+  service:
+    name: ingress-default-backend
+    annotations: {}
+    clusterIP: ""
+
+    ## List of IP addresses at which the default backend service is available
+    ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+    ##
+    externalIPs: []
+
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+    servicePort: 8080
+    type: ClusterIP

--- a/incubator/haproxytech-haproxy-ingress/values.yaml
+++ b/incubator/haproxytech-haproxy-ingress/values.yaml
@@ -19,6 +19,8 @@ controller:
     tag: "1.0.2"
     pullPolicy: IfNotPresent
 
+  replicaCount: 1
+
   ## Name of the ingress class to route through this controller
   ingressClass: haproxytech
 


### PR DESCRIPTION
Signed-off-by: alec troemel <alec@mirusresearch.com>

#### What this PR does / why we need it:
This PR adds a chart for the new(ish) official haproxytech ingress controller.
https://github.com/haproxytech/kubernetes-ingress

this chart is heavily based off the current community haproxy ingress controller 
https://github.com/helm/charts/tree/master/incubator/haproxy-ingress

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
