### PR TITLE
[stable/jenkins] Add support for namespace specification

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.3.4
+version: 1.3.5
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -61,8 +61,8 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `checkDeprecation`                | Checks for deprecated values used    | `true`                                 |
 | `clusterZone`                     | Override the cluster name for FQDN resolving    | `cluster.local`                |
 | `nameOverride`                    | Override the resource name prefix    | `jenkins`                                 |
-| `fullnameOverride`                | Override the deployment namespace    | Not set (`Release.Namespace`)             |
-| `namespaceOverride`               | Override the full resource names     | `jenkins-{release-name}` (or `jenkins` if release-name is `jenkins`) |
+| `fullnameOverride`                | Override the full resource names     | `jenkins-{release-name}` (or `jenkins` if release-name is `jenkins`) |
+| `namespaceOverride`               | Override the deployment namespace    | Not set (`Release.Namespace`)             |
 | `master.componentName`            | Jenkins master name                  | `jenkins-master`                          |
 | `master.image`                    | Master image name                    | `jenkins/jenkins`                         |
 | `master.imageTag`                 | Master image tag                     | `lts`                                     |

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -61,7 +61,8 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `checkDeprecation`                | Checks for deprecated values used    | `true`                                 |
 | `clusterZone`                     | Override the cluster name for FQDN resolving    | `cluster.local`                |
 | `nameOverride`                    | Override the resource name prefix    | `jenkins`                                 |
-| `fullnameOverride`                | Override the full resource names     | `jenkins-{release-name}` (or `jenkins` if release-name is `jenkins`) |
+| `fullnameOverride`                | Override the deployment namespace    | Not set (`Release.Namespace`)             |
+| `namespaceOverride`               | Override the full resource names     | `jenkins-{release-name}` (or `jenkins` if release-name is `jenkins`) |
 | `master.componentName`            | Jenkins master name                  | `jenkins-master`                          |
 | `master.image`                    | Master image name                    | `jenkins/jenkins`                         |
 | `master.imageTag`                 | Master image tag                     | `lts`                                     |

--- a/stable/jenkins/templates/NOTES.txt
+++ b/stable/jenkins/templates/NOTES.txt
@@ -1,5 +1,5 @@
 1. Get your '{{ .Values.master.adminUser }}' user password by running:
-  printf $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "jenkins.fullname" . }} -o jsonpath="{.data.jenkins-admin-password}" | base64 --decode);echo
+  printf $(kubectl get secret --namespace {{ template "jenkins.namespace" . }} {{ template "jenkins.fullname" . }} -o jsonpath="{.data.jenkins-admin-password}" | base64 --decode);echo
 
 {{- if .Values.master.ingress.hostName }}
 
@@ -7,20 +7,20 @@
 {{- else }}
 2. Get the Jenkins URL to visit by running these commands in the same shell:
 {{- if contains "NodePort" .Values.master.serviceType }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "jenkins.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  export NODE_PORT=$(kubectl get --namespace {{ template "jenkins.namespace" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "jenkins.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ template "jenkins.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT/login
 
 {{- else if contains "LoadBalancer" .Values.master.serviceType }}
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        You can watch the status of by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "jenkins.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "jenkins.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+        You can watch the status of by running 'kubectl get svc --namespace {{ template "jenkins.namespace" . }} -w {{ template "jenkins.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ template "jenkins.namespace" . }} {{ template "jenkins.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
   echo http://$SERVICE_IP:{{ .Values.master.servicePort }}/login
 
 {{- else if contains "ClusterIP"  .Values.master.serviceType }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/component={{ .Values.master.componentName }}" -l "app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ template "jenkins.namespace" . }} -l "app.kubernetes.io/component={{ .Values.master.componentName }}" -l "app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo http://127.0.0.1:{{ .Values.master.servicePort }}
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.master.servicePort }}:{{ .Values.master.servicePort }}
+  kubectl --namespace {{ template "jenkins.namespace" . }} port-forward $POD_NAME {{ .Values.master.servicePort }}:{{ .Values.master.servicePort }}
 
 {{- end }}
 {{- end }}

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -7,6 +7,30 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts.
+*/}}
+{{- define "jenkins.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "jenkins.master.slaveKubernetesNamespace" -}}
+  {{- if .Values.master.slaveKubernetesNamespace -}}
+    {{- .Values.master.slaveKubernetesNamespace -}}
+  {{- else -}}
+    {{- if .Values.namespaceOverride -}}
+      {{- .Values.namespaceOverride -}}
+    {{- else -}}
+      {{- .Release.Namespace -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "jenkins.fullname" . }}
+  namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
     "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -92,7 +93,7 @@ data:
                   <envVars>
                     <org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar>
                       <key>JENKINS_URL</key>
-                      <value>http://{{ template "jenkins.fullname" . }}.{{.Release.Namespace}}.svc.{{.Values.clusterZone}}:{{.Values.master.servicePort}}{{ default "" .Values.master.jenkinsUriPrefix }}</value>
+                      <value>http://{{ template "jenkins.fullname" . }}.{{ template "jenkins.namespace" . }}.svc.{{.Values.clusterZone}}:{{.Values.master.servicePort}}{{ default "" .Values.master.jenkinsUriPrefix }}</value>
                     </org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar>
                   </envVars>
                 </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
@@ -125,10 +126,10 @@ data:
           </templates>
           <serverUrl>https://kubernetes.default</serverUrl>
           <skipTlsVerify>false</skipTlsVerify>
-          <namespace>{{ default .Release.Namespace .Values.master.slaveKubernetesNamespace }}</namespace>
+          <namespace>{{ template "jenkins.master.slaveKubernetesNamespace" . }}</namespace>
 {{- if .Values.master.slaveKubernetesNamespace }}
-          <jenkinsUrl>http://{{ template "jenkins.fullname" . }}.{{.Release.Namespace}}:{{.Values.master.servicePort}}{{ default "" .Values.master.jenkinsUriPrefix }}</jenkinsUrl>
-          <jenkinsTunnel>{{ template "jenkins.fullname" . }}-agent.{{.Release.Namespace}}:{{ .Values.master.slaveListenerPort }}</jenkinsTunnel>
+          <jenkinsUrl>http://{{ template "jenkins.fullname" . }}.{{ template "jenkins.namespace" . }}:{{.Values.master.servicePort}}{{ default "" .Values.master.jenkinsUriPrefix }}</jenkinsUrl>
+          <jenkinsTunnel>{{ template "jenkins.fullname" . }}-agent.{{ template "jenkins.namespace" . }}:{{ .Values.master.slaveListenerPort }}</jenkinsTunnel>
 {{- else }}
           <jenkinsUrl>http://{{ template "jenkins.fullname" . }}:{{.Values.master.servicePort}}{{ default "" .Values.master.jenkinsUriPrefix }}</jenkinsUrl>
           <jenkinsTunnel>{{ template "jenkins.fullname" . }}-agent:{{ .Values.master.slaveListenerPort }}</jenkinsTunnel>

--- a/stable/jenkins/templates/home-pvc.yaml
+++ b/stable/jenkins/templates/home-pvc.yaml
@@ -7,6 +7,7 @@ metadata:
 {{ toYaml .Values.persistence.annotations | indent 4 }}
 {{- end }}
   name: {{ template "jenkins.fullname" . }}
+  namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
     "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/jenkins/templates/jcasc-config.yaml
+++ b/stable/jenkins/templates/jcasc-config.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "jenkins.fullname" $root }}-jenkins-config-{{ $key }}
-  namespace: {{ template "jenkins.namespace" . }}
+  namespace: {{ template "jenkins.namespace" $root }}
   labels:
     "app.kubernetes.io/name": {{ template "jenkins.name" $root}}
     "helm.sh/chart": {{ $.Chart.Name }}-{{ $.Chart.Version }}

--- a/stable/jenkins/templates/jcasc-config.yaml
+++ b/stable/jenkins/templates/jcasc-config.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "jenkins.fullname" $root }}-jenkins-config-{{ $key }}
+  namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": {{ template "jenkins.name" $root}}
     "helm.sh/chart": {{ $.Chart.Name }}-{{ $.Chart.Version }}

--- a/stable/jenkins/templates/jenkins-agent-svc.yaml
+++ b/stable/jenkins/templates/jenkins-agent-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "jenkins.fullname" . }}-agent
+  namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
     "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/jenkins/templates/jenkins-backup-cronjob.yaml
+++ b/stable/jenkins/templates/jenkins-backup-cronjob.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: {{ template "jenkins.fullname" . }}-backup
+  namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
     "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -29,7 +30,7 @@ spec:
             args:
             - simple-backup
             - -n
-            - {{ .Release.Namespace }}
+            - {{ template "jenkins.namespace" . }}
             - -l
             - app.kubernetes.io/instance={{ .Release.Name }}
             - --container

--- a/stable/jenkins/templates/jenkins-backup-rbac.yaml
+++ b/stable/jenkins/templates/jenkins-backup-rbac.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "jenkins.fullname" . }}-backup
+  namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
     "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -14,6 +15,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "jenkins.fullname" . }}-backup
+  namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
     "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -32,6 +34,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "jenkins.fullname" . }}-backup
+  namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
     "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -45,5 +48,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "jenkins.fullname" . }}-backup
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "jenkins.namespace" . }}
 {{- end }}

--- a/stable/jenkins/templates/jenkins-master-alerting-rules.yaml
+++ b/stable/jenkins/templates/jenkins-master-alerting-rules.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ template "jenkins.fullname" . }}
+  namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
     "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -6,6 +6,7 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "jenkins.fullname" . }}
+  namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
     "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/jenkins/templates/jenkins-master-ingress.yaml
+++ b/stable/jenkins/templates/jenkins-master-ingress.yaml
@@ -2,6 +2,7 @@
 apiVersion: {{ .Values.master.ingress.apiVersion }}
 kind: Ingress
 metadata:
+  namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
     "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/jenkins/templates/jenkins-master-networkpolicy.yaml
+++ b/stable/jenkins/templates/jenkins-master-networkpolicy.yaml
@@ -3,6 +3,7 @@ kind: NetworkPolicy
 apiVersion: {{ .Values.networkPolicy.apiVersion }}
 metadata:
   name: "{{ .Release.Name }}-{{ .Values.master.componentName }}"
+  namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
     "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -31,6 +32,7 @@ kind: NetworkPolicy
 apiVersion: {{ .Values.networkPolicy.apiVersion }}
 metadata:
   name: "{{ .Release.Name }}-{{ .Values.agent.componentName }}"
+  namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
     "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/jenkins/templates/jenkins-master-route.yaml
+++ b/stable/jenkins/templates/jenkins-master-route.yaml
@@ -2,6 +2,7 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
+  namespace: {{ template "jenkins.namespace" . }}
   labels:
     app: {{ template "jenkins.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/jenkins/templates/jenkins-master-servicemonitor.yaml
+++ b/stable/jenkins/templates/jenkins-master-servicemonitor.yaml
@@ -4,6 +4,7 @@ kind: ServiceMonitor
 
 metadata:
   name: {{ template "jenkins.fullname" . }}
+  namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
     "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -22,7 +23,7 @@ spec:
   jobLabel: {{ template "jenkins.fullname" . }}
   namespaceSelector:
     matchNames:
-    - "{{ $.Release.Namespace }}"
+    - "{{ template "jenkins.namespace" $ }}"
   selector:
     matchLabels:
       "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'

--- a/stable/jenkins/templates/jenkins-master-svc.yaml
+++ b/stable/jenkins/templates/jenkins-master-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{template "jenkins.fullname" . }}
+  namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
     "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/jenkins/templates/jobs.yaml
+++ b/stable/jenkins/templates/jobs.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "jenkins.fullname" . }}-jobs
+  namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
     "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/jenkins/templates/rbac.yaml
+++ b/stable/jenkins/templates/rbac.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $serviceName }}-schedule-agents
-  namespace: {{ .Values.master.slaveKubernetesNamespace | default .Release.Namespace}}
+  namespace: {{ template "jenkins.master.slaveKubernetesNamespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
     "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ $serviceName }}-schedule-agents
-  namespace: {{ .Values.master.slaveKubernetesNamespace | default .Release.Namespace}}
+  namespace: {{ template "jenkins.master.slaveKubernetesNamespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
     "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -40,7 +40,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "jenkins.serviceAccountName" .}}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "jenkins.namespace" . }}
 
 ---
 
@@ -51,7 +51,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "jenkins.fullname" . }}-casc-reload
-  namespace: {{ .Release.Namespace}}
+  namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
     "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -69,7 +69,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ $serviceName }}-watch-configmaps
-  namespace: {{ .Release.Namespace}}
+  namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
     "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -83,7 +83,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "jenkins.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "jenkins.namespace" . }}
 
 {{- end}}
 

--- a/stable/jenkins/templates/secret.yaml
+++ b/stable/jenkins/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "jenkins.fullname" . }}
+  namespace: {{ template "jenkins.namespace" . }}
   labels:
     "app.kubernetes.io/name": '{{ template "jenkins.name" .}}'
     "helm.sh/chart": "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/jenkins/templates/service-account-agent.yaml
+++ b/stable/jenkins/templates/service-account-agent.yaml
@@ -3,9 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "jenkins.serviceAccountAgentName" . }}
-{{- if .Values.master.slaveKubernetesNamespace }}
-  namespace: {{ .Values.master.slaveKubernetesNamespace }}
-{{ end }}
+  namespace: {{ template "jenkins.master.slaveKubernetesNamespace" . }}
 {{- if .Values.serviceAccountAgent.annotations }}
   annotations:
 {{ toYaml .Values.serviceAccountAgent.annotations | indent 4 }}

--- a/stable/jenkins/templates/service-account.yaml
+++ b/stable/jenkins/templates/service-account.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "jenkins.serviceAccountName" . }}
+  namespace: {{ template "jenkins.namespace" . }}
 {{- if .Values.serviceAccount.annotations }}
   annotations:
 {{ toYaml .Values.serviceAccount.annotations | indent 4 }}

--- a/stable/jenkins/templates/tests/jenkins-test.yaml
+++ b/stable/jenkins/templates/tests/jenkins-test.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ .Release.Name }}-ui-test-{{ randAlphaNum 5 | lower }}"
+  namespace: {{ template "jenkins.namespace" . }}
   annotations:
     "helm.sh/hook": test-success
 spec:

--- a/stable/jenkins/templates/tests/test-config.yaml
+++ b/stable/jenkins/templates/tests/test-config.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "jenkins.fullname" . }}-tests
+  namespace: {{ template "jenkins.namespace" . }}
 data:
   run.sh: |-
     @test "Testing Jenkins UI is accessible" {

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -7,6 +7,7 @@
 # See templates/_helpers.tpl
 # nameOverride:
 # fullnameOverride:
+# namespaceOverride:
 
 # For FQDN resolving of the master service. Change this value to match your existing configuration.
 # ref: https://github.com/kubernetes/dns/blob/master/docs/specification.md


### PR DESCRIPTION
#### What this PR does / why we need it:
It adds a `namespaceOverride` parameter, which allows this chart to be used in cases where templating is used across namespaces, like mentioned in https://github.com/helm/helm/issues/5358 By providing this parameter, the resulting templating will output to the specified namespace. The parameter is added as an 'override' to imply that this is non-default behavior.

#### Special notes for your reviewer:
This is not a common pattern (yet), but it solves a specific use-case not solved by Helm itself. https://github.com/helm/helm/issues/5358 A similar option is already in place for the `slaveKubernetesNamespace`. In our case we use it to rollout Jenkins across our infrastructure for multiple projects. We use it internally, and hope to contribute this upstream for others to use.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)

Mentioning the fine people taking care of this chart: @lachie83 @viglesiasce @maorfr @torstenwalter 