### PR TITLE
[stable/datadog] allow host networking for metrics

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.38.1
+version: 1.38.2
 appVersion: 6.14.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -355,6 +355,8 @@ helm install --name <RELEASE_NAME> \
 | `clusterAgent.livenessProbe`             | Overrides the default liveness probe                                                      | http port 443 if external metrics enabled   |
 | `clusterAgent.readinessProbe`            | Overrides the default readiness probe                                                     | http port 443 if external metrics enabled   |
 | `clusterAgent.strategy`                  | Which update strategy to deploy the cluster-agent                                         | RollingUpdate with 0 maxUnavailable, 1 maxSurge |
+| `clusterAgent.useHostNetwork`            | If true, use the host's network                                                           | `nil`                                       |
+| `clusterAgent.service.type`              | The type of service to use for the clusterAgent                                           | `ClusterIP`                                 |
 | `clusterchecksDeployment.enabled`        | Enable Datadog agent deployment dedicated for running Cluster Checks. It allows having different resources (Request/Limit) for Cluster Checks agent pods.  | `false` |
 | `clusterchecksDeployment.env`                            | Additional Datadog environment variables for Cluster Checks Deployment                        | `nil`                                       |
 | `clusterchecksDeployment.resources.requests.cpu`         | CPU resource requests                                                                         | `200m`                                      |

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -343,6 +343,7 @@ helm install --name <RELEASE_NAME> \
 | `clusterAgent.image.pullPolicy`          | Image pull policy                                                                         | `IfNotPresent`                              |
 | `clusterAgent.image.pullSecrets`         | Image pull secrets                                                                        | `nil`                                       |
 | `clusterAgent.metricsProvider.enabled`   | Enable Datadog metrics as a source for HPA scaling                                        | `false`                                     |
+| `clusterAgent.metricsProvider.service.type` | The type of service to use for the clusterAgent metrics server                         | `ClusterIP`                                 |
 | `clusterAgent.clusterChecks.enabled`     | Enable Cluster Checks on both the Cluster Agent and the Agent daemonset                   | `false`                                     |
 | `clusterAgent.confd`                     | Additional check configurations (static and Autodiscovery)                                | `nil`                                       |
 | `clusterAgent.podAnnotations`            | Annotations to add to the Cluster Agent Pod(s)                                            | `nil`                                       |
@@ -356,7 +357,6 @@ helm install --name <RELEASE_NAME> \
 | `clusterAgent.readinessProbe`            | Overrides the default readiness probe                                                     | http port 443 if external metrics enabled   |
 | `clusterAgent.strategy`                  | Which update strategy to deploy the cluster-agent                                         | RollingUpdate with 0 maxUnavailable, 1 maxSurge |
 | `clusterAgent.useHostNetwork`            | If true, use the host's network                                                           | `nil`                                       |
-| `clusterAgent.service.type`              | The type of service to use for the clusterAgent                                           | `ClusterIP`                                 |
 | `clusterchecksDeployment.enabled`        | Enable Datadog agent deployment dedicated for running Cluster Checks. It allows having different resources (Request/Limit) for Cluster Checks agent pods.  | `false` |
 | `clusterchecksDeployment.env`                            | Additional Datadog environment variables for Cluster Checks Deployment                        | `nil`                                       |
 | `clusterchecksDeployment.resources.requests.cpu`         | CPU resource requests                                                                         | `200m`                                      |

--- a/stable/datadog/templates/agent-services.yaml
+++ b/stable/datadog/templates/agent-services.yaml
@@ -40,6 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
 spec:
+  type: {{ .Values.clusterAgent.service.type }}
   type: ClusterIP
   selector:
     app: {{ template "datadog.fullname" . }}-cluster-agent

--- a/stable/datadog/templates/agent-services.yaml
+++ b/stable/datadog/templates/agent-services.yaml
@@ -40,7 +40,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
 spec:
-  type: {{ .Values.clusterAgent.service.type }}
+  {{- if .Values.clusterAgent.serviceType }}
+  type: {{ .Values.clusterAgent.serviceType }}
+  {{- end }}
   type: ClusterIP
   selector:
     app: {{ template "datadog.fullname" . }}-cluster-agent

--- a/stable/datadog/templates/agent-services.yaml
+++ b/stable/datadog/templates/agent-services.yaml
@@ -40,10 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
 spec:
-  {{- if .Values.clusterAgent.serviceType }}
-  type: {{ .Values.clusterAgent.serviceType }}
-  {{- end }}
-  type: ClusterIP
+  type: {{ .Values.clusterAgent.metricsProvider.service.type }}
   selector:
     app: {{ template "datadog.fullname" . }}-cluster-agent
   ports:

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -58,6 +58,10 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.clusterAgent.image.pullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.clusterAgent.useHostNetwork }}
+      hostNetwork: {{ .Values.clusterAgent.useHostNetwork }}
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
       containers:
       - name: {{ .Values.clusterAgent.containerName }}
         image: "{{ .Values.clusterAgent.image.repository }}:{{ .Values.clusterAgent.image.tag }}"

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -424,6 +424,23 @@ clusterAgent:
   #
   # readinessProbe:
 
+  ## @param service - object - required
+  ##
+  #
+  service:
+    type: ClusterIP
+    annotations: {}
+
+  ## @param useHostNetwork - boolean - optional
+  ## Bind ports on the hostNetwork. Useful for CNI networking where hostPort might
+  ## not be supported. The ports need to be available on all hosts. It can be
+  ## used for custom metrics instead of a service endpoint.
+  ##
+  ## WARNING: Make sure that hosts using this are properly firewalled otherwise
+  ## metrics and traces are accepted from any host able to connect to this host.
+  #
+  # useHostNetwork: true
+
 rbac:
 
   ## @param created - boolean - required

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -356,7 +356,6 @@ clusterAgent:
   metricsProvider:
     enabled: false
 
-    ## @param service - object - optional
     ## Configuration for the service for the cluster-agent metrics server
     #
     service:

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -356,6 +356,15 @@ clusterAgent:
   metricsProvider:
     enabled: false
 
+    ## @param service - object - optional
+    ## Configuration for the service for the cluster-agent metrics server
+    #
+    service:
+      ## @param type - string - optional
+      ##
+      #
+      type: ClusterIP
+
   ## @param clusterChecks - object - required
   ## Enable the Cluster Checks feature on both the cluster-agents and the daemonset
   ## ref: https://docs.datadoghq.com/agent/autodiscovery/clusterchecks/
@@ -423,14 +432,6 @@ clusterAgent:
   ## Override the cluster-agent's readiness probe logic from the default:
   #
   # readinessProbe:
-
-  ## @param service - object - optional
-  ##
-  # serviceType: ClusterIP
-  ##
-  #
-  service:
-    type: ClusterIP
 
   ## @param useHostNetwork - boolean - optional
   ## Bind ports on the hostNetwork. Useful for CNI networking where hostPort might

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -424,7 +424,9 @@ clusterAgent:
   #
   # readinessProbe:
 
-  ## @param service - object - required
+  ## @param service - object - optional
+  ##
+  # serviceType: ClusterIP
   ##
   #
   service:

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -431,7 +431,6 @@ clusterAgent:
   #
   service:
     type: ClusterIP
-    annotations: {}
 
   ## @param useHostNetwork - boolean - optional
   ## Bind ports on the hostNetwork. Useful for CNI networking where hostPort might


### PR DESCRIPTION
Signed-off-by: Doug Winter <doug.winter@isotoma.com>

#### What this PR does / why we need it:

In CNI situations where the masters are unable to use CNI networking and you wish to make external metrics available, the metrics server needs to support host networking.

This PR includes the appropriate changes and values.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
