### PR TITLE
[stable/traefik]: traefik metrics port when prometheus is enabled

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.75.0
+version: 1.75.1
 appVersion: 1.7.12
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/templates/deployment.yaml
+++ b/stable/traefik/templates/deployment.yaml
@@ -162,7 +162,7 @@ spec:
           hostPort: {{ default 443 .Values.deployment.hostPort.httpsPort }}
           {{- end }}
           protocol: TCP
-        {{- if .Values.dashboard.enabled }}
+        {{- if or .Values.dashboard.enabled .Values.metrics.prometheus.enabled }}
         - name: dash
           containerPort: 8080
           {{- if .Values.deployment.hostPort.dashboardEnabled }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Need the metrics port exposed so it can be used on prometheus-operator's servicemonitors, eg:

```yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: traefik
spec:
  endpoints:
  - targetPort: 8080
  jobLabel: traefik
  namespaceSelector:
    matchNames:
    - traefik
  selector:
    matchLabels:
      app: traefik
```

#### Which issue this PR fixes

#### Special notes for your reviewer:

The port is already added to the service, but not to the pod when prometheus is enabled.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
