### PR TITLE
[stable/nexcloud] Multiple config.php file

### DIFF
--- a/stable/nextcloud/Chart.yaml
+++ b/stable/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nextcloud
-version: 1.5.0
+version: 1.6.0
 appVersion: 16.0.1
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/nextcloud/README.md
+++ b/stable/nextcloud/README.md
@@ -70,6 +70,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `nextcloud.mail.smtp.authtype`      | SMTP authentication method                    | `LOGIN`                                                 |
 | `nextcloud.mail.smtp.name`          | SMTP username                                 | `''`                                                    |
 | `nextcloud.mail.smtp.password`      | SMTP password                                 | `''`                                                    |
+| `nextcloud.configs`                 | Config files created in `/var/www/html/config`| `{}`                                                    |
 | `internalDatabase.enabled`          | Whether to use internal sqlite database       | `true`                                                  |
 | `internalDatabase.database`         | Name of the existing database                 | `nextcloud`                                             |
 | `externalDatabase.enabled`          | Whether to use external database              | `false`                                                 |
@@ -157,3 +158,31 @@ To use this functionality, set `cronjob.enabled` parameter to `true` and switch 
 See the [Configuration](#configuration) section for further configuration of the cronjob resource.
 
 > **Note**: For the cronjobs to work correctly, ingress must be also enabled (set `ingress.enabled` to `true`) and `nextcloud.host` has to be publicly resolvable.
+
+## Multiple config.php file
+
+Nextcloud supports loading configuration parameters from multiple files. 
+You can add arbitrary files ending with `.config.php` in the `config/` directory. 
+See [documentation](https://docs.nextcloud.com/server/15/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-config-php-file).
+
+For example, following config will configure Nextcloud with [S3 as primary storage](https://docs.nextcloud.com/server/13/admin_manual/configuration_files/primary_storage.html#simple-storage-service-s3) by creating file `/var/www/html/config/s3.config.php`:  
+
+```yaml
+nextcloud:
+  configs:
+    s3.config.php: |-
+      <?php
+      $CONFIG = array (
+        'objectstore' => array(
+          'class' => '\\OC\\Files\\ObjectStore\\S3',
+          'arguments' => array(
+            'bucket'     => 'my-bucket',
+            'autocreate' => true,
+            'key'        => 'xxx',
+            'secret'     => 'xxx',
+            'region'     => 'us-east-1',
+            'use_ssl'    => true
+          )
+        )
+      );
+```

--- a/stable/nextcloud/templates/config.yaml
+++ b/stable/nextcloud/templates/config.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.nextcloud.configs -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nextcloud.fullname" . }}-config
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+{{- range $key, $value := .Values.nextcloud.configs }}
+  {{ $key }}: |-
+{{ $value | indent 4 }}
+{{- end }}
+{{- end }}

--- a/stable/nextcloud/templates/deployment.yaml
+++ b/stable/nextcloud/templates/deployment.yaml
@@ -185,6 +185,11 @@ spec:
         - name: nextcloud-data
           mountPath: /var/www/html/themes
           subPath: themes
+        {{- range $key, $value := .Values.nextcloud.configs }}
+        - name: nextcloud-config
+          mountPath: /var/www/html/config/{{ $key }}
+          subPath: {{ $key }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -204,4 +209,9 @@ spec:
           claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "nextcloud.fullname" . }}-nextcloud{{- end }}
       {{- else }}
         emptyDir: {}
+      {{- end }}
+      {{- if .Values.nextcloud.configs }}
+      - name: nextcloud-config
+        configMap:
+          name: {{ template "nextcloud.fullname" . }}-config
       {{- end }}

--- a/stable/nextcloud/values.yaml
+++ b/stable/nextcloud/values.yaml
@@ -75,6 +75,29 @@ nextcloud:
       authtype: LOGIN
       name: user
       password: pass
+  # Extra config files created in /var/www/html/config/
+  # ref: https://docs.nextcloud.com/server/15/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-config-php-file
+  configs: {}
+
+  # For example, to use S3 as primary storage
+  # ref: https://docs.nextcloud.com/server/13/admin_manual/configuration_files/primary_storage.html#simple-storage-service-s3
+  #
+  #  configs:
+  #    s3.config.php: |-
+  #      <?php
+  #      $CONFIG = array (
+  #        'objectstore' => array(
+  #          'class' => '\\OC\\Files\\ObjectStore\\S3',
+  #          'arguments' => array(
+  #            'bucket'     => 'my-bucket',
+  #            'autocreate' => true,
+  #            'key'        => 'xxx',
+  #            'secret'     => 'xxx',
+  #            'region'     => 'us-east-1',
+  #            'use_ssl'    => true
+  #          )
+  #        )
+  #      );
 
 internalDatabase:
   enabled: true


### PR DESCRIPTION
#### What this PR does / why we need it:

Nextcloud supports loading configuration parameters from multiple files. You can add arbitrary files ending with .config.php in the config/ directory.

Use `ConfigMap` & `volumeMounts` to create extra config file in `/var/www/html/config`

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
