### PR TITLE
[stable/spinnaker] ensure spinnaker works behind nsx-t ingress

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.13.1
+version: 1.13.2
 appVersion: 1.12.5
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/configmap/additional-profile-configmaps.yaml
+++ b/stable/spinnaker/templates/configmap/additional-profile-configmaps.yaml
@@ -19,7 +19,7 @@ Render profiles for each service by merging predefined defaults with values pass
 {{- /* Defaults: Add special settings for gate if GCE or ALB ingress is used */}}
 {{- /* https://github.com/spinnaker/spinnaker/issues/1630#issuecomment-467359999 */}}
 {{- if index $.Values.ingress "annotations" -}}
-{{- if eq (index $.Values.ingress.annotations "kubernetes.io/ingress.class" | default "") "gce" "alb" }}
+{{- if eq (index $.Values.ingress.annotations "kubernetes.io/ingress.class" | default "") "gce" "alb" "nsx" }}
 {{- $tomcatProxySettings := dict -}}
 {{- $_ := set $tomcatProxySettings "protocolHeader" "X-Forwarded-Proto" -}}
 {{- $_ := set $tomcatProxySettings "remoteIpHeader" "X-Forwarded-For" -}}

--- a/stable/spinnaker/templates/ingress/deck.yaml
+++ b/stable/spinnaker/templates/ingress/deck.yaml
@@ -15,7 +15,7 @@ spec:
     http:
       paths:
       {{- if index $.Values.ingress "annotations" }}
-      {{- if eq (index $.Values.ingress.annotations "kubernetes.io/ingress.class" | default "") "gce" "alb" }}
+      {{- if eq (index $.Values.ingress.annotations "kubernetes.io/ingress.class" | default "") "gce" "alb" "nsx" }}
       - path: /*
       {{- else }}{{/* Has annotations but ingress class is not "gce" nor "alb" */}}
       - path: /

--- a/stable/spinnaker/templates/ingress/gate.yaml
+++ b/stable/spinnaker/templates/ingress/gate.yaml
@@ -15,7 +15,7 @@ spec:
     http:
       paths:
       {{- if index $.Values.ingress "annotations" }}
-      {{- if eq (index $.Values.ingress.annotations "kubernetes.io/ingress.class" | default "") "gce" "alb" }}
+      {{- if eq (index $.Values.ingress.annotations "kubernetes.io/ingress.class" | default "") "gce" "alb" "nsx" }}
       - path: /*
       {{- else }}{{/* Has annotations but ingress class is not "gce" nor "alb" */}}
       - path: /


### PR DESCRIPTION
VMware NSX-T ingress requires a `/*` pattern for the path, this allows the user
to specify the type of ingress controller via annotations to ensure
correct behavior.

Signed-off-by: Christopher Banck <cbanck@pivotal.io>

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
