### PR TITLE
[stable/instana-agent] Allow the agent configuration.yaml to be configurable via values.yaml in addition to editing the configmap

### DIFF
--- a/stable/instana-agent/Chart.yaml
+++ b/stable/instana-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: instana-agent
-version: 1.0.10
+version: 1.0.11
 appVersion: 1.0
 description: Instana Agent for Kubernetes
 home: https://www.instana.com/

--- a/stable/instana-agent/README.md
+++ b/stable/instana-agent/README.md
@@ -117,10 +117,16 @@ The following table lists the configurable parameters of the Instana chart and t
 | `agent.pod.requests.cpu`           | Container cpu requests in cpu cores                                     | `0.5`                                                                                                       |
 | `agent.pod.limits.memory`          | Container memory limits in MiB                                          | `512`                                                                                                       |
 | `agent.pod.limits.cpu`             | Container cpu limits in cpu cores                                       | `1.5`                                                                                                       |
+| `agent.configuration_yaml`         | Custom content for the agent configuration.yaml file                    | `nil` See [below](#agent) for more details                                                                  |
 | `rbac.create`                      | Whether RBAC resources should be created                                | `true`                                                                                                      |
 | `serviceAccount.create`            | Whether a ServiceAccount should be created                              | `true`                                                                                                      |
 | `serviceAccount.name`              | Name of the ServiceAccount to use                                       | `instana-agent`                                                                                             |
 
 ### Agent
 
-There is a [config map](templates/configmap.yaml) which you can edit to configure the agent. This configuration will be used for all instana agents on all nodes.
+To configure the agent, you can either:
+
+- edit the [config map](templates/configmap.yaml), or
+- provide the configuration via the `agent.configuration_yaml` parameter in [values.yaml](values.yaml)
+
+This configuration will be used for all instana agents on all nodes. Visit the [agent configuration documentation](https://docs.instana.io/quick_start/agent_configuration/#configuration) for more details on configuration options.

--- a/stable/instana-agent/templates/configmap.yaml
+++ b/stable/instana-agent/templates/configmap.yaml
@@ -38,3 +38,6 @@ data:
     #com.instana.plugin.generic.hardware:
     #  enabled: true # disabled by default
     #  availability-zone: 'zone'
+  {{- if .Values.agent.configuration_yaml -}}
+  {{ .Values.agent.configuration_yaml | nindent 4 }}
+  {{- end }}

--- a/stable/instana-agent/values.yaml
+++ b/stable/instana-agent/values.yaml
@@ -62,6 +62,9 @@ agent:
   # agent.proxyUseDNS sets the INSTANA_AGENT_PROXY_USE_DNS environment variable.
   # proxyUseDNS: null
 
+  configuration_yaml: |
+    # Place agent configuration here
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true


### PR DESCRIPTION
#### What this PR does / why we need it:

Allow the agent configuration.yaml to be configurable via values.yaml in addition to editing the configmap. 

#### Which issue this PR fixes
- addresses the request from @timothyclarke 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
