### PR TITLE
[stable/spinnaker] bump spinnaker and requirement versions

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.13.2
-appVersion: 1.12.5
+version: 1.14.0
+appVersion: 1.14.8
 home: http://spinnaker.io/
 sources:
 - https://github.com/spinnaker

--- a/stable/spinnaker/requirements.lock
+++ b/stable/spinnaker/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 3.8.0
+  version: 8.0.14
 - name: minio
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.6.3
-digest: sha256:bccb7348a48817b0c0c654dfecd2f399a64a50b0f677b483a27a76f4ff7ddd89
-generated: 2019-01-21T21:59:54.069291+05:30
+  version: 2.4.16
+digest: sha256:ffe8a8143282b89ef24aa047c52f2363b4468bdaccee03bc7c9f9f69129c85f2
+generated: "2019-07-01T23:35:20.087821+02:00"

--- a/stable/spinnaker/requirements.yaml
+++ b/stable/spinnaker/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
-  version: 3.8.0
+  version: 8.0.14
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: redis.enabled
 - name: minio
-  version: 1.6.3
+  version: 2.4.16
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: minio.enabled

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -1,5 +1,5 @@
 halyard:
-  spinnakerVersion: 1.12.5
+  spinnakerVersion: 1.14.8
   image:
     repository: gcr.io/spinnaker-marketplace/halyard
     tag: 1.20.2
@@ -179,7 +179,8 @@ redis:
 # Minio is not exposed publically
 minio:
   enabled: true
-  imageTag: RELEASE.2019-02-13T19-48-27Z
+#  image:
+#    tag: RELEASE.2019-06-19T18-24-42Z
   serviceType: ClusterIP
   accessKey: spinnakeradmin
   secretKey: spinnakeradmin


### PR DESCRIPTION
chart version 1.14.0

spinnaker 1.12.5 -> 1.14.8
redis 3.8.0 -> 8.0.14
minio 1.6.3 -> 2.4.16

Fixed specifying minio image tag in values.yml but uncommented it as the default is inherited by the requirements.

Tested on Kubernetes 1.13.5 and Helm 2.14.1

Signed-off-by: Christopher Banck <cbanck@pivotal.io>

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
