### PR TITLE
[stable/prometheus-mongodb-exporter] Add Service object for ServiceMonitor to work properly

### DIFF
--- a/stable/prometheus-mongodb-exporter/Chart.yaml
+++ b/stable/prometheus-mongodb-exporter/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 name: prometheus-mongodb-exporter
 sources:
 - https://github.com/percona/mongodb_exporter
-version: 2.1.0
+version: 2.2.0

--- a/stable/prometheus-mongodb-exporter/README.md
+++ b/stable/prometheus-mongodb-exporter/README.md
@@ -51,6 +51,9 @@ podAnnotations:
 | `resources` | Pod resource requests and limits | `{}` |
 | `env` | Extra environment variables passed to pod | `{}` |
 | `securityContext` | Security context for the pod | See values.yaml |
+| `service.annotations` | Annotations to be added to the service | `{}` |
+| `service.port` | The port to expose | `9216` |
+| `service.type` | The type of service to expose | `ClusterIP` |
 | `serviceMonitor.enabled` | Set to true if using the Prometheus Operator | `true` |
 | `serviceMonitor.interval` | Interval at which metrics should be scraped | `30s` |
 | `serviceMonitor.scrapeTimeout` | Interval at which metric scrapes should time out | `10s` |

--- a/stable/prometheus-mongodb-exporter/templates/NOTES.txt
+++ b/stable/prometheus-mongodb-exporter/templates/NOTES.txt
@@ -1,3 +1,13 @@
 Verify the application is working by running these commands:
-  kubectl port-forward deployment/{{ include "prometheus-mongodb-exporter.fullname" . }} {{ .Values.port }}
-  curl http://127.0.0.1:{{ .Values.port }}/metrics
+{{if contains "NodePort" .Values.service.type }}
+  NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "prometheus-mongodb-exporter.fullname" . }})
+  curl http://$NODE_IP:$NODE_PORT/metrics
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  # NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+  SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "prometheus-mongodb-exporter.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  curl http://$SERVICE_IP:{{ .Values.service.port }}/metrics
+{{- else if contains "ClusterIP" .Values.service.type }}
+  kubectl port-forward service/{{ include "prometheus-mongodb-exporter.fullname" . }} {{ .Values.service.port }}
+  curl http://127.0.0.1:{{ .Values.service.port }}/metrics
+{{- end }}

--- a/stable/prometheus-mongodb-exporter/templates/service.yaml
+++ b/stable/prometheus-mongodb-exporter/templates/service.yaml
@@ -1,0 +1,23 @@
+{{ if .Values.serviceMonitor.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "prometheus-mongodb-exporter.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "prometheus-mongodb-exporter.chart" . }}
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/stable/prometheus-mongodb-exporter/templates/service.yaml
+++ b/stable/prometheus-mongodb-exporter/templates/service.yaml
@@ -1,4 +1,3 @@
-{{ if .Values.serviceMonitor.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,15 +8,14 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "prometheus-mongodb-exporter.chart" . }}
   annotations:
-    {{- toYaml .Values.annotations | nindent 4 }}
+    {{- toYaml .Values.service.annotations | nindent 4 }}
 spec:
-  type: ClusterIP
   ports:
-    - port: {{ .Values.port }}
+    - port: {{ .Values.service.port }}
       targetPort: metrics
       protocol: TCP
       name: metrics
   selector:
     app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
+  type: {{ .Values.service.type }}

--- a/stable/prometheus-mongodb-exporter/templates/tests/test-connection.yaml
+++ b/stable/prometheus-mongodb-exporter/templates/tests/test-connection.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "prometheus-mongodb-exporter.fullname" . }}-test-connection"
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "prometheus-mongodb-exporter.chart" . }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+  - name: wget
+    image: busybox
+    command: ['wget']
+    args:  ['-qO-', '{{ include "prometheus-mongodb-exporter.fullname" . }}:{{ .Values.service.port }}/metrics']
+  restartPolicy: Never

--- a/stable/prometheus-mongodb-exporter/values.yaml
+++ b/stable/prometheus-mongodb-exporter/values.yaml
@@ -67,6 +67,11 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 10000
 
+service:
+  annotations: {}
+  port: 9216
+  type: ClusterIP
+
 serviceMonitor:
   enabled: true
   interval: 30s


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR creates a Service object if serviceMonitor is enabled.
It's needed to provide exporter's Endpoints for ServiceMonitor, so prometheus-operator will get targets to scrap metrics from.


> For Prometheus to monitor any application within Kubernetes an Endpoints object needs to exist. Endpoints objects are essentially lists of IP addresses. Typically an Endpoints object is populated by a Service object. A Service object discovers Pods by a label selector and adds those to the Endpoints object.

(from https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md#servicemonitor)



#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)