### PR TITLE
[stable/concourse] Fixes #13025 Worker-only deployments to take a list of hostnames & ports

### DIFF
--- a/stable/concourse/CHANGELOG.md
+++ b/stable/concourse/CHANGELOG.md
@@ -6,3 +6,7 @@
 # v7.0.0:
 
 - upgraded the PostgreSQL Chart (direct dependency of this Chart) from `0.13.1` to `5.3.8`. As various values (like `postgresUser`) changed (to, for instance, `postgresqlUsername`), a major dump was needed.
+
+# v8.0.0:
+
+- changed the format for worker-only deployments from `concourse.worker.tsa.host` and `concourse.worker.tsa.port` to `concourse.worker.tsa.hosts` to take in an array of parameters.

--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 7.0.2
+version: 8.0.0
 appVersion: 5.3.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/_helpers.tpl
+++ b/stable/concourse/templates/_helpers.tpl
@@ -52,3 +52,15 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
     {{- end }}
   {{- end }}
 {{- end }}
+
+
+{{/*
+Creates the address of the TSA service.
+*/}}
+{{- define "concourse.web.tsa.address" -}}
+{{- $port := .Values.concourse.web.tsa.bindPort -}}
+{{- if and (eq "NodePort" .Values.web.service.type) .Values.web.service.tsaNodePort -}}
+  {{- $port = .Values.web.service.tsaNodePort -}}
+{{- end -}}
+{{ template "concourse.web.fullname" . }}:{{- print $port -}}
+{{- end -}}

--- a/stable/concourse/templates/required-check.yaml
+++ b/stable/concourse/templates/required-check.yaml
@@ -1,3 +1,7 @@
 {{ if not (or .Values.web.enabled .Values.worker.enabled) }}
 {{- required "Must set either web.enabled or worker.enabled to create a concourse deployment" "" }}
 {{ end }}
+
+{{ if and (not .Values.concourse.worker.tsa.hosts) (and (not .Values.web.enabled) (.Values.worker.enabled)) }}
+{{- required "concourse.worker.tsa.hosts must be set in case of worker only deployment" "" }}
+{{ end }}

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -173,13 +173,13 @@ spec:
             - name: CONCOURSE_LOG_LEVEL
               value: {{ .Values.concourse.worker.logLevel | quote }}
             {{- end }}
-            {{ if and .Values.worker.enabled (not .Values.web.enabled) }}
+            {{ if not .Values.web.enabled }}
             - name: CONCOURSE_TSA_HOST
-              value: "{{ required "concourse.worker.tsa.host must be set in case of worker only deployment" .Values.concourse.worker.tsa.host }}:{{ .Values.concourse.worker.tsa.port}}"
+              value: "{{- range $i, $tsaHost := .Values.concourse.worker.tsa.hosts }}{{- if $i }},{{ end }}{{- $tsaHost }}{{- end -}}"
             {{ else }}
             - name: CONCOURSE_TSA_HOST
-              value: "{{ template "concourse.web.fullname" . }}:{{ .Values.concourse.worker.tsa.port}}"
-            {{ end }}
+              value: "{{ template "concourse.web.tsa.address" . -}}"
+            {{- end }}
             - name: CONCOURSE_TSA_PUBLIC_KEY
               value: "{{ .Values.worker.keySecretsPath }}/host_key.pub"
             - name: CONCOURSE_TSA_WORKER_PRIVATE_KEY

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1101,13 +1101,15 @@ concourse:
     volumeSweeperMaxInFlight: 5
 
     tsa:
-      ## TSA host to forward the worker through.
-      ##
-      host:
 
-      ## TSA port to forward the worker through.
+      ## TSA host(s) to forward the worker through.
+      ## Only used for worker-only deployments.
+      ## Example:
+      ## hosts:
+      ##   - 1.1.1.1:2222
+      ##   - 2.2.2.2:2222
       ##
-      port: 2222
+      hosts: []
 
       ## File containing a public key to expect from the TSA.
       ##


### PR DESCRIPTION
#### What this PR does / why we need it:

Removes the following properties:
```
worker.tsa.host
worker.tsa.port
```
and replaces them with the single property:
```
worker.tsa.hosts
```
which takes an array of IP's and ports in the format `IP:port`

#### Which issue this PR fixes
  - fixes #13025

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
