### PR TITLE
stable/opa: Fix OPA installation script with the right authz rego as …

### DIFF
--- a/stable/opa/Chart.yaml
+++ b/stable/opa/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - opa
 - admission control
 - policy
-version: 1.5.0
+version: 1.5.1
 home: https://www.openpolicyagent.org
 icon: https://raw.githubusercontent.com/open-policy-agent/opa/master/logo/logo.png
 sources:

--- a/stable/opa/templates/deployment.yaml
+++ b/stable/opa/templates/deployment.yaml
@@ -34,9 +34,12 @@ spec:
             cat > /authz/authz.rego <<EOF
             package system.authz
             default allow = false
+            # Allow anonymous access to the default policy decision.
             allow { input.path = [""]; input.method = "POST" }
             allow { input.path = [""]; input.method = "GET" }
-            allow { input.identity = "$TOKEN" }
+            # This is only used for health check in liveness and readiness probe
+            allow { input.path = ["health"]; input.method = "GET" }
+            allow { input.identity == "$TOKEN" }
             EOF
           volumeMounts:
             - name: authz

--- a/stable/opa/values.yaml
+++ b/stable/opa/values.yaml
@@ -158,14 +158,14 @@ sar:
 # To control the liveness and readiness probes change the fields below.
 readinessProbe:
   httpGet:
-    path: /
+    path: /health
     scheme: HTTPS
     port: 443
   initialDelaySeconds: 3
   periodSeconds: 5
 livenessProbe:
   httpGet:
-    path: /
+    path: /health
     scheme: HTTPS
     port: 443
   initialDelaySeconds: 3


### PR DESCRIPTION
…well as probe config.

This is from https://github.com/StyraInc/fetchdb/pull/3146.

Signed-off-by: Xin Jin <xin@styra.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Fix authorization policy for OPA as should have /health path for liveness and readiness probe. Also need to update it in authz policy so that it does not require token when authz is enabled. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
This is to apply changes here: https://github.com/StyraInc/fetchdb/pull/3146

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [ x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
