### PR TITLE
[stable/mongodb] Disable IPv6 by default

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 5.20.3
+version: 6.0.0
 appVersion: 4.0.10
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/README.md
+++ b/stable/mongodb/README.md
@@ -62,7 +62,7 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `mongodbUsername`                                  | MongoDB custom user                                                                          | `nil`                                                   |
 | `mongodbPassword`                                  | MongoDB custom user password                                                                 | `random alphanumeric string (10)`                       |
 | `mongodbDatabase`                                  | Database to create                                                                           | `nil`                                                   |
-| `mongodbEnableIPv6`                                | Switch to enable/disable IPv6 on MongoDB                                                     | `true`                                                  |
+| `mongodbEnableIPv6`                                | Switch to enable/disable IPv6 on MongoDB                                                     | `false`                                                 |
 | `mongodbDirectoryPerDB`                            | Switch to enable/disable DirectoryPerDB on MongoDB                                           | `false`                                                 |
 | `mongodbSystemLogVerbosity`                        | MongoDB systen log verbosity level                                                           | `0`                                                     |
 | `mongodbDisableSystemLog`                          | Whether to disable MongoDB system log or not                                                 | `false`                                                 |
@@ -248,6 +248,11 @@ The [Bitnami MongoDB](https://github.com/bitnami/bitnami-docker-mongodb) image s
 The chart mounts a [Persistent Volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) at this location. The volume is created using dynamic volume provisioning.
 
 ## Upgrading
+
+### To 6.0.0
+
+From this version, `mongodbEnableIPv6` is set to `false` by default in order to work properly in most k8s clusters, if you want to use IPv6 support, you need to set this variable to `true` by adding `--set mongodbEnableIPv6=true` to your `helm` command.
+You can find more information in the [`bitnami/mongodb` image README](https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md).
 
 ### To 5.0.0
 

--- a/stable/mongodb/values-production.yaml
+++ b/stable/mongodb/values-production.yaml
@@ -55,7 +55,7 @@ usePassword: true
 ## Whether enable/disable IPv6 on MongoDB
 ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#enabling/disabling-ipv6
 ##
-mongodbEnableIPv6: true
+mongodbEnableIPv6: false
 
 ## Whether enable/disable DirectoryPerDB on MongoDB
 ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#enabling/disabling-directoryperdb

--- a/stable/mongodb/values.yaml
+++ b/stable/mongodb/values.yaml
@@ -55,7 +55,7 @@ usePassword: true
 ## Whether enable/disable IPv6 on MongoDB
 ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#enabling/disabling-ipv6
 ##
-mongodbEnableIPv6: true
+mongodbEnableIPv6: false
 
 ## Whether enable/disable DirectoryPerDB on MongoDB
 ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#enabling/disabling-directoryperdb


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR disable the IPv6 support by default by setting to `false` the `mongodbEnableIPv6` variable.
Mainly, this variable set the `ipv6` parameter to `true` or `false` in the _mongodb.conf_ file:
```yaml
# network interfaces
net:
  port: 27017
  unixDomainSocket:
    enabled: true
    pathPrefix: /opt/bitnami/mongodb/tmp
  ipv6: true
  bindIpAll: true
```

In some k8s cluster, mongodb service is not running because of the following issue (_mongodb.log_):
```
2019-06-21T14:09:17.987+0000 I CONTROL  [main] Automatically disabling TLS 1.0, to force-enable TLS 1.0 specify --sslDisabledProtocols 'none'
2019-06-21T14:09:17.992+0000 I CONTROL  [initandlisten] MongoDB starting : pid=36 port=27017 dbpath=/opt/bitnami/mongodb/data/db 64-bit host=carlosrh-mongo-mongodb-76bc884646-ztpxl
2019-06-21T14:09:17.992+0000 I CONTROL  [initandlisten] db version v4.0.10
2019-06-21T14:09:17.992+0000 I CONTROL  [initandlisten] git version: c389e7f69f637f7a1ac3cc9fae843b635f20b766
2019-06-21T14:09:17.992+0000 I CONTROL  [initandlisten] OpenSSL version: OpenSSL 1.1.0j  20 Nov 2018
2019-06-21T14:09:17.992+0000 I CONTROL  [initandlisten] allocator: tcmalloc
2019-06-21T14:09:17.992+0000 I CONTROL  [initandlisten] modules: none
2019-06-21T14:09:17.992+0000 I CONTROL  [initandlisten] build environment:
2019-06-21T14:09:17.992+0000 I CONTROL  [initandlisten]     distmod: debian92
2019-06-21T14:09:17.992+0000 I CONTROL  [initandlisten]     distarch: x86_64
2019-06-21T14:09:17.992+0000 I CONTROL  [initandlisten]     target_arch: x86_64
2019-06-21T14:09:17.993+0000 I CONTROL  [initandlisten] options: { config: "/opt/bitnami/mongodb/conf/mongodb.conf", net: { bindIpAll: true, ipv6: true, port: 27017, unixDomainSocket: { enabled: true, pathPrefix: "/opt/bitnami/mongodb/tmp" } }, processManagement: { fork: false, pidFilePath: "/opt/bitnami/mongodb/tmp/mongodb.pid" }, security: { authorization: "disabled" }, setParameter: { enableLocalhostAuthBypass: "true" }, storage: { dbPath: "/opt/bitnami/mongodb/data/db", directoryPerDB: false, journal: { enabled: true } }, systemLog: { destination: "file", logAppend: true, logRotate: "reopen", path: "/opt/bitnami/mongodb/logs/mongodb.log", quiet: false, verbosity: 0 } }
2019-06-21T14:09:17.995+0000 I STORAGE  [initandlisten] exception in initAndListen std::exception: open: Address family not supported by protocol, terminating
2019-06-21T14:09:17.996+0000 I CONTROL  [initandlisten] now exiting
2019-06-21T14:09:17.996+0000 I CONTROL  [initandlisten] shutting down with code:100
```
This message is very descriptive:
```
2019-06-21T14:09:17.995+0000 I STORAGE  [initandlisten] exception in initAndListen std::exception: open: Address family not supported by protocol, terminating
```

Although the host has disabled IPv6, it is expected that MongoDB will try to use IPv4 in its absence, in fact, we tried it when using this parameter for the first time, so why in some k8s cluster works and not in others?

We can disable IPv6 support by running
```
sudo sysctl -w net.ipv6.conf.*.disable_ipv6=1
```
in this case, mongodb server does not complain about unsupported address family when IPv6 is enabled in the configs. This reflects with our earlier findings as we had used the same method to disable IPv6.

Continuing on our investigation, we found that the alternate way of disabling IPv6 support is to pass `ipv6.disable=1` as a bootarg to the Linux kernel and with this, we were able to see the unsupported address family error with mongodb.

With these findings, we cannot make the assumption that IPv6 enabled in the mongodb configs by default will always work regardless of whether the underlying host supports IPv6 or not.

#### Which issue this PR fixes
  - https://github.com/bitnami/bitnami-docker-mongodb/issues/108
  - https://github.com/kubeapps/kubeapps/issues/577
  - https://github.com/helm/charts/issues/14002
  - https://github.com/jenkins-x/jx/issues/1597 

#### Special notes for your reviewer:
We are working to use `false` as default value in the image itself, but we can merge this PR without waiting to the image changes as this is an env. variable that we're passing to the image and the image already support both values, we are only changing the default value.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
