### PR TITLE
[incubator/fluentd-cloudwatch] add a value for the busybox image

### DIFF
--- a/incubator/fluentd-cloudwatch/Chart.yaml
+++ b/incubator/fluentd-cloudwatch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-cloudwatch
-version: 0.10.1
+version: 0.10.2
 appVersion: v1.3.3-debian-cloudwatch-1.0
 description: A Fluentd CloudWatch Helm chart for Kubernetes.
 home: https://www.fluentd.org/

--- a/incubator/fluentd-cloudwatch/README.md
+++ b/incubator/fluentd-cloudwatch/README.md
@@ -51,6 +51,7 @@ The following table lists the configurable parameters of the Fluentd Cloudwatch 
 | `image.repository`           | Image repository                                                                | `fluent/fluentd-kubernetes-daemonset` |
 | `image.tag`                  | Image tag                                                                       | `v1.3.3-debian-cloudwatch-1.0`        |
 | `image.pullPolicy`           | Image pull policy                                                               | `IfNotPresent`                        |
+| `initContainers.config.image`| Image for the copy-fluentd-config init container                                | `busybox`                             |
 | `resources.limits.cpu`       | CPU limit                                                                       | `100m`                                |
 | `resources.limits.memory`    | Memory limit                                                                    | `200Mi`                               |
 | `resources.requests.cpu`     | CPU request                                                                     | `100m`                                |

--- a/incubator/fluentd-cloudwatch/templates/daemonset.yaml
+++ b/incubator/fluentd-cloudwatch/templates/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "fluentd-cloudwatch.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       initContainers:
         - name: copy-fluentd-config
-          image: busybox
+          image: {{ .Values.initContainers.config.image }}
           command: ['sh', '-c', 'cp /config-volume/* /etc/fluentd']
           volumeMounts:
             - name: config-volume

--- a/incubator/fluentd-cloudwatch/values.yaml
+++ b/incubator/fluentd-cloudwatch/values.yaml
@@ -6,6 +6,10 @@ image:
 ## ref: http://kubernetes.io/docs/user-guide/images/#updating-images
   pullPolicy: IfNotPresent
 
+initContainers:
+  config:
+    image: busybox
+
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##


### PR DESCRIPTION
## What this PR does / why we need it:

This would allow for changing the source registry of the busybox image used in the config initcontainer.
 
Would address scenarios in which the chart is deployed to nodes that have no internet egress access due to compliance or security reasons, or need to rely on all the images being present in a private registry (for the same compliance or security reasons).

#### Which issue this PR fixes
  - fixes #15232

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
