### PR TITLE
[stable/external-dns] Fix labels max length by truncating them

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.0.0
+version: 2.0.1
 appVersion: 0.5.14
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -14,10 +14,10 @@ spec:
       {{- end }}
       labels: {{ include "external-dns.labels" . | nindent 8 }}
         {{- if or (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey) .Values.cloudflare.apiKey .Values.digitalocean.apiToken (and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword) .Values.rfc2136.tsigSecret .Values.extraEnv .Values.google.serviceAccountKey }}
-        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum | trunc 63 }}
         {{- end }}
         {{- if and (eq .Values.provider "designate") .Values.designate.customCA.enabled }}
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 63 }}
         {{- end }}
     spec:
 {{- include "external-dns.imagePullSecrets" . | indent 6 }}
@@ -86,7 +86,7 @@ spec:
           {{- if .Values.crd.kind }}
         - --crd-source-kind={{ .Values.crd.kind }}
           {{- end }}
-        {{- end }}        
+        {{- end }}
         {{- range $key, $value := .Values.extraArgs }}
           {{- if $value }}
         - --{{ $key }}={{ $value }}
@@ -96,7 +96,7 @@ spec:
         {{- end }}
         {{- range .Values.istioIngressGateways }}
         - --istio-ingress-gateway={{ . }}
-        {{- end }}        
+        {{- end }}
         {{- range .Values.sources }}
         - --source={{ . }}
         {{- end }}
@@ -189,9 +189,11 @@ spec:
         {{- if eq .Values.provider "cloudflare" }}
         - name: CF_API_KEY
           valueFrom:
-            key: cloudflare_api_key
+            secretKeyRef:
+              name: {{ template "external-dns.fullname" . }}
+              key: cloudflare_api_key
         - name: CF_API_EMAIL
-            value: {{ .Values.cloudflare.email | quote }}
+          value: {{ .Values.cloudflare.email | quote }}
         {{- end }}
         # DigitalOcean environment variables
         {{- if eq .Values.provider "digitalocean" }}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

The `checksum` label based on the `sha256sum` calculation of the secret can exceed the 63 max characters limitations. This PR fixes that and it also address some issues with CloudFlare configuration

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
