### PR TITLE
[stable/external-dns] Removed duplicated Values.extraArgs in deployment template.

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.0.2
+version: 2.0.3
 appVersion: 0.5.15
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -87,13 +87,6 @@ spec:
         - --crd-source-kind={{ .Values.crd.kind }}
           {{- end }}
         {{- end }}
-        {{- range $key, $value := .Values.extraArgs }}
-          {{- if $value }}
-        - --{{ $key }}={{ $value }}
-          {{- else }}
-        - --{{ $key }}
-          {{- end }}
-        {{- end }}
         {{- range .Values.istioIngressGateways }}
         - --istio-ingress-gateway={{ . }}
         {{- end }}


### PR DESCRIPTION

Signed-off-by: Joe Hohertz <joe@viafoura.com>

@bitnami-bot (?)

Not sure who to individually mention here.

#### What this PR does / why we need it:

The chart was recently broken for anyone using the extraVars value to specify additional flags for external-dns.

#### Which issue this PR fixes

Removes the duplicate.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
