### PR TITLE
[stable/velero] Add value switch for volumesnapshot

### DIFF
--- a/stable/velero/Chart.yaml
+++ b/stable/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.0
 description: A Helm chart for velero
 name: velero
-version: 2.1.0
+version: 2.1.1
 home: https://github.com/heptio/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/stable/velero/README.md
+++ b/stable/velero/README.md
@@ -85,6 +85,7 @@ Parameter | Description | Default
 `credentials.existingSecret` | If specified and `useSecret` is `true`, uses an existing secret with this name instead of creating one | ``
 `credentials.useSecret` | Whether a secret should be used. Set this to `false` when using `kube2iam` | `true`
 `credentials.secretContents` | Contents for the credentials secret | `{}`
+`snapshotsEnabled` | If `true`, create volumesnapshotlocation crd. Set this to `false` to disable snapshot feature | `true`
 `deployRestic` | If `true`, enable restic deployment | `false`
 `metrics.enabled` | Set this to `true` to enable exporting Prometheus monitoring metrics | `false`
 `metrics.scrapeInterval` | Scrape interval for the Prometheus ServiceMonitor | `30s`

--- a/stable/velero/templates/volumesnapshotlocation.yaml
+++ b/stable/velero/templates/volumesnapshotlocation.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.snapshotsEnabled }}
 apiVersion: velero.io/v1
 kind: VolumeSnapshotLocation
 metadata:
@@ -28,6 +29,7 @@ spec:
   {{- with .project }}
     project: {{ . }}
   {{- end}}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/velero/values.yaml
+++ b/stable/velero/values.yaml
@@ -149,6 +149,9 @@ credentials:
   # of your IAM credentials file.
   secretContents: {}
 
+# Wheter to create volumesnapshotlocation crd, if false => disable snapshot feature
+snapshotsEnabled: true
+
 # Whether to deploy the restic daemonset.
 deployRestic: false
 


### PR DESCRIPTION
#### What this PR does / why we need it:
The velero installer includes an option `--use-volume-snapshots=false`
This will disable the volumesnapshotlocation CRD creation and so disable the volume snapshot feature.
The helm chart misses this switch, so every backup task that includes PVCs fails on non cloud provider installs.

#### Which issue this PR fixes
Add the same installation behavior for volumesnapshot feature enabling / disabling like on the cli installer already exists.
No backup failures for non cloud provider installs if volumesnapshotting is disabled.

#### Special notes for your reviewer:
This error will be fixed:
```
time="2019-07-04T14:39:19Z" level=error msg="Error getting volume snapshotter for volume snapshot location" backup=velero/cluster-backup error="unable to locate VolumeSnapshotter plugin named velero.io/" group=v1 logSource="pkg/backup/item_backupper.go:410" name=pv099 namespace= persistentVolume=pv099 resource=persistentvolumes volumeSnapshotLocation=default
time="2019-07-04T14:39:19Z" level=error msg="Error getting volume snapshotter for volume snapshot location" backup=velero/cluster-backup error="unable to locate VolumeSnapshotter plugin named velero.io/" group=v1 logSource="pkg/backup/item_backupper.go:410" name=pv100 namespace= persistentVolume=pv100 resource=persistentvolumes volumeSnapshotLocation=default
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ X] Chart Version bumped
- [ X] Variables are documented in the README.md
- [ X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
