### PR TITLE
[stable/telegraf] Allow ENV vars

### DIFF
--- a/stable/telegraf/Chart.yaml
+++ b/stable/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf
-version: 1.1.2
+version: 1.1.3
 appVersion: 1.10
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/stable/telegraf/templates/deployment.yaml
+++ b/stable/telegraf/templates/deployment.yaml
@@ -31,6 +31,7 @@ spec:
         env:
         - name: HOSTNAME
           value: "telegraf-polling-service"
+{{ toYaml .Values.env | indent 8 }}       
         volumeMounts:
         - name: config
           mountPath: /etc/telegraf

--- a/stable/telegraf/templates/deployment.yaml
+++ b/stable/telegraf/templates/deployment.yaml
@@ -29,8 +29,6 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         env:
-        - name: HOSTNAME
-          value: "telegraf-polling-service"
 {{ toYaml .Values.env | indent 8 }}       
         volumeMounts:
         - name: config

--- a/stable/telegraf/values.yaml
+++ b/stable/telegraf/values.yaml
@@ -11,6 +11,10 @@ image:
 
 podAnnotations: {}
 
+env:
+  - name: HOSTNAME
+    value: "telegraf-polling-service"
+
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 resources: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
   Allow ENV vars. Some telegraf plugins need ENV vars to work (like azure_monitor - https://github.com/influxdata/telegraf/tree/master/plugins/outputs/azure_monitor#authentication)

#### Which issue this PR fixes
 - fixes #15264

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
