### PR TITLE
[stable/sentry] Add note about Sentry ownership

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 1.5.6
+version: 1.5.7
 appVersion: 9.1.1
 keywords:
   - debugging

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -2,6 +2,8 @@
 
 [Sentry](https://sentry.io/) is a cross-platform crash reporting and aggregation platform.
 
+_This helm chart is **not** official nor maintained by Sentry itself._
+
 ## TL;DR;
 
 ```console


### PR DESCRIPTION
This PR adds a note to the readme stating that the chart is not maintained or backed by Sentry org itself.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
