### PR TITLE
stable/sealed-secrets: Add networkPolicy

### DIFF
--- a/stable/sealed-secrets/Chart.yaml
+++ b/stable/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.0.2
+version: 1.1.0
 appVersion: 0.7.0
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/stable/sealed-secrets/README.md
+++ b/stable/sealed-secrets/README.md
@@ -41,6 +41,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | **resources** | CPU/Memory resource requests/limits | `{}` |
 | **crd.create** | `true` if crd resources should be created | `true` |
 | **crd.keep** | `true` if the sealed secret CRD should be kept when the chart is deleted | `true` |
+|**networkPolicy** | Whether to create a network policy that allows access to the service | `false`|
 
 - In the case that **serviceAccount.create** is `false` and **rbac.create** is `true` it is expected for a service account with the name **serviceAccount.name** to exist _in the same namespace as this chart_ before installation.
 - If **serviceAccount.create** is `true` there cannot be an existing service account with the name **serviceAccount.name**.

--- a/stable/sealed-secrets/templates/networkpolicy.yaml
+++ b/stable/sealed-secrets/templates/networkpolicy.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.networkPolicy -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+  ingress:
+    - ports:
+      - port: 8080
+{{- end -}}

--- a/stable/sealed-secrets/values.yaml
+++ b/stable/sealed-secrets/values.yaml
@@ -26,3 +26,5 @@ crd:
   create: true
   # crd.keep: `true` if the sealed secret CRD should be kept when the chart is deleted
   keep: true
+
+networkPolicy: false


### PR DESCRIPTION
Signed-off-by: Sebastian Poehn <sebastian.poehn@gmail.com>

#### What this PR does / why we need it:
In some environments there might be a deny-all policy and service communication has to be allowed individually.

#### Which issue this PR fixes
Deploys a NetworkPolicy allowing incoming traffic for sealed-secrets

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
