### PR TITLE
[stable/atlantis] baseURL name consistency

### DIFF
--- a/stable/atlantis/templates/secret-webhook.yaml
+++ b/stable/atlantis/templates/secret-webhook.yaml
@@ -19,8 +19,8 @@ data:
   {{- end}}
   {{- if .Values.bitbucket }}
   bitbucket_token: {{ required "bitbucket.token is required if bitbucket configuration is specified." .Values.bitbucket.token | b64enc }}
-  {{- if .Values.bitbucket.baseUrl }}
-  bitbucket_secret: {{ required "bitbucket.secret is required if bitbucket.baseurl is specified." .Values.bitbucket.secret | b64enc }}
+  {{- if .Values.bitbucket.baseURL }}
+  bitbucket_secret: {{ required "bitbucket.secret is required if bitbucket.baseURL is specified." .Values.bitbucket.secret | b64enc }}
   {{- end}}
   {{- end }}
 {{- end }}

--- a/stable/atlantis/values.yaml
+++ b/stable/atlantis/values.yaml
@@ -34,7 +34,7 @@ orgWhitelist: <replace-me>
 #   token: bar
 # Bitbucket Server only:
 #   secret: baz
-#   base_url: https://bitbucket.yourorganization.com
+#   baseURL: https://bitbucket.yourorganization.com
 # (The chart will perform the base64 encoding for you for values that are stored in secrets.)
 
 # If managing secrets outside the chart for the webhook, use this variable to reference the secret name


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
When deploying for bitbucket server, the baseURL key is spelled differently in different places. If you supply baseUrl, the bitbucket token is generated, but if you supply baseURL, the webhook secret is generated. I changed them to both be baseURL.


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
