### PR TITLE
Finalizers

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 3.5.7
+version: 3.5.8
 appVersion: 6.2.4
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -64,6 +64,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `persistence.existingClaim`               | Use an existing PVC to persist data           | `nil`                                                   |
 | `persistence.storageClassName`            | Type of persistent volume claim               | `nil`                                                   |
 | `persistence.accessModes`                 | Persistence access modes                      | `[ReadWriteOnce]`                                       |
+| `persistence.annotations`                 | PersistentVolumeClaim annotations             | `{}`                                                    |
+| `persistence.finalizers`                  | PersistentVolumeClaim finalizers              | `[ "kubernetes.io/pvc-protection" ]`                    |
 | `persistence.subPath`                     | Mount a sub dir of the persistent volume      | `nil`                                                   |
 | `initChownData.enabled`                   | If false, don't reset data ownership at startup | true                                                  |
 | `initChownData.image.repository`          | init-chown-data container image repository    | `busybox`                                               |

--- a/stable/grafana/templates/pvc.yaml
+++ b/stable/grafana/templates/pvc.yaml
@@ -13,6 +13,10 @@ metadata:
   annotations:
 {{ toYaml . | indent 4 }}
   {{- end }}
+  {{- with .Values.persistence.finalizers  }}
+  finalizers:
+{{ toYaml . | indent 4 }}
+  {{- end }}
 spec:
   accessModes:
     {{- range .Values.persistence.accessModes }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -159,6 +159,8 @@ persistence:
     - ReadWriteOnce
   size: 10Gi
   # annotations: {}
+  finalizers:
+    - kubernetes.io/pvc-protection
   # subPath: ""
   # existingClaim:
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

@zanhsieh @rtluckie @maorfr 

#### What this PR does / why we need it:
This adds a `persistence.finalizers` section with a default finalizer of `io.kubernetes/pvc-protection`. This prevents helm from deleting the PersistentVolumeClaim when deleting a Grafana release that has `persistence.enabled` set to `true`. This avoids the issue of accidentally deleting all the users and logs along with the helm release. Instead you can reattach to the PersistentVolume with the `existingClaim` config -- or manually delete it by editing the `pvc` and removing the finalizer.

#### Which issue this PR fixes
  - fixes #15291

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
