### PR TITLE
[stable/memcached] Add security context to memcached chart

### DIFF
--- a/stable/memcached/Chart.yaml
+++ b/stable/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 2.8.3
+version: 2.8.4
 appVersion: 1.5.12
 description: Free & open source, high-performance, distributed memory object caching
   system.

--- a/stable/memcached/Chart.yaml
+++ b/stable/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 2.8.4
+version: 2.9.0
 appVersion: 1.5.12
 description: Free & open source, high-performance, distributed memory object caching
   system.

--- a/stable/memcached/README.md
+++ b/stable/memcached/README.md
@@ -59,9 +59,9 @@ The following table lists the configurable parameters of the Memcached chart and
 | `nodeSelector`             | Simple pod scheduling control | `{}`                                                      |
 | `tolerations`              | Allow or deny specific node taints | `{}`                                                 |
 | `affinity`                 | Advanced pod scheduling control | `{}`                                                    |
-| `securityContext.enabled`  | Enable security context (both redis master and slave pods) | `true`                       |
-| `securityContext.fsGroup`  | Group ID for the container | `11211`                                                      |
-| `securityContext.runAsUser`| User ID for the container  | `11211`                                                      |
+| `securityContext.enabled`  | Enable security context    | `true`                                                       |
+| `securityContext.fsGroup`  | Group ID for the container | `1001`                                                       |
+| `securityContext.runAsUser`| User ID for the container  | `1001`                                                       |
 
 The above parameters map to `memcached` params. For more information please refer to the [Memcached documentation](https://github.com/memcached/memcached/wiki/ConfiguringServer).
 

--- a/stable/memcached/README.md
+++ b/stable/memcached/README.md
@@ -40,25 +40,28 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Memcached chart and their default values.
 
-|      Parameter            |          Description            |                         Default                         |
-|---------------------------|---------------------------------|---------------------------------------------------------|
-| `image`                   | The image to pull and run       | A recent official memcached tag                         |
-| `imagePullPolicy`         | Image pull policy               | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
-| `memcached.verbosity`     | Verbosity level (v, vv, or vvv) | Un-set.                                                 |
-| `memcached.maxItemMemory` | Max memory for items (in MB)    | `64`                                                    |
-| `memcached.extraArgs`     | Additional memcached arguments  | `[]`                                                    |
-| `metrics.enabled`         | Expose metrics in prometheus format | false                                               |
-| `metrics.image`           | The image to pull and run for the metrics exporter | A recent official memcached tag      |
-| `metrics.imagePullPolicy` | Image pull policy               | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
-| `metrics.resources`       | CPU/Memory resource requests/limits for the metrics exporter | `{}`                       |
-| `extraContainers`         | Container sidecar definition(s) as string | Un-set                                        |
-| `extraVolumes`            | Volume definitions to add as string | Un-set                                              |
-| `kind`                    | Install as StatefulSet or Deployment | StatefulSet                                        |
-| `podAnnotations`          | Map of annotations to add to the pod(s) | `{}`                                            |
-| `podLabels`               | Custom Labels to be applied to statefulset | Un-set                                   |
-| `nodeSelector`            | Simple pod scheduling control | `{}`                                            |
-| `tolerations`             | Allow or deny specific node taints | `{}`                                            |
-| `affinity`                | Advanced pod scheduling control | `{}`                                            |
+|      Parameter             |          Description            |                         Default                         |
+|----------------------------|---------------------------------|---------------------------------------------------------|
+| `image`                    | The image to pull and run       | A recent official memcached tag                         |
+| `imagePullPolicy`          | Image pull policy               | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
+| `memcached.verbosity`      | Verbosity level (v, vv, or vvv) | Un-set.                                                 |
+| `memcached.maxItemMemory`  | Max memory for items (in MB)    | `64`                                                    |
+| `memcached.extraArgs`      | Additional memcached arguments  | `[]`                                                    |
+| `metrics.enabled`          | Expose metrics in prometheus format | false                                               |
+| `metrics.image`            | The image to pull and run for the metrics exporter | A recent official memcached tag      |
+| `metrics.imagePullPolicy`  | Image pull policy               | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
+| `metrics.resources`        | CPU/Memory resource requests/limits for the metrics exporter | `{}`                       |
+| `extraContainers`          | Container sidecar definition(s) as string | Un-set                                        |
+| `extraVolumes`             | Volume definitions to add as string | Un-set                                              |
+| `kind`                     | Install as StatefulSet or Deployment | StatefulSet                                        |
+| `podAnnotations`           | Map of annotations to add to the pod(s) | `{}`                                            |
+| `podLabels`                | Custom Labels to be applied to statefulset | Un-set                                       |
+| `nodeSelector`             | Simple pod scheduling control | `{}`                                                      |
+| `tolerations`              | Allow or deny specific node taints | `{}`                                                 |
+| `affinity`                 | Advanced pod scheduling control | `{}`                                                    |
+| `securityContext.enabled`  | Enable security context (both redis master and slave pods) | `true`                       |
+| `securityContext.fsGroup`  | Group ID for the container | `11211`                                                      |
+| `securityContext.runAsUser`| User ID for the container  | `11211`                                                      |
 
 The above parameters map to `memcached` params. For more information please refer to the [Memcached documentation](https://github.com/memcached/memcached/wiki/ConfiguringServer).
 

--- a/stable/memcached/templates/statefulset.yaml
+++ b/stable/memcached/templates/statefulset.yaml
@@ -86,7 +86,6 @@ spec:
           timeoutSeconds: 1
         resources:
 {{ toYaml .Values.resources | indent 10 }}
-
 {{- if .Values.metrics.enabled }}
       - name: metrics
         image: {{ .Values.metrics.image }}

--- a/stable/memcached/templates/statefulset.yaml
+++ b/stable/memcached/templates/statefulset.yaml
@@ -27,6 +27,10 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- end }}
       affinity:
         podAntiAffinity:
         {{- if eq .Values.AntiAffinity "hard" }}
@@ -50,6 +54,10 @@ spec:
       - name: {{ template "memcached.fullname" . }}
         image: {{ .Values.image }}
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        {{- if .Values.securityContext.enabled }}
+        securityContext:
+          runAsUser: {{ .Values.securityContext.runAsUser }}
+        {{- end }}
         command:
         - memcached
         - -m {{ .Values.memcached.maxItemMemory }}
@@ -78,10 +86,15 @@ spec:
           timeoutSeconds: 1
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+
 {{- if .Values.metrics.enabled }}
       - name: metrics
         image: {{ .Values.metrics.image }}
         imagePullPolicy: {{ default "" .Values.metrics.imagePullPolicy | quote }}
+        {{- if .Values.securityContext.enabled }}
+        securityContext:
+          runAsUser: {{ .Values.securityContext.runAsUser }}
+        {{- end }}
         ports:
         - name: metrics
           containerPort: 9150

--- a/stable/memcached/values.yaml
+++ b/stable/memcached/values.yaml
@@ -61,6 +61,13 @@ tolerations: {}
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 affinity: {}
 
+## Memcached pod Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+securityContext:
+  enabled: true
+  fsGroup: 11211
+  runAsUser: 11211
+
 metrics:
   ## Expose memcached metrics in Prometheus format
   enabled: false

--- a/stable/memcached/values.yaml
+++ b/stable/memcached/values.yaml
@@ -65,8 +65,8 @@ affinity: {}
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 securityContext:
   enabled: true
-  fsGroup: 11211
-  runAsUser: 11211
+  fsGroup: 1001
+  runAsUser: 1001
 
 metrics:
   ## Expose memcached metrics in Prometheus format


### PR DESCRIPTION
## What this PR does / why we need it:

This PR adds the securityContext option to be able to run this container as non-root. 
Right now if you have a PSP in your namespace with 

```
  runAsUser:
    rule: MustRunAsNonRoot
```

memcached will fail to start with `Error: container has runAsNonRoot and image has non-numeric user (memcache), cannot verify user is non-root`

#### Special notes for your reviewer:
This is my first PR to this repo so feel free to ping me if something is missing!
I'm not sure about the `version` for example, should I bump patch or minor?

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
