### PR TITLE
Adding PodDisruptionBudget for Prometheus (server, alertmanager, pushgateway) deployment or statefulset

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 8.14.0
+version: 8.14.1
 appVersion: 2.11.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 8.14.0
+version: 8.14.2
 appVersion: 2.11.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -139,6 +139,9 @@ Parameter | Description | Default
 `alertmanager.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 `alertmanager.service.servicePort` | alertmanager service port | `80`
 `alertmanager.service.type` | type of alertmanager service to create | `ClusterIP`
+`alertmanager.poddisruptionbudget.enabled` | If true, Prometheus server PodDisrubtionBudget will be created | `false`
+`alertmanager.poddisruptionbudget.maxUnavailable` | which is a description of the number of pods from that set that can be unavailable after the eviction. It can be either an absolute number or a percentage | `1`
+`alertmanager.poddisruptionbudget.minAvailbale` | which is a description of the number of pods from that set that must still be available after the eviction, even in the absence of the evicted pod. It can be either an absolute number or a percentage | `1`
 `alertmanagerFiles.alertmanager.yml` | Prometheus alertmanager configuration | example configuration
 `configmapReload.name` | configmap-reload container name | `configmap-reload`
 `configmapReload.image.repository` | configmap-reload container image repository | `jimmidyson/configmap-reload`
@@ -234,6 +237,9 @@ Parameter | Description | Default
 `pushgateway.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 `pushgateway.service.servicePort` | pushgateway service port | `9091`
 `pushgateway.service.type` | type of pushgateway service to create | `ClusterIP`
+`pushgateway.poddisruptionbudget.enabled` | If true, Prometheus server PodDisrubtionBudget will be created | `false`
+`pushgateway.poddisruptionbudget.maxUnavailable` | which is a description of the number of pods from that set that can be unavailable after the eviction. It can be either an absolute number or a percentage | `1`
+`pushgateway.poddisruptionbudget.minAvailbale` | which is a description of the number of pods from that set that must still be available after the eviction, even in the absence of the evicted pod. It can be either an absolute number or a percentage | `1`
 `rbac.create` | If true, create & use RBAC resources | `true`
 `server.name` | Prometheus server container name | `server`
 `server.image.repository` | Prometheus server container image repository | `prom/prometheus`
@@ -294,6 +300,9 @@ Parameter | Description | Default
 `server.service.servicePort` | Prometheus server service port | `80`
 `server.service.type` | type of Prometheus server service to create | `ClusterIP`
 `server.sidecarContainers` | array of snippets with your sidecar containers for prometheus server | `""`
+`server.poddisruptionbudget.enabled` | If true, Prometheus server PodDisrubtionBudget will be created | `false`
+`server.poddisruptionbudget.maxUnavailable` | which is a description of the number of pods from that set that can be unavailable after the eviction. It can be either an absolute number or a percentage | `1`
+`server.poddisruptionbudget.minAvailbale` | which is a description of the number of pods from that set that must still be available after the eviction, even in the absence of the evicted pod. It can be either an absolute number or a percentage | `1`
 `serviceAccounts.alertmanager.create` | If true, create the alertmanager service account | `true`
 `serviceAccounts.alertmanager.name` | name of the alertmanager service account to use or create | `{{ prometheus.alertmanager.fullname }}`
 `serviceAccounts.kubeStateMetrics.create` | If true, create the kubeStateMetrics service account | `true`

--- a/stable/prometheus/templates/alertmanager-poddisruptionbudget.yaml
+++ b/stable/prometheus/templates/alertmanager-poddisruptionbudget.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.alertmanager.enabled .Values.alertmanager.poddisruptionbudget.enabled -}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -5,10 +6,9 @@ metadata:
   labels:
     {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
 spec:
-{{- if .Values.alertmanager.maxUnavailable  -}}
+{{- if .Values.alertmanager.poddisruptionbudget.maxUnavailable  }}
   maxUnavailable: {{ .Values.alertmanager.poddisruptionbudget.maxUnavailable }}
-{{- end -}}
-{{- else if .Values.alertmanager.minAvailable -}}
+{{- else if .Values.alertmanager.poddisruptionbudget.minAvailable -}}
   minAvailable: {{ .Values.alertmanager.poddisruptionbudget.minAvailable }}
 {{- else -}}
   maxUnavailable: {{ .Values.alertmanager.poddisruptionbudget.maxUnavailable | default 1 }}
@@ -16,3 +16,5 @@ spec:
   selector:
     matchLabels:
       {{- include "prometheus.alertmanager.matchLabels" . | nindent 4 }}
+
+{{- end -}}

--- a/stable/prometheus/templates/alertmanager-poddisruptionbudget.yaml
+++ b/stable/prometheus/templates/alertmanager-poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "prometheus.alertmanager.fullname" . }}
+  labels:
+    {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
+spec:
+{{- if .Values.alertmanager.maxUnavailable  -}}
+  maxUnavailable: {{ .Values.alertmanager.poddisruptionbudget.maxUnavailable }}
+{{- end -}}
+{{- else if .Values.alertmanager.minAvailable -}}
+  minAvailable: {{ .Values.alertmanager.poddisruptionbudget.minAvailable }}
+{{- else -}}
+  maxUnavailable: {{ .Values.alertmanager.poddisruptionbudget.maxUnavailable | default 1 }}
+{{- end -}}
+  selector:
+    matchLabels:
+      {{- include "prometheus.alertmanager.matchLabels" . | nindent 4 }}

--- a/stable/prometheus/templates/pushgateway-poddisruptionbudget.yaml
+++ b/stable/prometheus/templates/pushgateway-poddisruptionbudget.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.pushgateway.enabled .Values.pushgateway.poddisruptionbudget.enabled -}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -5,10 +6,9 @@ metadata:
   labels:
     {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
 spec:
-{{- if .Values.pushgateway.maxUnavailable  -}}
+{{ if .Values.pushgateway.poddisruptionbudget.maxUnavailable  }}
   maxUnavailable: {{ .Values.pushgateway.poddisruptionbudget.maxUnavailable }}
-{{- end -}}
-{{- else if .Values.pushgateway.minAvailable -}}
+{{- else if .Values.pushgateway.poddisruptionbudget.minAvailable }}
   minAvailable: {{ .Values.pushgateway.poddisruptionbudget.minAvailable }}
 {{- else -}}
   maxUnavailable: {{ .Values.pushgateway.poddisruptionbudget.maxUnavailable | default 1 }}
@@ -16,3 +16,4 @@ spec:
   selector:
     matchLabels:
       {{- include "prometheus.pushgateway.matchLabels" . | nindent 4 }}
+{{- end -}}

--- a/stable/prometheus/templates/pushgateway-poddisruptionbudget.yaml
+++ b/stable/prometheus/templates/pushgateway-poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "prometheus.pushgateway.fullname" . }}
+  labels:
+    {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
+spec:
+{{- if .Values.pushgateway.maxUnavailable  -}}
+  maxUnavailable: {{ .Values.pushgateway.poddisruptionbudget.maxUnavailable }}
+{{- end -}}
+{{- else if .Values.pushgateway.minAvailable -}}
+  minAvailable: {{ .Values.pushgateway.poddisruptionbudget.minAvailable }}
+{{- else -}}
+  maxUnavailable: {{ .Values.pushgateway.poddisruptionbudget.maxUnavailable | default 1 }}
+{{- end -}}
+  selector:
+    matchLabels:
+      {{- include "prometheus.pushgateway.matchLabels" . | nindent 4 }}

--- a/stable/prometheus/templates/server-poddisruptionbudget.yaml
+++ b/stable/prometheus/templates/server-poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "prometheus.server.fullname" . }}
+  labels:
+    {{- include "prometheus.server.labels" . | nindent 4 }}
+spec:
+{{- if .Values.server.maxUnavailable  -}}
+  maxUnavailable: {{ .Values.server.poddisruptionbudget.maxUnavailable }}
+{{- end -}}
+{{- else if .Values.server.minAvailable -}}
+  minAvailable: {{ .Values.server.poddisruptionbudget.minAvailable }}
+{{- else -}}
+  maxUnavailable: {{ .Values.server.poddisruptionbudget.maxUnavailable | default 1 }}
+{{- end -}}
+  selector:
+    matchLabels:
+      {{- include "prometheus.server.matchLabels" . | nindent 4 }}

--- a/stable/prometheus/templates/server-poddisruptionbudget.yaml
+++ b/stable/prometheus/templates/server-poddisruptionbudget.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.server.enabled .Values.server.poddisruptionbudget.enabled -}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -5,10 +6,9 @@ metadata:
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
 spec:
-{{- if .Values.server.maxUnavailable  -}}
+{{- if .Values.server.poddisruptionbudget.maxUnavailable  }}
   maxUnavailable: {{ .Values.server.poddisruptionbudget.maxUnavailable }}
-{{- end -}}
-{{- else if .Values.server.minAvailable -}}
+{{- else if .Values.server.poddisruptionbudget.minAvailable -}}
   minAvailable: {{ .Values.server.poddisruptionbudget.minAvailable }}
 {{- else -}}
   maxUnavailable: {{ .Values.server.poddisruptionbudget.maxUnavailable | default 1 }}
@@ -16,3 +16,4 @@ spec:
   selector:
     matchLabels:
       {{- include "prometheus.server.matchLabels" . | nindent 4 }}
+{{- end -}}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -250,6 +250,18 @@ alertmanager:
     servicePort: 80
     # nodePort: 30000
     type: ClusterIP
+  
+  ## alertmanager Pod Disruption Budget
+  ## The pod Disruption Budget if enabled, the spec maxUnavailable will be 1 by default.
+  poddisruptionbudget:
+    ## If false, the pod disrubtion will not be installed. 
+    enabled: true
+    ## which is a description of the number of pods from that set that can be unavailable after the eviction.
+    ## It can be either an absolute number or a percentage.
+    maxUnavailable: 1
+    ## which is a description of the number of pods from that set that must still be available after the eviction, even in the absence of the evicted pod.
+    ## It can be either an absolute number or a percentage.
+    minAvailbale:
 
 ## Monitors ConfigMap changes and POSTs to a URL
 ## Ref: https://github.com/jimmidyson/configmap-reload
@@ -791,6 +803,11 @@ server:
   ##
   retention: "15d"
 
+  poddisruptionbudget:
+    enabled: true
+    maxUnavailable: 1
+    minAvailbale:
+
 pushgateway:
   ## If false, pushgateway will not be installed
   ##
@@ -942,7 +959,17 @@ pushgateway:
     ##
     subPath: ""
 
-
+  ## Pushgateway Pod Disruption Budget
+  ## The Pod Disruption Budget if enabled, the spec maxUnavailable will be 1 by default.
+  poddisruptionbudget:
+    ## If false, the pod disrubtion will not be installed. 
+    enabled: true
+    ## which is a description of the number of pods from that set that can be unavailable after the eviction.
+    ## It can be either an absolute number or a percentage.
+    maxUnavailable: 1
+    ## which is a description of the number of pods from that set that must still be available after the eviction, even in the absence of the evicted pod.
+    ## It can be either an absolute number or a percentage.
+    minAvailbale:
 ## alertmanager ConfigMap entries
 ##
 alertmanagerFiles:

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -255,7 +255,7 @@ alertmanager:
   ## The pod Disruption Budget if enabled, the spec maxUnavailable will be 1 by default.
   poddisruptionbudget:
     ## If false, the pod disrubtion will not be installed. 
-    enabled: true
+    enabled: false
     ## which is a description of the number of pods from that set that can be unavailable after the eviction.
     ## It can be either an absolute number or a percentage.
     maxUnavailable: 1
@@ -802,10 +802,16 @@ server:
   ## Prometheus data retention period (default if not specified is 15 days)
   ##
   retention: "15d"
-
+  ## Pushgateway Pod Disruption Budget
+  ## The Pod Disruption Budget if enabled, the spec maxUnavailable will be 1 by default.
   poddisruptionbudget:
-    enabled: true
+    ## If false, the pod disrubtion will not be installed. 
+    enabled: false
+    ## which is a description of the number of pods from that set that can be unavailable after the eviction.
+    ## It can be either an absolute number or a percentage.
     maxUnavailable: 1
+    ## which is a description of the number of pods from that set that must still be available after the eviction, even in the absence of the evicted pod.
+    ## It can be either an absolute number or a percentage.
     minAvailbale:
 
 pushgateway:
@@ -963,7 +969,7 @@ pushgateway:
   ## The Pod Disruption Budget if enabled, the spec maxUnavailable will be 1 by default.
   poddisruptionbudget:
     ## If false, the pod disrubtion will not be installed. 
-    enabled: true
+    enabled: false
     ## which is a description of the number of pods from that set that can be unavailable after the eviction.
     ## It can be either an absolute number or a percentage.
     maxUnavailable: 1

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -250,11 +250,10 @@ alertmanager:
     servicePort: 80
     # nodePort: 30000
     type: ClusterIP
-  
   ## alertmanager Pod Disruption Budget
   ## The pod Disruption Budget if enabled, the spec maxUnavailable will be 1 by default.
   poddisruptionbudget:
-    ## If false, the pod disrubtion will not be installed. 
+    ## If false, the pod disrubtion will not be installed.
     enabled: false
     ## which is a description of the number of pods from that set that can be unavailable after the eviction.
     ## It can be either an absolute number or a percentage.
@@ -432,7 +431,7 @@ nodeExporter:
   ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
   ##
   podSecurityPolicy:
-    enabled: False
+    enabled: false
     annotations: {}
       ## Specify pod annotations
       ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
@@ -805,14 +804,14 @@ server:
   ## Pushgateway Pod Disruption Budget
   ## The Pod Disruption Budget if enabled, the spec maxUnavailable will be 1 by default.
   poddisruptionbudget:
-    ## If false, the pod disrubtion will not be installed. 
+    ## If false, the pod disrubtion will not be installed.
     enabled: false
     ## which is a description of the number of pods from that set that can be unavailable after the eviction.
     ## It can be either an absolute number or a percentage.
     maxUnavailable: 1
     ## which is a description of the number of pods from that set that must still be available after the eviction, even in the absence of the evicted pod.
     ## It can be either an absolute number or a percentage.
-    minAvailbale:
+    minAvailbale: 0
 
 pushgateway:
   ## If false, pushgateway will not be installed
@@ -968,7 +967,7 @@ pushgateway:
   ## Pushgateway Pod Disruption Budget
   ## The Pod Disruption Budget if enabled, the spec maxUnavailable will be 1 by default.
   poddisruptionbudget:
-    ## If false, the pod disrubtion will not be installed. 
+    ## If false, the pod disrubtion will not be installed.
     enabled: false
     ## which is a description of the number of pods from that set that can be unavailable after the eviction.
     ## It can be either an absolute number or a percentage.


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
