### PR TITLE
[stable/mongodb] loadBalancerSourceRanges can be specified for mongodb Helm chart

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 6.0.0
+version: 6.1.0
 appVersion: 4.0.10
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/README.md
+++ b/stable/mongodb/README.md
@@ -73,6 +73,7 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `service.nodePort`                                 | Port to bind to for NodePort service type                                                    | `nil`                                                   |
 | `service.loadBalancerIP`                           | Static IP Address to use for LoadBalancer service type                                       | `nil`                                                   |
 | `service.externalIPs`                              | External IP list to use with ClusterIP service type                                          | `[]`                                                    |
+| `service.loadBalancerSourceRanges`                 | List of IP ranges allowed access to load balancer (if supported)                             | `[]` (does not add IP range restrictions to the service)|
 | `port`                                             | MongoDB service port                                                                         | `27017`                                                 |
 | `replicaSet.enabled`                               | Switch to enable/disable replica set configuration                                           | `false`                                                 |
 | `replicaSet.name`                                  | Name of the replica set                                                                      | `rs0`                                                   |

--- a/stable/mongodb/templates/svc-primary-rs.yaml
+++ b/stable/mongodb/templates/svc-primary-rs.yaml
@@ -22,6 +22,10 @@ spec:
   {{- if .Values.service.externalIPs }}
   externalIPs: {{ toYaml .Values.service.externalIPs | nindent 4 }}
   {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
   ports:
   - name: mongodb
     port: 27017

--- a/stable/mongodb/templates/svc-primary-rs.yaml
+++ b/stable/mongodb/templates/svc-primary-rs.yaml
@@ -23,8 +23,7 @@ spec:
   externalIPs: {{ toYaml .Values.service.externalIPs | nindent 4 }}
   {{- end }}
   {{- if .Values.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges:
-    {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
+  loadBalancerSourceRanges: {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
   ports:
   - name: mongodb

--- a/stable/mongodb/templates/svc-standalone.yaml
+++ b/stable/mongodb/templates/svc-standalone.yaml
@@ -22,6 +22,10 @@ spec:
   {{- if .Values.service.externalIPs }}
   externalIPs: {{ toYaml .Values.service.externalIPs | nindent 4 }}
   {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
   ports:
   - name: mongodb
     port: 27017

--- a/stable/mongodb/templates/svc-standalone.yaml
+++ b/stable/mongodb/templates/svc-standalone.yaml
@@ -23,8 +23,7 @@ spec:
   externalIPs: {{ toYaml .Values.service.externalIPs | nindent 4 }}
   {{- end }}
   {{- if .Values.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges:
-    {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
+  loadBalancerSourceRanges: {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
   ports:
   - name: mongodb

--- a/stable/mongodb/values-production.yaml
+++ b/stable/mongodb/values-production.yaml
@@ -108,6 +108,11 @@ service:
   ##
   # loadBalancerIP:
 
+  ## Specify the loadBalancerSourceRanges value for LoadBalancer service types.
+  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ##
+  # loadBalancerSourceRanges: []
+
 ## Setting up replication
 ## ref: https://github.com/bitnami/bitnami-docker-mongodb#setting-up-a-replication
 #

--- a/stable/mongodb/values.yaml
+++ b/stable/mongodb/values.yaml
@@ -108,6 +108,11 @@ service:
   ##
   # loadBalancerIP:
 
+  ## Specify the loadBalancerSourceRanges value for LoadBalancer service types.
+  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ##
+  # loadBalancerSourceRanges: []
+
 ## Setting up replication
 ## ref: https://github.com/bitnami/bitnami-docker-mongodb#setting-up-a-replication
 #


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows `loadBalancerSourceRanges` to be specified on the mongodb Service. This is required by anyone who wants to restrict the IP ranges which can access a deployed mongodb instance.

@tompizmor 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
