### PR TITLE
[stable/katafygio] Added volume definition to inherent persistence configuration

### DIFF
--- a/stable/katafygio/Chart.yaml
+++ b/stable/katafygio/Chart.yaml
@@ -5,7 +5,7 @@ name: katafygio
 home: https://github.com/bpineau/katafygio
 sources:
 - https://github.com/bpineau/katafygio
-version: 1.0.0
+version: 1.1.0
 keywords:
 - backup
 - dump

--- a/stable/katafygio/templates/deployment.yaml
+++ b/stable/katafygio/templates/deployment.yaml
@@ -55,6 +55,9 @@ spec:
             - --exclude-object={{ . }}
             {{- end }}
           {{- end }}
+          volumeMounts:
+            - name: {{ template "katafygio.fullname" . }}
+              mountPath: {{ .Values.localDir }}
           ports:
             - name: http
               containerPort: {{ .Values.healthcheckPort }}
@@ -67,7 +70,15 @@ spec:
             httpGet:
               path: /health
               port: http
-          resources:
+      volumes:
+        - name: {{ template "katafygio.fullname" . }}
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "katafygio.fullname" .) }}
+          {{- else }}
+            emptyDir: {}
+          {{- end }}
+      resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -81,11 +92,4 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    volumes:
-      - name: katafygio-data
-      {{- if .Values.persistence.enabled }}
-        persistentVolumeClaim:
-          claimName: {{ .Values.persistence.existingClaim | default (include "katafygio.fullname" .) }}
-      {{- else }}
-        emptyDir: {}
-      {{- end -}}
+


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR fixes the PVC `[stable/katafygio]` issue when setting persistence storage.

#### Which issue this PR fixes
  - fixes #68

#### Special notes for your reviewer:
I tested with an `emptyDir`, `existingClaim` and dynamic storage and worked in all cases.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
