### PR TITLE
[stable/external-dns] Allow provider.google without mounting secrets

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.1.1
+version: 2.1.2
 appVersion: 0.5.15
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -196,8 +196,10 @@ spec:
         {{- end }}
         # Google environment variables
         {{- if eq .Values.provider "google" }}
+        {{- if or .Values.google.serviceAccountSecret .Values.google.serviceAccountKey }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/secrets/service-account/credentials.json
+        {{- end }}
         {{- end }}
         # Infloblox environment variables
         {{- if eq .Values.provider "infoblox" }}
@@ -277,8 +279,10 @@ spec:
         {{- end }}
         # Google mountPath(s)
         {{- if eq .Values.provider "google" }}
+        {{- if or .Values.google.serviceAccountSecret .Values.google.serviceAccountKey }}
         - name: google-service-account
           mountPath: /etc/secrets/service-account/
+        {{- end }}
         {{- end }}
         # Designate mountPath(s)
         {{- if and (eq .Values.provider "designate") .Values.designate.customCA.enabled }}
@@ -307,13 +311,15 @@ spec:
       {{- end }}
       # Google volume(s)
       {{- if eq .Values.provider "google" }}
+      {{- if .Values.google.serviceAccountSecret }}
       - name: google-service-account
         secret:
-      {{- if .Values.google.serviceAccountSecret }}
           secretName: {{ .Values.google.serviceAccountSecret | quote }}
-      {{- else }}
+      {{- else if .Values.google.serviceAccountKey }}
+      - name: google-service-account
+        secret:
           secretName: {{ template "external-dns.fullname" . }}
-      {{- end }}
+      {{- end}}
       {{- end }}
       # Designate volume(s)
       {{- if and (eq .Values.provider "designate") .Values.designate.customCA.enabled }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

When deloyed in GCP/GKE it is not necessary to provide google auth credentials as secrets to
external-dns.

This is a followup to https://github.com/helm/charts/pull/15299 which removed the validation, but left the secret volumes and mounts.

#### Which issue this PR fixes

  - fixes #15298

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/chart]`)
