### PR TITLE
[stable/kubernetes-dashboard]: Add securityContext to deployment

### DIFF
--- a/stable/kubernetes-dashboard/Chart.yaml
+++ b/stable/kubernetes-dashboard/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubernetes-dashboard
-version: 1.6.0
+version: 1.7.0
 appVersion: 1.10.1
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/stable/kubernetes-dashboard/README.md
+++ b/stable/kubernetes-dashboard/README.md
@@ -78,6 +78,7 @@ The following table lists the configurable parameters of the kubernetes-dashboar
 | `podDisruptionBudget.enabled`       | Create a PodDisruptionBudget                                                                                                | `false`                                                                    |
 | `podDisruptionBudget.minAvailable`  | Minimum available instances; ignored if there is no PodDisruptionBudget                                                     |                                                                            |
 | `podDisruptionBudget.maxUnavailable`| Maximum unavailable instances; ignored if there is no PodDisruptionBudget                                                   |                                                                            |
+| `securityContext`                   | Security context                                                                                                            | `{}`                                                                       |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/kubernetes-dashboard/templates/deployment.yaml
+++ b/stable/kubernetes-dashboard/templates/deployment.yaml
@@ -31,6 +31,10 @@ spec:
         app: {{ template "kubernetes-dashboard.name" . }}
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.securityContext }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "kubernetes-dashboard.serviceAccountName" . }}
       containers:
       - name: {{ .Chart.Name }}

--- a/stable/kubernetes-dashboard/values.yaml
+++ b/stable/kubernetes-dashboard/values.yaml
@@ -173,3 +173,5 @@ podDisruptionBudget:
   enabled: false
   minAvailable:
   maxUnavailable:
+
+securityContext: {}


### PR DESCRIPTION
Signed-off-by: Sebastian Poehn <sebastian.poehn@gmail.com>

#### What this PR does / why we need it:
Adds `securityContext` to deployment so it can run in environments where running as root is not allowed.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
