### PR TITLE
[stable/rabbitmq-ha] Ensure ingress annotations defaults to empty map

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.15
-version: 1.29.0
+version: 1.29.1
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -426,7 +426,7 @@ ingress:
   tlsSecret: myTlsSecret
 
   ## Ingress annotations done as key:value pairs
-  annotations:
+  annotations: {}
   #  kubernetes.io/ingress.class: nginx
 
 livenessProbe:


### PR DESCRIPTION
#### What this PR does / why we need it:
This very simple PR fixes a small bug where if you use a deployment system called `Keel` it avoids spewing log lines like this every minute: 
```2019/07/09 08:39:30 Warning: Merging destination map for chart 'rabbitmq-ha'. The destination item 'annotations' is a table and ignoring the source 'annotations' as it has a non-table value of: <nil>```

#### Special notes for your reviewer:
I realise this is not necessarily required, but I don't think it hurts to have this value default to an empty map (there maybe other deployment systems which are fussy about default values being valid)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
