### PR TITLE
[incubator/cassandra-reaper] Fix ingress template failing on no labels

### DIFF
--- a/incubator/cassandra-reaper/Chart.yaml
+++ b/incubator/cassandra-reaper/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.3.0
+appVersion: 1.3.1
 description: Reaper is a centralized, stateful, and highly configurable tool for running Apache Cassandra repairs against single or multi-site clusters.
 name: cassandra-reaper
 home: http://cassandra-reaper.io/

--- a/incubator/cassandra-reaper/Chart.yaml
+++ b/incubator/cassandra-reaper/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
-appVersion: 1.3.1
+appVersion: 1.3.0
 description: Reaper is a centralized, stateful, and highly configurable tool for running Apache Cassandra repairs against single or multi-site clusters.
 name: cassandra-reaper
 home: http://cassandra-reaper.io/
 keywords:
   - cassandra
-version: 0.2.0
+version: 0.2.1
 maintainers:
   - name: kamsz
     email: kamil@szczygiel.io

--- a/incubator/cassandra-reaper/templates/ingress.yaml
+++ b/incubator/cassandra-reaper/templates/ingress.yaml
@@ -10,7 +10,9 @@ metadata:
     helm.sh/chart: {{ include "cassandra-reaper.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{ toYaml .Values.ingress.labels | indent 4 }}
+{{- with .Values.ingress.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}


### PR DESCRIPTION
#### What this PR does / why we need it:
The ingress template file fails if `.Values.ingress.labels` is left empty (default) due to a template syntax misuse. This PR fixes that.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
