### PR TITLE
Mysql exporter managing labels

### DIFF
--- a/stable/prometheus-mysql-exporter/Chart.yaml
+++ b/stable/prometheus-mysql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 0.5.0
+version: 0.5.1
 home: https://github.com/prometheus/mysqld_exporter
 appVersion: v0.11.0
 sources:

--- a/stable/prometheus-mysql-exporter/README.md
+++ b/stable/prometheus-mysql-exporter/README.md
@@ -64,6 +64,9 @@ The following table lists the configurable parameters of the mysql exporter char
 | `cloudsqlproxy.instanceConnectionName` | Google Cloud instance connection name               | `project:us-central1:dbname`       |
 | `cloudsqlproxy.port`                   | Cloud SQL Proxy listening port                      | `3306`                             |
 | `cloudsqlproxy.credentials`            | Cloud SQL Proxy service account credentials         | `bogus credential file`            |
+| `serviceMonitor.enable`                | Integration with prometheus-operator                | `false`                            |
+| `serviceMonitor.interval`              | Interval for polling this exporter                  |                                    |
+| `serviceMonitor.scrapeTimeout`         | Timeout where exporter is considered faulty         |                                    |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-mysql-exporter/README.md
+++ b/stable/prometheus-mysql-exporter/README.md
@@ -67,6 +67,9 @@ The following table lists the configurable parameters of the mysql exporter char
 | `serviceMonitor.enable`                | Integration with prometheus-operator                | `false`                            |
 | `serviceMonitor.interval`              | Interval for polling this exporter                  |                                    |
 | `serviceMonitor.scrapeTimeout`         | Timeout where exporter is considered faulty         |                                    |
+| `serviceMonitor.jobLabel`              | Label to use to retrieve the job name from          | `""`                               |
+| `serviceMonitor.targetLabels`          | Labels to transfer from service onto the target     | `[]`                               |
+| `serviceMonitor.podTargetLabels`       | Labels to transfor from pod onto the target         | `[]`                               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-mysql-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-mysql-exporter/templates/servicemonitor.yaml
@@ -16,6 +16,17 @@ spec:
     matchLabels:
       app: {{ template "prometheus-mysql-exporter.name" . }}
       release: {{ .Release.Name }}
+  {{- with .Values.serviceMonitor.jobLabel }}
+  jobLabel: {{ . | quote}}
+  {{- end }}
+  {{- with .Values.serviceMonitor.targetLabels }}
+  targetLabels:
+{{ toYaml . | trim | indent 4 -}}
+  {{- end }}
+  {{- with .Values.serviceMonitor.podTargetLabels }}
+  podTargetLabels:
+{{ toYaml . | trim | indent 4 -}}
+  {{- end }}
   endpoints:
     - path: /metrics
       port: {{ .Values.service.name }}

--- a/stable/prometheus-mysql-exporter/values.yaml
+++ b/stable/prometheus-mysql-exporter/values.yaml
@@ -24,6 +24,9 @@ serviceMonitor:
   # scrapeTimeout: 10s
   # additionalLabels is the set of additional labels to add to the ServiceMonitor
   additionalLabels: {}
+  jobLabel: ""
+  targetLabels: []
+  podTargetLabels: []
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
#### What this PR does / why we need it:
Help managing label for serviceMonitor in stable/prometheus-mysql-exporter

#### Special notes for your reviewer:
Add some missing docs about newly introduced servicemonitor

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
