### PR TITLE
[stable/cerebro] cerebro: iterate over .Values.env to set specific auth settings

### DIFF
--- a/stable/cerebro/Chart.yaml
+++ b/stable/cerebro/Chart.yaml
@@ -1,5 +1,5 @@
 name: cerebro
-version: 1.1.2
+version: 1.1.3
 appVersion: 0.8.3
 apiVersion: v1
 description: A Helm chart for Cerebro - a web admin tool that replaces Kopf.

--- a/stable/cerebro/README.md
+++ b/stable/cerebro/README.md
@@ -62,6 +62,7 @@ The following table lists the configurable parameters of the cerebro chart and t
 | `nodeSelector`                      | Settings for nodeselector           | `{}`                                      |
 | `tolerations`                       | Settings for toleration             | `{}`                                      |
 | `affinity`                          | Settings for affinity               | `{}`                                      |
+| `env`                               | Map of env vars (key/value   )      | `{}`                                      |
 | `envFromSecretRef`                  | Reference to Secret with env vars   |                                           |
 | `config.basePath`                   | Application base path               | `/`                                       |
 | `config.restHistorySize`            | Rest request history size per user  | `50`                                      |

--- a/stable/cerebro/templates/deployment.yaml
+++ b/stable/cerebro/templates/deployment.yaml
@@ -54,6 +54,13 @@ spec:
               mountPath: /var/db/cerebro
             - name: config
               mountPath: /etc/cerebro
+          {{- if .Values.env }}
+          env:
+          {{- range $index, $element := .Values.env }}
+          - name: {{ $index | quote }}
+            value: {{ $element | quote }}
+          {{- end }}
+          {{- end }}
           {{- if .Values.envFromSecretRef }}
           envFrom:
             - secretRef:

--- a/stable/cerebro/values.yaml
+++ b/stable/cerebro/values.yaml
@@ -1,5 +1,8 @@
 replicaCount: 1
 revisionHistoryLimit: 3
+env:
+  # AUTH_TYPE: "basic"
+  # BASIC_AUTH_USER: "admin"
 
 image:
   repository: lmenezes/cerebro


### PR DESCRIPTION
Currently, some auth settings from application.conf should be overwritter through env variables.
We can only set specific values from secret right now.

This PR allows to set some settings through env variables, and not only from secrets.