### PR TITLE
[stable/external-dns]Fix typo in values-production

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.2.0
+version: 2.2.1
 appVersion: 0.5.15
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/values-production.yaml
+++ b/stable/external-dns/values-production.yaml
@@ -285,7 +285,7 @@ rbac:
 ## Kubernetes Security Context
 ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 ##
-securityContext: {}
+securityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
   capabilities:


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>
#### What this PR does / why we need it:
Fix a typo in the values-production:
```
$ helm template . -f values-production.yaml --name foobar
Error: failed to parse values-production.yaml: error converting YAML to JSON: yaml: line 288: did not find expected key
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
