### PR TITLE
[incubator/mysqlha] Add the way that how to test the master and slave work well

### DIFF
--- a/incubator/mysqlha/Chart.yaml
+++ b/incubator/mysqlha/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mysqlha
-version: 0.7.1
+version: 0.8.0
 appVersion: 5.7.13
 description: MySQL cluster with a single master and zero or more slave replicas
 keywords:

--- a/incubator/mysqlha/README.md
+++ b/incubator/mysqlha/README.md
@@ -37,6 +37,7 @@ The following table lists the configurable parameters of the MySQL chart and the
 | -----------------------------------------    | ------------------------------------------------- | -------------------------------------- |
 | `mysqlImage`                                 | `mysql` image and tag.                            | `mysql:5.7.13`                         |
 | `xtraBackupImage`                            | `xtrabackup` image and tag.                       | `gcr.io/google-samples/xtrabackup:1.0` |
+| `imagePullPolicy`                            | Image pull policy.                                | `IfNotPresent`                         |
 | `replicaCount`                               | Number of MySQL replicas                          | 3                                      |
 | `mysqlRootPassword`                          | Password for the `root` user.                     | Randomly generated                     |
 | `mysqlUser`                                  | Username of new user to create.                   | `nil`                                  |

--- a/incubator/mysqlha/templates/NOTES.txt
+++ b/incubator/mysqlha/templates/NOTES.txt
@@ -12,8 +12,16 @@ To connect to your database:
 
 2. Run a pod to use as a client:
 
-    kubectl run mysql-client --image={{ .Values.mysqlImage }} -it --rm --restart=Never -- /bin/sh
+    kubectl run mysql-client --image={{ .Values.mysqlImage }} -it --rm --restart='Never' --namespace {{ .Release.Namespace }} -- /bin/sh
 
-2. Open a connection to one of the MySQL pods
+3. To connect to Master service (read/write):
 
-    mysql -h {{ template "fullname" . }}-0.{{ template "fullname" . }} -p
+    mysql -h {{ template "fullname" . }}-0.{{ template "fullname" . }} -u root -p
+
+{{- if lt 1 (.Values.mysqlha.replicaCount | int64) }}
+
+4. To connect to slave service (read-only):
+   
+   mysql -h {{ template "fullname" . }}-readonly -u root -p
+
+{{- end }}

--- a/incubator/mysqlha/templates/statefulset.yaml
+++ b/incubator/mysqlha/templates/statefulset.yaml
@@ -25,6 +25,7 @@ spec:
       initContainers:
       - name: clone-mysql
         image: {{ .Values.xtraBackupImage }}
+        imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         command:
           - bash
           - "-c"
@@ -58,6 +59,7 @@ spec:
           mountPath: /etc/mysql/conf.d
       - name: init-mysql
         image: {{ .Values.mysqlImage }}
+        imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         command: ["/bin/bash"]
         args:
           - "-c"
@@ -89,6 +91,7 @@ spec:
       containers:
       - name: mysql
         image: {{ .Values.mysqlImage }}
+        imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         env:
         - name: MYSQL_DATABASE
           value: {{ default "" .Values.mysqlha.mysqlDatabase | quote }}
@@ -146,6 +149,7 @@ spec:
           timeoutSeconds: 1
       - name: xtrabackup
         image: {{ .Values.xtraBackupImage }}
+        imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         env:
         - name: MYSQL_PWD
           valueFrom:
@@ -226,7 +230,7 @@ spec:
       {{- if .Values.metrics.enabled }}
       - name: metrics
         image: "{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}"
-        imagePullPolicy: {{ .Values.pullPolicy | quote }}
+        imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         {{- if .Values.mysqlha.mysqlAllowEmptyPassword }}
         command: ['sh', '-c', 'DATA_SOURCE_NAME="root@(localhost:3306)/" /bin/mysqld_exporter' ]
         {{- else }}

--- a/incubator/mysqlha/values.yaml
+++ b/incubator/mysqlha/values.yaml
@@ -4,6 +4,12 @@
 mysqlImage: mysql:5.7.13
 xtraBackupImage: gcr.io/google-samples/xtrabackup:1.0
 
+## Specify an imagePullPolicy (Required)
+## It's recommended to change this to 'Always' if the image tag is 'latest'
+## ref: http://kubernetes.io/docs/user-guide/images/#updating-images
+##
+imagePullPolicy: IfNotPresent
+
 mysqlha:
   replicaCount: 3
 
@@ -76,7 +82,6 @@ metrics:
   enabled: false
   image: prom/mysqld-exporter
   imageTag: v0.10.0
-  imagePullPolicy: IfNotPresent
   annotations: {}
 
   livenessProbe:


### PR DESCRIPTION
Signed-off-by: Aisuko <urakiny@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
  
  * Add the way that how to test the master and slave work well.
  * Add a common image pull policy for all image in the charts.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
