### PR TITLE
[stable/fluent-bit] Determine correct PodSecurityPolicy ApiGroup

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.4.0
+version: 2.4.1
 appVersion: 1.2.1
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.4.1
+version: 2.4.2
 appVersion: 1.2.1
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/_helpers.tpl
+++ b/stable/fluent-bit/templates/_helpers.tpl
@@ -55,3 +55,13 @@ Create the name of the service account to use
 {{- end -}}
 {{- end -}}
 
+{{/*
+Return the appropriate apiGroup for PodSecurityPolicy.
+*/}}
+{{- define "rbac.pspApiGroup" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions" -}}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "policy" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/fluent-bit/templates/cluster-role.yaml
+++ b/stable/fluent-bit/templates/cluster-role.yaml
@@ -17,7 +17,7 @@ rules:
       - get
 {{- if .Values.rbac.pspEnabled }}
   - apiGroups:
-    - policy
+    - {{ template "rbac.pspApiGroup" . }}
     resources:
     - podsecuritypolicies
     resourceNames:


### PR DESCRIPTION
PodSecurityPolicy API Group is detected based on Kubernetes version.

version <1.14 uses `extensions` while version >=1.14 uses `policy`

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Sets the correct PodSecurityPolicy ApiGroup based on the version of Kubernetes in use.  PodSecurityPolicy is not in the 'policy' ApiGroup until Kubernetes version 1.14

#### Special notes for your reviewer:

Current chart does not work on Kubernetes <=1.13 with `rbac.pspEnabled: true`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ X ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ X ] Chart Version bumped
- [ X ] Title of the PR starts with chart name (e.g. `[stable/chart]`)

@kfox1111 @edsiper 