### PR TITLE
[stable/fluent-bit] adds option to start fluent-bit in privileged mode

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.4.0
+version: 2.5.0
 appVersion: 1.2.1
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -118,7 +118,8 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `serviceAccount.create`            | Specifies whether a ServiceAccount should be created. | `true`                                 |
 | `serviceAccount.name`              | The name of the ServiceAccount to use.     | `NULL`                                            |
 | `rawConfig`                        | Raw contents of fluent-bit.conf            | `@INCLUDE fluent-bit-service.conf`<br>`@INCLUDE fluent-bit-input.conf`<br>`@INCLUDE fluent-bit-filter.conf`<br>` @INCLUDE fluent-bit-output.conf`                                                                         |
-| `resources`                        | Pod resource requests & limits                                 | `{}`                          |
+| `privileged`                       | Start fluent-bit as a privileged container | `false`                          |
+| `resources`                        | Pod resource requests & limits             | `{}`                          |
 | `hostNetwork`                      | Use host's network                         | `false`                                           |
 | `dnsPolicy`                        | Specifies the dnsPolicy to use             | `ClusterFirst`                                    |
 | `priorityClassName`                | Specifies the priorityClassName to use     | `NULL`                                            |

--- a/stable/fluent-bit/templates/daemonset.yaml
+++ b/stable/fluent-bit/templates/daemonset.yaml
@@ -38,6 +38,8 @@ spec:
       - name: fluent-bit
         image: "{{ .Values.image.fluent_bit.repository }}:{{ .Values.image.fluent_bit.tag }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+        securityContext:
+          privileged: {{ .Values.privileged }}
         env:
 {{ toYaml .Values.env | indent 10 }}
         resources:

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -180,6 +180,8 @@ extraVolumes: []
 ##
 extraVolumeMounts: []
 
+privileged: false
+
 resources: {}
   # limits:
   #   cpu: 100m


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds an option to start fluent-bit in a privileged container. This is needed in some environments, e.g. with SElinux enabled.

#### Special notes for your reviewer:

Defaults to `false` so no change for existing deployments.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
