### PR TITLE
[stable/drone] Add support for custom volumes in drone agent

### DIFF
--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 2.0.6
+version: 2.0.7
 appVersion: 1.2
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/stable/drone/README.md
+++ b/stable/drone/README.md
@@ -107,8 +107,11 @@ The following table lists the configurable parameters of the drone charts and th
 | `agent.tolerations`         | Drone **agent** node taints to tolerate                                                       | `[]`                        |
 | `agent.livenessProbe` | Not currently used. | `{}` |
 | `agent.readinessProbe` | Not currently used  | `{}` |
+| `agent.volumes`             | Additional volumes to make available to agent (shared by dind if used)                        | `nil`                       |
+| `agent.volumeMounts`        | Mount points for volumes                                                                      | `nil`                       |
 | `dind.enabled`              | Enable or disable **DinD**                                                                    | `true`                      |
 | `dind.driver`               | **DinD** storage driver                                                                       | `overlay2`                  |
+| `dind.volumeMounts`         | Mount points for volumes (defined in agent.volumes)                                           | `nil`                       |
 | `dind.resources`            | **DinD** pod resource requests & limits                                                       | `{}`                        |
 | `dind.env`                  | **DinD** environment variables                                                                | `nil`                       |
 | `dind.command`              | **DinD** custom command instead of default entry point                                        | `nil`                       |

--- a/stable/drone/templates/deployment-agent.yaml
+++ b/stable/drone/templates/deployment-agent.yaml
@@ -71,11 +71,18 @@ spec:
         volumeMounts:
           - mountPath: /var/run/docker.sock
             name: docker-socket
+      {{- with .Values.agent.volumeMounts }}
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
       volumes:
         - name: docker-socket
           hostPath:
             path: /var/run/docker.sock
 {{- else }}
+      {{- with .Values.agent.volumeMounts }}
+        volumeMounts:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
       - name: dind
         image: "{{ .Values.images.dind.repository }}:{{ .Values.images.dind.tag }}"
         imagePullPolicy: {{ .Values.images.dind.pullPolicy }}
@@ -99,8 +106,14 @@ spec:
         volumeMounts:
           - name: docker-graph-storage
             mountPath: /var/lib/docker
+      {{- with .Values.dind.volumeMounts }}
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
       volumes:
       - name: docker-graph-storage
         emptyDir: {}
 {{- end }}
+    {{- with .Values.agent.volumes }}
+        {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- end -}}

--- a/stable/drone/values.yaml
+++ b/stable/drone/values.yaml
@@ -225,6 +225,34 @@ agent:
   ##
   annotations: {}
 
+  ## Additional volumes e.g. for shared caching between agents on different nodes or
+  ## shared cache between agents on the same node when using dind or
+  ## for a global docker login config as per
+  ## Option 2 ref: https://discourse.drone.io/t/how-to-pull-private-images-with-1-0/3155
+  ## Note: Option 2 also requires DRONE_DOCKER_CONFIG: /root/.docker/config.json env var in agent
+  ## NB: This will make the credentials available globally to all builds and all repositories
+  # volumes:
+  # - name: docker-config
+  #   secret:
+  #     defaultMode: 420
+  #     items:
+  #     - key: .dockerconfigjson
+  #       path: config.json
+  #     secretName: drone-docker-config
+  # - name: persistent-data
+  #   persistentVolumeClaim:
+  #     claimName: drone-agent-pvc
+  # - name: cache
+  #   hostPath:
+  #     path: /drone-cache
+  #     type: Directory
+
+  ## Volume mount into agent container
+  # volumeMounts:
+  # - name: docker-config
+  #   mountPath: /root/.docker
+  #   readOnly: true
+
   ## CPU and memory limits for drone agent
   ##
   resources: {}
@@ -285,6 +313,15 @@ dind:
   ## ref: https://docs.docker.com/engine/userguide/storagedriver/selectadriver/
   ##
   driver: overlay2
+
+  ## Volume mount into dind container
+  ## Volumes are defined under agent values.
+  # volumeMounts:
+  # - mountPath: /root/.docker
+  #   name: docker-config
+  #   readOnly: true
+  # - name: persistent-data
+  #   mountPath: /mnt/drone-cache
 
   ## CPU and memory limits for dind
   ##


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds support for custom volumes to drone agent, which allows for global docker login for pulls, and shared cache volumes when using dind or agents on multiple nodes.

#### Special notes for your reviewer:
see: Option 2 ref: https://discourse.drone.io/t/how-to-pull-private-images-with-1-0/3155
Also useful for other purposes.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
