### PR TITLE
[stable/prometheus] add the option to add alert_relabel_configs in prometheus.yml

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 9.1.1
+version: 9.1.2
 appVersion: 2.11.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -322,6 +322,7 @@ Parameter | Description | Default
 `serverFiles.rules` | Prometheus server rules configuration | `{}`
 `serverFiles.prometheus.yml` | Prometheus server scrape configuration | example configuration
 `extraScrapeConfigs` | Prometheus server additional scrape configuration | ""
+`alertRelabelConfigs` | Prometheus server [alert relabeling configs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alert_relabel_configs) for H/A prometheus | ""
 `networkPolicy.enabled` | Enable NetworkPolicy | `false` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/prometheus/templates/server-configmap.yaml
+++ b/stable/prometheus/templates/server-configmap.yaml
@@ -21,6 +21,9 @@ data:
 {{- end -}}
 {{- if $root.Values.alertmanager.enabled }}
     alerting:
+{{- if $root.Values.alertRelabelConfigs }}
+{{ $root.Values.alertRelabelConfigs | toYaml  | trimSuffix "\n" | indent 6 }}
+{{- end }}
       alertmanagers:
       - kubernetes_sd_configs:
           - role: pod

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -1317,6 +1317,14 @@ extraScrapeConfigs:
   #     - target_label: __address__
   #       replacement: prometheus-blackbox-exporter:9115
 
+# Adds option to add alert_relabel_configs to avoid duplicate alerts in alertmanager
+# useful in H/A prometheus with different external labels but the same alerts
+alertRelabelConfigs:
+  # alert_relabel_configs:
+  # - source_labels: [dc]
+  #   regex: (.+)\d+
+  #   target_label: dc
+
 networkPolicy:
   ## Enable creation of NetworkPolicy resources.
   ##


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This pull request introduces the option to add `alert_relabel_configs` when alertmanager is enabled, useful for prometheus high availability environment to prevent duplicate alerts.

Ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alert_relabel_configs


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
