### PR TITLE
[stable/sentry] add a prefix to helper defines

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 2.0.0
+version: 2.0.1
 appVersion: 9.1.1
 keywords:
   - debugging

--- a/stable/sentry/templates/NOTES.txt
+++ b/stable/sentry/templates/NOTES.txt
@@ -1,15 +1,15 @@
 1. Get the application URL by running these commands:
 {{- if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "sentry.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT/auth/login/sentry
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+           You can watch the status of by running 'kubectl get svc -w {{ template "sentry.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "sentry.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
 {{- else if contains "ClusterIP"  .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }},role=web" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "sentry.fullname" . }},role=web" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:{{ .Values.service.externalPort }}
 {{- end }}
@@ -18,4 +18,4 @@
 
   USER: {{ .Values.user.email }}
   Get login password with
-    kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.user-password}" | base64 --decode
+    kubectl get secret --namespace {{ .Release.Namespace }} {{ template "sentry.fullname" . }} -o jsonpath="{.data.user-password}" | base64 --decode

--- a/stable/sentry/templates/_helpers.tpl
+++ b/stable/sentry/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "sentry.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -11,7 +11,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "fullname" -}}
+{{- define "sentry.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -28,22 +28,22 @@ If release name contains chart name it will be used as a full name.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "postgresql.fullname" -}}
+{{- define "sentry.postgresql.fullname" -}}
 {{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-{{- define "redis.fullname" -}}
+{{- define "sentry.redis.fullname" -}}
 {{- printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-{{- define "smtp.fullname" -}}
+{{- define "sentry.smtp.fullname" -}}
 {{- printf "%s-%s" .Release.Name "smtp" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Set postgres host
 */}}
-{{- define "postgresql.host" -}}
+{{- define "sentry.postgresql.host" -}}
 {{- if .Values.postgresql.enabled -}}
-{{- template "postgresql.fullname" . -}}
+{{- template "sentry.postgresql.fullname" . -}}
 {{- else -}}
 {{- .Values.postgresql.postgresHost | quote -}}
 {{- end -}}
@@ -52,18 +52,18 @@ Set postgres host
 {{/*
 Set postgres secret
 */}}
-{{- define "postgresql.secret" -}}
+{{- define "sentry.postgresql.secret" -}}
 {{- if .Values.postgresql.enabled -}}
-{{- template "postgresql.fullname" . -}}
+{{- template "sentry.postgresql.fullname" . -}}
 {{- else -}}
-{{- template "fullname" . -}}
+{{- template "sentry.fullname" . -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
 Set postgres port
 */}}
-{{- define "postgresql.port" -}}
+{{- define "sentry.postgresql.port" -}}
 {{- if .Values.postgresql.enabled -}}
     "5432"
 {{- else -}}
@@ -74,9 +74,9 @@ Set postgres port
 {{/*
 Set redis host
 */}}
-{{- define "redis.host" -}}
+{{- define "sentry.redis.host" -}}
 {{- if .Values.redis.enabled -}}
-{{- template "redis.fullname" . -}}-master
+{{- template "sentry.redis.fullname" . -}}-master
 {{- else -}}
 {{- .Values.redis.host | quote -}}
 {{- end -}}
@@ -85,18 +85,18 @@ Set redis host
 {{/*
 Set redis secret
 */}}
-{{- define "redis.secret" -}}
+{{- define "sentry.redis.secret" -}}
 {{- if .Values.redis.enabled -}}
-{{- template "redis.fullname" . -}}
+{{- template "sentry.redis.fullname" . -}}
 {{- else -}}
-{{- template "fullname" . -}}
+{{- template "sentry.fullname" . -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
 Set redis port
 */}}
-{{- define "redis.port" -}}
+{{- define "sentry.redis.port" -}}
 {{- if .Values.redis.enabled -}}
     "6379"
 {{- else -}}

--- a/stable/sentry/templates/configmap.yaml
+++ b/stable/sentry/templates/configmap.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "sentry.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -382,7 +382,7 @@ data:
 {{- if .Values.metrics.enabled }}
     SENTRY_METRICS_BACKEND = 'sentry.metrics.statsd.StatsdMetricsBackend'
     SENTRY_METRICS_OPTIONS = {
-        'host': '{{ template "fullname" . }}-metrics',
+        'host': '{{ template "sentry.fullname" . }}-metrics',
         'port': 9125,
     }
 {{- end }} 

--- a/stable/sentry/templates/cron-deployment.yaml
+++ b/stable/sentry/templates/cron-deployment.yaml
@@ -1,9 +1,9 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}-cron
+  name: {{ template "sentry.fullname" . }}-cron
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -19,7 +19,7 @@ spec:
 {{ toYaml .Values.cron.podAnnotations | indent 8 }}
       {{- end }}
       labels:
-        app: {{ template "fullname" . }}
+        app: {{ template "sentry.fullname" . }}
         release: "{{ .Release.Name }}"
         role: cron
         {{- if .Values.cron.podLabels }}
@@ -56,7 +56,7 @@ spec:
         - name: SENTRY_SECRET_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
+              name: {{ template "sentry.fullname" . }}
               key: sentry-secret
         - name: SENTRY_DB_USER
           value: {{ default "sentry" .Values.postgresql.postgresUser | quote }}
@@ -68,13 +68,13 @@ spec:
             {{- if .Values.postgresql.existingSecret }}
               name: {{ .Values.postgresql.existingSecret }}
             {{- else }}
-              name: {{ template "postgresql.secret" . }}
+              name: {{ template "sentry.postgresql.secret" . }}
             {{- end }}
               key: postgres-password
         - name: SENTRY_POSTGRES_HOST
-          value: {{ template "postgresql.host" . }}
+          value: {{ template "sentry.postgresql.host" . }}
         - name: SENTRY_POSTGRES_PORT
-          value: {{ template "postgresql.port" . }}
+          value: {{ template "sentry.postgresql.port" . }}
         {{- if or (.Values.redis.enabled) (.Values.redis.password) }}
         - name: SENTRY_REDIS_PASSWORD
           valueFrom:
@@ -82,14 +82,14 @@ spec:
             {{- if .Values.redis.existingSecret }}
               name: {{ .Values.redis.existingSecret }}
             {{- else }}
-              name: {{ template "redis.secret" . }}
+              name: {{ template "sentry.redis.secret" . }}
             {{- end }}
               key: redis-password
         {{- end }}
         - name: SENTRY_REDIS_HOST
-          value: {{ template "redis.host" . }}
+          value: {{ template "sentry.redis.host" . }}
         - name: SENTRY_REDIS_PORT
-          value: {{ template "redis.port" . }}
+          value: {{ template "sentry.redis.port" . }}
         - name: SENTRY_EMAIL_HOST
           value: {{ default "" .Values.email.host | quote }}
         - name: SENTRY_EMAIL_PORT
@@ -102,7 +102,7 @@ spec:
             {{- if .Values.email.existingSecret }}
               name: {{ .Values.email.existingSecret }}
             {{- else }}
-              name: {{ template "fullname" . }}
+              name: {{ template "sentry.fullname" . }}
             {{- end }}
               key: smtp-password
         - name: SENTRY_EMAIL_USE_TLS
@@ -123,11 +123,11 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: {{ template "fullname" . }}
+          name: {{ template "sentry.fullname" . }}
       - name: sentry-data
       {{- if and (.Values.filestore.filesystem.persistence.enabled) (.Values.filestore.filesystem.persistence.persistentWorkers) }}
         persistentVolumeClaim:
-          claimName: {{ .Values.filestore.filesystem.persistence.existingClaim | default (include "fullname" .) }}
+          claimName: {{ .Values.filestore.filesystem.persistence.existingClaim | default (include "sentry.fullname" .) }}
       {{- else }}
         emptyDir: {}
       {{ end }}

--- a/stable/sentry/templates/hooks/db-init.job.yaml
+++ b/stable/sentry/templates/hooks/db-init.job.yaml
@@ -4,7 +4,7 @@ kind: Job
 metadata:
   name: "{{ .Release.Name }}-db-init"
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -19,7 +19,7 @@ spec:
     metadata:
       name: "{{ .Release.Name }}-db-init"
       labels:
-        app: {{ template "fullname" . }}
+        app: {{ template "sentry.fullname" . }}
         release: "{{ .Release.Name }}"
         {{- if .Values.worker.podLabels }}
 {{ toYaml .Values.worker.podLabels | indent 8 }}
@@ -42,7 +42,7 @@ spec:
         - name: SENTRY_SECRET_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
+              name: {{ template "sentry.fullname" . }}
               key: sentry-secret
         - name: SENTRY_DB_USER
           value: {{ default "sentry" .Values.postgresql.postgresUser | quote }}
@@ -54,13 +54,13 @@ spec:
             {{- if .Values.postgresql.existingSecret }}
               name: {{ .Values.postgresql.existingSecret }}
             {{- else }}
-              name: {{ template "postgresql.secret" . }}
+              name: {{ template "sentry.postgresql.secret" . }}
             {{- end }}
               key: postgres-password
         - name: SENTRY_POSTGRES_HOST
-          value: {{ template "postgresql.host" . }}
+          value: {{ template "sentry.postgresql.host" . }}
         - name: SENTRY_POSTGRES_PORT
-          value: {{ template "postgresql.port" . }}
+          value: {{ template "sentry.postgresql.port" . }}
         {{- if or (.Values.redis.enabled) (.Values.redis.password) }}
         - name: SENTRY_REDIS_PASSWORD
           valueFrom:
@@ -68,14 +68,14 @@ spec:
             {{- if .Values.redis.existingSecret }}
               name: {{ .Values.redis.existingSecret }}
             {{- else }}
-              name: {{ template "redis.secret" . }}
+              name: {{ template "sentry.redis.secret" . }}
             {{- end }}
               key: redis-password
         {{- end }}
         - name: SENTRY_REDIS_HOST
-          value: {{ template "redis.host" . }}
+          value: {{ template "sentry.redis.host" . }}
         - name: SENTRY_REDIS_PORT
-          value: {{ template "redis.port" . }}
+          value: {{ template "sentry.redis.port" . }}
         - name: SENTRY_EMAIL_HOST
           value: {{ default "" .Values.email.host | quote }}
         - name: SENTRY_EMAIL_PORT
@@ -88,7 +88,7 @@ spec:
             {{- if .Values.email.existingSecret }}
               name: {{ .Values.email.existingSecret }}
             {{- else }}
-              name: {{ template "fullname" . }}
+              name: {{ template "sentry.fullname" . }}
             {{- end }}
               key: smtp-password
         - name: SENTRY_EMAIL_USE_TLS
@@ -102,4 +102,4 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: {{ template "fullname" . }}
+          name: {{ template "sentry.fullname" . }}

--- a/stable/sentry/templates/hooks/user-create.job.yaml
+++ b/stable/sentry/templates/hooks/user-create.job.yaml
@@ -4,7 +4,7 @@ kind: Job
 metadata:
   name: "{{ .Release.Name }}-user-create"
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -19,7 +19,7 @@ spec:
     metadata:
       name: "{{ .Release.Name }}-user-create"
       labels:
-        app: {{ template "fullname" . }}
+        app: {{ template "sentry.fullname" . }}
         release: "{{ .Release.Name }}"
         {{- if .Values.worker.podLabels }}
 {{ toYaml .Values.worker.podLabels | indent 8 }}
@@ -42,7 +42,7 @@ spec:
         - name: SENTRY_SECRET_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
+              name: {{ template "sentry.fullname" . }}
               key: sentry-secret
         - name: SENTRY_DB_USER
           value: {{ default "sentry" .Values.postgresql.postgresUser | quote }}
@@ -54,13 +54,13 @@ spec:
             {{- if .Values.postgresql.existingSecret }}
               name: {{ .Values.postgresql.existingSecret }}
             {{- else }}
-              name: {{ template "postgresql.secret" . }}
+              name: {{ template "sentry.postgresql.secret" . }}
             {{- end }}
               key: postgres-password
         - name: SENTRY_POSTGRES_HOST
-          value: {{ template "postgresql.host" . }}
+          value: {{ template "sentry.postgresql.host" . }}
         - name: SENTRY_POSTGRES_PORT
-          value: {{ template "postgresql.port" . }}
+          value: {{ template "sentry.postgresql.port" . }}
         {{- if or (.Values.redis.enabled) (.Values.redis.password) }}
         - name: SENTRY_REDIS_PASSWORD
           valueFrom:
@@ -68,14 +68,14 @@ spec:
             {{- if .Values.redis.existingSecret }}
               name: {{ .Values.redis.existingSecret }}
             {{- else }}
-              name: {{ template "redis.secret" . }}
+              name: {{ template "sentry.redis.secret" . }}
             {{- end }}
               key: redis-password
         {{- end }}
         - name: SENTRY_REDIS_HOST
-          value: {{ template "redis.host" . }}
+          value: {{ template "sentry.redis.host" . }}
         - name: SENTRY_REDIS_PORT
-          value: {{ template "redis.port" . }}
+          value: {{ template "sentry.redis.port" . }}
         - name: SENTRY_EMAIL_HOST
           value: {{ default "" .Values.smtpHost | quote }}
         - name: SENTRY_EMAIL_PORT
@@ -88,13 +88,13 @@ spec:
             {{- if .Values.email.existingSecret }}
               name: {{ .Values.email.existingSecret }}
             {{- else }}
-              name: {{ template "fullname" . }}
+              name: {{ template "sentry.fullname" . }}
             {{- end }}
               key: smtp-password
         - name: SENTRY_USER_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
+              name: {{ template "sentry.fullname" . }}
               key: user-password
         - name: SENTRY_EMAIL_USE_TLS
           value: {{ .Values.email.use_tls | quote }}
@@ -107,5 +107,5 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: {{ template "fullname" . }}
+          name: {{ template "sentry.fullname" . }}
 {{- end -}}

--- a/stable/sentry/templates/ingress.yaml
+++ b/stable/sentry/templates/ingress.yaml
@@ -2,9 +2,9 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
- name: {{ template "fullname" . }}
+ name: {{ template "sentry.fullname" . }}
  labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -19,7 +19,7 @@ spec:
         paths:
           - path: {{ default "/" .Values.ingress.path | quote }}
             backend:
-              serviceName: {{ template "fullname" . }}
+              serviceName: {{ template "sentry.fullname" . }}
               servicePort: {{ .Values.service.externalPort }}
 {{- if .Values.ingress.tls }}
   tls:

--- a/stable/sentry/templates/metrics-deployment.yaml
+++ b/stable/sentry/templates/metrics-deployment.yaml
@@ -2,9 +2,9 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}-metrics
+  name: {{ template "sentry.fullname" . }}-metrics
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}
+        app: {{ template "sentry.fullname" . }}
         release: "{{ .Release.Name }}"
         role: metrics
     spec:

--- a/stable/sentry/templates/metrics-prometheus.yaml
+++ b/stable/sentry/templates/metrics-prometheus.yaml
@@ -2,12 +2,12 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "sentry.fullname" . }}
   {{- if .Values.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.metrics.serviceMonitor.namespace }}
   {{- end }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -22,7 +22,7 @@ spec:
     {{- end }}
   selector:
     matchLabels:
-      app: {{ template "fullname" . }}
+      app: {{ template "sentry.fullname" . }}
       release: {{ .Release.Name }}
   namespaceSelector:
     matchNames:

--- a/stable/sentry/templates/metrics-service.yaml
+++ b/stable/sentry/templates/metrics-service.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}-metrics
+  name: {{ template "sentry.fullname" . }}-metrics
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -23,7 +23,7 @@ spec:
     protocol: UDP
     name: statsd
   selector:
-    app: {{ template "fullname" . }}
+    app: {{ template "sentry.fullname" . }}
     release: {{ .Release.Name }}
     role: metrics
 {{- end }} 

--- a/stable/sentry/templates/pvc.yaml
+++ b/stable/sentry/templates/pvc.yaml
@@ -2,9 +2,9 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "sentry.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/stable/sentry/templates/secrets.yaml
+++ b/stable/sentry/templates/secrets.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "sentry.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/stable/sentry/templates/web-deployment.yaml
+++ b/stable/sentry/templates/web-deployment.yaml
@@ -1,9 +1,9 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}-web
+  name: {{ template "sentry.fullname" . }}-web
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -19,7 +19,7 @@ spec:
 {{ toYaml .Values.web.podAnnotations | indent 8 }}
       {{- end }}
       labels:
-        app: {{ template "fullname" . }}
+        app: {{ template "sentry.fullname" . }}
         release: "{{ .Release.Name }}"
         role: web
         {{- if .Values.worker.podLabels }}
@@ -55,7 +55,7 @@ spec:
         - name: SENTRY_SECRET_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
+              name: {{ template "sentry.fullname" . }}
               key: sentry-secret
         - name: SENTRY_DB_USER
           value: {{ default "sentry" .Values.postgresql.postgresUser | quote }}
@@ -67,13 +67,13 @@ spec:
             {{- if .Values.postgresql.existingSecret }}
               name: {{ .Values.postgresql.existingSecret }}
             {{- else }}
-              name: {{ template "postgresql.secret" . }}
+              name: {{ template "sentry.postgresql.secret" . }}
             {{- end }}
               key: postgres-password
         - name: SENTRY_POSTGRES_HOST
-          value: {{ template "postgresql.host" . }}
+          value: {{ template "sentry.postgresql.host" . }}
         - name: SENTRY_POSTGRES_PORT
-          value: {{ template "postgresql.port" . }}
+          value: {{ template "sentry.postgresql.port" . }}
         {{- if or (.Values.redis.enabled) (.Values.redis.password) }}
         - name: SENTRY_REDIS_PASSWORD
           valueFrom:
@@ -81,14 +81,14 @@ spec:
             {{- if .Values.redis.existingSecret }}
               name: {{ .Values.redis.existingSecret }}
             {{- else }}
-              name: {{ template "redis.secret" . }}
+              name: {{ template "sentry.redis.secret" . }}
             {{- end }}
               key: redis-password
         {{- end }}
         - name: SENTRY_REDIS_HOST
-          value: {{ template "redis.host" . }}
+          value: {{ template "sentry.redis.host" . }}
         - name: SENTRY_REDIS_PORT
-          value: {{ template "redis.port" . }}
+          value: {{ template "sentry.redis.port" . }}
         - name: SENTRY_EMAIL_HOST
           value: {{ default "" .Values.email.host | quote }}
         - name: SENTRY_EMAIL_PORT
@@ -101,7 +101,7 @@ spec:
             {{- if .Values.email.existingSecret }}
               name: {{ .Values.email.existingSecret }}
             {{- else }}
-              name: {{ template "fullname" . }}
+              name: {{ template "sentry.fullname" . }}
             {{- end }}
               key: smtp-password
         - name: SENTRY_EMAIL_USE_TLS
@@ -150,11 +150,11 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: {{ template "fullname" . }}
+          name: {{ template "sentry.fullname" . }}
       - name: sentry-data
       {{- if and (eq .Values.filestore.backend "filesystem") .Values.filestore.filesystem.persistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ .Values.filestore.filesystem.persistence.existingClaim | default (include "fullname" .) }}
+          claimName: {{ .Values.filestore.filesystem.persistence.existingClaim | default (include "sentry.fullname" .) }}
       {{- else }}
         emptyDir: {}
       {{ end }}

--- a/stable/sentry/templates/web-service.yaml
+++ b/stable/sentry/templates/web-service.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "sentry.fullname" . }}
   annotations:
    {{- range $key, $value := .Values.service.annotations }}
      {{ $key }}: {{ $value | quote }}
    {{- end }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -30,7 +30,7 @@ spec:
 {{ toYaml .Values.service.externalIPs | indent 4 }}
 {{- end }}
   selector:
-    app: {{ template "fullname" . }}
+    app: {{ template "sentry.fullname" . }}
     role: web
   {{- with .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:

--- a/stable/sentry/templates/workers-deployment.yaml
+++ b/stable/sentry/templates/workers-deployment.yaml
@@ -1,9 +1,9 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}-worker
+  name: {{ template "sentry.fullname" . }}-worker
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "sentry.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -19,7 +19,7 @@ spec:
 {{ toYaml .Values.worker.podAnnotations | indent 8 }}
       {{- end }}
       labels:
-        app: {{ template "fullname" . }}
+        app: {{ template "sentry.fullname" . }}
         release: "{{ .Release.Name }}"
         role: worker
         {{- if .Values.worker.podLabels }}
@@ -62,7 +62,7 @@ spec:
         - name: SENTRY_SECRET_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
+              name: {{ template "sentry.fullname" . }}
               key: sentry-secret
         - name: SENTRY_DB_USER
           value: {{ default "sentry" .Values.postgresql.postgresUser | quote }}
@@ -74,13 +74,13 @@ spec:
             {{- if .Values.postgresql.existingSecret }}
               name: {{ .Values.postgresql.existingSecret }}
             {{- else }}
-              name: {{ template "postgresql.secret" . }}
+              name: {{ template "sentry.postgresql.secret" . }}
             {{- end }}
               key: postgres-password
         - name: SENTRY_POSTGRES_HOST
-          value: {{ template "postgresql.host" . }}
+          value: {{ template "sentry.postgresql.host" . }}
         - name: SENTRY_POSTGRES_PORT
-          value: {{ template "postgresql.port" . }}
+          value: {{ template "sentry.postgresql.port" . }}
         {{- if or (.Values.redis.enabled) (.Values.redis.password) }}
         - name: SENTRY_REDIS_PASSWORD
           valueFrom:
@@ -88,14 +88,14 @@ spec:
             {{- if .Values.redis.existingSecret }}
               name: {{ .Values.redis.existingSecret }}
             {{- else }}
-              name: {{ template "redis.secret" . }}
+              name: {{ template "sentry.redis.secret" . }}
             {{- end }}
               key: redis-password
         {{- end }}
         - name: SENTRY_REDIS_HOST
-          value: {{ template "redis.host" . }}
+          value: {{ template "sentry.redis.host" . }}
         - name: SENTRY_REDIS_PORT
-          value: {{ template "redis.port" . }}
+          value: {{ template "sentry.redis.port" . }}
         - name: SENTRY_EMAIL_HOST
           value: {{ default "" .Values.email.host | quote }}
         - name: SENTRY_EMAIL_PORT
@@ -108,7 +108,7 @@ spec:
             {{- if .Values.email.existingSecret }}
               name: {{ .Values.email.existingSecret }}
             {{- else }}
-              name: {{ template "fullname" . }}
+              name: {{ template "sentry.fullname" . }}
             {{- end }}
               key: smtp-password
         - name: SENTRY_EMAIL_USE_TLS
@@ -139,7 +139,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: {{ template "fullname" . }}
+          name: {{ template "sentry.fullname" . }}
       {{- if eq .Values.filestore.backend "gcs" }}
       - name: sentry-google-cloud-key
         secret:
@@ -148,7 +148,7 @@ spec:
       - name: sentry-data
       {{- if and (.Values.filestore.filesystem.persistence.enabled) (.Values.filestore.filesystem.persistence.persistentWorkers) }}
         persistentVolumeClaim:
-          claimName: {{ .Values.filestore.filesystem.persistence.existingClaim | default (include "fullname" .) }}
+          claimName: {{ .Values.filestore.filesystem.persistence.existingClaim | default (include "sentry.fullname" .) }}
       {{- else }}
         emptyDir: {}
       {{ end }}


### PR DESCRIPTION
Signed-off-by: Sébastien Prud'homme <sebastien.prudhomme@gmail.com>

#### What this PR does / why we need it:

This PR add a prefix to all helper names so that theses names doesn't conflict with helper names in subcharts.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
