### PR TITLE
[stable/hlf-ca] Fix affiliations rendering

### DIFF
--- a/stable/hlf-ca/Chart.yaml
+++ b/stable/hlf-ca/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Hyperledger Fabric Certificate Authority chart (these charts are created by AID:Tech and are currently not directly associated with the Hyperledger project)
 name: hlf-ca
-version: 1.1.6
+version: 1.1.7
 appVersion: 1.3.0
 keywords:
   - blockchain

--- a/stable/hlf-ca/templates/configmap--config.yaml
+++ b/stable/hlf-ca/templates/configmap--config.yaml
@@ -178,7 +178,7 @@ data:
     # Note: Affiliations are case sensitive except for the non-leaf affiliations.
     #############################################################################
     affiliations:
-    {{ toYaml .Values.config.affiliations | indent 4 }}
+    {{- toYaml .Values.config.affiliations | nindent 6 }}
     #############################################################################
     #  Signing section
     #

--- a/stable/hlf-ca/values.yaml
+++ b/stable/hlf-ca/values.yaml
@@ -133,8 +133,8 @@ config:
   #     url: parent-ca.example.com
   #     port: 7054
   ## Affiliations used in ca Server configuration file
-  affiliations:
-    org1: []
+  affiliations: {}
+    # org1: []
 
 resources: {}
   ## We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
## What this PR does / why we need it:
This pull request fixes an issue during the rendering of the Server affiliations parameter. There was actually 2 things that was making the feature unusable:
* First, you had no way to remove `org1: []` from the values. You could add an affiliation but never remove the default one because of the way helm performs deep merge of objects. That's why I removed the default value and commented the org1 as example
* Finally the indentation was not good. You could have been lucky during the rendering if your affiliation was after in alphabetical order: this way it just got ignored, but if it was before org1 in alphabetical order you would get an awkward error while trying to start the CA server. Bellow the examples

```
# Before the fix, adding an affiliation after the default one
helm template . --set config.affiliations.org2={paris} | grep affiliations: --after-context=5
    affiliations:
        org1: []
    org2:
    - paris
```
```
# Before the fix, adding an affiliation before the default one
helm template . --set config.affiliations.org0={paris} | grep affiliations: --after-context=5
    affiliations:
        org0:
    - paris
    org1: []
```
```
# After the fix
helm template . --set config.affiliations.org0={paris} | grep affiliations: --after-context=5
    affiliations:
      org0:
      - paris
```

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
If you are looking for maintainers I'm currently working daily on hyperledger on Kubernetes and happy to help.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
