### PR TITLE
[stable/ambassador] Add AMBASSADOR_NAMESPACE env var to pro container

### DIFF
--- a/stable/ambassador/Chart.yaml
+++ b/stable/ambassador/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.72.0
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 2.12.1
+version: 2.12.2
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/stable/ambassador/templates/deployment.yaml
+++ b/stable/ambassador/templates/deployment.yaml
@@ -186,6 +186,14 @@ spec:
             value: "{{ .Values.pro.ports.ratelimitDebug }}"
           - name: APP_LOG_LEVEL
             value: "{{ .Values.pro.logLevel  }}"
+          - name: AMBASSADOR_NAMESPACE
+          {{- if .Values.namespace }}
+            value: {{ .Values.namespace.name | quote }}
+          {{ else }}
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          {{- end -}}
           - name: AMBASSADOR_LICENSE_KEY
           {{- if .Values.pro.licenseKey.secret }}
             valueFrom:


### PR DESCRIPTION
Signed-off-by: Ben Pehling <shinjipehling@gmail.com>

#### What this PR does / why we need it:
To configure `AMBASSADOR_NAMESPACE` for the pro container

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
