### PR TITLE
[stable/prometheus-operator] Add option to only deploy ServiceMonitors of subchart components

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -11,7 +11,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 5.15.0
+version: 5.15.1
 appVersion: 0.31.1
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -309,7 +309,8 @@ The following tables list the configurable parameters of the prometheus-operator
 ### Grafana
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
-| `grafana.enabled` | If true, deploy the grafana sub-chart | `true` |
+| `grafana.enabled` | If true, deploy the `serviceMonitor`for Grafana | `true` |
+| `grafana.deployed` | If true, deploy the grafana sub-chart | `true` |
 | `grafana.serviceMonitor.selfMonitor` | Create a `serviceMonitor` to automatically monitor the grafana instance | `true` |
 | `grafana.serviceMonitor.metricRelabelings` | The `metric_relabel_configs` for scraping the grafana instance. | `` |
 | `grafana.serviceMonitor.relabelings` | The `relabel_configs` for scraping the grafana instance. | `` |
@@ -397,13 +398,15 @@ The following tables list the configurable parameters of the prometheus-operator
 | `kubeScheduler.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
 | `kubeScheduler.serviceMonitor.metricRelabelings` | The `metric_relabel_configs` for scraping the Kubernetes scheduler. | `` |
 | `kubeScheduler.serviceMonitor.relabelings` | The `relabel_configs` for scraping the Kubernetes scheduler. | `` |
-| `kubeStateMetrics.enabled` | Deploy the `kube-state-metrics` chart and configure a servicemonitor to scrape | `true` |
+| `kubeStateMetrics.enabled` | If true, deploy the `serviceMonitor` for kube-state-metrics | `true` |
+| `kubeStateMetrics.deployed` | Deploy the `kube-state-metrics` sub-chart | `true` |
 | `kubeStateMetrics.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
 | `kubeStateMetrics.serviceMonitor.metricRelabelings` | Metric relablings for the `kube-state-metrics` ServiceMonitor | `[]` |
 | `kubeStateMetrics.serviceMonitor.relabelings` | The `relabel_configs` for scraping `kube-state-metrics`. | `` |
 | `kube-state-metrics.rbac.create` | Create RBAC components in kube-state-metrics. See `global.rbac.create` | `true` |
 | `kube-state-metrics.podSecurityPolicy.enabled` | Create pod security policy resource for kube-state-metrics. | `true` |
-| `nodeExporter.enabled` | Deploy the `prometheus-node-exporter` and scrape it | `true` |
+| `nodeExporter.enabled` | If true, deploy the `serviceMonitor`for node exporter | `true` |
+| `nodeExporter.deployed` | Deploy the `prometheus-node-exporter` sub-chart | `true` |
 | `nodeExporter.jobLabel` | The name of the label on the target service to use as the job name in prometheus. See `prometheus-node-exporter.podLabels.jobLabel=node-exporter` default | `jobLabel` |
 | `nodeExporter.serviceMonitor.metricRelabelings` | Metric relablings for the `prometheus-node-exporter` ServiceMonitor | `[]` |
 | `nodeExporter.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -313,6 +313,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `grafana.deployed` | If true, deploy the grafana sub-chart | `true` |
 | `grafana.serviceMonitor.selfMonitor` | Create a `serviceMonitor` to automatically monitor the grafana instance | `true` |
 | `grafana.serviceMonitor.metricRelabelings` | The `metric_relabel_configs` for scraping the grafana instance. | `` |
+| `grafana.serviceMonitor.namespaceSelector` | Select namespace where `grafana` is deployed | `""` |
 | `grafana.serviceMonitor.relabelings` | The `relabel_configs` for scraping the grafana instance. | `` |
 | `grafana.additionalDataSources` | Configure additional grafana datasources | `[]` |
 | `grafana.adminPassword` | Admin password to log into the grafana UI | "prom-operator" |
@@ -402,6 +403,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `kubeStateMetrics.deployed` | Deploy the `kube-state-metrics` sub-chart | `true` |
 | `kubeStateMetrics.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
 | `kubeStateMetrics.serviceMonitor.metricRelabelings` | Metric relablings for the `kube-state-metrics` ServiceMonitor | `[]` |
+| `kubeStateMetrics.serviceMonitor.namespaceSelector` | Select namespace where `kube-state-metrics` is deployed | `""` |
 | `kubeStateMetrics.serviceMonitor.relabelings` | The `relabel_configs` for scraping `kube-state-metrics`. | `` |
 | `kube-state-metrics.rbac.create` | Create RBAC components in kube-state-metrics. See `global.rbac.create` | `true` |
 | `kube-state-metrics.podSecurityPolicy.enabled` | Create pod security policy resource for kube-state-metrics. | `true` |
@@ -410,6 +412,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `nodeExporter.jobLabel` | The name of the label on the target service to use as the job name in prometheus. See `prometheus-node-exporter.podLabels.jobLabel=node-exporter` default | `jobLabel` |
 | `nodeExporter.serviceMonitor.metricRelabelings` | Metric relablings for the `prometheus-node-exporter` ServiceMonitor | `[]` |
 | `nodeExporter.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
+| `nodeExporter.serviceMonitor.namespaceSelector` | Select namespace where `node-exporter` is deployed | `""` |
 | `nodeExporter.serviceMonitor.relabelings` | The `relabel_configs` for scraping the `prometheus-node-exporter`. | `` |
 | `prometheus-node-exporter.podLabels` | Additional labels for pods in the DaemonSet | `{"jobLabel":"node-exporter"}` |
 | `prometheus-node-exporter.extraArgs` | Additional arguments for the node exporter container | `["--collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)", "--collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$"]` |

--- a/stable/prometheus-operator/ci/test-values.yaml
+++ b/stable/prometheus-operator/ci/test-values.yaml
@@ -364,6 +364,7 @@ alertmanager:
 ##
 grafana:
   enabled: true
+  deployed: true
 
   ## Deploy default dashboards.
   ##
@@ -788,6 +789,7 @@ kubeScheduler:
 ##
 kubeStateMetrics:
   enabled: true
+  deployed: true
   serviceMonitor:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
@@ -822,6 +824,7 @@ kube-state-metrics:
 ##
 nodeExporter:
   enabled: true
+  deployed: true
 
   ## Use the value configured in prometheus-node-exporter.podLabels
   ##

--- a/stable/prometheus-operator/requirements.lock
+++ b/stable/prometheus-operator/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.6.3
+  version: 1.6.5
 - name: prometheus-node-exporter
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.5.0
+  version: 1.5.1
 - name: grafana
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 3.3.10
-digest: sha256:7e2bb81348c99897fca9fffd21c0a2e5bbbd93200a249fabe4c1576b700f43de
-generated: 2019-06-01T00:40:22.8458175+01:00
+  version: 3.3.11
+digest: sha256:37e64568ddd781b6c1555dc9fa283c5397123bc2b6825833d59ca16fb5f311c9
+generated: 2019-07-10T17:59:08.041968+02:00

--- a/stable/prometheus-operator/requirements.yaml
+++ b/stable/prometheus-operator/requirements.yaml
@@ -3,14 +3,14 @@ dependencies:
   - name: kube-state-metrics
     version: 1.6.*
     repository: https://kubernetes-charts.storage.googleapis.com/
-    condition: kubeStateMetrics.enabled
+    condition: kubeStateMetrics.deployed
 
   - name: prometheus-node-exporter
     version: 1.5.*
     repository: https://kubernetes-charts.storage.googleapis.com/
-    condition: nodeExporter.enabled
+    condition: nodeExporter.deployed
 
   - name: grafana
     version: 3.3.*
     repository: https://kubernetes-charts.storage.googleapis.com/
-    condition: grafana.enabled
+    condition: grafana.deployed

--- a/stable/prometheus-operator/templates/exporters/kube-state-metrics/serviceMonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-state-metrics/serviceMonitor.yaml
@@ -25,5 +25,7 @@ spec:
   selector:
     matchLabels:
       app: kube-state-metrics
+      {{- if .Values.kubeStateMetrics.deployed }}
       release: "{{ .Release.Name }}"
+      {{- end }}
 {{- end }}

--- a/stable/prometheus-operator/templates/exporters/kube-state-metrics/serviceMonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-state-metrics/serviceMonitor.yaml
@@ -8,6 +8,11 @@ metadata:
 {{ include "prometheus-operator.labels" . | indent 4 }}
 spec:
   jobLabel: app
+  {{- if not (eq .Values.kubeStateMetrics.serviceMonitor.namespaceSelector "") }}
+  namespaceSelector:
+    matchNames:
+      - "{{ .Values.kubeStateMetrics.serviceMonitor.namespaceSelector }}"
+  {{- end }}
   endpoints:
   - port: http
     {{- if .Values.kubeStateMetrics.serviceMonitor.interval }}

--- a/stable/prometheus-operator/templates/exporters/node-exporter/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/node-exporter/servicemonitor.yaml
@@ -14,6 +14,11 @@ spec:
       {{- if .Values.nodeExporter.deployed }}
       release: "{{ .Release.Name }}"
       {{- end }}
+  {{- if not (eq .Values.nodeExporter.serviceMonitor.namespaceSelector "") }}
+  namespaceSelector:
+    matchNames:
+      - "{{ .Values.nodeExporter.serviceMonitor.namespaceSelector }}"
+  {{- end }}
   endpoints:
   - port: metrics
     {{- if .Values.nodeExporter.serviceMonitor.interval }}

--- a/stable/prometheus-operator/templates/exporters/node-exporter/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/node-exporter/servicemonitor.yaml
@@ -11,7 +11,9 @@ spec:
   selector:
     matchLabels:
       app: prometheus-node-exporter
-      release: {{ .Release.Name }}
+      {{- if .Values.nodeExporter.deployed }}
+      release: "{{ .Release.Name }}"
+      {{- end }}
   endpoints:
   - port: metrics
     {{- if .Values.nodeExporter.serviceMonitor.interval }}

--- a/stable/prometheus-operator/templates/grafana/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/grafana/servicemonitor.yaml
@@ -10,7 +10,9 @@ spec:
   selector:
     matchLabels:
       app: grafana
-      release: {{ .Release.Name | quote }}
+      {{- if .Values.grafana.deployed }}
+      release: "{{ .Release.Name }}"
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}

--- a/stable/prometheus-operator/templates/grafana/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/grafana/servicemonitor.yaml
@@ -13,9 +13,15 @@ spec:
       {{- if .Values.grafana.deployed }}
       release: "{{ .Release.Name }}"
       {{- end }}
+  {{- if not (eq .Values.grafana.serviceMonitor.namespaceSelector "") }}
+  namespaceSelector:
+    matchNames:
+      - "{{ .Values.grafana.serviceMonitor.namespaceSelector }}"
+  {{- else }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}
+  {{- end }}
   endpoints:
   - port: service
     {{- if .Values.grafana.serviceMonitor.interval }}

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -451,6 +451,10 @@ grafana:
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
 
+    ## Namespace selector. In case grafana run in a different namespace.
+    ##
+    namespaceSelector: ""
+
     # 	relabel configs to apply to samples before ingestion.
     ##
     relabelings: []
@@ -802,6 +806,10 @@ kubeStateMetrics:
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
 
+    ## Namespace selector. In case kube-state-metrics run in a different namespace.
+    ##
+    namespaceSelector: ""
+
     # 	relabel configs to apply to samples before ingestion.
     ##
     relabelings: []
@@ -843,6 +851,10 @@ nodeExporter:
     #   regex: ^node_mountstats_nfs_(event|operations|transport)_.+
     #   replacement: $1
     #   action: drop
+
+    ## Namespace selector. In case node operator run in a different namespace.
+    ##
+    namespaceSelector: ""
 
     ## 	relabel configs to apply to samples before ingestion.
     ##

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -364,6 +364,7 @@ alertmanager:
 ##
 grafana:
   enabled: true
+  deployed: true
 
   ## Deploy default dashboards.
   ##
@@ -788,6 +789,7 @@ kubeScheduler:
 ##
 kubeStateMetrics:
   enabled: true
+  deployed: true
   serviceMonitor:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
@@ -822,6 +824,7 @@ kube-state-metrics:
 ##
 nodeExporter:
   enabled: true
+  deployed: true
 
   ## Use the value configured in prometheus-node-exporter.podLabels
   ##


### PR DESCRIPTION
#### What this PR does / why we need it:

Add an option in values to allow only deploying the ServiceMonitors of sub-components (kube-state-metrics and node-exporter). It allows to have already in your cluster those components and dont have to duplicate them.

#### Which issue this PR fixes

  - None

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)