### PR TITLE
[stable/concourse]: Add a default prefix

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 8.0.2
+version: 8.1.0
 appVersion: 5.3.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -170,7 +170,6 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.ingress.hosts` | Concourse Web Ingress Hostnames | `[]` |
 | `web.ingress.tls` | Concourse Web Ingress TLS configuration | `[]` |
 | `web.keySecretsPath` | Specify the mount directory of the web keys secrets | `/concourse-keys` |
-| `web.labels`| Additional labels to be added to the web pods | `{}` |
 | `web.labels`| Additional labels to be added to the worker pods | `{}` |
 | `web.livenessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded | `5` |
 | `web.livenessProbe.httpGet.path` | Path to access on the HTTP server when performing the healthcheck | `/api/v1/info` |

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -160,6 +160,10 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.authSecretsPath` | Specify the mount directory of the web auth secrets | `/concourse-auth` |
 | `web.credhubSecretsPath` | Specify the mount directory of the web credhub secrets | `/concourse-credhub` |
 | `web.enabled` | Enable or disable the web component | `true` |
+| `web.datadog.agentHostUseHostIP` | Use IP of Pod's node overrides `agentHost` | `false` |
+| `web.datadog.agentHost` | Datadog Agent host | `127.0.0.1` |
+| `web.datadog.enabled` | Enable or disable Datadog metrics | `false` |
+| `web.datadog.prefix` | Prefix for emitted metrics | `"concourse.ci"` |
 | `web.env` | Configure additional environment variables for the web containers | `[]` |
 | `web.ingress.annotations` | Concourse Web Ingress annotations | `{}` |
 | `web.ingress.enabled` | Enable Concourse Web Ingress | `false` |

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -155,22 +155,23 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.additionalAffinities` | Additional affinities to apply to web pods. E.g: node affinity | `{}` |
 | `web.additionalVolumeMounts` | VolumeMounts to be added to the web pods | `nil` |
 | `web.additionalVolumes` | Volumes to be added to the web pods | `nil` |
-| `web.labels`| Additional labels to be added to the web pods | `{}` |
 | `web.annotations`| Annotations to be added to the web pods | `{}` |
 | `web.authSecretsPath` | Specify the mount directory of the web auth secrets | `/concourse-auth` |
 | `web.credhubSecretsPath` | Specify the mount directory of the web credhub secrets | `/concourse-credhub` |
-| `web.enabled` | Enable or disable the web component | `true` |
-| `web.datadog.enabled` | Enable or disable Datadog metrics | `false` |
 | `web.datadog.agentHostUseHostIP` | Use IP of Pod's node overrides `agentHost` | `false` |
-| `web.datadog.agentPort` | Datadog Agent port | `8125` |
 | `web.datadog.agentHost` | Datadog Agent host | `127.0.0.1` |
+| `web.datadog.agentPort` | Datadog Agent port | `8125` |
+| `web.datadog.enabled` | Enable or disable Datadog metrics | `false` |
 | `web.datadog.prefix` | Prefix for emitted metrics | `"concourse.ci"` |
+| `web.enabled` | Enable or disable the web component | `true` |
 | `web.env` | Configure additional environment variables for the web containers | `[]` |
 | `web.ingress.annotations` | Concourse Web Ingress annotations | `{}` |
 | `web.ingress.enabled` | Enable Concourse Web Ingress | `false` |
 | `web.ingress.hosts` | Concourse Web Ingress Hostnames | `[]` |
 | `web.ingress.tls` | Concourse Web Ingress TLS configuration | `[]` |
 | `web.keySecretsPath` | Specify the mount directory of the web keys secrets | `/concourse-keys` |
+| `web.labels`| Additional labels to be added to the web pods | `{}` |
+| `web.labels`| Additional labels to be added to the worker pods | `{}` |
 | `web.livenessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded | `5` |
 | `web.livenessProbe.httpGet.path` | Path to access on the HTTP server when performing the healthcheck | `/api/v1/info` |
 | `web.livenessProbe.httpGet.port` | Name or number of the port to access on the container | `atc` |
@@ -183,7 +184,6 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.readinessProbe.httpGet.path` | Path to access on the HTTP server when performing the healthcheck | `/api/v1/info` |
 | `web.readinessProbe.httpGet.port` | Name or number of the port to access on the container | `atc` |
 | `web.replicas` | Number of Concourse Web replicas | `1` |
-| `web.strategy` | Strategy for updates to deployment. | `{}` |
 | `web.resources.requests.cpu` | Minimum amount of cpu resources requested | `100m` |
 | `web.resources.requests.memory` | Minimum amount of memory resources requested | `128Mi` |
 | `web.service.annotations` | Concourse Web Service annotations | `nil` |
@@ -195,6 +195,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.service.tsaNodePort` | Sets the nodePort for tsa when using `NodePort` | `nil` |
 | `web.service.type` | Concourse Web service type | `ClusterIP` |
 | `web.sidecarContainers` | Array of extra containers to run alongside the Concourse web container | `nil` |
+| `web.strategy` | Strategy for updates to deployment. | `{}` |
 | `web.syslogSecretsPath` | Specify the mount directory of the web syslog secrets | `/concourse-syslog` |
 | `web.tlsSecretsPath` | Where in the container the web TLS secrets should be mounted | `/concourse-web-tls` |
 | `web.tolerations` | Tolerations for the web nodes | `[]` |
@@ -202,7 +203,6 @@ The following table lists the configurable parameters of the Concourse chart and
 | `worker.additionalAffinities` | Additional affinities to apply to worker pods. E.g: node affinity | `{}` |
 | `worker.additionalVolumeMounts` | VolumeMounts to be added to the worker pods | `nil` |
 | `worker.additionalVolumes` | Volumes to be added to the worker pods | `nil` |
-| `web.labels`| Additional labels to be added to the worker pods | `{}` |
 | `worker.annotations` | Annotations to be added to the worker pods | `{}` |
 | `worker.cleanUpWorkDirOnStart` | Removes any previous state created in `concourse.worker.workDir` | `true` |
 | `worker.emptyDirSize` | When persistance is disabled this value will be used to limit the emptyDir volume size | `nil` |

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -160,9 +160,10 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.authSecretsPath` | Specify the mount directory of the web auth secrets | `/concourse-auth` |
 | `web.credhubSecretsPath` | Specify the mount directory of the web credhub secrets | `/concourse-credhub` |
 | `web.enabled` | Enable or disable the web component | `true` |
-| `web.datadog.agentHostUseHostIP` | Use IP of Pod's node overrides `agentHost` | `false` |
-| `web.datadog.agentHost` | Datadog Agent host | `127.0.0.1` |
 | `web.datadog.enabled` | Enable or disable Datadog metrics | `false` |
+| `web.datadog.agentHostUseHostIP` | Use IP of Pod's node overrides `agentHost` | `false` |
+| `web.datadog.agentPort` | Datadog Agent port | `8125` |
+| `web.datadog.agentHost` | Datadog Agent host | `127.0.0.1` |
 | `web.datadog.prefix` | Prefix for emitted metrics | `"concourse.ci"` |
 | `web.env` | Configure additional environment variables for the web containers | `[]` |
 | `web.ingress.annotations` | Concourse Web Ingress annotations | `{}` |

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -496,7 +496,7 @@ concourse:
 
       ## Prefix for all metrics to easily find them in Datadog
       ##
-      prefix:
+      prefix: "concourse.ci"
 
     influxdb:
       enabled: false


### PR DESCRIPTION
This commit adds a default value for prefix, per reference:
https://docs.datadoghq.com/integrations/concourse_ci/.
It avoids emitting custom metrics.

Signed-off-by: Zabielski, Kamil <kamil.zabielski@lintops.tech>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
