### PR TITLE
[stable/wordpress] Standardize 'fullname' and 'name' macros

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 5.13.0
+version: 5.13.1
 appVersion: 5.2.2
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -56,6 +56,8 @@ The following table lists the configurable parameters of the WordPress chart and
 | `image.tag`                      | WordPress image tag                                                           | `{TAG_NAME}`                                                 |
 | `image.pullPolicy`               | Image pull policy                                                             | `IfNotPresent`                                               |
 | `image.pullSecrets`              | Specify docker-registry secret names as an array                              | `[]` (does not add image pull secrets to deployed pods)      |
+| `nameOverride`                   | String to partially override wordpress.fullname template with a string (will prepend the release name) | `nil`                               |
+| `fullnameOverride`               | String to fully override wordpress.fullname template with a string                                     | `nil`                               |
 | `wordpressSkipInstall`           | Skip wizard installation                                                      | `false`                                                      |
 | `wordpressUsername`              | User of the application                                                       | `user`                                                       |
 | `wordpressPassword`              | Application password                                                          | _random 10 character long alphanumeric string_               |

--- a/stable/wordpress/templates/_helpers.tpl
+++ b/stable/wordpress/templates/_helpers.tpl
@@ -11,10 +11,17 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "wordpress.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
+{{- end -}}
+{{- end -}}
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).

--- a/stable/wordpress/values-production.yaml
+++ b/stable/wordpress/values-production.yaml
@@ -26,6 +26,14 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## String to partially override wordpress.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override wordpress.fullname template
+##
+# fullnameOverride:
+
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
 ##

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -26,6 +26,14 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## String to partially override wordpress.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override wordpress.fullname template
+##
+# fullnameOverride:
+
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
 ##


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR standardize 'fullname' and 'name' macros.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
