### PR TITLE
[stable/phpmyadmin] Standardize 'fullname' and 'name' macros

### DIFF
--- a/stable/phpmyadmin/Chart.yaml
+++ b/stable/phpmyadmin/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: phpmyadmin
-version: 2.2.5
+version: 2.2.6
 appVersion: 4.9.0-1
 description: phpMyAdmin is an mysql administration frontend
 keywords:

--- a/stable/phpmyadmin/README.md
+++ b/stable/phpmyadmin/README.md
@@ -44,39 +44,41 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the phpMyAdmin chart and their default values.
 
-|         Parameter          |               Description                |                         Default                         |
-|----------------------------|------------------------------------------|---------------------------------------------------------|
-| `global.imageRegistry`     | Global Docker image registry             | `nil`                                                   |
-| `global.imagePullSecrets`  | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
-| `image.registry`           | phpMyAdmin image registry                | `docker.io`                                             |
-| `image.repository`         | phpMyAdmin image name                    | `bitnami/phpmyadmin`                                    |
-| `image.tag`                | phpMyAdmin image tag                     | `{TAG_NAME}`                                            |
-| `image.pullPolicy`         | Image pull policy                        | `IfNotPresent`                                          |
-| `image.pullSecrets`        | Specify docker-registry secret names as an array               | `[]` (does not add image pull secrets to deployed pods)                                                   |
-| `service.type`             | Type of service for phpMyAdmin frontend  | `ClusterIP`                                             |
-| `service.port`             | Port to expose service                   | `80`                                                    |
-| `db.port`                  | Database port to use to connect          | `3306`                                                  |
-| `db.chartName`             | Database suffix if included in the same release | `nil`                                            |
-| `db.host`                  | Database host to connect to              | `nil`                                                   |
-| `db.bundleTestDB`                  | Deploy a MariaDB instance for testing purposes              | `false`                                                   |
-| `ingress.enabled`          | Ingress resource to be added             | `false`                                                 |
-| `ingress.annotations`      | Ingress annotations                      | `{ingress.kubernetes.io/rewrite-target: /,    nginx.ingress.kubernetes.io/rewrite-target: /}`          |
-| `ingress.path`             | Path to access frontend                  | `/`                                                     |
-| `ingress.host`             | Ingress host                             | `nil`                                                   |
-| `ingress.tls`              | TLS for ingress                          | `[]`                                                    |
-| `resources`                | CPU/Memory resource requests/limits      | `{}`                                                    |
-| `nodeSelector`             | Node labels for pod assignment           | `{}`                                                    |
-| `tolerations`              | List of node taints to tolerate          | `[]`                                                    |
-| `affinity`                 | Map of node/pod affinities               | `{}`                                                    |
-| `podAnnotations`                | Pod annotations                                   | `{}`                                                       |
-| `metrics.enabled`                          | Start a side-car prometheus exporter                                                                           | `false`                                              |
-| `metrics.image.registry`                   | Apache exporter image registry                                                                                  | `docker.io`                                          |
-| `metrics.image.repository`                 | Apache exporter image name                                                                                      | `lusotycoon/apache-exporter`                           |
-| `metrics.image.tag`                        | Apache exporter image tag                                                                                       | `v0.5.0`                                            |
-| `metrics.image.pullPolicy`                 | Image pull policy                                                                                              | `IfNotPresent`                                       |
-| `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                                               | `[]` (does not add image pull secrets to deployed pods)  |
-| `metrics.podAnnotations`                   | Additional annotations for Metrics exporter pod                                                                | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}`                                                   |
-| `metrics.resources`                        | Exporter resource requests/limit                                                                               | {}                        |
+|         Parameter           |               Description                         |                         Default                         |
+|-----------------------------|---------------------------------------------------|---------------------------------------------------------|
+| `global.imageRegistry`      | Global Docker image registry                      | `nil`                                                   |
+| `global.imagePullSecrets`   | Global Docker registry secret names as an array   | `[]` (does not add image pull secrets to deployed pods) |
+| `image.registry`            | phpMyAdmin image registry                         | `docker.io`                                             |
+| `image.repository`          | phpMyAdmin image name                             | `bitnami/phpmyadmin`                                    |
+| `image.tag`                 | phpMyAdmin image tag                              | `{TAG_NAME}`                                            |
+| `image.pullPolicy`          | Image pull policy                                 | `IfNotPresent`                                          |
+| `image.pullSecrets`         | Specify docker-registry secret names as an array  | `[]` (does not add image pull secrets to deployed pods) |
+| `nameOverride`              | String to partially override phpmyadmin.fullname template with a string (will prepend the release name) | `nil` |
+| `fullnameOverride`          | String to fully override phpmyadmin.fullname template with a string                                     | `nil` |
+| `service.type`              | Type of service for phpMyAdmin frontend           | `ClusterIP`                                             |
+| `service.port`              | Port to expose service                            | `80`                                                    |
+| `db.port`                   | Database port to use to connect                   | `3306`                                                  |
+| `db.chartName`              | Database suffix if included in the same release   | `nil`                                                   |
+| `db.host`                   | Database host to connect to                       | `nil`                                                   |
+| `db.bundleTestDB`           | Deploy a MariaDB instance for testing purposes    | `false`                                                 |
+| `ingress.enabled`           | Ingress resource to be added                      | `false`                                                 |
+| `ingress.annotations`       | Ingress annotations                               | `{ingress.kubernetes.io/rewrite-target: /,    nginx.ingress.kubernetes.io/rewrite-target: /}` |
+| `ingress.path`              | Path to access frontend                           | `/`                                                     |
+| `ingress.host`              | Ingress host                                      | `nil`                                                   |
+| `ingress.tls`               | TLS for ingress                                   | `[]`                                                    |
+| `resources`                 | CPU/Memory resource requests/limits               | `{}`                                                    |
+| `nodeSelector`              | Node labels for pod assignment                    | `{}`                                                    |
+| `tolerations`               | List of node taints to tolerate                   | `[]`                                                    |
+| `affinity`                  | Map of node/pod affinities                        | `{}`                                                    |
+| `podAnnotations`            | Pod annotations                                   | `{}`                                                    |
+| `metrics.enabled`           | Start a side-car prometheus exporter              | `false`                                                 |
+| `metrics.image.registry`    | Apache exporter image registry                    | `docker.io`                                             |
+| `metrics.image.repository`  | Apache exporter image name                        | `lusotycoon/apache-exporter`                            |
+| `metrics.image.tag`         | Apache exporter image tag                         | `v0.5.0`                                                |
+| `metrics.image.pullPolicy`  | Image pull policy                                 | `IfNotPresent`                                          |
+| `metrics.image.pullSecrets` | Specify docker-registry secret names as an array  | `[]` (does not add image pull secrets to deployed pods) |
+| `metrics.podAnnotations`    | Additional annotations for Metrics exporter pod   | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
+| `metrics.resources`         | Exporter resource requests/limit                  | {}                                                      |
 
 For more information please refer to the [bitnami/phpmyadmin](http://github.com/bitnami/bitnami-docker-Phpmyadmin) image documentation.
 

--- a/stable/phpmyadmin/values.yaml
+++ b/stable/phpmyadmin/values.yaml
@@ -23,6 +23,14 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## String to partially override phpmyadmin.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override phpmyadmin.fullname template
+##
+# fullnameOverride:
+
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-phpmyadmin#environment-variables
 ##


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR standardize 'fullname' and 'name' macros.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
