### PR TITLE
[stable/owncloud] Standardize 'fullname' and 'name' macros

### DIFF
--- a/stable/owncloud/Chart.yaml
+++ b/stable/owncloud/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: owncloud
-version: 4.3.4
-appVersion: 10.2.2
+version: 4.3.5
+appVersion: 10.2.1
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
 - owncloud

--- a/stable/owncloud/Chart.yaml
+++ b/stable/owncloud/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: owncloud
 version: 4.3.4
-appVersion: 10.2.1
+appVersion: 10.2.2
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
 - owncloud

--- a/stable/owncloud/README.md
+++ b/stable/owncloud/README.md
@@ -56,6 +56,8 @@ The following table lists the configurable parameters of the ownCloud chart and 
 | `image.tag`                         | ownCloud Image tag                         | `{TAG_NAME}`                                            |
 | `image.pullPolicy`                  | Image pull policy                          | `IfNotPresent`                                          |
 | `image.pullSecrets`                 | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
+| `nameOverride`                      | String to partially override owncloud.fullname template with a string (will prepend the release name) | `nil` |
+| `fullnameOverride`                  | String to fully override owncloud.fullname template with a string                                     | `nil` |
 | `ingress.enabled`                   | Enable ingress controller resource         | `false`                                                 |
 | `ingress.hosts[0].name`             | Hostname to your ownCloud installation     | `owncloud.local`                                        |
 | `ingress.hosts[0].path`             | Path within the url structure              | `/`                                                     |
@@ -91,15 +93,15 @@ The following table lists the configurable parameters of the ownCloud chart and 
 | `persistence.owncloud.accessMode`   | PVC Access Mode for ownCloud volume        | `ReadWriteOnce`                                         |
 | `persistence.owncloud.size`         | PVC Storage Request for ownCloud volume    | `8Gi`                                                   |
 | `resources`                         | CPU/Memory resource requests/limits        | Memory: `512Mi`, CPU: `300m`                            |
-| `podAnnotations`                | Pod annotations                                   | `{}`                                                       |
-| `metrics.enabled`                          | Start a side-car prometheus exporter                                                                           | `false`                                              |
-| `metrics.image.registry`                   | Apache exporter image registry                                                                                  | `docker.io`                                          |
-| `metrics.image.repository`                 | Apache exporter image name                                                                                      | `lusotycoon/apache-exporter`                           |
-| `metrics.image.tag`                        | Apache exporter image tag                                                                                       | `v0.5.0`                                            |
-| `metrics.image.pullPolicy`                 | Image pull policy                                                                                              | `IfNotPresent`                                       |
-| `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                                               | `[]` (does not add image pull secrets to deployed pods)  |
-| `metrics.podAnnotations`                   | Additional annotations for Metrics exporter pod                                                                | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}`                                                   |
-| `metrics.resources`                        | Exporter resource requests/limit                                                                               | {}                        |
+| `podAnnotations`                    | Pod annotations                            | `{}`                                                    |
+| `metrics.enabled`                   | Start a side-car prometheus exporter       | `false`                                                 |
+| `metrics.image.registry`            | Apache exporter image registry             | `docker.io`                                             |
+| `metrics.image.repository`          | Apache exporter image name                 | `lusotycoon/apache-exporter`                            |
+| `metrics.image.tag`                 | Apache exporter image tag                  | `v0.5.0`                                                |
+| `metrics.image.pullPolicy`          | Image pull policy                          | `IfNotPresent`                                          |
+| `metrics.image.pullSecrets`         | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)  |
+| `metrics.podAnnotations`            | Additional annotations for Metrics exporter pod  | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
+| `metrics.resources`                 | Exporter resource requests/limit           | {}                                                      |
 
 The above parameters map to the env variables defined in [bitnami/owncloud](http://github.com/bitnami/bitnami-docker-owncloud). For more information please refer to the [bitnami/owncloud](http://github.com/bitnami/bitnami-docker-owncloud) image documentation.
 

--- a/stable/owncloud/templates/_helpers.tpl
+++ b/stable/owncloud/templates/_helpers.tpl
@@ -11,8 +11,16 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "owncloud.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/owncloud/values.yaml
+++ b/stable/owncloud/values.yaml
@@ -26,6 +26,14 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## String to partially override owncloud.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override owncloud.fullname template
+##
+# fullnameOverride:
+
 ## For Kubernetes v1.4, v1.5 and v1.6, use 'extensions/v1beta1'
 ## For Kubernetes v1.7, use 'networking.k8s.io/v1'
 networkPolicyApiVersion: extensions/v1beta1


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR standardize 'fullname' and 'name' macros.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)