### PR TITLE
[stable/osclass] Standardize 'fullname' and 'name' macros

### DIFF
--- a/stable/osclass/Chart.yaml
+++ b/stable/osclass/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: osclass
-version: 4.4.3
+version: 4.4.4
 appVersion: 3.7.4
 description: Osclass is a php script that allows you to quickly create and manage
   your own free classifieds site.

--- a/stable/osclass/README.md
+++ b/stable/osclass/README.md
@@ -56,6 +56,8 @@ The following table lists the configurable parameters of the Osclass chart and t
 | `image.tag`                        | Osclass Image tag                        | `{TAG_NAME}`                                            |
 | `image.pullPolicy`                 | Image pull policy                        | `IfNotPresent`                                          |
 | `image.pullSecrets`                | Specify docker-registry secret names as an array               | `[]` (does not add image pull secrets to deployed pods) |
+| `nameOverride`                     | String to partially override osclass.fullname template with a string (will prepend the release name) | `nil` |
+| `fullnameOverride`                 | String to fully override osclass.fullname template with a string                                     | `nil` |
 | `osclassHost`                      | Osclass host to create application URLs  | `nil`                                                   |
 | `osclassLoadBalancerIP`            | `loadBalancerIP` for the Osclass Service | `nil`                                                   |
 | `osclassUsername`                  | User of the application                  | `user`                                                  |

--- a/stable/osclass/templates/_helpers.tpl
+++ b/stable/osclass/templates/_helpers.tpl
@@ -11,9 +11,18 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "osclass.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+{{- end -}}
+{{- end -}}
+
 
 {{/*
 Create a default fully qualified app name.

--- a/stable/osclass/values.yaml
+++ b/stable/osclass/values.yaml
@@ -26,6 +26,14 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## String to partially override osclass.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override osclass.fullname template
+##
+# fullnameOverride:
+
 ## Osclass host to create application URLs
 ## ref: https://github.com/bitnami/bitnami-docker-osclass#configuration
 ##


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR standardize 'fullname' and 'name' macros.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)