### PR TITLE
[stable/orangehrm] Standardize 'fullname' and 'name' macros

### DIFF
--- a/stable/orangehrm/Chart.yaml
+++ b/stable/orangehrm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: orangehrm
-version: 4.4.4
+version: 4.4.5
 appVersion: 4.3.2-0
 description: OrangeHRM is a free HR management system that offers a wealth of modules
   to suit the needs of your business.

--- a/stable/orangehrm/README.md
+++ b/stable/orangehrm/README.md
@@ -56,6 +56,8 @@ The following table lists the configurable parameters of the OrangeHRM chart and
 | `image.tag`                          | OrangeHRM Image tag                      | `{TAG_NAME}`                                            |
 | `image.pullPolicy`                   | Image pull policy                        | `IfNotPresent`                                          |
 | `image.pullSecrets`                  | Specify docker-registry secret names as an array               | `[]` (does not add image pull secrets to deployed pods) |
+| `nameOverride`                       | String to partially override orangehrm.fullname template with a string (will prepend the release name) | `nil` |
+| `fullnameOverride`                   | String to fully override orangehrm.fullname template with a string                                     | `nil` |
 | `orangehrmUsername`                  | User of the application                  | `user`                                                  |
 | `orangehrmPassword`                  | Application password                     | _random 10 character long alphanumeric string_          |
 | `smtpHost`                           | SMTP host                                | `nil`                                                   |

--- a/stable/orangehrm/templates/_helpers.tpl
+++ b/stable/orangehrm/templates/_helpers.tpl
@@ -11,8 +11,16 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "orangehrm.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/orangehrm/values.yaml
+++ b/stable/orangehrm/values.yaml
@@ -26,6 +26,14 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## String to partially override orangehrm.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override orangehrm.fullname template
+##
+# fullnameOverride:
+
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-orangehrm#configuration
 ##


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR standardize 'fullname' and 'name' macros.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)