### PR TITLE
[stable/nats] Standardize 'fullname' and 'name' macros

### DIFF
--- a/stable/nats/Chart.yaml
+++ b/stable/nats/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nats
-version: 3.0.1
+version: 3.0.2
 appVersion: 2.0.0
 description: An open-source, cloud-native messaging system
 keywords:

--- a/stable/nats/README.md
+++ b/stable/nats/README.md
@@ -54,6 +54,8 @@ The following table lists the configurable parameters of the NATS chart and thei
 | `image.tag`                          | NATS Image tag                                                                               | `{TAG_NAME}`                                                  |
 | `image.pullPolicy`                   | Image pull policy                                                                            | `IfNotPresent`                                                |
 | `image.pullSecrets`                  | Specify docker-registry secret names as an array                                             | `[]` (does not add image pull secrets to deployed pods)       |
+| `nameOverride`                       | String to partially override nats.fullname template with a string (will prepend the release name) | `nil`                                                    |
+| `fullnameOverride`                   | String to fully override nats.fullname template with a string                                | `nil`                                                         |
 | `auth.enabled`                       | Switch to enable/disable client authentication                                               | `true`                                                        |
 | `auth.user`                          | Client authentication user                                                                   | `nats_cluster`                                                |
 | `auth.password`                      | Client authentication password                                                               | `random alhpanumeric string (10)`                             |

--- a/stable/nats/templates/_helpers.tpl
+++ b/stable/nats/templates/_helpers.tpl
@@ -12,8 +12,16 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "nats.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "nats.chart" -}}

--- a/stable/nats/values-production.yaml
+++ b/stable/nats/values-production.yaml
@@ -26,6 +26,14 @@ image:
   # pullSecrets:
   #   - name: myRegistryKeySecretName
 
+## String to partially override nats.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override nats.fullname template
+##
+# fullnameOverride:
+
 ## NATS replicas
 replicaCount: 3
 

--- a/stable/nats/values.yaml
+++ b/stable/nats/values.yaml
@@ -26,6 +26,14 @@ image:
   # pullSecrets:
   #   - name: myRegistryKeySecretName
 
+## String to partially override nats.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override nats.fullname template
+##
+# fullnameOverride:
+
 ## NATS replicas
 replicaCount: 1
 


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR standardize 'fullname' and 'name' macros.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)