### PR TITLE
[stable/joomla] Standardize 'fullname' and 'name' macros

### DIFF
--- a/stable/joomla/Chart.yaml
+++ b/stable/joomla/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: joomla
-version: 4.3.6
+version: 4.3.7
 appVersion: 3.9.9
 description: PHP content management system (CMS) for publishing web content
 keywords:

--- a/stable/joomla/README.md
+++ b/stable/joomla/README.md
@@ -56,6 +56,8 @@ The following table lists the configurable parameters of the Joomla! chart and t
 | `image.tag`                          | Joomla! Image tag                                           | `{TAG_NAME}`                                   |
 | `image.pullPolicy`                   | Image pull policy                                           | `Always`                                       |
 | `image.pullSecrets`                  | Specify docker-registry secret names as an array            | `[]` (does not add image pull secrets to deployed pods) |
+| `nameOverride`                       | String to partially override joomla.fullname template with a string (will prepend the release name) | `nil`  |
+| `fullnameOverride`                   | String to fully override joomla.fullname template with a string                                     | `nil`  |
 | `joomlaUsername`                     | User of the application                                     | `user`                                         |
 | `joomlaPassword`                     | Application password                                        | _random 10 character long alphanumeric string_ |
 | `joomlaEmail`                        | Admin email                                                 | `user@example.com`                             |

--- a/stable/joomla/templates/_helpers.tpl
+++ b/stable/joomla/templates/_helpers.tpl
@@ -11,8 +11,16 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "joomla.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/joomla/values.yaml
+++ b/stable/joomla/values.yaml
@@ -26,6 +26,14 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## String to partially override joomla.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override joomla.fullname template
+##
+# fullnameOverride:
+
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-joomla#environment-variables
 ##


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR standardize 'fullname' and 'name' macros.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)