### PR TITLE
[stable/datadog] ensure init scripts run in correct order

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.31.5
+version: 1.31.6
 appVersion: 6.10.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/containers-init.yaml
+++ b/stable/datadog/templates/containers-init.yaml
@@ -11,7 +11,7 @@
   image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
   command: ["bash", "-c"]
   args:
-    - for script in $(find /etc/cont-init.d/ -type f -name '*.sh') ; do bash $script ; done
+    - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
   volumeMounts:
     - name: config
       mountPath: /etc/datadog-agent


### PR DESCRIPTION
Signed-off-by: Joe Hohertz <joe@viafoura.com>

@hkaj @irabinovitch @CharlyF @mfpierre @clamoriniere @xlucas 

#### What this PR does / why we need it:

The init-config container is running a list of scripts prefixed with numbers indicating the order in which they should run. The invocation of these scripts however is NOT sorting the list of scripts to run, resulting in non-deterministic behaviour. 

This was found when we tried switching our OS image, and found different behaviour on different images, and was traced down to this flaw.

IE: an example where we modified it to also print the scripts as it run, yielded this before (meanting an empty datadog.yaml was created initially, where this is meant to only happen if all prior steps did not create one):

```
$ kubectl -n monitoring logs datadog-5klhk init-config
/etc/cont-init.d/01-check-apikey.sh
/etc/cont-init.d/59-defaults.sh
/etc/cont-init.d/60-network-check.sh
/etc/cont-init.d/50-cri.sh
/etc/cont-init.d/50-ecs.sh
/etc/cont-init.d/50-kubernetes.sh
Disabling the apiserver check as leader election is disabled
/etc/cont-init.d/89-copy-customfiles.sh
/etc/cont-init.d/50-mesos.sh
/etc/cont-init.d/51-docker.sh
```

And this fix results in the correct order:

```
$ kubectl -n monitoring logs datadog-hgj6g init-config
/etc/cont-init.d/01-check-apikey.sh
/etc/cont-init.d/50-cri.sh
/etc/cont-init.d/50-ecs.sh
/etc/cont-init.d/50-kubernetes.sh
Disabling the apiserver check as leader election is disabled
/etc/cont-init.d/50-mesos.sh
/etc/cont-init.d/51-docker.sh
/etc/cont-init.d/59-defaults.sh
/etc/cont-init.d/60-network-check.sh
/etc/cont-init.d/89-copy-customfiles.sh
```

#### Which issue this PR fixes

Unknown if any existing PRs are impacted by this.

#### Special notes for your reviewer:

None

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
