### PR TITLE
[stable/seq] Configure liveness and readiness probe values 

### DIFF
--- a/stable/seq/Chart.yaml
+++ b/stable/seq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: seq
-version: 1.0.1
+version: 1.0.2
 appVersion: 5
 description: Seq is the easiest way for development teams to capture, search and visualize structured log events! This page will walk you through the very quick setup process.
 keywords:

--- a/stable/seq/README.md
+++ b/stable/seq/README.md
@@ -5,7 +5,7 @@
 ## TL;DR;
 
 ```bash
-$ helm install seq
+$ helm install stable/seq
 ```
 
 ## Introduction
@@ -43,30 +43,42 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Seq chart and their default values.
 
-|           Parameter           |                Description                        |           Default            |
-|-------------------------------|-------------------------------------------------- |------------------------------|
-| `image.repository`         | Image repository                    | `datalust/seq`                                          |
-| `image.tag`                | Seq image tag. Possible values listed [here](https://hub.docker.com/r/datalust/seq/tags/).| `5`|
-| `image.pullPolicy`         | Image pull policy                   | `IfNotPresent`                                          |
-| `acceptEULA`               | Accept EULA                         | `Y`                                                     |
-| `baseURI`                  | Base URL for ingress/AAD (see values.yaml)|                                                   |
-| `service.type`             | Kubernetes service type             | `ClusterIP`                                             |
-| `service.port`             | Kubernetes port where service is exposed| `5341`                                              |
-| `persistence.enabled`      | Use persistent volume to store data | `true`                                                  |
-| `persistence.size`         | Size of persistent volume claim     | `8Gi`                                                   |
-| `persistence.existingClaim`| Use an existing PVC to persist data | `nil`                                                   |
-| `persistence.storageClass` | Type of persistent volume claim     | `generic`                                               |
-| `persistence.accessMode`   | ReadWriteOnce or ReadOnly           | `ReadWriteOnce`                                         |
-| `persistence.subPath`      | Mount a sub directory of the persistent volume if set | `""`                                  |
-| `resources`                | CPU/Memory resource requests/limits | Memory: `256Mi`, CPU: `100m`                            |
-| `nodeSelector`             | Node labels for pod assignment      | `{}`                                                    |
-| `affinity`                 | Affinity settings for pod assignment | `{}`                                                   |
-| `tolerations`              | Toleration labels for pod assignment | `[]`                                                   |
-| `ingress.enabled`          | Enables Ingress                      | `false`                                                |
-| `ingress.annotations`      | Ingress annotations                  | `{}`                                                   |
-| `ingress.labels`           | Custom labels                        | `{}`                                                   |
-| `ingress.hosts`            | Ingress accepted hostnames           | `[]`                                                   |
-| `ingress.tls`              | Ingress TLS configuration            | `[]`                                                   |
+| Parameter                            | Description                                                                                           | Default         |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------- | --------------- |
+| `image.repository`                   | Image repository                                                                                      | `datalust/seq`  |
+| `image.tag`                          | Seq image tag. Possible values listed [here](https://hub.docker.com/r/datalust/seq/tags/).            | `5`             |
+| `image.pullPolicy`                   | Image pull policy                                                                                     | `IfNotPresent`  |
+| `acceptEULA`                         | Accept EULA                                                                                           | `Y`             |
+| `baseURI`                            | Base URL for ingress/AAD (see values.yaml)                                                            |                 |
+| `service.type`                       | Kubernetes service type                                                                               | `ClusterIP`     |
+| `service.port`                       | Kubernetes port where service is exposed                                                              | `5341`          |
+| `persistence.enabled`                | Use persistent volume to store data                                                                   | `true`          |
+| `persistence.size`                   | Size of persistent volume claim                                                                       | `8Gi`           |
+| `persistence.existingClaim`          | Use an existing PVC to persist data                                                                   | `nil`           |
+| `persistence.storageClass`           | Type of persistent volume claim                                                                       | `generic`       |
+| `persistence.accessMode`             | ReadWriteOnce or ReadOnly                                                                             | `ReadWriteOnce` |
+| `persistence.subPath`                | Mount a sub directory of the persistent volume if set                                                 | `""`            |
+| `resources`                          | CPU/Memory resource requests/limits                                                                   | `{}`            |
+| `nodeSelector`                       | Node labels for pod assignment                                                                        | `{}`            |
+| `affinity`                           | Affinity settings for pod assignment                                                                  | `{}`            |
+| `tolerations`                        | Toleration labels for pod assignment                                                                  | `[]`            |
+| `ingress.enabled`                    | Enables Ingress                                                                                       | `false`         |
+| `ingress.annotations`                | Ingress annotations                                                                                   | `{}`            |
+| `ingress.labels`                     | Custom labels                                                                                         | `{}`            |
+| `ingress.hosts`                      | Ingress accepted hostnames                                                                            | `[]`            |
+| `ingress.tls`                        | Ingress TLS configuration                                                                             | `[]`            |
+| `livenessProbe.enabled`              | Enable/disable the Liveness probe                                                                     | `true`          |
+| `livenessProbe.failureThreshold`     | Minimum consecutive failures for the liveness probe to be considered failed after having succeeded    | `3`             |
+| `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                                              | `0`             |
+| `livenessProbe.periodSeconds`        | How often to perform the liveness probe                                                               | `10`            |
+| `livenessProbe.successThreshold`     | Minimum consecutive successes for the liveness probe to be considered successful after having failed  | `1`             |
+| `livenessProbe.timeoutSeconds`       | When the liveness probe times out                                                                     | `1`             |
+| `readinessProbe.enabled`             | Enable/disable the Readiness probe                                                                    | `true`          |
+| `readinessProbe.failureThreshold`    | Minimum consecutive failures for the readiness probe to be considered failed after having succeeded   | `3`             |
+| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                                             | `0`             |
+| `readinessProbe.periodSeconds`       | How often to perform the readiness probe                                                              | `10`            |
+| `readinessProbe.successThreshold`    | Minimum consecutive successes for the readiness probe to be considered successful after having failed | `1`             |
+| `readinessProbe.timeoutSeconds`      | When the readiness probe times out                                                                    | `1`             |
 
 Some of the parameters above map to the env variables defined in the [Seq DockerHub image](https://hub.docker.com/r/datalust/seq/).
 
@@ -75,13 +87,13 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```bash
 $ helm install --name my-release \
   --set persistence.size=8Gi \
-    seq
+    stable/seq
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml seq
+$ helm install --name my-release -f values.yaml stable/seq
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
@@ -95,9 +107,9 @@ By default, the chart mounts a [Persistent Volume](http://kubernetes.io/docs/use
 ### Existing PersistentVolumeClaim
 
 1. Create the PersistentVolume
-1. Create the PersistentVolumeClaim
-1. Install the chart
+2. Create the PersistentVolumeClaim
+3. Install the chart
 
 ```bash
-$ helm install --set persistence.existingClaim=PVC_NAME seq
+$ helm install --set persistence.existingClaim=PVC_NAME stable/seq
 ```

--- a/stable/seq/templates/deployment.yaml
+++ b/stable/seq/templates/deployment.yaml
@@ -36,14 +36,28 @@ spec:
             - name: ui
               containerPort: 80
               protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /
               port: ui
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /
               port: ui
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          {{- end }}
           volumeMounts:
           - name: seq-data
             mountPath: {{ .Values.persistence.path }}

--- a/stable/seq/values.yaml
+++ b/stable/seq/values.yaml
@@ -34,10 +34,10 @@ resources: {}
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
   #  cpu: 100m
-  #  memory: 128Mi
+  #  memory: 256Mi
   # requests:
   #  cpu: 100m
-  #  memory: 128Mi
+  #  memory: 256Mi
 
 nodeSelector: {}
 
@@ -63,7 +63,7 @@ persistence:
   ## If defined, PVC must be created manually before volume will be bound
   # existingClaim:
 
-  ## redis data Persistent Volume Storage Class
+  ## seq data Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning
   ## If undefined (the default) or set to null, no storageClassName spec is
@@ -87,3 +87,20 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+
+## Configure liveness and readiness probe values
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+livenessProbe:
+  enabled: true
+  failureThreshold: 3
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+readinessProbe:
+  enabled: true
+  failureThreshold: 3
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1


### PR DESCRIPTION
#### What this PR does / why we need it:
The Seq chart does not currently allow setting values for the liveness and readiness probes. In a slower Docker for Desktop cluster on Windows I have been unable to bring Seq up due to how aggressive the default probe values are. Adjusting the values allowed it to start up properly.

Additionally, update the README to change the chart from `seq` to `stable/seq` in the sample helm commands, and change the default value of `resources` to `{}` to reflect the values file.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
