### PR TITLE
[stable/dex] Update Dex version to v2.17.0

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: dex
-version: 1.5.0
-appVersion: 2.16.0
+version: 1.5.1
+appVersion: 2.17.0
 description: CoreOS Dex
 keywords:
 - dex

--- a/stable/dex/values.yaml
+++ b/stable/dex/values.yaml
@@ -4,7 +4,7 @@
 # name: value
 
 image: quay.io/dexidp/dex
-imageTag: "v2.16.0"
+imageTag: "v2.17.0"
 imagePullPolicy: "IfNotPresent"
 
 inMiniKube: false


### PR DESCRIPTION
#### What this PR does / why we need it:
Dex v2.17.0 has been released recently and finally it has `/userinfo` endpoint support. 

From the helm chart perspective, there are no backward incompatible changes.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
