### PR TITLE
[stable/external-dns]: fix checksum on annotations

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.2.3
+version: 2.2.4
 appVersion: 0.5.15
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -9,15 +9,16 @@ spec:
     matchLabels: {{ include "external-dns.matchLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- if or .Values.podAnnotations .Values.metrics.enabled }}
-      annotations: {{ include "external-dns.podAnnotations" . | nindent 8 }}
-      {{- end }}
       labels: {{ include "external-dns.labels" . | nindent 8 }}
+      annotations:
+        {{- if or .Values.podAnnotations .Values.metrics.enabled }}
+        {{ include "external-dns.podAnnotations" . | nindent 8 }}
+        {{- end }}
         {{- if or (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey) .Values.cloudflare.apiKey .Values.digitalocean.apiToken (and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword) .Values.rfc2136.tsigSecret .Values.extraEnv .Values.google.serviceAccountKey }}
-        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum | trunc 63 }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
         {{- if and (eq .Values.provider "designate") .Values.designate.customCA.enabled }}
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 63 }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
     spec:
 {{- include "external-dns.imagePullSecrets" . | indent 6 }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Truncating may not work as the hash may start with a number, which would also be invalid. AS far as I looked into the other charts, those things are usually on pod annotations, which cause the same effect and accepts virtually everything.

#### Which issue this PR fixes
- fixes https://github.com/helm/charts/issues/15011

#### Special notes for your reviewer:
I tested it on a k3d cluster with:

```
helm install --namespace default --name dns ./stable/external-dns --set podAnnotations.foo=bar
```

and

```
helm upgrade --namespace default dns ./stable/external-dns --set podAnnotations.foo=bar --set aws.credentials.secretKey=aaaaaaaaaa --set aws.credentials.accessKey=aaaaaaaaaaaaaaaab
```

seemed to work as expected.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
