### PR TITLE
incubator/sentry-kubernetes: add support for additional environment variables

### DIFF
--- a/incubator/sentry-kubernetes/Chart.yaml
+++ b/incubator/sentry-kubernetes/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for sentry-kubernetes (https://github.com/getsentry/sentry-kubernetes)
 name: sentry-kubernetes
-version: 0.2.1
+version: 0.2.2
 appVersion: latest
 icon: https://sentry-brand.storage.googleapis.com/sentry-glyph-white.png
 home: https://github.com/getsentry/sentry-kubernetes

--- a/incubator/sentry-kubernetes/README.md
+++ b/incubator/sentry-kubernetes/README.md
@@ -19,6 +19,11 @@ The following table lists the configurable parameters of the sentry-kubernetes c
 | `sentry.environment`    | Sentry environment                                                                                                          | Empty                         |
 | `sentry.release`        | Sentry release                                                                                                              | Empty                         |
 | `sentry.logLevel`       | Sentry log level                                                                                                            | Empty                         |
+| `sentry.mangleNames`    | Comma-separated list of object kinds for which object name should be mangled                                                | Empty                         |
+| `sentry.eventLevels`    | Comma-separated list of event levels for which events should be reported                                                    | Empty                         |
+| `sentry.reasonFilter`   | Comma-separated list of reasons for which events should *not* be reported                                                   | Empty                         |
+| `sentry.componentFilter`| Comma-separated list of components for which events should *not* be reported                                                | Empty                         |
+| `sentry.eventNamespaces`| Comma-separated list of namespaces for which events should be reported                                                      | Empty                         |
 | `image.repository`      | Container image name                                                                                                        | `getsentry/sentry-kubernetes` |
 | `image.tag`             | Container image tag                                                                                                         | `latest`                      |
 | `rbac.create`           | If `true`, create and use RBAC resources                                                                                    | `true`                        |

--- a/incubator/sentry-kubernetes/templates/deployment.yaml
+++ b/incubator/sentry-kubernetes/templates/deployment.yaml
@@ -38,6 +38,26 @@ spec:
           - name: LOG_LEVEL
             value: {{ .Values.sentry.logLevel }}
           {{ end }}
+          {{ if .Values.sentry.mangleNames }}
+          - name: MANGLE_NAMES
+            value: {{ .Values.sentry.mangleNames }}
+          {{ end }}
+          {{ if .Values.sentry.eventLevels }}
+          - name: EVENT_LEVELS
+            value: {{ .Values.sentry.eventLevels }}
+          {{ end }}
+          {{ if .Values.sentry.reasonFilter }}
+          - name: REASON_FILTER
+            value: {{ .Values.sentry.reasonFilter }}
+          {{ end }}
+          {{ if .Values.sentry.componentFilter }}
+          - name: COMPONENT_FILTER
+            value: {{ .Values.sentry.componentFilter }}
+          {{ end }}
+          {{ if .Values.sentry.eventNamespaces }}
+          - name: EVENT_NAMESPACES
+            value: {{ .Values.sentry.eventNamespaces }}
+          {{ end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
     {{- if .Values.nodeSelector }}

--- a/incubator/sentry-kubernetes/values.yaml
+++ b/incubator/sentry-kubernetes/values.yaml
@@ -5,6 +5,16 @@ sentry:
   logLevel: ~
 # Sentry DSN config using an existing secret:
 # existingSecret:
+# Comma-separated list of object kinds for which object name should be mangled
+# mangleNames:
+# Comma-separated list of event levels for which events should be reported
+# eventLevels:
+# Comma-separated list of reasons for which events should *not* be reported
+# reasonFilter:
+# Comma-separated list of components for which events should *not* be reported
+# componentFilter:
+# Comma-separated list of namespaces for which events should be reported
+# eventNamespaces:
 image:
   repository: getsentry/sentry-kubernetes
   tag: latest


### PR DESCRIPTION
Signed-off-by: Jay Howard <jay.howard@rmn.com>

#### What this PR does / why we need it:

Adds support for some additional environment variables used by the sentry-kubernetes code that, among other things, allow users to filter which events are reported into Sentry.

#### Which issue this PR fixes

None

#### Special notes for your reviewer:

None

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)