### PR TITLE
[stable/ambassador] Make ports configuration flexible to allow for TCPMapping ports

### DIFF
--- a/stable/ambassador/Chart.yaml
+++ b/stable/ambassador/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.72.0
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 2.12.3
+version: 2.12.5
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/stable/ambassador/Chart.yaml
+++ b/stable/ambassador/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.72.0
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 2.12.5
+version: 3.0.0
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/stable/ambassador/README.md
+++ b/stable/ambassador/README.md
@@ -77,14 +77,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `initContainers`                   | Containers used to initialize context for pods                                  | `[]`                              |
 | `service.annotations`              | Annotations to apply to Ambassador service                                      | See "Annotations" below           |
 | `service.externalTrafficPolicy`    | Sets the external traffic policy for the service                                | `""`                              |
-| `service.http.enabled`             | if port 80 should be opened for service                                         | `true`                            |
-| `service.http.nodePort`            | If explicit NodePort is required                                                | None                              |
-| `service.http.port`                | if port 443 should be opened for service                                        | `true`                            |
-| `service.http.targetPort`          | Sets the targetPort that maps to the service's cleartext port                   | `8080`                            |
-| `service.https.enabled`            | if port 443 should be opened for service                                        | `true`                            |
-| `service.https.nodePort`           | If explicit NodePort is required                                                | None                              |
-| `service.https.port`               | if port 443 should be opened for service                                        | `true`                            |
-| `service.https.targetPort`         | Sets the targetPort that maps to the service's TLS port                         | `8443`                            |
+| `service.ports`                    | List of ports Ambassador is listening on                                        |  `[{"name": "http","port": 80,"targetPort": 8080},{"name": "https","port": 443,"targetPort": 8443}]` |
 | `service.loadBalancerIP`           | IP address to assign (if cloud provider supports it)                            | `""`                              |
 | `service.loadBalancerSourceRanges` | Passed to cloud provider load balancer if created (e.g: AWS ELB)                | None                              |
 | `service.type`                     | Service type to be used                                                         | `LoadBalancer`                    |
@@ -156,6 +149,37 @@ $ helm upgrade --install --wait my-release -f values.yaml stable/ambassador
 ---
 
 # Upgrading
+
+## To 3.0.0
+
+The way ports are assigned has been changed for a more dynamic method.
+
+Now, instead of setting the port assignments for only the http and https, any port can be open on the load balancer using a list like you would in a standard Kubernetes YAML manifest.
+
+`pre-3.0.0`
+```yaml
+service:
+  http:
+    enabled: true
+    port: 80
+    targetPort: 8080
+  https:
+    enabled: true
+    port: 443
+    targetPort: 8443
+```
+
+`3.0.0`
+```yaml
+service:
+  port:
+  - name: http
+    port: 80
+    targetPort: 8080
+  - name: https
+    port: 443
+    targetPort: 8443
+```
 
 ## To 2.0.0
 

--- a/stable/ambassador/templates/deployment.yaml
+++ b/stable/ambassador/templates/deployment.yaml
@@ -96,14 +96,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            {{- if .Values.service.http.enabled }}
-            - name: http
-              containerPort: {{ .Values.service.http.targetPort }}
-            {{- end }}
-            {{- if .Values.service.https.enabled }}
-            - name: https
-              containerPort: {{ .Values.service.https.targetPort }}
-            {{- end }}
+            {{- range .Values.service.ports }}
+            - name: {{ .name }}
+              containerPort: {{ .targetPort }}
+            {{- end}}
             - name: admin
               containerPort: 8877
           {{- range $key := .Values.additionalTCPPorts }}

--- a/stable/ambassador/templates/service.yaml
+++ b/stable/ambassador/templates/service.yaml
@@ -21,24 +21,14 @@ spec:
   externalTrafficPolicy: "{{ .Values.service.externalTrafficPolicy }}"
   {{- end }}
   ports:
-    {{- if .Values.service.http.enabled }}
-    - port: {{ .Values.service.http.port }}
-      targetPort: {{ .Values.service.http.targetPort }}
-      protocol: TCP
-      name: http
-      {{- with .Values.service.http.nodePort }}
-      nodePort: {{ toYaml . }}
+    {{- range .Values.service.ports}}
+    - name: {{ .name }}
+      port: {{ .port }}
+      targetPort: {{ .targetPort }}
+      {{- if .nodePort }}
+      nodePort: {{ .nodePort }}
       {{- end }}
-    {{- end }}
-    {{- if .Values.service.https.enabled }}
-    - port: {{ .Values.service.https.port }}
-      targetPort: {{ .Values.service.https.targetPort }}
-      protocol: TCP
-      name: https
-      {{- with .Values.service.https.nodePort }}
-      nodePort: {{ toYaml . }}
-      {{- end }}
-    {{- end }}
+    {{- end}}
     {{- range $key := .Values.additionalTCPPorts }}
     - name: "{{ $key }}-tcp"
       port: {{ $key }}

--- a/stable/ambassador/templates/tests/test-ready.yaml
+++ b/stable/ambassador/templates/tests/test-ready.yaml
@@ -15,6 +15,6 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args:  ['{{ include "ambassador.fullname" . }}:{{ .Values.service.http.port }}/ambassador/v0/check_ready']
+      args:  ['{{ include "ambassador.fullname" . }}:{{ .Values.adminService.port }}/ambassador/v0/check_ready']
   restartPolicy: Never
 {{- end }}

--- a/stable/ambassador/values.yaml
+++ b/stable/ambassador/values.yaml
@@ -60,17 +60,20 @@ service:
 
   # Note that target http ports need to match your ambassador configurations service_port
   # https://www.getambassador.io/reference/modules/#the-ambassador-module
-  http:
-    enabled: true
-    port: 80
-    targetPort: 8080
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
     # nodePort: 30080
-
-  https:
-    enabled: true
-    port: 443
-    targetPort: 8443
-    # nodePort: 30443
+    - name: https
+      port: 443
+      targetPort: 8443
+      # nodePort: 30443
+    # TCPMapping_Port
+      # port: 2222
+      # targetPort: 2222
+      # nodePort: 30222
+    
 
   annotations:
     getambassador.io/config: |


### PR DESCRIPTION
Signed-off-by: Noah Krause <krausenoah@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Resolves: https://github.com/datawire/ambassador/issues/1672

This PR changes the service configuration from relying on `.Values.service.http(s)` to using a range to assign any port in the `.Value.service.ports` list.

#### Special notes for your reviewer:

This PR is part of a list of breaking changes I would like to make to the helm chart and is not intended to be accepted as is.

@Flydiverny I would like your opinion on this change. There is a way to accomplish what I want without removing the current functionality by just keeping the `service.http(s)` as is and adding the `service.ports` only for extra ports. That would make this no longer a breaking change but the UX is less desirable.

Should breaking changes like the one I am proposing be avoided at all cost regardless of the UX experience?

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
