### PR TITLE
[stable/prometheus-postgres-exporter] Bump to prometheus-postgres-exporter v0.5.1 + use prometheus-postgres-exporter.chart

### DIFF
--- a/stable/prometheus-postgres-exporter/Chart.yaml
+++ b/stable/prometheus-postgres-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.5.0"
+appVersion: "0.5.1"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 0.7.0
+version: 0.7.1
 home: https://github.com/wrouesnel/postgres_exporter
 sources:
 - https://github.com/wrouesnel/postgres_exporter

--- a/stable/prometheus-postgres-exporter/README.md
+++ b/stable/prometheus-postgres-exporter/README.md
@@ -39,7 +39,7 @@ The following table lists the configurable parameters of the postgres Exporter c
 | Parameter                       | Description                                | Default                                                    |
 | ------------------------------- | ------------------------------------------ | ---------------------------------------------------------- |
 | `image`                         | Image                                      | `wrouesnel/postgres_exporter`                      |
-| `imageTag`                      | Image tag                                  | `v0.5.0`                                      |
+| `imageTag`                      | Image tag                                  | `v0.5.1`                                      |
 | `imagePullPolicy`               | Image pull policy                          | `IfNotPresent` |
 | `service.annotations`           | annotations for the service                | `{}`           |
 | `service.type`      | Service type |  `ClusterIP` |

--- a/stable/prometheus-postgres-exporter/templates/podsecuritypolicy.yaml
+++ b/stable/prometheus-postgres-exporter/templates/podsecuritypolicy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}
   labels:
     app: {{ template "prometheus-postgres-exporter.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "prometheus-postgres-exporter.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:

--- a/stable/prometheus-postgres-exporter/templates/role.yaml
+++ b/stable/prometheus-postgres-exporter/templates/role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}
   labels:
     app: {{ template "prometheus-postgres-exporter.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "prometheus-postgres-exporter.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 {{- if .Values.rbac.pspEnabled }}

--- a/stable/prometheus-postgres-exporter/templates/rolebinding.yaml
+++ b/stable/prometheus-postgres-exporter/templates/rolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}
   labels:
     app: {{ template "prometheus-postgres-exporter.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "prometheus-postgres-exporter.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 roleRef:

--- a/stable/prometheus-postgres-exporter/values.yaml
+++ b/stable/prometheus-postgres-exporter/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: wrouesnel/postgres_exporter
-  tag: v0.5.0
+  tag: v0.5.1
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
https://github.com/wrouesnel/postgres_exporter/releases/tag/v0.5.1
+ update to use  prometheus-postgres-exporter.chart

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)