### PR TITLE
[stable/cluster-overprovisioner] Update documentation for cluster-autoscaler 1.12

### DIFF
--- a/stable/cluster-overprovisioner/Chart.yaml
+++ b/stable/cluster-overprovisioner/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: Installs the a deployment that overprovisions the cluster
 name: cluster-overprovisioner
 home: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler
-version: 0.2.0
+version: 0.2.1
 maintainers:
 - name: max-rocket-internet
   email: max.williams@deliveryhero.com

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -9,7 +9,8 @@ This approach is the [current recommended method to achieve overprovisioning](ht
 ## Prerequisites
 
 - Kubernetes 1.11+ with Beta APIs enabled or 1.8-1.10 with alpha APIs enabled
-- Configure the `cluster-autoscaler` for [your k8s version](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler). Usually just add `extraArgs.expendable-pods-priority-cutoff=-10` setting.
+- [Pod priority and preemption](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler) enabled in your cluster.  Pod priority and preemption is enabled by default in Kubernetes >= 1.11.
+- `cluster-autoscaler` installed in your cluster with [`--expendable-pods-priority-cutoff=-10` ](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption).  Priority cutoff has a default of `-10` in `cluster-autoscaler` >= 1.12.
 
 ## Installing the Chart
 


### PR DESCRIPTION
cluster-autoscaler >=1.12 uses a compatible default priority cutoff and requires no configuration changes.

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ X ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ X ] Chart Version bumped
- [ X ] Title of the PR starts with chart name (e.g. `[stable/chart]`)

@max-rocket-internet 