### PR TITLE
[stable/nginx-ingress] Add controller service ports aguments

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.10.1
+version: 1.10.2
 appVersion: 0.25.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -104,6 +104,8 @@ Parameter | Description | Default
 `controller.service.enableHttps` | if port 443 should be opened for service | `true`
 `controller.service.targetPorts.http` | Sets the targetPort that maps to the Ingress' port 80 | `80`
 `controller.service.targetPorts.https` | Sets the targetPort that maps to the Ingress' port 443 | `443`
+`controller.service.ports.http` | Sets service http port | `80`
+`controller.service.ports.https` | Sets service https port | `443`
 `controller.service.type` | type of controller service to create | `LoadBalancer`
 `controller.service.nodePorts.http` | If `controller.service.type` is either `NodePort` or `LoadBalancer` and this is non-empty, it sets the nodePort that maps to the Ingress' port 80 | `""`
 `controller.service.nodePorts.https` | If `controller.service.type` is either `NodePort` or `LoadBalancer` and this is non-empty, it sets the nodePort that maps to the Ingress' port 443 | `""`

--- a/stable/nginx-ingress/templates/controller-service.yaml
+++ b/stable/nginx-ingress/templates/controller-service.yaml
@@ -42,7 +42,7 @@ spec:
     {{- $setNodePorts := (or (eq .Values.controller.service.type "NodePort") (eq .Values.controller.service.type "LoadBalancer")) }}
     {{- if .Values.controller.service.enableHttp }}
     - name: http
-      port: 80
+      port: {{ .Values.controller.service.ports.http }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.http }}
       {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.http))) }}
@@ -51,7 +51,7 @@ spec:
     {{- end }}
     {{- if .Values.controller.service.enableHttps }}
     - name: https
-      port: 443
+      port: {{ .Values.controller.service.ports.https }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.https }}
       {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.https))) }}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -198,6 +198,10 @@ controller:
 
     healthCheckNodePort: 0
 
+    ports:
+      http: 80
+      https: 443
+
     targetPorts:
       http: http
       https: https


### PR DESCRIPTION
#### What this PR does / why we need it:
Support overriding nginx service ports so we can use 2 nginx-ingress on a shared load balancer IP.
