### PR TITLE
[stable/traefik] add support for setting auth response headers

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.71.2
+version: 1.71.3
 appVersion: 1.7.12
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -242,6 +242,7 @@ The following table lists the configurable parameters of the Traefik chart and t
 | `forwardAuth.entryPoints`              | Enable forward authentication for these entryPoints: "http", "https", "httpn"                                                |                                                   |
 | `forwardAuth.address`                  | URL for forward authentication                                                                                               |                                                   |
 | `forwardAuth.trustForwardHeader`       | Trust X-Forwarded-* headers                                                                                                  |                                                   |
+| `forwardAuth.authResponseHeaders`      | Set authentication response headers                                                                                                  |  `[]`                                                   |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/stable/traefik/templates/_helpers.tpl
+++ b/stable/traefik/templates/_helpers.tpl
@@ -123,3 +123,15 @@ Create the block for RootCAs.
 	   {{- end -}}
          ]
 {{- end -}}
+
+{{/*
+Create the blocks for authResponseHeaders.
+*/}}
+{{- define "traefik.authResponseHeaders" -}}
+        authResponseHeaders = [
+        {{- range $idx, $header := .Values.forwardAuth.authResponseHeaders }}
+          {{- if $idx }}, {{ end }}
+          {{- $header | quote }}
+        {{- end -}}
+        ]
+{{- end -}}

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -38,6 +38,7 @@ data:
         [entryPoints.http.auth.forward]
         address = {{ .Values.forwardAuth.address | quote }}
         trustForwardHeader = {{ .Values.forwardAuth.trustForwardHeader }}
+        {{ template "traefik.authResponseHeaders" . }}
       {{- end }}
       {{- end }}
       {{- if .Values.whiteListSourceRange }}
@@ -71,6 +72,7 @@ data:
         [entryPoints.https.auth.forward]
         address = {{ .Values.forwardAuth.address | quote }}
         trustForwardHeader = {{ .Values.forwardAuth.trustForwardHeader }}
+        {{ template "traefik.authResponseHeaders" . }}
       {{- end }}
       {{- end }}
       {{- if .Values.proxyProtocol.enabled }}
@@ -118,6 +120,7 @@ data:
         [entryPoints.httpn.auth.forward]
         address = {{ .Values.forwardAuth.address | quote }}
         trustForwardHeader = {{ .Values.forwardAuth.trustForwardHeader }}
+        {{ template "traefik.authResponseHeaders" . }}
       {{- end }}
       {{- end }}
       {{- end }}

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -472,3 +472,4 @@ tracing:
 #   entryPoints: ["http", "https"]
 #   address: https://authserver.com/auth
 #   trustForwardHeader: true
+#   authResponseHeaders: []


### PR DESCRIPTION


#### What this PR does / why we need it:

Add support to set auth response hearders as part of the possible settings here: https://docs.traefik.io/configuration/entrypoints/#forward-authentication

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
