### PR TITLE
[stable/datadog] update default image versions

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog
-version: 1.31.10
-appVersion: 6.10.1
+version: 1.31.11
+appVersion: 6.12.1
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -16,9 +16,9 @@ image:
 
   ## @param tag - string - required
   ## Define the Agent version to use.
-  ## Use 6.9.0-jmx to enable jmx fetch collection
+  ## Use 6.12.1-jmx to enable jmx fetch collection
   #
-  tag: 6.10.1
+  tag: 6.12.1
 
   ## @param pullPolicy - string - required
   ## The Kubernetes pull policy.
@@ -272,12 +272,12 @@ datadog:
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
   #
   resources: {}
-#    requests:
-#      cpu: 200m
-#      memory: 256Mi
-#    limits:
-#      cpu: 200m
-#      memory: 256Mi
+  # requests:
+  #   cpu: 200m
+  #   memory: 256Mi
+  # limits:
+  #   cpu: 200m
+  #   memory: 256Mi
 
 ## @param clusterAgent - object - required
 ## This is the Datadog Cluster Agent implementation that handles cluster-wide
@@ -295,7 +295,7 @@ clusterAgent:
   containerName: cluster-agent
   image:
     repository: datadog/cluster-agent
-    tag: 1.2.0
+    tag: 1.3.2
     pullPolicy: IfNotPresent
 
   ## @param token - string - required
@@ -642,12 +642,12 @@ clusterchecksDeployment:
   ## Datadog clusterchecks-agent resource requests and limits.
   #
   resources: {}
-#    requests:
-#      cpu: 200m
-#      memory: 500Mi
-#    limits:
-#      cpu: 200m
-#      memory: 500Mi
+  # requests:
+  #   cpu: 200m
+  #   memory: 500Mi
+  # limits:
+  #   cpu: 200m
+  #   memory: 500Mi
 
   ## @param affinity - object - optional
   ## Allow the ClusterChecks Deployment to schedule using affinity rules.


### PR DESCRIPTION
#### What this PR does / why we need it:

Update default image versions:
agent => 6.12.1
cluster-agent => 1.3.2

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
