### PR TITLE
[stable/mercure] Fix #13717 (Wrong option in readme)

### DIFF
--- a/stable/mercure/Chart.yaml
+++ b/stable/mercure/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: The Mercure hub allows to push data updates using the Mercure protocol to web browsers and other HTTP clients in a convenient, fast, reliable and battery-efficient way
 name: mercure
-version: 1.0.6
+version: 1.0.7
 keywords:
 - mercure
 - hub

--- a/stable/mercure/README.md
+++ b/stable/mercure/README.md
@@ -68,7 +68,7 @@ The following table lists the configurable parameters of the Moodle chart and th
 | `service.port`            | Service port                                                                                        | `80`                |   |   |
 | `ingress.enabled`         | Enables Ingress                                                                                     | `false`             |   |   |
 | `ingress.annotations`     | Ingress annotations                                                                                 | `{}`                |   |   |
-| `ingress.path`            | Ingress path                                                                                        | `/`                 |   |   |
+| `ingress.paths`           | Ingress paths for all hostnames                                                                     | `["/"]`             |   |   |
 | `ingress.hosts`           | Ingress accepted hostnames                                                                          | `["mercure.local"]` |   |   |
 | `ingress.tls`             | Ingress TLS configuration                                                                           | `[]`                |   |   |
 | `resources`               | controller pod resource requests & limits                                                           | `{}`                |   |   |

--- a/stable/mercure/values.yaml
+++ b/stable/mercure/values.yaml
@@ -34,7 +34,8 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  paths: []
+  paths:
+    - /
   hosts:
     - mercure.local
   tls: []


### PR DESCRIPTION
#### Which issue this PR fixes
Fixes #13717 : default value and ingress documentation so installing when specifying only `ingress.enabled=true` will work out of the box.


#### Special notes for your reviewer:

It's a bit weird the way the ingress is done, I'm not sure it's even useful, but there is maybe something specific to mercure to justify that. I was unsure so I kept the current structure and modified the minimum in order to make it work. If there is nothing specific for mercure we should maybe use a template for the ingress closer to the example describe at the root of the helm/charts repo.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
