### PR TITLE
[stable/nginx-ldap-proxy] Add protocol configuration for nginx-ldap-proxy

### DIFF
--- a/stable/nginx-ldapauth-proxy/Chart.yaml
+++ b/stable/nginx-ldapauth-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: nginx proxy with ldapauth
 name: nginx-ldapauth-proxy
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
-version: 0.1.2
+version: 0.1.3
 appVersion: 1.13.5
 sources:
 - https://github.com/dweomer/dockerfiles-nginx-auth-ldap
@@ -12,3 +12,4 @@ maintainers:
   email: pete.brown@powerhrg.com
 - name: jar361
   email: jrodgers@powerhrg.com
+home: https://github.com/nginxinc/nginx-ldap-auth

--- a/stable/nginx-ldapauth-proxy/templates/configmap.yaml
+++ b/stable/nginx-ldapauth-proxy/templates/configmap.yaml
@@ -24,7 +24,7 @@ data:
 
 {{- if and .Values.proxy.ldapHost .Values.secrets.ldapBindPassword }}
         ldap_server ldapserver {
-            url ldap://{{ .Values.proxy.ldapHost }}:{{ .Values.proxy.ldapPort }}/{{ .Values.proxy.ldapDN }}?uid?sub?(&({{ .Values.proxy.ldapFilter}}));
+            url {{ .Values.proxy.protocol }}://{{ .Values.proxy.ldapHost }}:{{ .Values.proxy.ldapPort }}/{{ .Values.proxy.ldapDN }}?uid?sub?(&({{ .Values.proxy.ldapFilter}}));
             binddn "{{ .Values.proxy.ldapBindDN }}";
             binddn_passwd {{ .Values.secrets.ldapBindPassword }};
             group_attribute {{ .Values.proxy.ldapGroup }};

--- a/stable/nginx-ldapauth-proxy/values.yaml
+++ b/stable/nginx-ldapauth-proxy/values.yaml
@@ -14,6 +14,7 @@ service:
   externalPort: 443
   internalPort: 80
 proxy:
+  protocol: "ldap"
   port: 443
   host: "kubernetes.default.svc.cluster.local"
   authName: "Auth Required"


### PR DESCRIPTION
## What this PR does / why we need it:
This PR allows the use of LDAPs instead of the hard-coded ldap protocol.
Retro-compatiblity is assured by the value file. 

J
 
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ x] Chart Version bumped
- [ x] Variables are documented in the README.md
- [ x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
