### PR TITLE
[stable/datadog] fix various whitespace and missing separator issues

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.31.8
+version: 1.31.9
 appVersion: 6.10.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/agent-rbac.yaml
+++ b/stable/datadog/templates/agent-rbac.yaml
@@ -98,9 +98,9 @@ metadata:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
   name: {{ template "datadog.fullname" . }}-cluster-agent
-{{- end -}}
+{{- end }}
 
-{{- if and .Values.rbac.create .Values.clusterAgent.enabled .Values.clusterAgent.metricsProvider.enabled -}}
+{{- if and .Values.rbac.create .Values.clusterAgent.enabled .Values.clusterAgent.metricsProvider.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -119,4 +119,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "datadog.fullname" . }}-cluster-agent
     namespace: {{ .Release.Namespace }}
-{{- end -}}
+{{- end }}

--- a/stable/datadog/templates/rbac.yaml
+++ b/stable/datadog/templates/rbac.yaml
@@ -82,7 +82,7 @@ rules:
   verbs:
   - get
 ---
-{{- if not .Values.clusterchecksDeployment.rbac.dedicated -}}
+{{- if not .Values.clusterchecksDeployment.rbac.dedicated }}
 apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
@@ -100,7 +100,7 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "datadog.fullname" . }}
     namespace: {{ .Release.Namespace }}
-{{- end -}}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -111,4 +111,4 @@ metadata:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
   name: {{ template "datadog.fullname" . }}
-{{- end -}}
+{{- end }}


### PR DESCRIPTION
Signed-off-by: Joe Hohertz <joe@viafoura.com>

@mfpierre 

#### What this PR does / why we need it:

Some recent refactoring of the templates resulted in broken manifests when rendering, with some lines inappropriately joined, or separators missing between different manifest items. The chart is simply broken for some configurations, such as using RBAC. This patch remedies that.

#### Which issue this PR fixes

No known open issues relating to this.

#### Special notes for your reviewer:

None

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
