### PR TITLE
[stable/minecraft] Correction to README Documentation

### DIFF
--- a/stable/minecraft/Chart.yaml
+++ b/stable/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 1.0.3
+version: 1.0.4
 appVersion: 1.13.1
 home: https://minecraft.net/
 description: Minecraft server

--- a/stable/minecraft/README.md
+++ b/stable/minecraft/README.md
@@ -21,7 +21,12 @@ $ helm install --name my-release \
     --set minecraftServer.eula=true stable/minecraft
 ```
 
-This command deploys a Minecraft dedicated server with sensible defaults.
+It is important to note that the deployment will not run correctly without specifying a Server Type.  For example...
+```bash
+$ helm install --name my-release \
+    --set minecraftServer.type=VANILLA stable/minecraft
+```
+Acceptable values include the following - "FORGE", "SPIGOT", "BUKKIT", "PAPER", "FTB", "SPONGEVANILLA"
 
 > **Tip**: List all releases using `helm list`
 
@@ -34,6 +39,12 @@ $ helm delete my-release
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+```bash
+$ helm del --purge my-release
+
+```
+This command will delete the Kubernetes components, as well as remove the release name from Helm so that the release name can be re-used.
 
 ## Configuration
 


### PR DESCRIPTION
Author: Joshua Burke <jburke521@gmail.com>
Date:   Mon Jul 15 01:07:00 2019 -0800

Update Readme.md
Apologies as this is my first git commit attempt...

- Added example server type values that must be provided in order to successfully deploy the chart.
- Added a line on how to purge the release from helm in addition to deleting the components.

Signed-off-by: Joshua Burke <jburke521@gmail.com>
@itburkealert

@billimek @itzg @gtaylor 

#### What this PR does / why we need it:
This would address a gap in the documentation.  The values.yaml file also incorrectly states that leaving this value blank will create a vanilla server.  In my attempts to install, that proved to be incorrect.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
