### PR TITLE
[stable/concourse] add missing credhub mtls auth

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 8.1.3
+version: 8.2.0
 appVersion: 5.4.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -117,6 +117,8 @@ The following table lists the configurable parameters of the Concourse chart and
 | `secrets.credhubCaCert` | Value of PEM-encoded CA cert file to use to verify the CredHub server SSL cert. | `nil` |
 | `secrets.credhubClientId` | Client ID for CredHub authorization. | `nil` |
 | `secrets.credhubClientSecret` | Client secret for CredHub authorization. | `nil` |
+| `secrets.credhubClientKey` | Client key for Credhub authorization. | `nil` |
+| `secrets.credhubClientCert` | Client cert for Credhub authorization | `nil` |
 | `secrets.encryptionKey` | current encryption key | `nil` |
 | `secrets.githubCaCert` | CA certificate for Enterprise Github OAuth | `nil` |
 | `secrets.githubClientId` | Application client ID for GitHub OAuth | `nil` |

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -479,6 +479,7 @@ spec:
             - name: CONCOURSE_CREDHUB_INSECURE_SKIP_VERIFY
               value: {{ .Values.concourse.web.credhub.insecureSkipVerify | quote }}
             {{- end }}
+            {{- if (eq .Values.concourse.web.credhub.authenticationMode "secrets") }}
             - name: CONCOURSE_CREDHUB_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -489,6 +490,18 @@ spec:
                 secretKeyRef:
                   name: {{ template "concourse.web.fullname" . }}
                   key: credhub-client-secret
+            {{- else if (eq .Values.concourse.web.credhub.authenticationMode "mtls") }}
+            - name: CONCOURSE_CREDHUB_CLIENT_CERT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.web.fullname" . }}
+                  key: credhub-client-cert
+            - name: CONCOURSE_CREDHUB_CLIENT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.web.fullname" . }}
+                  key: credhub-client-key
+            {{- end }}
             {{- end }}
             {{- if .Values.concourse.web.noop }}
             - name: CONCOURSE_NOOP

--- a/stable/concourse/templates/web-secrets.yaml
+++ b/stable/concourse/templates/web-secrets.yaml
@@ -73,8 +73,15 @@ data:
   {{- end }}
   {{- if .Values.concourse.web.credhub.enabled }}
   credhub-ca-cert: {{ default "" .Values.secrets.credhubCaCert | b64enc | quote }}
-  credhub-client-id: {{ template "concourse.secret.required" dict "key" "credhubClientId" "is" "concourse.web.credhub.enabled" "root" . }}
-  credhub-client-secret: {{ template "concourse.secret.required" dict "key" "credhubClientSecret" "is" "concourse.web.credhub.enabled" "root" . }}
+  {{- if eq .Values.concourse.web.credhub.authenticationMode "secrets" }}
+  credhub-client-id: {{ template "concourse.secret.required" dict "key" "credhubClientId" "is" "authenticationMode set to 'secrets' with concourse.web.credhub.enabled" "root" . }}
+  credhub-client-secret: {{ template "concourse.secret.required" dict "key" "credhubClientSecret" "is" "authenticationMode set to 'secrets' with concourse.web.credhub.enabled" "root" . }}
+  {{- else if eq .Values.concourse.web.credhub.authenticationMode "mtls" }}
+  credhub-client-cert: {{ template "concourse.secret.required" dict "key" "credhubClientCert" "is" "authenticationMode set to 'mtls' with concourse.web.credhub.enabled" "root" . }}
+  credhub-client-key: {{ template "concourse.secret.required" dict "key" "credhubClientKey" "is" "authenticationMode set to 'mtls' with concourse.web.credhub.enabled" "root" . }}
+  {{- else }}
+  {{- required (printf "value %s is not recognized as an option for concourse.web.credhub.authenticationMode" .Values.concourse.web.credhub.authenticationMode) "" }}
+  {{- end }}
   {{- end }}
   {{- if .Values.concourse.web.awsSsm.enabled }}
   aws-ssm-access-key: {{ default "" .Values.secrets.awsSsmAccessKey | b64enc | quote }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -444,6 +444,13 @@ concourse:
       ##
       insecureSkipVerify: false
 
+      ## Configures the way that the Concourse authenticates against CredHub
+      ## - secrets: makes use of `client-id` and `client-secret`
+      ## - mtls: leverages client certificates
+      ##
+      authenticationMode: "secrets"
+
+
     ## Don't actually do any automatic scheduling or checking.
     ##
     noop: false
@@ -1921,6 +1928,14 @@ secrets:
   ## Client secret for CredHub authorization.
   ##
   credhubClientSecret:
+
+  ## Client cert for Credhub authorization
+  ##
+  credhubClientCert:
+
+  ## Client key for Credhub authorization
+  ##
+  credhubClientKey:
 
   ## Secrets for CF OAuth
   ##


### PR DESCRIPTION
## What this PR does / why we need it:

Previously (https://github.com/helm/charts/pull/14545), configuration
was added to allow folks to leverage CredHub as a credential management
for Concourse.

While that allowed people to have that functionality, it was only
partially implemented - mutual TLS was still missing.

This commit aims at addressing that by introducing a
`authenticationMode` key that allows one to either specify a secret & id
pair for the authentication, or client certificates.


#### Which issue this PR fixes

  - fixes #15459

#### Special notes for your reviewer:

Here's a break down of some possible cases:

```yaml
# mTLS with nothing set - fails
#
concourse:
  web:
    credhub:
      enabled: true
      authenticationMode: "mtls"
```

```yaml
# mTLS with certificates set - succeeds
#
concourse:
  web:
    credhub:
      enabled: true
      authenticationMode: "mtls"
secrets:
  credhubClientKey: dhisuah
  credhubClientCert: iusahdi
```

```yaml
# secrets with nothing set - fails
#
concourse:
  web:
    credhub:
      enabled: true
      authenticationMode: "secrets"
```

```yaml
# secrets with the keys set - suceeds
#
concourse:
  web:
    credhub:
      enabled: true
      authenticationMode: "secrets"
secrets:
  credhubClientId: dhisuah
  credhubClientSecret: iusahdi
```

```yaml
# values for both set - succeeds
# - selects "mtls" variables (as that's the auth mode configured)
#
concourse:
  web:
    credhub:
      enabled: true
      authenticationMode: "mtls"
secrets:
  credhubClientKey: dhisuah
  credhubClientCert: iusahdi
  credhubClientId: dhisuah
  credhubClientSecret: iusahdi
```

```yaml
# empty - works without credhub 😁 
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
