### PR TITLE
[stable/concourse] Remove `nodePort` in tsa addr template

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 8.1.0
+version: 8.1.1
 appVersion: 5.3.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/_helpers.tpl
+++ b/stable/concourse/templates/_helpers.tpl
@@ -59,8 +59,5 @@ Creates the address of the TSA service.
 */}}
 {{- define "concourse.web.tsa.address" -}}
 {{- $port := .Values.concourse.web.tsa.bindPort -}}
-{{- if and (eq "NodePort" .Values.web.service.type) .Values.web.service.tsaNodePort -}}
-  {{- $port = .Values.web.service.tsaNodePort -}}
-{{- end -}}
 {{ template "concourse.web.fullname" . }}:{{- print $port -}}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

Previously, the `concourse.web.tsa.address` template used to take
`tsaNodePort` (the `nodePort` set for the TSA endpoint in the web
service) as part of the address that the worker should use to connect to
it, but that is just wrong as the `worker`s are fully able to connect
through regular target ports within the cluster (which is the case when
running a full deployment).

#### Which issue this PR fixes

-

#### Special notes for your reviewer:

Without this patch applied, try deploying Concourse with the following `sample-values.yaml` values file:

```yaml
web:
  service:
    type: NodePort
    tsaNodePort: 32001
```

Which leads to workers not being able to connect to the `web` instances.

Now, with this patch applied, see that it works.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
