### PR TITLE
[stable/influxdb] Set default value for ingress.annotations

### DIFF
--- a/stable/influxdb/Chart.yaml
+++ b/stable/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 1.1.9
+version: 1.1.10
 appVersion: 1.7.6
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/stable/influxdb/values.yaml
+++ b/stable/influxdb/values.yaml
@@ -91,7 +91,7 @@ ingress:
   tls: false
   # secretName: my-tls-cert # only needed if tls above is true
   hostname: influxdb.foobar.com
-  annotations:
+  annotations: {}
     # kubernetes.io/ingress.class: "nginx"
     # kubernetes.io/tls-acme: "true"
 


### PR DESCRIPTION
Signed-off-by: Julian Schlarb <js@project-deadline.com>

#### What this PR does / why we need it:
Remove a warning if ingress is enabled.

```
2019/07/16 09:56:01 Warning: Merging destination map for chart 'influxdb'. The destination item 'annotations' is a table and ignoring the source 'annotations' as it has a non-table value of: <nil>
```

#### Special notes for your reviewer:
-

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)