### PR TITLE
[stable/openvpn] Fix CRL keystore secret permissions

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 3.13.8
+version: 3.13.9
 appVersion: 1.1.0
 maintainers:
 - name: jasongwartz

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -18,12 +18,10 @@ data:
       {{- if .Values.openvpn.useCrl }}
       if [ ! -e ${EASY_RSA_LOC}/crl.pem ]
       then
-        {{- if not .Values.openvpn.keystoreSecret }}
         echo "generating missed crl file"
         ./easyrsa gen-crl
-        {{- end }}
-        cp -a ${EASY_RSA_LOC}/pki/crl.pem ${EASY_RSA_LOC}/crl.pem
-        chown nobody:nogroup ${EASY_RSA_LOC}/crl.pem
+        cp ${EASY_RSA_LOC}/pki/crl.pem ${EASY_RSA_LOC}/crl.pem
+        chmod 644 ${EASY_RSA_LOC}/crl.pem
       fi
       {{- end }}
       {{- if .Values.openvpn.taKey }}
@@ -42,8 +40,8 @@ data:
       ./easyrsa gen-dh
       {{- if .Values.openvpn.useCrl }}
       ./easyrsa gen-crl
-      cp -a ${EASY_RSA_LOC}/pki/crl.pem ${EASY_RSA_LOC}/crl.pem # Note: the pki/ directory is inaccessible after openvpn drops privileges, so we cp crl.pem to ${EASY_RSA_LOC} and chown to allow CRL updates without a restart
-      chown nobody:nogroup ${EASY_RSA_LOC}/crl.pem
+      cp ${EASY_RSA_LOC}/pki/crl.pem ${EASY_RSA_LOC}/crl.pem # Note: the pki/ directory is inaccessible after openvpn drops privileges, so we cp crl.pem to ${EASY_RSA_LOC} to allow CRL updates without a restart
+      chmod 644 ${EASY_RSA_LOC}/crl.pem
       {{- end }}
       {{- if .Values.openvpn.taKey }}
       openvpn --genkey --secret ${EASY_RSA_LOC}/pki/ta.key
@@ -92,8 +90,8 @@ data:
       cd $EASY_RSA_LOC
       ./easyrsa revoke $1 
       ./easyrsa gen-crl
-      cp -a ${EASY_RSA_LOC}/pki/crl.pem ${EASY_RSA_LOC}
-      chown nobody:nogroup ${EASY_RSA_LOC}/crl.pem
+      cp ${EASY_RSA_LOC}/pki/crl.pem ${EASY_RSA_LOC}
+      chmod 644 ${EASY_RSA_LOC}/crl.pem
 
   configure.sh: |-
       #!/bin/sh

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -16,7 +16,7 @@ data:
     then
       echo "found existing certs - reusing"
       {{- if .Values.openvpn.useCrl }}
-      if [ ! -e ${EASY_RSA_LOC}/pki/crl.pem ]
+      if [ ! -e ${EASY_RSA_LOC}/crl.pem ]
       then
         echo "generating missed crl file"
         ./easyrsa gen-crl

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -22,7 +22,7 @@ data:
         echo "generating missed crl file"
         ./easyrsa gen-crl
         {{- end }}
-        cp ${EASY_RSA_LOC}/pki/crl.pem ${EASY_RSA_LOC}/crl.pem
+        cp -a ${EASY_RSA_LOC}/pki/crl.pem ${EASY_RSA_LOC}/crl.pem
         chown nobody:nogroup ${EASY_RSA_LOC}/crl.pem
       fi
       {{- end }}
@@ -42,7 +42,7 @@ data:
       ./easyrsa gen-dh
       {{- if .Values.openvpn.useCrl }}
       ./easyrsa gen-crl
-      cp ${EASY_RSA_LOC}/pki/crl.pem ${EASY_RSA_LOC}/crl.pem # Note: the pki/ directory is inaccessible after openvpn drops privileges, so we cp crl.pem to ${EASY_RSA_LOC} and chown to allow CRL updates without a restart
+      cp -a ${EASY_RSA_LOC}/pki/crl.pem ${EASY_RSA_LOC}/crl.pem # Note: the pki/ directory is inaccessible after openvpn drops privileges, so we cp crl.pem to ${EASY_RSA_LOC} and chown to allow CRL updates without a restart
       chown nobody:nogroup ${EASY_RSA_LOC}/crl.pem
       {{- end }}
       {{- if .Values.openvpn.taKey }}
@@ -92,7 +92,7 @@ data:
       cd $EASY_RSA_LOC
       ./easyrsa revoke $1 
       ./easyrsa gen-crl
-      cp ${EASY_RSA_LOC}/pki/crl.pem ${EASY_RSA_LOC}
+      cp -a ${EASY_RSA_LOC}/pki/crl.pem ${EASY_RSA_LOC}
       chown nobody:nogroup ${EASY_RSA_LOC}/crl.pem
 
   configure.sh: |-

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -11,6 +11,7 @@ data:
   setup-certs.sh: |-
     #!/bin/bash
     EASY_RSA_LOC="/etc/openvpn/certs"
+    cd $EASY_RSA_LOC
     SERVER_CERT="${EASY_RSA_LOC}/pki/issued/server.crt"
     if [ -e "$SERVER_CERT" ]
     then
@@ -33,7 +34,6 @@ data:
       {{- end }}
     else
       cp -R /usr/share/easy-rsa/* $EASY_RSA_LOC
-      cd $EASY_RSA_LOC
       ./easyrsa init-pki
       echo "ca\n" | ./easyrsa build-ca nopass
       ./easyrsa build-server-full server nopass

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -18,10 +18,12 @@ data:
       {{- if .Values.openvpn.useCrl }}
       if [ ! -e ${EASY_RSA_LOC}/crl.pem ]
       then
+        {{- if not .Values.openvpn.keystoreSecret }}
         echo "generating missed crl file"
         ./easyrsa gen-crl
+        {{- end }}
         cp ${EASY_RSA_LOC}/pki/crl.pem ${EASY_RSA_LOC}/crl.pem
-        chmod 644 ${EASY_RSA_LOC}/crl.pem
+        chown nobody:nogroup ${EASY_RSA_LOC}/crl.pem
       fi
       {{- end }}
       {{- if .Values.openvpn.taKey }}
@@ -40,8 +42,8 @@ data:
       ./easyrsa gen-dh
       {{- if .Values.openvpn.useCrl }}
       ./easyrsa gen-crl
-      cp ${EASY_RSA_LOC}/pki/crl.pem ${EASY_RSA_LOC}/crl.pem # Note: the pki/ directory is inaccessible after openvpn drops privileges, so we cp crl.pem to ${EASY_RSA_LOC} to allow CRL updates without a restart
-      chmod 644 ${EASY_RSA_LOC}/crl.pem
+      cp ${EASY_RSA_LOC}/pki/crl.pem ${EASY_RSA_LOC}/crl.pem # Note: the pki/ directory is inaccessible after openvpn drops privileges, so we cp crl.pem to ${EASY_RSA_LOC} and chown to allow CRL updates without a restart
+      chown nobody:nogroup ${EASY_RSA_LOC}/crl.pem
       {{- end }}
       {{- if .Values.openvpn.taKey }}
       openvpn --genkey --secret ${EASY_RSA_LOC}/pki/ta.key
@@ -91,7 +93,7 @@ data:
       ./easyrsa revoke $1 
       ./easyrsa gen-crl
       cp ${EASY_RSA_LOC}/pki/crl.pem ${EASY_RSA_LOC}
-      chmod 644 ${EASY_RSA_LOC}/crl.pem
+      chown nobody:nogroup ${EASY_RSA_LOC}/crl.pem
 
   configure.sh: |-
       #!/bin/sh

--- a/stable/openvpn/templates/openvpn-deployment.yaml
+++ b/stable/openvpn/templates/openvpn-deployment.yaml
@@ -67,7 +67,7 @@ spec:
           - mountPath: /etc/openvpn/setup
             name: openvpn
             readOnly: false
-          - mountPath: /etc/openvpn/certs/pki
+          - mountPath: /etc/openvpn/certs
             {{- if .Values.persistence.subPath }}
             subPath: {{ .Values.persistence.subPath }}
             {{- end }}
@@ -88,20 +88,21 @@ spec:
           defaultMode: 448
           items:
           - key: "server.key"
-            path: "private/server.key"
+            path: "pki/private/server.key"
           - key: "ca.crt"
-            path: "ca.crt"
+            path: "pki/ca.crt"
           - key: "server.crt"
-            path: "issued/server.crt"
+            path: "pki/issued/server.crt"
           - key: "dh.pem"
-            path: "dh.pem"
+            path: "pki/dh.pem"
           {{- if .Values.openvpn.useCrl }}
           - key: "crl.pem"
             path: "crl.pem"
+            mode: 484
           {{- end }}
           {{- if .Values.openvpn.taKey }}
           - key: "ta.key"
-            path: "ta.key"
+            path: "pki/ta.key"
           {{- end }}
         {{- else }}
         emptyDir: {}

--- a/stable/openvpn/templates/openvpn-deployment.yaml
+++ b/stable/openvpn/templates/openvpn-deployment.yaml
@@ -98,7 +98,7 @@ spec:
           {{- if .Values.openvpn.useCrl }}
           - key: "crl.pem"
             path: "crl.pem"
-            mode: 484
+            mode: 0644
           {{- end }}
           {{- if .Values.openvpn.taKey }}
           - key: "ta.key"

--- a/stable/openvpn/templates/openvpn-deployment.yaml
+++ b/stable/openvpn/templates/openvpn-deployment.yaml
@@ -98,6 +98,7 @@ spec:
           {{- if .Values.openvpn.useCrl }}
           - key: "crl.pem"
             path: "crl.pem"
+            mode: 484
           {{- end }}
           {{- if .Values.openvpn.taKey }}
           - key: "ta.key"

--- a/stable/openvpn/templates/openvpn-deployment.yaml
+++ b/stable/openvpn/templates/openvpn-deployment.yaml
@@ -67,7 +67,7 @@ spec:
           - mountPath: /etc/openvpn/setup
             name: openvpn
             readOnly: false
-          - mountPath: /etc/openvpn/certs
+          - mountPath: /etc/openvpn/certs/pki
             {{- if .Values.persistence.subPath }}
             subPath: {{ .Values.persistence.subPath }}
             {{- end }}
@@ -88,21 +88,20 @@ spec:
           defaultMode: 448
           items:
           - key: "server.key"
-            path: "pki/private/server.key"
+            path: "private/server.key"
           - key: "ca.crt"
-            path: "pki/ca.crt"
+            path: "ca.crt"
           - key: "server.crt"
-            path: "pki/issued/server.crt"
+            path: "issued/server.crt"
           - key: "dh.pem"
-            path: "pki/dh.pem"
+            path: "dh.pem"
           {{- if .Values.openvpn.useCrl }}
           - key: "crl.pem"
             path: "crl.pem"
-            mode: 484
           {{- end }}
           {{- if .Values.openvpn.taKey }}
           - key: "ta.key"
-            path: "pki/ta.key"
+            path: "ta.key"
           {{- end }}
         {{- else }}
         emptyDir: {}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it: 

Chowns crl.pem file to nobody:nogroup in the keystore secret - this is needed since this file is read on every client connection and so once OpenVPN is running as nobody it still needs to be able to read it.

From the [OpenVPN reference](https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/):
> As the crl file (or directory) is read every time a peer connects, if you are dropping root privileges with –user, make sure that this user has sufficient privileges to read the file

The PR also fixes the check for the existence of the CRL file (as it is moved to `${EASY_RSA_LOC}/crl.pem` instead of `${EASY_RSA_LOC}/pki/crl.pem`).

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
