### PR TITLE
[stable/superset] Add extra annotation / labels for deployment resource

### DIFF
--- a/stable/superset/Chart.yaml
+++ b/stable/superset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Apache Superset (incubating) is a modern, enterprise-ready business intelligence web application
 name: superset
-version: 1.1.6
+version: 1.1.7
 appVersion: "0.28.1"
 keywords:
 - bi

--- a/stable/superset/README.md
+++ b/stable/superset/README.md
@@ -45,6 +45,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.tag`                | `superset` image tag                            | `0.28.1`                                                     |
 | `image.pullPolicy`         | Image pull policy                               | `IfNotPresent`                                               |
 | `image.pullSecrets`        | Secrets for private registry                    | `[]`                                                         |
+| `annotations`              | Add annotations to deployment                   | `{}`                                                         |
+| `labels`                   | Add extra labels to deployment                  | `{}`                                                         |
+| `podAnnotations`           | Add extra annotations to deployment             | `{}`                                                         |
 | `configFile`               | Content of [`superset_config.py`](https://superset.incubator.apache.org/installation.html) | See values.yaml](./values.yaml) |
 | `extraConfigFiles`         | Content of additional configuration files. Let the dictionary key name represent the name of the file and its value the files content. | `{}` |
 | `initFile`                 | Content of init shell script                    | See [values.yaml](./values.yaml)                             |

--- a/stable/superset/templates/deployment.yaml
+++ b/stable/superset/templates/deployment.yaml
@@ -2,11 +2,18 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "superset.fullname" . }}
+{{- if .Values.annotations }}
+  annotations:
+{{ toYaml .Values.annotations | indent 4 }}
+{{- end }}
   labels:
     app: {{ include "superset.name" . }}
     chart: {{ include "superset.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -23,6 +30,9 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- end }}
     spec:
       securityContext:
         runAsUser: 1000

--- a/stable/superset/values.yaml
+++ b/stable/superset/values.yaml
@@ -12,6 +12,18 @@ image:
   pullPolicy: "IfNotPresent"
   pullSecrets: []
 
+## Here annotations can be added to the superset deployment
+##
+annotations: {}
+## Extra labels that can be added to the superset deployment
+##
+labels: {}
+# kubernetes.io/name: "superset"
+
+# Extra annotations to be added to superset pods
+##
+podAnnotations: {}
+
 initFile: |-
   /usr/local/bin/superset-init --username admin --firstname admin --lastname user --email admin@fab.org --password admin
   superset runserver


### PR DESCRIPTION
Signed-off-by: arielev <levinsonarie@gmail.com>

@alitari 
#### What this PR does / why we need it:
The PR will add extra annotations / labels to the deployment resource (both deployment and pod template level)
This is needed for the use of other apps in the cluster, for example log collection app, that gets relevant pods configurations by their annotations.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
