### PR TITLE
[stable/spinnaker] Add ecr as docker registry with --password-command parameter

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.8.1
+version: 1.8.2
 appVersion: 1.12.5
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/README.md
+++ b/stable/spinnaker/README.md
@@ -78,6 +78,10 @@ dockerRegistries:
 #   username: _json_key
 #   password: '<INSERT YOUR SERVICE ACCOUNT JSON HERE>'
 #   email: 1234@5678.com
+# - name: ecr
+#   address: https://<AWS-ACCOUNT-ID>.dkr.ecr.<REGION>.amazonaws.com
+#   username: AWS
+#   passwordCommand: "aws --region <REGION> ecr get-authorization-token --output text --query 'authorizationData[].authorizationToken' | base64 -d | sed 's/^AWS://'"
 ```
 
 You can provide passwords as a Helm value, or you can use a pre-created secret containing your registry passwords.  The secret should have an item per Registry in the format: `<registry name>: <password>`. In which case you'll specify the secret to use in `dockerRegistryAccountSecret` like so:

--- a/stable/spinnaker/templates/configmap/halyard-config.yaml
+++ b/stable/spinnaker/templates/configmap/halyard-config.yaml
@@ -84,7 +84,12 @@ data:
 
     CREDS=""
     {{ if $registry.username -}}
-    CREDS+="--username {{ $registry.username }} --password-file /opt/registry/passwords/{{ $registry.name }}"
+    CREDS+="--username {{ $registry.username }}"
+    {{ if $registry.passwordCommand -}}
+    CREDS+=" --password-command {{ $registry.passwordCommand }}"
+    {{- else -}}
+    CREDS+=" --password-file /opt/registry/passwords/{{ $registry.name }}"
+    {{- end -}}
     {{ if $registry.email -}}
     CREDS+=" --email {{ $registry.email }}"
     {{- end -}}

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -63,6 +63,10 @@ dockerRegistries:
 #   username: _json_key
 #   password: '<INSERT YOUR SERVICE ACCOUNT JSON HERE>'
 #   email: 1234@5678.com
+# - name: ecr
+#   address: <AWS-ACCOUNT-ID>.dkr.ecr.<REGION>.amazonaws.com
+#   username: AWS
+#   passwordCommand: "aws --region <REGION> ecr get-authorization-token --output text --query 'authorizationData[].authorizationToken' | base64 -d | sed 's/^AWS://'"
 
 # If you don't want to put your passwords into a values file
 # you can use a pre-created secret instead of putting passwords


### PR DESCRIPTION
Signed-off-by: Cédric Menassa <cedric.menassa@gmail.com>

#### What this PR does / why we need it:
Add `--password-command` parameter in Halyard to add ECR as Docker registry

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
