### PR TITLE
[stable/jenkins] Change the value name for docker image tags - standartise to helm preferred value name - tag; this also allows auto-deployments using weaveworks flux

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.3.6
+version: 1.4.0
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -65,7 +65,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `namespaceOverride`               | Override the deployment namespace    | Not set (`Release.Namespace`)             |
 | `master.componentName`            | Jenkins master name                  | `jenkins-master`                          |
 | `master.image`                    | Master image name                    | `jenkins/jenkins`                         |
-| `master.imageTag`                 | Master image tag                     | `lts`                                     |
+| `master.tag`                      | Master image tag                     | `lts`                                     |
 | `master.imagePullPolicy`          | Master image pull policy             | `Always`                                  |
 | `master.imagePullSecret`          | Master image pull secret             | Not set                                   |
 | `master.numExecutors`             | Set Number of executors              | 0                                         |
@@ -176,7 +176,7 @@ Some third-party systems, e.g. GitHub, use HTML-formatted data in their payload 
 | `agent.enabled`            | Enable Kubernetes plugin jnlp-agent podTemplate | `true`                 |
 | `agent.image`              | Agent image name                                | `jenkins/jnlp-slave`   |
 | `agent.imagePullSecret`    | Agent image pull secret                         | Not set                |
-| `agent.imageTag`           | Agent image tag                                 | `3.27-1`               |
+| `agent.tag`                | Agent image tag                                 | `3.27-1`               |
 | `agent.privileged`         | Agent privileged container                      | `false`                |
 | `agent.resources`          | Resources allocation (Requests and Limits)      | `{requests: {cpu: 200m, memory: 256Mi}, limits: {cpu: 200m, memory: 256Mi}}`|
 | `agent.volumes`            | Additional volumes                              | `nil`                  |

--- a/stable/jenkins/templates/NOTES.txt
+++ b/stable/jenkins/templates/NOTES.txt
@@ -46,10 +46,15 @@ https://jenkins.io/projects/jcasc/
 {{- end }}
 
 {{- if .Values.master.imageTag }}
-
 #################################################################################
 ######   WARNING: `master.imageTag` will be obsoleted soon!!!               #####
 ######            It has been renamed to `master.tag`.                      #####
 #################################################################################
 {{- end }}
 
+{{- if .Values.agent.imageTag }}
+#################################################################################
+######   WARNING: `agent.imageTag` will be obsoleted soon!!!                #####
+######            It has been renamed to `agent.tag`.                       #####
+#################################################################################
+{{- end }}

--- a/stable/jenkins/templates/NOTES.txt
+++ b/stable/jenkins/templates/NOTES.txt
@@ -44,3 +44,12 @@ https://jenkins.io/projects/jcasc/
 ######            the Jenkins pod is terminated.                            #####
 #################################################################################
 {{- end }}
+
+{{- if .Values.master.imageTag }}
+
+#################################################################################
+######   WARNING: `master.imageTag` will be obsoleted soon!!!               #####
+######            It has been renamed to `master.tag`.                      #####
+#################################################################################
+{{- end }}
+

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -16,7 +16,11 @@ data:
     <?xml version='1.0' encoding='UTF-8'?>
     <hudson>
       <disabledAdministrativeMonitors/>
+{{- if .Values.master.imageTag }}
+      <version>{{ .Values.master.imageTag }}</version>
+{{- else }}
       <version>{{ .Values.master.tag }}</version>
+{{- end }}
       <numExecutors>{{ .Values.master.numExecutors }}</numExecutors>
       <mode>NORMAL</mode>
       <useSecurity>{{ .Values.master.useSecurity }}</useSecurity>
@@ -68,7 +72,11 @@ data:
               <containers>
                 <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
                   <name>{{ .Values.agent.sideContainerName }}</name>
+{{- if .Values.agent.imageTag }}
+                  <image>{{ .Values.agent.image }}:{{ .Values.agent.imageTag }}</image>
+{{- else }}
                   <image>{{ .Values.agent.image }}:{{ .Values.agent.tag }}</image>
+{{- end }}
 {{- if .Values.agent.privileged }}
                   <privileged>true</privileged>
 {{- else }}

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -16,7 +16,7 @@ data:
     <?xml version='1.0' encoding='UTF-8'?>
     <hudson>
       <disabledAdministrativeMonitors/>
-      <version>{{ .Values.master.imageTag }}</version>
+      <version>{{ .Values.master.tag }}</version>
       <numExecutors>{{ .Values.master.numExecutors }}</numExecutors>
       <mode>NORMAL</mode>
       <useSecurity>{{ .Values.master.useSecurity }}</useSecurity>
@@ -68,7 +68,7 @@ data:
               <containers>
                 <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
                   <name>{{ .Values.agent.sideContainerName }}</name>
-                  <image>{{ .Values.agent.image }}:{{ .Values.agent.imageTag }}</image>
+                  <image>{{ .Values.agent.image }}:{{ .Values.agent.tag }}</image>
 {{- if .Values.agent.privileged }}
                   <privileged>true</privileged>
 {{- else }}

--- a/stable/jenkins/templates/deprecation.yaml
+++ b/stable/jenkins/templates/deprecation.yaml
@@ -10,7 +10,7 @@
         {{- end }}
 
         {{- if .Values.master.imageTag }}
-           {{ fail "`master.imageTag` does no longer exist. It has been renamed to `master.tag`" }}
+           {{ fail "`master.imageTag` will be obsoleted soon. It has been renamed to `master.tag`" }}
         {{- end }}
 
         {{- if .Values.Master.ImageTag }}
@@ -324,7 +324,7 @@
         {{- end }}
 
         {{- if .Values.agent.imageTag }}
-           {{ fail "`agent.imageTag` does no longer exist. It has been renamed to `agent.tag`" }}
+           {{ fail "`agent.imageTag` will be obsoleted soon. It has been renamed to `agent.tag`" }}
         {{- end }}
 
         {{- if .Values.Agent.ImageTag }}

--- a/stable/jenkins/templates/deprecation.yaml
+++ b/stable/jenkins/templates/deprecation.yaml
@@ -9,8 +9,12 @@
            {{ fail "`Master.Image` does no longer exist. It has been renamed to `master.image`" }}
         {{- end }}
 
+        {{- if .Values.master.imageTag }}
+           {{ fail "`master.imageTag` does no longer exist. It has been renamed to `master.tag`" }}
+        {{- end }}
+
         {{- if .Values.Master.ImageTag }}
-           {{ fail "`Master.ImageTag` does no longer exist. It has been renamed to `master.imageTag`" }}
+           {{ fail "`Master.ImageTag` does no longer exist. It has been renamed to `master.tag`" }}
         {{- end }}
 
         {{- if .Values.Master.ImagePullPolicy }}
@@ -317,6 +321,10 @@
 
         {{- if .Values.Agent.ImagePullSecret }}
            {{ fail "`Agent.ImagePullSecret` does no longer exist. It has been renamed to `agent.imagePullSecret`" }}
+        {{- end }}
+
+        {{- if .Values.agent.imageTag }}
+           {{ fail "`agent.imageTag` does no longer exist. It has been renamed to `agent.tag`" }}
         {{- end }}
 
         {{- if .Values.Agent.ImageTag }}

--- a/stable/jenkins/templates/deprecation.yaml
+++ b/stable/jenkins/templates/deprecation.yaml
@@ -9,10 +9,6 @@
            {{ fail "`Master.Image` does no longer exist. It has been renamed to `master.image`" }}
         {{- end }}
 
-        {{- if .Values.master.imageTag }}
-           {{ fail "`master.imageTag` will be obsoleted soon. It has been renamed to `master.tag`" }}
-        {{- end }}
-
         {{- if .Values.Master.ImageTag }}
            {{ fail "`Master.ImageTag` does no longer exist. It has been renamed to `master.tag`" }}
         {{- end }}
@@ -321,10 +317,6 @@
 
         {{- if .Values.Agent.ImagePullSecret }}
            {{ fail "`Agent.ImagePullSecret` does no longer exist. It has been renamed to `agent.imagePullSecret`" }}
-        {{- end }}
-
-        {{- if .Values.agent.imageTag }}
-           {{ fail "`agent.imageTag` will be obsoleted soon. It has been renamed to `agent.tag`" }}
         {{- end }}
 
         {{- if .Values.Agent.ImageTag }}

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -82,7 +82,11 @@ spec:
 {{ tpl (toYaml .Values.master.customInitContainers) . | indent 8 }}
 {{- end }}
         - name: "copy-default-config"
+{{- if .Values.master.imageTag }}
+          image: "{{ .Values.master.image }}:{{ .Values.master.imageTag }}"
+{{- else }}
           image: "{{ .Values.master.image }}:{{ .Values.master.tag }}"
+{{- end }}
           imagePullPolicy: "{{ .Values.master.imagePullPolicy }}"
           command: [ "sh", "/var/jenkins_config/apply_config.sh" ]
           env:
@@ -147,7 +151,11 @@ spec:
               name: secrets-dir
       containers:
         - name: {{ template "jenkins.fullname" . }}
+{{- if .Values.master.imageTag }}
+          image: "{{ .Values.master.image }}:{{ .Values.master.imageTag }}"
+{{- else }}
           image: "{{ .Values.master.image }}:{{ .Values.master.tag }}"
+{{- end }}
           imagePullPolicy: "{{ .Values.master.imagePullPolicy }}"
           {{- if .Values.master.useSecurity }}
           args: [ "--argumentsRealm.passwd.$(ADMIN_USER)=$(ADMIN_PASSWORD)",  "--argumentsRealm.roles.$(ADMIN_USER)=admin"]

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -82,7 +82,7 @@ spec:
 {{ tpl (toYaml .Values.master.customInitContainers) . | indent 8 }}
 {{- end }}
         - name: "copy-default-config"
-          image: "{{ .Values.master.image }}:{{ .Values.master.imageTag }}"
+          image: "{{ .Values.master.image }}:{{ .Values.master.tag }}"
           imagePullPolicy: "{{ .Values.master.imagePullPolicy }}"
           command: [ "sh", "/var/jenkins_config/apply_config.sh" ]
           env:
@@ -147,7 +147,7 @@ spec:
               name: secrets-dir
       containers:
         - name: {{ template "jenkins.fullname" . }}
-          image: "{{ .Values.master.image }}:{{ .Values.master.imageTag }}"
+          image: "{{ .Values.master.image }}:{{ .Values.master.tag }}"
           imagePullPolicy: "{{ .Values.master.imagePullPolicy }}"
           {{- if .Values.master.useSecurity }}
           args: [ "--argumentsRealm.passwd.$(ADMIN_USER)=$(ADMIN_PASSWORD)",  "--argumentsRealm.roles.$(ADMIN_USER)=admin"]

--- a/stable/jenkins/templates/tests/jenkins-test.yaml
+++ b/stable/jenkins/templates/tests/jenkins-test.yaml
@@ -29,7 +29,7 @@ spec:
         name: tools
   containers:
     - name: {{ .Release.Name }}-ui-test
-      image: {{ .Values.master.image }}:{{ .Values.master.imageTag }}
+      image: {{ .Values.master.image }}:{{ .Values.master.tag }}
       command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
       volumeMounts:
       - mountPath: /tests

--- a/stable/jenkins/templates/tests/jenkins-test.yaml
+++ b/stable/jenkins/templates/tests/jenkins-test.yaml
@@ -29,7 +29,11 @@ spec:
         name: tools
   containers:
     - name: {{ .Release.Name }}-ui-test
+{{- if .Values.master.imageTag }}
+      image: {{ .Values.master.image }}:{{ .Values.master.imageTag }}
+{{- else }}
       image: {{ .Values.master.image }}:{{ .Values.master.tag }}
+{{- end }}
       command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
       volumeMounts:
       - mountPath: /tests

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -17,7 +17,7 @@ master:
   # Used for label app.kubernetes.io/component
   componentName: "jenkins-master"
   image: "jenkins/jenkins"
-  imageTag: "lts"
+  tag: "lts"
   imagePullPolicy: "Always"
   imagePullSecretName:
   # Optionally configure lifetime for master-container
@@ -337,7 +337,7 @@ master:
 agent:
   enabled: true
   image: "jenkins/jnlp-slave"
-  imageTag: "3.27-1"
+  tag: "3.27-1"
   customJenkinsLabels: []
   # name of the secret to be used for image pulling
   imagePullSecretName:


### PR DESCRIPTION
* Change the value name for docker image tags - standartise to what is accepted standard in all charts - tag
* This also allows auto-deployments using weaveworks flux

@torstenwalter
@maorfr
@viglesiasce
@lachie83

Signed-off-by: Eriks Zelenka <isindir@users.sf.net>

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
