### PR TITLE
[incubator/patroni] add schedulerName option

### DIFF
--- a/incubator/patroni/Chart.yaml
+++ b/incubator/patroni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: patroni
 description: 'Highly available elephant herd: HA PostgreSQL cluster.'
-version: 0.13.1
+version: 0.14.0
 appVersion: 1.4-p16
 home: https://github.com/zalando/patroni
 sources:

--- a/incubator/patroni/README.md
+++ b/incubator/patroni/README.md
@@ -94,6 +94,7 @@ The following table lists the configurable parameters of the patroni chart and t
 | `tolerations`                     | List of node taints to tolerate             | `[]`                                                |
 | `affinityTemplate`                | A template string to use to generate the affinity settings | Anti-affinity preferred on hostname  |
 | `affinity`                        | Affinity settings. Overrides `affinityTemplate` if set. | `{}`                                    |
+| `schedulerName`                   | Alternate scheduler name                    | `nil`                                               |
 | `persistentVolume.accessModes`    | Persistent Volume access modes              | `[ReadWriteOnce]`                                   |
 | `persistentVolume.annotations`    | Annotations for Persistent Volume Claim`    | `{}`                                                |
 | `persistentVolume.mountPath`      | Persistent Volume mount root path           | `/home/postgres/pgdata`                             |

--- a/incubator/patroni/templates/statefulset-patroni.yaml
+++ b/incubator/patroni/templates/statefulset-patroni.yaml
@@ -155,6 +155,9 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- with .Values.schedulerName }}
+      schedulerName: {{ . }}
+    {{- end }}
     {{- if .Values.affinity }}
       affinity:
 {{ .Values.affinity | toYaml | indent 8 }}

--- a/incubator/patroni/templates/statefulset-patroni.yaml
+++ b/incubator/patroni/templates/statefulset-patroni.yaml
@@ -155,8 +155,8 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.schedulerName }}
-      schedulerName: {{ . }}
+    {{- if .Values.schedulerName }}
+      schedulerName: {{ .Values.schedulerName }}
     {{- end }}
     {{- if .Values.affinity }}
       affinity:

--- a/incubator/patroni/values.yaml
+++ b/incubator/patroni/values.yaml
@@ -110,6 +110,11 @@ affinityTemplate: |
             release: {{ .Release.Name | quote }}
 affinity: {}
 
+## Use an alternate scheduler, e.g. "stork".
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+# schedulerName:
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true


### PR DESCRIPTION
@alexeyklyukin @linki

#### What this PR does / why we need it:

This adds the ability to set the [`podSpec.schedulerName`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#podspec-v1-core) field in the `StatefulSet` template in the patroni chart.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
