### PR TITLE
[stable/openvpn/ Exec OpenVPN Process

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 3.13.1
+version: 3.13.2
 appVersion: 1.1.0
 maintainers:
 - name: jfelten

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -155,6 +155,7 @@ data:
       sed 's|NETWORK|'"${NETWORK}"'|' -i /etc/openvpn/openvpn.conf
       sed 's|NETMASK|'"${NETMASK}"'|' -i /etc/openvpn/openvpn.conf
 
+      # exec openvpn process so it receives lifecycle signals
       exec openvpn --config /etc/openvpn/openvpn.conf
   openvpn.conf: |-
       server {{ .Values.openvpn.OVPN_NETWORK }} {{ .Values.openvpn.OVPN_SUBNET }}

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -155,7 +155,7 @@ data:
       sed 's|NETWORK|'"${NETWORK}"'|' -i /etc/openvpn/openvpn.conf
       sed 's|NETMASK|'"${NETMASK}"'|' -i /etc/openvpn/openvpn.conf
 
-      openvpn --config /etc/openvpn/openvpn.conf
+      exec openvpn --config /etc/openvpn/openvpn.conf
   openvpn.conf: |-
       server {{ .Values.openvpn.OVPN_NETWORK }} {{ .Values.openvpn.OVPN_SUBNET }}
       verb 3


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it: 

Exec's OpenVPN process so that it runs as PID 1. In particular this means it receives the SIGTERM when it is terminated so that it stops gracefully.

This is particularly useful for version 2.4 of OpenVPN to make use of the `explicit-exit-notify` setting in server mode and trigger clients to reconnect when the server is terminated (instead of timing out).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
