### PR TITLE
[stable/datadog] Fix whitespace trimming

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.31.8
+version: 1.31.9
 appVersion: 6.10.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/agent-rbac.yaml
+++ b/stable/datadog/templates/agent-rbac.yaml
@@ -98,9 +98,9 @@ metadata:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
   name: {{ template "datadog.fullname" . }}-cluster-agent
-{{- end -}}
+{{- end }}
 
-{{- if and .Values.rbac.create .Values.clusterAgent.enabled .Values.clusterAgent.metricsProvider.enabled -}}
+{{- if and .Values.rbac.create .Values.clusterAgent.enabled .Values.clusterAgent.metricsProvider.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/stable/datadog/templates/confd-configmap.yaml
+++ b/stable/datadog/templates/confd-configmap.yaml
@@ -18,8 +18,8 @@ override duplicates
 */}}
 {{- if .Values.datadog.autoconf }}
 {{ tpl (toYaml .Values.datadog.autoconf) . | indent 2 }}
-{{- end -}}
+{{- end }}
 {{- if .Values.datadog.confd }}
 {{ tpl (toYaml .Values.datadog.confd) . | indent 2 }}
-{{- end -}}
+{{- end }}
 {{- end -}}

--- a/stable/datadog/templates/rbac.yaml
+++ b/stable/datadog/templates/rbac.yaml
@@ -82,7 +82,7 @@ rules:
   verbs:
   - get
 ---
-{{- if not .Values.clusterchecksDeployment.rbac.dedicated -}}
+{{- if not .Values.clusterchecksDeployment.rbac.dedicated }}
 apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
@@ -100,7 +100,7 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "datadog.fullname" . }}
     namespace: {{ .Release.Namespace }}
-{{- end -}}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
#### What this PR does / why we need it:
1.31.8 (and a couple of versions before it) were broken as shipped for me, 
this PR fixes the fundamental issue.

Using double-sided whitespace trimming (something like `{{- end -}}` can be
dangerous anywhere other than at the very beginning and the very end of a
template file, because it trims carriage returns.  This makes it possible to
inadvertently create a manifest like the following:

```yaml
apiVersion: "rbac.authorization.k8s.io/v1"
kind: ClusterRoleBinding
metadata:
  labels:
    app: "datadog"
    chart: "datadog-1.31.8"
    release: "datadog"
    heritage: "Tiller"
  name: datadog
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: datadog
subjects:
  - kind: ServiceAccount
    name: datadog
    namespace: datadog---
apiVersion: v1
kind: ServiceAccount
metadata:
  labels:
    app: "datadog"
    chart: "datadog-1.31.8"
    heritage: "Tiller"
    release: "datadog"
  name: datadog
---
```

Signed-off-by: Steve Huff <shuff@vecna.org>

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
attn @hkaj @irabinovitch @CharlyF @mfpierre @clamoriniere @xlucas 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
