### PR TITLE
[stable/prometheus-operator] Updated the kube-state-metrics svc matchlabels

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -11,7 +11,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 5.18.0
+version: 6.0.0
 appVersion: 0.31.1
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -93,6 +93,12 @@ The `crd-install` hook is required to deploy the prometheus operator CRDs before
 1. Install prometheus-operator by itself, disabling everything but the prometheus-operator component, and also setting `prometheusOperator.serviceMonitor.selfMonitor=false`
 2. Install all the other components, and configure `prometheus.additionalServiceMonitors` to scrape the prometheus-operator service.
 
+
+### Upgrade
+When executing the `helm upgrade` to avoid the error below is need add the argument `--force`.
+> invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/name":"kube-state-metrics"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
+
+
 ## Configuration
 
 The following tables list the configurable parameters of the prometheus-operator chart and their default values.

--- a/stable/prometheus-operator/requirements.lock
+++ b/stable/prometheus-operator/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.6.5
+  version: 2.0.0
 - name: prometheus-node-exporter
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 1.5.1
 - name: grafana
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 3.5.10
-digest: sha256:a3d1b543bd95ccc050bec80481dc4ab231d8c8e9febda173654c462ab9105b48
-generated: "2019-07-10T09:21:49.560501-07:00"
+  version: 3.5.11
+digest: sha256:f1b0b94a4f7a5f58dbb6f13007f9d3379a6f7cdd320b4ebdaf8c85da96b0b955
+generated: 2019-07-17T08:11:31.394436052-03:00

--- a/stable/prometheus-operator/requirements.yaml
+++ b/stable/prometheus-operator/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 
   - name: kube-state-metrics
-    version: 1.6.*
+    version: 2.0.*
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: kubeStateMetrics.enabled
 

--- a/stable/prometheus-operator/templates/exporters/kube-state-metrics/serviceMonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-state-metrics/serviceMonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-kube-state-metrics
 {{ include "prometheus-operator.labels" . | indent 4 }}
 spec:
-  jobLabel: app
+  jobLabel: app.kubernetes.io/name
   endpoints:
   - port: http
     {{- if .Values.kubeStateMetrics.serviceMonitor.interval }}

--- a/stable/prometheus-operator/templates/exporters/kube-state-metrics/serviceMonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-state-metrics/serviceMonitor.yaml
@@ -24,6 +24,6 @@ spec:
 {{- end }}
   selector:
     matchLabels:
-      app: kube-state-metrics
-      release: "{{ .Release.Name }}"
+      app.kubernetes.io/name: kube-state-metrics
+      app.kubernetes.io/instance: "{{ .Release.Name }}"
 {{- end }}


### PR DESCRIPTION
##### What this PR does / why we need it:
The labels from kube-state-metrics service have been changed in commit: https://github.com/helm/charts/commit/ece06ce7535925760b901d630320b429524e6dea#diff-5683c47f1fce3f75f10401ba9b88815b

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
