### PR TITLE
[stable/concourse] #13019 remove workerKeyPub from worker statefulset

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 8.1.2
+version: 8.1.3
 appVersion: 5.4.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/worker-secrets.yaml
+++ b/stable/concourse/templates/worker-secrets.yaml
@@ -13,6 +13,5 @@ type: Opaque
 data:
   host-key-pub: {{ .Values.secrets.hostKeyPub | b64enc | quote }}
   worker-key: {{ .Values.secrets.workerKey | b64enc | quote }}
-  worker-key-pub: {{ .Values.secrets.workerKeyPub | b64enc | quote }}
 {{- end }}
 {{- end }}

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -324,8 +324,6 @@ spec:
                 path: host_key.pub
               - key: worker-key
                 path: worker_key
-              - key: worker-key-pub
-                path: worker_key.pub
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:


### PR DESCRIPTION
#### What this PR does / why we need it:

- @zoetian and I removed references to the worker public key from the worker deployment
- On the Concourse side, we added more tests to make sure this is not used
anywhere (see: concourse/concourse#4133)


#### Which issue this PR fixes

fixes: #13019 
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- ~Variables are documented in the README.md~
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)