### PR TITLE
[stable/prometheus-operator] fix #15572 alertmanager

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -11,7 +11,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 6.1.1
+version: 6.1.2
 appVersion: 0.31.1
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/ci/test-values.yaml
+++ b/stable/prometheus-operator/ci/test-values.yaml
@@ -245,7 +245,7 @@ alertmanager:
 
     ## Define Log Format
     # Use logfmt (default) or json-formatted logging
-    # logFormat: logfmt
+    logFormat: logfmt
 
     ## Log level for Alertmanager to be configured with.
     ##

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -245,7 +245,7 @@ alertmanager:
 
     ## Define Log Format
     # Use logfmt (default) or json-formatted logging
-    # logFormat: logfmt
+    logFormat: logfmt
 
     ## Log level for Alertmanager to be configured with.
     ##


### PR DESCRIPTION
- fixes issue with alertmanager not coming up due to <nil> logFormat
value

Signed-off-by: John Naulty <johnnaulty@bitgo.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Fixes an issue with altermanager not coming up with default values.

#### Which issue this PR fixes

  - fixes #15572 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
