### PR TITLE
[stable/traefik]: Use correct target port for https

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.72.0
+version: 1.72.1
 appVersion: 1.7.12
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/templates/service.yaml
+++ b/stable/traefik/templates/service.yaml
@@ -53,6 +53,8 @@ spec:
     {{- end }}
     {{- if not .Values.ssl.enabled }}
     targetPort: httpn
+    {{- else }}
+    targetPort: https
     {{- end }}
   {{- if (and (.Values.metrics.prometheus.enabled) (not (.Values.metrics.prometheus.restrictAccess)))}}
   - port: 8080


### PR DESCRIPTION
Signed-off-by: Sebastian Poehn <sebastian.poehn@gmail.com>

#### What this PR does / why we need it:

#### Which issue this PR fixes
When `useNonPriviledgedPorts: true` and `ssl.enabled: true` the service will not have a `targetPort` set. Kubernetes will automatically use 443 because the name is https. But in this scenario `targetPort` should be 6443. Thus setting it to the containerPort name.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
