### PR TITLE
[stable/eventrouter] Configurable pod securityContext

### DIFF
--- a/stable/eventrouter/Chart.yaml
+++ b/stable/eventrouter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for eventruter (https://github.com/heptiolabs/eventrouter)
 name: eventrouter
-version: 0.2.0
+version: 0.2.1
 appVersion: 0.2
 home: https://github.com/heptiolabs/eventrouter
 sources:

--- a/stable/eventrouter/README.md
+++ b/stable/eventrouter/README.md
@@ -25,3 +25,4 @@ The following table lists the configurable parameters of the eventrouter chart a
 | `sink`                  | Sink to send the events to                                                                                                  | `glog`                             |
 | `podAnnotations`        | Annotations for pod metadata                                                                                                | `{}`                               |
 | `containerPorts`        | List of ports for the container                                                                                             | `[]`                               |
+| `securityContext`       | Security context for the pod                                                                                                | `{}`                               |

--- a/stable/eventrouter/templates/deployment.yaml
+++ b/stable/eventrouter/templates/deployment.yaml
@@ -41,6 +41,10 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
     {{- end }}
+    {{- if .Values.securityContext }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+    {{- end }}
       serviceAccountName: {{ template "eventrouter.serviceAccountName" . }}
       volumes:
         - name: config-volume

--- a/stable/eventrouter/values.yaml
+++ b/stable/eventrouter/values.yaml
@@ -32,3 +32,6 @@ sink: glog
 podAnnotations: {}
 
 containerPorts: []
+
+securityContext: {}
+  # runAsUser: 1000


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Our clusters run with pod security policy admission controller enabled and the default policies prevent containers from running as privileged users. While the chart default configured eventrouter docker image in fact runs as a non-privileged user, the admission controller prevents it from running due to the use of a username rather than uid. This PR was created to give the user of this helm chart the ability to tailor security context to the requirements of his organisation.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
