### PR TITLE
[stable/kubewatch] Revert pull request #15444

### DIFF
--- a/stable/kubewatch/Chart.yaml
+++ b/stable/kubewatch/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubewatch
-version: 0.8.3
+version: 0.8.4
 apiVersion: v1
 appVersion: 0.0.4
 home: https://github.com/bitnami-labs/kubewatch

--- a/stable/kubewatch/README.md
+++ b/stable/kubewatch/README.md
@@ -37,51 +37,49 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the kubewatch chart and their default values.
 
-|               Parameter                  |        Description                                                                                         |              Default              |
-| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------- | --------------------------------- |
-| `global.imageRegistry`                   | Global Docker image registry                                                                               | `nil`                             |
-| `global.imagePullSecrets`                | Global Docker registry secret names as an array                                                            | `[]` (does not add image pull secrets to deployed pods) |
-| `affinity`                               | node/pod affinities                                                                                        | None                              |
-| `image.registry`                         | Image registry                                                                                             | `docker.io`                       |
-| `image.repository`                       | Image repository                                                                                           | `bitnami/kubewatch`               |
-| `image.tag`                              | Image tag                                                                                                  | `{VERSION}`                       |
-| `image.pullPolicy`                       | Image pull policy                                                                                          | `Always`                          |
-| `nameOverride`                           | String to partially override kubewatch.fullname template with a string (will prepend the release name)     | `nil`                             |
-| `fullnameOverride`                       | String to fully override kubewatch.fullname template with a string                                         | `nil`                             |
-| `nodeSelector`                           | node labels for pod assignment                                                                             | `{}`                              |
-| `podAnnotations`                         | annotations to add to each pod                                                                             | `{}`                              |
-| `podLabels`                              | additional labesl to add to each pod                                                                       | `{}`                              |
-| `replicaCount`                           | desired number of pods                                                                                     | `1`                               |
-| `rbac.create`                            | If true, create & use RBAC resources                                                                       | `true`                            |
-| `serviceAccount.create`                  | If true, create a serviceAccount                                                                           | `true`                            |
-| `serviceAccount.name`                    | existing ServiceAccount to use (ignored if rbac.create=true)                                               | ``                                |
-| `resources`                              | pod resource requests & limits                                                                             | `{}`                              |
-| `slack.enabled`                          | Enable Slack notifications                                                                                 | `true`                            |
-| `slack.channel`                          | Slack channel to notify                                                                                    | `""`                              |
-| `slack.token`                            | Slack API token                                                                                            | `""`                              |
-| `hipchat.enabled`                        | Enable HipChat notifications                                                                               | `false`                           |
-| `hipchat.url`                            | HipChat URL                                                                                                | `""`                              |
-| `hipchat.room`                           | HipChat room to notify                                                                                     | `""`                              |
-| `hipchat.token`                          | HipChat token                                                                                              | `""`                              |
-| `mattermost.enabled`                     | Enable Mattermost notifications                                                                            | `false`                           |
-| `mattermost.channel`                     | Mattermost channel to notify                                                                               | `""`                              |
-| `mattermost.username`                    | Mattermost user to notify                                                                                  | `""`                              |
-| `mattermost.url`                         | Mattermost URL                                                                                             | `""`                              |
-| `flock.enabled`                          | Enable Flock notifications                                                                                 | `false`                           |
-| `flock.url`                              | Flock URL                                                                                                  | `""`                              |
-| `webhook.enabled`                        | Enable Webhook notifications                                                                               | `false`                           |
-| `webhook.url`                            | Webhook URL                                                                                                | `""`                              |
-| `tolerations`                            | List of node taints to tolerate (requires Kubernetes >= 1.6)                                               | `[]`                              |
-| `namespaceToWatch`                       | namespace to watch, leave it empty for watching all                                                        | `""`                              |
-| `resourcesToWatch`                       | list of resources which kubewatch should watch and notify slack                                            | `{pod: true, deployment: true}`   |
-| `resourcesToWatch.pod`                   | watch changes to [Pods](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/)                  | `true`                            |
-| `resourcesToWatch.deployment`            | watch changes to [Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)      | `true`                            |
-| `resourcesToWatch.replicationcontroller` | watch changes to [ReplicationControllers](https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/) | `false`          |
-| `resourcesToWatch.replicaset`            | watch changes to [ReplicaSets](https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/)      | `false`                           |
-| `resourcesToWatch.daemonset`             | watch changes to [DaemonSets](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/)        | `false`                           |
-| `resourcesToWatch.services`              | watch changes to [Services](https://kubernetes.io/docs/concepts/services-networking/service/)              | `false`                           |
-| `resourcesToWatch.job`                   | watch changes to [Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/) | `false`                           |
-| `resourcesToWatch.persistentvolume`      | watch changes to [PersistentVolumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)      | `false`                           |
+|               Parameter                  |        Description                   |              Default              |
+| ---------------------------------------- | ------------------------------------ | --------------------------------- |
+| `global.imageRegistry`                   | Global Docker image registry         | `nil`                             |
+| `global.imagePullSecrets`                | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
+| `affinity`                               | node/pod affinities                  | None                              |
+| `image.registry`                         | Image registry                       | `docker.io`                       |
+| `image.repository`                       | Image repository                     | `bitnami/kubewatch`               |
+| `image.tag`                              | Image tag                            | `{VERSION}`                       |
+| `image.pullPolicy`                       | Image pull policy                    | `Always`                          |
+| `nodeSelector`                           | node labels for pod assignment       | `{}`                              |
+| `podAnnotations`                         | annotations to add to each pod       | `{}`                              |
+| `podLabels`                              | additional labesl to add to each pod | `{}`                              |
+| `replicaCount`                           | desired number of pods               | `1`                               |
+| `rbac.create`                            | If true, create & use RBAC resources | `true`                            |
+| `serviceAccount.create`                  | If true, create a serviceAccount     | `true`                            |
+| `serviceAccount.name`                    | existing ServiceAccount to use (ignored if rbac.create=true) | ``        |
+| `resources`                              | pod resource requests & limits       | `{}`                              |
+| `slack.enabled`                          | Enable Slack notifications           | `true`                            |
+| `slack.channel`                          | Slack channel to notify              | `""`                              |
+| `slack.token`                            | Slack API token                      | `""`                              |
+| `hipchat.enabled`                        | Enable HipChat notifications         | `false`                           |
+| `hipchat.url`                            | HipChat URL                          | `""`                              |
+| `hipchat.room`                           | HipChat room to notify               | `""`                              |
+| `hipchat.token`                          | HipChat token                        | `""`                              |
+| `mattermost.enabled`                     | Enable Mattermost notifications      | `false`                           |
+| `mattermost.channel`                     | Mattermost channel to notify         | `""`                              |
+| `mattermost.username`                    | Mattermost user to notify            | `""`                              |
+| `mattermost.url`                         | Mattermost URL                       | `""`                              |
+| `flock.enabled`                          | Enable Flock notifications           | `false`                           |
+| `flock.url`                              | Flock URL                            | `""`                              |
+| `webhook.enabled`                        | Enable Webhook notifications         | `false`                           |
+| `webhook.url`                            | Webhook URL                          | `""`                              |
+| `tolerations`                            | List of node taints to tolerate (requires Kubernetes >= 1.6)                                                                | `[]`                              |
+| `namespaceToWatch`                       | namespace to watch, leave it empty for watching all                                                                         | `""`                              |
+| `resourcesToWatch`                       | list of resources which kubewatch should watch and notify slack                                                             | `{pod: true, deployment: true}`   |
+| `resourcesToWatch.pod`                   | watch changes to [Pods](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/)                                   | `true`                            |
+| `resourcesToWatch.deployment`            | watch changes to [Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)                       | `true`                            |
+| `resourcesToWatch.replicationcontroller` | watch changes to [ReplicationControllers](https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/) | `false`                           |
+| `resourcesToWatch.replicaset`            | watch changes to [ReplicaSets](https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/)                       | `false`                           |
+| `resourcesToWatch.daemonset`             | watch changes to [DaemonSets](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/)                         | `false`                           |
+| `resourcesToWatch.services`              | watch changes to [Services](https://kubernetes.io/docs/concepts/services-networking/service/)                               | `false`                           |
+| `resourcesToWatch.job`                   | watch changes to [Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/)                  | `false`                           |
+| `resourcesToWatch.persistentvolume`      | watch changes to [PersistentVolumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)                       | `false`                           |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/kubewatch/values.yaml
+++ b/stable/kubewatch/values.yaml
@@ -58,14 +58,6 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
-## String to partially override kubewatch.fullname template (will maintain the release name)
-##
-# nameOverride:
-
-## String to fully override kubewatch.fullname template
-##
-# fullnameOverride:
-
 rbac:
   # If true, create & use RBAC resources
   #


### PR DESCRIPTION
This reverts commit baefdbaf9e16a152de2d70f3b8e07af1d83acd64.

Changes in the previous commit are breaking changes when used in some configurations, for example `helm upgrade` doesn't work using a static IP in the `loadBalancer`. 
According to [semver](http://semver.org/):

> Given a version number `MAJOR.MINOR.PATCH`, increment the:
> - MAJOR version when you make incompatible API changes,
> - MINOR version when you add functionality in a backward-compatible manner, and
> - PATCH version when you make backward-compatible bug fixes.
> Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.

Those changes are not backward-compatible, so we should have increased the _MAJOR_ version instead of the _PATCH_ one. In this PR, we are reverting the breaking changes so the current _MAJOR_ version will continue working without issues. 
In the same way, we will create a new PR adding again those changes but bumping the chart version in a _MAJOR_

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)