### PR TITLE
[stable/moodle] Revert pull request #15440

### DIFF
--- a/stable/moodle/Chart.yaml
+++ b/stable/moodle/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: moodle
-version: 4.2.9
+version: 4.2.10
 appVersion: 3.7.1
 description: Moodle is a learning platform designed to provide educators, administrators and learners with a single robust, secure and integrated system to create personalised learning environments
 keywords:

--- a/stable/moodle/README.md
+++ b/stable/moodle/README.md
@@ -56,8 +56,6 @@ The following table lists the configurable parameters of the Moodle chart and th
 | `image.tag`                           | Moodle Image tag                                                                             | `{TAG_NAME}`                                  |
 | `image.pullPolicy`                    | Image pull policy                                                                            | `IfNotPresent`                                |
 | `image.pullSecrets`                   | Specify docker-registry secret names as an array                                             | `[]` (does not add image pull secrets to deployed pods) |
-| `nameOverride`                        | String to partially override moodle.fullname template with a string (will prepend the release name) | `nil`                                   |
-| `fullnameOverride`                    | String to fully override moodle.fullname template with a string                              | `nil`                                          |
 | `moodleUsername`                      | User of the application                                                                      | `user`                                         |
 | `moodlePassword`                      | Application password                                                                         | _random 10 character alphanumeric string_      |
 | `moodleEmail`                         | Admin email                                                                                  | `user@example.com`                             |

--- a/stable/moodle/templates/_helpers.tpl
+++ b/stable/moodle/templates/_helpers.tpl
@@ -11,16 +11,8 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "moodle.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
@@ -28,16 +20,15 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "moodle.mariadb.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- printf "%s-%s" .Values.fullnameOverride "mariadb" | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
 {{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s-%s" .Release.Name $name "mariadb" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "moodle.moodle.fullname" -}}
+{{- printf "%s-%s" .Release.Name "moodle" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/stable/moodle/templates/deployment.yaml
+++ b/stable/moodle/templates/deployment.yaml
@@ -154,7 +154,7 @@ spec:
       - name: moodle-data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ .Values.persistence.existingClaim | default (include "moodle.fullname" . ) }}
+          claimName: {{ .Values.persistence.existingClaim | default (include "moodle.moodle.fullname" . ) }}
       {{- else }}
         emptyDir: {}
       {{- end }}

--- a/stable/moodle/values.yaml
+++ b/stable/moodle/values.yaml
@@ -26,14 +26,6 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
-## String to partially override moodle.fullname template (will maintain the release name)
-##
-# nameOverride:
-
-## String to fully override moodle.fullname template
-##
-# fullnameOverride:
-
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-moodle#configuration
 ##


### PR DESCRIPTION
This reverts commit 4d1ca2afa6992964c8f0929bdf157873dd6eaae6.

Changes in the previous commit are breaking changes when used in some configurations, for example `helm upgrade` doesn't work using a static IP in the `loadBalancer`. 
According to [semver](http://semver.org/):

> Given a version number `MAJOR.MINOR.PATCH`, increment the:
> - MAJOR version when you make incompatible API changes,
> - MINOR version when you add functionality in a backward-compatible manner, and
> - PATCH version when you make backward-compatible bug fixes.
> Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.

Those changes are not backward-compatible, so we should have increased the _MAJOR_ version instead of the _PATCH_ one. In this PR, we are reverting the breaking changes so the current _MAJOR_ version will continue working without issues. 
In the same way, we will create a new PR adding again those changes but bumping the chart version in a _MAJOR_

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)