### PR TITLE
[stable/nats] Revert pull request #15439

### DIFF
--- a/stable/nats/Chart.yaml
+++ b/stable/nats/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nats
-version: 3.0.3
+version: 3.0.4
 appVersion: 2.0.2
 description: An open-source, cloud-native messaging system
 keywords:

--- a/stable/nats/README.md
+++ b/stable/nats/README.md
@@ -54,8 +54,6 @@ The following table lists the configurable parameters of the NATS chart and thei
 | `image.tag`                          | NATS Image tag                                                                               | `{TAG_NAME}`                                                  |
 | `image.pullPolicy`                   | Image pull policy                                                                            | `IfNotPresent`                                                |
 | `image.pullSecrets`                  | Specify docker-registry secret names as an array                                             | `[]` (does not add image pull secrets to deployed pods)       |
-| `nameOverride`                       | String to partially override nats.fullname template with a string (will prepend the release name) | `nil`                                                    |
-| `fullnameOverride`                   | String to fully override nats.fullname template with a string                                | `nil`                                                         |
 | `auth.enabled`                       | Switch to enable/disable client authentication                                               | `true`                                                        |
 | `auth.user`                          | Client authentication user                                                                   | `nats_cluster`                                                |
 | `auth.password`                      | Client authentication password                                                               | `random alhpanumeric string (10)`                             |

--- a/stable/nats/templates/_helpers.tpl
+++ b/stable/nats/templates/_helpers.tpl
@@ -12,16 +12,8 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "nats.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
 {{- end -}}
 
 {{- define "nats.chart" -}}

--- a/stable/nats/values-production.yaml
+++ b/stable/nats/values-production.yaml
@@ -26,14 +26,6 @@ image:
   # pullSecrets:
   #   - name: myRegistryKeySecretName
 
-## String to partially override nats.fullname template (will maintain the release name)
-##
-# nameOverride:
-
-## String to fully override nats.fullname template
-##
-# fullnameOverride:
-
 ## NATS replicas
 replicaCount: 3
 

--- a/stable/nats/values.yaml
+++ b/stable/nats/values.yaml
@@ -26,14 +26,6 @@ image:
   # pullSecrets:
   #   - name: myRegistryKeySecretName
 
-## String to partially override nats.fullname template (will maintain the release name)
-##
-# nameOverride:
-
-## String to fully override nats.fullname template
-##
-# fullnameOverride:
-
 ## NATS replicas
 replicaCount: 1
 


### PR DESCRIPTION
This reverts commit f526decd27ab8e00769c2c48f61af6fca520dd8d.

Changes in the previous commit are breaking changes when used in some configurations, for example `helm upgrade` doesn't work using a static IP in the `loadBalancer`. 
According to [semver](http://semver.org/):

> Given a version number `MAJOR.MINOR.PATCH`, increment the:
> - MAJOR version when you make incompatible API changes,
> - MINOR version when you add functionality in a backward-compatible manner, and
> - PATCH version when you make backward-compatible bug fixes.
> Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.

Those changes are not backward-compatible, so we should have increased the _MAJOR_ version instead of the _PATCH_ one. In this PR, we are reverting the breaking changes so the current _MAJOR_ version will continue working without issues. 
In the same way, we will create a new PR adding again those changes but bumping the chart version in a _MAJOR_

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)