### PR TITLE
[stable/opencart] Revert pull request #15435

### DIFF
--- a/stable/opencart/Chart.yaml
+++ b/stable/opencart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: opencart
-version: 4.5.4
+version: 4.5.5
 appVersion: 3.0.3-2
 description: A free and open source e-commerce platform for online merchants. It provides a professional and reliable foundation for a successful online store.
 keywords:

--- a/stable/opencart/README.md
+++ b/stable/opencart/README.md
@@ -56,8 +56,6 @@ The following table lists the configurable parameters of the OpenCart chart and 
 | `image.tag`                         | OpenCart Image tag                        | `{TAG_NAME}`                                             |
 | `image.pullPolicy`                  | Image pull policy                         | `IfNotPresent`                                           |
 | `image.pullSecrets`                 | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
-| `nameOverride`                      | String to partially override opencart.fullname template with a string (will prepend the release name) | `nil` |
-| `fullnameOverride`                  | String to fully override opencart.fullname template with a string                                     | `nil` |
 | `opencartHost`                      | OpenCart host to create application URLs  | `nil`                                                    |
 | `service.type`                      | Kubernetes Service type                   | `LoadBalancer`                                           |
 | `service.port`                      | Service HTTP port                         | `80`                                                     |

--- a/stable/opencart/templates/_helpers.tpl
+++ b/stable/opencart/templates/_helpers.tpl
@@ -11,16 +11,8 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "opencart.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/opencart/values.yaml
+++ b/stable/opencart/values.yaml
@@ -26,14 +26,6 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
-## String to partially override opencart.fullname template (will maintain the release name)
-##
-# nameOverride:
-
-## String to fully override opencart.fullname template
-##
-# fullnameOverride:
-
 ## OpenCart host to create application URLs
 ## ref: https://github.com/bitnami/bitnami-docker-opencart#configuration
 ##


### PR DESCRIPTION
This reverts commit aa098c8a9ecf23e31dc8f02abeb364024ed1d338.

Changes in the previous commit are breaking changes when used in some configurations, for example `helm upgrade` doesn't work using a static IP in the `loadBalancer`. 
According to [semver](http://semver.org/):

> Given a version number `MAJOR.MINOR.PATCH`, increment the:
> - MAJOR version when you make incompatible API changes,
> - MINOR version when you add functionality in a backward-compatible manner, and
> - PATCH version when you make backward-compatible bug fixes.
> Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.

Those changes are not backward-compatible, so we should have increased the _MAJOR_ version instead of the _PATCH_ one. In this PR, we are reverting the breaking changes so the current _MAJOR_ version will continue working without issues. 
In the same way, we will create a new PR adding again those changes but bumping the chart version in a _MAJOR_

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)