### PR TITLE
[stable/phpbb] Revert pull request #15429

### DIFF
--- a/stable/phpbb/Chart.yaml
+++ b/stable/phpbb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: phpbb
-version: 4.4.4
+version: 4.4.5
 appVersion: 3.2.7
 description: Community forum that supports the notion of users and groups, file attachments, full-text search, notifications and more.
 keywords:

--- a/stable/phpbb/README.md
+++ b/stable/phpbb/README.md
@@ -55,9 +55,7 @@ The following table lists the configurable parameters of the phpBB chart and the
 | `image.repository`                | phpBB image name                      | `bitnami/phpbb`                                         |
 | `image.tag`                       | phpBB image tag                       | `{TAG_NAME}`                                            |
 | `image.pullPolicy`                | Image pull policy                     | `IfNotPresent`                                          |
-| `image.pullSecrets`               | Specify docker-registry secret names as an array  | `[]` (does not add image pull secrets to deployed pods)    |
-| `nameOverride`                    | String to partially override phpbb.fullname template with a string (will prepend the release name) | `nil`     |
-| `fullnameOverride`                | String to fully override phpbb.fullname template with a string                                     | `nil`     |
+| `image.pullSecrets`               | Specify docker-registry secret names as an array            | `[]` (does not add image pull secrets to deployed pods)                                                   |
 | `phpbbUser`                       | User of the application               | `user`                                                  |
 | `phpbbPassword`                   | Application password                  | _random 10 character long alphanumeric string_          |
 | `phpbbEmail`                      | Admin email                           | `user@example.com`                                      |
@@ -70,44 +68,44 @@ The following table lists the configurable parameters of the phpBB chart and the
 | `externalDatabase.user`           | Existing username in the external db  | `bn_phpbb`                                              |
 | `externalDatabase.password`       | Password for the above username       | `nil`                                                   |
 | `externalDatabase.database`       | Name of the existing database         | `bitnami_phpbb`                                         |
-| `ingress.enabled`                 | Enable ingress controller resource    | `false`                                                 |
-| `ingress.annotations`             | Ingress annotations                   | `[]`                                                    |
-| `ingress.certManager`             | Add annotations for cert-manager      | `false`                                                 |
-| `ingress.hosts[0].name`           | Hostname to your phpbb installation   | `phpbb.local`                                           |
-| `ingress.hosts[0].path`           | Path within the url structure         | `/`                                                     |
-| `ingress.hosts[0].tls`            | Utilize TLS backend in ingress        | `false`                                                 |
-| `ingress.hosts[0].tlsHosts`       | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`) | `nil`    |
-| `ingress.hosts[0].tlsSecret`      | TLS Secret (certificates)             | `phpbb.local-tls-secret`                                |
-| `ingress.secrets[0].name`         | TLS Secret Name                       | `nil`                                                   |
-| `ingress.secrets[0].certificate`  | TLS Secret Certificate                | `nil`                                                   |
-| `ingress.secrets[0].key`          | TLS Secret Key                        | `nil`                                                   |
+| `ingress.enabled`                   | Enable ingress controller resource                            | `false`                                                  |
+| `ingress.annotations`               | Ingress annotations                                           | `[]`                                                     |
+| `ingress.certManager`               | Add annotations for cert-manager                              | `false`                                                  |
+| `ingress.hosts[0].name`             | Hostname to your phpbb installation                           | `phpbb.local`                                            |
+| `ingress.hosts[0].path`             | Path within the url structure                                 | `/`                                                      |
+| `ingress.hosts[0].tls`              | Utilize TLS backend in ingress                                | `false`                                                  |
+| `ingress.hosts[0].tlsHosts`         | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`)                               | `nil`                                                  |
+| `ingress.hosts[0].tlsSecret`        | TLS Secret (certificates)                                     | `phpbb.local-tls-secret`                                 |
+| `ingress.secrets[0].name`           | TLS Secret Name                                               | `nil`                                                    |
+| `ingress.secrets[0].certificate`    | TLS Secret Certificate                                        | `nil`                                                    |
+| `ingress.secrets[0].key`            | TLS Secret Key                                                | `nil`                                                    |
 | `mariadb.enabled`                 | Use or not the MariaDB chart          | `true`                                                  |
-| `mariadb.rootUser.password`       | MariaDB admin password                | `nil`                                                   |
-| `mariadb.db.name`                 | Database name to create               | `bitnami_phpbb`                                         |
-| `mariadb.db.user`                 | Database user to create               | `bn_phpbb`                                              |
-| `mariadb.db.password`             | Password for the database             | _random 10 character long alphanumeric string_          |
-| `service.type`                    | Kubernetes Service type               | `LoadBalancer`                                          |
-| `service.port`                    | Service HTTP port (Dashboard)         | `80`                                                    |
-| `nodePorts.http`                  | Kubernetes http node port             | `""`                                                    |
-| `nodePorts.https`                 | Kubernetes https node port            | `""`                                                    |
-| `service.externalTrafficPolicy`   | Enable client source IP preservation  | `Cluster`                                               |
-| `service.nodePorts.http`          | Kubernetes http node port             | `""`                                                    |
-| `service.nodePorts.https`         | Kubernetes https node port            | `""`                                                    |
-| `service.loadBalancerIP`          | LoadBalancer service IP               | `""`                                                    |
+| `mariadb.rootUser.password`     | MariaDB admin password                | `nil`                                                   |
+| `mariadb.db.name`         | Database name to create               | `bitnami_phpbb`                                         |
+| `mariadb.db.user`             | Database user to create               | `bn_phpbb`                                              |
+| `mariadb.db.password`         | Password for the database             | _random 10 character long alphanumeric string_          |
+| `service.type`                    | Kubernetes Service type                    | `LoadBalancer`                                          |
+| `service.port`                    | Service HTTP port (Dashboard)                   | `80`                                          |
+| `nodePorts.http`                 | Kubernetes http node port                  | `""`                                                    |
+| `nodePorts.https`                | Kubernetes https node port                 | `""`                                                    |
+| `service.externalTrafficPolicy`   | Enable client source IP preservation       | `Cluster`                                               |
+| `service.nodePorts.http`                 | Kubernetes http node port                  | `""`                                                    |
+| `service.nodePorts.https`                 | Kubernetes https node port                  | `""`                                                    |
+| `service.loadBalancerIP`                 | LoadBalancer service IP                  | `""`                                                    |
 | `persistence.enabled`             | Enable persistence using PVC          | `true`                                                  |
 | `persistence.phpbb.storageClass`  | PVC Storage Class for phpBB volume    | `nil` (uses alpha storage class annotation)             |
 | `persistence.phpbb.accessMode`    | PVC Access Mode for phpBB volume      | `ReadWriteOnce`                                         |
 | `persistence.phpbb.size`          | PVC Storage Request for phpBB volume  | `8Gi`                                                   |
 | `resources`                       | CPU/Memory resource requests/limits   | Memory: `512Mi`, CPU: `300m`                            |
-| `podAnnotations`                  | Pod annotations                       | `{}`                                                    |
-| `metrics.enabled`                 | Start a side-car prometheus exporter  | `false`                                                 |
-| `metrics.image.registry`          | Apache exporter image registry        | `docker.io`                                             |
-| `metrics.image.repository`        | Apache exporter image name            | `lusotycoon/apache-exporter`                            |
-| `metrics.image.tag`               | Apache exporter image tag             | `v0.5.0`                                                |
-| `metrics.image.pullPolicy`        | Image pull policy                     | `IfNotPresent`                                          |
-| `metrics.image.pullSecrets`       | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
-| `metrics.podAnnotations`          | Additional annotations for Metrics exporter pod | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}`|
-| `metrics.resources`               | Exporter resource requests/limit      | {}                                                       |
+| `podAnnotations`                | Pod annotations                                   | `{}`                                                       |
+| `metrics.enabled`                          | Start a side-car prometheus exporter                                                                           | `false`                                              |
+| `metrics.image.registry`                   | Apache exporter image registry                                                                                  | `docker.io`                                          |
+| `metrics.image.repository`                 | Apache exporter image name                                                                                      | `lusotycoon/apache-exporter`                           |
+| `metrics.image.tag`                        | Apache exporter image tag                                                                                       | `v0.5.0`                                            |
+| `metrics.image.pullPolicy`                 | Image pull policy                                                                                              | `IfNotPresent`                                       |
+| `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                                               | `[]` (does not add image pull secrets to deployed pods)                                                |
+| `metrics.podAnnotations`                   | Additional annotations for Metrics exporter pod                                                                | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}`                                                   |
+| `metrics.resources`                        | Exporter resource requests/limit                                                                               | {}                        |
 
 The above parameters map to the env variables defined in [bitnami/phpbb](http://github.com/bitnami/bitnami-docker-phpbb). For more information please refer to the [bitnami/phpbb](http://github.com/bitnami/bitnami-docker-phpbb) image documentation.
 

--- a/stable/phpbb/templates/_helpers.tpl
+++ b/stable/phpbb/templates/_helpers.tpl
@@ -11,16 +11,8 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "phpbb.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/phpbb/values.yaml
+++ b/stable/phpbb/values.yaml
@@ -26,14 +26,6 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
-## String to partially override phpbb.fullname template (will maintain the release name)
-##
-# nameOverride:
-
-## String to fully override phpbb.fullname template
-##
-# fullnameOverride:
-
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-phpbb#environment-variables
 ##


### PR DESCRIPTION
This reverts commit fcd60d392daba96e8129610cfc25f21898e4011f.

Changes in the previous commit are breaking changes when used in some configurations, for example `helm upgrade` doesn't work using a static IP in the `loadBalancer`. 
According to [semver](http://semver.org/):

> Given a version number `MAJOR.MINOR.PATCH`, increment the:
> - MAJOR version when you make incompatible API changes,
> - MINOR version when you add functionality in a backward-compatible manner, and
> - PATCH version when you make backward-compatible bug fixes.
> Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.

Those changes are not backward-compatible, so we should have increased the _MAJOR_ version instead of the _PATCH_ one. In this PR, we are reverting the breaking changes so the current _MAJOR_ version will continue working without issues. 
In the same way, we will create a new PR adding again those changes but bumping the chart version in a _MAJOR_

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)