### PR TITLE
[stable/parse] Revert pull request #15431

### DIFF
--- a/stable/parse/Chart.yaml
+++ b/stable/parse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: parse
-version: 6.2.15
+version: 6.2.16
 appVersion: 3.6.0
 description: Parse is a platform that enables users to add a scalable and powerful backend to launch a full-featured app for iOS, Android, JavaScript, Windows, Unity, and more.
 keywords:

--- a/stable/parse/README.md
+++ b/stable/parse/README.md
@@ -49,8 +49,6 @@ The following table lists the configurable parameters of the Parse chart and the
 |---------------------------------------|------------------------------------------|-------------------------------------------------------- |
 | `global.imageRegistry`                | Global Docker image registry             | `nil`                                                   |
 | `global.imagePullSecrets`             | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
-| `nameOverride`                        | String to partially override parse.fullname template with a string (will prepend the release name) | `nil`|
-| `fullnameOverride`                    | String to fully override parse.fullname template with a string                                     | `nil`|
 | `service.type`                        | Kubernetes Service type                  | `LoadBalancer`                                          |
 | `service.port`                        | Service HTTP port (Dashboard)            | `80`                                                    |
 | `service.loadBalancerIP`              | `loadBalancerIP` for the Parse Service   | `nil`                                                   |
@@ -86,22 +84,22 @@ The following table lists the configurable parameters of the Parse chart and the
 | `persistence.storageClass`            | PVC Storage Class for Parse volume       | `nil` (uses alpha storage class annotation)             |
 | `persistence.accessMode`              | PVC Access Mode for Parse volume         | `ReadWriteOnce`                                         |
 | `persistence.size`                    | PVC Storage Request for Parse volume     | `8Gi`                                                   |
-| `ingress.enabled`                     | Enable ingress controller resource       | `false`                                                 |
-| `ingress.annotations`                 | Ingress annotations                      | `[]`                                                    |
-| `ingress.certManager`                 | Add annotations for cert-manager         | `false`                                                 |
-| `ingress.dashboard.hosts[0].name`     | Hostname to your Parse Dashboard installation | `ghost.local`                                      |
-| `ingress.dashboard.hosts[0].path`     | Path within the url structure            | `/`                                                     |
-| `ingress.dashboard.hosts[0].tls`      | Utilize TLS backend in ingress           | `false`                                                 |
-| `ingress.dashboard.hosts[0].tlsHosts` | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`) | `nil`       |
-| `ingress.dashboard.hosts[0].tlsSecret`| TLS Secret (certificates)                | `ghost.local-tls-secret`                                |
-| `ingress.server.hosts[0].name`        | Hostname to your Parse Server installation | `ghost.local`                                         |
-| `ingress.server.hosts[0].path`        | Path within the url structure            | `/`                                                     |
-| `ingress.server.hosts[0].tls`         | Utilize TLS backend in ingress           | `false`                                                 |
-| `ingress.server.hosts[0].tlsHosts`    | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`) | `nil`       |
-| `ingress.server.hosts[0].tlsSecret`   | TLS Secret (certificates)                | `ghost.local-tls-secret`                                |
-| `ingress.secrets[0].name`             | TLS Secret Name                          | `nil`                                                   |
-| `ingress.secrets[0].certificate`      | TLS Secret Certificate                   | `nil`                                                   |
-| `ingress.secrets[0].key`              | TLS Secret Key                           | `nil`                                                   |
+| `ingress.enabled`                   | Enable ingress controller resource                            | `false`                                                  |
+| `ingress.annotations`               | Ingress annotations                                           | `[]`                                                     |
+| `ingress.certManager`               | Add annotations for cert-manager                              | `false`                                                  |
+| `ingress.dashboard.hosts[0].name`             | Hostname to your Parse Dashboard installation                           | `ghost.local`                                            |
+| `ingress.dashboard.hosts[0].path`             | Path within the url structure                                 | `/`                                                      |
+| `ingress.dashboard.hosts[0].tls`              | Utilize TLS backend in ingress                                | `false`                                                  |
+| `ingress.dashboard.hosts[0].tlsHosts`         | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`)                               | `nil`                                                  |
+| `ingress.dashboard.hosts[0].tlsSecret`        | TLS Secret (certificates)                                     | `ghost.local-tls-secret`                                 |
+| `ingress.server.hosts[0].name`             | Hostname to your Parse Server installation                           | `ghost.local`                                            |
+| `ingress.server.hosts[0].path`             | Path within the url structure                                 | `/`                                                      |
+| `ingress.server.hosts[0].tls`              | Utilize TLS backend in ingress                                | `false`                                                  |
+| `ingress.server.hosts[0].tlsHosts`         | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`)                               | `nil`                                                  |
+| `ingress.server.hosts[0].tlsSecret`        | TLS Secret (certificates)                                     | `ghost.local-tls-secret`                                 |
+| `ingress.secrets[0].name`           | TLS Secret Name                                               | `nil`                                                    |
+| `ingress.secrets[0].certificate`    | TLS Secret Certificate                                        | `nil`                                                    |
+| `ingress.secrets[0].key`            | TLS Secret Key                                                | `nil`                                                    |
 | `mongodb.usePassword`                 | Enable MongoDB password authentication   | `true`                                                  |
 | `mongodb.password`                    | MongoDB admin password                   | `nil`                                                   |
 | `mongodb.persistence.enabled`         | Enable MongoDB persistence using PVC     | `true`                                                  |

--- a/stable/parse/templates/_helpers.tpl
+++ b/stable/parse/templates/_helpers.tpl
@@ -18,32 +18,16 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "parse.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-{{- end -}}
-{{- end -}}
+
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "parse.mongodb.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- printf "%s-%s" .Values.fullnameOverride "mongodb" | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
 {{- printf "%s-%s" .Release.Name "mongodb" | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s-%s" .Release.Name $name "mongodb" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/parse/values.yaml
+++ b/stable/parse/values.yaml
@@ -7,14 +7,6 @@
 #   imagePullSecrets:
 #     - myRegistryKeySecretName
 
-## String to partially override parse.fullname template (will maintain the release name)
-##
-# nameOverride:
-
-## String to fully override parse.fullname template
-##
-# fullnameOverride:
-
 ## Kubernetes serviceType for Parse Deployment
 ## ref: http://kubernetes.io/docs/user-guide/services/#publishing-services---service-types
 ##


### PR DESCRIPTION
This reverts commit a39c89ccc87e43dbeabf6b45061b41d3d5f2400e.

Changes in the previous commit are breaking changes when used in some configurations, for example `helm upgrade` doesn't work using a static IP in the `loadBalancer`. 
According to [semver](http://semver.org/):

> Given a version number `MAJOR.MINOR.PATCH`, increment the:
> - MAJOR version when you make incompatible API changes,
> - MINOR version when you add functionality in a backward-compatible manner, and
> - PATCH version when you make backward-compatible bug fixes.
> Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.

Those changes are not backward-compatible, so we should have increased the _MAJOR_ version instead of the _PATCH_ one. In this PR, we are reverting the breaking changes so the current _MAJOR_ version will continue working without issues. 
In the same way, we will create a new PR adding again those changes but bumping the chart version in a _MAJOR_

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)