### PR TITLE
[stable/mongodb] Revert pull request #15441

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 6.1.3
+version: 6.1.4
 appVersion: 4.0.10
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/README.md
+++ b/stable/mongodb/README.md
@@ -55,8 +55,6 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `image.pullPolicy`                                 | Image pull policy                                                                            | `IfNotPresent`                                          |
 | `image.pullSecrets`                                | Specify docker-registry secret names as an array                                             | `[]` (does not add image pull secrets to deployed pods) |
 | `image.debug`                                      | Specify if debug logs should be enabled                                                      | `false`                                                 |
-| `nameOverride`                                     | String to partially override mongodb.fullname template with a string (will prepend the release name) | `nil`                                           |
-| `fullnameOverride`                                 | String to fully override mongodb.fullname template with a string                             | `nil`                                                   |
 | `clusterDomain`                                    | Default Kubernetes cluster domain                                                            | `cluster.local`                                         |
 | `usePassword`                                      | Enable password authentication                                                               | `true`                                                  |
 | `existingSecret`                                   | Existing secret with MongoDB credentials                                                     | `nil`                                                   |

--- a/stable/mongodb/values-production.yaml
+++ b/stable/mongodb/values-production.yaml
@@ -34,14 +34,6 @@ image:
   ## ref:  https://github.com/bitnami/minideb-extras-base
   debug: false
 
-## String to partially override mongodb.fullname template (will maintain the release name)
-##
-# nameOverride:
-
-## String to fully override mongodb.fullname template
-##
-# fullnameOverride:
-
 ## Enable authentication
 ## ref: https://docs.mongodb.com/manual/tutorial/enable-authentication/
 #

--- a/stable/mongodb/values.yaml
+++ b/stable/mongodb/values.yaml
@@ -34,14 +34,6 @@ image:
   ## ref:  https://github.com/bitnami/minideb-extras-base
   debug: false
 
-## String to partially override mongodb.fullname template (will maintain the release name)
-##
-# nameOverride:
-
-## String to fully override mongodb.fullname template
-##
-# fullnameOverride:
-
 ## Enable authentication
 ## ref: https://docs.mongodb.com/manual/tutorial/enable-authentication/
 #


### PR DESCRIPTION
This reverts commit eb209d4210998dcea147c54688cc42a83c0ea897.

Changes in the previous commit are breaking changes when used in some configurations, for example `helm upgrade` doesn't work using a static IP in the `loadBalancer`. 
According to [semver](http://semver.org/):

> Given a version number `MAJOR.MINOR.PATCH`, increment the:
> - MAJOR version when you make incompatible API changes,
> - MINOR version when you add functionality in a backward-compatible manner, and
> - PATCH version when you make backward-compatible bug fixes.
> Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.

Those changes are not backward-compatible, so we should have increased the _MAJOR_ version instead of the _PATCH_ one. In this PR, we are reverting the breaking changes so the current _MAJOR_ version will continue working without issues. 
In the same way, we will create a new PR adding again those changes but bumping the chart version in a _MAJOR_

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)