### PR TITLE
[stable/drupal] Revert pull request #15449

### DIFF
--- a/stable/drupal/Chart.yaml
+++ b/stable/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 3.3.7
+version: 3.3.8
 appVersion: 8.7.4
 description: One of the most versatile open source content management systems.
 keywords:

--- a/stable/drupal/README.md
+++ b/stable/drupal/README.md
@@ -56,8 +56,6 @@ The following table lists the configurable parameters of the Drupal chart and th
 | `image.tag`                       | Drupal Image tag                           | `{TAG_NAME}`                                              |
 | `image.pullPolicy`                | Drupal image pull policy                   | `IfNotPresent`                                            |
 | `image.pullSecrets`               | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)  |
-| `nameOverride`                    | String to partially override drupal.fullname template with a string (will prepend the release name) | `nil` |
-| `fullnameOverride`                | String to fully override drupal.fullname template with a string                                     | `nil` |
 | `drupalProfile`                   | Drupal installation profile                | `standard`                                                |
 | `drupalUsername`                  | User of the application                    | `user`                                                    |
 | `drupalPassword`                  | Application password                       | _random 10 character long alphanumeric string_            |

--- a/stable/drupal/templates/_helpers.tpl
+++ b/stable/drupal/templates/_helpers.tpl
@@ -11,16 +11,8 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "drupal.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/drupal/values.yaml
+++ b/stable/drupal/values.yaml
@@ -26,14 +26,6 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
-## String to partially override drupal.fullname template (will maintain the release name)
-##
-# nameOverride:
-
-## String to fully override drupal.fullname template
-##
-# fullnameOverride:
-
 ## Installation Profile
 ## ref: https://github.com/bitnami/bitnami-docker-drupal#configuration
 ##


### PR DESCRIPTION
This reverts commit bdde9b209403179cb6d31de4c27c13222d302f5b.

Changes in the previous commit are breaking changes when used in some configurations, for example `helm upgrade` doesn't work using a static IP in the `loadBalancer`. 
According to [semver](http://semver.org/):

> Given a version number `MAJOR.MINOR.PATCH`, increment the:
> - MAJOR version when you make incompatible API changes,
> - MINOR version when you add functionality in a backward-compatible manner, and
> - PATCH version when you make backward-compatible bug fixes.
> Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.

Those changes are not backward-compatible, so we should have increased the _MAJOR_ version instead of the _PATCH_ one. In this PR, we are reverting the breaking changes so the current _MAJOR_ version will continue working without issues. 
In the same way, we will create a new PR adding again those changes but bumping the chart version in a _MAJOR_

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
