### PR TITLE
[stable/odoo] Revert pull request #15437

### DIFF
--- a/stable/odoo/Chart.yaml
+++ b/stable/odoo/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: odoo
-version: 8.1.7
+version: 8.1.8
 appVersion: 12.0.20190715
 description: A suite of web based open source business apps.
 home: https://www.odoo.com/

--- a/stable/odoo/README.md
+++ b/stable/odoo/README.md
@@ -56,8 +56,6 @@ The following table lists the configurable parameters of the Odoo chart and thei
 | `image.tag`                           | Odoo Image tag                                            | `{TAG_NAME}`                                            |
 | `image.pullPolicy`                    | Image pull policy                                         | `Always`                                                |
 | `image.pullSecrets`                   | Specify docker-registry secret names as an array          | `[]` (does not add image pull secrets to deployed pods) |
-| `nameOverride`                        | String to partially override odoo.fullname template with a string (will prepend the release name) | `nil`           |
-| `fullnameOverride`                    | String to fully override odoo.fullname template with a string                                     | `nil`           |
 | `odooUsername`                        | User of the application                                   | `user@example.com`                                      |
 | `odooPassword`                        | Admin account password                                    | _random 10 character long alphanumeric string_          |
 | `odooEmail`                           | Admin account email                                       | `user@example.com`                                      |

--- a/stable/odoo/templates/_helpers.tpl
+++ b/stable/odoo/templates/_helpers.tpl
@@ -11,16 +11,8 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "odoo.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/odoo/values.yaml
+++ b/stable/odoo/values.yaml
@@ -26,14 +26,6 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
-## String to partially override odoo.fullname template (will maintain the release name)
-##
-# nameOverride:
-
-## String to fully override odoo.fullname template
-##
-# fullnameOverride:
-
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-odoo#configuration
 ##


### PR DESCRIPTION
This reverts commit 9baed0405ed320a486b44872dbf7978bfef4e9e0.

Changes in the previous commit are breaking changes when used in some configurations, for example `helm upgrade` doesn't work using a static IP in the `loadBalancer`. 
According to [semver](http://semver.org/):

> Given a version number `MAJOR.MINOR.PATCH`, increment the:
> - MAJOR version when you make incompatible API changes,
> - MINOR version when you add functionality in a backward-compatible manner, and
> - PATCH version when you make backward-compatible bug fixes.
> Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.

Those changes are not backward-compatible, so we should have increased the _MAJOR_ version instead of the _PATCH_ one. In this PR, we are reverting the breaking changes so the current _MAJOR_ version will continue working without issues. 
In the same way, we will create a new PR adding again those changes but bumping the chart version in a _MAJOR_

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)