### PR TITLE
[stable/suitecrm] Revert pull request #15422

### DIFF
--- a/stable/suitecrm/Chart.yaml
+++ b/stable/suitecrm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: suitecrm
-version: 5.4.6
+version: 5.4.7
 appVersion: 7.11.6
 description: SuiteCRM is a completely open source enterprise-grade Customer Relationship Management (CRM) application. SuiteCRM is a software fork of the popular customer relationship management (CRM) system SugarCRM.
 keywords:

--- a/stable/suitecrm/README.md
+++ b/stable/suitecrm/README.md
@@ -55,9 +55,7 @@ The following table lists the configurable parameters of the SuiteCRM chart and 
 | `image.repository`                  | SuiteCRM image name                             | `bitnami/suitecrm`                                      |
 | `image.tag`                         | SuiteCRM image tag                              | `{TAG_NAME}`                                            |
 | `image.pullPolicy`                  | Image pull policy                               | `IfNotPresent`                                          |
-| `image.pullSecrets`                 | Specify docker-registry secret names as an array| `[]` (does not add image pull secrets to deployed pods) |
-| `nameOverride`                      | String to partially override suitecrm.fullname template with a string (will prepend the release name) | `nil` |
-| `fullnameOverride`                  | String to fully override suitecrm.fullname template with a string                                     | `nil` |
+| `image.pullSecrets`                 | Specify docker-registry secret names as an array| `[]` (does not add image pull secrets to deployed pods)|
 | `suitecrmHost`                      | SuiteCRM host to create application URLs        | `nil`                                                   |
 | `suitecrmUsername`                  | User of the application                         | `user`                                                  |
 | `suitecrmPassword`                  | Application password                            | _random 10 character alphanumeric string_               |

--- a/stable/suitecrm/templates/_helpers.tpl
+++ b/stable/suitecrm/templates/_helpers.tpl
@@ -11,16 +11,8 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "suitecrm.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/suitecrm/values.yaml
+++ b/stable/suitecrm/values.yaml
@@ -26,14 +26,6 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
-## String to partially override suitecrm.fullname template (will maintain the release name)
-##
-# nameOverride:
-
-## String to fully override suitecrm.fullname template
-##
-# fullnameOverride:
-
 ## SuiteCRM host to create application URLs
 ## ref: https://github.com/bitnami/bitnami-docker-suitecrm#configuration
 ##


### PR DESCRIPTION
This reverts commit 95732866ce688cc6f816f01bdfac94ed0739d7d8.

Changes in the previous commit are breaking changes when used in some configurations, for example `helm upgrade` doesn't work using a static IP in the `loadBalancer`. 
According to [semver](http://semver.org/):

> Given a version number `MAJOR.MINOR.PATCH`, increment the:
> - MAJOR version when you make incompatible API changes,
> - MINOR version when you add functionality in a backward-compatible manner, and
> - PATCH version when you make backward-compatible bug fixes.
> Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.

Those changes are not backward-compatible, so we should have increased the _MAJOR_ version instead of the _PATCH_ one. In this PR, we are reverting the breaking changes so the current _MAJOR_ version will continue working without issues. 
In the same way, we will create a new PR adding again those changes but bumping the chart version in a _MAJOR_

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)