### PR TITLE
[stable/datadog] allow setting tolerations for clusterchecks

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.32.0
+version: 1.32.1
 appVersion: 6.12.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -322,6 +322,7 @@ helm install --name <RELEASE_NAME> \
 | `clusterchecksDeployment.resources.requests.memory`      | Memory resource requests                                                                      | `256Mi`                                     |
 | `clusterchecksDeployment.resources.limits.memory`        | Memory resource limits                                                                        | `256Mi`                                     |
 | `clusterchecksDeployment.nodeSelector`                   | Node selectors                                                                                | `nil`                                       |
+| `clusterchecksDeployment.tolerations`                    | List of node taints to tolerate                                                               | `nil`                                       |
 | `clusterchecksDeployment.affinity`                       | Node affinities                                                                               | avoid running pods on the same node         |
 | `clusterchecksDeployment.livenessProbe`                  | Overrides the default liveness probe                                                          | http port 5555                              |
 | `clusterchecksDeployment.rbac.dedicated`                  | If true, use dedicated RBAC resources for clusterchecks agent's pods                          | `false`                                     |

--- a/stable/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/stable/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -96,4 +96,8 @@ spec:
       nodeSelector:
 {{ toYaml .Values.clusterchecksDeployment.nodeSelector | indent 8 }}
       {{- end }}
+      {{- if .Values.clusterchecksDeployment.tolerations }}
+      tolerations:
+{{ toYaml .Values.clusterchecksDeployment.tolerations | indent 8 }}
+      {{- end }}
 {{ end }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -672,7 +672,7 @@ clusterchecksDeployment:
   ## Tolerations for pod assignment
   ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   #
-  tolerations: []
+  # tolerations: []
 
   ## @param livenessProbe - object - optional
   ## Override the agent's liveness probe logic from the default:


### PR DESCRIPTION
Signed-off-by: Joe Hohertz <joe@viafoura.com>

#### What this PR does / why we need it:

The newer clusterchecks deployment had values stubbed in the values.yaml for setting tolerations for the clusterchecks deployment, but this was not document in the README nor implemented in the manifest template. This PR addresses that.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
