### PR TITLE
[stable/kube2iam] Upgrade version, Add prometheus service annotations

### DIFF
--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kube2iam
-version: 1.0.1
-appVersion: 0.10.4
+version: 1.1.0
+appVersion: 0.10.7
 description: Provide IAM credentials to pods based on annotations.
 keywords:
 - kube2iam

--- a/stable/kube2iam/README.md
+++ b/stable/kube2iam/README.md
@@ -55,6 +55,8 @@ Parameter | Description | Default
 `podAnnotations` | annotations to be added to pods | `{}`
 `priorityClassName` | priorityClassName to be added to pods | `{}`
 `prometheus.metricsPort` | Port to expose prometheus metrics on (if unspecified, `host.port` is used) | `host.port`
+`prometheus.service.enabled` | If true, create a Service resource for Prometheus | `false`
+`prometheus.service.annotations` | Annotations to be added to the service | `{}`
 `prometheus.serviceMonitor.enabled` | If true, create a Prometheus Operator ServiceMonitor resource | `false`
 `prometheus.serviceMonitor.interval` | Interval at which the metrics endpoint is scraped | `10s`
 `prometheus.serviceMonitor.namespace` | An alternative namespace in which to install the ServiceMonitor | `""`

--- a/stable/kube2iam/templates/service.yaml
+++ b/stable/kube2iam/templates/service.yaml
@@ -1,14 +1,17 @@
-{{- if .Values.prometheus.serviceMonitor.enabled }}
+{{- if or .Values.prometheus.serviceMonitor.enabled .Values.prometheus.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
   name: {{ template "kube2iam.fullname" . }}-metrics
   labels:
     app: {{ template "kube2iam.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- if .Values.prometheus.service.annotations }}
+  annotations:
+    {{- toYaml .Values.prometheus.service.annotations | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     app: {{ template "kube2iam.name" . }}

--- a/stable/kube2iam/values.yaml
+++ b/stable/kube2iam/values.yaml
@@ -16,7 +16,14 @@ host:
 
 prometheus:
   # Port to expose the /metrics endpoint on. If unset, defaults to `host.port`
-  # metricsPort: 8181
+  # metricsPort: 9543
+
+  service:
+    enabled: false
+#    annotations:
+#      prometheus.io/scrape: "true"
+#      prometheus.io/port: "9543"
+#      prometheus.io/path: "/metrics"
 
   serviceMonitor:
     # Create prometheus-operator ServiceMonitor
@@ -28,7 +35,7 @@ prometheus:
 
 image:
   repository: jtblin/kube2iam
-  tag: 0.10.4
+  tag: 0.10.7
   pullPolicy: IfNotPresent
 
 # AWS Access keys to inject as environment variables


### PR DESCRIPTION
Signed-off-by: Fabio Todaro <fbregist@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
- Upgrade kube2iam version
- Make possible to enable only the service to expose prometheus metrics

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
