### PR TITLE
[stable/sentry] Sentry resources related changes

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 2.0.1
+version: 2.1.0
 appVersion: 9.1.1
 keywords:
   - debugging

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -159,6 +159,8 @@ Parameter                                            | Description              
 `metrics.serviceMonitor.interval`                    | How frequently to scrape metrics (use by default, falling back to Prometheus' default)                     | `nil`
 `metrics.serviceMonitor.selector`                    | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install | `{ prometheus: kube-prometheus }`
 `hooks.affinity`                                     | Affinity settings for hooks pods                                                                           | `{}`
+`hooks.dbInit.resources.limits`                      | Hook job resource limits                                                                                   | `{memory: 3200Mi}`
+`hooks.dbInit.resources.requests`                    | Hook job resource requests                                                                                 | `{memory: 3000Mi}`
 
 Dependent charts can also have values overwritten. Preface values with postgresql. _or redis._
 

--- a/stable/sentry/templates/NOTES.txt
+++ b/stable/sentry/templates/NOTES.txt
@@ -1,3 +1,11 @@
+{{- if (ne .Values.hooks.dbInit.resources.requests.memory "3000Mi") }}
+WARNING:
+  You have changed the default memory request for the db-init job hook. It may affect your setup.
+  If you are facing problems, check next links:
+    - https://github.com/helm/charts/issues/15296
+    - https://github.com/getsentry/onpremise/blob/master/install.sh
+
+{{- end }}
 1. Get the application URL by running these commands:
 {{- if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "sentry.fullname" . }})

--- a/stable/sentry/templates/hooks/db-init.job.yaml
+++ b/stable/sentry/templates/hooks/db-init.job.yaml
@@ -99,7 +99,10 @@ spec:
         - mountPath: /etc/sentry
           name: config
           readOnly: true
+        resources:
+{{ toYaml .Values.hooks.dbInit.resources | indent 10 }}
       volumes:
       - name: config
         configMap:
           name: {{ template "sentry.fullname" . }}
+

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -268,6 +268,15 @@ metrics:
     ## [Kube Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#exporters)
     selector:
       prometheus: kube-prometheus
+
 # Provide affinity for hooks if needed
 hooks:
   affinity: {}
+  dbInit:
+    resources:
+    # We setup 3000Mi for the memory limit because of a Sentry instance need at least 3Gb RAM to perform a migration process
+    # reference: https://github.com/helm/charts/issues/15296
+      limits:
+        memory: 3200Mi
+      requests:
+        memory: 3100Mi


### PR DESCRIPTION
Added the default memory limit for db-init-hook refs #15296
Added a warning related to changing default memory limit for db-init-hook

Signed-off-by: Mikhail Naletov <okgolove@markeloff.net>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Sentry need a lot of memory to make migrations.

#### Special notes for your reviewer:
@BYK feel free to comment and improve the PR!

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
