### PR TITLE
[stable/joomla] Implement again "Standardize 'fullname' and 'name' macros"

### DIFF
--- a/stable/joomla/Chart.yaml
+++ b/stable/joomla/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: joomla
-version: 4.3.8
+version: 5.0.0
 appVersion: 3.9.9
 description: PHP content management system (CMS) for publishing web content
 keywords:

--- a/stable/joomla/README.md
+++ b/stable/joomla/README.md
@@ -56,6 +56,8 @@ The following table lists the configurable parameters of the Joomla! chart and t
 | `image.tag`                          | Joomla! Image tag                                           | `{TAG_NAME}`                                   |
 | `image.pullPolicy`                   | Image pull policy                                           | `Always`                                       |
 | `image.pullSecrets`                  | Specify docker-registry secret names as an array            | `[]` (does not add image pull secrets to deployed pods) |
+| `nameOverride`                       | String to partially override joomla.fullname template with a string (will prepend the release name) | `nil`  |
+| `fullnameOverride`                   | String to fully override joomla.fullname template with a string                                     | `nil`  |
 | `joomlaUsername`                     | User of the application                                     | `user`                                         |
 | `joomlaPassword`                     | Application password                                        | _random 10 character long alphanumeric string_ |
 | `joomlaEmail`                        | Admin email                                                 | `user@example.com`                             |

--- a/stable/joomla/templates/_helpers.tpl
+++ b/stable/joomla/templates/_helpers.tpl
@@ -11,8 +11,16 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "joomla.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/joomla/values.yaml
+++ b/stable/joomla/values.yaml
@@ -26,6 +26,14 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## String to partially override joomla.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override joomla.fullname template
+##
+# fullnameOverride:
+
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-joomla#environment-variables
 ##


### PR DESCRIPTION
This reverts commit b0f99f804db9e87c60815c78c95f569edbfb607d.
Implement #15445 bumping a major version after #15613
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)