### PR TITLE
[stable/jasperreports] Implement again "Standardize 'fullname' and 'name' macros"

### DIFF
--- a/stable/jasperreports/Chart.yaml
+++ b/stable/jasperreports/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: jasperreports
-version: 4.2.8
+version: 5.0.0
 appVersion: 7.2.0
 description: The JasperReports server can be used as a stand-alone or embedded reporting
   and BI server that offers web-based reporting, analytic tools and visualization,

--- a/stable/jasperreports/README.md
+++ b/stable/jasperreports/README.md
@@ -47,55 +47,57 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the JasperReports chart and their default values.
 
-|           Parameter           |                 Description                  |                         Default                          |
-|-------------------------------|----------------------------------------------|----------------------------------------------------------|
-| `global.imageRegistry`        | Global Docker image registry                 | `nil`                                                    |
-| `global.imagePullSecrets`     | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
-| `image.registry`              | JasperReports image registry                 | `docker.io`                                              |
-| `image.repository`            | JasperReports Image name                     | `bitnami/jasperreports`                                  |
-| `image.tag`                   | JasperReports Image tag                      | `{TAG_NAME}`                                             |
-| `image.pullPolicy`            | Image pull policy                            | `IfNotPresent`                                           |
-| `image.pullSecrets`           | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
-| `jasperreportsUsername`       | User of the application                      | `user`                                                   |
-| `jasperreportsPassword`       | Application password                         | _random 10 character long alphanumeric string_           |
-| `jasperreportsEmail`          | User email                                   | `user@example.com`                                       |
-| `smtpHost`                    | SMTP host                                    | `nil`                                                    |
-| `smtpPort`                    | SMTP port                                    | `nil`                                                    |
-| `smtpEmail`                   | SMTP email                                   | `nil`                                                    |
-| `smtpUser`                    | SMTP user                                    | `nil`                                                    |
-| `smtpPassword`                | SMTP password                                | `nil`                                                    |
-| `smtpProtocol`                | SMTP protocol [`ssl`, `none`]                | `nil`                                                    |
-| `allowEmptyPassword`          | Allow DB blank passwords                     | `yes`                                                    |
-| `ingress.enabled`                   | Enable ingress controller resource                            | `false`                                                  |
-| `ingress.annotations`               | Ingress annotations                                           | `[]`                                                     |
-| `ingress.certManager`               | Add annotations for cert-manager                              | `false`                                                  |
-| `ingress.hosts[0].name`             | Hostname to your JasperReports installation                           | `jasperreports.local`                                            |
-| `ingress.hosts[0].path`             | Path within the url structure                                 | `/`                                                      |
-| `ingress.hosts[0].tls`              | Utilize TLS backend in ingress                                | `false`                                                  |
-| `ingress.hosts[0].tlsHosts`         | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`)                               | `nil`                                                  |
-| `ingress.hosts[0].tlsSecret`        | TLS Secret (certificates)                                     | `jasperreports.local-tls-secret`                                 |
-| `ingress.secrets[0].name`           | TLS Secret Name                                               | `nil`                                                    |
-| `ingress.secrets[0].certificate`    | TLS Secret Certificate                                        | `nil`                                                    |
-| `ingress.secrets[0].key`            | TLS Secret Key                                                | `nil`                                                    |
-| `externalDatabase.host`       | Host of the external database                | `nil`                                                    |
-| `externalDatabase.port`       | Port of the external database                | `3306`                                                   |
-| `externalDatabase.user`       | Existing username in the external db         | `bn_jasperreports`                                       |
-| `externalDatabase.password`   | Password for the above username              | `nil`                                                    |
-| `externalDatabase.database`   | Name of the existing database                | `bitnami_jasperreports`                                  |
-| `mariadb.enabled`             | Whether to use the MariaDB chart             | `true`                                                   |
-| `mariadb.db.name`             | Database name to create                      | `bitnami_jasperreports`                                  |
-| `mariadb.db.user`             | Database user to create                      | `bn_jasperreports`                                       |
-| `mariadb.db.password`         | Password for the database                    | `nil`                                                    |
-| `mariadb.rootUser.password`   | MariaDB admin password                       | `nil`                                                    |
-| `service.type`                | Kubernetes Service type                      | `LoadBalancer`                                           |
-| `service.externalTrafficPolicy`   | Enable client source IP preservation     | `Cluster`                                                |
-| `service.port`                | Service HTTP port                            | `80`                                                     |
-| `service.nodePorts.http`      | Kubernetes http node port                    | `""`                                                     |
-| `persistence.enabled`         | Enable persistence using PVC                 | `true`                                                   |
-| `persistence.storageClass`    | PVC Storage Class for JasperReports volume   | `nil` (uses alpha storage annotation)                    |
-| `persistence.accessMode`      | PVC Access Mode for JasperReports volume     | `ReadWriteOnce`                                          |
-| `persistence.size`            | PVC Storage Request for JasperReports volume | `8Gi`                                                    |
-| `resources`                   | CPU/Memory resource requests/limits          | Memory: `512Mi`, CPU: `300m`                             |
+|           Parameter              |                 Description                  |                         Default                          |
+|----------------------------------|----------------------------------------------|----------------------------------------------------------|
+| `global.imageRegistry`           | Global Docker image registry                 | `nil`                                                    |
+| `global.imagePullSecrets`        | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
+| `image.registry`                 | JasperReports image registry                 | `docker.io`                                              |
+| `image.repository`               | JasperReports Image name                     | `bitnami/jasperreports`                                  |
+| `image.tag`                      | JasperReports Image tag                      | `{TAG_NAME}`                                             |
+| `image.pullPolicy`               | Image pull policy                            | `IfNotPresent`                                           |
+| `image.pullSecrets`              | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
+| `nameOverride`                   | String to partially override jasperreports.fullname template with a string (will prepend the release name) | `nil` |
+| `fullnameOverride`               | String to fully override jasperreports.fullname template with a string                                     | `nil` |
+| `jasperreportsUsername`          | User of the application                      | `user`                                                   |
+| `jasperreportsPassword`          | Application password                         | _random 10 character long alphanumeric string_           |
+| `jasperreportsEmail`             | User email                                   | `user@example.com`                                       |
+| `smtpHost`                       | SMTP host                                    | `nil`                                                    |
+| `smtpPort`                       | SMTP port                                    | `nil`                                                    |
+| `smtpEmail`                      | SMTP email                                   | `nil`                                                    |
+| `smtpUser`                       | SMTP user                                    | `nil`                                                    |
+| `smtpPassword`                   | SMTP password                                | `nil`                                                    |
+| `smtpProtocol`                   | SMTP protocol [`ssl`, `none`]                | `nil`                                                    |
+| `allowEmptyPassword`             | Allow DB blank passwords                     | `yes`                                                    |
+| `ingress.enabled`                | Enable ingress controller resource           | `false`                                                  |
+| `ingress.annotations`            | Ingress annotations                          | `[]`                                                     |
+| `ingress.certManager`            | Add annotations for cert-manager             | `false`                                                  |
+| `ingress.hosts[0].name`          | Hostname to your JasperReports installation  | `jasperreports.local`                                    |
+| `ingress.hosts[0].path`          | Path within the url structure                | `/`                                                      |
+| `ingress.hosts[0].tls`           | Utilize TLS backend in ingress               | `false`                                                  |
+| `ingress.hosts[0].tlsHosts`      | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`) | `nil`            |
+| `ingress.hosts[0].tlsSecret`     | TLS Secret (certificates)                    | `jasperreports.local-tls-secret`                         |
+| `ingress.secrets[0].name`        | TLS Secret Name                              | `nil`                                                    |
+| `ingress.secrets[0].certificate` | TLS Secret Certificate                       | `nil`                                                    |
+| `ingress.secrets[0].key`         | TLS Secret Key                               | `nil`                                                    |
+| `externalDatabase.host`          | Host of the external database                | `nil`                                                    |
+| `externalDatabase.port`          | Port of the external database                | `3306`                                                   |
+| `externalDatabase.user`          | Existing username in the external db         | `bn_jasperreports`                                       |
+| `externalDatabase.password`      | Password for the above username              | `nil`                                                    |
+| `externalDatabase.database`      | Name of the existing database                | `bitnami_jasperreports`                                  |
+| `mariadb.enabled`                | Whether to use the MariaDB chart             | `true`                                                   |
+| `mariadb.db.name`                | Database name to create                      | `bitnami_jasperreports`                                  |
+| `mariadb.db.user`                | Database user to create                      | `bn_jasperreports`                                       |
+| `mariadb.db.password`            | Password for the database                    | `nil`                                                    |
+| `mariadb.rootUser.password`      | MariaDB admin password                       | `nil`                                                    |
+| `service.type`                   | Kubernetes Service type                      | `LoadBalancer`                                           |
+| `service.externalTrafficPolicy`  | Enable client source IP preservation         | `Cluster`                                                |
+| `service.port`                   | Service HTTP port                            | `80`                                                     |
+| `service.nodePorts.http`         | Kubernetes http node port                    | `""`                                                     |
+| `persistence.enabled`            | Enable persistence using PVC                 | `true`                                                   |
+| `persistence.storageClass`       | PVC Storage Class for JasperReports volume   | `nil` (uses alpha storage annotation)                    |
+| `persistence.accessMode`         | PVC Access Mode for JasperReports volume     | `ReadWriteOnce`                                          |
+| `persistence.size`               | PVC Storage Request for JasperReports volume | `8Gi`                                                    |
+| `resources`                      | CPU/Memory resource requests/limits          | `{Memory: 512Mi, CPU: 300m}`                             |
 
 The above parameters map to the env variables defined in [bitnami/jasperreports](http://github.com/bitnami/bitnami-docker-jasperreports). For more information please refer to the [bitnami/jasperreports](http://github.com/bitnami/bitnami-docker-jasperreports) image documentation.
 

--- a/stable/jasperreports/templates/_helpers.tpl
+++ b/stable/jasperreports/templates/_helpers.tpl
@@ -11,8 +11,16 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "jasperreports.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/jasperreports/values.yaml
+++ b/stable/jasperreports/values.yaml
@@ -26,6 +26,14 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## String to partially override jasperreports.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override jasperreports.fullname template
+##
+# fullnameOverride:
+
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-jasperreports#configuration
 ##


### PR DESCRIPTION
This reverts commit eeceb63e3d186e658236f20494a561d578910f45.
Implement #15446 bumping a major version after #15614
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
