### PR TITLE
[stable/drupal] Implement again "Standardize 'fullname' and 'name' macros"

### DIFF
--- a/stable/drupal/Chart.yaml
+++ b/stable/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 3.3.8
+version: 4.0.0
 appVersion: 8.7.4
 description: One of the most versatile open source content management systems.
 keywords:

--- a/stable/drupal/README.md
+++ b/stable/drupal/README.md
@@ -56,6 +56,8 @@ The following table lists the configurable parameters of the Drupal chart and th
 | `image.tag`                       | Drupal Image tag                           | `{TAG_NAME}`                                              |
 | `image.pullPolicy`                | Drupal image pull policy                   | `IfNotPresent`                                            |
 | `image.pullSecrets`               | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)  |
+| `nameOverride`                    | String to partially override drupal.fullname template with a string (will prepend the release name) | `nil` |
+| `fullnameOverride`                | String to fully override drupal.fullname template with a string                                     | `nil` |
 | `drupalProfile`                   | Drupal installation profile                | `standard`                                                |
 | `drupalUsername`                  | User of the application                    | `user`                                                    |
 | `drupalPassword`                  | Application password                       | _random 10 character long alphanumeric string_            |

--- a/stable/drupal/templates/_helpers.tpl
+++ b/stable/drupal/templates/_helpers.tpl
@@ -11,8 +11,16 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "drupal.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/drupal/values.yaml
+++ b/stable/drupal/values.yaml
@@ -26,6 +26,14 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## String to partially override drupal.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override drupal.fullname template
+##
+# fullnameOverride:
+
 ## Installation Profile
 ## ref: https://github.com/bitnami/bitnami-docker-drupal#configuration
 ##


### PR DESCRIPTION
This reverts commit 80c396c77691724221f37140576c105dc5fd455d.
Implement #15449 bumping a major version after #15615
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)