### PR TITLE
[stable/suitecrm] Implement again "Standardize 'fullname' and 'name' macros"

### DIFF
--- a/stable/suitecrm/Chart.yaml
+++ b/stable/suitecrm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: suitecrm
-version: 5.4.7
+version: 6.0.0
 appVersion: 7.11.6
 description: SuiteCRM is a completely open source enterprise-grade Customer Relationship Management (CRM) application. SuiteCRM is a software fork of the popular customer relationship management (CRM) system SugarCRM.
 keywords:

--- a/stable/suitecrm/README.md
+++ b/stable/suitecrm/README.md
@@ -55,7 +55,9 @@ The following table lists the configurable parameters of the SuiteCRM chart and 
 | `image.repository`                  | SuiteCRM image name                             | `bitnami/suitecrm`                                      |
 | `image.tag`                         | SuiteCRM image tag                              | `{TAG_NAME}`                                            |
 | `image.pullPolicy`                  | Image pull policy                               | `IfNotPresent`                                          |
-| `image.pullSecrets`                 | Specify docker-registry secret names as an array| `[]` (does not add image pull secrets to deployed pods)|
+| `image.pullSecrets`                 | Specify docker-registry secret names as an array| `[]` (does not add image pull secrets to deployed pods) |
+| `nameOverride`                      | String to partially override suitecrm.fullname template with a string (will prepend the release name) | `nil` |
+| `fullnameOverride`                  | String to fully override suitecrm.fullname template with a string                                     | `nil` |
 | `suitecrmHost`                      | SuiteCRM host to create application URLs        | `nil`                                                   |
 | `suitecrmUsername`                  | User of the application                         | `user`                                                  |
 | `suitecrmPassword`                  | Application password                            | _random 10 character alphanumeric string_               |

--- a/stable/suitecrm/templates/_helpers.tpl
+++ b/stable/suitecrm/templates/_helpers.tpl
@@ -11,8 +11,16 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "suitecrm.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/suitecrm/values.yaml
+++ b/stable/suitecrm/values.yaml
@@ -26,6 +26,14 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## String to partially override suitecrm.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override suitecrm.fullname template
+##
+# fullnameOverride:
+
 ## SuiteCRM host to create application URLs
 ## ref: https://github.com/bitnami/bitnami-docker-suitecrm#configuration
 ##


### PR DESCRIPTION
This reverts commit 0f9d6238c6d4d50459697643f0a74b96eeefe36a.
Implement #15422 bumping a major version after #15619
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)