### PR TITLE
[stable/odoo] Implement again "Standardize 'fullname' and 'name' macros"

### DIFF
--- a/stable/odoo/Chart.yaml
+++ b/stable/odoo/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: odoo
-version: 8.1.8
+version: 9.0.0
 appVersion: 12.0.20190715
 description: A suite of web based open source business apps.
 home: https://www.odoo.com/

--- a/stable/odoo/README.md
+++ b/stable/odoo/README.md
@@ -56,6 +56,8 @@ The following table lists the configurable parameters of the Odoo chart and thei
 | `image.tag`                           | Odoo Image tag                                            | `{TAG_NAME}`                                            |
 | `image.pullPolicy`                    | Image pull policy                                         | `Always`                                                |
 | `image.pullSecrets`                   | Specify docker-registry secret names as an array          | `[]` (does not add image pull secrets to deployed pods) |
+| `nameOverride`                        | String to partially override odoo.fullname template with a string (will prepend the release name) | `nil`           |
+| `fullnameOverride`                    | String to fully override odoo.fullname template with a string                                     | `nil`           |
 | `odooUsername`                        | User of the application                                   | `user@example.com`                                      |
 | `odooPassword`                        | Admin account password                                    | _random 10 character long alphanumeric string_          |
 | `odooEmail`                           | Admin account email                                       | `user@example.com`                                      |

--- a/stable/odoo/templates/_helpers.tpl
+++ b/stable/odoo/templates/_helpers.tpl
@@ -11,8 +11,16 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "odoo.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/odoo/values.yaml
+++ b/stable/odoo/values.yaml
@@ -26,6 +26,14 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## String to partially override odoo.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override odoo.fullname template
+##
+# fullnameOverride:
+
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-odoo#configuration
 ##


### PR DESCRIPTION
This reverts commit cac2468fe5f7a267581e5b440369575e023925d0.
Implement #15437 bumping a major version after #15617
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
