### PR TITLE
[stable/prestashop] Implement again "Standardize 'fullname' and 'name' macros"

### DIFF
--- a/stable/prestashop/Chart.yaml
+++ b/stable/prestashop/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prestashop
-version: 6.6.6
+version: 7.0.0
 appVersion: 1.7.6-0
 description: A popular open source ecommerce solution. Professional tools are easily accessible to increase online sales including instant guest checkout, abandoned cart reminders and automated Email marketing.
 keywords:

--- a/stable/prestashop/README.md
+++ b/stable/prestashop/README.md
@@ -56,6 +56,8 @@ The following table lists the configurable parameters of the PrestaShop chart an
 | `image.tag`                           | PrestaShop image tag                                                                         | `{TAG_NAME}`                                                 |
 | `image.pullPolicy`                    | Image pull policy                                                                            | `IfNotPresent`                                               |
 | `image.pullSecrets`                   | Specify docker-registry secret names as an array                                             | `[]` (does not add image pull secrets to deployed pods)      |
+| `nameOverride`                        | String to partially override prestashop.fullname template with a string (will prepend the release name) | `nil`                                             |
+| `fullnameOverride`                    | String to fully override prestashop.fullname template with a string                          | `nil`                                                        |
 | `service.type`                        | Kubernetes Service type                                                                      | `LoadBalancer`                                               |
 | `service.port`                        | Service HTTP port                                                                            | `80`                                                         |
 | `service.httpsPort`                   | Service HTTPS port                                                                           | `443`                                                        |

--- a/stable/prestashop/templates/_helpers.tpl
+++ b/stable/prestashop/templates/_helpers.tpl
@@ -11,8 +11,16 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "prestashop.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/prestashop/values.yaml
+++ b/stable/prestashop/values.yaml
@@ -26,6 +26,14 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## String to partially override prestashop.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override prestashop.fullname template
+##
+# fullnameOverride:
+
 ## PrestaShop host to create application URLs
 ## ref: https://github.com/bitnami/bitnami-docker-prestashop#configuration
 ##


### PR DESCRIPTION
This reverts commit 06c808f232f2cfc5586d0bdfce3363b2a30ac52b.
Implement #15426 bumping a major version after #15594
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)