### PR TITLE
[stable/testlink] Implement again "Standardize 'fullname' and 'name' macros"

### DIFF
--- a/stable/testlink/Chart.yaml
+++ b/stable/testlink/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: testlink
-version: 4.4.5
+version: 5.0.0
 appVersion: 1.9.19
 description: Web-based test management system that facilitates software quality assurance.
 icon: https://bitnami.com/assets/stacks/testlink/img/testlink-stack-220x234.png

--- a/stable/testlink/README.md
+++ b/stable/testlink/README.md
@@ -56,6 +56,8 @@ The following table lists the configurable parameters of the TestLink chart and 
 | `image.tag`                         | TestLink image tag                      | `{TAG_NAME}`                                            |
 | `image.pullPolicy`                  | Image pull policy                       | `IfNotPresent`                                          |
 | `image.pullSecrets`                 | Specify docker-registry secret names as an array  | `[]` (does not add image pull secrets to deployed pods) |
+| `nameOverride`                      | String to partially override testlink.fullname template with a string (will prepend the release name) | `nil` |
+| `fullnameOverride`                  | String to fully override testlink.fullname template with a string                                     | `nil` |
 | `testlinkUsername`                  | Admin username                          | `user`                                                  |
 | `testlinkPassword`                  | Admin user password                     | _random 10 character long alphanumeric string_          |
 | `testlinkEmail`                     | Admin user email                        | `user@example.com`                                      |

--- a/stable/testlink/templates/_helpers.tpl
+++ b/stable/testlink/templates/_helpers.tpl
@@ -11,8 +11,16 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "testlink.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/testlink/values.yaml
+++ b/stable/testlink/values.yaml
@@ -26,6 +26,13 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## String to partially override testlink.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override testlink.fullname template
+##
+# fullnameOverride:
 
 ## List of nodeSelectors to limit where testlink can run
 ## i.e


### PR DESCRIPTION
This reverts commit 16e34fe06a63179281a80c3a600a43bf4757d318.
Implement #15421 bumping a major version after #15602
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)