### PR TITLE
[stable/redmine] Implement again "Standardize 'fullname' and 'name' macros"

### DIFF
--- a/stable/redmine/Chart.yaml
+++ b/stable/redmine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redmine
-version: 10.0.9
+version: 11.0.0
 appVersion: 4.0.4
 description: A flexible project management web application.
 keywords:

--- a/stable/redmine/README.md
+++ b/stable/redmine/README.md
@@ -63,7 +63,9 @@ The following table lists the configurable parameters of the Redmine chart and t
 | `image.repository`                  | Redmine image name                         | `bitnami/redmine`                                       |
 | `image.tag`                         | Redmine image tag                          | `{TAG_NAME}`                                            |
 | `image.pullPolicy`                  | Image pull policy                          | `IfNotPresent`                                          |
-| `image.pullSecrets`                 | Specify docker-registry secret names as an array                 | `[]` (does not add image pull secrets to deployed pods)   |
+| `image.pullSecrets`                 | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)   |
+| `nameOverride`                      | String to partially override redmine.fullname template with a string (will prepend the release name) | `nil`     |
+| `fullnameOverride`                  | String to fully override redmine.fullname template with a string                                     | `nil`     |
 | `redmineUsername`                   | User of the application                    | `user`                                                  |
 | `redminePassword`                   | Application password                       | _random 10 character long alphanumeric string_          |
 | `redmineEmail`                      | Admin email                                | `user@example.com`                                      |

--- a/stable/redmine/templates/_helpers.tpl
+++ b/stable/redmine/templates/_helpers.tpl
@@ -11,8 +11,16 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "redmine.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/redmine/values.yaml
+++ b/stable/redmine/values.yaml
@@ -26,6 +26,14 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## String to partially override redmine.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override redmine.fullname template
+##
+# fullnameOverride:
+
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-redmine/#environment-variables
 ##


### PR DESCRIPTION
This reverts commit addcde4813ab37978adc6d3d45b5f0f4a2a770bf.
Implement #15423 bumping a major version after #15603
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)