### PR TITLE
[stable/phabricator] Implement again "Standardize 'fullname' and 'name' macros"

### DIFF
--- a/stable/phabricator/Chart.yaml
+++ b/stable/phabricator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: phabricator
-version: 5.0.5
+version: 6.0.0
 appVersion: 2019.26.0
 description: Collection of open source web applications that help software companies build better software.
 keywords:

--- a/stable/phabricator/README.md
+++ b/stable/phabricator/README.md
@@ -47,62 +47,64 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Phabricator chart and their default values.
 
-|               Parameter                |                 Description                  |                         Default                          |
-|----------------------------------------|----------------------------------------------|----------------------------------------------------------|
-| `global.imageRegistry`                 | Global Docker image registry                 | `nil`                                                    |
-| `global.imagePullSecrets`              | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
-| `image.registry`                       | Phabricator image registry                   | `docker.io`                                              |
-| `image.repository`                     | Phabricator image name                       | `bitnami/phabricator`                                    |
-| `image.tag`                            | Phabricator image tag                        | `{TAG_NAME}`                                             |
-| `image.pullPolicy`                     | Image pull policy                            | `IfNotPresent`                                           |
-| `image.pullSecrets`                    | Specify docker-registry secret names as an array                   | `[]` (does not add image pull secrets to deployed pods)                                                    |
-| `phabricatorHost`                      | Phabricator host to create application URLs  | `nil`                                                    |
-| `phabricatorAlternateFileDomain`       | Phabricator alternate domain to upload files | `nil`                                                    |
-| `phabricatorUsername`                  | User of the application                      | `user`                                                   |
-| `phabricatorPassword`                  | Application password                         | _random 10 character long alphanumeric string_           |
-| `phabricatorEmail`                     | Admin email                                  | `user@example.com`                                       |
-| `phabricatorFirstName`                 | First name                                   | `First Name`                                             |
-| `phabricatorLastName`                  | Last name                                    | `Last Name`                                              |
-| `smtpHost`                             | SMTP host                                    | `nil`                                                    |
-| `smtpPort`                             | SMTP port                                    | `nil`                                                    |
-| `smtpUser`                             | SMTP user                                    | `nil`                                                    |
-| `smtpPassword`                         | SMTP password                                | `nil`                                                    |
-| `smtpProtocol`                         | SMTP protocol [`ssl`, `tls`]                 | `nil`                                                    |
-| `mariadb.rootUser.password`            | MariaDB admin password                       | `nil`                                                    |
-| `service.type`                    | Kubernetes Service type                    | `LoadBalancer`                                          |
-| `service.port`                    | Service HTTP port                 | `80`                                          |
-| `service.httpsPort`                    | Service HTTP port                 | `443`                                          |
-| `service.loadBalancerIP`            | `loadBalancerIP` for the Phabricator Service | `nil`                                                    |
-| `service.externalTrafficPolicy`   | Enable client source IP preservation       | `Cluster`                                               |
-| `service.nodePorts.http`                 | Kubernetes http node port                  | `""`                                                    |
-| `service.nodePorts.https`                 | Kubernetes https node port                  | `""`                                                    |
-| `persistence.enabled`                  | Enable persistence using PVC                 | `true`                                                   |
-| `persistence.phabricator.storageClass` | PVC Storage Class for Phabricator volume     | `nil` (uses alpha storage class annotation)              |
-| `persistence.phabricator.accessMode`   | PVC Access Mode for Phabricator volume       | `ReadWriteOnce`                                          |
-| `persistence.phabricator.size`         | PVC Storage Request for Phabricator volume   | `8Gi`                                                    |
-| `resources`                            | CPU/Memory resource requests/limits          | Memory: `512Mi`, CPU: `300m`                             |
-| `ingress.enabled`                      | Enable ingress controller resource           | `false`                                                  |
-| `ingress.hosts[0].name`                | Hostname to your Phabricator installation    | `phabricator.local`                                      |
-| `ingress.hosts[0].path`                | Path within the url structure                | `/`                                                      |
-| `ingress.hosts[0].tls`                 | Utilize TLS backend in ingress               | `false`                                                  |
-| `ingress.hosts[0].certManager`         | Add annotations for cert-manager             | `false`                                                  |
-| `ingress.hosts[0].tlsSecret`           | TLS Secret (certificates)                    | `phabricator.local-tls-secret`                           |
-| `ingress.hosts[0].annotations`         | Annotations for this host's ingress record   | `[]`                                                     |
-| `ingress.secrets[0].name`              | TLS Secret Name                              | `nil`                                                    |
-| `ingress.secrets[0].certificate`       | TLS Secret Certificate                       | `nil`                                                    |
-| `ingress.secrets[0].key`               | TLS Secret Key                               | `nil`                                                    |
-| `podAnnotations`                       | Pod annotations                                  | `{}`                                                 |
-| `metrics.enabled`                      | Start a side-car prometheus exporter             | `false`                                              |
-| `metrics.image.registry`               | Apache exporter image registry                   | `docker.io`                                          |
-| `metrics.image.repository`             | Apache exporter image name                       | `lusotycoon/apache-exporter`                         |
-| `metrics.image.tag`                    | Apache exporter image tag                        | `v0.5.0`                                             |
-| `metrics.image.pullPolicy`             | Image pull policy                                | `IfNotPresent`                                       |
-| `metrics.image.pullSecrets`            | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)      |
+|               Parameter                |                 Description                      |                         Default                          |
+|----------------------------------------|--------------------------------------------------|----------------------------------------------------------|
+| `global.imageRegistry`                 | Global Docker image registry                     | `nil`                                                    |
+| `global.imagePullSecrets`              | Global Docker registry secret names as an array  | `[]` (does not add image pull secrets to deployed pods)  |
+| `image.registry`                       | Phabricator image registry                       | `docker.io`                                              |
+| `image.repository`                     | Phabricator image name                           | `bitnami/phabricator`                                    |
+| `image.tag`                            | Phabricator image tag                            | `{TAG_NAME}`                                             |
+| `image.pullPolicy`                     | Image pull policy                                | `IfNotPresent`                                           |
+| `image.pullSecrets`                    | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)  |
+| `nameOverride`                         | String to partially override phabricator.fullname template with a string (will prepend the release name) | `nil` |
+| `fullnameOverride`                     | String to fully override phabricator.fullname template with a string                                     | `nil` |
+| `phabricatorHost`                      | Phabricator host to create application URLs      | `nil`                                                    |
+| `phabricatorAlternateFileDomain`       | Phabricator alternate domain to upload files     | `nil`                                                    |
+| `phabricatorUsername`                  | User of the application                          | `user`                                                   |
+| `phabricatorPassword`                  | Application password                             | _random 10 character long alphanumeric string_           |
+| `phabricatorEmail`                     | Admin email                                      | `user@example.com`                                       |
+| `phabricatorFirstName`                 | First name                                       | `First Name`                                             |
+| `phabricatorLastName`                  | Last name                                        | `Last Name`                                              |
+| `smtpHost`                             | SMTP host                                        | `nil`                                                    |
+| `smtpPort`                             | SMTP port                                        | `nil`                                                    |
+| `smtpUser`                             | SMTP user                                        | `nil`                                                    |
+| `smtpPassword`                         | SMTP password                                    | `nil`                                                    |
+| `smtpProtocol`                         | SMTP protocol [`ssl`, `tls`]                     | `nil`                                                    |
+| `mariadb.rootUser.password`            | MariaDB admin password                           | `nil`                                                    |
+| `service.type`                         | Kubernetes Service type                          | `LoadBalancer`                                           |
+| `service.port`                         | Service HTTP port                                | `80`                                                     |
+| `service.httpsPort`                    | Service HTTP port                                | `443`                                                    |
+| `service.loadBalancerIP`               | `loadBalancerIP` for the Phabricator Service     | `nil`                                                    |
+| `service.externalTrafficPolicy`        | Enable client source IP preservation             | `Cluster`                                                |
+| `service.nodePorts.http`               | Kubernetes http node port                        | `""`                                                     |
+| `service.nodePorts.https`              | Kubernetes https node port                       | `""`                                                     |
+| `persistence.enabled`                  | Enable persistence using PVC                     | `true`                                                   |
+| `persistence.phabricator.storageClass` | PVC Storage Class for Phabricator volume         | `nil` (uses alpha storage class annotation)              |
+| `persistence.phabricator.accessMode`   | PVC Access Mode for Phabricator volume           | `ReadWriteOnce`                                          |
+| `persistence.phabricator.size`         | PVC Storage Request for Phabricator volume       | `8Gi`                                                    |
+| `resources`                            | CPU/Memory resource requests/limits              | Memory: `512Mi`, CPU: `300m`                             |
+| `ingress.enabled`                      | Enable ingress controller resource               | `false`                                                  |
+| `ingress.hosts[0].name`                | Hostname to your Phabricator installation        | `phabricator.local`                                      |
+| `ingress.hosts[0].path`                | Path within the url structure                    | `/`                                                      |
+| `ingress.hosts[0].tls`                 | Utilize TLS backend in ingress                   | `false`                                                  |
+| `ingress.hosts[0].certManager`         | Add annotations for cert-manager                 | `false`                                                  |
+| `ingress.hosts[0].tlsSecret`           | TLS Secret (certificates)                        | `phabricator.local-tls-secret`                           |
+| `ingress.hosts[0].annotations`         | Annotations for this host's ingress record       | `[]`                                                     |
+| `ingress.secrets[0].name`              | TLS Secret Name                                  | `nil`                                                    |
+| `ingress.secrets[0].certificate`       | TLS Secret Certificate                           | `nil`                                                    |
+| `ingress.secrets[0].key`               | TLS Secret Key                                   | `nil`                                                    |
+| `podAnnotations`                       | Pod annotations                                  | `{}`                                                     |
+| `metrics.enabled`                      | Start a side-car prometheus exporter             | `false`                                                  |
+| `metrics.image.registry`               | Apache exporter image registry                   | `docker.io`                                              |
+| `metrics.image.repository`             | Apache exporter image name                       | `lusotycoon/apache-exporter`                             |
+| `metrics.image.tag`                    | Apache exporter image tag                        | `v0.5.0`                                                 |
+| `metrics.image.pullPolicy`             | Image pull policy                                | `IfNotPresent`                                           |
+| `metrics.image.pullSecrets`            | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)  |
 | `metrics.podAnnotations`               | Additional annotations for Metrics exporter pod  | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
-| `metrics.resources`                    | Exporter resource requests/limit                 | {}                                                    |
-| `nodeSelector`                         | Node labels for pod assignment                   | `nil`                                                  |
-| `affinity`                             | Node/pod affinities                              | `nil`                                                  |
-| `tolerations`                          | List of node taints to tolerate                  | `nil`                                                  |
+| `metrics.resources`                    | Exporter resource requests/limit                 | {}                                                       |
+| `nodeSelector`                         | Node labels for pod assignment                   | `nil`                                                    |
+| `affinity`                             | Node/pod affinities                              | `nil`                                                    |
+| `tolerations`                          | List of node taints to tolerate                  | `nil`                                                    |
 
 The above parameters map to the env variables defined in [bitnami/phabricator](http://github.com/bitnami/bitnami-docker-phabricator). For more information please refer to the [bitnami/phabricator](http://github.com/bitnami/bitnami-docker-phabricator) image documentation.
 

--- a/stable/phabricator/templates/_helpers.tpl
+++ b/stable/phabricator/templates/_helpers.tpl
@@ -11,8 +11,16 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "phabricator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/phabricator/values.yaml
+++ b/stable/phabricator/values.yaml
@@ -26,6 +26,14 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## String to partially override phabricator.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override phabricator.fullname template
+##
+# fullnameOverride:
+
 ## Phabricator host to create application URLs
 ## ref: https://github.com/bitnami/bitnami-docker-phabricator#configuration
 ##


### PR DESCRIPTION
This reverts commit b3a2f3b590368441d58bd2093a1528136279942f.
Implement #15430 bumping a major version after #15606
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)