### PR TITLE
[stable/parse] Implement again "Standardize 'fullname' and 'name' macros"

### DIFF
--- a/stable/parse/Chart.yaml
+++ b/stable/parse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: parse
-version: 6.2.16
+version: 7.0.0
 appVersion: 3.6.0
 description: Parse is a platform that enables users to add a scalable and powerful backend to launch a full-featured app for iOS, Android, JavaScript, Windows, Unity, and more.
 keywords:

--- a/stable/parse/README.md
+++ b/stable/parse/README.md
@@ -49,6 +49,8 @@ The following table lists the configurable parameters of the Parse chart and the
 |---------------------------------------|------------------------------------------|-------------------------------------------------------- |
 | `global.imageRegistry`                | Global Docker image registry             | `nil`                                                   |
 | `global.imagePullSecrets`             | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
+| `nameOverride`                        | String to partially override parse.fullname template with a string (will prepend the release name) | `nil`|
+| `fullnameOverride`                    | String to fully override parse.fullname template with a string                                     | `nil`|
 | `service.type`                        | Kubernetes Service type                  | `LoadBalancer`                                          |
 | `service.port`                        | Service HTTP port (Dashboard)            | `80`                                                    |
 | `service.loadBalancerIP`              | `loadBalancerIP` for the Parse Service   | `nil`                                                   |
@@ -84,22 +86,22 @@ The following table lists the configurable parameters of the Parse chart and the
 | `persistence.storageClass`            | PVC Storage Class for Parse volume       | `nil` (uses alpha storage class annotation)             |
 | `persistence.accessMode`              | PVC Access Mode for Parse volume         | `ReadWriteOnce`                                         |
 | `persistence.size`                    | PVC Storage Request for Parse volume     | `8Gi`                                                   |
-| `ingress.enabled`                   | Enable ingress controller resource                            | `false`                                                  |
-| `ingress.annotations`               | Ingress annotations                                           | `[]`                                                     |
-| `ingress.certManager`               | Add annotations for cert-manager                              | `false`                                                  |
-| `ingress.dashboard.hosts[0].name`             | Hostname to your Parse Dashboard installation                           | `ghost.local`                                            |
-| `ingress.dashboard.hosts[0].path`             | Path within the url structure                                 | `/`                                                      |
-| `ingress.dashboard.hosts[0].tls`              | Utilize TLS backend in ingress                                | `false`                                                  |
-| `ingress.dashboard.hosts[0].tlsHosts`         | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`)                               | `nil`                                                  |
-| `ingress.dashboard.hosts[0].tlsSecret`        | TLS Secret (certificates)                                     | `ghost.local-tls-secret`                                 |
-| `ingress.server.hosts[0].name`             | Hostname to your Parse Server installation                           | `ghost.local`                                            |
-| `ingress.server.hosts[0].path`             | Path within the url structure                                 | `/`                                                      |
-| `ingress.server.hosts[0].tls`              | Utilize TLS backend in ingress                                | `false`                                                  |
-| `ingress.server.hosts[0].tlsHosts`         | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`)                               | `nil`                                                  |
-| `ingress.server.hosts[0].tlsSecret`        | TLS Secret (certificates)                                     | `ghost.local-tls-secret`                                 |
-| `ingress.secrets[0].name`           | TLS Secret Name                                               | `nil`                                                    |
-| `ingress.secrets[0].certificate`    | TLS Secret Certificate                                        | `nil`                                                    |
-| `ingress.secrets[0].key`            | TLS Secret Key                                                | `nil`                                                    |
+| `ingress.enabled`                     | Enable ingress controller resource       | `false`                                                 |
+| `ingress.annotations`                 | Ingress annotations                      | `[]`                                                    |
+| `ingress.certManager`                 | Add annotations for cert-manager         | `false`                                                 |
+| `ingress.dashboard.hosts[0].name`     | Hostname to your Parse Dashboard installation | `ghost.local`                                      |
+| `ingress.dashboard.hosts[0].path`     | Path within the url structure            | `/`                                                     |
+| `ingress.dashboard.hosts[0].tls`      | Utilize TLS backend in ingress           | `false`                                                 |
+| `ingress.dashboard.hosts[0].tlsHosts` | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`) | `nil`       |
+| `ingress.dashboard.hosts[0].tlsSecret`| TLS Secret (certificates)                | `ghost.local-tls-secret`                                |
+| `ingress.server.hosts[0].name`        | Hostname to your Parse Server installation | `ghost.local`                                         |
+| `ingress.server.hosts[0].path`        | Path within the url structure            | `/`                                                     |
+| `ingress.server.hosts[0].tls`         | Utilize TLS backend in ingress           | `false`                                                 |
+| `ingress.server.hosts[0].tlsHosts`    | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`) | `nil`       |
+| `ingress.server.hosts[0].tlsSecret`   | TLS Secret (certificates)                | `ghost.local-tls-secret`                                |
+| `ingress.secrets[0].name`             | TLS Secret Name                          | `nil`                                                   |
+| `ingress.secrets[0].certificate`      | TLS Secret Certificate                   | `nil`                                                   |
+| `ingress.secrets[0].key`              | TLS Secret Key                           | `nil`                                                   |
 | `mongodb.usePassword`                 | Enable MongoDB password authentication   | `true`                                                  |
 | `mongodb.password`                    | MongoDB admin password                   | `nil`                                                   |
 | `mongodb.persistence.enabled`         | Enable MongoDB persistence using PVC     | `true`                                                  |

--- a/stable/parse/templates/_helpers.tpl
+++ b/stable/parse/templates/_helpers.tpl
@@ -18,16 +18,32 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "parse.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
+{{- end -}}
+{{- end -}}
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "parse.mongodb.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- printf "%s-%s" .Values.fullnameOverride "mongodb" | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
 {{- printf "%s-%s" .Release.Name "mongodb" | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name $name "mongodb" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/parse/values.yaml
+++ b/stable/parse/values.yaml
@@ -7,6 +7,14 @@
 #   imagePullSecrets:
 #     - myRegistryKeySecretName
 
+## String to partially override parse.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override parse.fullname template
+##
+# fullnameOverride:
+
 ## Kubernetes serviceType for Parse Deployment
 ## ref: http://kubernetes.io/docs/user-guide/services/#publishing-services---service-types
 ##


### PR DESCRIPTION
This reverts commit 191ac296d8e27798c953a9befd6ac5466784f419.
Implement #15431 bumping a major version after #15607
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)