### PR TITLE
[stable/dokuwiki] Implement again "Standardize 'fullname' and 'name' macros"

### DIFF
--- a/stable/dokuwiki/Chart.yaml
+++ b/stable/dokuwiki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dokuwiki
-version: 4.3.4
+version: 5.0.0
 appVersion: 0.20180422.201901061035
 description: DokuWiki is a standards-compliant, simple to use wiki optimized for creating
   documentation. It is targeted at developer teams, workgroups, and small companies.

--- a/stable/dokuwiki/README.md
+++ b/stable/dokuwiki/README.md
@@ -54,6 +54,8 @@ The following table lists the configurable parameters of the DokuWiki chart and 
 | `image.tag`                          | DokuWiki image tag                                         | `{TAG_NAME}`                                  |
 | `image.pullPolicy`                   | Image pull policy                                          | `Always`                                      |
 | `image.pullSecrets`                  | Specify docker-registry secret names as an array           | `[]` (does not add image pull secrets to deployed pods) |
+| `nameOverride`                       | String to partially override dokuwiki.fullname template with a string (will prepend the release name) | `nil` |
+| `fullnameOverride`                   | String to fully override dokuwiki.fullname template with a string                                     | `nil` |
 | `dokuwikiUsername`                   | User of the application                                    | `user`                                        |
 | `dokuwikiFullName`                   | User's full name                                           | `User Name`                                   |
 | `dokuwikiPassword`                   | Application password                                       | _random 10 character alphanumeric string_     |

--- a/stable/dokuwiki/templates/_helpers.tpl
+++ b/stable/dokuwiki/templates/_helpers.tpl
@@ -11,8 +11,16 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "dokuwiki.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/dokuwiki/values.yaml
+++ b/stable/dokuwiki/values.yaml
@@ -26,6 +26,14 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## String to partially override dokuwiki.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override dokuwiki.fullname template
+##
+# fullnameOverride:
+
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-dokuwiki#environment-variables
 ##


### PR DESCRIPTION
This reverts commit 3e51dd5d3f6f2bcc65e32c07a449857b39d052c7.
Implement #15438 bumping a major version after #15609
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)