### PR TITLE
[stable/mongodb] Implement again "Standardize 'fullname' and 'name' macros"

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 6.1.4
+version: 7.0.0
 appVersion: 4.0.10
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 7.0.0
+version: 6.1.5
 appVersion: 4.0.10
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/README.md
+++ b/stable/mongodb/README.md
@@ -55,6 +55,8 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `image.pullPolicy`                                 | Image pull policy                                                                            | `IfNotPresent`                                          |
 | `image.pullSecrets`                                | Specify docker-registry secret names as an array                                             | `[]` (does not add image pull secrets to deployed pods) |
 | `image.debug`                                      | Specify if debug logs should be enabled                                                      | `false`                                                 |
+| `nameOverride`                                     | String to partially override mongodb.fullname template with a string (will prepend the release name) | `nil`                                           |
+| `fullnameOverride`                                 | String to fully override mongodb.fullname template with a string                             | `nil`                                                   |
 | `clusterDomain`                                    | Default Kubernetes cluster domain                                                            | `cluster.local`                                         |
 | `usePassword`                                      | Enable password authentication                                                               | `true`                                                  |
 | `existingSecret`                                   | Existing secret with MongoDB credentials                                                     | `nil`                                                   |

--- a/stable/mongodb/values-production.yaml
+++ b/stable/mongodb/values-production.yaml
@@ -34,6 +34,14 @@ image:
   ## ref:  https://github.com/bitnami/minideb-extras-base
   debug: false
 
+## String to partially override mongodb.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override mongodb.fullname template
+##
+# fullnameOverride:
+
 ## Enable authentication
 ## ref: https://docs.mongodb.com/manual/tutorial/enable-authentication/
 #

--- a/stable/mongodb/values.yaml
+++ b/stable/mongodb/values.yaml
@@ -34,6 +34,14 @@ image:
   ## ref:  https://github.com/bitnami/minideb-extras-base
   debug: false
 
+## String to partially override mongodb.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override mongodb.fullname template
+##
+# fullnameOverride:
+
 ## Enable authentication
 ## ref: https://docs.mongodb.com/manual/tutorial/enable-authentication/
 #


### PR DESCRIPTION
This reverts commit 57286b2585b15306c63a07d9442460dbdfde26cf that was implemented by mistake following a batch approach for other charts
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)