### PR TITLE
[stable/sonatype-nexus] Allow for better ingress and service customization

### DIFF
--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 1.18.4
+version: 1.18.5
 appVersion: 3.15.2-01
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/templates/ingress.yaml
+++ b/stable/sonatype-nexus/templates/ingress.yaml
@@ -11,6 +11,7 @@ metadata:
     {{- end }}
 spec:
   rules:
+{{- if .Values.nexusProxy.enabled -}}  
   {{- if .Values.nexusProxy.env.nexusHttpHost }}
     - host: {{ .Values.nexusProxy.env.nexusHttpHost }}
       http:
@@ -37,6 +38,10 @@ spec:
               servicePort: {{ .Values.nexusProxy.port }}
             path: {{ .Values.ingress.path }}
   {{- end }}
+{{- end -}}  
+{{- with .Values.ingress.rules  }}
+{{ toYaml . | indent 2 }}
+  {{- end -}}
 {{- if .Values.ingress.tls.enabled }}
   tls:
     - hosts:

--- a/stable/sonatype-nexus/templates/service.yaml
+++ b/stable/sonatype-nexus/templates/service.yaml
@@ -18,12 +18,17 @@ metadata:
 {{- end }}
 spec:
   ports:
-    - name: {{ .Values.service.portName }}
-      port: {{ .Values.service.port }}
-      protocol: TCP
-      targetPort: {{ .Values.service.targetPort }}
+  {{- if .Values.service.portName }}
+  - name: {{ .Values.service.portName }}
+    port: {{ .Values.service.port }}
+    targetPort: {{ .Values.service.targetPort }}
+  {{- end }}
+  {{- with .Values.service.ports  }}
+{{ toYaml . | indent 2 }}
+  {{- end -}}
   selector:
     app: {{ template "nexus.name" . }}
     release: {{ .Release.Name }}
   type: {{ .Values.service.serviceType }}
 {{- end}}
+

--- a/stable/sonatype-nexus/values.yaml
+++ b/stable/sonatype-nexus/values.yaml
@@ -155,6 +155,15 @@ ingress:
   tls:
     enabled: true
     secretName: nexus-tls
+  # Specify custom rules in addition to or instead of the nexus-proxy rules
+  rules: 
+  # - host: http://nexus.127.0.0.1.nip.io
+  #   http:
+  #     paths:
+  #     - backend:
+  #         serviceName: additional-svc
+  #         servicePort: 80
+        
 
 tolerations: []
 
@@ -195,8 +204,10 @@ secret:
 service:
   # name: additional-svc
   enabled: false
-  portName: nexus-service
   labels: {}
-  annotations: {}
-  targetPort: 80
-  port: 80
+  annotations: {}  
+  ports: 
+  - name: nexus-service
+    targetPort: 80
+    port: 80
+


### PR DESCRIPTION
#### What this PR does / why we need it:
I needed to replace default nexus_proxy by a different set of oauth proxy containers in order to provide a similar functionality with a identity provider other than google. I was able to add more containers and share the configmap and secret manifests but the current chart didn't allow me to specify ingress and service entries for those new containers.

This pull request maintains backwards compatibility while allowing the definition of new ingress host and service mappings. These enhancements just extend the existing variables.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
