### PR TITLE
[stable/airflow]: Added checking redis and postgres env 

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 3.0.3
+version: 3.0.4
 appVersion: 1.10.3
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/templates/_helpers.tpl
+++ b/stable/airflow/templates/_helpers.tpl
@@ -97,6 +97,7 @@ See script/entrypoint.sh in that repo for more info.
 The key names for postgres and redis are fixed, which is consistent with the subcharts.
 */}}
 {{- define "airflow.mapenvsecrets" }}
+  {{- if .Values.postgresql.enabled }}
   - name: POSTGRES_USER
     value: {{ default "postgres" .Values.postgresql.postgresUser | quote }}
   - name: POSTGRES_PASSWORD
@@ -104,11 +105,14 @@ The key names for postgres and redis are fixed, which is consistent with the sub
       secretKeyRef:
         name: {{ default (include "airflow.postgresql.fullname" .) .Values.postgresql.existingSecret }}
         key: postgres-password
+  {{- end }}
+  {{- if .Values.redis.enabled }}
   - name: REDIS_PASSWORD
     valueFrom:
       secretKeyRef:
         name: {{ default (include "airflow.redis.fullname" .) .Values.redis.existingSecret }}
         key: redis-password
+  {{- end }}
   {{- if .Values.airflow.extraEnv }}
 {{ toYaml .Values.airflow.extraEnv | indent 2 }}
   {{- end }}


### PR DESCRIPTION
## What this PR does / why we need it: 
Setting the redis.enabled option to false
Airflow fail to install because of trying to read Redis **secret** and not found 
There's no need for me to use Redis as I am using a different Broker client.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/chart]`)
