### PR TITLE
[stable/concourse]: use `detect` as default baggageclaim driver

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 8.2.0
+version: 8.2.1
 appVersion: 5.4.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/NOTES.txt
+++ b/stable/concourse/templates/NOTES.txt
@@ -35,23 +35,6 @@
   {{- end }}
 * If this is your first time using Concourse, follow the tutorials at https://concourse-ci.org/tutorials.html
 
-{{- if .Values.concourse.worker.baggageclaim.driver }}
-{{- if contains "naive" .Values.concourse.worker.baggageclaim.driver }}
-
-*******************
-******WARNING******
-*******************
-
-You are using the "naive" baggage claim driver, which is also the default value for this chart.
-
-This is the default for compatibility reasons, but is very space inefficient, and should be changed to either "btrfs" (recommended) or "overlay" depending on that filesystem's support in the Linux kernel your cluster is using.
-
-Please see https://github.com/concourse/concourse/issues/1230 and https://github.com/concourse/concourse/issues/1966 for background.
-
-{{- end }}
-{{- end }}
-
-
 
 {{- if .Values.concourse.web.localAuth.enabled }}
 {{- if contains "test:test" .Values.secrets.localUsers }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1188,7 +1188,7 @@ concourse:
       ## Driver to use for managing volumes.
       ## Possible values: detect, naive, btrfs, and overlay.
       ##
-      driver: naive
+      driver: detect
 
       ## Path to btrfs binary
       ##


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR switches the default baggageclaim driver from `naive` to `detect`, so that `baggageclaim` can take the decision on whether it should use one driver or another based on kernel features and the mountpoint that `CONCOURSE_WORK_DIR` indicates.

https://github.com/concourse/baggageclaim/blob/538ce58b9dc4896cf7a4ba42a822d0003bbfccf1/baggageclaimcmd/driver_linux.go#L52-L60

#### Which issue this PR fixes

  - fixes #14033

#### Special notes for your reviewer:

I also removed the note under `NOTES.txt` as now one would need to explicitly opt-in to leverage this driver.

Regarding upgrades:

- because we remove all of the contents of the attached persistent volume on start up, the transition should not see any impacts.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
