### PR TITLE
[stable/airflow]: Added extraInitContainers option

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 4.0.9
+version: 4.1.0
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -345,6 +345,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `airflow.extraEnv`                       | specify additional environment variables to mount       | `{}`                      |
 | `airflow.extraConfigmapMounts`           | Additional configMap volume mounts on the airflow pods. | `[]`                      |
 | `airflow.podAnnotations`                 | annotations for scheduler, worker and web pods          | `{}`                      |
+| `airflow.extraInitContainers`            | additional Init Containers to run in the scheduler pods | `[]`                      |
 | `airflow.extraContainers`                | additional containers to run in the scheduler, worker & web pods | `[]`             |
 | `airflow.extraVolumeMounts`              | additional volumeMounts to the main container in scheduler, worker & web pods | `[]`|
 | `airflow.extraVolumes`                   | additional volumes for the scheduler, worker & web pods | `[]`                      |

--- a/stable/airflow/templates/deployments-scheduler.yaml
+++ b/stable/airflow/templates/deployments-scheduler.yaml
@@ -77,6 +77,12 @@ spec:
               mountPath: /keys
             {{- end }}
       {{- end }}
+{{- if and ( .Values.airflow.extraInitContainers ) ( .Values.dags.initContainer.enabled ) }}
+{{ toYaml .Values.airflow.extraInitContainers | indent 8 }}
+{{- else if and ( .Values.airflow.extraInitContainers ) ( not .Values.dags.initContainer.enabled ) }}
+      initContainers:
+{{ toYaml .Values.airflow.extraInitContainers | indent 8 }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}-scheduler
           image: {{ .Values.airflow.image.repository }}:{{ .Values.airflow.image.tag }}

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -137,6 +137,17 @@ airflow:
   podAnnotations: {}
     ## Example:
     ## iam.amazonaws.com/role: airflow-Role
+
+  extraInitContainers: []
+  ## Additional init containers to run before the Scheduler pods.
+  ## for example, be used to run a sidecar that chown Logs storage .
+  # - name: volume-mount-hack
+  #   image: busybox
+  #   command: ["sh", "-c", "chown -R 1000:1000 logs"]
+  #   volumeMounts:
+  #     - mountPath: /usr/local/airflow/logs
+  #       name: logs-data
+
   extraContainers: []
   ## Additional containers to run alongside the Scheduler, Worker and Web pods
   ## This could, for example, be used to run a sidecar that syncs DAGs from object storage.


### PR DESCRIPTION

#### What this PR does / why we need it:
Additional init containers to run before the Scheduler pods.
usr/local/airflow/logs storage. This directory needs to be writable by the airflow user, which runs as UID 1000.
There is no way to set the UID of user using the definition of Pod, but Kubernetes saves the UID of sourced volume.
So, i can set the UID by InitContainer, which launches before the main container

#### Which issue this PR fixes
#15671 
