### PR TITLE
[stable/cluster-autoscaler] Use labels recommended by Helm

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 1.1.0
+version: 2.0.0
 appVersion: 1.13.1
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/README.md
+++ b/stable/cluster-autoscaler/README.md
@@ -19,6 +19,17 @@ This chart bootstraps a cluster-autoscaler deployment on a [Kubernetes](http://k
   - Azure AKS specific Prerequisites:
     - Kubernetes 1.10+ with RBAC-enabled
 
+## Upgrading from <2.X
+
+In order to upgrade to chart version to 2.X from 1.X or 0.X, deleting the old helm release first is required.
+
+```console
+$ helm del --purge my-release
+```
+
+Once the old release is deleted, the new 2.X release can be installed using the standard instructions.
+Note that autoscaling will not occur during the time between deletion and installation.
+
 ## Installing the Chart
 
 **By default, no deployment is created and nothing will autoscale**.

--- a/stable/cluster-autoscaler/templates/_helpers.tpl
+++ b/stable/cluster-autoscaler/templates/_helpers.tpl
@@ -18,3 +18,28 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cluster-autoscaler.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return instance and name labels.
+*/}}
+{{- define "cluster-autoscaler.instance-name" -}}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/name: {{ include "cluster-autoscaler.name" . | quote }}
+{{- end -}}
+
+
+{{/*
+Return labels, including instance and name.
+*/}}
+{{- define "cluster-autoscaler.labels" -}}
+{{ include "cluster-autoscaler.instance-name" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+helm.sh/chart: {{ include "cluster-autoscaler.chart" . | quote }}
+{{- end -}}

--- a/stable/cluster-autoscaler/templates/clusterrole.yaml
+++ b/stable/cluster-autoscaler/templates/clusterrole.yaml
@@ -3,10 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   labels:
-    app: {{ template "cluster-autoscaler.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+{{ include "cluster-autoscaler.labels" . | indent 4 }}
   name: {{ template "cluster-autoscaler.fullname" . }}
 rules:
   - apiGroups:

--- a/stable/cluster-autoscaler/templates/clusterrolebinding.yaml
+++ b/stable/cluster-autoscaler/templates/clusterrolebinding.yaml
@@ -3,10 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app: {{ template "cluster-autoscaler.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+{{ include "cluster-autoscaler.labels" . | indent 4 }}
   name: {{ template "cluster-autoscaler.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/cluster-autoscaler/templates/deployment.yaml
+++ b/stable/cluster-autoscaler/templates/deployment.yaml
@@ -4,17 +4,13 @@ apiVersion: {{ .Values.deployment.apiVersion }}
 kind: Deployment
 metadata:
   labels:
-    app: {{ template "cluster-autoscaler.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+{{ include "cluster-autoscaler.labels" . | indent 4 }}
   name: {{ template "cluster-autoscaler.fullname" . }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "cluster-autoscaler.name" . }}
-      release: {{ .Release.Name }}
+{{ include "cluster-autoscaler.instance-name" . | indent 6 }}
     {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 6 }}
     {{- end }}
@@ -25,8 +21,7 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     {{- end }}
       labels:
-        app: {{ template "cluster-autoscaler.name" . }}
-        release: {{ .Release.Name }}
+{{ include "cluster-autoscaler.instance-name" . | indent 8 }}
       {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
       {{- end }}

--- a/stable/cluster-autoscaler/templates/pdb.yaml
+++ b/stable/cluster-autoscaler/templates/pdb.yaml
@@ -3,15 +3,11 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    app: {{ template "cluster-autoscaler.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+{{ include "cluster-autoscaler.labels" . | indent 4 }}
   name: {{ template "cluster-autoscaler.fullname" . }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "cluster-autoscaler.name" . }}
-      release: {{ .Release.Name }}
+{{ include "cluster-autoscaler.instance-name" . | indent 6 }}
 {{ .Values.podDisruptionBudget | indent 2 }}
 {{- end -}}

--- a/stable/cluster-autoscaler/templates/role.yaml
+++ b/stable/cluster-autoscaler/templates/role.yaml
@@ -3,10 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   labels:
-    app: {{ template "cluster-autoscaler.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+{{ include "cluster-autoscaler.labels" . | indent 4 }}
   name: {{ template "cluster-autoscaler.fullname" . }}
 rules:
   - apiGroups:

--- a/stable/cluster-autoscaler/templates/rolebinding.yaml
+++ b/stable/cluster-autoscaler/templates/rolebinding.yaml
@@ -3,10 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   labels:
-    app: {{ template "cluster-autoscaler.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+{{ include "cluster-autoscaler.labels" . | indent 4 }}
   name: {{ template "cluster-autoscaler.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/cluster-autoscaler/templates/service.yaml
+++ b/stable/cluster-autoscaler/templates/service.yaml
@@ -6,10 +6,7 @@ metadata:
 {{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "cluster-autoscaler.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+{{ include "cluster-autoscaler.labels" . | indent 4 }}
   name: {{ template "cluster-autoscaler.fullname" . }}
 spec:
 {{- if .Values.service.clusterIP }}
@@ -32,6 +29,5 @@ spec:
       targetPort: 8085
       name: {{ .Values.service.portName }}
   selector:
-    app: {{ template "cluster-autoscaler.name" . }}
-    release: {{ .Release.Name }}
+{{ include "cluster-autoscaler.instance-name" . | indent 4 }}
   type: "{{ .Values.service.type }}"

--- a/stable/cluster-autoscaler/templates/serviceaccount.yaml
+++ b/stable/cluster-autoscaler/templates/serviceaccount.yaml
@@ -3,9 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ template "cluster-autoscaler.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+{{ include "cluster-autoscaler.labels" . | indent 4 }}
   name: {{ template "cluster-autoscaler.fullname" . }}
 {{- end -}}

--- a/stable/cluster-autoscaler/templates/servicemonitor.yaml
+++ b/stable/cluster-autoscaler/templates/servicemonitor.yaml
@@ -13,8 +13,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ template "cluster-autoscaler.name" . }}
-      release: {{ .Release.Name }}
+{{ include "cluster-autoscaler.instance-name" . | indent 6 }}
   endpoints:
   - port: {{ .Values.service.portName }}
     interval: {{ .Values.serviceMonitor.interval }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates the resources in cluster-autoscaler to use standard label keys recommended by helm.

See https://helm.sh/docs/chart_best_practices/#standard-labels

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - N/A

#### Special notes for your reviewer:

Since the Deployment's selector is immutable, this is a breaking change and will require a deletion and recreation of the deployment, hence the major version bump.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
