### PR TITLE
[stable/filebeat] Use labels recommended by Helm

### DIFF
--- a/stable/filebeat/Chart.yaml
+++ b/stable/filebeat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart to collect Kubernetes logs with filebeat
 icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.svg
 name: filebeat
-version: 2.0.2
+version: 3.0.0
 appVersion: 7.0.1
 home: https://www.elastic.co/products/beats/filebeat
 sources:

--- a/stable/filebeat/templates/clusterrole.yaml
+++ b/stable/filebeat/templates/clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 metadata:
   name: {{ template "filebeat.fullname" . }}
   labels:
-    app: {{ template "filebeat.name" . }}
-    chart: {{ template "filebeat.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "filebeat.name" . }}
+    helm.sh/chart: {{ template "filebeat.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 rules:
 - apiGroups: [""]
   resources:

--- a/stable/filebeat/templates/clusterrolebinding.yaml
+++ b/stable/filebeat/templates/clusterrolebinding.yaml
@@ -4,10 +4,10 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "filebeat.fullname" . }}
   labels:
-    app: {{ template "filebeat.name" . }}
-    chart: {{ template "filebeat.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "filebeat.name" . }}
+    helm.sh/chart: {{ template "filebeat.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/stable/filebeat/templates/daemonset.yaml
+++ b/stable/filebeat/templates/daemonset.yaml
@@ -3,15 +3,15 @@ kind: DaemonSet
 metadata:
   name: {{ template "filebeat.fullname" . }}
   labels:
-    app: {{ template "filebeat.name" . }}
-    chart: {{ template "filebeat.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "filebeat.name" . }}
+    helm.sh/chart: {{ template "filebeat.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "filebeat.name" . }}
-      release: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ template "filebeat.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   minReadySeconds: 10
   updateStrategy:
     type: RollingUpdate
@@ -20,8 +20,8 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "filebeat.name" . }}
-        release: {{ .Release.Name }}
+        app.kubernetes.io/name: {{ template "filebeat.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:
         checksum/secret: {{ toYaml (default .Values.config .Values.overrideConfig) | sha256sum }}
 {{- if .Values.annotations }}

--- a/stable/filebeat/templates/role.yaml
+++ b/stable/filebeat/templates/role.yaml
@@ -5,10 +5,10 @@ kind: Role
 metadata:
   name: {{ template "filebeat.fullname" . }}
   labels:
-    app: {{ template "filebeat.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ template "filebeat.name" . }}
+    helm.sh/chart: {{ template "filebeat.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
   namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups: ['extensions']

--- a/stable/filebeat/templates/rolebinding.yaml
+++ b/stable/filebeat/templates/rolebinding.yaml
@@ -5,10 +5,10 @@ kind: RoleBinding
 metadata:
   name: {{ template "filebeat.fullname" . }}
   labels:
-    app: {{ template "filebeat.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ template "filebeat.name" . }}
+    helm.sh/chart: {{ template "filebeat.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role

--- a/stable/filebeat/templates/secret.yaml
+++ b/stable/filebeat/templates/secret.yaml
@@ -3,10 +3,10 @@ kind: Secret
 metadata:
   name: {{ template "filebeat.fullname" . }}
   labels:
-    app: {{ template "filebeat.name" . }}
-    chart: {{ template "filebeat.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "filebeat.name" . }}
+    helm.sh/chart: {{ template "filebeat.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
   filebeat.yml: {{ toYaml (default .Values.config .Values.overrideConfig) | indent 4 | b64enc }}

--- a/stable/filebeat/templates/service.yaml
+++ b/stable/filebeat/templates/service.yaml
@@ -15,13 +15,14 @@ metadata:
   name: {{ template "filebeat.fullname" . }}-metrics
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "filebeat.name" . }}
-    chart: {{ template "filebeat.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "filebeat.name" . }}
+    helm.sh/chart: {{ template "filebeat.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   selector:
-    app: {{ template "filebeat.name" . }}
+    app.kubernetes.io/name: {{ template "filebeat.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
   ports:
     - name: metrics
       port: {{ .Values.monitoring.exporterPort }}

--- a/stable/filebeat/templates/serviceaccount.yaml
+++ b/stable/filebeat/templates/serviceaccount.yaml
@@ -4,8 +4,8 @@ kind: ServiceAccount
 metadata:
   name: {{ template "filebeat.serviceAccountName" . }}
   labels:
-    app: {{ template "filebeat.name" . }}
-    chart: {{ template "filebeat.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "filebeat.name" . }}
+    helm.sh/chart: {{ template "filebeat.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}

--- a/stable/filebeat/templates/servicemonitor.yaml
+++ b/stable/filebeat/templates/servicemonitor.yaml
@@ -25,6 +25,6 @@ spec:
     - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      app: {{ template "filebeat.name" . }}
-      release: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ template "filebeat.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates the resources in filebeat to use standard label keys recommended by helm.

See https://helm.sh/docs/chart_best_practices/#standard-labels

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - N/A

#### Special notes for your reviewer:

Since the Deployment's selector is immutable, this is a breaking change and will require a deletion and recreation of the deployment, hence the major version bump.

The only functional change in this is that I added the `app.kubernetes.io/instance` label to the Service's selector since it was missing and is typically used in charts' Service selectors.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
