### PR TITLE
[stable/datadog] Add labels recommended by Helm

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.33.0
+version: 1.34.0
 appVersion: 6.13.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/agent-apiservice.yaml
+++ b/stable/datadog/templates/agent-apiservice.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 spec:
   service:
     name: {{ template "datadog.fullname" . }}-cluster-agent-metrics-api

--- a/stable/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/stable/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 spec:
   replicas: {{ .Values.clusterchecksDeployment.replicas }}
   template:

--- a/stable/datadog/templates/agent-clusterchecks-rbac.yaml
+++ b/stable/datadog/templates/agent-clusterchecks-rbac.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
   name: {{ template "datadog.fullname" . }}-cluster-checks
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -25,5 +29,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
   name: {{ template "datadog.fullname" . }}-cluster-checks
 {{- end -}}

--- a/stable/datadog/templates/agent-rbac.yaml
+++ b/stable/datadog/templates/agent-rbac.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
   name: {{ template "datadog.fullname" . }}-cluster-agent
 rules:
 - apiGroups:
@@ -79,6 +83,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
   name: {{ template "datadog.fullname" . }}-cluster-agent
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -97,6 +105,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
   name: {{ template "datadog.fullname" . }}-cluster-agent
 {{- end }}
 
@@ -110,6 +122,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
   name: {{ template "datadog.fullname" . }}-cluster-agent:system:auth-delegator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/datadog/templates/agent-secret.yaml
+++ b/stable/datadog/templates/agent-secret.yaml
@@ -10,6 +10,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 type: Opaque
 data:
   {{ if .Values.clusterAgent.token -}}

--- a/stable/datadog/templates/agent-services.yaml
+++ b/stable/datadog/templates/agent-services.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}-cluster-agent"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 spec:
   type: ClusterIP
   selector:
@@ -29,6 +33,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 spec:
   type: ClusterIP
   selector:

--- a/stable/datadog/templates/checksd-configmap.yaml
+++ b/stable/datadog/templates/checksd-configmap.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
   annotations:
     checksum/checksd-config: {{ tpl (toYaml .Values.datadog.checksd) . | sha256sum }}
 data:

--- a/stable/datadog/templates/cluster-agent-confd-configmap.yaml
+++ b/stable/datadog/templates/cluster-agent-confd-configmap.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
   annotations:
     checksum/confd-config: {{ tpl (toYaml .Values.clusterAgent.confd) . | sha256sum }}
 data:

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 spec:
   replicas: {{ .Values.clusterAgent.replicas }}
   selector:

--- a/stable/datadog/templates/confd-configmap.yaml
+++ b/stable/datadog/templates/confd-configmap.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
   annotations:
     checksum/confd-config: {{ tpl (toYaml .Values.datadog.confd) . | sha256sum }}
     checksum/autoconf-config: {{ tpl (toYaml .Values.datadog.autoconf) . | sha256sum }}

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 spec:
   template:
     metadata:

--- a/stable/datadog/templates/datadog-yaml-configmap.yaml
+++ b/stable/datadog/templates/datadog-yaml-configmap.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
   annotations:
 data:
   datadog.yaml: |

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 spec:
   replicas: {{ .Values.deployment.replicas }}
   template:

--- a/stable/datadog/templates/hpa-rbac.yaml
+++ b/stable/datadog/templates/hpa-rbac.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
   name: {{ template "datadog.fullname" . }}-cluster-agent-external-metrics-reader
 rules:
 - apiGroups:
@@ -26,6 +30,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
   name: {{ template "datadog.fullname" . }}-cluster-agent-external-metrics-reader
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -44,6 +52,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
   name: "{{ template "datadog.fullname" . }}-cluster-agent"
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/datadog/templates/rbac.yaml
+++ b/stable/datadog/templates/rbac.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
   name: {{ template "datadog.fullname" . }}
 rules:
 {{- if not .Values.clusterAgent.enabled }}
@@ -91,6 +95,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
   name: {{ template "datadog.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -110,5 +118,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
   name: {{ template "datadog.fullname" . }}
 {{- end -}}

--- a/stable/datadog/templates/secrets.yaml
+++ b/stable/datadog/templates/secrets.yaml
@@ -10,6 +10,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 type: Opaque
 data:
   api-key: {{ default "MISSING" .Values.datadog.apiKey | b64enc | quote }}
@@ -29,6 +33,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 type: Opaque
 data:
   app-key: {{ default "MISSING" .Values.datadog.appKey | b64enc | quote }}

--- a/stable/datadog/templates/service.yaml
+++ b/stable/datadog/templates/service.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    helm.sh/chart: "{{ template "datadog.chart" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
   {{- if .Values.deployment.service.annotations }}
   annotations:
 {{ toYaml .Values.deployment.service.annotations | indent 4 }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates the resources in datadog to use standard label keys recommended by helm.

See https://helm.sh/docs/chart_best_practices/#standard-labels

#### Which issue this PR fixes
  - N/A

#### Special notes for your reviewer:

Since the DaemonSet and Deployment selectors are immutable, this is breaking change and will require a deletion and recreation, hence the major version bump.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
