### PR TITLE
[incubator/mysqlha] Standardize the `fullnameOverride` and the `nameOverride` mysqlha 

### DIFF
--- a/incubator/mysqlha/Chart.yaml
+++ b/incubator/mysqlha/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mysqlha
-version: 0.8.0
+version: 1.0.0
 appVersion: 5.7.13
 description: MySQL cluster with a single master and zero or more slave replicas
 keywords:
@@ -12,7 +12,5 @@ icon: https://www.mysql.com/common/logos/logo-mysql-170x115.png
 maintainers:
   - name: jpoon
     email: helmchart-mysql@jasonpoon.ca
-  - name: jonhoare
-    email: jon.bitbucket@livewire-uk.co.uk
   - name: aisuko
     email: urakiny@gmail.com

--- a/incubator/mysqlha/README.md
+++ b/incubator/mysqlha/README.md
@@ -38,6 +38,8 @@ The following table lists the configurable parameters of the MySQL chart and the
 | `mysqlImage`                                 | `mysql` image and tag.                            | `mysql:5.7.13`                         |
 | `xtraBackupImage`                            | `xtrabackup` image and tag.                       | `gcr.io/google-samples/xtrabackup:1.0` |
 | `imagePullPolicy`                            | Image pull policy.                                | `IfNotPresent`                         |
+| `nameOverride`                               | `String to partially override mysqlha.fullname template with a string (will prepend the release name)` | `nil` |
+| `fullnameOverride`                           | `String to fully override mysqlha.fullname template with a string`                 | `nil` |
 | `replicaCount`                               | Number of MySQL replicas                          | 3                                      |
 | `mysqlRootPassword`                          | Password for the `root` user.                     | Randomly generated                     |
 | `mysqlUser`                                  | Username of new user to create.                   | `nil`                                  |

--- a/incubator/mysqlha/templates/_helpers.tpl
+++ b/incubator/mysqlha/templates/_helpers.tpl
@@ -3,14 +3,29 @@
 Expand the name of the chart.
 */}}
 {{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 | trimSuffix "-" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mysqlha.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/incubator/mysqlha/templates/configmap.yaml
+++ b/incubator/mysqlha/templates/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "fullname" . }}
   labels:
     app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ template "mysqlha.chart" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:

--- a/incubator/mysqlha/templates/secret.yaml
+++ b/incubator/mysqlha/templates/secret.yaml
@@ -4,25 +4,25 @@ metadata:
   name: {{ template "fullname" . }}
   labels:
     app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ template "mysqlha.chart" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
-  {{ if .Values.mysqlha.mysqlRootPassword }}
+  {{- if .Values.mysqlha.mysqlRootPassword }}
   mysql-root-password:  {{ .Values.mysqlha.mysqlRootPassword | b64enc | quote }}
-  {{ else }}
+  {{- else }}
   mysql-root-password: {{ randAlphaNum 12 | b64enc | quote }}
-  {{ end }}
-  {{ if .Values.mysqlha.mysqlUser }}
-  {{ if .Values.mysqlha.mysqlPassword }}
+  {{- end }}
+  {{- if .Values.mysqlha.mysqlUser }}
+  {{- if .Values.mysqlha.mysqlPassword }}
   mysql-password: {{ .Values.mysqlha.mysqlPassword | b64enc | quote }}
-  {{ else }}
+  {{- else }}
   mysql-password: {{ randAlphaNum 12 | b64enc | quote }}
-  {{ end }}
-  {{ end }}
-  {{ if .Values.mysqlha.mysqlReplicationPassword }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.mysqlha.mysqlReplicationPassword }}
   mysql-replication-password: {{ .Values.mysqlha.mysqlReplicationPassword | b64enc | quote }}
-  {{ else }}
+  {{- else }}
   mysql-replication-password: {{ randAlphaNum 12 | b64enc | quote }}
-  {{ end }}
+  {{- end }}

--- a/incubator/mysqlha/templates/statefulset.yaml
+++ b/incubator/mysqlha/templates/statefulset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "fullname" . }}
   labels:
     app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ template "mysqlha.chart" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
@@ -251,7 +251,7 @@ spec:
             port: metrics
           initialDelaySeconds: {{ .Values.metrics.livenessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.metrics.livenessProbe.timeoutSeconds }}
-        readinessprobe:
+        readinessProbe:
           httpGet:
             path: /
             port: metrics

--- a/incubator/mysqlha/templates/svc.yaml
+++ b/incubator/mysqlha/templates/svc.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "fullname" . }}
   labels:
     app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ template "mysqlha.chart" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
@@ -24,7 +24,7 @@ metadata:
   name: {{ template "fullname" . }}-readonly
   labels:
     app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ template "mysqlha.chart" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:

--- a/incubator/mysqlha/values.yaml
+++ b/incubator/mysqlha/values.yaml
@@ -10,6 +10,13 @@ xtraBackupImage: gcr.io/google-samples/xtrabackup:1.0
 ##
 imagePullPolicy: IfNotPresent
 
+## String to partially override orangehrm.fullname template (will maintain the release name)
+##
+# nameOverride: ""
+## String to fully override orangehrm.fullname template
+##
+# fullnameOverride: ""
+
 mysqlha:
   replicaCount: 3
 


### PR DESCRIPTION
Signed-off-by: Aisuko <urakiny@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Standardize the `fullnameOverride` and the `nameOverride` mysqlha.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

> Given a version number MAJOR.MINOR.PATCH, increment the:
>    * MAJOR version when you make incompatible API changes,
>    * MINOR version when you add functionality in a backward-compatible manner
>    * PATCH version when you make backward-compatible bug fixes.
>    * Additional labels for pre-release and build metadata are available as extensions to the 
>    MAJOR.MINOR.PATCH format.

These changes are not backward-compatible, e.g if there were any chart dependency on older mysqlha and if they want to use the `mysqlha` latest version which has been set `fullnameOverride`, the chart would not work well, and you have to reapir the connection of mysqlha(There may have to modify the chart context). so we should have increased the MAJOR version instead of the PATCH one. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
