### PR TITLE
[stable/newrelic-infrastructure] add ability to use custom secret for license key

### DIFF
--- a/stable/newrelic-infrastructure/Chart.yaml
+++ b/stable/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 0.13.0
+version: 0.13.1
 appVersion: 1.9.0
 home: https://hub.docker.com/r/newrelic/infrastructure-k8s/
 source:

--- a/stable/newrelic-infrastructure/README.md
+++ b/stable/newrelic-infrastructure/README.md
@@ -8,16 +8,18 @@ This chart will deploy the New Relic Infrastructure agent as a Daemonset.
 
 | Parameter                 | Description                                                  | Default                    |
 | ------------------------- | ------------------------------------------------------------ | -------------------------- |
-| `cluster`                 | The cluster name for the Kubernetes cluster.                 |                          |
+| `cluster`                 | The cluster name for the Kubernetes cluster.                 |                            |
 | `licenseKey`              | The [license key](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/license-key)  for your New Relic Account. | |
-| `config`                  | A `newrelic.yml` file if you wish to provide.                |                         |
+| `customSecret.name`       | Same as `licenseKey` but specified as custom secret          |                            |
+| `customSecret.key`        | Same as `licenseKey` but specified as custom secret          |                            |
+| `config`                  | A `newrelic.yml` file if you wish to provide.                |                            |
 | `kubeStateMetricsUrl`     | If provided, the discovery process for kube-state-metrics endpoint won't be triggered. Example: http://172.17.0.3:8080 |
 | `kubeStateMetricsTimeout` | Timeout for accessing kube-state-metrics in milliseconds. If not set the newrelic default is 5000 | |
 | `rbac.create`             | Enable Role-based authentication                             | `true`                     |
 | `rbac.pspEnabled`         | Enable pod security policy support                           | `false`                    |
 | `image.name`              | The container to pull.                                       | `newrelic/infrastructure`  |
 | `image.pullPolicy`        | The pull policy.                                             | `IfNotPresent`             |
-| `image.tag`               | The version of the container to pull.                        | `1.9.0`            |
+| `image.tag`               | The version of the container to pull.                        | `1.9.0`                    |
 | `resources`               | Any resources you wish to assign to the pod.                 | See Resources below        |
 | `verboseLog`              | Should the agent log verbosely. (Boolean)                    | `false`                    |
 | `priorityClassName`       | Scheduling priority of the pod                               | `nil`                      |

--- a/stable/newrelic-infrastructure/README.md
+++ b/stable/newrelic-infrastructure/README.md
@@ -9,9 +9,9 @@ This chart will deploy the New Relic Infrastructure agent as a Daemonset.
 | Parameter                 | Description                                                  | Default                    |
 | ------------------------- | ------------------------------------------------------------ | -------------------------- |
 | `cluster`                 | The cluster name for the Kubernetes cluster.                 |                            |
-| `licenseKey`              | The [license key](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/license-key)  for your New Relic Account. | |
-| `customSecret.name`       | Same as `licenseKey` but specified as custom secret          |                            |
-| `customSecret.key`        | Same as `licenseKey` but specified as custom secret          |                            |
+| `licenseKey`              | The [license key](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/license-key)  for your New Relic Account. This will be preferred configuration option if both `licenseKey` and `customSecret` are specified. | |
+| `customSecret.name`       | Name of the Secret object where the license key is stored    |                            |
+| `customSecret.key`        | Key in the Secret object where the license key is stored.    |                            |
 | `config`                  | A `newrelic.yml` file if you wish to provide.                |                            |
 | `kubeStateMetricsUrl`     | If provided, the discovery process for kube-state-metrics endpoint won't be triggered. Example: http://172.17.0.3:8080 |
 | `kubeStateMetricsTimeout` | Timeout for accessing kube-state-metrics in milliseconds. If not set the newrelic default is 5000 | |

--- a/stable/newrelic-infrastructure/templates/daemonset.yaml
+++ b/stable/newrelic-infrastructure/templates/daemonset.yaml
@@ -32,19 +32,17 @@ spec:
           securityContext:
             privileged: true
           env:
-            {{- if .Values.licenseKey }}
+            {{- if or .Values.licenseKey .Values.customSecret }}
             - name: NRIA_LICENSE_KEY
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.licenseKey }}
                   name: {{ template "newrelic.fullname" . }}-config
                   key: license
-            {{- end }}
-            {{- if and .Values.customSecret (not .Values.licenseKey) }}
-            - name: "NRIA_LICENSE_KEY"
-              valueFrom:
-                secretKeyRef:
+                  {{- else }}
                   name: {{ .Values.customSecret.name }}
                   key: {{ .Values.customSecret.key }}
+                  {{- end }}
             {{- end }}
             - name: "CLUSTER_NAME"
               value: "{{ .Values.cluster }}"

--- a/stable/newrelic-infrastructure/templates/daemonset.yaml
+++ b/stable/newrelic-infrastructure/templates/daemonset.yaml
@@ -32,7 +32,6 @@ spec:
           securityContext:
             privileged: true
           env:
-            {{- if or .Values.licenseKey .Values.customSecret }}
             - name: NRIA_LICENSE_KEY
               valueFrom:
                 secretKeyRef:
@@ -43,7 +42,6 @@ spec:
                   name: {{ .Values.customSecret.name }}
                   key: {{ .Values.customSecret.key }}
                   {{- end }}
-            {{- end }}
             - name: "CLUSTER_NAME"
               value: "{{ .Values.cluster }}"
             {{- if .Values.kubeStateMetricsUrl }}

--- a/stable/newrelic-infrastructure/templates/daemonset.yaml
+++ b/stable/newrelic-infrastructure/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.licenseKey .Values.cluster }}
+{{- if and (or .Values.licenseKey .Values.customSecret) .Values.cluster }}
 apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
@@ -32,21 +32,30 @@ spec:
           securityContext:
             privileged: true
           env:
+            {{- if .Values.licenseKey }}
             - name: NRIA_LICENSE_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ template "newrelic.fullname" . }}-config
                   key: license
+            {{- end }}
+            {{- if and .Values.customSecret (not .Values.licenseKey) }}
+            - name: "NRIA_LICENSE_KEY"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.customSecret.name }}
+                  key: {{ .Values.customSecret.key }}
+            {{- end }}
             - name: "CLUSTER_NAME"
               value: "{{ .Values.cluster }}"
-           {{- if .Values.kubeStateMetricsUrl }}
+            {{- if .Values.kubeStateMetricsUrl }}
             - name: "KUBE_STATE_METRICS_URL"
               value: "{{ .Values.kubeStateMetricsUrl }}"
-           {{- end }}
-           {{- if .Values.kubeStateMetricsTimeout }}
+            {{- end }}
+            {{- if .Values.kubeStateMetricsTimeout }}
             - name: TIMEOUT
               value: {{ .Values.kubeStateMetricsTimeout | quote }}
-           {{- end }}
+            {{- end }}
             - name: "NRIA_DISPLAY_NAME"
               valueFrom:
                 fieldRef:

--- a/stable/newrelic-infrastructure/values.yaml
+++ b/stable/newrelic-infrastructure/values.yaml
@@ -1,5 +1,10 @@
 # IMPORTANT: Specify your New Relic API key here.
 # licenseKey:
+#
+# or Specify secret which contains New Relic API key
+# customSecret:
+#   name: secret_name
+#   key: secret_key
 
 # IMPORTANT: The Kubernetes cluster name
 # https://docs.newrelic.com/docs/kubernetes-monitoring-integration


### PR DESCRIPTION
Signed-off-by: Eriks Zelenka <isindir@users.sf.net>

* adds ability to specify preconfigured secret instead of passing License API key as value

@jfjoly
@smoya
@areina
@douglascamata
@rk295

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
