### PR TITLE
stable/ipfs Update, Scrape, NodePort, etc

### DIFF
--- a/stable/ipfs/Chart.yaml
+++ b/stable/ipfs/Chart.yaml
@@ -4,7 +4,7 @@ name: ipfs
 version: 0.2.4
 icon: https://raw.githubusercontent.com/ipfs/logo/master/raster-generated/ipfs-logo-128-ice-text.png
 home: https://ipfs.io/
-appVersion: v0.4.20
+appVersion: v0.4.21
 keywords:
 - ipfs
 - distributed-web

--- a/stable/ipfs/Chart.yaml
+++ b/stable/ipfs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the Interplanetary File System
 name: ipfs
-version: 0.2.4
+version: 0.3.0
 icon: https://raw.githubusercontent.com/ipfs/logo/master/raster-generated/ipfs-logo-128-ice-text.png
 home: https://ipfs.io/
 appVersion: v0.4.21

--- a/stable/ipfs/README.md
+++ b/stable/ipfs/README.md
@@ -48,6 +48,9 @@ The following table lists the configurable parameters of the Memcached chart and
 | `persistence.annotations` | Extra annotations for the persistent volume claim. | `{}` |
 | `persistence.accessModes` | List of access modes for use with the persistent volume claim | `["ReadWriteOnce"]` |
 | `persistence.size` | Size of the PVC for each IPFS pod, used as persistent cache | `8Gi`  |
+| `service.swarm.enabled` | Expose port `4001` (IPFS swarm network port) | `false` |
+| `service.swarm.type` | Service type for swarm | `LoadBalancer` |
+| `service.swarm.nodePort` | Desired nodePort for service of type NodePort used for swarm requests | blank ('') - will assign a dynamic node port |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/ipfs/templates/service.yaml
+++ b/stable/ipfs/templates/service.yaml
@@ -33,6 +33,10 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "5001"
+    prometheus.io/path: /debug/metrics/prometheus
 spec:
   type: {{ .Values.swarm.type }}
   {{- if .Values.swarm.loadBalancerIP }}

--- a/stable/ipfs/templates/service.yaml
+++ b/stable/ipfs/templates/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -20,3 +21,36 @@ spec:
   selector:
     app: {{ template "ipfs.name" . }}
     release: {{ .Release.Name }}
+
+{{- if .Values.swarm.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "ipfs.servicename" . }}-swarm
+  labels:
+    app: {{ template "ipfs.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  type: {{ .Values.swarm.type }}
+  {{- if .Values.swarm.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.swarm.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.swarm.externalIP }}
+  externalIPs:
+    - {{ .Values.swarm.externalIP }}
+  {{- end }}
+  ports:
+  - port: 4001
+    {{- if (and (eq .Values.swarm.type "NodePort") (not (empty .Values.swarm.nodePort)))}}
+    nodePort: {{ .Values.swarm.nodePort }}
+    {{- end }}
+    targetPort: 4001
+    protocol: TCP
+    name: swarm
+  selector:
+    app: {{ template "ipfs.name" . }}
+    release: {{ .Release.Name }}
+{{- end -}}

--- a/stable/ipfs/templates/statefulset.yaml
+++ b/stable/ipfs/templates/statefulset.yaml
@@ -27,6 +27,10 @@ spec:
       - name: {{ .Chart.Name }}
         image: {{ .Values.image }}
         ports:
+{{- if .Values.swarm.enabled }}
+        - containerPort: 4001
+          name: swarm
+{{- end }}
         - containerPort: 5001
           name: api
         - containerPort: 8080

--- a/stable/ipfs/templates/statefulset.yaml
+++ b/stable/ipfs/templates/statefulset.yaml
@@ -23,6 +23,18 @@ spec:
         # the persistent volume to be able to start.
         fsGroup: 1000
         runAsUser: 1000
+      livenessProbe:
+        httpGet:
+          path: /debug/metrics/prometheus
+          port: api
+        initialDelaySeconds: 15
+        periodSeconds: 3
+      readinessProbe:
+        httpGet:
+          path: /debug/metrics/prometheus
+          port: api
+        initialDelaySeconds: 15
+        periodSeconds: 3
       containers:
       - name: {{ .Chart.Name }}
         image: {{ .Values.image }}

--- a/stable/ipfs/values.yaml
+++ b/stable/ipfs/values.yaml
@@ -1,6 +1,6 @@
 replicaCount: 1
 
-image: ipfs/go-ipfs:v0.4.20
+image: ipfs/go-ipfs:v0.4.21
 
 service:
   type: ClusterIP

--- a/stable/ipfs/values.yaml
+++ b/stable/ipfs/values.yaml
@@ -15,7 +15,7 @@ swarm:
   nodePort: ""
   ## If static nodePort configuration is required it can be enabled as below
   ## Configure ports in allowable range (eg. 30000 - 32767 on minikube)
-  # nodePort: 304001
+  # nodePort: 34001
 
 resources: {}
 

--- a/stable/ipfs/values.yaml
+++ b/stable/ipfs/values.yaml
@@ -5,6 +5,18 @@ image: ipfs/go-ipfs:v0.4.20
 service:
   type: ClusterIP
 
+swarm:
+  enabled: false
+  type: ClusterIP
+  # loadBalancerIP: ""
+  # externalIP: ""
+  ## Further config for service of type NodePort
+  ## Default config with empty string "" will assign a dynamic nodePort
+  nodePort: ""
+  ## If static nodePort configuration is required it can be enabled as below
+  ## Configure ports in allowable range (eg. 30000 - 32767 on minikube)
+  # nodePort: 304001
+
 resources: {}
 
 persistence:


### PR DESCRIPTION
#### What this PR does / why we need it:

- Update IPFS from `0.4.20` to latest stable version `0.4.21`
- Add ready/live probes
- Add annotation for Prometheus Kubernetes service discovery
- Swarm (P2P protocol of IPFS) can be optionally exposed (ClusterIP or NodePort). This allow the IPFS node to be reachable from public Internet through port `4001`

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
