### PR TITLE
[stable/oauth2-proxy] ADD extra volumes and volumemounts

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 0.14.1
+version: 0.15.0
 apiVersion: v1
 appVersion: 3.2.0
 home: http://www.videntity.com/

--- a/stable/oauth2-proxy/README.md
+++ b/stable/oauth2-proxy/README.md
@@ -102,3 +102,34 @@ $ helm install stable/oauth2-proxy --name my-release -f values.yaml
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+## SSL Configuration
+
+See: [SSL Configuration](https://pusher.github.io/oauth2_proxy/tls-configuration).
+Use ```values.yaml``` like:
+
+```yaml
+...
+extraArgs:
+  tls-cert: /path/to/cert.pem
+  tls-key: /path/to/cert.key
+
+extraVolumes:
+  - name: ssl-cert
+    secret: 
+      secretName: my-ssl-secret
+
+extraVolumeMounts:
+  - mountPath: /path/to/
+    name: ssl-cert 
+...
+```
+
+With a secret called `my-ssl-secret`:
+
+```yaml
+...
+data:
+  cert.pem: AB..==
+  cert.key: CD..==
+```

--- a/stable/oauth2-proxy/README.md
+++ b/stable/oauth2-proxy/README.md
@@ -57,7 +57,7 @@ Parameter | Description | Default
 `extraVolumeMounts` | list of extra volumeMounts | `[]`
 `htpasswdFile.enabled` | enable htpasswd-file option | `false`
 `htpasswdFile.entries` | list of [SHA encrypted user:passwords](https://pusher.github.io/oauth2_proxy/configuration#command-line-options) | `{}`
-`htpasswdFile.existingSecret` | existing Kubernetes secret to use for OAuth2 htpasswd file` | `""`
+`htpasswdFile.existingSecret` | existing Kubernetes secret to use for OAuth2 htpasswd file | `""`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `image.repository` | Image repository | `quay.io/pusher/oauth2_proxy`
 `image.tag` | Image tag | `v3.2.0`

--- a/stable/oauth2-proxy/README.md
+++ b/stable/oauth2-proxy/README.md
@@ -84,7 +84,7 @@ Parameter | Description | Default
 `service.clusterIP` | cluster ip address | `nil`
 `service.loadBalancerIP` | ip of load balancer | `nil`
 `service.loadBalancerSourceRanges` | allowed source ranges in load balancer | `nil`
-`tolerations` | List of node taints to tolerate | `[]`
+`tolerations` | list of node taints to tolerate | `[]`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/oauth2-proxy/README.md
+++ b/stable/oauth2-proxy/README.md
@@ -53,6 +53,8 @@ Parameter | Description | Default
 `config.google.existingConfig` | existing Kubernetes configmap to use for the service account file. See [google secret template](https://github.com/helm/charts/blob/master/stable/oauth2-proxy/templates/google-secret.yaml) for the required values | `nil`
 `extraArgs` | key:value list of extra arguments to give the binary | `{}`
 `extraEnv` | key:value list of extra environment variables to give the binary | `[]`
+`extraVolumes` | list of extra volumes | `[]`
+`extraVolumeMounts` | list of extra volumeMounts | `[]`
 `htpasswdFile.enabled` | enable htpasswd-file option | `false`
 `htpasswdFile.entries` | list of [SHA encrypted user:passwords](https://pusher.github.io/oauth2_proxy/configuration#command-line-options) | `{}`
 `htpasswdFile.existingSecret` | existing Kubernetes secret to use for OAuth2 htpasswd file` | `""`

--- a/stable/oauth2-proxy/README.md
+++ b/stable/oauth2-proxy/README.md
@@ -116,12 +116,12 @@ extraArgs:
 
 extraVolumes:
   - name: ssl-cert
-    secret: 
+    secret:
       secretName: my-ssl-secret
 
 extraVolumeMounts:
   - mountPath: /path/to/
-    name: ssl-cert 
+    name: ssl-cert
 ...
 ```
 

--- a/stable/oauth2-proxy/templates/deployment.yaml
+++ b/stable/oauth2-proxy/templates/deployment.yaml
@@ -130,6 +130,9 @@ spec:
           name: {{ template "oauth2-proxy.fullname" . }}-htpasswd-file
           readOnly: true
 {{- end }}
+{{- if ne (len .Values.extraVolumeMounts) 0 }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+{{- end }}
       volumes:
 {{- with .Values.config.google }}
 {{- if and .adminEmail (or .serviceAccountJson .existingSecret) }}
@@ -150,6 +153,9 @@ spec:
           defaultMode: 420
           name: {{ if .Values.config.existingConfig }}{{ .Values.config.existingConfig }}{{ else }}{{ template "oauth2-proxy.fullname" . }}{{ end }}
         name: configmain
+{{- end }}
+{{- if ne (len .Values.extraVolumes) 0 }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
 {{- end }}
 {{- if .Values.authenticatedEmailsFile.enabled }}
       - configMap:

--- a/stable/oauth2-proxy/values.yaml
+++ b/stable/oauth2-proxy/values.yaml
@@ -93,6 +93,15 @@ resources: {}
   #   cpu: 100m
   #   memory: 300Mi
 
+extraVolumes: []
+  # - name: ca-bundle-cert
+  #   secret: 
+  #     secretName: <secret-name>
+
+extraVolumeMounts: []
+  # - mountPath: /etc/ssl/certs/
+  #   name: ca-bundle-cert 
+
 priorityClassName: ""
 
 # Affinity for pod assignment

--- a/stable/oauth2-proxy/values.yaml
+++ b/stable/oauth2-proxy/values.yaml
@@ -95,12 +95,12 @@ resources: {}
 
 extraVolumes: []
   # - name: ca-bundle-cert
-  #   secret: 
+  #   secret:
   #     secretName: <secret-name>
 
 extraVolumeMounts: []
   # - mountPath: /etc/ssl/certs/
-  #   name: ca-bundle-cert 
+  #   name: ca-bundle-cert
 
 priorityClassName: ""
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Add support for extra volumes and volume mounts for the oauth2-proxy deployment, in order to mount in extra files for ssl certificates and certificate authors. 

Improve documentation by adding SSH Configuration to README.

#### Which issue this PR fixes

  - fixes #15621 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
