### PR TITLE
[stable/karma] support securityContext to run as non-root

### DIFF
--- a/stable/karma/Chart.yaml
+++ b/stable/karma/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/prymitive/karma
 sources:
   - https://hub.docker.com/r/lmierzwa/karma/
   - https://github.com/prymitive/karma
-version: 1.1.16
+version: 1.1.17
 maintainers:
 - name: davidkarlsen
   email: david@davidkarlsen.com

--- a/stable/karma/README.md
+++ b/stable/karma/README.md
@@ -56,6 +56,7 @@ The following table lists the configurable parameters of the karma chart and the
 | `nodeSelector`                      | Settings for nodeselector              | `{}`                                      |
 | `tolerations`                       | Settings for toleration                | `{}`                                      |
 | `affinity`                          | Settings for affinity                  | `{}`                                      |
+| `securityContext`                   | Settings for security context          | `{}`                                      |
 | `serviceAccount.create`             | Create service-account                 | `true`                                    |
 | `serviceAccount.name`               | Override service-account name          | ``                                        |
 | `livenessProbe.delay`               | Specify delay in executing probe       | `5`                                       |

--- a/stable/karma/templates/deployment.yaml
+++ b/stable/karma/templates/deployment.yaml
@@ -24,6 +24,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "karma.serviceAccountName" . }}
+      {{- if .Values.securityContext }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/karma/values.yaml
+++ b/stable/karma/values.yaml
@@ -60,6 +60,8 @@ tolerations: []
 
 affinity: {}
 
+securityContext: {}
+
 # configuration for liveness probe
 livenessProbe:
   delay: 5


### PR DESCRIPTION
Signed-off-by: David J. M. Karlsen <david@davidkarlsen.com>

#### What this PR does / why we need it:
Adds support for security-context in order to be able to run as non-root.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
