### PR TITLE
[stable/cluster-autoscaler] Fix missing cluster role rules for priority expander

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 0.14.2
+version: 0.14.3
 appVersion: 1.13.1
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/templates/clusterrole.yaml
+++ b/stable/cluster-autoscaler/templates/clusterrole.yaml
@@ -102,6 +102,13 @@ rules:
     - watch
     - list
     - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - list
+      - watch
 {{- if .Values.rbac.pspEnabled }}
   - apiGroups:
     - extensions


### PR DESCRIPTION
#### What this PR does / why we need it:
In case we using  **priority** expander, cluster auto-scaler need to watch the **cluster-autoscaler-priority-expander** configmap in the same namespace. More details can be found [here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/expander/priority/readme.md)
This PR is to add those necessary cluster role rules.
#### Which issue this PR fixes
n/a
#### Special notes for your reviewer:  
@mgoodness 
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
