### PR TITLE
[stable/dex] ADD annotations to grpc and web pods FIX #15451

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 2.0.1
+version: 2.0.2
 appVersion: 2.17.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 2.0.2
+version: 2.1.0
 appVersion: 2.17.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/README.md
+++ b/stable/dex/README.md
@@ -65,30 +65,31 @@ Parameters introduced starting from v2
 | --------- | ----------- | ------- |
 | `certs.grpc.pod.annotations` | Annotations for the pod created by the `grpc-certs` job | `{}` |
 | `certs.web.pod.annotations` | Annotations for the pod created by the `web-certs` job | `{}` |
-| `grpc` | Enable dex grpc endpoint | `true` |
-| `https` | Enable TLS termination for the dex http endpoint | `false` |
-| `ports.web.containerPort` | http/https port listened by the dex | `5556` |
-| `ports.web.nodePort` | K8S Service node port for the dex http/https listener | `32000` |
-| `ports.web.servicePort` | K8S Service port for the dex http/https listener | `32000` |
-| `ports.grpc.containerPort` | grpc port listened by the dex | `5000` |
-| `ports.grpc.nodePort` | K8S Service node port for the dex grpc listener | `35000` |
-| `ports.grpc.servicePort` | K8S Service port for the dex grpc listener | `35000` |
-| `service.loadBalancerIP` | IP override for K8S LoadBalancer Service | `""` |
+| `config.connectors` | Maps to the dex config `connectors` dict param | `{}` |
+| `config.enablePasswordDB` | Maps to the dex config `enablePasswordDB` param | `true` |
+| `config.grpc.address` | dex grpc listen address | `127.0.0.1` |
+| `config.grpc.tlsCert` | Maps to the dex config `grpc.tlsCert` param | `/etc/dex/tls/grpc/server/tls.crt` |
+| `config.grpc.tlsClientCA` | Maps to the dex config `grpc.tlsClientCA` param | `/etc/dex/tls/grpc/ca/tls.crt` |
+| `config.grpc.tlsKey` | Maps to the dex config `grpc.tlsKey` param | `/etc/dex/tls/grpc/server/tls.key` |
 | `config.issuer` | Maps to the dex config `issuer` param | `http://dex.io:8080` |
-| `config.storage` | Maps to the dex config `storage` dict param | `{"type": "kubernetes", "config": {"inCluster": true}}` |
 | `config.logger` | Maps to the dex config `logger` dict param | `{"level": "debug"}` |
+| `config.oauth2.skipApprovalScreen` | Maps to the dex config `oauth2.skipApprovalScreen` param | `true` |
+| `config.staticClients` | Maps to the dex config `staticClients` list param | `""` |
+| `config.staticPasswords` | Maps to the dex config `staticPasswords` list param | `""` |
+| `config.storage` | Maps to the dex config `storage` dict param | `{"type": "kubernetes", "config": {"inCluster": true}}` |
 | `config.web.address` | dex http/https listen address | `0.0.0.0` |
 | `config.web.tlsCert` | Maps to the dex config `web.tlsCert` param | `/etc/dex/tls/https/server/tls.crt` |
 | `config.web.tlsKey` | Maps to the dex config `web.tlsKey` param | `/etc/dex/tls/https/server/tls.key` |
-| `config.grpc.address` | dex grpc listen address | `127.0.0.1` |
-| `config.grpc.tlsCert` | Maps to the dex config `grpc.tlsCert` param | `/etc/dex/tls/grpc/server/tls.crt` |
-| `config.grpc.tlsKey` | Maps to the dex config `grpc.tlsKey` param | `/etc/dex/tls/grpc/server/tls.key` |
-| `config.grpc.tlsClientCA` | Maps to the dex config `grpc.tlsClientCA` param | `/etc/dex/tls/grpc/ca/tls.crt` |
-| `config.connectors` | Maps to the dex config `connectors` dict param | `{}` |
-| `config.oauth2.skipApprovalScreen` | Maps to the dex config `oauth2.skipApprovalScreen` param | `true` |
-| `config.staticClients` | Maps to the dex config `staticClients` list param | `""` |
-| `config.enablePasswordDB` | Maps to the dex config `enablePasswordDB` param | `true` |
-| `config.staticPasswords` | Maps to the dex config `staticPasswords` list param | `""` |
+| `grpc` | Enable dex grpc endpoint | `true` |
+| `https` | Enable TLS termination for the dex http endpoint | `false` |
+| `ports.grpc.containerPort` | grpc port listened by the dex | `5000` |
+| `ports.grpc.nodePort` | K8S Service node port for the dex grpc listener | `35000` |
+| `ports.grpc.servicePort` | K8S Service port for the dex grpc listener | `35000` |
+| `ports.web.containerPort` | http/https port listened by the dex | `5556` |
+| `ports.web.nodePort` | K8S Service node port for the dex http/https listener | `32000` |
+| `ports.web.servicePort` | K8S Service port for the dex http/https listener | `32000` |
+| `service.loadBalancerIP` | IP override for K8S LoadBalancer Service | `""` |
+
 
 
 Check [values.yaml](values.yaml) notes together with [dex documentation][dex] and [config examples](https://github.com/dexidp/dex/tree/master/examples) for all the possible configuration options.

--- a/stable/dex/README.md
+++ b/stable/dex/README.md
@@ -59,10 +59,12 @@ In order to upgrade, please update your values file and uninstall/reinstall the 
 
 ## Configuration
 
-The following table lists parameters introduced in v2.0.0
+Parameters introduced starting from v2
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
+| `certs.grpc.pod.annotations` | Annotations for the pod created by the `grpc-certs` job | `{}` |
+| `certs.web.pod.annotations` | Annotations for the pod created by the `web-certs` job | `{}` |
 | `grpc` | Enable dex grpc endpoint | `true` |
 | `https` | Enable TLS termination for the dex http endpoint | `false` |
 | `ports.web.containerPort` | http/https port listened by the dex | `5556` |

--- a/stable/dex/templates/job-grpc-certs.yaml
+++ b/stable/dex/templates/job-grpc-certs.yaml
@@ -27,6 +27,10 @@ spec:
         app.kubernetes.io/name: {{ include "dex.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: "job-grpc-certs"
+{{- if .Values.certs.grpc.pod.annotations }}
+      annotations:
+{{ toYaml .Values.certs.grpc.pod.annotations | trim | indent 8 }}
+{{- end }}
     spec:
       {{- if .Values.certs.securityContext.enabled }}
       securityContext:

--- a/stable/dex/templates/job-web-certs.yaml
+++ b/stable/dex/templates/job-web-certs.yaml
@@ -24,6 +24,10 @@ spec:
         app.kubernetes.io/name: {{ include "dex.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: "job"
+{{- if .Values.certs.web.pod.annotations }}
+      annotations:
+{{ toYaml .Values.certs.web.pod.annotations | trim | indent 8 }}
+{{- end }}
     spec:
       {{- if .Values.certs.securityContext.enabled }}
       securityContext:

--- a/stable/dex/values.yaml
+++ b/stable/dex/values.yaml
@@ -92,6 +92,8 @@ certs:
     secret:
       tlsName: dex-web-server-tls
       caName: dex-web-server-ca
+    pod:
+      annotations: {}
   # Section below is relevant only when grpc support is enabled
   grpc:
     create: true
@@ -103,6 +105,8 @@ certs:
       serverTlsName: dex-grpc-server-tls
       clientTlsName: dex-grpc-client-tls
       caName: dex-grpc-ca
+    pod:
+      annotations: {}
 
 env: []
 


### PR DESCRIPTION
Signed-off-by: Nicolaj Græsholt <figaw@hotmail.com>

#### What this PR does / why we need it:

Adds custom annotations to the pods created by the grpc- or web-jobs. See #15451.

#### Which issue this PR fixes

  - fixes #15451

#### Special notes for your reviewer:

#15451 is about the grpc-job. I added custom annotations to the web-job as well for consistency.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
