### PR TITLE
[stable/openvpn] add option to restrict vpn clients to cluster connections only.

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 3.13.4
+version: 3.13.5
 appVersion: 1.1.0
 maintainers:
 - name: jfelten

--- a/stable/openvpn/README.md
+++ b/stable/openvpn/README.md
@@ -106,6 +106,7 @@ Parameter | Description | Default
 `openvpn.cipher`               | Override the default cipher                                          | `nil` (OpenVPN default)
 `openvpn.istio.enabled`        | Enables istio support for openvpn clients                            | `false`
 `openvpn.istio.proxy.port`     | Istio proxy port                                                     | `15001`
+`openvpn.restrictToCluster`    | Adds iptables rules to only allow connections inside of the cluster  | `false`
 `nodeSelector`                 | Node labels for pod assignment                                       | `{}`
 
 This chart has been engineered to use kube-dns and route all network traffic to kubernetes pods and services,

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -127,6 +127,11 @@ data:
 {{ if .Values.openvpn.istio.enabled }}
       iptables -t nat -A ISTIO_INBOUND -s {{ .Values.openvpn.OVPN_NETWORK }}/{{ .Values.openvpn.OVPN_SUBNET }} -i tun0 -p tcp -j REDIRECT --to-ports {{ .Values.openvpn.istio.proxy.port }}
 {{ end }}
+{{ if .Values.openvpn.restrictToCluster }}
+      iptables -A FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+      iptables -A FORWARD -m conntrack --ctstate NEW -d {{ .Values.openvpn.OVPN_K8S_POD_NETWORK }}/{{ .Values.openvpn.OVPN_K8S_POD_SUBNET }} -j ACCEPT
+      iptables -A FORWARD -j REJECT
+{{ end }}
 
       iptables -t nat -A POSTROUTING -s {{ .Values.openvpn.OVPN_NETWORK }}/{{ .Values.openvpn.OVPN_SUBNET }} -o eth0 -j MASQUERADE
       mkdir -p /dev/net

--- a/stable/openvpn/values.yaml
+++ b/stable/openvpn/values.yaml
@@ -96,5 +96,8 @@ openvpn:
     enabled: false
     proxy:
       port: 15001
+  # Installs iptables rules to restrict network access of a openvpn client to the pod
+  # network
+  restrictToCluster: false
 
 nodeSelector: {}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR adds a configuration option to restrict VPN clients to the cluster's Pod subnets.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
