### PR TITLE
[stable/grafana] Allows securityContext for test pod

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 3.7.0
+version: 3.7.1
 appVersion: 6.2.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -123,6 +123,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `command`                     | Define command to be executed by grafana container at startup  | `nil` |
 | `testFramework.image`                     | `test-framework` image repository.             | `dduportal/bats`                                       |
 | `testFramework.tag`                       | `test-framework` image tag.                    | `0.4.0`                                                |
+| `testFramework.securityContext`           | `test-framework securityContext                | `{}`                                                   |
 
 
 ### Example of extraVolumeMounts

--- a/stable/grafana/templates/tests/test.yaml
+++ b/stable/grafana/templates/tests/test.yaml
@@ -11,6 +11,9 @@ metadata:
     "helm.sh/hook": test-success
 spec:
   serviceAccountName: {{ template "grafana.serviceAccountNameTest" . }}
+  {{- if .Values.testFramework.securityContext }}
+  securityContext: {{ toYaml .Values.testFramework.securityContext | nindent 4 }}
+  {{- end }}
   initContainers:
     - name: test-framework
       image: "{{ .Values.testFramework.image}}:{{ .Values.testFramework.tag }}"

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -48,6 +48,7 @@ image:
 testFramework:
   image: "dduportal/bats"
   tag: "0.4.0"
+  securityContext: {}
 
 securityContext:
   runAsUser: 472


### PR DESCRIPTION
Signed-off-by: Marcos Estevez <marcos.stvz@gmail.com>

#### What this PR does / why we need it:
Allows setting securityContext for the test-framework Pod

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
