### PR TITLE
[stable/parse] Add initContainer for adjusting volume permissions 

### DIFF
--- a/stable/parse/Chart.yaml
+++ b/stable/parse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: parse
-version: 7.0.0
+version: 7.1.0
 appVersion: 3.6.0
 description: Parse is a platform that enables users to add a scalable and powerful backend to launch a full-featured app for iOS, Android, JavaScript, Windows, Unity, and more.
 keywords:

--- a/stable/parse/README.md
+++ b/stable/parse/README.md
@@ -45,69 +45,75 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Parse chart and their default values.
 
-|             Parameter                 |              Description                 |                   Default                               |
-|---------------------------------------|------------------------------------------|-------------------------------------------------------- |
-| `global.imageRegistry`                | Global Docker image registry             | `nil`                                                   |
-| `global.imagePullSecrets`             | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
-| `nameOverride`                        | String to partially override parse.fullname template with a string (will prepend the release name) | `nil`|
-| `fullnameOverride`                    | String to fully override parse.fullname template with a string                                     | `nil`|
-| `service.type`                        | Kubernetes Service type                  | `LoadBalancer`                                          |
-| `service.port`                        | Service HTTP port (Dashboard)            | `80`                                                    |
-| `service.loadBalancerIP`              | `loadBalancerIP` for the Parse Service   | `nil`                                                   |
-| `service.externalTrafficPolicy`       | Enable client source IP preservation     | `Cluster`                                               |
-| `service.nodePorts.http`              | Kubernetes http node port                | `""`                                                    |
-| `server.image.registry`               | Parse image registry                     | `docker.io`                                             |
-| `server.image.repository`             | Parse image name                         | `bitnami/parse`                                         |
-| `server.image.tag`                    | Parse image tag                          | `{TAG_NAME}`                                            |
-| `server.image.pullPolicy`             | Image pull policy                        | `IfNotPresent`                                          |
-| `server.image.pullSecrets`            | Specify docker-registry secret names as an array               | `[]` (does not add image pull secrets to deployed pods) |
-| `server.securityContext.enabled`      | Enable security context for Parse Server | `true`                                                  |
-| `server.securityContext.fsGroup`      | Group ID for Parse Server container      | `1001`                                                  |
-| `server.securityContext.runAsUser`    | User ID for Parse Server container       | `1001`                                                  |
-| `server.port`                         | Parse server server port                 | `1337`                                                  |
-| `server.mountPath`                    | Parse server API mount path              | `/parse`                                                |
-| `server.appId`                        | Parse server App Id                      | `myappID`                                               |
-| `server.masterKey`                    | Parse server Master Key                  | `random 10 character alphanumeric string`               |
-| `server.resources`                    | CPU/Memory resource requests/limits      | Memory: `512Mi`, CPU: `300m`                            |
-| `dashboard.enabled`                   | Enable parse dashboard                   | `true`                                                  |
-| `dashboard.image.registry`            | Dashboard image registry                 | `docker.io`                                             |
-| `dashboard.image.repository`          | Dashboard image name                     | `bitnami/parse-dashboard`                               |
-| `dashboard.image.tag`                 | Dashboard image tag                      | `{TAG_NAME}`                                            |
-| `dashboard.image.pullPolicy`          | Image pull policy                        | `IfNotPresent`                                          |
-| `dashboard.securityContext.enabled`   | Enable security context for Dashboard    | `true`                                                  |
-| `dashboard.securityContext.fsGroup`   | Group ID for Dashboard container         | `1001`                                                  |
-| `dashboard.securityContext.runAsUser` | User ID for Dashboard container          | `1001`                                                  |
-| `dashboard.image.pullSecrets`         | Specify docker-registry secret names as an array               | `[]` (does not add image pull secrets to deployed pods) |
-| `dashboard.username`                  | Dashboard username                       | `user`                                                  |
-| `dashboard.password`                  | Dashboard user password                  | `random 10 character alphanumeric string`               |
-| `dashboard.appName`                   | Dashboard application name               | `MyDashboard`                                           |
-| `dashboard.resources`                 | CPU/Memory resource requests/limits      | Memory: `512Mi`, CPU: `300m`                            |
-| `persistence.enabled`                 | Enable Parse persistence using PVC       | `true`                                                  |
-| `persistence.storageClass`            | PVC Storage Class for Parse volume       | `nil` (uses alpha storage class annotation)             |
-| `persistence.accessMode`              | PVC Access Mode for Parse volume         | `ReadWriteOnce`                                         |
-| `persistence.size`                    | PVC Storage Request for Parse volume     | `8Gi`                                                   |
-| `ingress.enabled`                     | Enable ingress controller resource       | `false`                                                 |
-| `ingress.annotations`                 | Ingress annotations                      | `[]`                                                    |
-| `ingress.certManager`                 | Add annotations for cert-manager         | `false`                                                 |
-| `ingress.dashboard.hosts[0].name`     | Hostname to your Parse Dashboard installation | `ghost.local`                                      |
-| `ingress.dashboard.hosts[0].path`     | Path within the url structure            | `/`                                                     |
-| `ingress.dashboard.hosts[0].tls`      | Utilize TLS backend in ingress           | `false`                                                 |
-| `ingress.dashboard.hosts[0].tlsHosts` | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`) | `nil`       |
-| `ingress.dashboard.hosts[0].tlsSecret`| TLS Secret (certificates)                | `ghost.local-tls-secret`                                |
-| `ingress.server.hosts[0].name`        | Hostname to your Parse Server installation | `ghost.local`                                         |
-| `ingress.server.hosts[0].path`        | Path within the url structure            | `/`                                                     |
-| `ingress.server.hosts[0].tls`         | Utilize TLS backend in ingress           | `false`                                                 |
-| `ingress.server.hosts[0].tlsHosts`    | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`) | `nil`       |
-| `ingress.server.hosts[0].tlsSecret`   | TLS Secret (certificates)                | `ghost.local-tls-secret`                                |
-| `ingress.secrets[0].name`             | TLS Secret Name                          | `nil`                                                   |
-| `ingress.secrets[0].certificate`      | TLS Secret Certificate                   | `nil`                                                   |
-| `ingress.secrets[0].key`              | TLS Secret Key                           | `nil`                                                   |
-| `mongodb.usePassword`                 | Enable MongoDB password authentication   | `true`                                                  |
-| `mongodb.password`                    | MongoDB admin password                   | `nil`                                                   |
-| `mongodb.persistence.enabled`         | Enable MongoDB persistence using PVC     | `true`                                                  |
-| `mongodb.persistence.storageClass`    | PVC Storage Class for MongoDB volume     | `nil` (uses alpha storage class annotation)             |
-| `mongodb.persistence.accessMode`      | PVC Access Mode for MongoDB volume       | `ReadWriteOnce`                                         |
-| `mongodb.persistence.size`            | PVC Storage Request for MongoDB volume   | `8Gi`                                                   |
+| Parameter                              | Description                                                                                                                                               | Default                                                 |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `global.imageRegistry`                 | Global Docker image registry                                                                                                                              | `nil`                                                   |
+| `global.imagePullSecrets`              | Global Docker registry secret names as an array                                                                                                           | `[]` (does not add image pull secrets to deployed pods) |
+| `nameOverride`                         | String to partially override parse.fullname template with a string (will prepend the release name)                                                        | `nil`                                                   |
+| `fullnameOverride`                     | String to fully override parse.fullname template with a string                                                                                            | `nil`                                                   |
+| `volumePermissions.enabled`            | Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work) | `false`                                                 |
+| `volumePermissions.image.registry`     | Init container volume-permissions image registry                                                                                                          | `docker.io`                                             |
+| `volumePermissions.image.repository`   | Init container volume-permissions image name                                                                                                              | `bitnami/minideb`                                       |
+| `volumePermissions.image.tag`          | Init container volume-permissions image tag                                                                                                               | `latest`                                                |
+| `volumePermissions.image.pullPolicy`   | Init container volume-permissions image pull policy                                                                                                       | `Always`                                                |
+| `volumePermissions.resources`          | Init container resource requests/limit                                                                                                                    | `nil`                                                   |
+| `service.type`                         | Kubernetes Service type                                                                                                                                   | `LoadBalancer`                                          |
+| `service.port`                         | Service HTTP port (Dashboard)                                                                                                                             | `80`                                                    |
+| `service.loadBalancerIP`               | `loadBalancerIP` for the Parse Service                                                                                                                    | `nil`                                                   |
+| `service.externalTrafficPolicy`        | Enable client source IP preservation                                                                                                                      | `Cluster`                                               |
+| `service.nodePorts.http`               | Kubernetes http node port                                                                                                                                 | `""`                                                    |
+| `server.image.registry`                | Parse image registry                                                                                                                                      | `docker.io`                                             |
+| `server.image.repository`              | Parse image name                                                                                                                                          | `bitnami/parse`                                         |
+| `server.image.tag`                     | Parse image tag                                                                                                                                           | `{TAG_NAME}`                                            |
+| `server.image.pullPolicy`              | Image pull policy                                                                                                                                         | `IfNotPresent`                                          |
+| `server.image.pullSecrets`             | Specify docker-registry secret names as an array                                                                                                          | `[]` (does not add image pull secrets to deployed pods) |
+| `server.securityContext.enabled`       | Enable security context for Parse Server                                                                                                                  | `true`                                                  |
+| `server.securityContext.fsGroup`       | Group ID for Parse Server container                                                                                                                       | `1001`                                                  |
+| `server.securityContext.runAsUser`     | User ID for Parse Server container                                                                                                                        | `1001`                                                  |
+| `server.port`                          | Parse server server port                                                                                                                                  | `1337`                                                  |
+| `server.mountPath`                     | Parse server API mount path                                                                                                                               | `/parse`                                                |
+| `server.appId`                         | Parse server App Id                                                                                                                                       | `myappID`                                               |
+| `server.masterKey`                     | Parse server Master Key                                                                                                                                   | `random 10 character alphanumeric string`               |
+| `server.resources`                     | CPU/Memory resource requests/limits                                                                                                                       | Memory: `512Mi`, CPU: `300m`                            |
+| `dashboard.enabled`                    | Enable parse dashboard                                                                                                                                    | `true`                                                  |
+| `dashboard.image.registry`             | Dashboard image registry                                                                                                                                  | `docker.io`                                             |
+| `dashboard.image.repository`           | Dashboard image name                                                                                                                                      | `bitnami/parse-dashboard`                               |
+| `dashboard.image.tag`                  | Dashboard image tag                                                                                                                                       | `{TAG_NAME}`                                            |
+| `dashboard.image.pullPolicy`           | Image pull policy                                                                                                                                         | `IfNotPresent`                                          |
+| `dashboard.securityContext.enabled`    | Enable security context for Dashboard                                                                                                                     | `true`                                                  |
+| `dashboard.securityContext.fsGroup`    | Group ID for Dashboard container                                                                                                                          | `1001`                                                  |
+| `dashboard.securityContext.runAsUser`  | User ID for Dashboard container                                                                                                                           | `1001`                                                  |
+| `dashboard.image.pullSecrets`          | Specify docker-registry secret names as an array                                                                                                          | `[]` (does not add image pull secrets to deployed pods) |
+| `dashboard.username`                   | Dashboard username                                                                                                                                        | `user`                                                  |
+| `dashboard.password`                   | Dashboard user password                                                                                                                                   | `random 10 character alphanumeric string`               |
+| `dashboard.appName`                    | Dashboard application name                                                                                                                                | `MyDashboard`                                           |
+| `dashboard.resources`                  | CPU/Memory resource requests/limits                                                                                                                       | Memory: `512Mi`, CPU: `300m`                            |
+| `persistence.enabled`                  | Enable Parse persistence using PVC                                                                                                                        | `true`                                                  |
+| `persistence.storageClass`             | PVC Storage Class for Parse volume                                                                                                                        | `nil` (uses alpha storage class annotation)             |
+| `persistence.accessMode`               | PVC Access Mode for Parse volume                                                                                                                          | `ReadWriteOnce`                                         |
+| `persistence.size`                     | PVC Storage Request for Parse volume                                                                                                                      | `8Gi`                                                   |
+| `ingress.enabled`                      | Enable ingress controller resource                                                                                                                        | `false`                                                 |
+| `ingress.annotations`                  | Ingress annotations                                                                                                                                       | `[]`                                                    |
+| `ingress.certManager`                  | Add annotations for cert-manager                                                                                                                          | `false`                                                 |
+| `ingress.dashboard.hosts[0].name`      | Hostname to your Parse Dashboard installation                                                                                                             | `ghost.local`                                           |
+| `ingress.dashboard.hosts[0].path`      | Path within the url structure                                                                                                                             | `/`                                                     |
+| `ingress.dashboard.hosts[0].tls`       | Utilize TLS backend in ingress                                                                                                                            | `false`                                                 |
+| `ingress.dashboard.hosts[0].tlsHosts`  | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`)                                                                      | `nil`                                                   |
+| `ingress.dashboard.hosts[0].tlsSecret` | TLS Secret (certificates)                                                                                                                                 | `ghost.local-tls-secret`                                |
+| `ingress.server.hosts[0].name`         | Hostname to your Parse Server installation                                                                                                                | `ghost.local`                                           |
+| `ingress.server.hosts[0].path`         | Path within the url structure                                                                                                                             | `/`                                                     |
+| `ingress.server.hosts[0].tls`          | Utilize TLS backend in ingress                                                                                                                            | `false`                                                 |
+| `ingress.server.hosts[0].tlsHosts`     | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`)                                                                      | `nil`                                                   |
+| `ingress.server.hosts[0].tlsSecret`    | TLS Secret (certificates)                                                                                                                                 | `ghost.local-tls-secret`                                |
+| `ingress.secrets[0].name`              | TLS Secret Name                                                                                                                                           | `nil`                                                   |
+| `ingress.secrets[0].certificate`       | TLS Secret Certificate                                                                                                                                    | `nil`                                                   |
+| `ingress.secrets[0].key`               | TLS Secret Key                                                                                                                                            | `nil`                                                   |
+| `mongodb.usePassword`                  | Enable MongoDB password authentication                                                                                                                    | `true`                                                  |
+| `mongodb.password`                     | MongoDB admin password                                                                                                                                    | `nil`                                                   |
+| `mongodb.persistence.enabled`          | Enable MongoDB persistence using PVC                                                                                                                      | `true`                                                  |
+| `mongodb.persistence.storageClass`     | PVC Storage Class for MongoDB volume                                                                                                                      | `nil` (uses alpha storage class annotation)             |
+| `mongodb.persistence.accessMode`       | PVC Access Mode for MongoDB volume                                                                                                                        | `ReadWriteOnce`                                         |
+| `mongodb.persistence.size`             | PVC Storage Request for MongoDB volume                                                                                                                    | `8Gi`                                                   |
 
 The above parameters map to the env variables defined in [bitnami/parse](http://github.com/bitnami/bitnami-docker-parse). For more information please refer to the [bitnami/parse](http://github.com/bitnami/bitnami-docker-parse) image documentation.
 

--- a/stable/parse/README.md
+++ b/stable/parse/README.md
@@ -162,6 +162,15 @@ The [Bitnami Parse](https://github.com/bitnami/bitnami-docker-parse) image store
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Configuration](#configuration) section to configure the PVC or to disable persistence.
 
+### Adjust permissions of persistent volume mountpoint
+
+As the image run as non-root by default, it is necessary to adjust the ownership of the persistent volume so that the container can write data into it.
+
+By default, the chart is configured to use Kubernetes Security Context to automatically change the ownership of the volume. However, this feature does not work in all Kubernetes distributions.
+As an alternative, this chart supports using an initContainer to change the ownership of the volume before mounting it in the final destination.
+
+You can enable this initContainer by setting `volumePermissions.enabled` to `true`.
+
 ## Upgrading
 
 ### To 5.1.0

--- a/stable/parse/templates/_helpers.tpl
+++ b/stable/parse/templates/_helpers.tpl
@@ -128,21 +128,27 @@ imagePullSecrets:
 {{- range .Values.global.imagePullSecrets }}
   - name: {{ . }}
 {{- end }}
-{{- else if or .Values.server.image.pullSecrets .Values.dashboard.image.pullSecrets }}
+{{- else if or .Values.server.image.pullSecrets .Values.dashboard.image.pullSecrets .Values.volumePermissions.image.pullSecrets }}
 imagePullSecrets:
 {{- range .Values.server.image.pullSecrets }}
   - name: {{ . }}
 {{- end }}
 {{- range .Values.dashboard.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.volumePermissions.image.pullSecrets }}
   - name: {{ . }}
 {{- end }}
 {{- end -}}
-{{- else if or .Values.server.image.pullSecrets .Values.dashboard.image.pullSecrets }}
+{{- else if or .Values.server.image.pullSecrets .Values.dashboard.image.pullSecrets .Values.volumePermissions.image.pullSecrets }}
 imagePullSecrets:
 {{- range .Values.server.image.pullSecrets }}
   - name: {{ . }}
 {{- end }}
 {{- range .Values.dashboard.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.volumePermissions.image.pullSecrets }}
   - name: {{ . }}
 {{- end }}
 {{- end -}}
@@ -158,4 +164,27 @@ WARNING: Rolling tag detected ({{ .Values.server.image.repository }}:{{ .Values.
 WARNING: Rolling tag detected ({{ .Values.dashboard.image.repository }}:{{ .Values.dashboard.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
 +info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
 {{- end }}
+{{- end -}}
+
+{{/*
+Return the proper image name (for the init container volume-permissions image)
+*/}}
+{{- define "parse.volumePermissions.image" -}}
+{{- $registryName := .Values.volumePermissions.image.registry -}}
+{{- $repositoryName := .Values.volumePermissions.image.repository -}}
+{{- $tag := .Values.volumePermissions.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
 {{- end -}}

--- a/stable/parse/templates/server-deployment.yaml
+++ b/stable/parse/templates/server-deployment.yaml
@@ -29,6 +29,19 @@ spec:
         runAsUser: {{ .Values.server.securityContext.runAsUser }}
       {{- end }}
 {{- include "parse.imagePullSecrets" . | indent 6 }}
+      {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
+      initContainers:
+      - name: volume-permissions
+        image: {{ template "parse.volumePermissions.image" . }}
+        imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+        command: ["chown", "-R", "{{ .Values.server.securityContext.runAsUser }}:{{ .Values.server.securityContext.fsGroup }}", "/bitnami/parse"]
+        securityContext:
+          runAsUser: 0
+        resources: {{ toYaml .Values.volumePermissions.resources | nindent 10 -}}
+        volumeMounts:
+        - name: parse-data
+          mountPath: /bitnami/parse
+      {{- end }}
       containers:
       - name: {{ template "parse.fullname" . }}
         image: {{ template "parse.server.image" . }}

--- a/stable/parse/templates/server-deployment.yaml
+++ b/stable/parse/templates/server-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         command: ["chown", "-R", "{{ .Values.server.securityContext.runAsUser }}:{{ .Values.server.securityContext.fsGroup }}", "/bitnami/parse"]
         securityContext:
           runAsUser: 0
-        resources: {{ toYaml .Values.volumePermissions.resources | nindent 10 -}}
+        resources: {{ toYaml .Values.volumePermissions.resources | nindent 10 }}
         volumeMounts:
         - name: parse-data
           mountPath: /bitnami/parse

--- a/stable/parse/values.yaml
+++ b/stable/parse/values.yaml
@@ -15,6 +15,24 @@
 ##
 # fullnameOverride:
 
+## Init containers parameters:
+## volumePermissions: Change the owner and group of the persistent volume mountpoint to runAsUser:fsGroup values from the securityContext section.
+##
+volumePermissions:
+  enabled: false
+  image:
+    registry: docker.io
+    repository: bitnami/minideb
+    tag: latest
+    pullPolicy: Always
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+  resources: {}
+
 ## Kubernetes serviceType for Parse Deployment
 ## ref: http://kubernetes.io/docs/user-guide/services/#publishing-services---service-types
 ##


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Sometimes the built-in Kubernetes functionality to adjust file permissions in the volumes is not available (securityContext). If that is the case and we want to run non-root containers, we have to adjust the permissions of the volume previously with a privileged init container.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
