### PR TITLE
[stable/rabbitmq-ha] Add support for configuring global_paramaters definition

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.15
-version: 1.29.1
+version: 1.30.0
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -72,6 +72,7 @@ and their default values.
 | `extraInitContainers`                          | Additional init containers passed through the tpl 	                                                                                                                                                   | `[]`                                                         |
 | `env`                                          | Environment variables to set for Rabbitmq container                                                                                                                                                   | `{}`                                                         |
 | `advancedConfig`                               | Additional configuration in classic config format                                                                                                                                                   | `""`                                                           |
+| `definitions.globalParameters`                 | Pre-configured global parameters | `""` |
 | `definitions.users`                            | Additional users | `""` |
 | `definitions.vhosts`                           | Additional vhosts | `""` |
 | `definitions.parameters`                       | Additional parameters | `""` |

--- a/stable/rabbitmq-ha/templates/_helpers.tpl
+++ b/stable/rabbitmq-ha/templates/_helpers.tpl
@@ -62,6 +62,9 @@ users, virtual hosts, permissions and parameters) to load by the management plug
 */}}
 {{- define "rabbitmq-ha.definitions" -}}
 {
+  "global_parameters": [
+{{ .Values.definitions.globalParameters | indent 4 }}
+  ],
   "users": [
     {
       "name": {{ .Values.managementUsername | quote }},

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -30,6 +30,11 @@ extraPlugins: |
   rabbitmq_federation_management,
 
 definitions:
+  globalParameters: |-
+#    {
+#        "name": "cluster_name",
+#        "value": "rabbitmq-ha"
+#    }
   users: |-
 #   {
 #     "name": "myUsername",


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
We're just getting to setting up rabbitmq in production with federation; we were having an issue whereby in federation it uses the cluster_name for uniqueness so it was essentially only federating to a single location until we changed the cluster names to be unique.

I thought the best way of making this configurable was to simply put in the global_parameters definition into the chart. I think separately there's a question whether or not you want to be setting cluster name which after this pull request would be as simple as updating the defaults.

#### Special notes for your reviewer:
Nothing should happen to existing deployments but I have tested this has the desired outcome when setting a global parameter. I've bumped the minor version on the chart to reflect a new feature which isn't breaking though.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
