### PR TITLE
[stable/reloader] Update ClusterRole and ClusterRoleBinding to use full name

### DIFF
--- a/stable/reloader/Chart.yaml
+++ b/stable/reloader/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: reloader
 description: Reloader chart that runs on kubernetes
-version: 1.1.0
+version: 1.1.1
 appVersion: "v0.0.29"
 keywords:
   - Reloader

--- a/stable/reloader/templates/clusterrole.yaml
+++ b/stable/reloader/templates/clusterrole.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- if .Values.reloader.matchLabels }}
 {{ toYaml .Values.reloader.matchLabels | indent 4 }}
 {{- end }}
-  name: {{ template "reloader-name" . }}-role
+  name: {{ template "reloader-fullname" . }}-role
   namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:

--- a/stable/reloader/templates/clusterrolebinding.yaml
+++ b/stable/reloader/templates/clusterrolebinding.yaml
@@ -12,12 +12,12 @@ metadata:
 {{- if .Values.reloader.matchLabels }}
 {{ toYaml .Values.reloader.matchLabels | indent 4 }}
 {{- end }}
-  name: {{ template "reloader-name" . }}-role-binding
+  name: {{ template "reloader-fullname" . }}-role-binding
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "reloader-name" . }}-role
+  name: {{ template "reloader-fullname" . }}-role
 subjects:
   - kind: ServiceAccount
     name: {{ template "serviceAccountName" . }}


### PR DESCRIPTION
Signed-off-by: James Ritter <jamesritter15@gmail.com>

#### What this PR does / why we need it:
Updates ClusterRole and ClusterRoleBinding to use the chart full name in their names, so the chart can be deployed multiple times

#### Which issue this PR fixes
  - fixes #15759

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
