### PR TITLE
[stable/spinnaker] add --only-spinnaker-managed option to halyard provider

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.13.2
+version: 1.13.3
 appVersion: 1.12.5
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/configmap/halyard-config.yaml
+++ b/stable/spinnaker/templates/configmap/halyard-config.yaml
@@ -110,7 +110,9 @@ data:
 
     $HAL_COMMAND config provider kubernetes account $PROVIDER_COMMAND {{ $context }} --docker-registries dockerhub \
                 --context {{ $context }} {{ if not $.Values.kubeConfig.enabled }}--service-account true{{ end }} \
-                {{ if $.Values.kubeConfig.enabled }}--kubeconfig-file /opt/kube/{{ $.Values.kubeConfig.secretKey }}{{ end }} --omit-namespaces={{ template "omittedNameSpaces" $ }} --provider-version v2
+                {{ if $.Values.kubeConfig.enabled }}--kubeconfig-file /opt/kube/{{ $.Values.kubeConfig.secretKey }}{{ end }} \
+                {{ if $.Values.kubeConfig.onlySpinnakerManaged.enabled }}--only-spinnaker-managed true{{ end }} \
+                --omit-namespaces={{ template "omittedNameSpaces" $ }} --provider-version v2
     {{- end }}
     $HAL_COMMAND config deploy edit --account-name {{ .Values.kubeConfig.deploymentContext }} --type distributed \
                            --location {{ .Release.Namespace }}

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -117,7 +117,7 @@ kubeConfig:
   omittedNameSpaces:
   - kube-system
   - kube-public
-  onlySpinnakerManaged: 
+  onlySpinnakerManaged:
     enabled: false
 
 # Change this if youd like to expose Spinnaker outside the cluster

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -117,6 +117,8 @@ kubeConfig:
   omittedNameSpaces:
   - kube-system
   - kube-public
+  onlySpinnakerManaged: 
+    enabled: false
 
 # Change this if youd like to expose Spinnaker outside the cluster
 ingress:


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds the --only-spinnaker-managed option to the  hal config provider kubernetes account  command.
By default this is disabled but this can now be overridden with kubeConfig.onlySpinnakerManaged:enabled 
#### Which issue this PR fixes
  - fixes https://github.com/helm/charts/issues/15766

#### Special notes for your reviewer:
I tested this out in 2 different spinnaker deployments with this option enabled and disabled.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
