### PR TITLE
[stable/kong] Add support for declarative config and existing ConfigMap

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.14.1
+version: 0.15.0
 appVersion: 1.2

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -141,7 +141,7 @@ Postgres is enabled by default.
 | postgresql.enabled                | Spin up a new postgres instance for Kong                               | `true`                |
 | waitImage.repository              | Image used to wait for database to become ready                        | `busybox`             |
 | waitImage.tag                     | Tag for image used to wait for database to become ready                | `latest`              |
-| env.database                      | Choose either `postgres` or `cassandra`                                | `postgres`            |
+| env.database                      | Choose either `postgres`, `cassandra` or `"off"` to use declarativeMode| `postgres`            |
 | env.pg_user                       | Postgres username                                                      | `kong`                |
 | env.pg_database                   | Postgres database name                                                 | `kong`                |
 | env.pg_password                   | Postgres database password (required if you are using your own database)| `kong`               |
@@ -151,7 +151,8 @@ Postgres is enabled by default.
 | env.cassandra_port                | Cassandra query port                                                   | `9042`                |
 | env.cassandra_keyspace            | Cassandra keyspace                                                     | `kong`                |
 | env.cassandra_repl_factor         | Replication factor for the Kong keyspace                               | `2`                   |
-
+| declarativeMode.existingConfigMap | Name of an existing ConfigMap containing the `kong.yml` file. This must have the key `kong.yml`.| `` |
+| declarativeMode.config            | Yaml configuration file for the declarative configuration of Kong      | see in `values.yaml`   |
 
 All `kong.env` parameters can also accept a mapping instead of a value to ensure the parameters can be set through configmaps and secrets.
 
@@ -323,6 +324,16 @@ If your SMTP server requires authentication, you should the `username` and
 `smtp_password_secret` keys under `.enterprise.smtp.auth`.
 `smtp_password_secret` must be a Secret containing an `smtp_password` key whose
 value is your SMTP password.
+
+### Declarative Configuration
+
+The helm chart assumes to be running in declarative mode when it is started in 
+DB-less mode (`env.database: "off"`) and without the ingress controller 
+(`ingressController.enabled: false`). 
+
+In this case, the user-provided ConfigMap referenced by `declarativeMode.existingConfigMap`
+is used. If no existing ConfigMap is given, then the values section `declarativeMode.config`
+is parsed into a ConfigMap which gets injected into Kong during startup.
 
 ### Kong Ingress Controller
 

--- a/stable/kong/templates/config-declarative.yaml
+++ b/stable/kong/templates/config-declarative.yaml
@@ -1,0 +1,16 @@
+{{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
+{{- if not .Values.declarativeMode.existingConfigMap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kong-custom-declarative-config
+  labels:
+    app: {{ template "kong.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  kong.yml: |
+{{ .Values.declarativeMode.config | toYaml | indent 4 }}
+{{- end }}
+{{- end }}

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -17,10 +17,13 @@ spec:
       component: app
   template:
     metadata:
-    {{- if .Values.podAnnotations }}
       annotations:
+        {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off" )) }}
+        checksum/declarativeMode.config: {{ toYaml .Values.declarativeMode.config | sha256sum }}
+        {{- end }}
+        {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
-    {{- end }}
+        {{- end }}
       labels:
         app: {{ template "kong.name" . }}
         release: {{ .Release.Name }}
@@ -40,7 +43,7 @@ spec:
       {{- include "kong.wait-for-db" . | nindent 6 }}
       {{ end }}
       containers:
-      {{- if (and (.Values.ingressController) (eq .Values.env.database "off")) }}
+      {{- if (and (.Values.ingressController.enabled) (eq .Values.env.database "off")) }}
       {{- include "kong.controller-container" . | nindent 6 }}
       {{ end }}
       - name: {{ template "kong.name" . }}
@@ -153,6 +156,10 @@ spec:
         - name: KONG_CASSANDRA_CONTACT_POINTS
           value: {{ template "kong.cassandra.fullname" . }}
         {{- end }}
+        {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
+        - name: KONG_DECLARATIVE_CONFIG
+          value: "/kong_declarative/kong.yml"
+        {{- end }}
         ports:
         - name: admin
           containerPort: {{ .Values.admin.containerPort }}
@@ -232,6 +239,10 @@ spec:
         volumeMounts:
           - name: custom-nginx-template-volume
             mountPath: /kong
+          {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
+          - name: kong-custom-declarative-config-volume
+            mountPath: /kong_declarative/
+          {{- end }}
         readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 10 }}
         livenessProbe:
@@ -252,4 +263,12 @@ spec:
         - name: custom-nginx-template-volume
           configMap:
             name: kong-default-custom-server-blocks
-
+{{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
+        - name: kong-custom-declarative-config-volume
+          configMap:
+            {{- if .Values.declarativeMode.existingConfigMap }}
+            name: {{ .Values.declarativeMode.existingConfigMap }}
+            {{- else }}
+            name: kong-custom-declarative-config
+            {{- end }}
+{{- end }}

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -384,3 +384,31 @@ ingressController:
     name:
 
   ingressClass: kong
+
+# We pass the declarative config over here.
+declarativeMode:
+  # Either Kong's configuration is managed from an existing ConfigMap
+  existingConfigMap: ""
+  # Or the configuration is passed in full-text below
+  config:
+    _format_version: "1.1"
+    services:
+      - name: version
+        url: http://localhost
+        routes:
+        - name: version
+          paths:
+          - /version
+        plugins:
+        - name: request-termination
+          config:
+            status_code: 200
+            message: "declarative-config"
+      # Example httpbin
+      # - name: httpbin.org
+      #   url: https://httpbin.org/
+      #   routes:
+      #   - name: httpbin.org
+      #     paths:
+      #     - "/httpbin"
+

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -411,4 +411,3 @@ declarativeMode:
       #   - name: httpbin.org
       #     paths:
       #     - "/httpbin"
-


### PR DESCRIPTION
This commit adds the capabilities to specify a declarative configuration. This
is necessary if you would like to run in DB-less mode with deploying the Kong
ingress controller. Documentation has also been adapted.

#### What this PR does / why we need it:

Allow to run Kong helm chart with declarative configration

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #15284 
  - fixes #15286 

#### Special notes for your reviewer:
@hbagdi This is a new PR implements your review from PR #15286 because original author @xtof2all is not available and I cannot commit in his fork. Please close #15286 if you're happy with the current PR.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
