### PR TITLE
[stable/grafana] Support multiple types of dashboard provisioning

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 3.7.2
+version: 3.7.3
 appVersion: 6.2.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -217,11 +217,9 @@ spec:
 {{- if .Values.sidecar.dashboards.enabled }}
             - name: sc-dashboard-volume
               mountPath: {{ .Values.sidecar.dashboards.folder | quote }}
-{{- if not .Values.dashboardProviders }}
             - name: sc-dashboard-provider
               mountPath: "/etc/grafana/provisioning/dashboards/sc-dashboardproviders.yaml"
               subPath: provider.yaml
-{{- end}}
 {{- end}}
 {{- if .Values.sidecar.datasources.enabled }}
             - name: sc-datasources-volume
@@ -359,7 +357,7 @@ spec:
       {{- if .Values.sidecar.dashboards.enabled }}
         - name: sc-dashboard-volume
           emptyDir: {}
-{{- if not .Values.dashboardProviders }}
+{{- if .Values.sidecar.dashboards.enabled }}
         - name: sc-dashboard-provider
           configMap:
             name: {{ template "grafana.fullname" . }}-config-dashboards

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
           image: "{{ .Values.downloadDashboardsImage.repository }}:{{ .Values.downloadDashboardsImage.tag }}"
           imagePullPolicy: {{ .Values.downloadDashboardsImage.pullPolicy }}
           command: ["/bin/sh"]
-          args: [ "-c", "mkdir -p /var/lib/grafana/dashboards/default && /etc/grafana/download_dashboards.sh" ]
+          args: [ "-c", "mkdir -p /var/lib/grafana/dashboards/default && /bin/sh /etc/grafana/download_dashboards.sh" ]
           volumeMounts:
             - name: config
               mountPath: "/etc/grafana/download_dashboards.sh"


### PR DESCRIPTION
#### What this PR does / why we need it:

Support both the "standard" method of dashboard provisioning and the "sidecar" method of dashboard provisioning within this Helm chart, at the same time.

The Grafana chart currently supports both methods of automated dashboard provisioning, however both methods are not supported at the same time. This is a limitation of the Helm chart, which has been lifted by this commit.

This PR was created so that I can use the `stable/prometheus-operator` Helm chart, version 6.0.0 to deploy Grafana with Kubernetes monitoring dashboards. In addition to the dashboards which are part of `stable/prometheus-operator`, I wish to have additional dashboards from the [Official Grafana Dashboard Hub](https://grafana.com/grafana/dashboards) provisioned automatically. This commit lifts the Helm chart's restriction on doing both of these two types of dashboard provisioning at the same time.

#### Which issue this PR fixes

No issue was created.

#### Special notes for your reviewer:

The automatic Grafana dashboard provisioning has been broken since `stable/grafana` version 3.5.6. Please see Issue #15725 for further information. I have tested this change by using `stable/grafana` 3.7.0 with my proposed fix in https://github.com/helm/charts/issues/15725#issuecomment-513926149 and the `stable/prometheus-operator` chart version 6.0.0.

I have mentioned all maintainers listed in Chart.yaml, per the instructions in the PR template:
@zanhsieh
@rtluckie 
@maorfr 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
