### PR TITLE
[stable/fluent-bit] fix - enable parsers

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.4.3
+version: 2.4.4
 appVersion: 1.2.1
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -72,7 +72,7 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `backend.splunk.tls_debug`        | Set TLS debug verbosity level. It accept the following values: 0-4 | `1` |
 | `backend.splunk.message_key`           | Tag applied to all incoming logs | `kubernetes` |
 | **Parsers**                   |
-| `parsers.enabled`                  | Enable custom parsers | `false` |
+| `parsers.enabled`                  | Enable custom parsers (needs to be set for all parsers) | `false` |
 | `parsers.regex`                    | List of regex parsers | `NULL` |
 | `parsers.json`                     | List of json parsers | `NULL` |
 | `parsers.logfmt`                   | List of logfmt parsers | `NULL` |

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -14,7 +14,6 @@ data:
         Flush        {{ .Values.service.flush }}
         Daemon       Off
         Log_Level    {{ .Values.service.logLevel }}
-        Parsers_File parsers.conf
 {{- if .Values.parsers.enabled }}
         Parsers_File parsers_custom.conf
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

The flag `parsers.enabled` has to be set to include the final parsers.conf in [daemonset.yaml](https://github.com/helm/charts/blob/master/stable/fluent-bit/templates/daemonset.yaml#L95)

#### Special notes for your reviewer:
Please check @kfox1111, @edsiper, @hectorj2f

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
