### PR TITLE
[stable/fluent-bit] feature - add support for lua filter

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.4.4
+version: 2.4.5
 appVersion: 1.2.1
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.4.3
+version: 2.4.4
 appVersion: 1.2.1
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.4.5
+version: 2.5.0
 appVersion: 1.2.1
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -72,7 +72,7 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `backend.splunk.tls_debug`        | Set TLS debug verbosity level. It accept the following values: 0-4 | `1` |
 | `backend.splunk.message_key`           | Tag applied to all incoming logs | `kubernetes` |
 | **Parsers**                   |
-| `parsers.enabled`                  | Enable custom parsers | `false` |
+| `parsers.enabled`                  | Enable custom parsers (needs to be set for all parsers) | `false` |
 | `parsers.regex`                    | List of regex parsers | `NULL` |
 | `parsers.json`                     | List of json parsers | `NULL` |
 | `parsers.logfmt`                   | List of logfmt parsers | `NULL` |

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -99,6 +99,8 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `filter.kubeTagPrefix`             | Optional tag prefix used by Tail   | `kube.var.log.containers.`                                |
 | `filter.mergeJSONLog`              | If the log field content is a JSON string map, append the map fields as part of the log structure         | `true`                                 |
 | `filter.mergeLogKey`               | If set, append the processed log keys under a new root key specified by this variable. | `nil` |
+| `filter.lua.enabled`               | Enable the use of [lua](https://docs.fluentbit.io/manual/filter/lua) filters                   | `false`                                 |
+| `filter.lua.raw`                   | Provide your Lua file; the file is mounted as `extra.lua` | ``                                 | |
 | `image.fluent_bit.repository`      | Image                                      | `fluent/fluent-bit`                               |
 | `image.fluent_bit.tag`             | Image tag                                  | `1.2.1`                                           |
 | `image.pullPolicy`                 | Image pull policy                          | `Always`                                          |

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -14,7 +14,6 @@ data:
         Flush        {{ .Values.service.flush }}
         Daemon       Off
         Log_Level    {{ .Values.service.logLevel }}
-        Parsers_File parsers.conf
 {{- if .Values.parsers.enabled }}
         Parsers_File parsers_custom.conf
 {{- end }}

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -212,6 +212,6 @@ data:
 {{- end }}
 
   extra.lua: |-
-{{ .Values.filter.raw | indent 4 }}
+{{ .Values.filter.lua.raw | indent 4 }}
 
 {{- end -}}

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -212,4 +212,7 @@ data:
 {{ end }}
 {{- end }}
 
+  extra.lua: |-
+{{ .Values.filter.raw | indent 4 }}
+
 {{- end -}}

--- a/stable/fluent-bit/templates/daemonset.yaml
+++ b/stable/fluent-bit/templates/daemonset.yaml
@@ -91,7 +91,11 @@ spec:
         - name: config
           mountPath: /fluent-bit/etc/fluent-bit-output.conf
           subPath: fluent-bit-output.conf
-
+{{- if .Values.filter.lua.enabled }}
+        - name: config
+          mountPath: /fluent-bit/etc/extra.lua
+          subPath: extra.lua
+{{- end }}
 {{- if .Values.parsers.enabled }}
         - name: config
           mountPath: /fluent-bit/etc/parsers_custom.conf

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -120,21 +120,6 @@ parsers:
   ##
   json: []
 
-filters:
-  lua:
-    enabled: false
-    raw: |-
-    ## example callback from https://docs.fluentbit.io/manual/filter/lua
-    #   function cb_print(tag, timestamp, record)
-    #     return code, timestamp, record
-    #   end
-    ##  Usage:
-    # [FILTER]
-    # Name    lua
-    # Match   *
-    # script  extra.lua
-    # call    cb_print
-
 env: []
 
 ## Annotations to add to the DaemonSet's Pods
@@ -268,6 +253,23 @@ filter:
 # If true, enable the use of monitoring for a pod annotation of
 # fluentbit.io/exclude: true. If present, discard logs from that pod.
   enableExclude: true
+
+# if true, enable support for Lua filters in final `extra.lua` file
+# see documentation at https://docs.fluentbit.io/manual/filter/lua
+  lua:
+    enabled: false
+    raw: |-   
+    ## example callback
+    #   function cb_print(tag, timestamp, record)
+    #     return code, timestamp, record
+    #   end
+    ##  Usage:
+    # [FILTER]
+    # Name    lua
+    # Match   *
+    # script  extra.lua
+    # call    cb_print
+
 
 rbac:
   # Specifies whether RBAC resources should be created

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -120,6 +120,21 @@ parsers:
   ##
   json: []
 
+filters:
+  lua:
+    enabled: false
+    raw: |-
+    ## example callback from https://docs.fluentbit.io/manual/filter/lua
+    #   function cb_print(tag, timestamp, record)
+    #     return code, timestamp, record
+    #   end
+    ##  Usage:
+    # [FILTER]
+    # Name    lua
+    # Match   *
+    # script  extra.lua
+    # call    cb_print
+
 env: []
 
 ## Annotations to add to the DaemonSet's Pods

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -258,7 +258,7 @@ filter:
 # see documentation at https://docs.fluentbit.io/manual/filter/lua
   lua:
     enabled: false
-    raw: |-   
+    raw: |-
     ## example callback
     #   function cb_print(tag, timestamp, record)
     #     return code, timestamp, record


### PR DESCRIPTION
#### What this PR does / why we need it:
Fluent Bit supports Lua as Filter. I enabled that feature in this chart - see the [fluent-bit documentation](https://docs.fluentbit.io/manual/filter/lua)

The Lua script is provided as `raw` data as shown below and must be referenced as `extra.lua` in the FILTER

```Yaml
filter:
  lua:
    enabled: true
    raw: |-
    # example callback
      function cb_print(tag, timestamp, record)
        return code, timestamp, record
      end
```

The filter can then be configured like this:
```Yaml
rawConfig: |
  @INCLUDE fluent-bit-service.conf
  @INCLUDE fluent-bit-input.conf
  @INCLUDE fluent-bit-filter.conf
  [FILTER]
      Name    lua
      Match   *
      script  extra.lua
      call    cb_print
  @INCLUDE fluent-bit-output.conf
```

#### Special notes for your reviewer:
This PR already incorporates PR #15775
Please check @kfox1111, @edsiper, @hectorj2f

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
