### PR TITLE
[stable/owncloud] Replace lusotycoon/apache-exporter with bitnami/apache-exporter

### DIFF
--- a/stable/owncloud/Chart.yaml
+++ b/stable/owncloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: owncloud
-version: 5.0.0
+version: 5.0.1
 appVersion: 10.2.1
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/owncloud/Chart.yaml
+++ b/stable/owncloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: owncloud
-version: 5.0.1
+version: 5.1.0
 appVersion: 10.2.1
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/owncloud/README.md
+++ b/stable/owncloud/README.md
@@ -96,8 +96,8 @@ The following table lists the configurable parameters of the ownCloud chart and 
 | `podAnnotations`                    | Pod annotations                            | `{}`                                                    |
 | `metrics.enabled`                   | Start a side-car prometheus exporter       | `false`                                                 |
 | `metrics.image.registry`            | Apache exporter image registry             | `docker.io`                                             |
-| `metrics.image.repository`          | Apache exporter image name                 | `lusotycoon/apache-exporter`                            |
-| `metrics.image.tag`                 | Apache exporter image tag                  | `v0.5.0`                                                |
+| `metrics.image.repository`          | Apache exporter image name                 | `bitnami/apache-exporter`                            |
+| `metrics.image.tag`                 | Apache exporter image tag                  | `0.7.0-debian-9-r1`                                                |
 | `metrics.image.pullPolicy`          | Image pull policy                          | `IfNotPresent`                                          |
 | `metrics.image.pullSecrets`         | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)  |
 | `metrics.podAnnotations`            | Additional annotations for Metrics exporter pod  | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |

--- a/stable/owncloud/README.md
+++ b/stable/owncloud/README.md
@@ -97,7 +97,7 @@ The following table lists the configurable parameters of the ownCloud chart and 
 | `metrics.enabled`                   | Start a side-car prometheus exporter       | `false`                                                 |
 | `metrics.image.registry`            | Apache exporter image registry             | `docker.io`                                             |
 | `metrics.image.repository`          | Apache exporter image name                 | `bitnami/apache-exporter`                            |
-| `metrics.image.tag`                 | Apache exporter image tag                  | `0.7.0-debian-9-r1`                                                |
+| `metrics.image.tag`                 | Apache exporter image tag                  | `0.7.0-debian-9-r2`                                                |
 | `metrics.image.pullPolicy`          | Image pull policy                          | `IfNotPresent`                                          |
 | `metrics.image.pullSecrets`         | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)  |
 | `metrics.podAnnotations`            | Additional annotations for Metrics exporter pod  | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |

--- a/stable/owncloud/values.yaml
+++ b/stable/owncloud/values.yaml
@@ -236,7 +236,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.7.0-debian-9-r1
+    tag: 0.7.0-debian-9-r2
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/stable/owncloud/values.yaml
+++ b/stable/owncloud/values.yaml
@@ -235,8 +235,8 @@ metrics:
   enabled: false
   image:
     registry: docker.io
-    repository: lusotycoon/apache-exporter
-    tag: v0.5.0
+    repository: bitnami/apache-exporter
+    tag: 0.7.0-debian-9-r1
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Signed-off-by: Marcos Bjoerkelund <marcos@bitnami.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Bitnami now builds an Apache Exporter based on the Lusitaniae/apache_exporter project. This PR updates this chart to use that container image.

#### Which issue this PR fixes
None

#### Special notes for your reviewer:
None
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
