### PR TITLE
[stable/kube-state-metrics] add customLabels to service, deployment and pods

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - monitoring
 - prometheus
 - kubernetes
-version: 2.1.0
+version: 2.1.1
 appVersion: 1.7.1
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -19,6 +19,7 @@ $ helm install stable/kube-state-metrics
 | `image.pullPolicy`                      | Image pull policy                                                                     | `IfNotPresent`                             |
 | `replicas`                              | Number of replicas                                                                    | `1`                                        |
 | `service.port`                          | The port of the container                                                             | `8080`                                     |
+| `customLabels`                          | Custom labels to apply to service, deployment and pods                                | `{}`                                       |
 | `hostNetwork`                           | Whether or not to use the host network                                                | `false`                                    |
 | `prometheusScrape`                      | Whether or not enable prom scrape                                                     | `true`                                     |
 | `rbac.create`                           | If true, create & use RBAC resources                                                  | `true`                                     |

--- a/stable/kube-state-metrics/templates/deployment.yaml
+++ b/stable/kube-state-metrics/templates/deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
 spec:
   selector:
     matchLabels:
@@ -17,6 +20,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
         app.kubernetes.io/instance: "{{ .Release.Name }}"
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 8 }}
+{{- end }}
 {{- if .Values.podAnnotations }}
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}

--- a/stable/kube-state-metrics/templates/service.yaml
+++ b/stable/kube-state-metrics/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
   {{- if .Values.prometheusScrape }}
   annotations:
     prometheus.io/scrape: '{{ .Values.prometheusScrape }}'

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -14,6 +14,8 @@ service:
   nodePort: 0
   loadBalancerIP: ""
 
+customLabels: {}
+
 hostNetwork: false
 
 rbac:


### PR DESCRIPTION
Signed-off-by: Eriks Zelenka <isindir@users.sf.net>

#### What this PR does / why we need it:

* newrelic does not support new labeling, need the way to specify custom labels on the resources which are being monitored by newrelic. Documentation can be found here: https://docs.newrelic.com/docs/integrations/kubernetes-integration/installation/kubernetes-installation-configuration . See "Specify the kube-state-metrics URL" section.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)

@fiunchinho
@tariq1890