### PR TITLE
[stable/cluster-autoscaler] Update tags to match documentation

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 0.14.4
+version: 1.0.0
 appVersion: 1.13.1
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/README.md
+++ b/stable/cluster-autoscaler/README.md
@@ -37,7 +37,7 @@ To install the chart with the release name `my-release`:
 
 Auto-discovery finds ASGs tags as below and automatically manages them based on the min and max size specified in the ASG. `cloudProvider=aws` only.
 
-1) tag the ASGs with _key_ `k8s.io/cluster-autoscaler/enabled` and _key_ `kubernetes.io/cluster/<YOUR CLUSTER NAME>`
+1) tag the ASGs with _key_ `k8s.io/cluster-autoscaler/enabled` and _key_ `k8s.io/cluster/<YOUR CLUSTER NAME>`
 2) verify the [IAM Permissions](#iam)
 3) set `autoDiscovery.clusterName=<YOUR CLUSTER NAME>`
 4) set `awsRegion=<YOUR AWS REGION>`
@@ -217,7 +217,7 @@ Unfortunately AWS does not support ARNs for autoscaling groups yet so you must u
 ## Auto-discovery
 
 For auto-discovery of instances to work, they must be tagged with
-`k8s.io/cluster-autoscaler/enabled` and `kubernetes.io/cluster/<ClusterName>`
+`k8s.io/cluster-autoscaler/enabled` and `k8s.io/cluster/<ClusterName>`
 
 The value of the tag does not matter, only the key.
 
@@ -245,7 +245,7 @@ metadata:
 spec:
   cloudLabels:
     k8s.io/cluster-autoscaler/enabled: ""
-    kubernetes.io/cluster/my.cluster.internal: owned
+    k8s.io/cluster/my.cluster.internal: owned
   image: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-14
   machineType: r4.large
   maxSize: 4
@@ -281,6 +281,6 @@ Containers:
 # if specifying ASGs manually
       --nodes=1:10:your-scaling-group-name
 # if using autodiscovery
-      --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,kubernetes.io/cluster/<ClusterName>
+      --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster/<ClusterName>
       --v=4
 ```

--- a/stable/cluster-autoscaler/templates/deployment.yaml
+++ b/stable/cluster-autoscaler/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
           {{- end }}
           {{- if eq .Values.cloudProvider "aws" }}
             {{- if .Values.autoDiscovery.clusterName }}
-            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,kubernetes.io/cluster/
+            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster/
               {{- .Values.autoDiscovery.clusterName }}
             {{- end }}
           {{- else if eq .Values.cloudProvider "gce" }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Prior to this change, the cluster tag had prefix `kubernetes.io`. The upstream documentation was updated in June 2018.

This change updates the cluster tag prefix to the correct value, `k8s.io`.

Since this is a breaking change, bump the major version of the chart.

#### Special notes for your reviewer:

https://github.com/kubernetes/autoscaler/pull/916

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
