### PR TITLE
[stable/kong] add release to template ConfigMap

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.14.1
+version: 0.14.2
 appVersion: 1.2

--- a/stable/kong/templates/config-custom-server-blocks.yaml
+++ b/stable/kong/templates/config-custom-server-blocks.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kong-default-custom-server-blocks
+  name: {{ .Release.Name }}-kong-default-custom-server-blocks
   labels:
     app: {{ template "kong.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -251,5 +251,5 @@ spec:
       volumes:
         - name: custom-nginx-template-volume
           configMap:
-            name: kong-default-custom-server-blocks
+            name: {{ .Release.Name }}-kong-default-custom-server-blocks
 


### PR DESCRIPTION
Adds the release name as a prefix to the custom NGINX template
ConfigMap. The static name created a regression preventing multiple
installations of Kong in the same namespace, as Helm would attempt to
create the same ConfigMap twice.

Signed-off-by: Travis Raines <traines@konghq.com>

#### What this PR does / why we need it:
9799f2048d36adea79e3ad421c9b873375bd532f introduced a regression blocking multiple installations of Kong within the same namespace. Helm would attempt to create the `kong-default-custom-server-blocks` ConfigMap for every install, and would fail an install if it already existed.

This PR prepends the release name to the ConfigMap name to avoid this conflict.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
