### PR TITLE
[stable/minio] Fixes launching minio as an oss gateway.

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: MinIO is a high performance distributed object storage server, designed for large-scale private cloud infrastructure.
 name: minio
-version: 2.5.1
+version: 2.5.2
 appVersion: RELEASE.2019-07-17T22-54-12Z
 keywords:
 - storage

--- a/stable/minio/templates/deployment.yaml
+++ b/stable/minio/templates/deployment.yaml
@@ -74,8 +74,7 @@ spec:
           {{- if .Values.ossgateway.enabled }}
           command: [ "/bin/sh", 
           "-ce", 
-          "cp /tmp/config.json {{ .Values.configPath }} && 
-          /usr/bin/docker-entrypoint.sh minio -C {{ .Values.configPath }} gateway oss {{ .Values.ossgateway.endpointURL }}" ]
+          "/usr/bin/docker-entrypoint.sh minio -C {{ .Values.configPath }} gateway oss {{ .Values.ossgateway.endpointURL }}" ]
           {{- else }}
           {{- if .Values.nasgateway.enabled }}
           command: [ "/bin/sh", 


### PR DESCRIPTION
Signed-off-by: Qiu Yuzhou <qiuyuzhou@gmail.com>

#### What this PR does / why we need it:

There is no `/tmp/config.json` been generated in current version chart.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
