### PR TITLE
[stable/rabbitmq-ha] Update README.md

### DIFF
--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -248,7 +248,7 @@ the following keys:
 
 * `rabbitmq-user`
 * `rabbitmq-password`
-* `rabbitmq-management-user`
+* `rabbitmq-management-username`
 * `rabbitmq-management-password`
 * `rabbitmq-erlang-cookie`
 * `definitions.json` (the name can be altered by setting the `definitionsSource`)


### PR DESCRIPTION
To fix the following error:
`Couldn't find key rabbitmq-management-username in Secret default/rabbitmq-secret: CreateContainerConfigError `