### PR TITLE
[stable/logstash] add servicemonitor

### DIFF
--- a/stable/logstash/Chart.yaml
+++ b/stable/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 2.3.0
+version: 2.3.1
 appVersion: 7.1.1
 sources:
 - https://www.docker.elastic.co

--- a/stable/logstash/README.md
+++ b/stable/logstash/README.md
@@ -118,6 +118,7 @@ The following table lists the configurable parameters of the chart and its defau
 | `metrics.serviceMonitor.namespace`            | Optional namespace in which to create ServiceMonitor                                          | `nil`                                                         |
 | `metrics.serviceMonitor.interval`             | Timeout after which the scrape is ended                                                       | `nil`                                                         |
 | `metrics.serviceMonitor.scrapeTimeout`        | Scrape timeout. If not set, the Logstash default scrape timeout is used                       | `nil`                                                         |
+| `metrics.serviceMonitor.scheme`               | Scheme to use for scraping                                                                    | `http`                                                         |
 | `metrics.image.repository`                    | Logstash Image name                                                                           | `bitnami/postgres-exporter`                                   |
 | `metrics.image.tag`                           | Logstash Image tag                                                                            | `{TAG_NAME}`                                                  |
 | `metrics.image.pullPolicy`                    | Logstash Image pull policy                                                                    | `IfNotPresent`                                                |

--- a/stable/logstash/README.md
+++ b/stable/logstash/README.md
@@ -69,67 +69,77 @@ Please review the following links that expound on current best practices.
 
 The following table lists the configurable parameters of the chart and its default values.
 
-|              Parameter          |                    Description                     |                     Default                      |
-| ------------------------------- | -------------------------------------------------- | ------------------------------------------------ |
-| `replicaCount`                  | Number of replicas                                 | `1`                                              |
-| `podDisruptionBudget`           | Pod disruption budget                              | `maxUnavailable: 1`                              |
-| `updateStrategy`                | Update strategy                                    | `type: RollingUpdate`                            |
-| `image.repository`              | Container image name                               | `docker.elastic.co/logstash/logstash-oss`        |
-| `image.tag`                     | Container image tag                                | `7.1.1`                                          |
-| `image.pullPolicy`              | Container image pull policy                        | `IfNotPresent`                                   |
-| `service.type`                  | Service type (ClusterIP, NodePort or LoadBalancer) | `ClusterIP`                                      |
-| `service.annotations`           | Service annotations                                | `{}`                                             |
-| `service.ports`                 | Ports exposed by service                           | beats                                            |
-| `service.loadBalancerIP`        | The load balancer IP for the service               | unset                                            |
-| `service.loadBalancerSourceRanges` | CIDR ranges to allow access to load balancer       | unset                                            |
-| `service.clusterIP`             | The cluster IP for the service                     | unset                                            |
-| `service.nodePort`              | The nodePort for the service                       | unset                                            |
-| `service.externalTrafficPolicy` | Set externalTrafficPolicy                          | unset                                            |
-| `ports`                         | Ports exposed by logstash container                | beats                                            |
-| `ingress.enabled`               | Enables Ingress                                    | `false`                                          |
-| `ingress.annotations`           | Ingress annotations                                | `{}`                                             |
-| `ingress.path`                  | Ingress path                                       | `/`                                              |
-| `ingress.hosts`                 | Ingress accepted hostnames                         | `["logstash.cluster.local"]`                     |
-| `ingress.tls`                   | Ingress TLS configuration                          | `[]`                                             |
-| `logstashJavaOpts`              | Java options for logstash like heap size           | `"-Xmx1g -Xms1g"`                                |
-| `resources`                     | Pod resource requests & limits                     | `{}`                                             |
-| `priorityClassName`             | priorityClassName                                  | `nil`                                            |
-| `nodeSelector`                  | Node selector                                      | `{}`                                             |
-| `tolerations`                   | Tolerations                                        | `[]`                                             |
-| `affinity`                      | Affinity or Anti-Affinity                          | `{}`                                             |
-| `podAnnotations`                | Pod annotations                                    | `{}`                                             |
-| `podLabels`                     | Pod labels                                         | `{}`                                             |
-| `extraEnv`                      | Extra pod environment variables                    | `[]`                                             |
-| `extraInitContainers`           | Add additional initContainers                      | `[]`                                             |
-| `podManagementPolicy`           | podManagementPolicy of the StatefulSet             | `OrderedReady`                                   |
-| `livenessProbe`                 | Liveness probe settings for logstash container     | (see `values.yaml`)                              |
-| `readinessProbe`                | Readiness probe settings for logstash container    | (see `values.yaml`)                              |
-| `persistence.enabled`           | Enable persistence                                 | `true`                                           |
-| `persistence.storageClass`      | Storage class for PVCs                             | unset                                            |
-| `persistence.accessMode`        | Access mode for PVCs                               | `ReadWriteOnce`                                  |
-| `persistence.size`              | Size for PVCs                                      | `2Gi`                                            |
-| `volumeMounts`                  | Volume mounts to configure for logstash container  | (see `values.yaml`)                              |
-| `volumes`                       | Volumes to configure for logstash container        | []                                               |
-| `terminationGracePeriodSeconds` | Duration the pod needs to terminate gracefully     | `30`                                             |
-| `exporter.logstash`             | Prometheus logstash-exporter settings              | (see `values.yaml`)                              |
-| `exporter.logstash.enabled`     | Enables Prometheus logstash-exporter               | `false`                                          |
-| `exporter.serviceMonitor.enabled` | If true, a ServiceMonitor CRD is created for a prometheus operator | `false`
-| `exporter.serviceMonitor.namespace` | If set, the ServiceMonitor will be installed in a different namespace  | `""`
-| `exporter.serviceMonitor.labels` | Labels for prometheus operator | `{}`
-| `exporter.serviceMonitor.interval` | Interval at which metrics should be scraped | `10s`
-| `exporter.serviceMonitor.scrapeTimeout` | Timeout after which the scrape is ended | `10s`
-| `exporter.serviceMonitor.scheme` | Scheme to use for scraping | `http`
-| `elasticsearch.host`            | ElasticSearch hostname (passed through tpl)        | `elasticsearch-client.default.svc.cluster.local` |
-| `elasticsearch.port`            | ElasticSearch port                                 | `9200`                                           |
-| `config`                        | Logstash configuration key-values                  | (see `values.yaml`)                              |
-| `patterns`                      | Logstash patterns configuration                    | `nil`                                            |
-| `files`                         | Logstash custom files configuration                | `nil`                                            |
-| `binaryFiles`                   | Logstash custom binary files                       | `nil`                                            |
-| `inputs`                        | Logstash inputs configuration                      | beats                                            |
-| `filters`                       | Logstash filters configuration                     | `nil`                                            |
-| `outputs`                       | Logstash outputs configuration                     | elasticsearch                                    |
-| `securityContext.fsGroup`       | Group ID for the container                         | `1000`                                           |
-| `securityContext.runAsUser`     | User ID for the container                          | `1000`                                           |
-| `args`                          | Additional arguments to pass to Logstash           | `1000`                                           |
-| `serviceAccount.create`         | Specifies if a ServiceAccount should be created    | `true`                                           |
-| `serviceAccount.name`           | The name of the ServiceAccount to use              | `""`                                             |
+|              Parameter                        |                    Description                                                                |                     Default                                   |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `replicaCount`                                | Number of replicas                                                                            | `1`                                                           |
+| `podDisruptionBudget`                         | Pod disruption budget                                                                         | `maxUnavailable: 1`                                           |
+| `updateStrategy`                              | Update strategy                                                                               | `type: RollingUpdate`                                         |
+| `image.repository`                            | Container image name                                                                          | `docker.elastic.co/logstash/logstash-oss`                     |
+| `image.tag`                                   | Container image tag                                                                           | `7.1.1`                                                       |
+| `image.pullPolicy`                            | Container image pull policy                                                                   | `IfNotPresent`                                                |
+| `service.type`                                | Service type (ClusterIP, NodePort or LoadBalancer)                                            | `ClusterIP`                                                   |
+| `service.annotations`                         | Service annotations                                                                           | `{}`                                                          |
+| `service.ports`                               | Ports exposed by service                                                                      | beats                                                         |
+| `service.loadBalancerIP`                      | The load balancer IP for the service                                                          | unset                                                         |
+| `service.loadBalancerSourceRanges`            | CIDR ranges to allow access to load balancer                                                  | unset                                                         |
+| `service.clusterIP`                           | The cluster IP for the service                                                                | unset                                                         |
+| `service.nodePort`                            | The nodePort for the service                                                                  | unset                                                         |
+| `service.externalTrafficPolicy`               | Set externalTrafficPolicy                                                                     | unset                                                         |
+| `ports`                                       | Ports exposed by logstash container                                                           | beats                                                         |
+| `ingress.enabled`                             | Enables Ingress                                                                               | `false`                                                       |
+| `ingress.annotations`                         | Ingress annotations                                                                           | `{}`                                                          |
+| `ingress.path`                                | Ingress path                                                                                  | `/`                                                           |
+| `ingress.hosts`                               | Ingress accepted hostnames                                                                    | `["logstash.cluster.local"]`                                  |
+| `ingress.tls`                                 | Ingress TLS configuration                                                                     | `[]`                                                          |
+| `logstashJavaOpts`                            | Java options for logstash like heap size                                                      | `"-Xmx1g -Xms1g"`                                             |
+| `resources`                                   | Pod resource requests & limits                                                                | `{}`                                                          |
+| `priorityClassName`                           | priorityClassName                                                                             | `nil`                                                         |
+| `nodeSelector`                                | Node selector                                                                                 | `{}`                                                          |
+| `tolerations`                                 | Tolerations                                                                                   | `[]`                                                          |
+| `affinity`                                    | Affinity or Anti-Affinity                                                                     | `{}`                                                          |
+| `podAnnotations`                              | Pod annotations                                                                               | `{}`                                                          |
+| `podLabels`                                   | Pod labels                                                                                    | `{}`                                                          |
+| `extraEnv`                                    | Extra pod environment variables                                                               | `[]`                                                          |
+| `extraInitContainers`                         | Add additional initContainers                                                                 | `[]`                                                          |
+| `podManagementPolicy`                         | podManagementPolicy of the StatefulSet                                                        | `OrderedReady`                                                |
+| `livenessProbe`                               | Liveness probe settings for logstash container                                                | (see `values.yaml`)                                           |
+| `readinessProbe`                              | Readiness probe settings for logstash container                                               | (see `values.yaml`)                                           |
+| `persistence.enabled`                         | Enable persistence                                                                            | `true`                                                        |
+| `persistence.storageClass`                    | Storage class for PVCs                                                                        | unset                                                         |
+| `persistence.accessMode`                      | Access mode for PVCs                                                                          | `ReadWriteOnce`                                               |
+| `persistence.size`                            | Size for PVCs                                                                                 | `2Gi`                                                         |
+| `volumeMounts`                                | Volume mounts to configure for logstash container                                             | (see `values.yaml`)                                           |
+| `volumes`                                     | Volumes to configure for logstash container                                                   | []                                                            |
+| `terminationGracePeriodSeconds`               | Duration the pod needs to terminate gracefully                                                | `30`                                                          |
+| `metrics.enabled`                             | Start a logstash exporter                                                                     | `false`                                                       |
+| `metrics.serviceMonitor.enabled`              | If true, a ServiceMonitor CRD is created for a prometheus operator                            | `false`                                                       |
+| `metrics.serviceMonitor.port`                 | Name of the service port                                                                      | `metrics`                                                     |
+| `metrics.serviceMonitor.additionalLabels`     | Additional labels that can be used so ServiceMonitor will be discovered by Logstash           | `{}`                                                          |
+| `metrics.serviceMonitor.namespace`            | Optional namespace in which to create ServiceMonitor                                          | `nil`                                                         |
+| `metrics.serviceMonitor.interval`             | Timeout after which the scrape is ended                                                       | `nil`                                                         |
+| `metrics.serviceMonitor.scrapeTimeout`        | Scrape timeout. If not set, the Logstash default scrape timeout is used                       | `nil`                                                         |
+| `metrics.image.repository`                    | Logstash Image name                                                                           | `bitnami/postgres-exporter`                                   |
+| `metrics.image.tag`                           | Logstash Image tag                                                                            | `{TAG_NAME}`                                                  |
+| `metrics.image.pullPolicy`                    | Logstash Image pull policy                                                                    | `IfNotPresent`                                                |
+| `metrics.livenessProbe.periodSeconds`         | How often to perform the probe                                                                | 10                                                            |
+| `metrics.livenessProbe.timeoutSeconds`        | When the probe times out                                                                      | 5                                                             |
+| `metrics.livenessProbe.failureThreshold`      | Minimum consecutive failures for the probe to be considered failed after having succeeded.    | 6                                                             |
+| `metrics.livenessProbe.successThreshold`      | Minimum consecutive successes for the probe to be considered successful after having failed   | 1                                                             |
+| `metrics.readinessProbe.periodSeconds`        | How often to perform the probe                                                                | 10                                                            |
+| `metrics.readinessProbe.timeoutSeconds`       | When the probe times out                                                                      | 5                                                             |
+| `metrics.readinessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.    | 6                                                             |
+| `metrics.readinessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed   | 1                                                             |
+| `elasticsearch.host`                          | ElasticSearch hostname (passed through tpl)                                                   | `elasticsearch-client.default.svc.cluster.local`              |
+| `elasticsearch.port`                          | ElasticSearch port                                                                            | `9200`                                                        |
+| `config`                                      | Logstash configuration key-values                                                             | (see `values.yaml`)                                           |
+| `patterns`                                    | Logstash patterns configuration                                                               | `nil`                                                         |
+| `files`                                       | Logstash custom files configuration                                                           | `nil`                                                         |
+| `binaryFiles`                                 | Logstash custom binary files                                                                  | `nil`                                                         |
+| `inputs`                                      | Logstash inputs configuration                                                                 | beats                                                         |
+| `filters`                                     | Logstash filters configuration                                                                | `nil`                                                         |
+| `outputs`                                     | Logstash outputs configuration                                                                | elasticsearch                                                 |
+| `securityContext.fsGroup`                     | Group ID for the container                                                                    | `1000`                                                        |
+| `securityContext.runAsUser`                   | User ID for the container                                                                     | `1000`                                                        |
+| `args`                                        | Additional arguments to pass to Logstash                                                      | `1000`                                                        |
+| `serviceAccount.create`                       | Specifies if a ServiceAccount should be created                                               | `true`                                                        |
+| `serviceAccount.name`                         | The name of the ServiceAccount to use                                                         | `""`                                                          |

--- a/stable/logstash/templates/servicemonitor.yaml
+++ b/stable/logstash/templates/servicemonitor.yaml
@@ -1,36 +1,33 @@
-{{- if .Values.exporter.serviceMonitor.enabled }}
----
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "logstash.fullname" . }}
-  {{- if .Values.exporter.serviceMonitor.namespace }}
-  namespace: {{ .Values.exporter.serviceMonitor.namespace }}
+  name: {{ include "logstash.fullname" . }}
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
   {{- end }}
   labels:
-    chart: {{ template "logstash.chart" . }}
     app: {{ template "logstash.name" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
-    {{- if .Values.exporter.serviceMonitor.labels }}
-    {{- toYaml .Values.exporter.serviceMonitor.labels | nindent 4 }}
+    chart: {{ template "logstash.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
     {{- end }}
 spec:
   endpoints:
-  - interval: {{ .Values.exporter.serviceMonitor.interval }}
-    {{- if .Values.exporter.serviceMonitor.scrapeTimeout }}
-    scrapeTimeout: {{ .Values.exporter.serviceMonitor.scrapeTimeout }}
-    {{- end }}
-    honorLabels: true
-    targetPort: {{ .Values.exporter.logstash.port }}
-    path: {{ .Values.exporter.logstash.path }}
-    scheme: {{ .Values.exporter.serviceMonitor.scheme }}
-  jobLabel: "{{ .Release.Name }}"
-  selector:
-    matchLabels:
-      app: {{ template "logstash.name" . }}
-      release: "{{ .Release.Name }}"
+    - port: {{ .Values.metrics.serviceMonitor.port }}
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "logstash.name" . }}
+      release: {{ .Release.Name }}
 {{- end }}

--- a/stable/logstash/templates/servicemonitor.yaml
+++ b/stable/logstash/templates/servicemonitor.yaml
@@ -23,6 +23,11 @@ spec:
       {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
       {{- end }}
+      honorLabels: true
+      targetPort: {{ .Values.metrics.port }}
+      path: {{ .Values.metrics.path }}
+      scheme: {{ .Values.metrics.serviceMonitor.scheme }}
+  jobLabel: {{ .Release.Name }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/stable/logstash/templates/statefulset.yaml
+++ b/stable/logstash/templates/statefulset.yaml
@@ -59,7 +59,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: monitor
-              containerPort: {{ .Values.exporter.logstash.target.port }}
+              containerPort: {{ .Values.metrics.target.port }}
               protocol: TCP
 {{ toYaml .Values.ports | indent 12 }}
           livenessProbe:
@@ -75,7 +75,7 @@ spec:
             - name: HTTP_HOST
               value: "0.0.0.0"
             - name: HTTP_PORT
-              value: {{ .Values.exporter.logstash.target.port | quote }}
+              value: {{ .Values.metrics.target.port | quote }}
             ## Elasticsearch output
             - name: ELASTICSEARCH_HOST
               value: {{ tpl (.Values.elasticsearch.host | toString) $ | quote }}
@@ -97,28 +97,28 @@ spec:
           volumeMounts:
 {{ toYaml .Values.volumeMounts | indent 12 }}
 
-{{- if .Values.exporter.logstash.enabled }}
+{{- if .Values.metrics.enabled }}
         ## logstash-exporter
         - name: {{ .Chart.Name }}-exporter
-          image: "{{ .Values.exporter.logstash.image.repository }}:{{ .Values.exporter.logstash.image.tag }}"
-          imagePullPolicy: {{ .Values.exporter.logstash.image.pullPolicy }}
+          image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
           command: ["/bin/sh", "-c"]
           ## Delay start of logstash-exporter to give logstash more time to come online.
           args:
             - >-
               sleep 60;
               exec /logstash_exporter
-                --logstash.endpoint=http://localhost:{{ .Values.exporter.logstash.target.port }}
-                --web.listen-address=:{{ .Values.exporter.logstash.port }}
+                --logstash.endpoint=http://localhost:{{ .Values.metrics.target.port }}
+                --web.listen-address=:{{ .Values.metrics.port }}
           ports:
             - name: ls-exporter
-              containerPort: {{ .Values.exporter.logstash.port }}
+              containerPort: {{ .Values.metrics.port }}
               protocol: TCP
           livenessProbe:
-{{ toYaml .Values.exporter.logstash.livenessProbe | indent 12 }}
+{{ toYaml .Values.metrics.livenessProbe | indent 12 }}
           readinessProbe:
-{{ toYaml .Values.exporter.logstash.readinessProbe | indent 12 }}
-          {{- with .Values.exporter.logstash.config }}
+{{ toYaml .Values.metrics.readinessProbe | indent 12 }}
+          {{- with .Values.metrics.config }}
           env:
             {{- range $key, $value := . }}
             - name: {{ $key | upper | replace "." "_" }}
@@ -126,7 +126,7 @@ spec:
             {{- end }}
           {{- end }}
           resources:
-{{ toYaml .Values.exporter.logstash.resources | indent 12 }}
+{{ toYaml .Values.metrics.resources | indent 12 }}
 {{- end }}
 
     {{- with .Values.nodeSelector }}

--- a/stable/logstash/values.yaml
+++ b/stable/logstash/values.yaml
@@ -47,6 +47,10 @@ service:
     # loadBalancerIP: 10.0.0.1
     # loadBalancerSourceRanges:
     #   - 192.168.0.1
+    # exporter:
+    #   port: 9198
+    #   protocol: TCP
+    #   targetPort: ls-exporter
 ports:
   # - name: syslog-udp
   #   containerPort: 1514
@@ -183,47 +187,44 @@ volumes: []
   #   hostPath:
   #     path: /tmp
 
-exporter:
-  logstash:
-    enabled: false
-    image:
-      repository: bonniernews/logstash_exporter
-      tag: v0.1.2
-      pullPolicy: IfNotPresent
-    env: {}
-    resources: {}
-    path: /metrics
-    port: 9198
-    target:
-      port: 9600
-      path: /metrics
-    livenessProbe:
-      httpGet:
-        path: /metrics
-        port: ls-exporter
-      periodSeconds: 15
-      timeoutSeconds: 60
-      failureThreshold: 8
-      successThreshold: 1
-    readinessProbe:
-      httpGet:
-        path: /metrics
-        port: ls-exporter
-      periodSeconds: 15
-      timeoutSeconds: 60
-      failureThreshold: 8
-      successThreshold: 1
+metrics:
+  enabled: false
   serviceMonitor:
-    ## If true, a ServiceMonitor CRD is created for a prometheus operator
-    ## https://github.com/coreos/prometheus-operator
-    ##
     enabled: false
-    #  namespace: monitoring
-    labels: {}
-    interval: 10s
-    scrapeTimeout: 10s
-    scheme: http
     port: metrics
+    additionalLabels: {}
+    # namespace: monitoring
+    # interval: 30s
+    # scrapeTimeout: 10s
+  image:
+    repository: bonniernews/logstash_exporter
+    tag: v0.1.2
+    pullPolicy: IfNotPresent
+  env: {}
+  resources: {}
+  path: /metrics
+  port: 9198
+  target:
+    port: 9600
+    path: /metrics
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+  ## Configure extra options for liveness and readiness probes
+  livenessProbe:
+    httpGet:
+      path: /metrics
+      port: ls-exporter
+    periodSeconds: 15
+    timeoutSeconds: 60
+    failureThreshold: 8
+    successThreshold: 1
+  readinessProbe:
+    httpGet:
+      path: /metrics
+      port: ls-exporter
+    periodSeconds: 15
+    timeoutSeconds: 60
+    failureThreshold: 8
+    successThreshold: 1
 
 elasticsearch:
   host: elasticsearch-client.default.svc.cluster.local

--- a/stable/logstash/values.yaml
+++ b/stable/logstash/values.yaml
@@ -193,6 +193,7 @@ metrics:
     enabled: false
     port: metrics
     additionalLabels: {}
+    scheme: http
     # namespace: monitoring
     # interval: 30s
     # scrapeTimeout: 10s


### PR DESCRIPTION
Signed-off-by: Julian Marié <ang3lfs@gmail.com>

#### What this PR does / why we need it:

When use exporter, allow to create a servicemonitor for prometheus metrics.
Add a comment in values.yaml (service.exporter) to create the service which expose metrics.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
I change exporter.logstash by metrics, in some of charts, this convention is used.
If you prefere, I can change exporter.logstash in another PR.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/chart]`)
