### PR TITLE
[incubator/fluent-bit-aws] Feature/fluent bit aws

### DIFF
--- a/incubator/fluent-bit-aws/Chart.yaml
+++ b/incubator/fluent-bit-aws/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.4.3
+version: 2.6.0
 appVersion: 1.2.1
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/incubator/fluent-bit-aws/Chart.yaml
+++ b/incubator/fluent-bit-aws/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: fluent-bit-aws
 version: 0.0.1
-appVersion: 1.2.1
+appVersion: 1.2.0
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:
 - logging

--- a/incubator/fluent-bit-aws/Chart.yaml
+++ b/incubator/fluent-bit-aws/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-name: fluent-bit
-version: 2.6.0
+name: fluent-bit-aws
+version: 0.0.1
 appVersion: 1.2.1
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/incubator/fluent-bit-aws/Chart.yaml
+++ b/incubator/fluent-bit-aws/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+name: fluent-bit
+version: 2.4.3
+appVersion: 1.2.1
+description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
+keywords:
+- logging
+- monitoring
+- fluent
+- fluentd
+sources:
+- https://fluentbit.io
+icon: https://fluentbit.io/assets/img/logo1-default.png
+home: https://fluentbit.io
+maintainers:
+- name: kfox1111
+  email: Kevin.Fox@pnnl.gov
+- name: edsiper
+  email: eduardo@treasure-data.com
+- name: hectorj2f
+  email: hfernandez@mesosphere.com

--- a/incubator/fluent-bit-aws/OWNERS
+++ b/incubator/fluent-bit-aws/OWNERS
@@ -1,0 +1,10 @@
+approvers:
+- kfox1111
+- edsiper
+- hectorj2f
+- Towmeykaw
+reviewers:
+- kfox1111
+- edsiper
+- hectorj2f
+- Towmeykaw

--- a/incubator/fluent-bit-aws/README.md
+++ b/incubator/fluent-bit-aws/README.md
@@ -1,0 +1,165 @@
+# Fluent-Bit Chart
+
+[Fluent Bit](http://fluentbit.io/) is an open source and multi-platform Log Forwarder.
+
+## Chart Details
+
+This chart will do the following:
+
+* Install a configmap for Fluent Bit
+* Install a daemonset that provisions Fluent Bit [per-host architecture]
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release stable/fluent-bit
+```
+
+When installing this chart on [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/), it's required to specify that so the DaemonSet will be able to mount the log files properly, make sure to append the _--set on\_minikube=true_ option at the end of the _helm_ command, e.g:
+
+```bash
+$ helm install --name my-release stable/fluent-bit --set on_minikube=true
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the Fluent-Bit chart and the default values.
+
+| Parameter                  | Description                        | Default                 |
+| -----------------------    | ---------------------------------- | ----------------------- |
+| **Backend Selection**      |
+| `backend.type`             | Set the backend to which Fluent-Bit should flush the information it gathers | `forward` |
+| **Forward Backend**        |
+| `backend.forward.host`     | Target host where Fluent-Bit or Fluentd are listening for Forward messages | `fluentd` |
+| `backend.forward.port`     | TCP Port of the target service | `24284` |
+| `backend.forward.shared_key`       | A key string known by the remote Fluentd used for authorization. | `` |
+| `backend.forward.tls`              | Enable or disable TLS support | `off` |
+| `backend.forward.tls_verify`       | Force certificate validation  | `on` |
+| `backend.forward.tls_debug`        | Set TLS debug verbosity level. It accept the following values: 0-4 | `1` |
+| **ElasticSearch Backend**  |
+| `backend.es.host`          | IP address or hostname of the target Elasticsearch instance | `elasticsearch` |
+| `backend.es.port`          | TCP port of the target Elasticsearch instance. | `9200` |
+| `backend.es.index`         | Elastic Index name | `kubernetes_cluster` |
+| `backend.es.type`          | Elastic Type name | `flb_type` |
+| `backend.es.time_key`          | Elastic Time Key | `@timestamp` |
+| `backend.es.logstash_prefix`  | Index Prefix. If Logstash_Prefix is equals to 'mydata' your index will become 'mydata-YYYY.MM.DD'. | `kubernetes_cluster` |
+| `backend.es.replace_dots`     | Enable/Disable Replace_Dots option. | `On` |
+| `backend.es.http_user`        | Optional username credential for Elastic X-Pack access. | `` |
+| `backend.es.http_passwd:`     | Password for user defined in HTTP_User. | `` |
+| `backend.es.tls`              | Enable or disable TLS support | `off` |
+| `backend.es.tls_verify`       | Force certificate validation  | `on` |
+| `backend.es.tls_ca`           | TLS CA certificate for the Elastic instance (in PEM format). Specify if tls: on. | `` |
+| `backend.es.tls_debug`        | Set TLS debug verbosity level. It accept the following values: 0-4 | `1` |
+| **HTTP Backend**              |
+| `backend.http.host`           | IP address or hostname of the target HTTP Server | `127.0.0.1` |
+| `backend.http.port`           | TCP port of the target HTTP Server | `80` |
+| `backend.http.uri`            | Specify an optional HTTP URI for the target web server, e.g: /something | `"/"`
+| `backend.http.http_user`        | Optional username credential for Basic Authentication. | `` |
+| `backend.http.http_passwd:`     | Password for user defined in HTTP_User. | `` |
+| `backend.http.format`         | Specify the data format to be used in the HTTP request body, by default it uses msgpack, optionally it can be set to json.  | `msgpack` |
+| `backend.http.tls`              | Enable or disable TLS support | `off` |
+| `backend.http.tls_verify`       | Force certificate validation  | `on` |
+| `backend.http.tls_debug`        | Set TLS debug verbosity level. It accept the following values: 0-4 | `1` |
+| **Splunk Backend**              |
+| `backend.splunk.host`           | IP address or hostname of the target Splunk Server | `127.0.0.1` |
+| `backend.splunk.port`           | TCP port of the target Splunk Server | `8088` |
+| `backend.splunk.token`            | Specify the Authentication Token for the HTTP Event Collector interface. | `` |
+| `backend.splunk.send_raw`         | If enabled, record keys and values are set in the main map. | `off` |
+| `backend.splunk.tls`           | Enable or disable TLS support | `on` |
+| `backend.splunk.tls_verify`           | Force TLS certificate validation | `off` |
+| `backend.splunk.tls_debug`        | Set TLS debug verbosity level. It accept the following values: 0-4 | `1` |
+| `backend.splunk.message_key`           | Tag applied to all incoming logs | `kubernetes` |
+| **Parsers**                   |
+| `parsers.enabled`                  | Enable custom parsers | `false` |
+| `parsers.regex`                    | List of regex parsers | `NULL` |
+| `parsers.json`                     | List of json parsers | `NULL` |
+| `parsers.logfmt`                   | List of logfmt parsers | `NULL` |
+| **General**                   |
+| `annotations`                      | Optional deamonset set annotations        | `NULL`                |
+| `podAnnotations`                   | Optional pod annotations                  | `NULL`                |
+| `podLabels`                        | Optional pod labels                       | `NULL`                |
+| `fullConfigMap`                    | User has provided entire config (parsers + system)  | `false`      |
+| `existingConfigMap`                | ConfigMap override                         | ``                    |
+| `extraEntries.input`               |    Extra entries for existing [INPUT] section                     | ``                    |
+| `extraEntries.filter`              |    Extra entries for existing [FILTER] section                     | ``                    |
+| `extraEntries.output`              |   Extra entries for existing [OUPUT] section                     | ``                    |
+| `extraPorts`                       | List of extra ports                        |                       |
+| `extraVolumeMounts`                | Mount an extra volume, required to mount ssl certificates when elasticsearch has tls enabled |          |
+| `extraVolume`                      | Extra volume                               |                                                |
+| `service.flush`                    | Interval to flush output (seconds)        | `1`                   |
+| `service.logLevel`                 | Diagnostic level (error/warning/info/debug/trace)        | `info`                   |
+| `filter.enableExclude`             | Enable the use of monitoring for a pod annotation of `fluentbit.io/exclude: true`. If present, discard logs from that pod.         | `true`                                 |
+| `filter.enableParser`              | Enable the use of monitoring for a pod annotation of `fluentbit.io/parser: parser_name`. parser_name must be the name of a parser contained within parsers.conf         | `true`                                 |
+| `filter.kubeURL`                   | Optional custom configmaps                 | `https://kubernetes.default.svc:443`            |
+| `filter.kubeCAFile`                | Optional custom configmaps       | `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`    |
+| `filter.kubeTokenFile`             | Optional custom configmaps       | `/var/run/secrets/kubernetes.io/serviceaccount/token`     |
+| `filter.kubeTag`                   | Optional top-level tag for matching in filter         | `kube`                                 |
+| `filter.kubeTagPrefix`             | Optional tag prefix used by Tail   | `kube.var.log.containers.`                                |
+| `filter.mergeJSONLog`              | If the log field content is a JSON string map, append the map fields as part of the log structure         | `true`                                 |
+| `filter.mergeLogKey`               | If set, append the processed log keys under a new root key specified by this variable. | `nil` |
+| `image.fluent_bit.repository`      | Image                                      | `fluent/fluent-bit`                               |
+| `image.fluent_bit.tag`             | Image tag                                  | `1.2.1`                                           |
+| `image.pullPolicy`                 | Image pull policy                          | `Always`                                          |
+| `nameOverride`                     | Override name of app                   | `nil`                                        |
+| `fullnameOverride`                 | Override full name of app              | `nil`                                        |
+| `image.pullSecrets`                | Specify image pull secrets                 | `nil`                                             |
+| `input.tail.memBufLimit`           | Specify Mem_Buf_Limit in tail input        | `5MB`                                             |
+| `input.tail.parser`                | Specify Parser in tail input.        | `docker`                                             |
+| `input.tail.path`                  | Specify log file(s) through the use of common wildcards.        | `/var/log/containers/*.log`                                             |
+| `input.systemd.enabled`            | [Enable systemd input](https://docs.fluentbit.io/manual/input/systemd)                   | `false`                                       |
+| `input.systemd.filters.systemdUnit` | Please see https://docs.fluentbit.io/manual/input/systemd | `[docker.service, kubelet.service`, `node-problem-detector.service]`                                       |
+| `input.systemd.maxEntries`         | Please see https://docs.fluentbit.io/manual/input/systemd | `1000`                             |
+| `input.systemd.readFromTail`       | Please see https://docs.fluentbit.io/manual/input/systemd | `true`                             |
+| `input.systemd.tag`                | Please see https://docs.fluentbit.io/manual/input/systemd | `host.*`                           |
+| `rbac.create`                      | Specifies whether RBAC resources should be created.   | `true`                                 |
+| `rbac.pspEnabled`                  | Specifies whether a PodSecurityPolicy should be created. | `false`                             |
+| `serviceAccount.create`            | Specifies whether a ServiceAccount should be created. | `true`                                 |
+| `serviceAccount.name`              | The name of the ServiceAccount to use.     | `NULL`                                            |
+| `rawConfig`                        | Raw contents of fluent-bit.conf            | `@INCLUDE fluent-bit-service.conf`<br>`@INCLUDE fluent-bit-input.conf`<br>`@INCLUDE fluent-bit-filter.conf`<br>` @INCLUDE fluent-bit-output.conf`                                                                         |
+| `resources`                        | Pod resource requests & limits                                 | `{}`                          |
+| `securityContext`                  | [Security settings for a container](https://kubernetes.io/docs/concepts/policy/security-context) | `{}` |
+| `podSecurityContext`               | [Security settings for a pod](https://kubernetes.io/docs/concepts/policy/security-context)       | `{}` |
+| `hostNetwork`                      | Use host's network                         | `false`                                           |
+| `dnsPolicy`                        | Specifies the dnsPolicy to use             | `ClusterFirst`                                    |
+| `priorityClassName`                | Specifies the priorityClassName to use     | `NULL`                                            |
+| `tolerations`                      | Optional daemonset tolerations             | `NULL`                                            |
+| `nodeSelector`                     | Node labels for fluent-bit pod assignment  | `NULL`                                            |
+| `affinity`                         | Expressions for affinity                   | `NULL`                                            |
+| `metrics.enabled`                  | Specifies whether a service for metrics should be exposed | `false`                            |
+| `metrics.service.annotations`      | Optional metrics service annotations       | `NULL`                                            |
+| `metrics.service.labels`           | Additional labels for the fluent-bit metrics service definition, specified as a map.                                                    | None                                              |
+| `metrics.service.port`             | Port on where metrics should be exposed    | `2020`                                            |
+| `metrics.service.type`             | Service type for metrics                   | `ClusterIP`                                       |
+| `metrics.serviceMonitor.enabled`          | Set this to `true` to create ServiceMonitor for Prometheus operator                   | `false` |
+| `metrics.serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`    |
+| `metrics.serviceMonitor.namespace`        | Optional namespace in which to create ServiceMonitor                                  | `nil`   |
+| `metrics.serviceMonitor.interval`         | Scrape interval. If not set, the Prometheus default scrape interval is used           | `nil`   |
+| `metrics.serviceMonitor.scrapeTimeout`    | Scrape timeout. If not set, the Prometheus default scrape timeout is used             | `nil`   |
+| `trackOffsets`                     | Specify whether to track the file offsets for tailing docker logs. This allows fluent-bit to pick up where it left after pod restarts but requires access to a `hostPath` | `false` |
+| `testFramework.image`              | `test-framework` image repository.         | `dduportal/bats`                                  |
+| `testFramework.tag`                | `test-framework` image tag.                | `0.4.0`                                           |
+
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/fluent-bit
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Upgrading
+
+### From < 1.0.0 To >= 1.0.0
+
+Values `extraInputs`, `extraFilters` and `extraOutputs` have been removed in version `1.0.0` of the fluent-bit chart.
+To add additional entries to the existing sections, please use the `extraEntries.input`, `extraEntries.filter` and `extraEntries.output` values.
+For entire sections, please use the `rawConfig` value, inserting blocks of text as desired.
+
+### From < 1.8.0 to >= 1.8.0
+
+Version `1.8.0` introduces the use of release name as full name if it contains the chart name(fluent-bit in this case). E.g. with a release name of `fluent-bit`, this renames the DaemonSet from `fluent-bit-fluent-bit` to `fluent-bit`. The suggested approach is to delete the release and reinstall it.

--- a/incubator/fluent-bit-aws/README.md
+++ b/incubator/fluent-bit-aws/README.md
@@ -77,6 +77,15 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `backend.firehose.endpoint`       | Specify a custom endpoint for the Kinesis Firehose API. |  |
 | `backend.firehose.region`         | The region which your Firehose delivery stream(s) is/are in. |  |
 | `backend.firehose.role_arn`       | ARN of an IAM role to assume (for cross account access). |  |
+| **AWS Cloudwatch Backend**              |
+| `backend.cloudwatch.auto_create_group`       | Automatically create the log group. Valid values are "true" or "false" (case insensitive). Defaults to *false*. |  |
+| `backend.cloudwatch.endpoint`       | Specify a custom endpoint for the Cloudwatch Logs API. |  |
+| `backend.cloudwatch.log_group_name`       | The name of the CloudWatch Log Group that you want log records sent to. |  |
+| `backend.cloudwatch.log_key`       | By default, the whole log record will be sent to CloudWatch. If you specify a key name with this option, then only the value of that key will be sent to CloudWatch. |  |
+| `backend.cloudwatch.log_stream_name`       | The name of the CloudWatch Log Stream that you want log records sent to. |  |
+| `backend.cloudwatch.log_stream_prefix`       | Prefix for the Log Stream name. The tag is appended to the prefix to construct the full log stream name. _Not compatible with the log_stream_name option._ |  |
+| `backend.cloudwatch.region`         | The region which your cloudwatch delivery stream(s) is/are in. |  |
+| `backend.cloudwatch.role_arn`       | ARN of an IAM role to assume (for cross account access). |  |
 | **Parsers**                   |
 | `parsers.enabled`                  | Enable custom parsers | `false` |
 | `parsers.regex`                    | List of regex parsers | `NULL` |

--- a/incubator/fluent-bit-aws/README.md
+++ b/incubator/fluent-bit-aws/README.md
@@ -71,6 +71,12 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `backend.splunk.tls_verify`           | Force TLS certificate validation | `off` |
 | `backend.splunk.tls_debug`        | Set TLS debug verbosity level. It accept the following values: 0-4 | `1` |
 | `backend.splunk.message_key`           | Tag applied to all incoming logs | `kubernetes` |
+| **AWS Firehose Backend**              |
+| `backend.firehose.data_keys`       | By default, the whole log record will be sent to Kinesis. If you specify a key name(s) with this option, then only those keys and values will be sent to Kinesis. If you specify multiple keys, they should be comma delimited. |  |
+| `backend.firehose.delivery_stream`       | The name of the delivery stream that you want log records sent to. |  |
+| `backend.firehose.endpoint`       | Specify a custom endpoint for the Kinesis Firehose API. |  |
+| `backend.firehose.region`         | The region which your Firehose delivery stream(s) is/are in. |  |
+| `backend.firehose.role_arn`       | ARN of an IAM role to assume (for cross account access). |  |
 | **Parsers**                   |
 | `parsers.enabled`                  | Enable custom parsers | `false` |
 | `parsers.regex`                    | List of regex parsers | `NULL` |

--- a/incubator/fluent-bit-aws/README.md
+++ b/incubator/fluent-bit-aws/README.md
@@ -14,14 +14,18 @@ This chart will do the following:
 To install the chart with the release name `my-release`:
 
 ```bash
-$ helm install --name my-release stable/fluent-bit
+$ helm install --name my-release incubator/fluent-bit-aws
 ```
 
 When installing this chart on [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/), it's required to specify that so the DaemonSet will be able to mount the log files properly, make sure to append the _--set on\_minikube=true_ option at the end of the _helm_ command, e.g:
 
 ```bash
-$ helm install --name my-release stable/fluent-bit --set on_minikube=true
+$ helm install --name my-release incubator/fluent-bit-aws --set on_minikube=true
 ```
+## AWS provided OUTPUTs
+This chart is based on the AWS provided docker image [amazon/aws-for-fluent-bit](https://hub.docker.com/r/amazon/aws-for-fluent-bit) which provides 2 additional OUTPUTs. Please read their documentation for correct configuration.
+- [cloudwatch](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit)
+- [firehose](https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit)
 
 ## Configuration
 
@@ -87,7 +91,7 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `backend.cloudwatch.region`         | The region which your cloudwatch delivery stream(s) is/are in. |  |
 | `backend.cloudwatch.role_arn`       | ARN of an IAM role to assume (for cross account access). |  |
 | **Parsers**                   |
-| `parsers.enabled`                  | Enable custom parsers | `false` |
+| `parsers.enabled`                  | Enable custom parsers (needs to be set for all parsers) | `false` |
 | `parsers.regex`                    | List of regex parsers | `NULL` |
 | `parsers.json`                     | List of json parsers | `NULL` |
 | `parsers.logfmt`                   | List of logfmt parsers | `NULL` |
@@ -114,6 +118,8 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `filter.kubeTagPrefix`             | Optional tag prefix used by Tail   | `kube.var.log.containers.`                                |
 | `filter.mergeJSONLog`              | If the log field content is a JSON string map, append the map fields as part of the log structure         | `true`                                 |
 | `filter.mergeLogKey`               | If set, append the processed log keys under a new root key specified by this variable. | `nil` |
+| `filter.lua.enabled`               | Enable the use of [lua](https://docs.fluentbit.io/manual/filter/lua) filters                   | `false`                                 |
+| `filter.lua.raw`                   | Provide your Lua file; the file is mounted as `extra.lua` | ``                                 | |
 | `image.fluent_bit.repository`      | Image                                      | `fluent/fluent-bit`                               |
 | `image.fluent_bit.tag`             | Image tag                                  | `1.2.1`                                           |
 | `image.pullPolicy`                 | Image pull policy                          | `Always`                                          |
@@ -162,7 +168,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml stable/fluent-bit
+$ helm install --name my-release -f values.yaml incubator/fluent-bit-aws
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)

--- a/incubator/fluent-bit-aws/templates/NOTES.txt
+++ b/incubator/fluent-bit-aws/templates/NOTES.txt
@@ -1,0 +1,15 @@
+fluent-bit is now running.
+
+{{- if eq .Values.backend.type "forward" }}
+
+It will forward all container logs to the svc named {{ .Values.backend.forward.host }} on port: {{ .Values.backend.forward.port }}
+{{- else if eq .Values.backend.type "es" }}
+
+It will forward all container logs to the svc named {{ .Values.backend.es.host }} on port: {{ .Values.backend.es.port }}
+{{- else if eq .Values.backend.type "http" }}
+
+It will forward all container logs to the svc named {{ .Values.backend.http.host }} on port: {{ .Values.backend.http.port }}
+{{- else if eq .Values.backend.type "splunk" }}
+
+It will forward all container logs to the svc named {{ .Values.backend.splunk.host }} on port: {{ .Values.backend.splunk.port }}
+{{- end }}

--- a/incubator/fluent-bit-aws/templates/_helpers.tpl
+++ b/incubator/fluent-bit-aws/templates/_helpers.tpl
@@ -1,0 +1,67 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fluent-bit.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fluent-bit.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "fluent-bit.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for RBAC APIs.
+*/}}
+{{- define "rbac.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" -}}
+rbac.authorization.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" -}}
+rbac.authorization.k8s.io/v1beta1
+{{- else -}}
+rbac.authorization.k8s.io/v1alpha1
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "fluent-bit.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "fluent-bit.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiGroup for PodSecurityPolicy.
+*/}}
+{{- define "rbac.pspApiGroup" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions" -}}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "policy" -}}
+{{- end -}}
+{{- end -}}

--- a/incubator/fluent-bit-aws/templates/cluster-role.yaml
+++ b/incubator/fluent-bit-aws/templates/cluster-role.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.rbac.create -}}
+apiVersion: {{ template "rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "fluent-bit.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fluent-bit.fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+{{- if .Values.rbac.pspEnabled }}
+  - apiGroups:
+    - {{ template "rbac.pspApiGroup" . }}
+    resources:
+    - podsecuritypolicies
+    resourceNames:
+    - {{ template "fluent-bit.fullname" . }}
+    verbs:
+    - use
+{{- end }}
+{{- end -}}

--- a/incubator/fluent-bit-aws/templates/cluster-rolebinding.yaml
+++ b/incubator/fluent-bit-aws/templates/cluster-rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: {{ template "rbac.apiVersion" . }}
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "fluent-bit.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fluent-bit.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "fluent-bit.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "fluent-bit.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/incubator/fluent-bit-aws/templates/config.yaml
+++ b/incubator/fluent-bit-aws/templates/config.yaml
@@ -1,0 +1,215 @@
+{{- if (empty .Values.existingConfigMap) -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fluent-bit.fullname" . }}-config
+  labels:
+    app: {{ template "fluent-bit.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+data:
+  fluent-bit-service.conf: |-
+    [SERVICE]
+        Flush        {{ .Values.service.flush }}
+        Daemon       Off
+        Log_Level    {{ .Values.service.logLevel }}
+        Parsers_File parsers.conf
+{{- if .Values.parsers.enabled }}
+        Parsers_File parsers_custom.conf
+{{- end }}
+{{- if .Values.metrics.enabled }}
+        HTTP_Server  On
+        HTTP_Listen  0.0.0.0
+        HTTP_Port    2020
+{{- end }}
+
+  fluent-bit-input.conf: |-
+    [INPUT]
+        Name             tail
+        Path             {{ .Values.input.tail.path }}
+        Parser           {{ .Values.input.tail.parser }}
+        Tag              {{ .Values.filter.kubeTag }}.*
+        Refresh_Interval 5
+        Mem_Buf_Limit    {{ .Values.input.tail.memBufLimit }}
+        Skip_Long_Lines  On
+{{- if .Values.trackOffsets }}
+        DB               /tail-db/tail-containers-state.db
+        DB.Sync          Normal
+{{- end }}
+{{- if .Values.input.systemd.enabled }}
+    [INPUT]
+        Name            systemd
+        Tag             {{ .Values.input.systemd.tag }}
+{{- range $value := .Values.input.systemd.filters.systemdUnit }}
+        Systemd_Filter  _SYSTEMD_UNIT={{ $value }}
+{{- end }}
+        Max_Entries     {{ .Values.input.systemd.maxEntries }}
+        Read_From_Tail  {{ .Values.input.systemd.readFromTail }}
+{{- end }}
+{{ .Values.extraEntries.input | indent 8 }}
+
+  fluent-bit-filter.conf: |-
+    [FILTER]
+        Name                kubernetes
+        Match               {{ .Values.filter.kubeTag }}.*
+        Kube_Tag_Prefix     {{ .Values.filter.kubeTagPrefix }}
+        Kube_URL            {{ .Values.filter.kubeURL }}
+        Kube_CA_File        {{ .Values.filter.kubeCAFile }}
+        Kube_Token_File     {{ .Values.filter.kubeTokenFile }}
+{{- if .Values.filter.mergeJSONLog }}
+        Merge_Log           On
+{{- end }}
+
+{{- if .Values.filter.mergeLogKey }}
+        Merge_Log_Key       {{ .Values.filter.mergeLogKey }}
+{{- end }}
+
+{{- if .Values.filter.enableParser }}
+        K8S-Logging.Parser  On
+{{- end }}
+{{- if .Values.filter.enableExclude }}
+        K8S-Logging.Exclude On
+{{- end }}
+{{ .Values.extraEntries.filter | indent 8 }}
+
+  fluent-bit-output.conf: |-
+{{ if eq .Values.backend.type "test" }}
+    [OUTPUT]
+        Name  file
+        Match *
+        Path /tmp/fluent-bit.log
+{{ else if eq .Values.backend.type "forward" }}
+    [OUTPUT]
+        Name          forward
+        Match         *
+        Host          {{ .Values.backend.forward.host }}
+        Port          {{ .Values.backend.forward.port }}
+        Retry_Limit False
+{{- if .Values.backend.forward.shared_key }}
+        Shared_Key    {{ .Values.backend.forward.shared_key }}
+{{- end }}
+{{ else if eq .Values.backend.type "es" }}
+    [OUTPUT]
+        Name  es
+        Match *
+        Host  {{ .Values.backend.es.host }}
+        Port  {{ .Values.backend.es.port }}
+        Logstash_Format On
+        Retry_Limit False
+        Type  {{ .Values.backend.es.type }}
+{{- if .Values.backend.es.time_key }}
+        Time_Key {{ .Values.backend.es.time_key }}
+{{- end }}
+{{- if .Values.backend.es.replace_dots }}
+        Replace_Dots {{ .Values.backend.es.replace_dots }}
+{{- end }}
+{{- if .Values.backend.es.logstash_prefix }}
+        Logstash_Prefix {{ .Values.backend.es.logstash_prefix }}
+{{ else if .Values.backend.es.index }}
+        Index {{ .Values.backend.es.index }}
+{{- end }}
+{{- if .Values.backend.es.http_user }}
+        HTTP_User {{ .Values.backend.es.http_user }}
+        HTTP_Passwd {{ .Values.backend.es.http_passwd }}
+{{- end }}
+{{if eq .Values.backend.es.tls "on" }}
+        tls {{ .Values.backend.es.tls }}
+        tls.verify {{ .Values.backend.es.tls_verify }}
+        tls.debug {{ .Values.backend.es.tls_debug }}
+{{- if .Values.backend.es.tls_ca }}
+        tls.ca_file /secure/es-tls-ca.crt
+{{- end }}
+{{- end }}
+{{ else if eq .Values.backend.type "splunk" }}
+    [OUTPUT]
+        Name  splunk
+        Match *
+        Host  {{ .Values.backend.splunk.host }}
+        Port  {{ .Values.backend.splunk.port }}
+        Splunk_Token  {{ .Values.backend.splunk.token }}
+        Splunk_Send_Raw {{ .Values.backend.splunk.send_raw}}
+        TLS   {{ .Values.backend.splunk.tls }}
+        TLS.Verify   {{ .Values.backend.splunk.tls_verify }}
+        tls.debug {{ .Values.backend.splunk.tls_debug }}
+        Message_Key   {{ .Values.backend.splunk.message_key }}
+{{ else if eq .Values.backend.type "http" }}
+    [OUTPUT]
+        Name  http
+        Match *
+        Host {{ .Values.backend.http.host }}
+        Port {{ .Values.backend.http.port }}
+        URI {{ .Values.backend.http.uri }}
+{{- if .Values.backend.http.http_user }}
+        HTTP_User {{ .Values.backend.http.http_user }}
+        HTTP_Passwd {{ .Values.backend.http.http_passwd }}
+{{- end }}
+        tls {{ .Values.backend.http.tls }}
+        tls.verify {{ .Values.backend.http.tls_verify }}
+        tls.debug {{ .Values.backend.http.tls_debug }}
+{{- if .Values.backend.http.proxy }}
+        Proxy {{ .Values.backend.http.proxy }}
+{{- end }}
+        Format {{ .Values.backend.http.format }}
+{{- end }}
+{{ .Values.extraEntries.output | indent 8 }}
+
+
+  fluent-bit.conf: |-
+{{ .Values.rawConfig | indent 4 }}
+
+  parsers.conf: |-
+{{- if .Values.parsers.regex }}
+{{- range .Values.parsers.regex }}
+    [PARSER]
+        Name        {{ .name }}
+        Format      regex
+        Regex       {{ .regex }}
+{{- if .timeKey }}
+        Time_Key    {{ .timeKey }}
+{{- end }}
+{{- if .timeFormat }}
+        Time_Format {{ .timeFormat }}
+{{- end }}
+{{ end }}
+{{- end }}
+{{- if .Values.parsers.json }}
+{{- range .Values.parsers.json }}
+    [PARSER]
+        Name        {{ .name }}
+        Format      json
+{{- if .timeKeep }}
+        Time_Keep   {{ .timeKeep }}
+{{- end }}
+{{- if .timeKey }}
+        Time_Key    {{ .timeKey }}
+{{- end }}
+{{- if .timeFormat }}
+        Time_Format {{ .timeFormat }}
+{{- end }}
+{{- if .decodeFieldAs  }}
+        Decode_Field_As {{ .decodeFieldAs }} {{ .decodeField | default "log" }}
+{{- end}}
+{{- if .extraEntries }}
+{{ .extraEntries | indent 8 }}
+{{- end }}
+{{ end }}
+{{- end }}
+{{- if .Values.parsers.logfmt }}
+{{- range .Values.parsers.logfmt }}
+    [PARSER]
+        Name        {{ .name }}
+        Format      logfmt
+{{- if .timeKey }}
+        Time_Key    {{ .timeKey }}
+{{- end }}
+{{- if .timeFormat }}
+        Time_Format {{ .timeFormat }}
+{{- end }}
+{{- if .extraEntries }}
+{{ .extraEntries | indent 8 }}
+{{- end }}
+{{ end }}
+{{- end }}
+
+{{- end -}}

--- a/incubator/fluent-bit-aws/templates/config.yaml
+++ b/incubator/fluent-bit-aws/templates/config.yaml
@@ -163,14 +163,16 @@ data:
         endpoint {{ .Values.backend.firehose.endpoint }}
 {{- end }}
         region {{ .Values.backend.firehose.region }}
-{{ .Values.backend.firehose.role_arn }}
+{{- if .Values.backend.firehose.role_arn }}
         role_arn {{ .Values.backend.firehose.role_arn }}
 {{- end }}
-{{ else if eq .Values.backend.type "firehose" }}
+{{ else if eq .Values.backend.type "cloudwatch" }}
     [OUTPUT]
         Name  cloudwatch
         Match **
+{{- if .Values.backend.cloudwatch.auto_create_group }}
         auto_create_group {{ .Values.backend.cloudwatch.auto_create_group }}
+{{- end }}
 {{- if .Values.backend.cloudwatch.endpoint }}
         endpoint {{ .Values.backend.cloudwatch.endpoint }}
 {{- end }}
@@ -178,7 +180,9 @@ data:
 {{- if .Values.backend.cloudwatch.log_key }}
         log_key {{ .Values.backend.cloudwatch.log_key }}
 {{- end }}
+{{- if .Values.backend.cloudwatch.log_stream_name }}
         log_stream_name {{ .Values.backend.cloudwatch.log_stream_name }}
+{{- end }}
 {{- if .Values.backend.cloudwatch.log_stream_prefix }}
         log_stream_prefix {{ .Values.backend.cloudwatch.log_stream_prefix }}
 {{- end }}

--- a/incubator/fluent-bit-aws/templates/config.yaml
+++ b/incubator/fluent-bit-aws/templates/config.yaml
@@ -151,6 +151,41 @@ data:
         Proxy {{ .Values.backend.http.proxy }}
 {{- end }}
         Format {{ .Values.backend.http.format }}
+{{ else if eq .Values.backend.type "firehose" }}
+    [OUTPUT]
+        Name  firehose
+        Match **
+{{- if .Values.backend.firehose.data_keys }}
+        data_keys {{ .Values.backend.firehose.data_keys }}
+{{- end }}
+        delivery_stream {{ .Values.backend.firehose.delivery_stream }}
+{{- if .Values.backend.firehose.endpoint }}
+        endpoint {{ .Values.backend.firehose.endpoint }}
+{{- end }}
+        region {{ .Values.backend.firehose.region }}
+{{ .Values.backend.firehose.role_arn }}
+        role_arn {{ .Values.backend.firehose.role_arn }}
+{{- end }}
+{{ else if eq .Values.backend.type "firehose" }}
+    [OUTPUT]
+        Name  cloudwatch
+        Match **
+        auto_create_group {{ .Values.backend.cloudwatch.auto_create_group }}
+{{- if .Values.backend.cloudwatch.endpoint }}
+        endpoint {{ .Values.backend.cloudwatch.endpoint }}
+{{- end }}
+        log_group_name {{ .Values.backend.cloudwatch.log_group_name }}
+{{- if .Values.backend.cloudwatch.log_key }}
+        log_key {{ .Values.backend.cloudwatch.log_key }}
+{{- end }}
+        log_stream_name {{ .Values.backend.cloudwatch.log_stream_name }}
+{{- if .Values.backend.cloudwatch.log_stream_prefix }}
+        log_stream_prefix {{ .Values.backend.cloudwatch.log_stream_prefix }}
+{{- end }}
+        region {{ .Values.backend.cloudwatch.region }}
+{{- if .Values.backend.cloudwatch.role_arn }}
+        role_arn {{ .Values.backend.cloudwatch.role_arn }}
+{{- end }}
 {{- end }}
 {{ .Values.extraEntries.output | indent 8 }}
 

--- a/incubator/fluent-bit-aws/templates/config.yaml
+++ b/incubator/fluent-bit-aws/templates/config.yaml
@@ -14,7 +14,6 @@ data:
         Flush        {{ .Values.service.flush }}
         Daemon       Off
         Log_Level    {{ .Values.service.logLevel }}
-        Parsers_File parsers.conf
 {{- if .Values.parsers.enabled }}
         Parsers_File parsers_custom.conf
 {{- end }}
@@ -250,5 +249,8 @@ data:
 {{- end }}
 {{ end }}
 {{- end }}
+
+  extra.lua: |-
+{{ .Values.filter.lua.raw | indent 4 }}
 
 {{- end -}}

--- a/incubator/fluent-bit-aws/templates/daemonset.yaml
+++ b/incubator/fluent-bit-aws/templates/daemonset.yaml
@@ -1,0 +1,165 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: {{ template "fluent-bit.fullname" . }}
+  labels:
+    app: {{ template "fluent-bit.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: {{ template "fluent-bit.name" . }}
+        release: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+    spec:
+{{- if .Values.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
+{{- end }}
+{{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+{{- end }}
+{{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.pullSecrets | indent 8 }}
+{{- end }}
+      hostNetwork: {{ .Values.hostNetwork }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      serviceAccountName: {{ template "fluent-bit.serviceAccountName" . }}
+      containers:
+      - name: fluent-bit
+        image: "{{ .Values.image.fluent_bit.repository }}:{{ .Values.image.fluent_bit.tag }}"
+        imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+        env:
+{{ toYaml .Values.env | indent 10 }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+{{- if or .Values.metrics.enabled .Values.extraPorts }}
+        ports:
+{{- if .Values.metrics.enabled }}
+        - name: metrics
+          containerPort: 2020
+          protocol: TCP
+{{- end -}}
+{{- if .Values.extraPorts }}
+{{ toYaml .Values.extraPorts | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if .Values.securityContext }}
+        securityContext:
+{{ toYaml .Values.securityContext | indent 10 }}
+{{- end }}
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+      {{- if .Values.input.systemd.enabled }}
+        - name: etcmachineid
+          mountPath: /etc/machine-id
+          readOnly: true
+      {{- end }}
+{{- if .Values.fullConfigMap }}
+        - name: config
+          mountPath: /fluent-bit/etc
+{{- else }}
+        - name: config
+          mountPath: /fluent-bit/etc/fluent-bit.conf
+          subPath: fluent-bit.conf
+        - name: config
+          mountPath: /fluent-bit/etc/fluent-bit-service.conf
+          subPath: fluent-bit-service.conf
+        - name: config
+          mountPath: /fluent-bit/etc/fluent-bit-input.conf
+          subPath: fluent-bit-input.conf
+        - name: config
+          mountPath: /fluent-bit/etc/fluent-bit-filter.conf
+          subPath: fluent-bit-filter.conf
+        - name: config
+          mountPath: /fluent-bit/etc/fluent-bit-output.conf
+          subPath: fluent-bit-output.conf
+
+{{- if .Values.parsers.enabled }}
+        - name: config
+          mountPath: /fluent-bit/etc/parsers_custom.conf
+          subPath: parsers.conf
+{{- end }}
+{{- end }}
+{{- if .Values.backend.es.tls_ca }}
+        - name: es-tls-secret
+          mountPath: /secure/es-tls-ca.crt
+          subPath: es-tls-ca.crt
+{{- end }}
+{{- if .Values.trackOffsets }}
+        - name: tail-db
+          mountPath: /tail-db
+{{- end }}
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+{{- end }}
+{{ if .Values.on_minikube }}
+        - name: mnt
+          mountPath: /mnt
+          readOnly: true
+{{ end }}
+      terminationGracePeriodSeconds: 10
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+      {{ if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end }}
+    {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+    {{- if .Values.input.systemd.enabled }}
+      - name: etcmachineid
+        hostPath:
+          path: /etc/machine-id
+          type: File
+    {{- end }}
+{{- if .Values.backend.es.tls_ca }}
+      - name: es-tls-secret
+        secret:
+          secretName: "{{ template "fluent-bit.fullname" . }}-es-tls-secret"
+{{- end }}
+{{- if .Values.trackOffsets }}
+      - name: tail-db
+        hostPath:
+          path: {{ .Values.taildb.directory }}
+          type: DirectoryOrCreate
+{{- end }}
+      - name: config
+        configMap:
+          name: {{ if .Values.existingConfigMap }}{{ .Values.existingConfigMap }}{{- else }}{{ template "fluent-bit.fullname" . }}-config{{- end }}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+{{- end }}
+{{ if .Values.on_minikube }}
+      - name: mnt
+        hostPath:
+          path: /mnt
+{{ end }}

--- a/incubator/fluent-bit-aws/templates/daemonset.yaml
+++ b/incubator/fluent-bit-aws/templates/daemonset.yaml
@@ -91,7 +91,11 @@ spec:
         - name: config
           mountPath: /fluent-bit/etc/fluent-bit-output.conf
           subPath: fluent-bit-output.conf
-
+{{- if .Values.filter.lua.enabled }}
+        - name: config
+          mountPath: /fluent-bit/etc/extra.lua
+          subPath: extra.lua
+{{- end }}
 {{- if .Values.parsers.enabled }}
         - name: config
           mountPath: /fluent-bit/etc/parsers_custom.conf

--- a/incubator/fluent-bit-aws/templates/psp.yaml
+++ b/incubator/fluent-bit-aws/templates/psp.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "fluent-bit.fullname" . }}
+spec:
+  # Prevents running in privileged mode
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'secret'
+    - 'hostPath'
+  allowedHostPaths:
+    - pathPrefix: "/var/log"
+    - pathPrefix: "/var/lib/docker/containers"
+      readOnly: true
+{{- if .Values.input.systemd.enabled }}
+    - pathPrefix: "/etc/machine-id"
+      readOnly: true
+{{- end }}
+    - pathPrefix: "/fluent-bit/etc"
+{{- if .Values.trackOffsets }}
+    - pathPrefix: {{ .Values.taildb.directory }}
+{{- end }}
+{{- if .Values.on_minikube }}
+    - pathPrefix: "/mnt"
+{{- end }}
+{{- range .Values.extraVolumes }}
+  {{- if .hostPath }}
+    - pathPrefix: {{ .hostPath.path }}
+  {{- end }}
+{{- end }}
+  hostNetwork: {{ .Values.hostNetwork }}
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/incubator/fluent-bit-aws/templates/secret.yaml
+++ b/incubator/fluent-bit-aws/templates/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ template "fluent-bit.fullname" . }}-es-tls-secret"
+  labels:
+    app: {{ template "fluent-bit.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  es-tls-ca.crt: {{ .Values.backend.es.tls_ca | b64enc | quote }}

--- a/incubator/fluent-bit-aws/templates/service.yaml
+++ b/incubator/fluent-bit-aws/templates/service.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.metrics.service.annotations }}
+  annotations:
+{{ toYaml .Values.metrics.service.annotations | indent 4 }}
+{{- end }}
+  name: {{ template "fluent-bit.fullname" . }}-metrics
+  labels:
+    app: {{ template "fluent-bit.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  {{- if .Values.metrics.service }}
+  {{- range $key, $value := .Values.metrics.service.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+spec:
+  type: {{ .Values.metrics.service.type}}
+  sessionAffinity: None
+  ports:
+  - port: {{ .Values.metrics.service.port }}
+    targetPort: metrics
+    name: metrics
+  selector:
+    app: {{ template "fluent-bit.name" . }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/incubator/fluent-bit-aws/templates/serviceaccount.yaml
+++ b/incubator/fluent-bit-aws/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "fluent-bit.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fluent-bit.serviceAccountName" . }}
+{{- end -}}

--- a/incubator/fluent-bit-aws/templates/servicemonitor.yaml
+++ b/incubator/fluent-bit-aws/templates/servicemonitor.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "fluent-bit.fullname" . }}
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "fluent-bit.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      path: /api/v1/metrics/prometheus
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ include "fluent-bit.name" . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/incubator/fluent-bit-aws/templates/tests/test-configmap.yaml
+++ b/incubator/fluent-bit-aws/templates/tests/test-configmap.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fluent-bit.fullname" . }}-test
+  labels:
+    app: {{ template "fluent-bit.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+data:
+  run.sh: |-
+    {{- if eq .Values.backend.type "forward"}}
+    {{- if eq .Values.backend.forward.tls "on"}}
+    fluent-gem install fluent-plugin-secure-forward
+    {{- end }}
+    @test "Test fluentd" {
+      fluentd -c /tests/fluentd.conf --dry-run
+    }
+    {{- else if eq .Values.backend.type "es"}}
+    @test "Test Elasticssearch Indices" {
+      url="http://{{ .Values.backend.es.host }}:{{ .Values.backend.es.port }}/_cat/indices?format=json"
+      body=$(curl $url)
+
+      result=$(echo $body | jq -cr '.[] | select(.index | contains("{{ .Values.backend.es.index }}"))')
+      [ "$result" != "" ]
+
+      result=$(echo $body | jq -cr '.[] | select((.index | contains("{{ .Values.backend.es.index }}")) and (.health != "green"))')
+      [ "$result" == "" ]
+    }
+    {{- end }}
+
+  fluentd.conf: |-
+    <source>
+      {{- if eq .Values.backend.forward.tls "off" }}
+      @type forward
+      bind 0.0.0.0
+      port {{ .Values.backend.forward.port }}
+      {{- else }}
+      @type secure_forward
+      self_hostname myserver.local
+      secure no
+      {{- end }}
+      shared_key {{ .Values.backend.forward.shared_key }}
+    </source>
+
+    <match **>
+      @type stdout
+    </match>

--- a/incubator/fluent-bit-aws/templates/tests/test.yaml
+++ b/incubator/fluent-bit-aws/templates/tests/test.yaml
@@ -1,0 +1,53 @@
+{{- if or (eq .Values.backend.type "forward") (and (eq .Values.backend.type "es") (eq .Values.backend.es.tls "off")) }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ template "fluent-bit.fullname" . }}-test
+  labels:
+    app: {{ template "fluent-bit.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  initContainers:
+    - name: test-framework
+      image: "{{ .Values.testFramework.image}}:{{ .Values.testFramework.tag }}"
+      command:
+      - "bash"
+      - "-c"
+      - |
+        set -ex
+        # copy bats to tools dir
+        cp -R /usr/local/libexec/ /tools/bats/
+      volumeMounts:
+      - mountPath: /tools
+        name: tools
+  containers:
+    - name: {{ .Release.Name }}-test
+      {{- if eq .Values.backend.type "forward"}}
+      image: "fluent/fluentd:v1.4-debian-1"
+      {{- else }}
+      image: "dwdraju/alpine-curl-jq"
+      {{- end }}
+      command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
+      {{- if and (eq .Values.backend.forward.tls "on") (eq .Values.backend.type "forward") }}
+      securityContext:
+        # run as root to install fluent gems
+        runAsUser: 0
+      {{- end }}
+      volumeMounts:
+        - mountPath: /tests
+          name: tests
+          readOnly: true
+        - mountPath: /tools
+          name: tools
+  volumes:
+  - name: tests
+    configMap:
+      name: {{ template "fluent-bit.fullname" . }}-test
+  - name: tools
+    emptyDir: {}
+  restartPolicy: Never
+{{- end }}

--- a/incubator/fluent-bit-aws/values.yaml
+++ b/incubator/fluent-bit-aws/values.yaml
@@ -1,0 +1,283 @@
+# Minikube stores its logs in a separate directory.
+# Enable if you install the chart in minikube.
+on_minikube: false
+
+image:
+  fluent_bit:
+    repository: fluent/fluent-bit
+    tag: 1.2.1
+  pullPolicy: Always
+
+testFramework:
+  image: "dduportal/bats"
+  tag: "0.4.0"
+
+nameOverride: ""
+fullnameOverride: ""
+
+# When enabled, exposes json and prometheus metrics on {{ .Release.Name }}-metrics service
+metrics:
+  enabled: false
+  service:
+    # labels:
+    #   key: value
+    annotations: {}
+    # In order for Prometheus to consume metrics automatically use the following annotations:
+    # prometheus.io/path: "/api/v1/metrics/prometheus"
+    # prometheus.io/port: "2020"
+    # prometheus.io/scrape: "true"
+    port: 2020
+    type: ClusterIP
+  serviceMonitor:
+    enabled: false
+    additionalLabels: {}
+    # namespace: monitoring
+    # interval: 30s
+    # scrapeTimeout: 10s
+
+# When enabled, fluent-bit will keep track of tailing offsets across pod restarts.
+trackOffsets: false
+
+## PriorityClassName
+## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+priorityClassName: ""
+
+backend:
+  type: forward
+  forward:
+    host: fluentd
+    port: 24284
+    tls: "off"
+    tls_verify: "on"
+    tls_debug: 1
+    shared_key:
+  es:
+    host: elasticsearch
+    port: 9200
+    # Elastic Index Name
+    index: kubernetes_cluster
+    type: flb_type
+    logstash_prefix: kubernetes_cluster
+    replace_dots: "On"
+    time_key: "@timestamp"
+    # Optional username credential for Elastic X-Pack access
+    http_user:
+    # Password for user defined in HTTP_User
+    http_passwd:
+    # Optional TLS encryption to ElasticSearch instance
+    tls: "off"
+    tls_verify: "on"
+    # TLS certificate for the Elastic (in PEM format). Use if tls=on and tls_verify=on.
+    tls_ca: ""
+    # TLS debugging levels = 1-4
+    tls_debug: 1
+  splunk:
+    host: 127.0.0.1
+    port: 8088
+    token: ""
+    send_raw: "on"
+    tls: "on"
+    tls_verify: "off"
+    tls_debug: 1
+    message_key: "kubernetes"
+
+  ##
+  ## Ref: http://fluentbit.io/documentation/current/output/http.html
+  ##
+  http:
+    host: 127.0.0.1
+    port: 80
+    uri: "/"
+    http_user:
+    http_passwd:
+    tls: "off"
+    tls_verify: "on"
+    tls_debug: 1
+    ## Specify the data format to be used in the HTTP request body
+    ## Can be either 'msgpack' or 'json'
+    format: msgpack
+
+parsers:
+  enabled: false
+  ## List the respective parsers in key: value format per entry
+  ## Regex required fields are name and regex. JSON and Logfmt required field
+  ## is name.
+  regex: []
+  logfmt: []
+  ##  json parser config can be defined by providing an extraEntries field.
+  ##  The following entry:
+  ## json:
+  ##   - extraEntries: |
+  ##       Decode_Field_As  escaped log do_next
+  ##       Decode_Field_As  json log
+  ##
+  ##  translates into
+  ##
+  ##   Command       |  Decoder  | Field | Optional Action   |
+  ##   ==============|===========|=======|===================|
+  ##   Decode_Field_As  escaped   log  do_next
+  ##   Decode_Field_As  json log
+  ##
+  json: []
+
+env: []
+
+## Annotations to add to the DaemonSet's Pods
+podAnnotations: {}
+
+## By default there different 'files' provides in the config
+## (fluent-bit.conf, custom_parsers.conf). This defeats
+## changing a configmap (since it uses subPath). If this
+## variable is set, the user is assumed to have provided,
+## in 'existingConfigMap' the entire config (etc/*) of fluent-bit,
+## parsers and system config. In this case, no subPath is
+## used
+fullConfigMap: false
+
+## ConfigMap override where fullname is {{.Release.Name}}-{{.Values.existingConfigMap}}
+## Defining existingConfigMap will cause templates/config.yaml
+## to NOT generate a ConfigMap resource
+##
+existingConfigMap: ""
+
+
+# NOTE If you want to add extra sections, add them here, inbetween the includes,
+# wherever they need to go. Sections order matters.
+
+rawConfig: |-
+  @INCLUDE fluent-bit-service.conf
+  @INCLUDE fluent-bit-input.conf
+  @INCLUDE fluent-bit-filter.conf
+  @INCLUDE fluent-bit-output.conf
+
+
+# WARNING!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# This is to add extra entries to an existing section, NOT for adding new sections
+# Do not submit bugs against indent being wrong. Add your new sections to rawConfig
+# instead.
+#
+extraEntries:
+  input: |-
+#     # >=1 additional Key/Value entrie(s) for existing Input section
+  filter: |-
+#     # >=1 additional Key/Value entrie(s) for existing Filter section
+  output: |-
+#     # >=1 additional Key/Value entrie(s) for existing Ouput section
+# WARNING!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+
+## Extra ports to add to the daemonset ports section
+extraPorts: []
+
+## Extra volumes containing additional files required for fluent-bit to work
+## (eg. CA certificates)
+## Ref: https://kubernetes.io/docs/concepts/storage/volumes/
+##
+extraVolumes: []
+
+## Extra volume mounts for the fluent-bit pod.
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/
+##
+extraVolumeMounts: []
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 10m
+  #   memory: 8Mi
+
+# When enabled, pods will bind to the node's network namespace.
+hostNetwork: false
+
+# Which DNS policy to use for the pod.
+# Consider switching to 'ClusterFirstWithHostNet' when 'hostNetwork' is enabled.
+dnsPolicy: ClusterFirst
+
+## Node tolerations for fluent-bit scheduling to nodes with taints
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+##
+tolerations: []
+# - key: "key"
+#  operator: "Equal|Exists"
+#  value: "value"
+#  effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+## Node labels for fluent-bit pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+affinity: {}
+
+service:
+  flush: 1
+  logLevel: info
+
+input:
+  tail:
+    memBufLimit: 5MB
+    parser: docker
+    path: /var/log/containers/*.log
+  systemd:
+    enabled: false
+    filters:
+      systemdUnit:
+        - docker.service
+        - kubelet.service
+        - node-problem-detector.service
+    maxEntries: 1000
+    readFromTail: true
+    tag: host.*
+
+filter:
+  kubeURL: https://kubernetes.default.svc:443
+  kubeCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  kubeTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+  kubeTag: kube
+  kubeTagPrefix: kube.var.log.containers.
+
+# If true, check to see if the log field content is a JSON string map, if so,
+# it append the map fields as part of the log structure.
+  mergeJSONLog: true
+
+# If set, all unpacked keys from mergeJSONLog (Merge_Log) will be packed under
+# the key name specified on mergeLogKey (Merge_Log_Key)
+  mergeLogKey: ""
+
+# If true, enable the use of monitoring for a pod annotation of
+# fluentbit.io/parser: parser_name. parser_name must be the name
+# of a parser contained within parsers.conf
+  enableParser: true
+
+# If true, enable the use of monitoring for a pod annotation of
+# fluentbit.io/exclude: true. If present, discard logs from that pod.
+  enableExclude: true
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+  # Specifies whether a PodSecurityPolicy should be created
+  pspEnabled: false
+
+taildb:
+  directory: /var/lib/fluent-bit
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+## Specifies security settings for a container
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+securityContext: {}
+  # securityContext:
+  #   privileged: true
+
+## Specifies security settings for a pod
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+podSecurityContext: {}
+  # podSecurityContext:
+  #   runAsUser: 1000

--- a/incubator/fluent-bit-aws/values.yaml
+++ b/incubator/fluent-bit-aws/values.yaml
@@ -4,8 +4,8 @@ on_minikube: false
 
 image:
   fluent_bit:
-    repository: fluent/fluent-bit
-    tag: 1.2.1
+    repository: amazon/aws-for-fluent-bit
+    tag: 1.2.0
   pullPolicy: Always
 
 testFramework:
@@ -80,6 +80,21 @@ backend:
     tls_verify: "off"
     tls_debug: 1
     message_key: "kubernetes"
+  firehose:
+    data_keys:
+    delivery_stream:
+    endpoint:
+    region:
+    role_arn:
+  cloudwatch:
+    auto_create_group:
+    endpoint:
+    log_group_name:
+    log_key:
+    log_stream_name:
+    log_stream_prefix:
+    region:
+    role_arn:
 
   ##
   ## Ref: http://fluentbit.io/documentation/current/output/http.html

--- a/incubator/fluent-bit-aws/values.yaml
+++ b/incubator/fluent-bit-aws/values.yaml
@@ -5,7 +5,7 @@ on_minikube: false
 image:
   fluent_bit:
     repository: amazon/aws-for-fluent-bit
-    tag: 1.2.0
+    tag: 1.2.2
   pullPolicy: Always
 
 testFramework:

--- a/incubator/fluent-bit-aws/values.yaml
+++ b/incubator/fluent-bit-aws/values.yaml
@@ -269,6 +269,22 @@ filter:
 # fluentbit.io/exclude: true. If present, discard logs from that pod.
   enableExclude: true
 
+# if true, enable support for Lua filters in final `extra.lua` file
+# see documentation at https://docs.fluentbit.io/manual/filter/lua
+  lua:
+    enabled: false
+    raw: |-
+    ## example callback
+    #   function cb_print(tag, timestamp, record)
+    #     return code, timestamp, record
+    #   end
+    ##  Usage:
+    # [FILTER]
+    # Name    lua
+    # Match   *
+    # script  extra.lua
+    # call    cb_print
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true


### PR DESCRIPTION
### What this PR does / why we need it:
This PR creates a new chart in `incubator/fluent-bit-aws` providing 2 additional OUTPUTs to AWS's eco-system.

This chart is based on the AWS provided docker image [amazon/aws-for-fluent-bit](https://hub.docker.com/r/amazon/aws-for-fluent-bit) which provides 2 additional OUTPUTs. Please read their documentation for correct configuration.
- [cloudwatch](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit)
- [firehose](https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit)

There is also a AWS blog post about the output plugins and docker image: https://aws.amazon.com/blogs/opensource/centralized-container-logging-fluent-bit/

Please note: I am not related to AWS. 

#### Special notes for your reviewer:
The chart is based on stable/fluent-bit. It contains 2 more PRs already: PR #15776 and PR #15775 .

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
