### PR TITLE
[stable/dokuwiki] Replace lusotycoon/apache-exporter with bitnami/apa…

### DIFF
--- a/stable/dokuwiki/Chart.yaml
+++ b/stable/dokuwiki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dokuwiki
-version: 5.0.0
+version: 5.1.0
 appVersion: 0.20180422.201901061035
 description: DokuWiki is a standards-compliant, simple to use wiki optimized for creating
   documentation. It is targeted at developer teams, workgroups, and small companies.

--- a/stable/dokuwiki/README.md
+++ b/stable/dokuwiki/README.md
@@ -101,8 +101,8 @@ The following table lists the configurable parameters of the DokuWiki chart and 
 | `podAnnotations`                     | Pod annotations                                            | `{}`                                          |
 | `metrics.enabled`                    | Start a side-car prometheus exporter                       | `false`                                       |
 | `metrics.image.registry`             | Apache exporter image registry                             | `docker.io`                                   |
-| `metrics.image.repository`           | Apache exporter image name                                 | `lusotycoon/apache-exporter`                  |
-| `metrics.image.tag`                  | Apache exporter image tag                                  | `v0.5.0`                                      |
+| `metrics.image.repository`           | Apache exporter image name                                 | `bitnami/apache-exporter`                     |
+| `metrics.image.tag`                  | Apache exporter image tag                                  | `{TAG_NAME}`                                  |
 | `metrics.image.pullPolicy`           | Image pull policy                                          | `IfNotPresent`                                |
 | `metrics.image.pullSecrets`          | Specify docker-registry secret names as an array           | `[]` (does not add image pull secrets to deployed pods)      |
 | `metrics.podAnnotations`             | Additional annotations for Metrics exporter pod            | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |

--- a/stable/dokuwiki/values.yaml
+++ b/stable/dokuwiki/values.yaml
@@ -191,8 +191,8 @@ metrics:
   enabled: false
   image:
     registry: docker.io
-    repository: lusotycoon/apache-exporter
-    tag: v0.5.0
+    repository: bitnami/apache-exporter
+    tag: 0.7.0-debian-9-r1
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
…che-exporter (II)

Signed-off-by: Andrés Bono <andresbonojimenez@gmail.com>

#### What this PR does / why we need it:

Bitnami now builds an Apache Exporter based on the Lusitaniae/apache_exporter project. This PR updates this chart to use that container image.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
