### PR TITLE
 [stable/testlink] Fix metrics image tag in README.md

### DIFF
--- a/stable/testlink/Chart.yaml
+++ b/stable/testlink/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: testlink
-version: 5.1.0
+version: 5.1.1
 appVersion: 1.9.19
 description: Web-based test management system that facilitates software quality assurance.
 icon: https://bitnami.com/assets/stacks/testlink/img/testlink-stack-220x234.png

--- a/stable/testlink/README.md
+++ b/stable/testlink/README.md
@@ -104,8 +104,8 @@ The following table lists the configurable parameters of the TestLink chart and 
 | `podAnnotations`                | Pod annotations                                   | `{}`                                                       |
 | `metrics.enabled`                          | Start a side-car prometheus exporter                        | `false`                                              |
 | `metrics.image.registry`                   | Apache exporter image registry                              | `docker.io`                                          |
-| `metrics.image.repository`                 | Apache exporter image name                                  | `bitnami/apache-exporter`                           |
-| `metrics.image.tag`                        | Apache exporter image tag                                   | `0.7.0-debian-9-r2`                                            |
+| `metrics.image.repository`                 | Apache exporter image name                                  | `bitnami/apache-exporter`                            |
+| `metrics.image.tag`                        | Apache exporter image tag                                   | `{TAG_NAME}`                                         |
 | `metrics.image.pullPolicy`                 | Image pull policy                                           | `IfNotPresent`                                       |
 | `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array            | `[]` (does not add image pull secrets to deployed pods)  |
 | `metrics.podAnnotations`                   | Additional annotations for Metrics exporter pod             | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}`                                                   |


### PR DESCRIPTION
Signed-off-by: Andrés Bono <andresbonojimenez@gmail.com>

#### What this PR does / why we need it:

It just fixes a typo in the README.md

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
