### PR TITLE
[stable/instana-agent] Fix information after deployment to show correct method for viewing logs

### DIFF
--- a/stable/instana-agent/Chart.yaml
+++ b/stable/instana-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: instana-agent
-version: 1.0.11
+version: 1.0.12
 appVersion: 1.0
 description: Instana Agent for Kubernetes
 home: https://www.instana.com/

--- a/stable/instana-agent/templates/NOTES.txt
+++ b/stable/instana-agent/templates/NOTES.txt
@@ -61,6 +61,6 @@ It may take a few moments for the agents to fully deploy. You can see what agent
 
 You can get the logs for all of the agents with `kubectl logs`:
 
-    kubectl logs -f $(kubectl get pods -n {{ .Release.Namespace }} -o name) -n {{ .Release.Namespace }} -c instana-agent
+    kubectl logs -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }} -c instana-agent
 
 {{- end }}


### PR DESCRIPTION
## What this PR does / why we need it:

This fixes an issue where the informational note after deploying the chart was incorrect. To obtain logs from multiple instana agent pods requires using the `-l` command with kubectl, which selects pods based on their label.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
