### PR TITLE
[stable/gangway] Add ability to define loadBalancerIP when using Load…

### DIFF
--- a/stable/gangway/Chart.yaml
+++ b/stable/gangway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: An application that can be used to easily enable authentication flows via OIDC for a kubernetes cluster.
 name: gangway
-version: 0.0.5
+version: 0.1.5
 appVersion: 3.0.0
 home: https://github.com/heptiolabs/gangway
 sources:

--- a/stable/gangway/templates/service.yaml
+++ b/stable/gangway/templates/service.yaml
@@ -18,6 +18,9 @@ spec:
       targetPort: {{ .Values.gangway.port }}
       protocol: TCP
       name: http
+{{- if and (eq "LoadBalancer" $.Values.service.type) (.Values.service.loadBalancerIP) }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end}}
   selector:
     app.kubernetes.io/name: {{ include "gangway.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/gangway/values.yaml
+++ b/stable/gangway/values.yaml
@@ -110,6 +110,8 @@ gangway:
 service:
   type: ClusterIP
   port: 80
+  # Specifies a loadBalancerIP when using LoadBalancer service type
+  # loadBalancerIP: 192.168.0.51
 
 ingress:
   enabled: false


### PR DESCRIPTION
…Balancer service type.

Signed-off-by: Nick Perry <nwperry@gmail.com>

@rk295 

#### What this PR does / why we need it:

This adds the ability to specify loadBalancerIP when using the LoadBalancer service type, allowing the user specify what IP address the load balancer will raise for the service.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
