### PR TITLE
[stable/dex] Add ability to define loadBalancerIP when using LoadBala…

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 1.5.1
+version: 1.6.0
 appVersion: 2.17.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/templates/service.yaml
+++ b/stable/dex/templates/service.yaml
@@ -23,6 +23,9 @@ spec:
     nodePort: {{ .nodePort }}
 {{- end}}
 {{- end}}
+{{- if and (eq "LoadBalancer" $.Values.service.type) (.Values.service.loadBalancerIP) }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end}}
 {{- if hasKey .Values.service "externalIPs" }}
   externalIPs:
 {{ toYaml .Values.service.externalIPs | indent 4 }}

--- a/stable/dex/values.yaml
+++ b/stable/dex/values.yaml
@@ -44,6 +44,8 @@ service:
   type: ClusterIP
   port: 8080
   annotations: {}
+  # Specifies a loadBalancerIP when using LoadBalancer service type
+  # loadBalancerIP: 192.168.0.50
 
 ingress:
   enabled: false


### PR DESCRIPTION
…Balancer service type.

Signed-off-by: Nick Perry <nwperry@gmail.com>

@desaintmartin

#### What this PR does / why we need it:

This adds the ability to specify loadBalancerIP when using the LoadBalancer service type, allowing the user specify what IP address the load balancer will raise for the service.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
