### PR TITLE
[stable/airflow] Split node/affinity/toleration features for each component

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 3.0.6
+version: 4.0.0
 appVersion: 1.10.3
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -434,6 +434,9 @@ Full and up-to-date documentation can be found in the comments of the `values.ya
 
 ## Upgrading
 
+### To 4.0.0
+This version splits the specs for the NodeSelector, Affinity and Toleration features. Instead of being global, and injected in every component, they are now defined _by component_ to provide more flexibility for your deployments. As such, the migration steps are really simple. Just copy and paste your node/affinity/tolerance definitions in the four airflow components, which are `worker`, `scheduler`, `flower` and `web`. The default values file should help you with locating those.
+
 ### To 3.0.0
 This version introduces a simplified way of managing secrets, including the database credentials to postgres and redis.
 With the default settings in prior versions, database credentials were generated and stored in an Airflow-managed Kubernetes secret.

--- a/stable/airflow/templates/deployments-flower.yaml
+++ b/stable/airflow/templates/deployments-flower.yaml
@@ -36,17 +36,17 @@ spec:
         - name: {{ .Values.airflow.image.pullSecret }}
       {{- end }}
       restartPolicy: Always
-      {{- if .Values.nodeSelector }}
+      {{- if .Values.flower.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
+{{ toYaml .Values.flower.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.affinity }}
+      {{- if .Values.flower.affinity }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
+{{ toYaml .Values.flower.affinity | indent 8 }}
       {{- end }}
-      {{- if .Values.tolerations }}
+      {{- if .Values.flower.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
+{{ toYaml .Values.flower.tolerations | indent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-flower

--- a/stable/airflow/templates/deployments-scheduler.yaml
+++ b/stable/airflow/templates/deployments-scheduler.yaml
@@ -43,17 +43,17 @@ spec:
         - name: {{ .Values.airflow.image.pullSecret }}
       {{- end }}
       restartPolicy: Always
-      {{- if .Values.nodeSelector }}
+      {{- if .Values.scheduler.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
+{{ toYaml .Values.scheduler.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.affinity }}
+      {{- if .Values.scheduler.affinity }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
+{{ toYaml .Values.scheduler.affinity | indent 8 }}
       {{- end }}
-      {{- if .Values.tolerations }}
+      {{- if .Values.scheduler.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
+{{ toYaml .Values.scheduler.tolerations | indent 8 }}
       {{- end }}
       serviceAccountName: {{ template "airflow.serviceAccountName" . }}
       {{- if .Values.dags.initContainer.enabled }}

--- a/stable/airflow/templates/deployments-web.yaml
+++ b/stable/airflow/templates/deployments-web.yaml
@@ -41,17 +41,17 @@ spec:
         - name: {{ .Values.airflow.image.pullSecret }}
       {{- end }}
       restartPolicy: Always
-      {{- if .Values.nodeSelector }}
+      {{- if .Values.web.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
+{{ toYaml .Values.web.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.affinity }}
+      {{- if .Values.web.affinity }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
+{{ toYaml .Values.web.affinity | indent 8 }}
       {{- end }}
-      {{- if .Values.tolerations }}
+      {{- if .Values.web.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
+{{ toYaml .Values.web.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.dags.initContainer.enabled }}
       initContainers:

--- a/stable/airflow/templates/statefulsets-workers.yaml
+++ b/stable/airflow/templates/statefulsets-workers.yaml
@@ -50,17 +50,17 @@ spec:
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
       serviceAccountName: {{ template "airflow.serviceAccountName" . }}
-      {{- if .Values.nodeSelector }}
+      {{- if .Values.workers.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
+{{ toYaml .Values.workers.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.affinity }}
+      {{- if .Values.workers.affinity }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
+{{ toYaml .Values.workers.affinity | indent 8 }}
       {{- end }}
-      {{- if .Values.tolerations }}
+      {{- if .Values.workers.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
+{{ toYaml .Values.workers.tolerations | indent 8 }}
       {{- end }}
 
       {{- if .Values.dags.initContainer.enabled }}

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -168,6 +168,13 @@ scheduler:
     #   cpu: "500m"
     #   memory: "512Mi"
 
+  ## Support Node, affinity and tolerations for scheduler pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
 
 flower:
   resources: {}
@@ -182,6 +189,14 @@ flower:
     type: ClusterIP
     externalPort: 5555
 
+  ## Support Node, affinity and tolerations for flower pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
 web:
   resources: {}
     # limits:
@@ -192,6 +207,15 @@ web:
     #   memory: "512Mi"
   initialStartupDelay: "60"
   initialDelaySeconds: "360"
+
+  ## Support Node, affinity and tolerations for web pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
 ##
 ## Workers configuration
 workers:
@@ -226,13 +250,14 @@ workers:
   ## Secrets which will be mounted as a file at `secretsDir/<secret name>`.
   secrets: []
 
-## Support Node, affinity and tolerations for airflow and workers labels for pod assignment
-## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
-nodeSelector: {}
-affinity: {}
-tolerations: []
+  ## Support Node, affinity and tolerations for worker pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
 ##
 ## Ingress configuration
 ingress:


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR redefines the affinity-like features to be component specific, instead of global. It's most obvious use case would be when we want to set an anti-affinity to split the workers on multiple nodes.
With a spec such as:
```
  affinity:
    podAntiAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector:
          matchExpressions:
          - key: app
            operator: In
            values:
            - airflow
          - key: component
            operator: In
            values:
            - worker
        topologyKey: "kubernetes.io/hostname"
```
... we can leverage cluster resources with a well spread worker load.
```
NAME                                 READY   STATUS    NODE                  
airflow-flower-7cc88c6b85-w4fwk      1/1     Running   aks-default-11466683-1
airflow-postgresql-75bf7d8774-27ksj  1/1     Running   aks-default-11466683-0
airflow-scheduler-644c9f8596-rj9xt   1/1     Running   aks-default-11466683-4
airflow-web-6984c9f9df-8pm74         1/1     Running   aks-default-11466683-0
airflow-worker-0                     1/1     Running   aks-default-11466683-1
airflow-worker-1                     1/1     Running   aks-default-11466683-0
airflow-worker-2                     1/1     Running   aks-default-11466683-5
airflow-worker-3                     1/1     Running   aks-default-11466683-2
airflow-worker-4                     1/1     Running   aks-default-11466683-3
airflow-worker-5                     1/1     Running   aks-default-11466683-4
```

#### Breaking changes
The obvious consequence is that this is a breaking change, because the already defined affinity, node and tolerations won't be injected in the templates anymore.

According to the best-practices, 
>Any breaking (backwards incompatible) changes to a chart should:
>
>    Bump the MAJOR version
>    In the README, under a section called "Upgrading", describe the manual steps necessary to upgrade to the new (specified) MAJOR version

I'm unsure of the release strategy for this chart, but I feel this PR should be part of `4.0.0`.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Major upgrade steps are documented in the README.md

@gsemet 