### PR TITLE
[stable/datadog] Fix several aspect of KSM integration

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.31.11
+version: 1.32.0
 appVersion: 6.12.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -225,7 +225,7 @@ helm install --name <RELEASE_NAME> \
 | `nameOverride`                           | Override name of app                                                                      | `nil`                                       |
 | `fullnameOverride`                       | Override full name of app                                                                 | `nil`                                       |
 | `rbac.create`                            | If true, create & use RBAC resources                                                      | `true`                                      |
-| `rbac.serviceAccount`                    | existing ServiceAccount to use (ignored if rbac.create=true)                              | `default`                                   |
+| `rbac.serviceAccountName`                | existing ServiceAccount to use (ignored if rbac.create=true)                              | `default`                                   |
 | `daemonset.podLabels`                    | labels to add to each pod                                                                 | `nil`                                       |
 | `datadog.name`                           | Container name if Daemonset or Deployment                                                 | `datadog`                                   |
 | `datadog.site`                           | Site ('datadoghq.com' or 'datadoghq.eu')                                                  | `nil`                                       |
@@ -294,7 +294,8 @@ helm install --name <RELEASE_NAME> \
 | `deployment.priorityClassName`           | Which Priority Class to associate with the deployment                                     | `nil`                                       |
 | `kubeStateMetrics.enabled`               | If true, create kube-state-metrics                                                        | `true`                                      |
 | `kube-state-metrics.rbac.create`         | If true, create & use RBAC resources for kube-state-metrics                               | `true`                                      |
-| `kube-state-metrics.rbac.serviceAccount` | existing ServiceAccount to use (ignored if rbac.create=true) for kube-state-metrics       | `default`                                   |
+| `kube-state-metrics.serviceAccount.create`                 | If true, create & use serviceAccount                                                  | `true`                                     |
+| `kube-state-metrics.serviceAccount.name`                   | If not set & create is true, use template fullname                                    |                                            |
 | `clusterAgent.enabled`                   | Use the cluster-agent for cluster metrics (Kubernetes 1.10+ only)                         | `false`                                     |
 | `clusterAgent.token`                     | A cluster-internal secret for agent-to-agent communication. Must be 32+ characters a-zA-Z | Generates a random value                    |
 | `clusterAgent.containerName`             | The container name for the Cluster Agent                                                  | `cluster-agent`                             |

--- a/stable/datadog/requirements.lock
+++ b/stable/datadog/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.16.0
-digest: sha256:0f9c623d315b30d1b0680cb0146e8740d866d8360eee2fc17d991401e724dfff
-generated: 2019-04-01T16:43:29.032424+02:00
+  version: 2.0.0
+digest: sha256:6ea066b494a2098bbd68567fa714b95f9be5d11c9c16e50db9e947fc96c60cb9
+generated: "2019-07-29T17:35:21.334241+02:00"

--- a/stable/datadog/requirements.yaml
+++ b/stable/datadog/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: kube-state-metrics
-    version: ~0.16.0
+    version: ~2.0.0
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: kubeStateMetrics.enabled

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -16,9 +16,9 @@ image:
 
   ## @param tag - string - required
   ## Define the Agent version to use.
-  ## Use 6.12.1-jmx to enable jmx fetch collection
+  ## Use 6.13.0-jmx to enable jmx fetch collection
   #
-  tag: 6.12.1
+  tag: 6.13.0
 
   ## @param pullPolicy - string - required
   ## The Kubernetes pull policy.
@@ -401,10 +401,16 @@ kube-state-metrics:
     #
     create: true
 
-    ## @param serviceAccountName - string - required
-    ## Ignored if rbac.create is true
-    #
-    serviceAccountName: default
+    serviceAccount:
+      ## @param created - boolean - required
+      ## If true, create ServiceAccount, require rbac kube-state-metrics.rbac.create true
+      #
+      create: true
+      ## @param name - string - required
+      ## The name of the ServiceAccount to use.
+      ## If not set and create is true, a name is generated using the fullname template
+      #
+      name:
 
 daemonset:
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

this PR include several improvements around the `stable/kube-state-metrics` chart integration as `stable/datadog` chat's dependency. 
Also fix another typo in `Readme.md`

- cherry-pick: #15527 that fix  #15526
- update `kube-state-metrics` chart version to `1.2.0` corresponding to the `v1.5.0`
- fix `kube-state-metrics` values overwrite in the `datadog` values.yaml` and `Readme.md`  

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
