### PR TITLE
[stable/metallb] Update MetalLB to 0.8.1.

### DIFF
--- a/stable/metallb/Chart.yaml
+++ b/stable/metallb/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-version: 0.9.7
+version: 0.10.0
 
 name: metallb
-appVersion: 0.7.3
+appVersion: 0.8.1
 description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters
 keywords: ["load-balancer", "balancer", "lb", "bgp", "arp", "vrrp", "vip"]
 home: https://metallb.universe.tf

--- a/stable/metallb/README.md
+++ b/stable/metallb/README.md
@@ -87,7 +87,21 @@ By default, this chart does not install a configuration for MetalLB, and simply
 warns you that you must follow [the configuration instructions on MetalLB's
 website][metallb-config] to create an appropriate ConfigMap.
 
-**Please note:** By default, this chart expects a ConfigMap named 'metallb-config' within the same namespace as the chart is deployed. _This is different than the MetalLB documentation_, which asks you to create a ConfigMap in the `metallb-system` namespace, with the name of 'config'.
+**Please note:** By default, this chart expects a ConfigMap named
+'metallb-config' within the same namespace as the chart is
+deployed. _This is different than the MetalLB documentation_, which
+asks you to create a ConfigMap in the `metallb-system` namespace, with
+the name of 'config'.
+
+For simple setups that only use MetalLB's [ARP mode][metallb-arpndp-concepts],
+you can specify a single IP range using the `arpAddresses` parameter to have the
+chart install a working configuration for you:
+
+```console
+$ helm install --name metallb \
+  --set arpAddresses=192.168.16.240/30 \
+  stable/metallb
+```
 
 If you have a more complex configuration and want Helm to manage it for you, you
 can provide it in the `config` parameter. The configuration format is

--- a/stable/metallb/templates/controller.yaml
+++ b/stable/metallb/templates/controller.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "metallb.fullname" . }}-controller
@@ -34,8 +34,9 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534 # nobody
-    {{- with .Values.controller.nodeSelector }}
       nodeSelector:
+        "beta.kubernetes.io/os": linux
+        {{- with .Values.controller.nodeSelector }}
 {{ toYaml . | indent 8 }}
     {{- end }}
     {{- with .Values.controller.tolerations }}
@@ -62,5 +63,5 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-            - ALL
+            - all
           readOnlyRootFilesystem: true

--- a/stable/metallb/templates/psp.yaml
+++ b/stable/metallb/templates/psp.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.psp.create -}}
 
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "metallb.fullname" . }}-speaker

--- a/stable/metallb/templates/rbac.yaml
+++ b/stable/metallb/templates/rbac.yaml
@@ -34,6 +34,9 @@ rules:
 - apiGroups: [""]
   resources: ["services", "endpoints", "nodes"]
   verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
 {{- if .Values.psp.create }}
 - apiGroups: ["extensions"]
   resources: ["podsecuritypolicies"]
@@ -54,9 +57,6 @@ rules:
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["get", "list", "watch"]
-- apiGroups: [""]
-  resources: ["events"]
-  verbs: ["create"]
 ---
 
 ## Role bindings

--- a/stable/metallb/templates/speaker.yaml
+++ b/stable/metallb/templates/speaker.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "metallb.fullname" . }}-speaker
@@ -28,6 +28,9 @@ spec:
         prometheus.io/port: "7472"
 {{- end }}
     spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       serviceAccountName: {{ template "metallb.speakerServiceAccountName" . }}
       terminationGracePeriodSeconds: 0
       hostNetwork: true
@@ -43,6 +46,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: METALLB_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         ports:
         - name: monitoring
           containerPort: 7472
@@ -55,9 +62,12 @@ spec:
             drop:
             - ALL
             add:
+            - NET_ADMIN
             - NET_RAW
-    {{- with .Values.speaker.nodeSelector }}
+            - SYS_ADMIN
       nodeSelector:
+        "beta.kubernetes.io/os": linux
+        {{- with .Values.speaker.nodeSelector }}
 {{ toYaml . | indent 8 }}
     {{- end }}
     {{- with .Values.speaker.tolerations }}

--- a/stable/metallb/values.yaml
+++ b/stable/metallb/values.yaml
@@ -17,24 +17,7 @@ existingConfigMap: metallb-config
 #
 # Refer to https://metallb.universe.tf/configuration/ for
 # available options.
-configInline: {}
-    # Example ARP Configuration
-    # address-pools:
-    # - name: default
-    #  protocol: layer2
-    #  addresses:
-    #  - 192.168.1.240-192.168.1.250
-    #
-    # Example BGP Configuration
-    # peers:
-    # - peer-address: 10.0.0.1
-    #   peer-asn: 64501
-    #   my-asn: 64500
-    # address-pools:
-    # - name: default
-    #   protocol: bgp
-    #   addresses:
-    #   - 192.168.10.0/24
+configInline:
 
 rbac:
   # create specifies whether to install and use RBAC rules.
@@ -74,7 +57,7 @@ serviceAccounts:
 controller:
   image:
     repository: metallb/controller
-    tag: v0.7.3
+    tag: v0.8.1
     pullPolicy: IfNotPresent
   resources: {}
     # limits:
@@ -89,7 +72,7 @@ controller:
 speaker:
   image:
     repository: metallb/speaker
-    tag: v0.7.3
+    tag: v0.8.1
     pullPolicy: IfNotPresent
   resources: {}
     # limits:


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates MetalLB's chart to 0.8.1. The chart here mirrors the authoritative chart maintained in the upstream repo (https://github.com/danderson/metallb), this PR is a straight `rm -rf && cp -R` of that chart, with minor tweaks like bumping the chart version in conformance with guidelines.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
