### PR TITLE
[stable/velero] Manage cloud-credentials volume(Mount) uniformly for all providers

### DIFF
--- a/stable/velero/Chart.yaml
+++ b/stable/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.0
 description: A Helm chart for velero
 name: velero
-version: 2.1.1
+version: 2.1.2
 home: https://github.com/heptio/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/stable/velero/templates/deployment.yaml
+++ b/stable/velero/templates/deployment.yaml
@@ -61,11 +61,6 @@ spec:
             - --restore-resource-priorities={{ . }}
             {{- end }}
           {{- end }}
-          {{- if eq $provider "azure" }}
-          envFrom:
-            - secretRef:
-                name: {{ include "velero.secretName" . }}
-          {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -73,19 +68,23 @@ spec:
           volumeMounts:
             - name: plugins
               mountPath: /plugins
-        {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp")) }}
-            - name: cloud-credentials
-              mountPath: /credentials
             - name: scratch
               mountPath: /scratch
+        {{- if .Values.credentials.useSecret }}
+            - name: cloud-credentials
+              mountPath: /credentials
         {{- end }}
-          {{- if (or (and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp"))) .Values.configuration.extraEnvVars) }}
+          {{- if (or .Values.credentials.useSecret .Values.configuration.extraEnvVars) }}
           env:
           {{- end }}
-          {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp")) }}
+          {{- if .Values.credentials.useSecret }}
             {{- if eq $provider "aws" }}
             - name: AWS_SHARED_CREDENTIALS_FILE
-            {{- else }}
+            {{- end }}
+            {{- if eq $provider "azure" }}
+            - name: AZURE_CREDENTIALS_FILE
+            {{- end }}
+            {{- if eq $provider "gcp" }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
             {{- end }}
               value: /credentials/cloud
@@ -103,7 +102,7 @@ spec:
         {{- toYaml .Values.initContainers | nindent 8 }}
 {{- end }}
       volumes:
-        {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp")) }}
+        {{- if .Values.credentials.useSecret }}
         - name: cloud-credentials
           secret:
             secretName: {{ include "velero.secretName" . }}


### PR DESCRIPTION
Signed-off-by: John Burns <jburns@ambitenergy.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Mounts a volume for the cloud-credential secret into the pod for all providers and creates a provider-appropriate environment variable in the deployment manifest pointing to the /credentials/cloud path.

#### Which issue this PR fixes
  - fixes #15915

#### Special notes for your reviewer:

@domcar @hectorj2f @nrb @prydonius 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
