### PR TITLE
[stable/jenkins] Allow overwrites of credentials and secrets

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.4.1
+version: 1.4.2
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -137,6 +137,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.sidecars.others`          | Configures additional sidecar container(s) for Jenkins master | `{}`             |
 | `master.initScripts`              | List of Jenkins init scripts         | Not set                                   |
 | `master.credentialsXmlSecret`     | Kubernetes secret that contains a 'credentials.xml' file | Not set               |
+| `master.overwriteCredentialsXml`  | Overwrite installed credentials on start. | `false`                              |
 | `master.secretsFilesSecret`       | Kubernetes secret that contains 'secrets' files | Not set                        |
 | `master.jobs`                     | Jenkins XML job configs              | Not set                                   |
 | `master.overwriteJobs`            | Replace jobs w/ ConfigMap on boot    | `false`                                   |

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -139,6 +139,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.credentialsXmlSecret`     | Kubernetes secret that contains a 'credentials.xml' file | Not set               |
 | `master.overwriteCredentialsXml`  | Overwrite installed credentials on start. | `false`                              |
 | `master.secretsFilesSecret`       | Kubernetes secret that contains 'secrets' files | Not set                        |
+| `master.overwriteSecretsFiles`    | Overwrite installed secrets on start. | `false`                                  |
 | `master.jobs`                     | Jenkins XML job configs              | Not set                                   |
 | `master.overwriteJobs`            | Replace jobs w/ ConfigMap on boot    | `false`                                   |
 | `master.installPlugins`           | List of Jenkins plugins to install. If you don't want to install plugins set it to `[]` | `kubernetes:1.14.0 workflow-aggregator:2.6 credentials-binding:1.17 git:3.9.1 workflow-job:2.31` |

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -286,7 +286,7 @@ data:
     yes {{ if not .Values.master.overwriteCredentialsXml }}n{{ end }} | cp -i /var/jenkins_credentials/credentials.xml /var/jenkins_home;
 {{- end }}
 {{- if .Values.master.secretsFilesSecret }}
-    yes n | cp -i /var/jenkins_secrets/* /usr/share/jenkins/ref/secrets/;
+    yes {{ if not .Values.master.overwriteSecretsFiles }}n{{ end }} | cp -i /var/jenkins_secrets/* /usr/share/jenkins/ref/secrets/;
 {{- end }}
 {{- if .Values.master.jobs }}
     for job in $(ls /var/jenkins_jobs); do

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -283,7 +283,7 @@ data:
   {{- end }}
 {{- end }}
 {{- if .Values.master.credentialsXmlSecret }}
-    yes n | cp -i /var/jenkins_credentials/credentials.xml /var/jenkins_home;
+    yes {{ if not .Values.master.overwriteCredentialsXml }}n{{ end }} | cp -i /var/jenkins_credentials/credentials.xml /var/jenkins_home;
 {{- end }}
 {{- if .Values.master.secretsFilesSecret }}
     yes n | cp -i /var/jenkins_secrets/* /usr/share/jenkins/ref/secrets/;

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -177,6 +177,8 @@ master:
   #    print 'adding global pipeline libraries, register properties, bootstrap jobs...'
   # Kubernetes secret that contains a 'credentials.xml' for Jenkins
   # credentialsXmlSecret: jenkins-credentials
+  # Overwrite installed credentials during Jenkins master start.
+  # overwriteCredentialsXml: false
   # Kubernetes secret that contains files to be put in the Jenkins 'secrets' directory,
   # useful to manage encryption keys used for credentials.xml for instance (such as
   # master.key and hudson.util.Secret)

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -183,6 +183,8 @@ master:
   # useful to manage encryption keys used for credentials.xml for instance (such as
   # master.key and hudson.util.Secret)
   # secretsFilesSecret: jenkins-secrets
+  # Overwrite installed secrets during Jenkins master start.
+  # overwriteSecretsFiles: false
   # Jenkins XML job configs to provision
   jobs:
   #  test: |-


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds 2 flags for overwriting. The first, allows to overwrite the credentials XML file (`master.credentialsXmlSecret`). The second, allows to overwrite the secrets files (`master.secretsFilesSecret`).

This allows to make update to the credentials/secrets when doing a `helm upgrade` on the deployment.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
