### PR TITLE
[stable/k8s-spot-termination-handler] possibility to set NOTICE_URL environment variable

### DIFF
--- a/stable/k8s-spot-termination-handler/Chart.yaml
+++ b/stable/k8s-spot-termination-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.13.0-1"
 description: The K8s Spot Termination handler handles draining AWS Spot Instances in response to termination requests.
 name: k8s-spot-termination-handler
-version: 1.4.0
+version: 1.4.1
 keywords:
   - spot
   - termination

--- a/stable/k8s-spot-termination-handler/README.md
+++ b/stable/k8s-spot-termination-handler/README.md
@@ -29,6 +29,7 @@ Parameter | Description | Default
 `image.repository` | container image repository | `kubeaws/kube-spot-termination-notice-handler`
 `image.tag` | container image tag | `1.13.0-1`
 `image.pullPolicy` | container image pull policy | `IfNotPresent`
+`noticeUrl` | the URL of EC2 spot instance termination notice endpoint | `http://169.254.169.254/latest/meta-data/spot/termination-time`
 `pollInterval` | the interval in seconds between attempts to poll EC2 metadata API for termination events | `"5"`
 `verbose` | Enable verbose | _not defined_
 `slackUrl` | Slack webhook URL to send messages when a termination notice is received | _not defined_

--- a/stable/k8s-spot-termination-handler/templates/daemonset.yaml
+++ b/stable/k8s-spot-termination-handler/templates/daemonset.yaml
@@ -37,6 +37,10 @@ spec:
             - name: VERBOSE
               value: {{ . | quote }}
             {{- end }}
+            {{- with .Values.noticeUrl }}
+            - name: NOTICE_URL
+              value: {{ . | quote }}
+            {{- end }}
             {{- if not .Values.enableLogspout }}
             - name: LOGSPOUT
               value: "ignore"

--- a/stable/k8s-spot-termination-handler/values.yaml
+++ b/stable/k8s-spot-termination-handler/values.yaml
@@ -17,6 +17,9 @@ image:
   tag: 1.13.0-1
   pullPolicy: IfNotPresent
 
+# URL of EC2 spot instance termination notice endpoint
+noticeUrl: http://169.254.169.254/latest/meta-data/spot/termination-time
+
 # Poll the metadata every pollInterval seconds for termination events:
 pollInterval: 5
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Added possibility to set NOTICE_URL environment variable. Useful for tests.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
