### PR TITLE
stable/stackdriver-exporter: Allow setting of pod ServiceAccount name

### DIFF
--- a/stable/stackdriver-exporter/Chart.yaml
+++ b/stable/stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: stackdriver-exporter
-version: 1.1.0
+version: 1.1.1
 appVersion: 0.6.0
 home: https://www.stackdriver.com/
 sources:

--- a/stable/stackdriver-exporter/README.md
+++ b/stable/stackdriver-exporter/README.md
@@ -64,7 +64,8 @@ Parameter                           | Description                               
 `image.tag`                         | Container image tag                                                             | `v0.6.0`
 `image.pullPolicy`                  | Container image pull policy                                                     | `IfNotPresent`
 `resources`                         | Resource requests & limits                                                      | `{}`
-`serviceAccount`                    | Name of Kubernetes service account to use                                       | `default`
+`serviceAccount.name`               | Name of Kubernetes service account to use                                       | `""` (defaults to `default`)
+`serviceAccount.create`             | Toggle for service account creation                                             | `false`
 `service.type`                      | Type of service to create                                                       | `ClusterIP`
 `service.httpPort`                  | Port for the http service                                                       | `9255`
 `stackdriver.projectId`             | GCP Project ID                                                                  | ``

--- a/stable/stackdriver-exporter/README.md
+++ b/stable/stackdriver-exporter/README.md
@@ -64,6 +64,7 @@ Parameter                           | Description                               
 `image.tag`                         | Container image tag                                                             | `v0.6.0`
 `image.pullPolicy`                  | Container image pull policy                                                     | `IfNotPresent`
 `resources`                         | Resource requests & limits                                                      | `{}`
+`serviceAccount`                    | Name of Kubernetes service account to use                                       | `default`
 `service.type`                      | Type of service to create                                                       | `ClusterIP`
 `service.httpPort`                  | Port for the http service                                                       | `9255`
 `stackdriver.projectId`             | GCP Project ID                                                                  | ``

--- a/stable/stackdriver-exporter/templates/_helpers.tpl
+++ b/stable/stackdriver-exporter/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "stackdriver-exporter.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "stackdriver-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "stackdriver-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/stackdriver-exporter/templates/deployment.yaml
+++ b/stable/stackdriver-exporter/templates/deployment.yaml
@@ -32,9 +32,7 @@ spec:
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
 {{- end }}
-{{- if .Values.serviceAccount }}
-      serviceAccount: {{ .Values.serviceAccount }}
-{{- end }}
+      serviceAccount: {{ template "stackdriver-exporter.serviceAccountName" . }}
       restartPolicy: {{ .Values.restartPolicy }}
       volumes:
       {{- if .Values.stackdriver.serviceAccountSecret }}

--- a/stable/stackdriver-exporter/templates/deployment.yaml
+++ b/stable/stackdriver-exporter/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
 {{- end }}
+{{- if .Values.serviceAccount }}
+      serviceAccount: {{ .Values.serviceAccount }}
+{{- end }}
       restartPolicy: {{ .Values.restartPolicy }}
       volumes:
       {{- if .Values.stackdriver.serviceAccountSecret }}

--- a/stable/stackdriver-exporter/templates/serviceaccount.yaml
+++ b/stable/stackdriver-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    chart: {{ template "stackdriver-exporter.chart" . }}
+    app: {{ template "stackdriver-exporter.name" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  name: {{ template "stackdriver-exporter.serviceAccountName" . }}
+{{- end -}}

--- a/stable/stackdriver-exporter/values.yaml
+++ b/stable/stackdriver-exporter/values.yaml
@@ -57,6 +57,9 @@ web:
 ##
 affinity: {}
 
+## Pod serviceAccount
+serviceAccount: default
+
 annotations: {}
 
 ## Node labels for stackdriver-exporter pod assignment

--- a/stable/stackdriver-exporter/values.yaml
+++ b/stable/stackdriver-exporter/values.yaml
@@ -57,9 +57,6 @@ web:
 ##
 affinity: {}
 
-## Pod serviceAccount
-serviceAccount: default
-
 annotations: {}
 
 ## Node labels for stackdriver-exporter pod assignment
@@ -75,3 +72,14 @@ tolerations: []
   #   operator: "Equal|Exists"
   #   value: "value"
   #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+
+## Service Account
+##
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: false
+  # The name of the ServiceAccount to use.
+  # If not set and create is false, 'default' is used
+  # If not set and create is true, a name is generated using the fullname template
+  name:


### PR DESCRIPTION
#### What this PR does / why we need it:

This makes it possible to use a serviceAccount other than the default.

I need this to aid my use the chart in conjunction with GKE's [Workload Identity feature](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) which requires the use of an annotated service account for pods using Google APIs.

#### Which issue this PR fixes
NA

#### Special notes for your reviewer:
NA

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
