### PR TITLE
[stable/k8s-spot-termination-handler] bump image version

### DIFF
--- a/stable/k8s-spot-termination-handler/Chart.yaml
+++ b/stable/k8s-spot-termination-handler/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.13.0-1"
+appVersion: "1.13.7-1"
 description: The K8s Spot Termination handler handles draining AWS Spot Instances in response to termination requests.
 name: k8s-spot-termination-handler
-version: 1.4.1
+version: 1.4.2
 keywords:
   - spot
   - termination

--- a/stable/k8s-spot-termination-handler/README.md
+++ b/stable/k8s-spot-termination-handler/README.md
@@ -27,7 +27,7 @@ The following table lists the configurable parameters of the k8s-spot-terminatio
 Parameter | Description | Default
 --- | --- | ---
 `image.repository` | container image repository | `kubeaws/kube-spot-termination-notice-handler`
-`image.tag` | container image tag | `1.13.0-1`
+`image.tag` | container image tag | `1.13.7-1`
 `image.pullPolicy` | container image pull policy | `IfNotPresent`
 `noticeUrl` | the URL of EC2 spot instance termination notice endpoint | `http://169.254.169.254/latest/meta-data/spot/termination-time`
 `pollInterval` | the interval in seconds between attempts to poll EC2 metadata API for termination events | `"5"`

--- a/stable/k8s-spot-termination-handler/values.yaml
+++ b/stable/k8s-spot-termination-handler/values.yaml
@@ -14,7 +14,7 @@ serviceAccount:
 
 image:
   repository: kubeaws/kube-spot-termination-notice-handler
-  tag: 1.13.0-1
+  tag: 1.13.7-1
   pullPolicy: IfNotPresent
 
 # URL of EC2 spot instance termination notice endpoint


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
Bumped `kube-spot-termination-notice-handler` image version to `1.13.7-1`. This version fixes `detach from the AutoScaling Group` step

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
