### PR TITLE
[stable/k8s-spot-termination-handler] possibility to set kubernetes secret with environment variables

### DIFF
--- a/stable/k8s-spot-termination-handler/Chart.yaml
+++ b/stable/k8s-spot-termination-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.13.7-1"
 description: The K8s Spot Termination handler handles draining AWS Spot Instances in response to termination requests.
 name: k8s-spot-termination-handler
-version: 1.4.2
+version: 1.4.3
 keywords:
   - spot
   - termination

--- a/stable/k8s-spot-termination-handler/README.md
+++ b/stable/k8s-spot-termination-handler/README.md
@@ -40,6 +40,7 @@ Parameter | Description | Default
 `serviceAccount.name` | the name of the service account to use. If not set and `create` is `true`, a name is generated using the fullname template. | ``
 `detachAsg` | if `true`, the spot termination handler will detect (standard) AutoScaling Group, and initiate detach when termination notice is detected. | `false`
 `gracePeriod` | Grace period for node draining | `120`
+`envFromSecret` | Name of a Kubenretes secret (must be manually created in the same namespace) containing values to be added to the environment | `""` |
 `resources` | pod resource requests & limits | `{}`
 `nodeSelector` | node labels for pod assignment | `{}`
 `tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`

--- a/stable/k8s-spot-termination-handler/templates/daemonset.yaml
+++ b/stable/k8s-spot-termination-handler/templates/daemonset.yaml
@@ -69,6 +69,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          {{- if .Values.envFromSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.envFromSecret }}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/stable/k8s-spot-termination-handler/values.yaml
+++ b/stable/k8s-spot-termination-handler/values.yaml
@@ -41,6 +41,10 @@ detachAsg: false
 # Grace period for node draining
 gracePeriod: 120
 
+## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
+## This can be useful for auth tokens, etc
+envFromSecret: ""
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
Added possibility to use kubernetes secret with environment variables. Can be useful for auth tokens, passwords for Slack, Gmail notifications.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
