### PR TITLE
[stable/hazelcast] Sync up with the hazelcast Helm Chart repo

### DIFF
--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,7 +1,8 @@
-apiVersion: v1
 name: hazelcast
-version: 1.4.0
+version: 2.0.0
 appVersion: "3.12.1"
+tillerVersion: ">=2.7.2"
+kubeVersion: ">=1.9.0-0"
 description: Hazelcast IMDG is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.
 keywords:
 - hazelcast
@@ -9,7 +10,7 @@ keywords:
 - in-memory
 - database
 - caching
-home: http://hazelcast.com/
+home: http://hazelcast.org/
 icon: http://hazelcast.com/images/logos/Hazelcast-IMDG-Logo-Orange_Dark_Icon_200px.png
 sources:
 - https://github.com/hazelcast/hazelcast

--- a/stable/hazelcast/README.md
+++ b/stable/hazelcast/README.md
@@ -10,7 +10,7 @@ $ helm install stable/hazelcast
 
 ## Introduction
 
-This chart bootstraps a [Hazelcast](https://github.com/hazelcast/hazelcast-docker/tree/master/hazelcast-kubernetes) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Hazelcast](https://github.com/hazelcast/hazelcast-docker/tree/master/hazelcast-kubernetes) and [Management Center](https://github.com/hazelcast/management-center-docker) deployments on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 
@@ -51,8 +51,11 @@ The following table lists the configurable parameters of the Hazelcast chart and
 | `cluster.memberCount`                      | Number of Hazelcast members                                                                                    | 2                                                    |
 | `hazelcast.rest`                           | Enable REST endpoints for Hazelcast member                                                                     | `true`                                               |
 | `hazelcast.javaOpts`                       | Additional JAVA_OPTS properties for Hazelcast member                                                           | `nil`                                                |
-| `hazelcast.configurationFiles`             | Hazelcast configuration files                                                                                  | `{DEFAULT_HAZELCAST_XML}`                            |
+| `hazelcast.existingConfigMap`              | ConfigMap which contains Hazelcast configuration file(s) that are used instead hazelcast.yaml embedded into values.yaml | `nil`                                                |
+| `hazelcast.yaml`                           | Hazelcast YAML Configuration (`hazelcast.yaml` embedded into `values.yaml`)                                    | `{DEFAULT_HAZELCAST_YAML}`                           |
+| `hazelcast.configurationFiles`             | Hazelcast configuration files                                                                                  | `nil`                                                |
 | `nodeSelector`                             | Hazelcast Node labels for pod assignment                                                                       | `nil`                                                |
+| `hostPort`                                 | Port under which Hazelcast PODs are exposed on the host machines                                               | `nil`                                                |
 | `gracefulShutdown.enabled`                 | Turn on and off Graceful Shutdown                                                                              | `true`                                               |
 | `gracefulShutdown.maxWaitSeconds`          | Maximum time to wait for the Hazelcast POD to shut down                                                        | `600`                                                |
 | `livenessProbe.enabled`                    | Turn on and off liveness probe                                                                                 | `true`                                               |
@@ -67,23 +70,55 @@ The following table lists the configurable parameters of the Hazelcast chart and
 | `readinessProbe.timeoutSeconds`            | When the probe times out                                                                                       | `1`                                                  |
 | `readinessProbe.successThreshold`          | Minimum consecutive successes for the probe to be considered successful after having failed                    | `1`                                                  |
 | `readinessProbe.failureThreshold`          | Minimum consecutive failures for the probe to be considered failed after having succeeded.                     | `3`                                                  |
-| `resources`                                | CPU/Memory resource requests/limits                                                                            | `nil`                                                |
+| `resources.limits.cpu`                     | CPU resource limit                                                                                             | `default`                                            |
+| `resources.limits.memory`                  | Memory resource limit                                                                                          | `default`                                            |
+| `resources.requests.cpu`                   | CPU resource requests                                                                                          | `default`                                            |
+| `resources.requests.memory`                | Memory resource requests                                                                                       | `default`                                            |
 | `service.type`                             | Kubernetes service type ('ClusterIP', 'LoadBalancer', or 'NodePort')                                           | `ClusterIP`                                          |
 | `service.port`                             | Kubernetes service port                                                                                        | `5701`                                               |
 | `rbac.create`                              | Enable installing RBAC Role authorization                                                                      | `true`                                               |
 | `serviceAccount.create`                    | Enable installing Service Account                                                                              | `true`                                               |
 | `serviceAccount.name`                      | Name of Service Account, if not set, the name is generated using the fullname template                         | `nil`                                                |
-| `securityContext.fsGroup`                  | Group ID associated with the Hazelcast container                                                               | `65534`                                              |
-| `securityContext.runAsUser`                | User ID associated with the Hazelcast container                                                                | `65534`                                              |
-| `securityContext.runAsNonRoot`             | Runs Hazelcast container as non-root user                                                                      | `true`                                               |
-| `securityContext.readOnlyRootFilesystem`   | Read only root filesystem                                                                                      | `true`                                               |
-| `securityContext.allowPrivilegeEscalation` | Allows privilege escalation                                                                                    | `false`                                              |
-| `securityContext.defaultAllowPrivilegeEscalation` | Default allow privilege escalation                                                                             | `false`                                              |
+| `securityContext.enabled`                  | Enables Security Context for Hazelcast and Management Center                                                   | `true`                                               |
+| `securityContext.runAsUser`                | User ID used to run the Hazelcast and Management Center containers                                             | `65534`                                              |
+| `securityContext.fsGroup`                  | Group ID associated with the Hazelcast and Management Center container                                         | `65534`                                              |
 | `metrics.enabled`                          | Turn on and off JMX Prometheus metrics available at `/metrics`                                                 | `false`                                              |
 | `metrics.service.type`                     | Type of the metrics service                                                                                    | `ClusterIP`                                          |
 | `metrics.service.port`                     | Port of the `/metrics` endpoint and the metrics service                                                        | `8080`                                               |
 | `metrics.service.annotations`              | Annotations for the Prometheus discovery                                                                       |                                                      |
-
+| `customVolume`                             | Configuration for a volume mounted as '/data/custom' (e.g. to mount a volume with custom JARs)                 | `nil`                                                |
+| `mancenter.enabled`                        | Turn on and off Management Center application                                                                  | `true`                                               |
+| `mancenter.image.repository`               | Hazelcast Management Center Image name                                                                         | `hazelcast/management-center`                        |
+| `mancenter.image.tag`                      | Hazelcast Management Center Image tag (NOTE: must be the same or one minor release greater than Hazelcast image version) | `{VERSION}`                                  |
+| `mancenter.image.pullPolicy`               | Image pull policy                                                                                              | `IfNotPresent`                                       |
+| `mancenter.image.pullSecrets`              | Specify docker-registry secret names as an array                                                               | `nil`                                                |
+| `mancenter.javaOpts`                       | Additional JAVA_OPTS properties for Hazelcast Management Center                                                | `nil`                                                |
+| `mancenter.licenseKey`                     | License Key for Hazelcast Management Center, if not provided, can be filled in the web interface               | `nil`                                                |
+| `mancenter.licenseKeySecretName`           | Kubernetes Secret Name, where Management Center License Key is stored (can be used instead of licenseKey)      | `nil`                                                |
+| `mancenter.nodeSelector`                   | Hazelcast Management Center node labels for pod assignment                                                     | `nil`                                                |
+| `mancenter.resources`                      | CPU/Memory resource requests/limits                                                                            | `nil`                                                |
+| `mancenter.persistence.enabled`            | Enable Persistent Volume for Hazelcast Management                                                              | `true`                                               |
+| `mancenter.persistence.existingClaim`      | Name of the existing Persistence Volume Claim, if not defined, a new is created                                | `nil`                                                |
+| `mancenter.persistence.accessModes`        | Access Modes of the new Persistent Volume Claim                                                                | `ReadWriteOnce`                                      |
+| `mancenter.persistence.size`               | Size of the new Persistent Volume Claim                                                                        | `8Gi`                                                |
+| `mancenter.service.type`                   | Kubernetes service type ('ClusterIP', 'LoadBalancer', or 'NodePort')                                           | `LoadBalancer`                                       |
+| `mancenter.service.port`                   | Kubernetes service port                                                                                        | `5701`                                               |
+| `mancenter.livenessProbe.enabled`          | Turn on and off liveness probe                                                                                 | `true`                                               |
+| `mancenter.livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated                                                                    | `30`                                                 |
+| `mancenter.livenessProbe.periodSeconds`    | How often to perform the probe                                                                                 | `10`                                                 |
+| `mancenter.livenessProbe.timeoutSeconds`   | When the probe times out                                                                                       | `5`                                                  |
+| `mancenter.livenessProbe.successThreshold` | Minimum consecutive successes for the probe to be considered successful after having failed                    | `1`                                                  |
+| `mancenter.livenessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded.                     | `3`                                                  |
+| `mancenter.readinessProbe.enabled`         | Turn on and off readiness probe                                                                                | `true`                                               |
+| `mancenter.readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                                                  | `30`                                                 |
+| `mancenter.readinessProbe.periodSeconds`   | How often to perform the probe                                                                                 | `10`                                                 |
+| `mancenter.readinessProbe.timeoutSeconds`  | When the probe times out                                                                                       | `1`                                                  |
+| `mancenter.readinessProbe.successThreshold`| Minimum consecutive successes for the probe to be considered successful after having failed                    | `1`                                                  |
+| `mancenter.readinessProbe.failureThreshold`| Minimum consecutive failures for the probe to be considered failed after having succeeded.                     | `3`                                                  |
+| `mancenter.ingress.enabled`                | Enable ingress for the management center                             | `false`                                     |
+| `mancenter.ingress.annotations`            | Any annotations for the ingress                                      | `{}`                                        |
+| `mancenter.ingress.hosts`                  | List of hostnames for ingress, see `values.yaml` for example         | `[]`                                        |
+| `mancenter.ingress.tls`                    | List of TLS configuration for ingress, see `values.yaml` for example | `[]`                                        |  
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -105,31 +140,20 @@ $ helm install --name my-release -f values.yaml stable/hazelcast
 
 ## Custom Hazelcast configuration
 
-Custom Hazelcast configuration can be specified inside `values.yaml`, as the `hazelcast.configurationFiles.hazelcast.xml` property.
+Custom Hazelcast configuration can be specified inside `values.yaml`, as the `hazelcast.yaml` property.
 
 ```yaml
 hazelcast:
-  configurationFiles:
-    hazelcast.xml: |-
-      <?xml version="1.0" encoding="UTF-8"?>
-      <hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-                     xmlns="http://www.hazelcast.com/schema/config"
-                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    
-        <properties>
-          <property name="hazelcast.discovery.enabled">true</property>
-        </properties>
-        <network>
-          <join>
-            <multicast enabled="false"/>
-            <tcp-ip enabled="false" />
-            <discovery-strategies>
-              <discovery-strategy enabled="true" class="com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy">
-              </discovery-strategy>
-            </discovery-strategies>
-          </join>
-        </network>
-
+   yaml:
+    hazelcast:
+      network:
+        join:
+          multicast:
+            enabled: false
+          kubernetes:
+            enabled: true
+            service-name: ${serviceName}
+            namespace: ${namespace}
+            resolve-not-ready-addresses: true
         <!-- Custom Configuration Placeholder -->
-      </hazelcast>
 ```

--- a/stable/hazelcast/templates/NOTES.txt
+++ b/stable/hazelcast/templates/NOTES.txt
@@ -4,14 +4,14 @@
 
 To access Hazelcast within the Kubernetes cluster:
 
-- Use Hazelcast Client with Kubernetes Discovery Strategy pointing to DNS: {{ template "hazelcast.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local. Read more at: https://github.com/hazelcast/hazelcast-kubernetes.
+- Use Hazelcast Client with Kubernetes Discovery Strategy. Read more at: https://github.com/hazelcast/hazelcast-kubernetes.
 {{- if .Values.hazelcast.rest }}
 
 - Use REST endpoint:
   *) Insert Data:
-     $ curl -v -X POST -H "Content-Type: text/plain" -d "bar" http://{{ template "hazelcast.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5701/hazelcast/rest/maps/mapName/foo
+     $ curl -v -X POST -H "Content-Type: text/plain" -d "bar" http://{{ template "hazelcast.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/hazelcast/rest/maps/mapName/foo
   *) Get Data:
-     $ curl http://{{ template "hazelcast.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5701/hazelcast/rest/maps/mapName/foo
+     $ curl http://{{ template "hazelcast.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/hazelcast/rest/maps/mapName/foo
 {{- end }}
 
 -------------------------------------------------------------------------------
@@ -27,8 +27,8 @@ To access Hazelcast from outside the Kubernetes cluster:
      clientConfig.getNetworkConfig().addAddress("$SERVICE_IP:{{ .Values.service.port }}");
 {{- else if contains "ClusterIP" .Values.service.type }}
   *) Forward port from POD:
-     $ export POD=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "hazelcast.name" . }}" -o jsonpath="{.items[0].metadata.name}")
-     $ kubectl port-forward --namespace {{ .Release.Namespace }} $POD 5701:5701
+     $ export POD=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "hazelcast.name" . }},role=hazelcast" -o jsonpath="{.items[0].metadata.name}")
+     $ kubectl port-forward --namespace {{ .Release.Namespace }} $POD 5701:{{ .Values.service.port }}
   *) In Hazelcast Client configure:
      clientConfig.getNetworkConfig().setSmartRouting(false);
      clientConfig.getNetworkConfig().addAddress("127.0.0.1:5701");
@@ -52,8 +52,8 @@ To access Hazelcast from outside the Kubernetes cluster:
      $ curl http://$SERVICE_IP:{{ .Values.service.port }}/hazelcast/rest/maps/mapName/foo
 {{- else if contains "ClusterIP" .Values.service.type }}
   *) Forward port from POD:
-     $ export POD=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "hazelcast.name" . }}" -o jsonpath="{.items[0].metadata.name}")
-     $ kubectl port-forward --namespace {{ .Release.Namespace }} $POD 5701:5701
+     $ export POD=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "hazelcast.name" . }},role=hazelcast" -o jsonpath="{.items[0].metadata.name}")
+     $ kubectl port-forward --namespace {{ .Release.Namespace }} $POD 5701:{{ .Values.service.port }}
   *) Insert Data:
      $ curl -v -X POST -H "Content-Type: text/plain" -d "bar" http://127.0.0.1:5701/hazelcast/rest/maps/mapName/foo
   *) Get Data:
@@ -66,5 +66,28 @@ To access Hazelcast from outside the Kubernetes cluster:
      $ curl -v -X POST -H "Content-Type: text/plain" -d "bar" http://$NODE_IP:$NODE_PORT/hazelcast/rest/maps/mapName/foo
   *) Get Data:
      $ curl http://$NODE_IP:$NODE_PORT/hazelcast/rest/maps/mapName/foo
+{{- end }}
+{{- end }}
+
+{{- if .Values.mancenter.enabled }}
+
+-------------------------------------------------------------------------------
+
+To access Hazelcast Management Center:
+
+{{- if contains "LoadBalancer" .Values.mancenter.service.type }}
+  *) Check Management Center external IP:
+     $ export MANCENTER_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "mancenter.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  *) Open Browser at: http://$MANCENTER_IP:{{ .Values.mancenter.service.port }}/hazelcast-mancenter
+{{- else if contains "ClusterIP" .Values.mancenter.service.type }}
+  *) Forward port from POD:
+     $ export POD=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "hazelcast.name" . }},role=mancenter" -o jsonpath="{.items[0].metadata.name}")
+     $ kubectl port-forward --namespace {{ .Release.Namespace }} $POD 8080:8080
+  *) Open Browser at: http://127.0.0.1:8080/hazelcast-mancenter
+{{- else if contains "NodePort" .Values.mancenter.service.type }}
+  *) Check Node IP and Port:
+     $ export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+     $ export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "mancenter.fullname" . }})
+  *) Open Browser at: http://$NODE_IP:$NODE_PORT/hazelcast-mancenter
 {{- end }}
 {{- end }}

--- a/stable/hazelcast/templates/_helpers.tpl
+++ b/stable/hazelcast/templates/_helpers.tpl
@@ -41,3 +41,12 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create a default fully qualified Management Center app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mancenter.fullname" -}}
+{{ (include "hazelcast.fullname" .) | trunc 53 | }}-mancenter
+{{- end -}}

--- a/stable/hazelcast/templates/config.yaml
+++ b/stable/hazelcast/templates/config.yaml
@@ -1,13 +1,13 @@
-{{- if or .Values.hazelcast.configurationFiles .Values.hazelcast.yaml }}
+{{- if and (or .Values.hazelcast.configurationFiles .Values.hazelcast.yaml) (not .Values.hazelcast.existingConfigMap) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "hazelcast.fullname" . }}-configuration
   labels:
-    app: {{ template "hazelcast.name" . }}
-    chart: {{ template "hazelcast.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "hazelcast.name" . }}
+    helm.sh/chart: {{ template "hazelcast.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 data:
 {{- range $key, $val := .Values.hazelcast.configurationFiles }}
   {{ $key }}: |-

--- a/stable/hazelcast/templates/mancenter-ingress.yaml
+++ b/stable/hazelcast/templates/mancenter-ingress.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.mancenter.ingress.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: "{{ include "mancenter.fullname" . }}"
+  labels:
+    app.kubernetes.io/name: {{ template "hazelcast.name" . }}
+    helm.sh/chart: {{ template "hazelcast.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+{{- if .Values.mancenter.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.mancenter.ingress.annotations | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.mancenter.ingress.tls }}
+  tls:
+  {{- range .Values.mancenter.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- $serviceName := include "mancenter.fullname" . -}}
+  {{- if .Values.mancenter.ingress.hosts }}
+  {{- range $host := .Values.mancenter.ingress.hosts }}
+    - host: {{ $host | quote }}
+      http:
+        paths:
+          - backend:
+              serviceName: {{ $serviceName }}
+              servicePort: mancenterport
+  {{- end }}
+  {{- else }}
+  - http:
+      paths:
+      - backend:
+          serviceName: {{ $serviceName }}
+          servicePort: mancenterport
+  {{- end }}
+{{- end }}

--- a/stable/hazelcast/templates/mancenter-pvc.yaml
+++ b/stable/hazelcast/templates/mancenter-pvc.yaml
@@ -1,0 +1,26 @@
+{{- if and (and .Values.mancenter.enabled .Values.mancenter.persistence.enabled (not .Values.mancenter.persistence.existingClaim)) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "mancenter.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "hazelcast.name" . }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+spec:
+  accessModes:
+  {{- range .Values.mancenter.persistence.accessModes }}
+    - {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.mancenter.persistence.size | quote }}
+{{- if .Values.mancenter.persistence.storageClass }}
+{{- if (eq "-" .Values.mancenter.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.mancenter.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/stable/hazelcast/templates/mancenter-service.yaml
+++ b/stable/hazelcast/templates/mancenter-service.yaml
@@ -1,23 +1,25 @@
+{{- if .Values.mancenter.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "hazelcast.fullname" . }}
+  name: {{ template "mancenter.fullname" . }}
   labels:
     app.kubernetes.io/name: {{ template "hazelcast.name" . }}
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 spec:
-  type: {{ .Values.service.type }}
-  {{- if .Values.service.clusterIP }}
-  clusterIP: {{ .Values.service.clusterIP }}
+  type: {{ .Values.mancenter.service.type }}
+  {{- if .Values.mancenter.service.clusterIP }}
+  clusterIP: {{ .Values.mancenter.service.clusterIP }}
   {{- end }}
   selector:
     app.kubernetes.io/name: {{ template "hazelcast.name" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
-    role: hazelcast
+    role: mancenter
   ports:
   - protocol: TCP
-    port: {{ .Values.service.port }}
-    targetPort: hazelcast
-    name: hzport
+    port: {{ .Values.mancenter.service.port }}
+    targetPort: mancenter
+    name: mancenterport
+{{- end }}

--- a/stable/hazelcast/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast/templates/mancenter-statefulset.yaml
@@ -1,0 +1,116 @@
+{{- if .Values.mancenter.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "mancenter.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "hazelcast.name" . }}
+    helm.sh/chart: {{ template "hazelcast.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+spec:
+  serviceName: {{ template "mancenter.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "hazelcast.name" . }}
+      app.kubernetes.io/instance: "{{ .Release.Name }}"
+      role: mancenter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "hazelcast.name" . }}
+        helm.sh/chart: {{ template "hazelcast.chart" . }}
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
+        app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+        role: mancenter
+    spec:
+      {{- if .Values.mancenter.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.mancenter.image.pullSecrets }}
+        - name: {{ . }}
+        {{- end}}
+      {{- end}}
+      {{- if .Values.mancenter.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.mancenter.nodeSelector | indent 8 }}
+      {{- end }}
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      containers:
+      - name: {{ template "mancenter.fullname" . }}
+        image: "{{ .Values.mancenter.image.repository }}:{{ .Values.mancenter.image.tag }}"
+        imagePullPolicy: {{ .Values.mancenter.image.pullPolicy | quote }}
+        resources:
+{{ toYaml .Values.mancenter.resources | indent 10 }}
+        ports:
+        - name: mancenter
+          containerPort: 8080
+        {{- if .Values.mancenter.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            path: /hazelcast-mancenter/health
+            port: 8080
+          initialDelaySeconds: {{ .Values.mancenter.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.mancenter.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.mancenter.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.mancenter.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.mancenter.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.mancenter.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: /hazelcast-mancenter/health
+            port: 8080
+          initialDelaySeconds: {{ .Values.mancenter.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.mancenter.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.mancenter.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.mancenter.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.mancenter.readinessProbe.failureThreshold }}
+        {{- end }}
+        volumeMounts:
+        - name: mancenter-storage
+          mountPath: /data
+        env:
+        - name: MC_LICENSE_KEY
+        {{- if .Values.mancenter.licenseKeySecretName }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.mancenter.licenseKeySecretName }}
+              key: key
+        {{- else }}
+          value: {{ .Values.mancenter.licenseKey }}
+        {{- end }}
+        - name: JAVA_OPTS
+          value: "{{ if or .Values.mancenter.licenseKey .Values.mancenter.licenseKeySecretName }}-Dhazelcast.mc.license=$(MC_LICENSE_KEY){{ end }} {{ .Values.mancenter.javaOpts }}"
+        serviceAccountName: {{ template "hazelcast.serviceAccountName" . }}
+        {{- if .Values.securityContext.enabled }}
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: {{ .Values.securityContext.runAsUser }}
+          privileged: false
+          readOnlyRootFilesystem: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        {{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- end }}
+      serviceAccountName: {{ template "hazelcast.serviceAccountName" . }}
+      volumes:
+      - name: mancenter-storage
+      {{- if .Values.mancenter.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.mancenter.persistence.existingClaim | default (include "mancenter.fullname" .) }}
+      {{- else }}
+        emptyDir: {}
+      {{- end -}}
+{{- end -}}

--- a/stable/hazelcast/templates/metrics-service.yaml
+++ b/stable/hazelcast/templates/metrics-service.yaml
@@ -4,17 +4,17 @@ kind: Service
 metadata:
   name: {{ template "hazelcast.fullname" . }}-metrics
   labels:
-    app: {{ template "hazelcast.name" . }}
-    chart: {{ template "hazelcast.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "hazelcast.name" . }}
+    helm.sh/chart: {{ template "hazelcast.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
   annotations:
 {{ toYaml .Values.metrics.service.annotations | indent 4 }}
 spec:
   type: {{ .Values.metrics.service.type }}
   selector:
-    app: {{ template "hazelcast.name" . }}
-    release: "{{ .Release.Name }}"
+    app.kubernetes.io/name: {{ template "hazelcast.name" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
   ports:
   - protocol: TCP
     port: {{ .Values.metrics.service.port }}

--- a/stable/hazelcast/templates/role.yaml
+++ b/stable/hazelcast/templates/role.yaml
@@ -1,18 +1,20 @@
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: {{ template "hazelcast.fullname" . }}
   labels:
-    app: {{ template "hazelcast.name" . }}
-    chart: {{ template "hazelcast.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "hazelcast.name" . }}
+    helm.sh/chart: {{ template "hazelcast.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 rules:
 - apiGroups:
   - ""
   resources:
   - endpoints
+  - pods
+  - nodes
   verbs:
   - get
   - list

--- a/stable/hazelcast/templates/rolebinding.yaml
+++ b/stable/hazelcast/templates/rolebinding.yaml
@@ -1,16 +1,16 @@
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: {{ template "hazelcast.fullname" . }}
   labels:
-    app: {{ template "hazelcast.name" . }}
-    chart: {{ template "hazelcast.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "hazelcast.name" . }}
+    helm.sh/chart: {{ template "hazelcast.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: {{ template "hazelcast.fullname" . }}
 subjects:
 - kind: ServiceAccount

--- a/stable/hazelcast/templates/serviceaccount.yaml
+++ b/stable/hazelcast/templates/serviceaccount.yaml
@@ -4,8 +4,8 @@ kind: ServiceAccount
 metadata:
   name: {{ template "hazelcast.serviceAccountName" . }}
   labels:
-    app: {{ template "hazelcast.name" . }}
-    chart: {{ template "hazelcast.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "hazelcast.name" . }}
+    helm.sh/chart: {{ template "hazelcast.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 {{- end -}}

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -3,22 +3,26 @@ kind: StatefulSet
 metadata:
   name: {{ template "hazelcast.fullname" . }}
   labels:
-    app: {{ template "hazelcast.name" . }}
-    chart: {{ template "hazelcast.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "hazelcast.name" . }}
+    helm.sh/chart: {{ template "hazelcast.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 spec:
   serviceName: {{ template "hazelcast.fullname" . }}
   replicas: {{ .Values.cluster.memberCount }}
   selector:
     matchLabels:
-      app: {{ template "hazelcast.name" . }}
-      release: "{{ .Release.Name }}"
+      app.kubernetes.io/name: {{ template "hazelcast.name" . }}
+      app.kubernetes.io/instance: "{{ .Release.Name }}"
+      role: hazelcast
   template:
     metadata:
       labels:
-        app: {{ template "hazelcast.name" . }}
-        release: "{{ .Release.Name }}"
+        app.kubernetes.io/name: {{ template "hazelcast.name" . }}
+        helm.sh/chart: {{ template "hazelcast.chart" . }}
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
+        app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+        role: hazelcast
     spec:
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
@@ -33,19 +37,23 @@ spec:
       {{- if .Values.gracefulShutdown.enabled }}
       terminationGracePeriodSeconds: {{ .Values.gracefulShutdown.maxWaitSeconds }}
       {{- end }}
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
       containers:
       - name: {{ template "hazelcast.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-        {{- if .Values.securityContext }}
-        securityContext:
-{{ toYaml .Values.securityContext | indent 10 }}
-        {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         ports:
         - name: hazelcast
           containerPort: 5701
+          hostPort: {{ .Values.hostPort }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
           containerPort: {{ .Values.metrics.service.port }}
@@ -75,15 +83,42 @@ spec:
         volumeMounts:
         - name: hazelcast-storage
           mountPath: /data/hazelcast
+        {{- if .Values.customVolume }}
+        - name: hazelcast-custom
+          mountPath: /data/custom
+        {{- end }}
         env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         {{- if .Values.metrics.enabled }}
         - name: PROMETHEUS_PORT
           value: "{{ .Values.metrics.service.port }}"
         {{- end }}
         - name: JAVA_OPTS
-          value: "-Dhazelcast.rest.enabled={{ .Values.hazelcast.rest }} -Dhazelcast.config=/data/hazelcast/hazelcast.yaml -DserviceName={{ template "hazelcast.fullname" . }} -Dnamespace={{ .Release.Namespace }} {{ if .Values.gracefulShutdown.enabled }}-Dhazelcast.shutdownhook.policy=GRACEFUL -Dhazelcast.shutdownhook.enabled=true -Dhazelcast.graceful.shutdown.max.wait={{ .Values.gracefulShutdown.maxWaitSeconds }} {{ end }} {{ if .Values.metrics.enabled }}-Dhazelcast.jmx=true{{ end }} {{ .Values.hazelcast.javaOpts }}"
+          value: "-Dhazelcast.rest.enabled={{ .Values.hazelcast.rest }} -Dhazelcast.config=/data/hazelcast/hazelcast.yaml -DserviceName={{ template "hazelcast.fullname" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mancenter.enabled={{ .Values.mancenter.enabled }} -Dhazelcast.mancenter.url=http://{{ template "mancenter.fullname" . }}:{{ .Values.mancenter.service.port }}/hazelcast-mancenter {{ if .Values.gracefulShutdown.enabled }}-Dhazelcast.shutdownhook.policy=GRACEFUL -Dhazelcast.shutdownhook.enabled=true -Dhazelcast.graceful.shutdown.max.wait={{ .Values.gracefulShutdown.maxWaitSeconds }} {{ end }} {{ if .Values.metrics.enabled }}-Dhazelcast.jmx=true{{ end }} {{ .Values.hazelcast.javaOpts }}"
+        {{- if .Values.securityContext.enabled }}
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: {{ .Values.securityContext.runAsUser }}
+          privileged: false
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        {{- end }}
       serviceAccountName: {{ template "hazelcast.serviceAccountName" . }}
       volumes:
       - name: hazelcast-storage
         configMap:
+          {{- if .Values.hazelcast.existingConfigMap }}
+          name: {{ .Values.hazelcast.existingConfigMap }}
+          {{- else }}
           name: {{ template "hazelcast.fullname" . }}-configuration
+          {{- end }}
+      {{- if .Values.customVolume }}
+      - name: hazelcast-custom
+{{ toYaml .Values.customVolume | indent 8 }}
+      {{- end }}

--- a/stable/hazelcast/templates/tests/test-hazelcast.yaml
+++ b/stable/hazelcast/templates/tests/test-hazelcast.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ template "hazelcast.fullname" . }}-test-{{ randAlphaNum 5 | lower }}"
+  annotations:
+    "helm.sh/hook": test-success
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+  labels:
+    app.kubernetes.io/name: {{ template "hazelcast.name" . }}
+    helm.sh/chart: {{ template "hazelcast.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+    app.kubernetes.io/component: "test"
+    role: test
+spec:
+  hostNetwork: false
+  hostPID: false
+  hostIPC: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+  containers:
+  - name: "{{ template "hazelcast.fullname" . }}-test"
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+    command:
+    - "bash"
+    - "-c"
+    - |
+      set -ex
+      # Get the number of Hazelcast members in the cluster
+      CLUSTER_SIZE=$(curl {{ template "hazelcast.fullname" . }}:{{ .Values.service.port }}/hazelcast/health/cluster-size)
+      # Test the currect number of Hazelcast members
+      test ${CLUSTER_SIZE} -eq {{ .Values.cluster.memberCount }}
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1001
+      privileged: false
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  restartPolicy: Never

--- a/stable/hazelcast/templates/tests/test-management-center.yaml
+++ b/stable/hazelcast/templates/tests/test-management-center.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ template "mancenter.fullname" . }}-test-{{ randAlphaNum 5 | lower }}"
+  annotations:
+    "helm.sh/hook": test-success
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+  labels:
+    app.kubernetes.io/name: {{ template "hazelcast.name" . }}
+    helm.sh/chart: {{ template "hazelcast.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+    app.kubernetes.io/component: "test"
+    role: test
+spec:
+  hostNetwork: false
+  hostPID: false
+  hostIPC: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+  containers:
+  - name: "{{ template "mancenter.fullname" . }}-test"
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+    command:
+    - "bash"
+    - "-c"
+    - |
+      set -ex
+      # Get the HTTP Response Code of the Health Check
+      HEALTH_CHECK_HTTP_RESPONSE_CODE=$(curl --write-out %{http_code} --silent --output /dev/null {{ template "mancenter.fullname" . }}:{{ .Values.mancenter.service.port }}/hazelcast-mancenter/health)
+      # Test the currect number of Hazelcast members
+      test ${HEALTH_CHECK_HTTP_RESPONSE_CODE} -eq 200
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1001
+      privileged: false
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  restartPolicy: Never

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -5,7 +5,7 @@ image:
   # repository is the Hazelcast image name
   repository: "hazelcast/hazelcast"
   # tag is the Hazelcast image tag
-  tag: "3.12"
+  tag: "3.12.1"
   # pullPolicy is the Docker image pull policy
   # It's recommended to change this to 'Always' if the image tag is 'latest'
   # ref: http://kubernetes.io/docs/user-guide/images/#updating-images
@@ -20,7 +20,7 @@ image:
 # Cluster settings
 cluster:
   # memberCount is the number Hazelcast members
-  memberCount: 2
+  memberCount: 3
 
 # Hazelcast properties
 hazelcast:
@@ -28,6 +28,8 @@ hazelcast:
   rest: true
   # javaOpts are additional JAVA_OPTS properties for Hazelcast member
   javaOpts:
+  # existingConfigMap defines a ConfigMap which contains Hazelcast configuration file(s) that are used instead hazelcast.yaml configuration below
+  # existingConfigMap
   # yaml is the Hazelcast YAML configuration file
   yaml:
     hazelcast:
@@ -40,23 +42,27 @@ hazelcast:
             service-name: ${serviceName}
             namespace: ${namespace}
             resolve-not-ready-addresses: true
+      management-center:
+        enabled: ${hazelcast.mancenter.enabled}
+        url: ${hazelcast.mancenter.url}
   # configurationFiles are any additional Hazelcast configuration files
   # configurationFiles:
+
 
 # nodeSelector is an array of Hazelcast Node labels for POD assignments
 # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 nodeSelector: {}
 
-# graceful shutdown properties
+# hostPort is a port under which Hazelcast PODs are exposed on the host machines
+# hostPort:
+
 gracefulShutdown:
-  # enabled is a flag used to enable Graceful Shutdown
   enabled: true
-  # maxWaitSeconds is the maximum time to wait for the Hazelcast POD to shut down
   maxWaitSeconds: 600
 
 # Hazelcast Liveness probe
 livenessProbe:
-  # enabled is a flag used to enable liveness probe
+  # enabled is a flag to used to enable liveness probe
   enabled: true
   # initialDelaySeconds is a delay before liveness probe is initiated
   initialDelaySeconds: 30
@@ -71,7 +77,7 @@ livenessProbe:
 
 # Hazelcast Readiness probe
 readinessProbe:
-  # enabled is a flag used to enable readiness probe
+  # enabled is a flag to used to enable readiness probe
   enabled: true
   # initialDelaySeconds is a delay before readiness probe is initiated
   initialDelaySeconds: 30
@@ -91,6 +97,9 @@ readinessProbe:
 #   requests:
 #     memory: 256Mi
 #     cpu: 100m
+#   limits:
+#     memory: 1024Mi
+#     cpu: 200m
 
 # Hazelcast Service properties
 service:
@@ -101,6 +110,7 @@ service:
   # clusterIP set to None makes the service headless
   # It is required if DNS Lookup is used (https://github.com/hazelcast/hazelcast-kubernetes#dns-lookup)
   # clusterIP: "None"
+
 
 # Role-based Access Control
 rbac:
@@ -115,12 +125,14 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
-# Default security-context to run unprivileged
+# Security Context properties
 securityContext:
+  # enabled is a flag to enable Security Context
+  enabled: true
+  # runAsUser is the user ID used to run the container
   runAsUser: 65534
-  runAsNonRoot: true
-  readOnlyRootFilesystem: true
-  allowPrivilegeEscalation: false
+  # fsGroup is the group ID associated with the container
+  fsGroup: 65534
 
 # Allows to enable a Prometheus to scrape pods, implemented for Hazelcast version >= 3.12 (or 'latest')
 metrics:
@@ -131,3 +143,113 @@ metrics:
     annotations:
       prometheus.io/scrape: "true"
       prometheus.io/path: "/metrics"
+
+# customVolume is the configuration for any volume mounted as '/data/custom/' (e.g. to mount a volume with custom JARs)
+# customVolume:
+
+# Hazelcast Management Center application properties
+mancenter:
+  # enabled is a flag to enable Management Center application
+  enabled: true
+  ## Hazelcast Management Center image version
+  ## ref: https://hub.docker.com/r/hazelcast/management-center/tags/
+  ##
+  image:
+    # repository is the Hazelcast Management Center image name
+    repository: "hazelcast/management-center"
+    # tag is the Hazelcast Management Center image tag
+    tag: "3.12.2"
+    # pullPolicy is the Docker image pull policy
+    # It's recommended to change this to 'Always' if the image tag is 'latest'
+    # ref: http://kubernetes.io/docs/user-guide/images/#updating-images
+    #
+    pullPolicy: IfNotPresent
+    # pullSecrets is an array of docker-registry secret names
+    # Secrets must be manually created in the namespace.
+    # ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    # pullSecrets:
+    # - myRegistryKeySecretName
+
+  # ingress configuration for mancenter
+  ingress:
+    enabled: false
+    annotations: {}
+    # hosts:
+    # - hazelcast-mancenter.cluster.domain
+    # tls:
+    # - secretName: hazelcast-ingress-tls
+    #   hosts:
+    #   - hazelcast-mancenter.cluster.domain
+
+  # javaOpts are additional JAVA_OPTS properties for Hazelcast Management Center
+  javaOpts:
+
+  # licenseKey is the license key for Hazelcast Management Center
+  # if not provided, it can be filled in the Management Center web interface
+  licenseKey:
+  # licenseKeySecretName is the name of the secret where the Hazelcast Management Center License Key is stored (can be used instead of licenseKey)
+  # licenseKeySecretName:
+
+  # nodeSelector is an array of Hazelcast Management Center Node labels for POD assignments
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  nodeSelector: {}
+
+  # Configure resource requests and limits
+  # ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  #
+  # resources:
+  #   requests:
+  #     memory: 256Mi
+  #     cpu: 100m
+  #   limits:
+  #     memory: 1024Mi
+  #     cpu: 200m
+
+  # Management Center persistence properties
+  persistence:
+    # enabled is a flag to enable persistence for Management Center
+    enabled: true
+    # existingClaim is a name of the existing Persistence Volume Claim that will be used for persistence
+    # if not defined, a new Persistent Value Claim is created with the default name
+    # existingClaim:
+    # accessModes defines the access modes for the created Persistent Volume Claim
+    accessModes:
+    - ReadWriteOnce
+    # size is the size of Persistent Volume Claim
+    size: 8Gi
+
+  # Hazelcast Management Center Service properties
+  service:
+    # type defines the Kubernetes service type ('ClusterIP', 'LoadBalancer', or 'NodePort')
+    type: LoadBalancer
+    # port is the Kubernetes service port
+    port: 8080
+
+  # Hazelcast Management Center Liveness probe
+  livenessProbe:
+    # enabled is a flag to used to enable liveness probe
+    enabled: true
+    # initialDelaySeconds is a delay before liveness probe is initiated
+    initialDelaySeconds: 30
+    # periodSeconds decides how often to perform the probe
+    periodSeconds: 10
+    # timeoutSeconds decides when the probe times out
+    timeoutSeconds: 5
+    # successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed
+    successThreshold: 1
+    # failureThreshold is the minimum consecutive failures for the probe to be considered failed after having succeeded
+    failureThreshold: 3
+  # Hazelcast Management Center Readiness probe
+  readinessProbe:
+    # enabled is a flag to used to enable readiness probe
+    enabled: true
+    # initialDelaySeconds is a delay before readiness probe is initiated
+    initialDelaySeconds: 30
+    # periodSeconds decides how often to perform the probe
+    periodSeconds: 10
+    # timeoutSeconds decides when the probe times out
+    timeoutSeconds: 1
+    # successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed
+    successThreshold: 1
+    # failureThreshold is the minimum consecutive failures for the probe to be considered failed after having succeeded
+    failureThreshold: 3


### PR DESCRIPTION
Signed-off-by: Rafal Leszko <rafal@hazelcast.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR adds a number of features:
- Hazelcast Management Center application
- Add `kubeVersion`, `tillerVersion` to `Chart.yaml`
- Rename annotation to the standard Helm annotations
- Update security context
- Change `Role` to `ClusterRole` (needed for Hazelcast Zone Aware and External Smart Client features)
- Add tests
- Change default Hazelcast members from 2 to 3
- Add `hostPort` possibility
- Add `customVolume` possibility
- Update Hazelcast image version

#### Which issue this PR fixes
None

#### Special notes for your reviewer:
N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
