### PR TITLE
[incubator/vault] support annotations for Vault service account

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.18.14
+version: 0.18.15
 appVersion: 1.1.2
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -81,6 +81,7 @@ The following table lists the configurable parameters of the Vault chart and the
 | `podLabels`                       | Extra labels for pods                    | `{}`                                |
 | `serviceAccount.create`           | Specifies whether a ServiceAccount should be created | `true`                 |
 | `serviceAccount.name`             | The name of the ServiceAccount to create | Generated from fullname template    |
+| `serviceAccount.annotations`      | Annotations for the created ServiceAccount | `{}`                              |
 | `rbac.create`                     | Specifies whether RBAC should be created | `true`                              |
 | `consulAgent.join`                | If set, start start a consul agent       | `nil`                               |
 | `consulAgent.repository`          | Container image for consul agent         | `consul`                            |

--- a/incubator/vault/templates/serviceaccount.yaml
+++ b/incubator/vault/templates/serviceaccount.yaml
@@ -8,4 +8,8 @@ metadata:
     chart: "{{ template "vault.chart" . }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+  {{- end }}
 {{- end -}}

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -148,7 +148,7 @@ serviceAccount:
   ## Annotations to set for the ServiceAccount
   # annotations:
     # my-annotation: my-annotation-value
-  annotations: {} 
+  annotations: {}
   ## The name of the ServiceAccount to use.
   ## If not set and create is true, a name is generated using the fullname template
   name:

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -145,6 +145,10 @@ serviceAccount:
   ## Specifies whether a ServiceAccount should be created
   ##
   create: true
+  ## Annotations to set for the ServiceAccount
+  # annotations:
+    # my-annotation: my-annotation-value
+  annotations: {} 
   ## The name of the ServiceAccount to use.
   ## If not set and create is true, a name is generated using the fullname template
   name:


### PR DESCRIPTION
Signed-off-by: Brian Surber <bsurber120@yahoo.com>

#### What this PR does / why we need it:
Add custom annotation support for the Vault pod's service account

#### Which issue this PR fixes
None created

#### Special notes for your reviewer:
Tested via `helm template` and my own installation
```
# Source: ha-vault/charts/vault/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: vault-vault
  labels:
    app: vault
    chart: "vault-0.18.15"
    release: "vault-vault"
    heritage: "Tiller"
  annotations:                                                                                                                                                         
    iam.gke.io/gcp-service-account: <redacted>
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
