### PR TITLE
[stable/sysdig] Add support for existing secrets in sysdig helm chart

### DIFF
--- a/stable/sysdig/Chart.yaml
+++ b/stable/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.4.11
+version: 1.4.12
 appVersion: 0.90.3
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/stable/sysdig/README.md
+++ b/stable/sysdig/README.md
@@ -55,6 +55,7 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `ebpf.enabled`                  | Enable eBPF support for Sysdig instead of `sysdig-probe` kernel module | `false`                                     |
 | `ebpf.settings.mountEtcVolume`  | Needed to detect which kernel version are running in Google COS        | `true`                                      |
 | `sysdig.accessKey`              | Your Sysdig Monitor Access Key                                         | `Nil` You must provide your own key         |
+| `sysdig.existingSecret`         | Use an existing secret                                                 | `false`                                     |
 | `sysdig.settings`               | Settings for agent's configuration file                                | ` `                                         |
 | `secure.enabled`                | Enable Sysdig Secure                                                   | `false`                                     |
 | `customAppChecks`               | The custom app checks deployed with your agent                         | `{}`                                        |

--- a/stable/sysdig/templates/daemonset.yaml
+++ b/stable/sysdig/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.sysdig.accessKey }}
+{{- if (or (.Values.sysdig.accessKey) (.Values.sysdig.existingSecret)) }}
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:

--- a/stable/sysdig/templates/secrets.yaml
+++ b/stable/sysdig/templates/secrets.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.sysdig.accessKey }}
+{{- if and .Values.sysdig.accessKey (not .Values.sysdig.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/sysdig/values.yaml
+++ b/stable/sysdig/values.yaml
@@ -57,6 +57,9 @@ sysdig:
   # Required: You need your Sysdig Monitor access key before running agents.
   accessKey: ""
 
+  # Use an existing secret with the same value as `sysdig.fullname`
+  existingSecret: false
+
   settings:
     ### Agent tags
     # tags: linux:ubuntu,dept:dev,local:nyc


### PR DESCRIPTION
Signed-off-by: Brian Choy <bycEEE@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Our deployments used `sealed-secrets` and/or `vault-crd` to create secrets for helm charts. It would be great if this use case was supported for the `sysdig` chart. Currently a secret is not created if `.Values.sysdig.accessKey` is not specified, which is fine. However the daemonset is also not created when that value is not specified. This PR adds support for using  `.Values.sysdig.existingSecret` to create a daemonset.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
