### PR TITLE
[incubator/jaeger] allow specifying priorityClassName

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.13.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.13.0
+version: 0.14.0
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -201,6 +201,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `agent.image`                            | Image for Jaeger Agent              |  `jaegertracing/jaeger-agent`            |
 | `agent.podAnnotations`                   | Annotations for Agent pod           |  `nil`                                   |
 | `agent.pullPolicy`                       | Agent image pullPolicy              |  `IfNotPresent`                          |
+| `agent.priorityClassName`                | PriorityClassName for agent pod     |  `nil`                                   |
 | `agent.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`       |
 | `agent.service.annotations`              | Annotations for Agent SVC           |  `nil`                                   |
 | `agent.service.binaryPort`               | jaeger.thrift over binary thrift    |  `6832`                                  |

--- a/incubator/jaeger/templates/agent-ds.yaml
+++ b/incubator/jaeger/templates/agent-ds.yaml
@@ -55,6 +55,9 @@ spec:
         - name: {{ $key | replace "." "_" | replace "-" "_" | upper | quote }}
           value: {{ $value }}
         {{- end }}
+        {{- if .Values.agent.priorityClassName }}
+        priorityClassName: {{ .Values.agent.priorityClassName }}
+        {{- end }}
         ports:
         - name: zipkin-compact
           containerPort: {{ .Values.agent.service.zipkinThriftPort }}

--- a/incubator/jaeger/templates/agent-ds.yaml
+++ b/incubator/jaeger/templates/agent-ds.yaml
@@ -33,6 +33,9 @@ spec:
 {{ toYaml .Values.agent.podLabels | indent 8 }}
 {{- end }}
     spec:
+      {{- if .Values.agent.priorityClassName }}
+      priorityClassName: {{ .Values.agent.priorityClassName }}
+      {{- end }}
       {{- if .Values.agent.useHostNetwork }}
       hostNetwork: true
       {{- end }}
@@ -54,9 +57,6 @@ spec:
         {{- range $key, $value := .Values.agent.cmdlineParams }}
         - name: {{ $key | replace "." "_" | replace "-" "_" | upper | quote }}
           value: {{ $value }}
-        {{- end }}
-        {{- if .Values.agent.priorityClassName }}
-        priorityClassName: {{ .Values.agent.priorityClassName }}
         {{- end }}
         ports:
         - name: zipkin-compact

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -98,6 +98,7 @@ elasticsearch:
       enabled: false
 
 agent:
+  priorityClassName: null
   enabled: true
   annotations: {}
   image: jaegertracing/jaeger-agent


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds configurable `priorityClassName` to jaeger agent daemonset. This is needed for environments that support `priorityClassName` to ensure scheduling of the jaeger agent on all nodes.

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
