### PR TITLE
[stable/external-dns] Allow for the usage of existing secrets

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.4.0
+version: 2.5.0
 appVersion: 0.5.15
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/templates/secret.yaml
+++ b/stable/external-dns/templates/secret.yaml
@@ -33,7 +33,9 @@ data:
   {{- if .Values.pdns.apiKey }}
   pdns_api_key: {{ .Values.pdns.apiKey | b64enc | quote }}
   {{- end }}
-  {{- range $key, $value := .Values.extraEnv }}
-  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- range .Values.extraEnv }}
+  {{- if .value }}
+  {{ .name }}: {{ .value | b64enc | quote }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/stable/external-dns/values-production.yaml
+++ b/stable/external-dns/values-production.yaml
@@ -211,7 +211,7 @@ istioIngressGateways: []
 extraArgs: {}
 ## Extra env. variable to set on external-dns container
 ##
-extraEnv: {}
+extraEnv: []
 
 ## Replica count
 ##

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -211,7 +211,15 @@ istioIngressGateways: []
 extraArgs: {}
 ## Extra env. variable to set on external-dns container
 ##
-extraEnv: {}
+## extraEnv:
+## - name: SECRET_TO_SAVE
+##   value: secret_value
+## - name: AWS_ACCESS_KEY_ID
+##   valueFrom:
+##     secretKeyRef:
+##       name: existing-secret
+##       key: access-key-id
+extraEnv: []
 
 ## Replica count
 ##


### PR DESCRIPTION
Signed-off-by: Marc Sensenich <sensenichm91@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Allows for the external secrets in the `extraEnv` field due to a template issue with the template providing a `map[string][string]` to the `secret.yaml` template.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
