### PR TITLE
[stable/jenkins] Provide default job value

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.4.1
+version: 1.4.2
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -138,7 +138,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.initScripts`              | List of Jenkins init scripts         | Not set                                   |
 | `master.credentialsXmlSecret`     | Kubernetes secret that contains a 'credentials.xml' file | Not set               |
 | `master.secretsFilesSecret`       | Kubernetes secret that contains 'secrets' files | Not set                        |
-| `master.jobs`                     | Jenkins XML job configs              | Not set                                   |
+| `master.jobs`                     | Jenkins XML job configs              | `{}`                                      |
 | `master.overwriteJobs`            | Replace jobs w/ ConfigMap on boot    | `false`                                   |
 | `master.installPlugins`           | List of Jenkins plugins to install. If you don't want to install plugins set it to `[]` | `kubernetes:1.14.0 workflow-aggregator:2.6 credentials-binding:1.17 git:3.9.1 workflow-job:2.31` |
 | `master.overwritePlugins`         | Overwrite installed plugins on start.| `false`                                   |

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -182,7 +182,7 @@ master:
   # master.key and hudson.util.Secret)
   # secretsFilesSecret: jenkins-secrets
   # Jenkins XML job configs to provision
-  jobs:
+  jobs: {}
   #  test: |-
   #    <<xml here>>
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This fixes the `helm template` warning when providing a job map.

```
warning: destination for jobs is a table. Ignoring non-table value <nil>
```

#### Special notes for your reviewer:

This should probably applied to all other values as well, because you'd get similar warnings when setting a value to a `nil` value.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
