### PR TITLE
stable/nginx-ingress Allows customization of the tcp/udp configmap namespace

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.11.5
+version: 1.12.0
 appVersion: 0.25.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -149,7 +149,7 @@ Parameter | Description | Default
 `controller.customTemplate.configMapKey` | configMap key containing the nginx template | `""`
 `controller.headers` | configMap key:value pairs containing the [custom headers](https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers) for Nginx | `{}`
 `controller.updateStrategy` | allows setting of RollingUpdate strategy | `{}`
-`controller.configMapNamespace` | The nginx-configmap namespace name | `""
+`controller.configMapNamespace` | The nginx-configmap namespace name | `""`
 `controller.tcp.configMapNamespace` | The tcp-services-configmap namespace name | `""`
 `controller.udp.configMapNamespace` | The udp-services-configmap namespace name | `""`
 `defaultBackend.enabled` | Use default backend component | `true`

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -190,7 +190,9 @@ Parameter | Description | Default
 `serviceAccount.create` | if `true`, create a service account | `true`
 `serviceAccount.name` | The name of the service account to use. If not set and `create` is `true`, a name is generated using the fullname template. | ``
 `revisionHistoryLimit` | The number of old history to retain to allow rollback. | `10`
+`controller.tcpConfigMapNamespace` | The tcp-services-configmap namespace name | `ingress-nginx`
 `tcp` | TCP service key:value pairs. The value is evaluated as a template. | `{}`
+`controller.udpConfigMapNamespace` | The udp-services-configmap namespace name | `ingress-nginx`
 `udp` | UDP service key:value pairs The value is evaluated as a template. | `{}`
 
 ```console

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -149,8 +149,9 @@ Parameter | Description | Default
 `controller.customTemplate.configMapKey` | configMap key containing the nginx template | `""`
 `controller.headers` | configMap key:value pairs containing the [custom headers](https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers) for Nginx | `{}`
 `controller.updateStrategy` | allows setting of RollingUpdate strategy | `{}`
-`controller.tcp.configMapNamespace` | The tcp-services-configmap namespace name | `ingress-nginx`
-`controller.udp.configMapNamespace` | The udp-services-configmap namespace name | `ingress-nginx`
+`controller.configMapNamespace` | The nginx-configmap namespace name | `""
+`controller.tcp.configMapNamespace` | The tcp-services-configmap namespace name | `""`
+`controller.udp.configMapNamespace` | The udp-services-configmap namespace name | `""`
 `defaultBackend.enabled` | Use default backend component | `true`
 `defaultBackend.name` | name of the default backend component | `default-backend`
 `defaultBackend.image.repository` | default backend container image repository | `k8s.gcr.io/defaultbackend-amd64`

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -149,6 +149,8 @@ Parameter | Description | Default
 `controller.customTemplate.configMapKey` | configMap key containing the nginx template | `""`
 `controller.headers` | configMap key:value pairs containing the [custom headers](https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers) for Nginx | `{}`
 `controller.updateStrategy` | allows setting of RollingUpdate strategy | `{}`
+`controller.tcp.configMapNamespace` | The tcp-services-configmap namespace name | `ingress-nginx`
+`controller.udp.configMapNamespace` | The udp-services-configmap namespace name | `ingress-nginx`
 `defaultBackend.enabled` | Use default backend component | `true`
 `defaultBackend.name` | name of the default backend component | `default-backend`
 `defaultBackend.image.repository` | default backend container image repository | `k8s.gcr.io/defaultbackend-amd64`
@@ -190,9 +192,7 @@ Parameter | Description | Default
 `serviceAccount.create` | if `true`, create a service account | `true`
 `serviceAccount.name` | The name of the service account to use. If not set and `create` is `true`, a name is generated using the fullname template. | ``
 `revisionHistoryLimit` | The number of old history to retain to allow rollback. | `10`
-`controller.tcpConfigMapNamespace` | The tcp-services-configmap namespace name | `ingress-nginx`
 `tcp` | TCP service key:value pairs. The value is evaluated as a template. | `{}`
-`controller.udpConfigMapNamespace` | The udp-services-configmap namespace name | `ingress-nginx`
 `udp` | UDP service key:value pairs The value is evaluated as a template. | `{}`
 
 ```console

--- a/stable/nginx-ingress/ci/daemonset-tcp-udp-configMapNamespace-values.yaml
+++ b/stable/nginx-ingress/ci/daemonset-tcp-udp-configMapNamespace-values.yaml
@@ -1,9 +1,9 @@
 controller:
   kind: DaemonSet
   tcp:
-    ConfigMapNamespace: default
+    configMapNamespace: default
   udp:
-    ConfigMapNamespace: default
+    configMapNamespace: default
 
 tcp:
   9000: "default/test:8080"

--- a/stable/nginx-ingress/ci/daemonset-tcp-udp-configMapNamespace-values.yaml
+++ b/stable/nginx-ingress/ci/daemonset-tcp-udp-configMapNamespace-values.yaml
@@ -1,0 +1,12 @@
+controller:
+  kind: DaemonSet
+  tcp:
+    ConfigMapNamespace: default
+  udp:
+    ConfigMapNamespace: default
+
+tcp:
+  9000: "default/test:8080"
+
+udp:
+  9001: "default/test:8080"

--- a/stable/nginx-ingress/ci/daemonset-tcp-udp-configMapNamespace-values.yaml
+++ b/stable/nginx-ingress/ci/daemonset-tcp-udp-configMapNamespace-values.yaml
@@ -1,5 +1,7 @@
 controller:
   kind: DaemonSet
+  service:
+    type: ClusterIP
   tcp:
     configMapNamespace: default
   udp:

--- a/stable/nginx-ingress/ci/deployment-tcp-udp-configMapNamespace-values.yaml
+++ b/stable/nginx-ingress/ci/deployment-tcp-udp-configMapNamespace-values.yaml
@@ -1,8 +1,8 @@
 controller:
   tcp:
-    ConfigMapNamespace: default
+    configMapNamespace: default
   udp:
-    ConfigMapNamespace: default
+    configMapNamespace: default
 
 tcp:
   9000: "default/test:8080"

--- a/stable/nginx-ingress/ci/deployment-tcp-udp-configMapNamespace-values.yaml
+++ b/stable/nginx-ingress/ci/deployment-tcp-udp-configMapNamespace-values.yaml
@@ -1,0 +1,11 @@
+controller:
+  tcp:
+    ConfigMapNamespace: default
+  udp:
+    ConfigMapNamespace: default
+
+tcp:
+  9000: "default/test:8080"
+
+udp:
+  9001: "default/test:8080"

--- a/stable/nginx-ingress/ci/deployment-tcp-udp-configMapNamespace-values.yaml
+++ b/stable/nginx-ingress/ci/deployment-tcp-udp-configMapNamespace-values.yaml
@@ -1,4 +1,6 @@
 controller:
+  service:
+    type: ClusterIP
   tcp:
     configMapNamespace: default
   udp:

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -69,10 +69,10 @@ spec:
             - --nginx-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
           {{- end }}
           {{- if .Values.tcp }}
-            - --tcp-services-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-tcp
+            - --tcp-services-configmap={{ default .Release.Namespace .Values.controller.tcpConfigMapNamespace }}/{{ template "nginx-ingress.fullname" . }}-tcp
           {{- end }}
           {{- if .Values.udp }}
-            - --udp-services-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-udp
+            - --udp-services-configmap={{ default .Release.Namespace .Values.controller.udpConfigMapNamespace }}/{{ template "nginx-ingress.fullname" . }}-udp
           {{- end }}
           {{- if .Values.controller.scope.enabled }}
             - --watch-namespace={{ default .Release.Namespace .Values.controller.scope.namespace }}

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -64,15 +64,15 @@ spec:
             - --ingress-class={{ .Values.controller.ingressClass }}
           {{- end }}
           {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
-            - --configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
+            - --configmap={{ default .Release.Namespace .Values.controller.configMapNamespace }}/{{ template "nginx-ingress.controller.fullname" . }}
           {{- else }}
-            - --nginx-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
+            - --nginx-configmap={{ default .Release.Namespace .Values.controller.configMapNamespace }}/{{ template "nginx-ingress.controller.fullname" . }}
           {{- end }}
           {{- if .Values.tcp }}
-            - --tcp-services-configmap={{ default .Release.Namespace .Values.controller.tcp.ConfigMapNamespace }}/{{ template "nginx-ingress.fullname" . }}-tcp
+            - --tcp-services-configmap={{ default .Release.Namespace .Values.controller.tcp.configMapNamespace }}/{{ template "nginx-ingress.fullname" . }}-tcp
           {{- end }}
           {{- if .Values.udp }}
-            - --udp-services-configmap={{ default .Release.Namespace .Values.controller.udp.ConfigMapNamespace }}/{{ template "nginx-ingress.fullname" . }}-udp
+            - --udp-services-configmap={{ default .Release.Namespace .Values.controller.udp.configMapNamespace }}/{{ template "nginx-ingress.fullname" . }}-udp
           {{- end }}
           {{- if .Values.controller.scope.enabled }}
             - --watch-namespace={{ default .Release.Namespace .Values.controller.scope.namespace }}

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -69,10 +69,10 @@ spec:
             - --nginx-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
           {{- end }}
           {{- if .Values.tcp }}
-            - --tcp-services-configmap={{ default .Release.Namespace .Values.controller.tcpConfigMapNamespace }}/{{ template "nginx-ingress.fullname" . }}-tcp
+            - --tcp-services-configmap={{ default .Release.Namespace .Values.controller.tcp.ConfigMapNamespace }}/{{ template "nginx-ingress.fullname" . }}-tcp
           {{- end }}
           {{- if .Values.udp }}
-            - --udp-services-configmap={{ default .Release.Namespace .Values.controller.udpConfigMapNamespace }}/{{ template "nginx-ingress.fullname" . }}-udp
+            - --udp-services-configmap={{ default .Release.Namespace .Values.controller.udp.ConfigMapNamespace }}/{{ template "nginx-ingress.fullname" . }}-udp
           {{- end }}
           {{- if .Values.controller.scope.enabled }}
             - --watch-namespace={{ default .Release.Namespace .Values.controller.scope.namespace }}

--- a/stable/nginx-ingress/templates/controller-service.yaml
+++ b/stable/nginx-ingress/templates/controller-service.yaml
@@ -63,18 +63,22 @@ spec:
       port: {{ $key }}
       protocol: TCP
       targetPort: "{{ $key }}-tcp"
+     {{- if $.Values.controller.service.nodePorts.tcp }}
       {{- if index $.Values.controller.service.nodePorts.tcp $key }}
       nodePort: {{ index $.Values.controller.service.nodePorts.tcp $key }}
       {{- end }}
+     {{- end }}
   {{- end }}
   {{- range $key, $value := .Values.udp }}
     - name: "{{ $key }}-udp"
       port: {{ $key }}
       protocol: UDP
       targetPort: "{{ $key }}-udp"
+     {{- if $.Values.controller.service.nodePorts.udp }}
       {{- if index $.Values.controller.service.nodePorts.udp $key }}
       nodePort: {{ index $.Values.controller.service.nodePorts.udp $key }}
       {{- end }}
+     {{- end }}
   {{- end }}
   selector:
     app: {{ template "nginx-ingress.name" . }}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -81,7 +81,15 @@ controller:
   scope:
     enabled: false
     namespace: ""   # defaults to .Release.Namespace
-
+  
+  ## Allows customization of the tcp-services-configmap namespace
+  tcp:
+    configMapNamespace: "" # defaults to .Release.Namespace
+  
+  ## Allows customization of the udp-services-configmap namespace
+  udp:
+    configMapNamespace: "" # defaults to .Release.Namespace
+  
   ## Additional command line arguments to pass to nginx-ingress-controller
   ## E.g. to specify the default SSL certificate you can use
   ## extraArgs:

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -82,6 +82,10 @@ controller:
     enabled: false
     namespace: ""   # defaults to .Release.Namespace
 
+  ## Allows customization of the configmap / nginx-configmap namespace
+  ##
+  configMapNamespace: ""   # defaults to .Release.Namespace
+
   ## Allows customization of the tcp-services-configmap namespace
   ##
   tcp:

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -81,15 +81,17 @@ controller:
   scope:
     enabled: false
     namespace: ""   # defaults to .Release.Namespace
-  
+
   ## Allows customization of the tcp-services-configmap namespace
+  ##
   tcp:
-    configMapNamespace: "" # defaults to .Release.Namespace
-  
+    configMapNamespace: ""   # defaults to .Release.Namespace
+
   ## Allows customization of the udp-services-configmap namespace
+  ##
   udp:
-    configMapNamespace: "" # defaults to .Release.Namespace
-  
+    configMapNamespace: ""   # defaults to .Release.Namespace
+
   ## Additional command line arguments to pass to nginx-ingress-controller
   ## E.g. to specify the default SSL certificate you can use
   ## extraArgs:


### PR DESCRIPTION
## What this PR does / why we need it:
I have a use case which I need to put my tcp-services-configmap/udp-services-configmap in my ```default``` namespace to be able to configure my tcp/udp ports instead of edit them in the  ```ingress-nginx``` namespace due to user permissions and roles permissions.
another use case, rancher is not allow to create configmap in different namespace than the App namespace [13057](https://github.com/rancher/rancher/issues/13057)

#### Special notes for your reviewer:
based on the security role and service account to read configmaps on all namespaces

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
