### PR TITLE
[stable/filebeat] Use data.hostPath in Pod Security Policy

### DIFF
--- a/stable/filebeat/Chart.yaml
+++ b/stable/filebeat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart to collect Kubernetes logs with filebeat
 icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.svg
 name: filebeat
-version: 2.0.1
+version: 2.0.2
 appVersion: 7.0.1
 home: https://www.elastic.co/products/beats/filebeat
 sources:

--- a/stable/filebeat/templates/podsecuritypolicy.yaml
+++ b/stable/filebeat/templates/podsecuritypolicy.yaml
@@ -16,7 +16,7 @@ spec:
       readOnly: true
     - pathPrefix: /var/lib/docker/containers
       readOnly: true
-    - pathPrefix: /var/lib/filebeat
+    - pathPrefix: {{ .Values.data.hostPath }}
   requiredDropCapabilities:
     - ALL
   volumes:


### PR DESCRIPTION
Signed-off-by: Marc Sensenich <sensenichm91@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
If the user defines `data.hostPath` and sets `podSecurityPolicy.enabled` to `true` this change allows for the Filebeat pods to access the correct hostPath

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
