### PR TITLE
[stable/concourse] Added variable limitActiveTask for web node

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 8.2.1
+version: 8.2.2
 appVersion: 5.4.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -231,6 +231,10 @@ spec:
             - name: CONCOURSE_CONTAINER_PLACEMENT_STRATEGY
               value: {{ .Values.concourse.web.containerPlacementStrategy | quote }}
             {{- end }}
+            {{- if .Values.concourse.web.limitActiveTasks }}
+            - name: CONCOURSE_MAX_ACTIVE_TASKS_PER_WORKER
+              value: {{ .Values.concourse.web.limitActiveTasks | quote }}
+            {{- end}}
             {{- if .Values.concourse.web.baggageclaimResponseHeaderTimeout }}
             - name: CONCOURSE_BAGGAGECLAIM_RESPONSE_HEADER_TIMEOUT
               value: {{ .Values.concourse.web.baggageclaimResponseHeaderTimeout | quote }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -199,8 +199,13 @@ concourse:
     resourceTypeCheckingInterval: 1m
 
     ## Method by which a worker is selected during container placement.
-    ## Possible values: volume-locality | random | fewest-build-containers
+    ## Possible values: volume-locality | random | fewest-build-containers| limit-active-tasks
     containerPlacementStrategy: volume-locality
+
+    # Maximum allowed number of active build tasks per worker. Has effect only when
+    # containerPlacementStrategy is set to use limit-active-tasks placement strategy.
+    # 0 means no limit. (default: 0)
+    limitActiveTasks: 0
 
     ## How long to wait for Baggageclaim to send the response header.
     ##


### PR DESCRIPTION
#### What this PR does / why we need it:
The latest developing concourse version is failing on k8s pipeline job [`k8s-check-helm-params`](https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/k8s-check-helm-params) for missing the variable `CONCOURSE_MAX_ACTIVE_TASKS_PER_WORKER `  in concourse helm chart. We're adding this per the code changes for limit-active-task (per worker) when the `containerPlacementStrategy` is set to use it.

#### Which issue this PR fixes

  - fixes #15975
- [currently failing job](https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/k8s-check-helm-params)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
