### PR TITLE
[stable/concourse] add new parameter for Concourse 5.5

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: concourse
-version: 8.2.3
-appVersion: 5.4.1
+version: 8.2.4
+appVersion: 5.5.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479
 keywords:

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -83,7 +83,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `imageDigest` | Specific image digest to use in place of a tag. | `nil` |
 | `imagePullPolicy` | Concourse image pull policy | `IfNotPresent` |
 | `imagePullSecrets` | Array of imagePullSecrets in the namespace for pulling images | `[]` |
-| `imageTag` | Concourse image version | `5.4.0` |
+| `imageTag` | Concourse image version | `5.5.0` |
 | `image` | Concourse image | `concourse/concourse` |
 | `nameOverride` | Provide a name in place of `concourse` for `app:` labels | `nil` |
 | `persistence.enabled` | Enable Concourse persistence using Persistent Volume Claims | `true` |

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -59,6 +59,10 @@ spec:
             - name: CONCOURSE_CLUSTER_NAME
               value: {{ .Values.concourse.web.clusterName | quote }}
             {{- end }}
+            {{- if .Values.concourse.web.maxConns }}
+            - name: CONCOURSE_MAX_CONNS
+              value: {{ .Values.concourse.web.maxConns | quote }}
+            {{- end }}
             {{- if .Values.concourse.web.enableGlobalResources }}
             - name: CONCOURSE_ENABLE_GLOBAL_RESOURCES
               value: {{ .Values.concourse.web.enableGlobalResources | quote }}
@@ -126,6 +130,10 @@ spec:
             {{- if .Values.concourse.web.awsSsm.region }}
             - name: CONCOURSE_AWS_SSM_REGION
               value: {{ .Values.concourse.web.awsSsm.region | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.metrics.bufferSize }}
+            - name: CONCOURSE_METRICS_BUFFER_SIZE
+              value: {{ .Values.concourse.web.metrics.bufferSize | quote }}
             {{- end }}
             {{- if .Values.concourse.web.metrics.captureErrorMetrics }}
             - name: CONCOURSE_CAPTURE_ERROR_METRICS
@@ -231,6 +239,10 @@ spec:
             - name: CONCOURSE_CONTAINER_PLACEMENT_STRATEGY
               value: {{ .Values.concourse.web.containerPlacementStrategy | quote }}
             {{- end }}
+            {{- if .Values.concourse.web.limitActiveTasks }}
+            - name: CONCOURSE_MAX_ACTIVE_TASKS_PER_WORKER
+              value: {{ .Values.concourse.web.limitActiveTasks | quote }}
+            {{- end}}
             {{- if .Values.concourse.web.baggageclaimResponseHeaderTimeout }}
             - name: CONCOURSE_BAGGAGECLAIM_RESPONSE_HEADER_TIMEOUT
               value: {{ .Values.concourse.web.baggageclaimResponseHeaderTimeout | quote }}
@@ -548,6 +560,14 @@ spec:
             {{- if .Values.concourse.web.influxdb.enabled }}
             - name: CONCOURSE_INFLUXDB_URL
               value: {{ .Values.concourse.web.influxdb.url | quote }}
+            {{- if .Values.concourse.web.influxdb.batchSize }}
+            - name: CONCOURSE_INFLUXDB_BATCH_SIZE
+              value: {{.Values.concourse.web.influxdb.batchSize | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.influxdb.batchDuration }}
+            - name: CONCOURSE_INFLUXDB_BATCH_DURATION
+              value: {{.Values.concourse.web.influxdb.batchDuration | quote }}
+            {{- end }}
             - name: CONCOURSE_INFLUXDB_DATABASE
               value: {{ .Values.concourse.web.influxdb.database | quote }}
             - name: CONCOURSE_INFLUXDB_USERNAME

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -56,6 +56,10 @@ concourse:
     ##
     clusterName:
 
+    ## The maximum number of open connections for a connection pool
+    ##
+    maxConns:
+
     ## Enable equivalent resources across pipelines and teams to share a single version history.
     ## Ref: https://concourse-ci.org/global-resources.html
     ##
@@ -199,8 +203,19 @@ concourse:
     resourceTypeCheckingInterval: 1m
 
     ## Method by which a worker is selected during container placement.
-    ## Possible values: volume-locality | random | fewest-build-containers
+    ## Possible values: volume-locality | random | fewest-build-containers| limit-active-tasks
     containerPlacementStrategy: volume-locality
+
+    ## Maximum allowed number of active build tasks per worker.
+    ##
+    ## Has effect only when containerPlacementStrategy is set to use
+    ## limit-active-tasks placement strategy.
+    ##
+    ## ps.: 0 means no limit.
+    ##
+    ## ref: https://concourse-ci.org/container-placement.html#limit-active-tasks-strategy
+    ##
+    limitActiveTasks:
 
     ## How long to wait for Baggageclaim to send the response header.
     ##
@@ -486,6 +501,10 @@ concourse:
       ##
       captureErrorMetrics: false
 
+      ## The size of the buffer used in emitting event metrics.
+      ##
+      bufferSize:
+
     datadog:
       enabled: false
 
@@ -507,6 +526,15 @@ concourse:
 
     influxdb:
       enabled: false
+
+      ## Number of points to batch together when emitting to InfluxDB
+      ##
+      batchSize:
+
+      ## The duration to wait before emitting a batch of points to InfluxDB,
+      ## disregarding # the batch size.
+      ##
+      batchDuration:
 
       ## InfluxDB server address to emit points to.
       ## Example: http://127.0.0.1:8086


### PR DESCRIPTION
#### What this PR does / why we need it:
The latest developing concourse version is failing on k8s pipeline job [`k8s-check-helm-params`](https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/k8s-check-helm-params) for missing the variable `CONCOURSE_MAX_ACTIVE_TASKS_PER_WORKER `  in concourse helm chart. We're adding this per the code changes for limit-active-task (per worker) when the `containerPlacementStrategy` is set to use it.

#### Which issue this PR fixes

  - fixes #15975
- [currently failing job](https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/k8s-check-helm-params)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
