### PR TITLE
[stable/prometheus-pushgateway] Add annotation support to push gateway service

### DIFF
--- a/stable/prometheus-pushgateway/Chart.yaml
+++ b/stable/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.9.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.0.0
+version: 1.0.1
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/stable/prometheus-pushgateway/README.md
+++ b/stable/prometheus-pushgateway/README.md
@@ -55,6 +55,7 @@ The following table lists the configurable parameters of the pushgateway chart a
 | `service.type`              | Service type                                                                                                                  | `ClusterIP`                       |
 | `service.port`              | The service port                                                                                                              | `9091`                            |
 | `service.targetPort`        | The target port of the container                                                                                              | `9091`                            |
+| `serviceAnnotations`        | Annotations for the service                                                                                                   | `{}`                              |
 | `serviceLabels`             | Labels for service                                                                                                            | `{}`                              |
 | `serviceAccount.create`     | Specifies whether a service account should be created.                                                                        | `true`                            |
 | `serviceAccount.name`       | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |                                   |

--- a/stable/prometheus-pushgateway/templates/service.yaml
+++ b/stable/prometheus-pushgateway/templates/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "prometheus-pushgateway.fullname" . }}
+  annotations:
+{{ .Values.service.annotations | toYaml | indent 4 }}
   labels:
 {{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.serviceLabels) .  }}
 spec:

--- a/stable/prometheus-pushgateway/values.yaml
+++ b/stable/prometheus-pushgateway/values.yaml
@@ -17,6 +17,9 @@ podAnnotations: {}
 # Optional pod labels
 podLabels: {}
 
+# Optional service annotations
+serviceAnnotations: {}
+
 # Optional service labels
 serviceLabels: {}
 


### PR DESCRIPTION
### What this PR does / why we need it:
Adds support for service annotations to the prometheus push gateway service. Annotations can be utilized to expose the push gateway outside of the cluster with an internal ELB.
