### PR TITLE
[stable/prometheus] add namespace: {{ .Release.Namespace }} to stable/prometheus

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 8.15.0
+version: 8.15.1
 appVersion: 2.11.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/alertmanager-configmap.yaml
+++ b/stable/prometheus/templates/alertmanager-configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
   name: {{ template "prometheus.alertmanager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 data:
 {{- $root := . -}}
 {{- range $key, $value := .Values.alertmanagerFiles }}

--- a/stable/prometheus/templates/alertmanager-deployment.yaml
+++ b/stable/prometheus/templates/alertmanager-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
   name: {{ template "prometheus.alertmanager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/stable/prometheus/templates/alertmanager-pvc.yaml
+++ b/stable/prometheus/templates/alertmanager-pvc.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
   name: {{ template "prometheus.alertmanager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
 {{ toYaml .Values.alertmanager.persistentVolume.accessModes | indent 4 }}

--- a/stable/prometheus/templates/alertmanager-service-headless.yaml
+++ b/stable/prometheus/templates/alertmanager-service-headless.yaml
@@ -12,6 +12,7 @@ metadata:
 {{ toYaml .Values.alertmanager.statefulSet.headless.labels | indent 4 }}
 {{- end }}
   name: {{ template "prometheus.alertmanager.fullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
 spec:
   clusterIP: None
   ports:

--- a/stable/prometheus/templates/alertmanager-service.yaml
+++ b/stable/prometheus/templates/alertmanager-service.yaml
@@ -12,6 +12,7 @@ metadata:
 {{ toYaml .Values.alertmanager.service.labels | indent 4 }}
 {{- end }}
   name: {{ template "prometheus.alertmanager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
 {{- if .Values.alertmanager.service.clusterIP }}
   clusterIP: {{ .Values.alertmanager.service.clusterIP }}

--- a/stable/prometheus/templates/alertmanager-serviceaccount.yaml
+++ b/stable/prometheus/templates/alertmanager-serviceaccount.yaml
@@ -5,4 +5,5 @@ metadata:
   labels:
     {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
   name: {{ template "prometheus.serviceAccountName.alertmanager" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/stable/prometheus/templates/alertmanager-statefulset.yaml
+++ b/stable/prometheus/templates/alertmanager-statefulset.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
   name: {{ template "prometheus.alertmanager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   serviceName: {{ template "prometheus.alertmanager.fullname" . }}-headless
   selector:

--- a/stable/prometheus/templates/kube-state-metrics-deployment.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-deployment.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     {{- include "prometheus.kubeStateMetrics.labels" . | nindent 4 }}
   name: {{ template "prometheus.kubeStateMetrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/stable/prometheus/templates/kube-state-metrics-serviceaccount.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-serviceaccount.yaml
@@ -5,4 +5,5 @@ metadata:
   labels:
     {{- include "prometheus.kubeStateMetrics.labels" . | nindent 4 }}
   name: {{ template "prometheus.serviceAccountName.kubeStateMetrics" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/stable/prometheus/templates/kube-state-metrics-svc.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-svc.yaml
@@ -12,6 +12,7 @@ metadata:
 {{ toYaml .Values.kubeStateMetrics.service.labels | indent 4 }}
 {{- end }}
   name: {{ template "prometheus.kubeStateMetrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
 {{- if .Values.kubeStateMetrics.service.clusterIP }}
   clusterIP: {{ .Values.kubeStateMetrics.service.clusterIP }}

--- a/stable/prometheus/templates/node-exporter-daemonset.yaml
+++ b/stable/prometheus/templates/node-exporter-daemonset.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     {{- include "prometheus.nodeExporter.labels" . | nindent 4 }}
   name: {{ template "prometheus.nodeExporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/stable/prometheus/templates/node-exporter-service.yaml
+++ b/stable/prometheus/templates/node-exporter-service.yaml
@@ -12,6 +12,7 @@ metadata:
 {{ toYaml .Values.nodeExporter.service.labels | indent 4 }}
 {{- end }}
   name: {{ template "prometheus.nodeExporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
 {{- if .Values.nodeExporter.service.clusterIP }}
   clusterIP: {{ .Values.nodeExporter.service.clusterIP }}

--- a/stable/prometheus/templates/node-exporter-serviceaccount.yaml
+++ b/stable/prometheus/templates/node-exporter-serviceaccount.yaml
@@ -5,4 +5,5 @@ metadata:
   labels:
     {{- include "prometheus.nodeExporter.labels" . | nindent 4 }}
   name: {{ template "prometheus.serviceAccountName.nodeExporter" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/stable/prometheus/templates/pushgateway-deployment.yaml
+++ b/stable/prometheus/templates/pushgateway-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
   name: {{ template "prometheus.pushgateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     {{- if .Values.schedulerName }}

--- a/stable/prometheus/templates/pushgateway-pvc.yaml
+++ b/stable/prometheus/templates/pushgateway-pvc.yaml
@@ -10,6 +10,7 @@ metadata:
   labels:
     {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
   name: {{ template "prometheus.pushgateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
 {{ toYaml .Values.pushgateway.persistentVolume.accessModes | indent 4 }}

--- a/stable/prometheus/templates/pushgateway-service.yaml
+++ b/stable/prometheus/templates/pushgateway-service.yaml
@@ -12,6 +12,7 @@ metadata:
 {{ toYaml .Values.pushgateway.service.labels | indent 4}}
 {{- end }}
   name: {{ template "prometheus.pushgateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
 {{- if .Values.pushgateway.service.clusterIP }}
   clusterIP: {{ .Values.pushgateway.service.clusterIP }}

--- a/stable/prometheus/templates/pushgateway-serviceaccount.yaml
+++ b/stable/prometheus/templates/pushgateway-serviceaccount.yaml
@@ -5,4 +5,5 @@ metadata:
   labels:
     {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
   name: {{ template "prometheus.serviceAccountName.pushgateway" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/stable/prometheus/templates/server-configmap.yaml
+++ b/stable/prometheus/templates/server-configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 data:
 {{- $root := . -}}
 {{- range $key, $value := .Values.serverFiles }}

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/stable/prometheus/templates/server-pvc.yaml
+++ b/stable/prometheus/templates/server-pvc.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
 {{ toYaml .Values.server.persistentVolume.accessModes | indent 4 }}

--- a/stable/prometheus/templates/server-service-headless.yaml
+++ b/stable/prometheus/templates/server-service-headless.yaml
@@ -12,6 +12,7 @@ metadata:
 {{ toYaml .Values.server.statefulSet.headless.labels | indent 4 }}
 {{- end }}
   name: {{ template "prometheus.server.fullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
 spec:
   clusterIP: None
   ports:

--- a/stable/prometheus/templates/server-service.yaml
+++ b/stable/prometheus/templates/server-service.yaml
@@ -11,6 +11,7 @@ metadata:
 {{ toYaml .Values.server.service.labels | indent 4 }}
 {{- end }}
   name: {{ template "prometheus.server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
 {{- if .Values.server.service.clusterIP }}
   clusterIP: {{ .Values.server.service.clusterIP }}

--- a/stable/prometheus/templates/server-serviceaccount.yaml
+++ b/stable/prometheus/templates/server-serviceaccount.yaml
@@ -5,4 +5,5 @@ metadata:
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.serviceAccountName.server" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/stable/prometheus/templates/server-statefulset.yaml
+++ b/stable/prometheus/templates/server-statefulset.yaml
@@ -12,6 +12,7 @@ metadata:
     {{ toYaml .Values.server.statefulSet.labels | nindent 4 }}
     {{- end}}
   name: {{ template "prometheus.server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   serviceName: {{ template "prometheus.server.fullname" . }}-headless
   selector:


### PR DESCRIPTION
#### What this PR does / why we need it:
```
helm template --name myname --namespace mynamespace stable/prometheus > apply.yaml
kubectl apply -f apply.yaml
```
when running the above command, resources get applied to namespace: **default**, not *mynamespace*


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)

@mgoodness @gianrubio