### PR TITLE
[stable/influxdb] Add support for imagePullSecrets (#15159)

### DIFF
--- a/stable/influxdb/Chart.yaml
+++ b/stable/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 1.3.0
+version: 1.3.1
 appVersion: 1.7.6
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/stable/influxdb/templates/deployment.yaml
+++ b/stable/influxdb/templates/deployment.yaml
@@ -15,6 +15,12 @@ spec:
         app: {{ template "influxdb.fullname" . }}
         release: "{{ .Release.Name }}"
     spec:
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end}}
+      {{- end }}
       containers:
       - name: {{ template "influxdb.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/influxdb/values.yaml
+++ b/stable/influxdb/values.yaml
@@ -4,6 +4,9 @@ image:
   repository: "influxdb"
   tag: "1.7.6-alpine"
   pullPolicy: IfNotPresent
+  ## If specified, use these secrets to access the images
+  # pullSecrets:
+  #   - registry-secret
 
 ## Specify a service type
 ## NodePort is default


### PR DESCRIPTION
Added imagePullSecrets to be able to pull docker image from private repository.

Signed-off-by: Alla Volkov <alla.volkov@sap.com>

#### What this PR does / why we need it:

Added imagePullSecrets to be able to pull docker image from private repository

#### Which issue this PR fixes
 fixes #15159

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
