### PR TITLE
[stable/airflow] Mount password when Postgres or Redis are enabled

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 4.0.4
+version: 4.0.5
 appVersion: 1.10.3
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/templates/_helpers.tpl
+++ b/stable/airflow/templates/_helpers.tpl
@@ -99,14 +99,14 @@ The key names for postgres and redis are fixed, which is consistent with the sub
 {{- define "airflow.mapenvsecrets" }}
   - name: POSTGRES_USER
     value: {{ default "postgres" .Values.postgresql.postgresUser | quote }}
-  {{- if .Values.postgresql.existingSecret }}
+  {{- if or .Values.postgresql.existingSecret .Values.postgresql.enabled }}
   - name: POSTGRES_PASSWORD
     valueFrom:
       secretKeyRef:
         name: {{ default (include "airflow.postgresql.fullname" .) .Values.postgresql.existingSecret }}
         key: postgres-password
   {{- end }}
-  {{- if .Values.redis.existingSecret }}
+  {{- if or .Values.redis.existingSecret .Values.redis.enabled }}
   - name: REDIS_PASSWORD
     valueFrom:
       secretKeyRef:


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes the if condition introduced  in PR #15712.
If we install the chart with the default values like `helm install stable/airflow --name=airflow` the web, scheduler and worker pods won't have the Redis and Postgres passwords mounted. This will cause the workers to fail on spawning:
`consumer: Cannot connect to redis://airflow-redis-master:6379/1: NOAUTH Authentication required..
Trying again in X seconds...`

#### Which issue this PR fixes
  - fixes #15896

#### Special notes for your reviewer:
The issue will still persist if `postgresql.enabled` or `redis.enabled` are set to `false` and the `existingSecret` is not set, which should be ok.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
