### PR TITLE
[stable/pomerium] Add prometheus operator ServiceMonitor support

### DIFF
--- a/stable/pomerium/Chart.yaml
+++ b/stable/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 1.2.1
+version: 1.2.2
 appVersion: 0.1.0
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo.svg

--- a/stable/pomerium/README.md
+++ b/stable/pomerium/README.md
@@ -75,9 +75,9 @@ Parameter                         | Description                                 
 `service.annotations`             | Service annotations                                                                                                                                                                                        | `{}`
 `service.externalPort`            | Pomerium's port                                                                                                                                                                                            | `443`
 `service.type`                    | Service type (ClusterIP, NodePort or LoadBalancer)                                                                                                                                                         | `ClusterIP`
-`serviceMonitor.enabled`          | Create Prometheus Operator ServiceMonitor                  | `false`
-`serviceMonitor.namespace`        | Namespace to create the ServiceMonitor resource in         | The namespace of the chart
-`serviceMonitor.labels`           | Additional labels to apply to the ServiceMonitor resource  | `release: prometheus`
+`serviceMonitor.enabled`          | Create Prometheus Operator ServiceMonitor                                            | `false`
+`serviceMonitor.namespace`        | Namespace to create the ServiceMonitor resource in                                   | The namespace of the chart
+`serviceMonitor.labels`           | Additional labels to apply to the ServiceMonitor resource                            | `release: prometheus`
 `ingress.enabled`                 | Enables Ingress for pomerium                                                                                                                                                                               | `false`
 `ingress.annotations`             | Ingress annotations                                                                                                                                                                                        | `{}`
 `ingress.hosts`                   | Ingress accepted hostnames                                                                                                                                                                                 | `nil`

--- a/stable/pomerium/README.md
+++ b/stable/pomerium/README.md
@@ -75,6 +75,9 @@ Parameter                         | Description                                 
 `service.annotations`             | Service annotations                                                                                                                                                                                        | `{}`
 `service.externalPort`            | Pomerium's port                                                                                                                                                                                            | `443`
 `service.type`                    | Service type (ClusterIP, NodePort or LoadBalancer)                                                                                                                                                         | `ClusterIP`
+`serviceMonitor.enabled`          | Create Prometheus Operator ServiceMonitor                  | `false`
+`serviceMonitor.namespace`        | Namespace to create the ServiceMonitor resource in         | The namespace of the chart
+`serviceMonitor.labels`           | Additional labels to apply to the ServiceMonitor resource  | `release: prometheus`
 `ingress.enabled`                 | Enables Ingress for pomerium                                                                                                                                                                               | `false`
 `ingress.annotations`             | Ingress annotations                                                                                                                                                                                        | `{}`
 `ingress.hosts`                   | Ingress accepted hostnames                                                                                                                                                                                 | `nil`
@@ -84,6 +87,32 @@ Parameter                         | Description                                 
 
 ## Metrics Discovery Configuration
 
+This chart provices two ways to surface metrics for discovery.  Under normal circumstances, you will only set up one method.
+
+### Prometheus Operator 
+
+This chart assumes you have already installed the Prometheus Operator CRDs.
+
+Example chart values:
+
+```yaml
+metrics:
+  enabled: true
+  port: 9090 # default
+serviceMonitor:
+  enabled: true
+  labels:
+    release: prometheus # default
+
+```
+
+Example ServiceMonitor configuration:
+
+```yaml
+    serviceMonitorSelector:
+      matchLabels:
+        release: prometheus # operator chart default
+```
 
 ### Prometheus kubernetes_sd_configs
 

--- a/stable/pomerium/templates/authenticate-service.yaml
+++ b/stable/pomerium/templates/authenticate-service.yaml
@@ -22,7 +22,10 @@ spec:
       targetPort: https
       protocol: TCP
       name: https
-
+    - name: metrics
+      port: {{ .Values.metrics.port }}
+      protocol: TCP
+      targetPort: metrics
 {{- if hasKey .Values.service "nodePort" }}
     nodePort: {{ .Values.service.nodePort }}
 {{- end }}

--- a/stable/pomerium/templates/authorize-service.yaml
+++ b/stable/pomerium/templates/authorize-service.yaml
@@ -22,7 +22,10 @@ spec:
       targetPort: https
       protocol: TCP
       name: https
-
+    - name: metrics
+      port: {{ .Values.metrics.port }}
+      protocol: TCP
+      targetPort: metrics
 {{- if hasKey .Values.service "nodePort" }}
     nodePort: {{ .Values.service.nodePort }}
 {{- end }}

--- a/stable/pomerium/templates/proxy-service.yaml
+++ b/stable/pomerium/templates/proxy-service.yaml
@@ -22,7 +22,10 @@ spec:
       targetPort: https
       protocol: TCP
       name: https
-
+    - name: metrics
+      port: {{ .Values.metrics.port }}
+      protocol: TCP
+      targetPort: metrics
 {{- if hasKey .Values.service "nodePort" }}
     nodePort: {{ .Values.service.nodePort }}
 {{- end }}

--- a/stable/pomerium/templates/servicemonitor.yaml
+++ b/stable/pomerium/templates/servicemonitor.yaml
@@ -1,0 +1,23 @@
+{{ if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "pomerium.fullname" . }}
+{{ if .Values.serviceMonitor.namespace -}}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+{{- end }}
+  labels:
+    helm.sh/chart: {{ template "pomerium.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.serviceMonitor.labels }}
+{{ toYaml .Values.serviceMonitor.labels | indent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+      helm.sh/chart: {{ template "pomerium.chart" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  endpoints:
+  - port: metrics
+{{ end }}

--- a/stable/pomerium/templates/servicemonitor.yaml
+++ b/stable/pomerium/templates/servicemonitor.yaml
@@ -3,13 +3,14 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "pomerium.fullname" . }}
-{{ if .Values.serviceMonitor.namespace -}}
+{{- if .Values.serviceMonitor.namespace }}
   namespace: {{ .Values.serviceMonitor.namespace }}
 {{- end }}
   labels:
     helm.sh/chart: {{ template "pomerium.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "pomerium.name" . }}
 {{- if .Values.serviceMonitor.labels }}
 {{ toYaml .Values.serviceMonitor.labels | indent 4 }}
 {{- end }}

--- a/stable/pomerium/values.yaml
+++ b/stable/pomerium/values.yaml
@@ -124,7 +124,6 @@ metrics:
 
 serviceMonitor:
   enabled: false
-  namespace: false
+  namespace: ""
   labels:
     release: prometheus
-  

--- a/stable/pomerium/values.yaml
+++ b/stable/pomerium/values.yaml
@@ -121,3 +121,10 @@ image:
 metrics:
   enabled: false
   port: 9090
+
+serviceMonitor:
+  enabled: false
+  namespace: false
+  labels:
+    release: prometheus
+  


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds/updates templates to support prometheus operator ServiceMonitor configuration

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
