### PR TITLE
[stable/external-dns] Moved back to original - upstream - image

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.4.2
+version: 3.0.0
 appVersion: 0.5.15
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:
@@ -10,7 +10,6 @@ keywords:
 home: https://github.com/kubernetes-incubator/external-dns
 sources:
 - https://github.com/kubernetes-incubator/external-dns
-- https://github.com/bitnami/bitnami-docker-external-dns
 maintainers:
 - name: Bitnami
   email: containers@bitnami.com

--- a/stable/external-dns/values-production.yaml
+++ b/stable/external-dns/values-production.yaml
@@ -11,9 +11,9 @@
 ## ref: https://hub.docker.com/r/bitnami/external-dns/tags/
 ##
 image:
-  registry: docker.io
-  repository: bitnami/external-dns
-  tag: 0.5.15-debian-9-r1
+  registry: registry.opensource.zalan.do
+  repository: teapot/external-dns
+  tag: 0.5.15
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -11,9 +11,9 @@
 ## ref: https://hub.docker.com/r/bitnami/external-dns/tags/
 ##
 image:
-  registry: docker.io
-  repository: bitnami/external-dns
-  tag: 0.5.15-debian-9-r1
+  registry: registry.opensource.zalan.do
+  repository: teapot/external-dns
+  tag: 0.5.15
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Fixes #16042

Signed-off-by: Marco Ceppi <marco@ceppi.net>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR restores the upstream external-dns repository prior to the bitnami takeover

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #16042 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
