### PR TITLE
[stable/grafana] Add env vars for download dashboard container

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 3.7.3
+version: 3.8.0
 appVersion: 6.2.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -123,7 +123,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `command`                     | Define command to be executed by grafana container at startup  | `nil` |
 | `testFramework.image`                     | `test-framework` image repository.             | `dduportal/bats`                                       |
 | `testFramework.tag`                       | `test-framework` image tag.                    | `0.4.0`                                                |
-| `testFramework.securityContext`           | `test-framework securityContext                | `{}`                                                   |
+| `testFramework.securityContext`           | `test-framework` securityContext                | `{}`                                                   |
+| `downloadDashboards.env`                  | Environment variables to be passed to the `download-dashboards` container | `{}`                                                   |
 
 
 ### Example of extraVolumeMounts

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -77,6 +77,11 @@ spec:
           imagePullPolicy: {{ .Values.downloadDashboardsImage.pullPolicy }}
           command: ["/bin/sh"]
           args: [ "-c", "mkdir -p /var/lib/grafana/dashboards/default && /bin/sh /etc/grafana/download_dashboards.sh" ]
+          env:
+{{- range $key, $value := .Values.downloadDashboardsEnv }}
+            - name: "{{ $key }}"
+              value: "{{ $value }}"
+{{- end }}
           volumeMounts:
             - name: config
               mountPath: "/etc/grafana/download_dashboards.sh"

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -78,7 +78,7 @@ spec:
           command: ["/bin/sh"]
           args: [ "-c", "mkdir -p /var/lib/grafana/dashboards/default && /bin/sh /etc/grafana/download_dashboards.sh" ]
           env:
-{{- range $key, $value := .Values.downloadDashboardsEnv }}
+{{- range $key, $value := .Values.downloadDashboards.env }}
             - name: "{{ $key }}"
               value: "{{ $value }}"
 {{- end }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -75,7 +75,8 @@ downloadDashboardsImage:
   tag: latest
   pullPolicy: IfNotPresent
 
-downloadDashboardsEnv: {}
+downloadDashboards:
+  env: {}
 
 ## Pod Annotations
 # podAnnotations: {}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -75,6 +75,8 @@ downloadDashboardsImage:
   tag: latest
   pullPolicy: IfNotPresent
 
+downloadDashboardsEnv: {}
+
 ## Pod Annotations
 # podAnnotations: {}
 


### PR DESCRIPTION
Signed-off-by: Caspar Rolfe <caspar.rolfe@gmail.com>

#### What this PR does / why we need it:

The `download-dashboards` container has no option to set environment variables. This change allows variables to be set for proxies.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
