### PR TITLE
[stable/prometheus-nats-exporter] fix hardcoded cluster dns name

### DIFF
--- a/stable/prometheus-nats-exporter/Chart.yaml
+++ b/stable/prometheus-nats-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart for prometheus-nats-exporter
 name: prometheus-nats-exporter
-version: 2.2.0
+version: 2.2.1
 home: https://github.com/nats-io/prometheus-nats-exporter
 sources:
   - https://github.com/nats-io/prometheus-nats-exporter

--- a/stable/prometheus-nats-exporter/templates/deployment.yaml
+++ b/stable/prometheus-nats-exporter/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
             {{- if .Values.config.metrics.subz }}
             - "-subz"
             {{- end }}
-            - "http://{{ .Values.config.nats.service }}.{{ .Values.config.nats.namespace }}.svc.cluster.local:{{ .Values.config.nats.port }}"
+            - "http://{{ .Values.config.nats.service }}.{{ .Values.config.nats.namespace }}.svc:{{ .Values.config.nats.port }}"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:


### PR DESCRIPTION
Signed-off-by: Arseniy Sh <ashemenev@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
it is impossible to resolve the path to nats svc when cluster has its own domain (e.g. nats-monitoring.dev.myown.cluster)
#### Special notes for your reviewer:
another way is to move cluster name into values.yaml, but i think short svc name could be enough

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
