### PR TITLE
[incubator/ado-agent] Added helm chart for azure devops build agent

### DIFF
--- a/incubator/ado-agent/.helmignore
+++ b/incubator/ado-agent/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/incubator/ado-agent/Chart.yaml
+++ b/incubator/ado-agent/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Azure DevOps Agents
+name: ado-agent
+home: https://github.com/gambtho/aks-azuredevops-agent
+version: 0.1.0
+keywords:
+- azure
+- devops
+- agent
+sources:
+- https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/docker?view=azure-devops
+- https://dev.azure.com
+maintainers:
+- name: gambtho
+  email: thomasgamble2@gmail.com

--- a/incubator/ado-agent/README.md
+++ b/incubator/ado-agent/README.md
@@ -1,0 +1,21 @@
+# Azure DevOps - Self Hosted Linux Agent
+
+This chart provides a basic configuration for an Azure DevOps Self-Hosted Agent.   It will allow a user to control the number of instances and the tools installed on their agents.   Additional detail on self hosted agents can be found [here](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/docker?view=azure-devops).  In addition, a sample setup of a full AKS Cluster using this chart, is available [here](https://github.com/gambtho/aks-azuredevops-agent)
+
+## Setup
+
+- Get the name of your Azure DevOps account, will be something like https://dev.azure.com/<your_account> - $ACCOUNT
+- Create a [personal access token](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=vsts) - $TOKEN
+- Create an [agent pool](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/pools-queues?view=vsts) - $POOL
+
+These values need to be encoded with base64, and can either be applied in a values file, or as part of the helm chart deployment
+
+```bash
+helm install ado-agent incubator/ado-agent --set vsts.account=${ACCOUNT},vsts.token=${TOKEN},vsts.pool=${POOL}
+```
+
+## Possible changes
+
+- Add pod autoscale
+- Use this [startup script](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/docker?view=azure-devops)
+- Fork [gambtho/azure-pipeline-agent](https://hub.docker.com/r/gambtho/azure-pipeline-agent/dockerfile) and add any additional tools you may want

--- a/incubator/ado-agent/templates/NOTES.txt
+++ b/incubator/ado-agent/templates/NOTES.txt
@@ -1,0 +1,6 @@
+- You must set the vsts variables to the approriate values for your Azure DevOps Organization
+- vsts.account is the suffix of the url for your Azure DevOps Org https://dev.azure.com/<account>
+- vsts.token is a personal access token - https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=vsts
+- vsts.pool is an agent pool - https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/pools-queues?view=vsts
+- the values for these should be encoded with base64
+- default docker image for this chart is located here - https://hub.docker.com/r/gambtho/azure-pipeline-agent/dockerfile

--- a/incubator/ado-agent/templates/_helpers.tpl
+++ b/incubator/ado-agent/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ado-agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ado-agent.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ado-agent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "ado-agent.labels" -}}
+app.kubernetes.io/name: {{ include "ado-agent.name" . }}
+helm.sh/chart: {{ include "ado-agent.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/incubator/ado-agent/templates/deployment.yaml
+++ b/incubator/ado-agent/templates/deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ado-agent.fullname" . }}
+  labels:
+{{ include "ado-agent.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "ado-agent.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "ado-agent.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          - name: VSTS_ACCOUNT
+            valueFrom:
+              secretKeyRef:
+                name: vsts
+                key: account
+          - name: VSTS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: vsts
+                key: token
+          - name: VSTS_POOL
+            valueFrom:
+              secretKeyRef:
+                name: vsts
+                key: pool
+          ports:
+            - name: https
+              containerPort: 443
+              protocol: TCP
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: docker-graph-storage
+              mountPath: /var/lib/docker
+            - mountPath: /var/run/docker.sock
+              name: docker-socket-volume
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      volumes:
+        - name: docker-graph-storage
+          emptyDir: {}
+        - name: docker-socket-volume
+          hostPath:
+            path: /var/run/docker.sock
+            type: File

--- a/incubator/ado-agent/templates/secret.yaml
+++ b/incubator/ado-agent/templates/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsts
+type: Opaque
+data:
+  account: {{ .Values.vsts.account }}
+  token: {{ .Values.vsts.token }}
+  pool: {{ .Values.vsts.pool }}

--- a/incubator/ado-agent/templates/service.yaml
+++ b/incubator/ado-agent/templates/service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ado-agent.fullname" . }}
+  labels:
+{{ include "ado-agent.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: 80
+      name: web
+      protocol: TCP
+      targetPort: 80
+    - port: 8080
+      name: web2
+      protocol: TCP
+      targetPort: 8080
+    - port: 443
+      name: secureweb
+      protocol: TCP
+      targetPort: 443
+  selector:
+    app.kubernetes.io/name: {{ include "ado-agent.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/incubator/ado-agent/templates/tests/test-connection.yaml
+++ b/incubator/ado-agent/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "ado-agent.fullname" . }}-test-connection"
+  labels:
+{{ include "ado-agent.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ include "ado-agent.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/incubator/ado-agent/values.yaml
+++ b/incubator/ado-agent/values.yaml
@@ -1,0 +1,20 @@
+replicaCount: 1
+image:
+  repository: gambtho/azure-pipeline-agent
+  tag: latest
+  pullPolicy: Always
+ingress:
+  enabled: false
+vsts:
+  account: "replacme"
+  token: "replaceme"
+  pool: "replaceme"
+service:
+  type: ClusterIP
+resources:
+  limits:
+    cpu: 200m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 256Mi


### PR DESCRIPTION
#### What this PR does / why we need it:

This chart provides a self-hosted linux agent for use with Azure DevOps.   It is not limited to Azure Kubernetes Service, but can be run anywhere that allows outbound connection.   These agents provide additional workers that can be customized for use during an Azure DevOps pipeline

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X ] Chart Version bumped
- [X ] Variables are documented in the README.md
- [ X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
