### PR TITLE
[stable/minecraft] Minecraft updates. Version bump, memory fix and pod assignment config

### DIFF
--- a/stable/minecraft/Chart.yaml
+++ b/stable/minecraft/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: minecraft
-version: 1.0.3
-appVersion: 1.13.1
+version: 1.1.0
+appVersion: 1.14.4
 home: https://minecraft.net/
 description: Minecraft server
 keywords:

--- a/stable/minecraft/templates/deployment.yaml
+++ b/stable/minecraft/templates/deployment.yaml
@@ -133,8 +133,12 @@ spec:
         {{- end }}
         - name: ONLINE_MODE
           value: {{ .Values.minecraftServer.onlineMode | quote }}
+        - name: MEMORY
+          value: {{ .Values.minecraftServer.memory | quote }}
         - name: JVM_OPTS
           value: {{ .Values.minecraftServer.jvmOpts | quote }}
+        - name: JVM_XX_OPTS
+          value: {{ .Values.minecraftServer.jvmXXOpts | quote }}
 
         {{- if .Values.minecraftServer.rcon.enabled }}
         - name: ENABLE_RCON
@@ -178,4 +182,16 @@ spec:
       {{- else }}
         emptyDir: {}
       {{- end }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}
 {{ end }}

--- a/stable/minecraft/values.yaml
+++ b/stable/minecraft/values.yaml
@@ -10,6 +10,12 @@ resources:
     memory: 512Mi
     cpu: 500m
 
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
 securityContext:
   # Security context settings
   runAsUser: 1000
@@ -34,9 +40,9 @@ minecraftServer:
   # This must be overridden, since we can't accept this for the user.
   eula: "FALSE"
   # One of: LATEST, SNAPSHOT, or a specific version (ie: "1.7.9").
-  version: "1.13.1"
-  # This can be one of empty string, "FORGE", "SPIGOT", "BUKKIT", "PAPER", "FTB", "SPONGEVANILLA"; empty string will produce a vanilla server
-  type: ""
+  version: "1.14.4"
+  # This can be one of "VANILLA", "FORGE", "SPIGOT", "BUKKIT", "PAPER", "FTB", "SPONGEVANILLA"
+  type: "VANILLA"
   # If type is set to FORGE, this sets the version; this is ignored if forgeInstallerUrl is set
   forgeVersion:
   # If type is set to SPONGEVANILLA, this sets the version
@@ -114,7 +120,11 @@ minecraftServer:
   # Check accounts against Minecraft account service.
   onlineMode: true
   # If you adjust this, you may need to adjust resources.requests above to match.
-  jvmOpts: "-Xmx512M -Xms512M"
+  memory: 512M
+  # General JVM options to be passed to the Minecraft server invocation
+  jvmOpts: ""
+  # Options like -X that need to proceed general JVM options 
+  jvmXXOpts: ""
   serviceType: LoadBalancer
   rcon:
     # If you enable this, make SURE to change your password below.

--- a/stable/minecraft/values.yaml
+++ b/stable/minecraft/values.yaml
@@ -123,7 +123,7 @@ minecraftServer:
   memory: 512M
   # General JVM options to be passed to the Minecraft server invocation
   jvmOpts: ""
-  # Options like -X that need to proceed general JVM options 
+  # Options like -X that need to proceed general JVM options
   jvmXXOpts: ""
   serviceType: LoadBalancer
   rcon:


### PR DESCRIPTION
Signed-off-by: Dave Oxley <dave@daveoxley.co.uk>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

- Adds new memory environment variable for setting memory. Having the memory settings in `JVM_OPTS` currently results in duplicate memory parameters on the Java command line.
- Makes the default type `VANILLA` as blank is not valid.
- Adds pod assignment config (nodeSelector, affinity and tolerations).
- Bumps minecraft version to 1.14.4.

@gtaylor @billimek @itzg 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
