### PR TITLE
[stable/redis-ha] Allow templating in customConfig blocks

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.7.0
+version: 3.7.1
 appVersion: 5.0.5
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/redis-ha-configmap.yaml
+++ b/stable/redis-ha/templates/redis-ha-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
 data:
   redis.conf: |
 {{- if .Values.redis.customConfig }}
-{{ .Values.redis.customConfig | indent 4 }}
+{{ tpl .Values.redis.customConfig . | indent 4 }}
 {{- else }}
     dir "/data"
     {{- range $key, $value := .Values.redis.config }}
@@ -24,7 +24,7 @@ data:
 
   sentinel.conf: |
 {{- if .Values.sentinel.customConfig }}
-{{ .Values.sentinel.customConfig | indent 4 }}
+{{ tpl .Values.sentinel.customConfig . | indent 4 }}
 {{- else }}
     dir "/data"
     {{- $root := . -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

The `customConfig` blocks when passed through `tpl` can contain Helm
templating placeholders to make more dynamic configurations possible.

#### Which issue this PR fixes

- fixes #16065

#### Special notes for your reviewer:

@ssalaues  PTAL

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)