### PR TITLE
[stable/kube2iam] Update version in documentation

### DIFF
--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kube2iam
-version: 2.0.0
+version: 2.0.1
 appVersion: 0.10.7
 description: Provide IAM credentials to pods based on annotations.
 keywords:

--- a/stable/kube2iam/README.md
+++ b/stable/kube2iam/README.md
@@ -49,7 +49,7 @@ Parameter | Description | Default
 `host.interface` | Host interface for proxying AWS metadata | `docker0`
 `host.port` | Port to listen on | `8181`
 `image.repository` | Image | `jtblin/kube2iam`
-`image.tag` | Image tag | `0.10.4`
+`image.tag` | Image tag | `0.10.7`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `nodeSelector` | node labels for pod assignment | `{}`
 `podAnnotations` | annotations to be added to pods | `{}`


### PR DESCRIPTION
#### What this PR does / why we need it:
Change version from 0.10.4 to 0.10.7 in the documented field because in `values.yaml`, the default value is 0.10.7 and not 0.10.4.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)

Signed-off-by: Nicolas Vanheuverzwijn <nicolas.vanheu@gmail.com>