### PR TITLE
[stable/elasticsearch-exporter] Support latest stable version

### DIFF
--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 1.7.0
+version: 1.7.1
 appVersion: 1.0.2
 home: https://github.com/justwatchcom/elasticsearch_exporter
 sources:

--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 1.7.1
-appVersion: 1.0.2
+version: 2.0.0
+appVersion: 1.1.0
 home: https://github.com/justwatchcom/elasticsearch_exporter
 sources:
   - https://github.com/justwatchcom/elasticsearch_exporter

--- a/stable/elasticsearch-exporter/README.md
+++ b/stable/elasticsearch-exporter/README.md
@@ -44,6 +44,7 @@ The following table lists the configurable parameters of the Elasticsearch-Expor
 
 Parameter | Description | Default
 --- | --- | ---
+`appVersion` | Application Version | `1.0.2`
 `replicaCount` | desired number of pods | `1`
 `restartPolicy` | container restart policy | `Always`
 `image.repository` | container image repository | `justwatch/elasticsearch_exporter`

--- a/stable/elasticsearch-exporter/README.md
+++ b/stable/elasticsearch-exporter/README.md
@@ -15,6 +15,8 @@ $ helm install stable/elasticsearch-exporter
 This chart creates an Elasticsearch-Exporter deployment on a [Kubernetes](http://kubernetes.io)
 cluster using the [Helm](https://helm.sh) package manager.
 
+**Note:** This chart does not support versions before [`elasticsearch-exporter:1.1.0`](https://github.com/justwatchcom/elasticsearch_exporter/releases/tag/v1.1.0).
+
 ## Prerequisites
 
 - Kubernetes 1.8+ with Beta APIs enabled
@@ -25,6 +27,11 @@ To install the chart with the release name `my-release`:
 
 ```bash
 $ helm install --name my-release stable/elasticsearch-exporter
+```
+
+> Note: To use [previous stable elasticsearch-exporter version](https://github.com/justwatchcom/elasticsearch_exporter/releases/tag/v1.0.2) run:
+```
+$ helm install --name my-release stable/elasticsearch-exporter --version 1.7.0
 ```
 
 The command deploys Elasticsearch-Exporter on the Kubernetes cluster using the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -44,7 +51,6 @@ The following table lists the configurable parameters of the Elasticsearch-Expor
 
 Parameter | Description | Default
 --- | --- | ---
-`appVersion` | Application Version | `1.0.2`
 `replicaCount` | desired number of pods | `1`
 `restartPolicy` | container restart policy | `Always`
 `image.repository` | container image repository | `justwatch/elasticsearch_exporter`

--- a/stable/elasticsearch-exporter/templates/deployment.yaml
+++ b/stable/elasticsearch-exporter/templates/deployment.yaml
@@ -68,7 +68,6 @@ spec:
             value: ":{{ .Values.service.httpPort }}"
           - name: WEB_TELEMETRY_PART
             value: "{{ .Values.web.path }}"
-          {{- end }}
           {{- if .Values.env }}
           {{- range $key, $value := .Values.env }}
           - name: {{ $key }}

--- a/stable/elasticsearch-exporter/templates/deployment.yaml
+++ b/stable/elasticsearch-exporter/templates/deployment.yaml
@@ -44,7 +44,6 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           env:
-          {{- if hasPrefix "1.1" .Values.appVersion }}
           - name: ES_URI
             value: "{{ .Values.es.uri }}"
           - name: ES_ALL
@@ -78,23 +77,6 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if hasPrefix "1.0." .Values.appVersion }}
-          command: ["elasticsearch_exporter",
-                    "-es.uri={{ .Values.es.uri }}",
-                    "-es.all={{ .Values.es.all }}",
-                    "-es.indices={{ .Values.es.indices }}",
-                    "-es.timeout={{ .Values.es.timeout }}",
-                    {{- if .Values.es.sslSkipVerify }}
-                    "-es.ssl-skip-verify=true",
-                    {{- end }}
-                    {{- if .Values.es.ssl.enabled }}
-                    "-es.ca=/ssl/ca.pem",
-                    "-es.client-cert=/ssl/client.pem",
-                    "-es.client-private-key=/ssl/client.key",
-                    {{- end }}
-                    "-web.listen-address=:{{ .Values.service.httpPort }}",
-                    "-web.telemetry-path={{ .Values.web.path }}"]
-          {{- end }}
           securityContext:
             capabilities:
               drop:

--- a/stable/elasticsearch-exporter/templates/deployment.yaml
+++ b/stable/elasticsearch-exporter/templates/deployment.yaml
@@ -43,8 +43,34 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          {{- if .Values.env }}
           env:
+          {{- if hasPrefix "1.1" .Values.appVersion }}
+          - name: ES_URI
+            value: "{{ .Values.es.uri }}"
+          - name: ES_ALL
+            value: "{{ .Values.es.all }}"
+          - name: ES_INDICES
+            value: "{{ .Values.es.indices }}"
+          - name: ES_TIMEOUT
+            value: "{{ .Values.es.timeout }}"
+          {{- if .Values.es.sslSkipVerify }}
+          - name: ES_SSL_SKIP_VERIFY
+            value: "true"
+          {{- end }}
+          {{- if .Values.es.ssl.enabled }}
+          - name: ES_CA
+            value: "/ssl/ca.pem"
+          - name: ES_CLIENT_CERT
+            value: "/ssl/client.pem"
+          - name: ES_CLIENT_PRIVATE_KEY
+            value: "/ssl/client.key"
+          {{- end }}
+          - name: WEB_LISTEN_ADDRESS
+            value: ":{{ .Values.service.httpPort }}"
+          - name: WEB_TELEMETRY_PART
+            value: "{{ .Values.web.path }}"
+          {{- end }}
+          {{- if .Values.env }}
           {{- range $key, $value := .Values.env }}
           - name: {{ $key }}
             value: "{{ $value }}"
@@ -52,6 +78,7 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if hasPrefix "1.0." .Values.appVersion }}
           command: ["elasticsearch_exporter",
                     "-es.uri={{ .Values.es.uri }}",
                     "-es.all={{ .Values.es.all }}",
@@ -67,6 +94,7 @@ spec:
                     {{- end }}
                     "-web.listen-address=:{{ .Values.service.httpPort }}",
                     "-web.telemetry-path={{ .Values.web.path }}"]
+          {{- end }}
           securityContext:
             capabilities:
               drop:

--- a/stable/elasticsearch-exporter/values.yaml
+++ b/stable/elasticsearch-exporter/values.yaml
@@ -1,4 +1,3 @@
-appVersion: 1.0.2
 ## number of exporter instances
 ##
 replicaCount: 1

--- a/stable/elasticsearch-exporter/values.yaml
+++ b/stable/elasticsearch-exporter/values.yaml
@@ -1,3 +1,4 @@
+appVersion: 1.0.2
 ## number of exporter instances
 ##
 replicaCount: 1


### PR DESCRIPTION
#### What this PR does / why we need it:
In latest `1.1.0` release https://github.com/justwatchcom/elasticsearch_exporter/releases/tag/v1.1.0 was introduced breaking changes:
```
[BREAKING] commandline flags are now POSIX flags with double dashes --
```
To use `1.1.0` was added `appVersion` to distinguish versions using `hasPrefix`:
- for `1.1` will be used env variables (so to enable any new arguments (like es.cluster_settings, es.indices_settings, etc.) can be used env variable defined in `.Values.env` without need to update `command`, to keep all settings in the same place, I've used env variables for all arguments)
- for `1.0` use the same `command` as before
#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
