### PR TITLE
[stable/airflow] Allow specifying nodePort for Web service

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 4.1.1
+version: 4.1.2
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -332,7 +332,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `airflow.service.type`                   | service type for Airflow UI                             | `ClusterIP`               |
 | `airflow.service.annotations`            | (optional) service annotations for Airflow UI           | `{}`                      |
 | `airflow.service.externalPort`           | (optional) external port for Airflow UI                 | `8080`                    |
-| `airflow.service.nodePort`               | (optional) when using service.type == NodePort, an optional NodePort to request | ``|
+| `airflow.service.nodePort.http`               | (optional) when using service.type == NodePort, an optional NodePort to request | ``|
 | `airflow.executor`                       | the executor to run                                     | `Celery`                  |
 | `airflow.initRetryLoop`                  | max number of retries during container init             |                           |
 | `airflow.image.repository`               | Airflow docker image                                    | `puckel/docker-airflow`   |

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -332,6 +332,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `airflow.service.type`                   | service type for Airflow UI                             | `ClusterIP`               |
 | `airflow.service.annotations`            | (optional) service annotations for Airflow UI           | `{}`                      |
 | `airflow.service.externalPort`           | (optional) external port for Airflow UI                 | `8080`                    |
+| `airflow.service.nodePort`               | (optional) when using service.type == NodePort, an optional NodePort to request | ``|
 | `airflow.executor`                       | the executor to run                                     | `Celery`                  |
 | `airflow.initRetryLoop`                  | max number of retries during container init             |                           |
 | `airflow.image.repository`               | Airflow docker image                                    | `puckel/docker-airflow`   |

--- a/stable/airflow/templates/service-web.yaml
+++ b/stable/airflow/templates/service-web.yaml
@@ -22,7 +22,7 @@ spec:
     - name: web
       protocol: TCP
       port: {{ .Values.airflow.service.externalPort | default 8080 }}
-      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort.http))) }}
+      {{- if (and (eq .Values.airflow.service.type "NodePort") (not (empty .Values.airflow.service.nodePort.http))) }}
       nodePort: {{ .Values.service.nodePort.http }}
       {{- end }}
       targetPort: 8080

--- a/stable/airflow/templates/service-web.yaml
+++ b/stable/airflow/templates/service-web.yaml
@@ -22,4 +22,7 @@ spec:
     - name: web
       protocol: TCP
       port: {{ .Values.airflow.service.externalPort | default 8080 }}
+      {{- if .Values.airflow.service.nodePort }}
+      nodePort: {{ .Values.airflow.service.nodePort }}
+      {{- end }}
       targetPort: 8080

--- a/stable/airflow/templates/service-web.yaml
+++ b/stable/airflow/templates/service-web.yaml
@@ -22,7 +22,7 @@ spec:
     - name: web
       protocol: TCP
       port: {{ .Values.airflow.service.externalPort | default 8080 }}
-      {{- if .Values.airflow.service.nodePort }}
-      nodePort: {{ .Values.airflow.service.nodePort }}
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort.http))) }}
+      nodePort: {{ .Values.service.nodePort.http }}
       {{- end }}
       targetPort: 8080

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -43,6 +43,7 @@ airflow:
     type: ClusterIP
     externalPort: 8080
     nodePort:
+      http:
   ##
   ## The executor to use.
   ##

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -42,6 +42,7 @@ airflow:
     annotations: {}
     type: ClusterIP
     externalPort: 8080
+    nodePort:
   ##
   ## The executor to use.
   ##


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Currently, it is not possible to request a specific NodePort in the Airflow chart.  Choosing a NodePort allows it to be included in the Webserver Base URL setting.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
