### PR TITLE
[stable/dask] Mount only jupyter_notebook_config.py file instead of whole jupyter directory.

### DIFF
--- a/stable/dask/Chart.yaml
+++ b/stable/dask/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dask
-version: 2.2.1
+version: 2.2.2
 appVersion: 1.1.0
 description: Distributed computation in Python with task scheduling
 home: https://dask.pydata.org

--- a/stable/dask/templates/dask-jupyter-deployment.yaml
+++ b/stable/dask/templates/dask-jupyter-deployment.yaml
@@ -36,7 +36,8 @@ spec:
 {{ toYaml .Values.jupyter.resources | indent 12 }}
           volumeMounts:
             - name: config-volume
-              mountPath: /home/jovyan/.jupyter
+              mountPath: /home/jovyan/.jupyter/jupyter_notebook_config.py
+              subPath: jupyter_notebook_config.py
           env:
             - name: DASK_SCHEDULER_ADDRESS
               value: {{ template "dask.fullname" . }}-scheduler:{{ .Values.scheduler.servicePort }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Instead of mounting the whole `~/.jupyter` directory with a config map, it only mounts the file specified in the config map now: `jupyter_notebook_config.py`. 

This way I can build images with custom configurations which are not overwritten by the mount, edit configurations in JuypterLab (e.g. keyboard shortcuts, etc.). Last but not least, I can actually use the dask labextension with kubectl port-forward without getting `{"message": "[Errno 30] Read-only file system: '/home/jovyan/.jupyter/lab'", "reason": null}`. 

I guess issue #13124 is somehow related..

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
