### PR TITLE
[stable/traefik]: reduce RBAC scope if one namespace is handled

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.77.2
+version: 1.77.3
 appVersion: 1.7.14
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/templates/_helpers.tpl
+++ b/stable/traefik/templates/_helpers.tpl
@@ -149,6 +149,21 @@ Helper for containerPort (http)
 {{- end -}}
 
 {{/*
+Helper for RBAC Scope
+If Kubernetes namespace selection is defined and the (one) selected
+namespace is the release namespace Cluster scope is unnecessary.
+*/}}
+{{- define "traefik.rbac.scope" -}}
+	{{- if .Values.kubernetes -}}
+		{{- if not (eq (.Values.kubernetes.namespaces | default (list) | toString) (list .Release.Namespace | toString)) -}}
+		Cluster
+		{{- end -}}
+	{{- else -}}
+	Cluster
+	{{- end -}}
+{{- end -}}
+
+{{/*
 Helper for containerPort (https)
 */}}
 {{- define "traefik.containerPort.https" -}}

--- a/stable/traefik/templates/rbac.yaml
+++ b/stable/traefik/templates/rbac.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   name: {{ template "traefik.fullname" . }}
 ---
-kind: ClusterRole
+kind: {{ include "traefik.rbac.scope" . | printf "%sRole" }}
 {{- if semverCompare "^1.8-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- else }}
@@ -39,7 +39,7 @@ rules:
     verbs:
       - update
 ---
-kind: ClusterRoleBinding
+kind: {{ include "traefik.rbac.scope" . | printf "%sRoleBinding" }}
 {{- if semverCompare "^1.8-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- else }}
@@ -49,7 +49,7 @@ metadata:
   name: {{ template "traefik.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: {{ include "traefik.rbac.scope" . | printf "%sRole" }}
   name: {{ template "traefik.fullname" . }}
 subjects:
 - kind: ServiceAccount


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
If Kubernetes namespace selection is defined and the (one) selected
namespace is the release namespace Cluster scope is unnecessary.

#### Which issue this PR fixes
- reduces the RBAC scope of this application in certain situations

#### Special notes for your reviewer:

Can be tested with:
```bash
helm upgrade --install traefik ./stable/traefik --set "kubernetes.namespaces[0]=default" --set rbac.enabled=true
```

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
