### PR TITLE
[stable/rocketchat] Correct the indentation for node affinity

### DIFF
--- a/stable/rocketchat/Chart.yaml
+++ b/stable/rocketchat/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rocketchat
-version: 1.1.7
+version: 1.1.8
 appVersion: 1.3.1
 description: Prepare to take off with the ultimate chat platform, experience the next level of team communications
 keywords:

--- a/stable/rocketchat/templates/deployment.yaml
+++ b/stable/rocketchat/templates/deployment.yaml
@@ -92,7 +92,7 @@ spec:
 {{- if or .Values.podAntiAffinity .Values.affinity }}
       affinity:
 {{- if .Values.affinity }}
-{{ toYaml .Values.affinity | indent 4 }}
+{{ toYaml .Values.affinity | indent 8 }}
 {{- end }}
 {{- if eq .Values.podAntiAffinity "hard" }}
         podAntiAffinity:


### PR DESCRIPTION
#### What this PR does / why we need it:

This character change fixes RocketChat deployment node affinity indentation. Node affinity is not otherwise respected.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)