### PR TITLE
[stable/node-problem-detector] upgrade node-problem-detector to 0.7

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: node-problem-detector
-version: "1.5.1"
-appVersion: v0.6.3
+version: "1.5.2"
+appVersion: v0.7.0
 home: https://github.com/kubernetes/node-problem-detector
 description: Installs the node-problem-detector daemonset for monitoring extra attributes on nodes
 icon: https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -51,9 +51,12 @@ The following table lists the configurable parameters for this chart and their d
 | `settings.custom_monitor_definitions` | User-specified custom monitor definitions  | `{}`                                                         |
 | `settings.log_monitors`               | System log monitor config files            | `/config/kernel-monitor.json`, `/config/docker-monitor.json` |
 | `settings.custom_plugin_monitors`     | Custom plugin monitor config files         | `[]`                                                         |
+| `settings.prometheus_address`         | Prometheus exporter address                | `0.0.0.0`                                                         |
+| `settings.prometheus_port`            | Prometheus exporter port                   | `20257`                                                         |
 | `serviceAccount.create`               | Whether a ServiceAccount should be created | `true`                                                       |
 | `serviceAccount.name`                 | Name of the ServiceAccount to create       | Generated value from template                                |
 | `tolerations`                         | Optional daemonset tolerations             | `[]`                                                         |
+| `nodeSelector`                        | Optional daemonset nodeSelector            | `{}`                                                         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
 

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -12,11 +12,13 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+      app: {{ include "node-problem-detector.name" . }}
   template:
     metadata:
       labels:
         app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app: {{ include "node-problem-detector.name" . }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/custom-config-configmap.yaml") . | sha256sum }}
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -37,7 +39,7 @@ spec:
           command:
             - "/bin/sh"
             - "-c"
-            - "exec /node-problem-detector --logtostderr --system-log-monitors={{- range $index, $monitor := .Values.settings.log_monitors }}{{if ne $index 0}},{{end}}{{ $monitor }}{{- end }} {{- if .Values.settings.custom_plugin_monitors }} --custom-plugin-monitors={{- range $index, $monitor := .Values.settings.custom_plugin_monitors }}{{if ne $index 0}},{{end}}{{ $monitor }}{{- end }} {{- end }}"
+            - "exec /node-problem-detector --logtostderr --system-log-monitors={{- range $index, $monitor := .Values.settings.log_monitors }}{{if ne $index 0}},{{end}}{{ $monitor }}{{- end }} {{- if .Values.settings.custom_plugin_monitors }} --custom-plugin-monitors={{- range $index, $monitor := .Values.settings.custom_plugin_monitors }}{{if ne $index 0}},{{end}}{{ $monitor }}{{- end }} {{- end }} --prometheus-address={{ .Values.settings.prometheus_address }} --prometheus-port={{ .Values.settings.prometheus_port }}"
           securityContext:
             privileged: true
           env:
@@ -54,6 +56,9 @@ spec:
             - name: custom-config
               mountPath: /custom-config
               readOnly: true
+          ports:
+            - containerPort: {{ .Values.settings.prometheus_port }}
+              name: exporter
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.affinity }}
@@ -64,6 +69,10 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
       volumes:
         - name: log
           hostPath:

--- a/stable/node-problem-detector/templates/service.yaml
+++ b/stable/node-problem-detector/templates/service.yaml
@@ -1,8 +1,13 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: node-problem-detector
+  name: {{ template "node-problem-detector.fullname" . }}
   labels:
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
     app: {{ include "node-problem-detector.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
@@ -14,4 +19,4 @@ spec:
     protocol: TCP
   selector:
     app: {{ include "node-problem-detector.name" . }}
-
+{{- end }}

--- a/stable/node-problem-detector/templates/service.yaml
+++ b/stable/node-problem-detector/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: node-problem-detector
+  labels:
+    app: {{ include "node-problem-detector.name" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: exporter
+    port: {{ .Values.settings.prometheus_port }}
+    protocol: TCP
+  selector:
+    app: {{ include "node-problem-detector.name" . }}
+

--- a/stable/node-problem-detector/templates/servicemonitor.yaml
+++ b/stable/node-problem-detector/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: node-problem-detector
+  labels:
+    app: {{ include "node-problem-detector.name" . }}
+    release: prometheus-operator
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "node-problem-detector.name" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  endpoints:
+  - port: exporter
+    path: /metrics
+    interval: 60s

--- a/stable/node-problem-detector/templates/servicemonitor.yaml
+++ b/stable/node-problem-detector/templates/servicemonitor.yaml
@@ -1,10 +1,16 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: node-problem-detector
+  name: {{ template "node-problem-detector.fullname" . }}
   labels:
-    app: {{ include "node-problem-detector.name" . }}
-    release: prometheus-operator
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:
   selector:
@@ -17,3 +23,4 @@ spec:
   - port: exporter
     path: /metrics
     interval: 60s
+{{- end }}

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -33,12 +33,15 @@ settings:
     # - /custom-config/docker-monitor-filelog.json
   custom_plugin_monitors: []
 
+  prometheus_address: 0.0.0.0
+  prometheus_port: 20257
+
 hostpath:
   logdir: /var/log/
 
 image:
   repository: k8s.gcr.io/node-problem-detector
-  tag: v0.6.3
+  tag: v0.7.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""
@@ -68,3 +71,5 @@ serviceAccount:
   name:
 
 affinity: {}
+
+nodeSelector: {}

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -73,3 +73,8 @@ serviceAccount:
 affinity: {}
 
 nodeSelector: {}
+
+metrics:
+  serviceMonitor:
+    enabled: false
+    additionalLabels: {}


### PR DESCRIPTION
- Expose nodeSelector & prometheus settings
- Add service & servicemonitor for the new prometheus exporter feature

Co-authored-by: Timothy Lee <timmy.ccl@gmail.com>
Signed-off-by: Ash Wu <hSATAC@gmail.com>

#### What this PR does / why we need it:

https://github.com/kubernetes/node-problem-detector/releases/tag/v0.7.0

NPD 0.7.0 is released 12 days ago, people are keen to embrace the bright new features in 0.7.0.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
