### PR TITLE
stable/cockroachdb: Add command overrides for init containers

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 2.1.12
+version: 2.1.13
 appVersion: 19.1.3
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -197,6 +197,8 @@ The following table lists the configurable parameters of the CockroachDB chart a
 | `Secure.Enabled`               | Whether to run securely using TLS certificates   | `false`                                   |
 | `Secure.RequestCertsImage`     | Image to use for requesting TLS certificates     | `cockroachdb/cockroach-k8s-request-cert`  |
 | `Secure.RequestCertsImageTag`  | Image tag to use for requesting TLS certificates | `0.4`                                     |
+| `Secure.RequestCertsInitCommandOverride` | Command to use for requesting TLS certificates in the cluster-init batch job | `[]` |
+| `Secure.RequestCertsCommandOverride` | Command to use for requesting TLS certificates | `[]`                                  |
 | `Secure.ServiceAccount.Create` | Whether to create a new RBAC service account     | `true`                                    |
 | `Secure.ServiceAccount.Name`   | Name of RBAC service account to use              | `""`                                      |
 | `JoinExisting`                 | List of already-existing cockroach instances     | `[]`                                      |

--- a/stable/cockroachdb/templates/cluster-init.yaml
+++ b/stable/cockroachdb/templates/cluster-init.yaml
@@ -32,9 +32,13 @@ spec:
         image: "{{ .Values.Secure.RequestCertsImage }}:{{ .Values.Secure.RequestCertsImageTag }}"
         imagePullPolicy: "{{ .Values.ImagePullPolicy }}"
         command:
+{{- if .Values.Secure.RequestCertsInitCommandOverride }}
+{{ toYaml .Values.Secure.RequestCertsInitCommandOverride |indent 8 }}
+{{- else }}
         - "/bin/ash"
         - "-ecx"
         - "/request-cert -namespace=${POD_NAMESPACE} -certs-dir=/cockroach-certs -type=client -user=root -symlink-ca-from=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+{{- end }}
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
+++ b/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
@@ -218,9 +218,13 @@ spec:
         image: "{{ .Values.Secure.RequestCertsImage }}:{{ .Values.Secure.RequestCertsImageTag }}"
         imagePullPolicy: "{{ .Values.ImagePullPolicy }}"
         command:
+{{- if .Values.Secure.RequestCertsCommandOverride }}
+{{ toYaml .Values.Secure.RequestCertsCommandOverride |indent 8 }}
+{{- else }}
         - "/bin/ash"
         - "-ecx"
         - "/request-cert -namespace=${POD_NAMESPACE} -certs-dir=/cockroach-certs -type=node -addresses=localhost,127.0.0.1,$(hostname -f),$(hostname -f|cut -f 1-2 -d '.'),{{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}-public,{{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}-public.$(hostname -f|cut -f 3- -d '.') -symlink-ca-from=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+{{- end }}
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -68,6 +68,10 @@ Secure:
   Enabled: false
   RequestCertsImage: "cockroachdb/cockroach-k8s-request-cert"
   RequestCertsImageTag: "0.4"
+  # If you are using a different RequestCertsImage you can override the command used in the cluster-init batch job here
+  RequestCertsInitCommandOverride: []
+  # If you are using a different RequestCertsImage you can override the command used in the statefulset init container here
+  RequestCertsCommandOverride: []
   ServiceAccount:
     # Specifies whether a service account should be created.
     Create: true


### PR DESCRIPTION
#### What this PR does / why we need it:
It is possible to configure the image:tag used for init containers, but
not possible to specify the command executed by init containers.
This change allows to overwrite the command.

Using a different init container might be necessary, to implement a
different certificate setup (Secure.Enabled: true), i.e. via
cert-manager or cockroachdb self-signed CA.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
