### PR TITLE
[stable/prometheus-rabbitmq-exporter] Rabbitmq prometheus exporter should use the same name for the port

### DIFF
--- a/stable/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/stable/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 0.5.1
+version: 0.5.2
 appVersion: v0.29.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/stable/prometheus-rabbitmq-exporter/templates/service.yaml
+++ b/stable/prometheus-rabbitmq-exporter/templates/service.yaml
@@ -13,7 +13,7 @@ spec:
     - port: {{ .Values.service.externalPort }}
       targetPort: publish
       protocol: TCP
-      name: rabbitmq-exporter
+      name: publish
   selector:
     app: {{ template "prometheus-rabbitmq-exporter.name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION

Signed-off-by: Luke Alexander <luke.alexander@mixcloud.com>


#### What this PR does / why we need it:
The Prometheus RabbitMQ exporter should use the same port name in the service template that is defined in the monitor template, otherwise the serviceMonitor will not scrape successfully

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
