### PR TITLE
[incubator/buzzfeed-sso] add suport for v2.0.0

### DIFF
--- a/incubator/buzzfeed-sso/Chart.yaml
+++ b/incubator/buzzfeed-sso/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Single sign-on for your Kubernetes services using Google OAuth
 name: buzzfeed-sso
-version: 0.0.8
-appVersion: 1.2.0
+version: 0.1.0
+appVersion: 2.0.0
 home: https://github.com/buzzfeed/sso
 sources:
   - https://hub.docker.com/r/buzzfeed/sso/

--- a/incubator/buzzfeed-sso/README.md
+++ b/incubator/buzzfeed-sso/README.md
@@ -83,6 +83,7 @@ Parameter | Description | Default
 `proxy.customSecret` | the secret key to reuse (avoids secret creation via helm) | REQUIRED if `proxy.secret` is not set
 `provider.google` | the Oauth provider to use (only Google support for now) | REQUIRED
 `provider.google.adminEmail` | the Google admin email | `undefined`
+`provider.google.slug` | the Google provider slug | `oauth2`
 `provider.google.secret` | the Google OAuth secrets | REQUIRED if `provider.google.customSecret` is not set
 `provider.google.customSecret` | the secret key to reuse instead of creating it via helm | REQUIRED if `provider.google.secret` is not set
 `image.repository` | container image repository | `buzzfeed/sso`

--- a/incubator/buzzfeed-sso/templates/auth-deployment.yaml
+++ b/incubator/buzzfeed-sso/templates/auth-deployment.yaml
@@ -53,67 +53,60 @@ spec:
               containerPort: 4180
               protocol: TCP
           env:
-            - name: SSO_EMAIL_DOMAIN
+            - name: AUTHORIZE_EMAIL_DOMAINS
               value: {{ .Values.emailDomain | quote }}
-            - name: HOST
-              value: {{ $authDomain }}
             {{- if .Values.whitelistedEmails }}
-            - name: SSO_EMAIL_ADDRESSES
+            - name: AUTHORIZE_EMAIL_ADDRESSES
               value: {{ .Values.whitelistedEmails }}
             {{- end }}
-            - name: REDIRECT_URL
-              value: https://{{ $authDomain }}
-            - name: PROXY_ROOT_DOMAIN
+            - name: SERVER_SCHEME
+              value: https
+            - name: SERVER_HOST
+              value: {{ $authDomain }}
+            - name: AUTHORIZE_PROXY_DOMAINS
               value: {{ .Values.rootDomain | quote }}
-            - name: PROXY_CLIENT_ID
+            - name: CLIENT_PROXY_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ $authSecret }}
                   key: proxy-client-id
-            - name: PROXY_CLIENT_SECRET
+            - name: CLIENT_PROXY_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ $authSecret }}
                   key: proxy-client-secret
-            - name: AUTH_CODE_SECRET
+            - name: SESSION_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ $authSecret }}
                   key: auth-code-secret
-            - name: COOKIE_SECRET
+            - name: SESSION_COOKIE_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ $authSecret }}
                   key: auth-cookie-secret
-            # # OLD_COOKIE_SECRET is the same as COOKIE_SECRET, not sure why its even needed at this point
-            - name: OLD_COOKIE_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $authSecret }}
-                  key: auth-cookie-secret
-            # STATSD_HOST and STATSD_PORT must be defined or the app wont launch, they dont need to be a real host / port
-            - name: STATSD_HOST
-              value: localhost
-            - name: STATSD_PORT
-              value: "11111"
-            - name: COOKIE_SECURE
+            - name: SESSION_COOKIE_SECURE
               value: "true"
             - name: CLUSTER
               value: {{ .Values.cluster | quote }}
             # Provider variables
           {{- with .Values.provider.google }}
+            - name: PROVIDER_GOOGLE_TYPE
+              value: google
+            - name: PROVIDER_GOOGLE_SLUG
+              value: {{ .slug | default "oauth2" | quote }}
           {{- if .adminEmail }}
-            - name: GOOGLE_ADMIN_EMAIL
+            - name: PROVIDER_GOOGLE_GOOGLE_IMPERSONATE
               value: {{ .adminEmail | quote }}
-            - name: GOOGLE_SERVICE_ACCOUNT_JSON
+            - name: PROVIDER_GOOGLE_GOOGLE_CREDENTIALS
               value: /creds/sso-serviceaccount.json
           {{- end }}
-            - name: CLIENT_ID
+            - name: PROVIDER_GOOGLE_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ $googleSecret }}
                   key: google-client-id
-            - name: CLIENT_SECRET
+            - name: PROVIDER_GOOGLE_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ $googleSecret }}

--- a/incubator/buzzfeed-sso/templates/proxy-deployment.yaml
+++ b/incubator/buzzfeed-sso/templates/proxy-deployment.yaml
@@ -71,15 +71,12 @@ spec:
               value: /sso/upstream_configs.yml
             - name: PROVIDER_URL
               value: https://{{ .Values.auth.domain }}
-            # STATSD_HOST and STATSD_PORT must be defined or the app wont launch, they dont need to be a real host / port, but they do need to be defined.
-            - name: STATSD_HOST
-              value: localhost
-            - name: STATSD_PORT
-              value: "11111"
             - name: COOKIE_SECURE
               value: "true"
             - name: CLUSTER
               value: {{ .Values.cluster | quote }}
+            - name: DEFAULT_PROVIDER_SLUG
+              value: {{ .Values.provider.google.slug | default "oauth2" | quote }}
           {{- if .Values.proxy.providerUrlInternal }}
             - name: PROVIDER_URL_INTERNAL
               value: {{ .Values.proxy.providerUrlInternal | quote }}

--- a/incubator/buzzfeed-sso/values.yaml
+++ b/incubator/buzzfeed-sso/values.yaml
@@ -36,7 +36,11 @@ auth:
 
 proxy:
   annotations: {}
-  extraEnv: []
+  extraEnv:
+    - name: STATSD_HOST
+      value: localhost
+    - name: STATSD_PORT
+      value: "11111"
   # providerUrlInternal: https://sso-auth.mydomain.com
   replicaCount: 1
   resources:
@@ -62,6 +66,7 @@ provider:
   google: {}  # Required.
   # google:
   #   adminEmail: me@mydomain.foo
+  #   slug: oauth2
   #   secret:
   #     clientId: foo123123-fake123123.apps.googleusercontent.com
   #     clientSecret: googleOauthClientSecret
@@ -73,7 +78,7 @@ provider:
 
 image:
   repository: buzzfeed/sso
-  tag: v1.2.0
+  tag: v2.0.0
   pullPolicy: IfNotPresent
 
 ingress:


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds support for `buzzfeed/sso` `v2.0.0`.

#### Special notes for your reviewer:
This is not backwards compatible with `v1.x.x`. Changes are documented [here](https://github.com/buzzfeed/sso/releases/tag/v2.0.0).

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)

@darioblanco @komljen 