### PR TITLE
[stable/external-dns] readd podLabels

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.5.1
+version: 2.5.2
 appVersion: 0.5.15
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/templates/_helpers.tpl
+++ b/stable/external-dns/templates/_helpers.tpl
@@ -40,6 +40,9 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{/* matchLabels */}}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels }}
+{{- end }}
 {{- define "external-dns.matchLabels" -}}
 app.kubernetes.io/name: {{ template "external-dns.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
#### What this PR does / why we need it:

In commit b241a62cb62a39aab2d3faf118378846de92c5e1 the `podLabels` for external-dns are removed. Now there is no possibility to extend labels for the pods which is needed for selecting custom labels.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
