### PR TITLE
[stable/external-dns] put podLabels inside the correct section

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.5.2
+version: 2.5.3
 appVersion: 0.5.15
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/templates/_helpers.tpl
+++ b/stable/external-dns/templates/_helpers.tpl
@@ -37,12 +37,12 @@ app.kubernetes.io/name: {{ template "external-dns.name" . }}
 helm.sh/chart: {{ template "external-dns.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end -}}
-
-{{/* matchLabels */}}
 {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels }}
 {{- end }}
+{{- end -}}
+
+{{/* matchLabels */}}
 {{- define "external-dns.matchLabels" -}}
 app.kubernetes.io/name: {{ template "external-dns.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR fixes an issue setting additional labels for external-dns. An earlier PR (#16162) add the podLabels in the wrong section. Sorry for this.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
