### PR TITLE
[stable/superset] Allow to override secret by using existing one

### DIFF
--- a/stable/superset/Chart.yaml
+++ b/stable/superset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Apache Superset (incubating) is a modern, enterprise-ready business intelligence web application
 name: superset
-version: 1.1.7
+version: 1.1.8
 appVersion: "0.28.1"
 keywords:
 - bi

--- a/stable/superset/README.md
+++ b/stable/superset/README.md
@@ -45,9 +45,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.tag`                | `superset` image tag                            | `0.28.1`                                                     |
 | `image.pullPolicy`         | Image pull policy                               | `IfNotPresent`                                               |
 | `image.pullSecrets`        | Secrets for private registry                    | `[]`                                                         |
+| `existingSecret`           | Use an existing secret to override `initFile` and `configFile` | `[]`                                          |
+| `initFile`                 | Content of init shell script                    | See [values.yaml](./values.yaml)                             |
 | `configFile`               | Content of [`superset_config.py`](https://superset.incubator.apache.org/installation.html) | See values.yaml](./values.yaml) |
 | `extraConfigFiles`         | Content of additional configuration files. Let the dictionary key name represent the name of the file and its value the files content. | `{}` |
-| `initFile`                 | Content of init shell script                    | See [values.yaml](./values.yaml)                             |
 | `replicas`                 | Number of replicas of superset                  | `1`                                                          |
 | `extraEnv`                 | Extra environment variables passed to pods      | `{}`                                                         |
 | `extraEnvFromSecret`       | The name of a Kubernetes secret (must be manually created in the same namespace) containing values to be added to the environment | `""` |

--- a/stable/superset/templates/deployment.yaml
+++ b/stable/superset/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       volumes:
         - name: superset-configs
           secret:
-            secretName: {{ include "superset.fullname" . }}
+            secretName: {{ .Values.existingSecret | default (include "superset.fullname" .) }}
         - name: storage-volume
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/stable/superset/values.yaml
+++ b/stable/superset/values.yaml
@@ -12,6 +12,9 @@ image:
   pullPolicy: "IfNotPresent"
   pullSecrets: []
 
+# Using existing secret will override the initFile and configFile values
+existingSecret: ""
+
 initFile: |-
   /usr/local/bin/superset-init --username admin --firstname admin --lastname user --email admin@fab.org --password admin
   superset runserver


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR will allow to use an existing secret file containg the `init_superset.sh` and `superset_config.py` scripts.
This is to allow users to create `files/init_superset.sh` and `files/superset_config.py`, and then use the helm templates with a custom secret file to take advantage of Helm templates.
This is not possible using `values.yaml` directly, because only files within the `templates/` folder can.

#### Which issue this PR fixes

  - none

#### Special notes for your reviewer:

  - none

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
