### PR TITLE
[stable/cerebro] run with security context and be able to run  as non…

### DIFF
--- a/stable/cerebro/Chart.yaml
+++ b/stable/cerebro/Chart.yaml
@@ -1,5 +1,5 @@
 name: cerebro
-version: 1.1.5
+version: 1.2.0
 appVersion: 0.8.4
 apiVersion: v1
 description: A Helm chart for Cerebro - a web admin tool that replaces Kopf.

--- a/stable/cerebro/README.md
+++ b/stable/cerebro/README.md
@@ -68,6 +68,7 @@ The following table lists the configurable parameters of the cerebro chart and t
 | `config.restHistorySize`            | Rest request history size per user  | `50`                                      |
 | `config.hosts`                      | A list of known hosts               | `[]`                                      |
 | `config.secret`                     | Secret used to sign session cookies | `(random alphanumeric 64 length string)`  |
+| `securityContext`                   | Security context for pod            | `See values.yaml`                         |
 
 
 

--- a/stable/cerebro/templates/deployment.yaml
+++ b/stable/cerebro/templates/deployment.yaml
@@ -26,14 +26,10 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
-      initContainers:
-        - name: chown-db
-          image: {{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}
-          imagePullPolicy: {{ .Values.init.image.pullPolicy }}
-          command: ["chown", "1000:1000", "/var/db/cerebro"]
-          volumeMounts:
-            - name: db
-              mountPath: /var/db/cerebro
+      {{- if .Values.securityContext }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+      {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}

--- a/stable/cerebro/values.yaml
+++ b/stable/cerebro/values.yaml
@@ -47,6 +47,11 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+
 resources: {}
 
 nodeSelector: {}

--- a/stable/cerebro/values.yaml
+++ b/stable/cerebro/values.yaml
@@ -11,19 +11,6 @@ image:
   tag: 0.8.4
   pullPolicy: IfNotPresent
 
-init:
-  image:
-    repository: docker.io/busybox
-    tag: musl
-    pullPolicy: IfNotPresent
-
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ##
-    # pullSecrets:
-    #   - myRegistrKeySecretName
-
 deployment:
   annotations: {}
 


### PR DESCRIPTION
…Root

Signed-off-by: David J. M. Karlsen <david@davidkarlsen.com>

#### What this PR does / why we need it:
This version will allow pod to run in strict environments which require nonRoot execution. With the removal of the init container the volume still looks correct and cerebro is able to create its database.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
