### PR TITLE
[stable/kong] render .env last in templates

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.14.2
+version: 0.14.3
 appVersion: 1.2

--- a/stable/kong/templates/controller-deployment.yaml
+++ b/stable/kong/templates/controller-deployment.yaml
@@ -61,7 +61,6 @@ spec:
         {{- end }}
         {{- include "kong.license" . | nindent 8 }}
         {{- end }}
-        {{- include "kong.env" .  | indent 8 }}
         {{- if .Values.admin.useTLS }}
         - name: KONG_ADMIN_LISTEN
           value: "0.0.0.0:{{ .Values.admin.containerPort }} ssl"
@@ -82,6 +81,7 @@ spec:
         - name: KONG_CASSANDRA_CONTACT_POINTS
           value: {{ template "kong.cassandra.fullname" . }}
         {{- end }}
+        {{- include "kong.env" .  | indent 8 }}
         ports:
         - name: admin
           containerPort: {{ .Values.admin.containerPort }}

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -135,7 +135,6 @@ spec:
         {{- end }}
         {{- include "kong.license" . | nindent 8 }}
         {{- end }}
-        {{- include "kong.env" .  | indent 8 }}
         - name: KONG_NGINX_HTTP_INCLUDE
           value: /kong/servers.conf
         {{- if .Values.postgresql.enabled }}
@@ -153,6 +152,7 @@ spec:
         - name: KONG_CASSANDRA_CONTACT_POINTS
           value: {{ template "kong.cassandra.fullname" . }}
         {{- end }}
+        {{- include "kong.env" .  | indent 8 }}
         ports:
         - name: admin
           containerPort: {{ .Values.admin.containerPort }}

--- a/stable/kong/templates/migrations-post-upgrade.yaml
+++ b/stable/kong/templates/migrations-post-upgrade.yaml
@@ -55,7 +55,6 @@ spec:
         {{- if .Values.enterprise.enabled }}
         {{- include "kong.license" . | nindent 8 }}
         {{- end }}
-        {{- include "kong.env" .  | indent 8 }}
         {{- if .Values.postgresql.enabled }}
         - name: KONG_PG_HOST
           value: {{ template "kong.postgresql.fullname" . }}
@@ -71,6 +70,7 @@ spec:
         - name: KONG_CASSANDRA_CONTACT_POINTS
           value: {{ template "kong.cassandra.fullname" . }}
         {{- end }}
+        {{- include "kong.env" .  | indent 8 }}
         command: [ "/bin/sh", "-c", "kong migrations finish" ]
       restartPolicy: OnFailure
 {{- end }}

--- a/stable/kong/templates/migrations-pre-upgrade.yaml
+++ b/stable/kong/templates/migrations-pre-upgrade.yaml
@@ -55,7 +55,6 @@ spec:
         {{- if .Values.enterprise.enabled }}
         {{- include "kong.license" . | nindent 8 }}
         {{- end }}
-        {{- include "kong.env" .  | indent 8 }}
         {{- if .Values.postgresql.enabled }}
         - name: KONG_PG_HOST
           value: {{ template "kong.postgresql.fullname" . }}
@@ -71,6 +70,7 @@ spec:
         - name: KONG_CASSANDRA_CONTACT_POINTS
           value: {{ template "kong.cassandra.fullname" . }}
         {{- end }}
+        {{- include "kong.env" .  | indent 8 }}
         command: [ "/bin/sh", "-c", "kong migrations up" ]
       restartPolicy: OnFailure
 {{- end }}

--- a/stable/kong/templates/migrations.yaml
+++ b/stable/kong/templates/migrations.yaml
@@ -50,7 +50,6 @@ spec:
         {{- if .Values.enterprise.enabled }}
         {{- include "kong.license" . | nindent 8 }}
         {{- end }}
-        {{- include "kong.env" .  | indent 8 }}
         {{- if .Values.postgresql.enabled }}
         - name: KONG_PG_HOST
           value: {{ template "kong.postgresql.fullname" . }}
@@ -66,6 +65,7 @@ spec:
         - name: KONG_CASSANDRA_CONTACT_POINTS
           value: {{ template "kong.cassandra.fullname" . }}
         {{- end }}
+        {{- include "kong.env" .  | indent 8 }}
         command: [ "/bin/sh", "-c", "kong migrations bootstrap" ]
       restartPolicy: OnFailure
 {{- end }}

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -253,6 +253,9 @@ runMigrations: true
 
 # Specify Kong configurations
 # Kong configurations guide https://getkong.org/docs/latest/configuration/
+# Values here take precedence over values from other sections of values.yaml,
+# e.g. setting pg_user here will override the value normally set when postgresql.enabled
+# is set below. In general, you should not set values here if they are set elsewhere.
 env:
   database: postgres
   proxy_access_log: /dev/stdout


### PR DESCRIPTION
#### What this PR does / why we need it:
Update all environment variable sections in templates to render variables from Values.env after rendering variables from other sections of values.yaml. Because the last variable definition wins, this ensures that users can override settings from elsewhere in values.yaml if needed without modifying templates, although use cases for this should be rare.

Previously, only wait-for-db placed env last. This should make all Pod/Job templates consistent.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)

@shashiranjan84 and @hbagdi please review.