### PR TITLE
[stable/minio] Fix 'mc policy' command syntax for new mc versions

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: MinIO is a high performance distributed object storage server, designed for large-scale private cloud infrastructure.
 name: minio
-version: 2.5.10
+version: 2.5.11
 appVersion: RELEASE.2019-08-07T01-59-21Z
 keywords:
 - storage

--- a/stable/minio/templates/_helper_create_bucket.txt
+++ b/stable/minio/templates/_helper_create_bucket.txt
@@ -67,7 +67,7 @@ createBucket() {
   # At this point, the bucket should exist, skip checking for existence
   # Set policy on the bucket
   echo "Setting policy of bucket '$BUCKET' to '$POLICY'."
-  /usr/bin/mc policy $POLICY myminio/$BUCKET
+  /usr/bin/mc policy set $POLICY myminio/$BUCKET
 }
 
 # Try connecting to Minio instance


### PR DESCRIPTION
Signed-off-by: Markus Schöpke <markus.schoepke@bedag.ch>

#### What this PR does / why we need it:
Makes the chart compatible with mc versions >= RELEASE.2019-08-07T23-14-43Z

#### Special notes for your reviewer:
https://github.com/minio/mc/releases/tag/RELEASE.2019-08-07T23-14-43Z

> BREAKING CHANGE: policy command syntax has been changed. Please see (#2768) for more details.
>        Existing scripts that use policy command needs to be modified to use the new syntax.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
