### PR TITLE
[incubator/vault] Start consul agent container before vault

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.18.15
+version: 0.18.16
 appVersion: 1.1.2
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -43,6 +43,43 @@ spec:
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
       containers:
+      {{- if .Values.consulAgent.join }}
+      - name: {{ .Chart.Name }}-consul-agent
+        image: "{{ .Values.consulAgent.repository }}:{{ .Values.consulAgent.tag }}"
+        imagePullPolicy: {{ .Values.consulAgent.pullPolicy }}
+        securityContext:
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - name: consul-data
+          mountPath: /etc/consul
+        {{- if .Values.consulAgent.gossipKeySecretName }}
+        - name: consul-gossip-key
+          mountPath: /etc/consul/secrets
+          readOnly: true
+        {{- end }}
+        command:
+          - "/bin/sh"
+          - "-ec"
+          - |
+            {{- if .Values.consulAgent.gossipKeySecretName }}
+            if [ -e /etc/consul/secrets/gossip-key ]; then
+              echo "{\"encrypt\": \"$(base64 /etc/consul/secrets/gossip-key)\"}" > /etc/consul/encrypt.json
+              GOSSIP_KEY="-config-file /etc/consul/encrypt.json"
+            fi
+            {{- end }}
+            {{- if .Values.vault.config.storage.consul.token }}
+            echo "{\"acl\":{\"tokens\":{\"agent\":\"{{ .Values.vault.config.storage.consul.token }}\"}}}" > /etc/consul/agent-token.json
+            AGENT_TOKEN="-config-file /etc/consul/agent-token.json"
+            {{- end }}
+
+            exec /bin/consul agent \
+              $GOSSIP_KEY \
+              $AGENT_TOKEN \
+              -join={{- .Values.consulAgent.join }} \
+              -data-dir=/etc/consul
+        resources:
+{{ toYaml .Values.consulAgent.resources | indent 10 }}
+      {{- end }}
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -115,43 +152,6 @@ spec:
 {{- if .Values.vault.extraContainers }}
 {{ tpl (toYaml .Values.vault.extraContainers) . | indent 6}}
 {{- end }}
-      {{- if .Values.consulAgent.join }}
-      - name: {{ .Chart.Name }}-consul-agent
-        image: "{{ .Values.consulAgent.repository }}:{{ .Values.consulAgent.tag }}"
-        imagePullPolicy: {{ .Values.consulAgent.pullPolicy }}
-        securityContext:
-          readOnlyRootFilesystem: true
-        volumeMounts:
-        - name: consul-data
-          mountPath: /etc/consul
-        {{- if .Values.consulAgent.gossipKeySecretName }}
-        - name: consul-gossip-key
-          mountPath: /etc/consul/secrets
-          readOnly: true
-        {{- end }}
-        command:
-          - "/bin/sh"
-          - "-ec"
-          - |
-            {{- if .Values.consulAgent.gossipKeySecretName }}
-            if [ -e /etc/consul/secrets/gossip-key ]; then
-              echo "{\"encrypt\": \"$(base64 /etc/consul/secrets/gossip-key)\"}" > /etc/consul/encrypt.json
-              GOSSIP_KEY="-config-file /etc/consul/encrypt.json"
-            fi
-            {{- end }}
-            {{- if .Values.vault.config.storage.consul.token }}
-            echo "{\"acl\":{\"tokens\":{\"agent\":\"{{ .Values.vault.config.storage.consul.token }}\"}}}" > /etc/consul/agent-token.json
-            AGENT_TOKEN="-config-file /etc/consul/agent-token.json"
-            {{- end }}
-
-            exec /bin/consul agent \
-              $GOSSIP_KEY \
-              $AGENT_TOKEN \
-              -join={{- .Values.consulAgent.join }} \
-              -data-dir=/etc/consul
-        resources:
-{{ toYaml .Values.consulAgent.resources | indent 10 }}
-      {{- end }}
       {{- if .Values.vaultExporter.enabled }}
       - name: {{ .Chart.Name }}-exporter
         image: "{{ .Values.vaultExporter.repository }}:{{ .Values.vaultExporter.tag }}"


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

If vault container has lifecycle postStart script which is waiting for vault to startup
and vault is configured to use Consul Agent then this postStart would never finish successfully.

Specifying consulAgent container before vault will fix this deadlock.

#### Which issue this PR fixes

No issue

#### Special notes for your reviewer:

it is simple block rearrangement. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
