### PR TITLE
[stable/mongodb-replicaset] when name is very long there are some places truncating doesnt happen

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.9.6
+version: 3.9.7
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/templates/_helpers.tpl
+++ b/stable/mongodb-replicaset/templates/_helpers.tpl
@@ -61,3 +61,19 @@ Create the name for the key secret.
         {{- template "mongodb-replicaset.fullname" . -}}-keyfile
     {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name for the client full name.
+*/}}
+{{- define "mongodb-replicaset.truncForSuffix" -}}
+    {{- if .Values.fullnameOverride -}}
+        {{- .Values.fullnameOverride | trunc (int (sub 63 (len .suffix))) | trimSuffix "-" -}}{{ .suffix }}
+    {{- else -}}
+        {{- $name := default .Chart.Name .Values.nameOverride -}}
+        {{- if contains $name .Release.Name -}}
+            {{- .Release.Name | trunc (int (sub 63 (len .suffix))) | trimSuffix "-" -}}{{ .suffix }}
+        {{- else -}}
+            {{- printf "%s-%s" .Release.Name $name | trunc (int (sub 63 (len .suffix))) | trimSuffix "-" -}}{{ .suffix }}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}

--- a/stable/mongodb-replicaset/templates/mongodb-init-configmap.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-init-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
     app: {{ template "mongodb-replicaset.name" . }}
     chart: {{ template "mongodb-replicaset.chart" . }}
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | trunc 63 | trimSuffix "-"  }}
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}

--- a/stable/mongodb-replicaset/templates/mongodb-mongodb-configmap.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-mongodb-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
     app: {{ template "mongodb-replicaset.name" . }}
     chart: {{ template "mongodb-replicaset.chart" . }}
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | trunc 63 | trimSuffix "-"  }}
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}

--- a/stable/mongodb-replicaset/templates/mongodb-service-client.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-service-client.yaml
@@ -10,11 +10,11 @@ metadata:
     app: {{ template "mongodb-replicaset.name" . }}
     chart: {{ template "mongodb-replicaset.chart" . }}
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
-  name: {{ template "mongodb-replicaset.fullname" . }}-client
+  name: {{ template "mongodb-replicaset.truncForSuffix" (dict "Values" .Values "Chart" .Chart "Release" .Release "suffix" "-client") }}
 spec:
   type: ClusterIP
   clusterIP: None
@@ -28,5 +28,5 @@ spec:
 {{- end }}
   selector:
     app: {{ template "mongodb-replicaset.name" . }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | trunc 63 | trimSuffix "-" }}
 

--- a/stable/mongodb-replicaset/templates/mongodb-service.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-service.yaml
@@ -8,7 +8,7 @@ metadata:
     app: {{ template "mongodb-replicaset.name" . }}
     chart: {{ template "mongodb-replicaset.chart" . }}
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
@@ -22,4 +22,4 @@ spec:
   publishNotReadyAddresses: true
   selector:
     app: {{ template "mongodb-replicaset.name" . }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | trunc 63 | trimSuffix "-" }}

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -5,7 +5,7 @@ metadata:
     app: {{ template "mongodb-replicaset.name" . }}
     chart: {{ template "mongodb-replicaset.chart" . }}
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
@@ -14,14 +14,14 @@ spec:
   selector:
     matchLabels:
       app: {{ template "mongodb-replicaset.name" . }}
-      release: {{ .Release.Name }}
+      release: {{ .Release.Name | trunc 63 | trimSuffix "-" }}
   serviceName: {{ template "mongodb-replicaset.fullname" . }}
   replicas: {{ .Values.replicas }}
   template:
     metadata:
       labels:
         app: {{ template "mongodb-replicaset.name" . }}
-        release: {{ .Release.Name }}
+        release: {{ .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels | indent 8 }}
 {{- end }}

--- a/stable/mongodb-replicaset/templates/tests/mongodb-up-test-configmap.yaml
+++ b/stable/mongodb-replicaset/templates/tests/mongodb-up-test-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
     app: {{ template "mongodb-replicaset.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | trunc 63 | trimSuffix "-" }}
   name: {{ template "mongodb-replicaset.fullname" . }}-tests
 data:
   mongodb-up-test.sh: |

--- a/stable/mongodb-replicaset/templates/tests/mongodb-up-test-pod.yaml
+++ b/stable/mongodb-replicaset/templates/tests/mongodb-up-test-pod.yaml
@@ -4,8 +4,8 @@ metadata:
   labels:
     app: {{ template "mongodb-replicaset.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service  | trunc 63 | trimSuffix "-" }}
+    release: {{ .Release.Name | trunc 63 | trimSuffix "-" }}
   name: {{ template "mongodb-replicaset.fullname" . }}-test
   annotations:
     "helm.sh/hook": test-success


### PR DESCRIPTION
Signed-off-by: Daniel Morgan <me@plod.tv>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #16190

#### Special notes for your reviewer:
After trying to fix this I found a few places that were not being truncated, this is my first time trying to solve such things so happy for some help on approach

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
