### PR TITLE
[stable/nextcloud] Add flexibility and more configurations

### DIFF
--- a/stable/nextcloud/Chart.yaml
+++ b/stable/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nextcloud
-version: 1.6.2
+version: 1.7.0
 appVersion: 16.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/nextcloud/README.md
+++ b/stable/nextcloud/README.md
@@ -45,71 +45,84 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the nextcloud chart and their default values.
 
-|              Parameter              |                   Description                 |                         Default                         |
-|-------------------------------------|-----------------------------------------------|-------------------------------------------------------- |
-| `image.repository`                  | nextcloud Image name                          | `nextcloud`                                             |
-| `image.tag`                         | nextcloud Image tag                           | `{VERSION}`                                             |
-| `image.pullPolicy`                  | Image pull policy                             | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
-| `image.pullSecrets`                 | Specify image pull secrets                    | `nil`                                                   |
-| `ingress.enabled`                   | Enable use of ingress controllers             | `false`                                                 |
-| `ingress.servicePort`               | Ingress' backend servicePort                  | `http`                                                  |
-| `ingress.annotations`               | An array of service annotations               | `nil`                                                   |
-| `ingress.tls`                       | Ingress TLS configuration                     | `[]`                                                    |
-| `nextcloud.host`                    | nextcloud host to create application URLs     | `nextcloud.kube.home`                                   |
-| `nextcloud.username`                | User of the application                       | `admin`                                                 |
-| `nextcloud.password`                | Application password                          | `changeme`                                              |
-| `nextcloud.update`                  | Trigger update if custom command is used      | `0`                                                     |
-| `nextcloud.datadir`                 | nextcloud data dir location                   | `/var/www/html/data`                                    |
-| `nextcloud.tableprefix`             | nextcloud db table prefix                     | `''`                                                    |
-| `nextcloud.mail.enabled`            | Whether to enable/disable email settings      | `false`                                                 |
-| `nextcloud.mail.fromAddress`        | nextcloud mail send from field                | `nil`                                                   |
-| `nextcloud.mail.domain`             | nextcloud mail domain                         | `nil`                                                   |
-| `nextcloud.mail.smtp.host`          | SMTP hostname                                 | `nil`                                                   |
-| `nextcloud.mail.smtp.secure`        | SMTP connection `ssl` or empty                | `''`                                                    |
-| `nextcloud.mail.smtp.port`          | Optional SMTP port                            | `nil`                                                   |
-| `nextcloud.mail.smtp.authtype`      | SMTP authentication method                    | `LOGIN`                                                 |
-| `nextcloud.mail.smtp.name`          | SMTP username                                 | `''`                                                    |
-| `nextcloud.mail.smtp.password`      | SMTP password                                 | `''`                                                    |
-| `nextcloud.configs`                 | Config files created in `/var/www/html/config`| `{}`                                                    |
-| `internalDatabase.enabled`          | Whether to use internal sqlite database       | `true`                                                  |
-| `internalDatabase.database`         | Name of the existing database                 | `nextcloud`                                             |
-| `externalDatabase.enabled`          | Whether to use external database              | `false`                                                 |
-| `externalDatabase.type`             | External database type: `mysql`, `postgresql` | `mysql`                                                 |
-| `externalDatabase.host`             | Host of the external database                 | `nil`                                                   |
-| `externalDatabase.database`         | Name of the existing database                 | `nextcloud`                                             |
-| `externalDatabase.user`             | Existing username in the external db          | `nextcloud`                                             |
-| `externalDatabase.password`         | Password for the above username               | `nil`                                                   |
-| `mariadb.enabled`                   | Whether to use the MariaDB chart              | `false`                                                 |
-| `mariadb.db.name`                   | Database name to create                       | `nextcloud`                                             |
-| `mariadb.db.password`               | Password for the database                     | `changeme`                                              |
-| `mariadb.db.user`                   | Database user to create                       | `nextcloud`                                             |
-| `mariadb.rootUser.password`         | MariaDB admin password                        | `nil`                                                   |
-| `redis.enabled`                     | Whether to install/use redis for locking      | `false`                                                 |
-| `cronjob.enabled`                   | Whether to enable/disable cronjob             | `false`                                                 |
-| `cronjob.schedule`                  | Schedule for the CronJob                      | `*/15 * * * *`                                          |
-| `cronjob.annotations`               | Annotations to add to the cronjob             | {}                                                      |
-| `cronjob.failedJobsHistoryLimit`    | Specify the number of failed Jobs to keep     | `5`                                                     |
-| `cronjob.successfulJobsHistoryLimit`| Specify the number of completed Jobs to keep  | `2`                                                     |
-| `service.type`                      | Kubernetes Service type                       | `ClusterIp`                                             |
-| `service.loadBalancerIP`            | LoadBalancerIp for service type LoadBalancer  | `nil`                                                   |
-| `persistence.enabled`               | Enable persistence using PVC                  | `false`                                                 |
-| `persistence.storageClass`          | PVC Storage Class for nextcloud volume        | `nil` (uses alpha storage class annotation)             |
-| `persistence.existingClaim`         | An Existing PVC name for nextcloud volume     | `nil` (uses alpha storage class annotation)             |
-| `persistence.accessMode`            | PVC Access Mode for nextcloud volume          | `ReadWriteOnce`                                         |
-| `persistence.size`                  | PVC Storage Request for nextcloud volume      | `8Gi`                                                   |
-| `resources`                         | CPU/Memory resource requests/limits           | `{}`                                                    |
-| `livenessProbe.enabled`             | Turn on and off liveness probe                | `true`                                                  |
-| `livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated      | `30`                                                    |
-| `livenessProbe.periodSeconds`       | How often to perform the probe                | `15`                                                    |
-| `livenessProbe.timeoutSeconds`      | When the probe times out                      | `5`                                                     |
-| `livenessProbe.failureThreshold`    | Minimum consecutive failures for the probe    | `3`                                                     |
-| `livenessProbe.successThreshold`    | Minimum consecutive successes for the probe   | `1`                                                     |
-| `readinessProbe.enabled`            | Turn on and off readiness probe               | `true`                                                  |
-| `readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated     | `30`                                                    |
-| `readinessProbe.periodSeconds`      | How often to perform the probe                | `15`                                                    |
-| `readinessProbe.timeoutSeconds`     | When the probe times out                      | `5`                                                     |
-| `readinessProbe.failureThreshold`   | Minimum consecutive failures for the probe    | `3`                                                     |
-| `readinessProbe.successThreshold`   | Minimum consecutive successes for the probe   | `1`                                                     |
+| Parameter                                                    | Description                                             | Default                                                 |
+| ------------------------------------------------------------ | ------------------------------------------------------- | ------------------------------------------------------- |
+| `image.repository`                                           | nextcloud Image name                                    | `nextcloud`                                             |
+| `image.tag`                                                  | nextcloud Image tag                                     | `{VERSION}`                                             |
+| `image.pullPolicy`                                           | Image pull policy                                       | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
+| `image.pullSecrets`                                          | Specify image pull secrets                              | `nil`                                                   |
+| `ingress.enabled`                                            | Enable use of ingress controllers                       | `false`                                                 |
+| `ingress.servicePort`                                        | Ingress' backend servicePort                            | `http`                                                  |
+| `ingress.annotations`                                        | An array of service annotations                         | `nil`                                                   |
+| `ingress.tls`                                                | Ingress TLS configuration                               | `[]`                                                    |
+| `nextcloud.host`                                             | nextcloud host to create application URLs               | `nextcloud.kube.home`                                   |
+| `nextcloud.username`                                         | User of the application                                 | `admin`                                                 |
+| `nextcloud.password`                                         | Application password                                    | `changeme`                                              |
+| `nextcloud.update`                                           | Trigger update if custom command is used                | `0`                                                     |
+| `nextcloud.datadir`                                          | nextcloud data dir location                             | `/var/www/html/data`                                    |
+| `nextcloud.tableprefix`                                      | nextcloud db table prefix                               | `''`                                                    |
+| `nextcloud.mail.enabled`                                     | Whether to enable/disable email settings                | `false`                                                 |
+| `nextcloud.mail.fromAddress`                                 | nextcloud mail send from field                          | `nil`                                                   |
+| `nextcloud.mail.domain`                                      | nextcloud mail domain                                   | `nil`                                                   |
+| `nextcloud.mail.smtp.host`                                   | SMTP hostname                                           | `nil`                                                   |
+| `nextcloud.mail.smtp.secure`                                 | SMTP connection `ssl` or empty                          | `''`                                                    |
+| `nextcloud.mail.smtp.port`                                   | Optional SMTP port                                      | `nil`                                                   |
+| `nextcloud.mail.smtp.authtype`                               | SMTP authentication method                              | `LOGIN`                                                 |
+| `nextcloud.mail.smtp.name`                                   | SMTP username                                           | `''`                                                    |
+| `nextcloud.mail.smtp.password`                               | SMTP password                                           | `''`                                                    |
+| `nextcloud.configs`                                          | Config files created in `/var/www/html/config`          | `{}`                                                    |
+| `nextcloud.phpConfigs`                                       | PHP Config files created in `/usr/local/etc/php/conf.d` | `{}`                                                    |
+| `nextcloud.defaultConfigs.\.htaccess`                        | Default .htaccess to protect `/var/www/html/config`     | `true`                                                  |
+| `nextcloud.defaultConfigs.\.redis\.config\.php`              | Default Redis configuration                             | `true`                                                  |
+| `nextcloud.defaultConfigs.\.apache-pretty-urls\.config\.php` | Default Apache configuration for rewrite urls           | `true`                                                  |
+| `nextcloud.defaultConfigs.\.apcu\.config\.php`               | Default configuration to define APCu as local cache     | `true`                                                  |
+| `nextcloud.defaultConfigs.\.apps\.config\.php`               | Default configuration for apps                          | `true`                                                  |
+| `nextcloud.defaultConfigs.\.autoconfig\.php`                 | Default auto-configuration for databases                | `true`                                                  |
+| `nextcloud.defaultConfigs.\.smtp\.config\.php`               | Default configuration for smtp                          | `true`                                                  |
+| `internalDatabase.enabled`                                   | Whether to use internal sqlite database                 | `true`                                                  |
+| `internalDatabase.database`                                  | Name of the existing database                           | `nextcloud`                                             |
+| `externalDatabase.enabled`                                   | Whether to use external database                        | `false`                                                 |
+| `externalDatabase.type`                                      | External database type: `mysql`, `postgresql`           | `mysql`                                                 |
+| `externalDatabase.host`                                      | Host of the external database                           | `nil`                                                   |
+| `externalDatabase.database`                                  | Name of the existing database                           | `nextcloud`                                             |
+| `externalDatabase.user`                                      | Existing username in the external db                    | `nextcloud`                                             |
+| `externalDatabase.password`                                  | Password for the above username                         | `nil`                                                   |
+| `mariadb.enabled`                                            | Whether to use the MariaDB chart                        | `false`                                                 |
+| `mariadb.db.name`                                            | Database name to create                                 | `nextcloud`                                             |
+| `mariadb.db.password`                                        | Password for the database                               | `changeme`                                              |
+| `mariadb.db.user`                                            | Database user to create                                 | `nextcloud`                                             |
+| `mariadb.rootUser.password`                                  | MariaDB admin password                                  | `nil`                                                   |
+| `redis.enabled`                                              | Whether to install/use redis for locking                | `false`                                                 |
+| `cronjob.enabled`                                            | Whether to enable/disable cronjob                       | `false`                                                 |
+| `cronjob.schedule`                                           | Schedule for the CronJob                                | `*/15 * * * *`                                          |
+| `cronjob.annotations`                                        | Annotations to add to the cronjob                       | {}                                                      |
+| `cronjob.failedJobsHistoryLimit`                             | Specify the number of failed Jobs to keep               | `5`                                                     |
+| `cronjob.successfulJobsHistoryLimit`                         | Specify the number of completed Jobs to keep            | `2`                                                     |
+| `cronjob.resources`                                          | Cronjob Resources                                       | `nil`                                                   |
+| `cronjob.nodeSelector`                                       | Cronjob Node selector                                   | `nil`                                                   |
+| `cronjob.tolerations`                                        | Cronjob tolerations                                     | `nil`                                                   |
+| `cronjob.affinity`                                           | Cronjob affinity                                        | `nil`                                                   |
+| `service.type`                                               | Kubernetes Service type                                 | `ClusterIp`                                             |
+| `service.loadBalancerIP`                                     | LoadBalancerIp for service type LoadBalancer            | `nil`                                                   |
+| `persistence.enabled`                                        | Enable persistence using PVC                            | `false`                                                 |
+| `persistence.annotations`                                    | PVC annotations                                         | `{}`                                                    |
+| `persistence.storageClass`                                   | PVC Storage Class for nextcloud volume                  | `nil` (uses alpha storage class annotation)             |
+| `persistence.existingClaim`                                  | An Existing PVC name for nextcloud volume               | `nil` (uses alpha storage class annotation)             |
+| `persistence.accessMode`                                     | PVC Access Mode for nextcloud volume                    | `ReadWriteOnce`                                         |
+| `persistence.size`                                           | PVC Storage Request for nextcloud volume                | `8Gi`                                                   |
+| `resources`                                                  | CPU/Memory resource requests/limits                     | `{}`                                                    |
+| `livenessProbe.enabled`                                      | Turn on and off liveness probe                          | `true`                                                  |
+| `livenessProbe.initialDelaySeconds`                          | Delay before liveness probe is initiated                | `30`                                                    |
+| `livenessProbe.periodSeconds`                                | How often to perform the probe                          | `15`                                                    |
+| `livenessProbe.timeoutSeconds`                               | When the probe times out                                | `5`                                                     |
+| `livenessProbe.failureThreshold`                             | Minimum consecutive failures for the probe              | `3`                                                     |
+| `livenessProbe.successThreshold`                             | Minimum consecutive successes for the probe             | `1`                                                     |
+| `readinessProbe.enabled`                                     | Turn on and off readiness probe                         | `true`                                                  |
+| `readinessProbe.initialDelaySeconds`                         | Delay before readiness probe is initiated               | `30`                                                    |
+| `readinessProbe.periodSeconds`                               | How often to perform the probe                          | `15`                                                    |
+| `readinessProbe.timeoutSeconds`                              | When the probe times out                                | `5`                                                     |
+| `readinessProbe.failureThreshold`                            | Minimum consecutive failures for the probe              | `3`                                                     |
+| `readinessProbe.successThreshold`                            | Minimum consecutive successes for the probe             | `1`                                                     |
 
 > **Note**:
 >
@@ -161,11 +174,11 @@ See the [Configuration](#configuration) section for further configuration of the
 
 ## Multiple config.php file
 
-Nextcloud supports loading configuration parameters from multiple files. 
-You can add arbitrary files ending with `.config.php` in the `config/` directory. 
+Nextcloud supports loading configuration parameters from multiple files.
+You can add arbitrary files ending with `.config.php` in the `config/` directory.
 See [documentation](https://docs.nextcloud.com/server/15/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-config-php-file).
 
-For example, following config will configure Nextcloud with [S3 as primary storage](https://docs.nextcloud.com/server/13/admin_manual/configuration_files/primary_storage.html#simple-storage-service-s3) by creating file `/var/www/html/config/s3.config.php`:  
+For example, following config will configure Nextcloud with [S3 as primary storage](https://docs.nextcloud.com/server/13/admin_manual/configuration_files/primary_storage.html#simple-storage-service-s3) by creating file `/var/www/html/config/s3.config.php`:
 
 ```yaml
 nextcloud:

--- a/stable/nextcloud/templates/config.yaml
+++ b/stable/nextcloud/templates/config.yaml
@@ -13,4 +13,115 @@ data:
   {{ $key }}: |-
 {{ $value | indent 4 }}
 {{- end }}
+{{- if .Values.nextcloud.defaultConfigs }}
+{{- if index .Values.nextcloud.defaultConfigs ".htaccess" }}
+  .htaccess: |-
+    # line below if for Apache 2.4
+    <ifModule mod_authz_core.c>
+    Require all denied
+    </ifModule>
+    # line below if for Apache 2.2
+    <ifModule !mod_authz_core.c>
+    deny from all
+    </ifModule>
+    # section for Apache 2.2 and 2.4
+    <ifModule mod_autoindex.c>
+    IndexIgnore *
+    </ifModule>
+{{- end }}
+{{- if index .Values.nextcloud.defaultConfigs "redis.config.php" }}
+  redis.config.php: |-
+    <?php
+    if (getenv('REDIS_HOST')) {
+      $CONFIG = array (
+        'memcache.distributed' => '\OC\Memcache\Redis',
+        'memcache.locking' => '\OC\Memcache\Redis',
+        'redis' => array(
+          'host' => getenv('REDIS_HOST'),
+          'port' => getenv('REDIS_HOST_PORT') ?: 6379,
+        ),
+      );
+    }
+{{- end }}
+{{- if index .Values.nextcloud.defaultConfigs "apache-pretty-urls.config.php" }}
+  apache-pretty-urls.config.php: |-
+    <?php
+    $CONFIG = array (
+      'htaccess.RewriteBase' => '/',
+    );
+{{- end }}
+{{- if index .Values.nextcloud.defaultConfigs "apcu.config.php" }}
+  apcu.config.php: |-
+    <?php
+    $CONFIG = array (
+      'memcache.local' => '\OC\Memcache\APCu',
+    );
+{{- end }}
+{{- if index .Values.nextcloud.defaultConfigs "apps.config.php" }}
+  apps.config.php: |-
+    <?php
+    $CONFIG = array (
+      "apps_paths" => array (
+          0 => array (
+                  "path"     => OC::$SERVERROOT."/apps",
+                  "url"      => "/apps",
+                  "writable" => false,
+          ),
+          1 => array (
+                  "path"     => OC::$SERVERROOT."/custom_apps",
+                  "url"      => "/custom_apps",
+                  "writable" => true,
+          ),
+      ),
+    );
+{{- end }}
+{{- if index .Values.nextcloud.defaultConfigs "autoconfig.php" }}
+  autoconfig.php: |-
+    <?php
+    $autoconfig_enabled = false;
+    if (getenv('SQLITE_DATABASE')) {
+        $AUTOCONFIG["dbtype"] = "sqlite";
+        $AUTOCONFIG["dbname"] = getenv('SQLITE_DATABASE');
+        $autoconfig_enabled = true;
+    } elseif (getenv('MYSQL_DATABASE') && getenv('MYSQL_USER') && getenv('MYSQL_PASSWORD') && getenv('MYSQL_HOST')) {
+        $AUTOCONFIG["dbtype"] = "mysql";
+        $AUTOCONFIG["dbname"] = getenv('MYSQL_DATABASE');
+        $AUTOCONFIG["dbuser"] = getenv('MYSQL_USER');
+        $AUTOCONFIG["dbpass"] = getenv('MYSQL_PASSWORD');
+        $AUTOCONFIG["dbhost"] = getenv('MYSQL_HOST');
+        $autoconfig_enabled = true;
+    } elseif (getenv('POSTGRES_DB') && getenv('POSTGRES_USER') && getenv('POSTGRES_PASSWORD') && getenv('POSTGRES_HOST')) {
+        $AUTOCONFIG["dbtype"] = "pgsql";
+        $AUTOCONFIG["dbname"] = getenv('POSTGRES_DB');
+        $AUTOCONFIG["dbuser"] = getenv('POSTGRES_USER');
+        $AUTOCONFIG["dbpass"] = getenv('POSTGRES_PASSWORD');
+        $AUTOCONFIG["dbhost"] = getenv('POSTGRES_HOST');
+        $autoconfig_enabled = true;
+    }
+    if ($autoconfig_enabled) {
+        if (getenv('NEXTCLOUD_TABLE_PREFIX')) {
+            $AUTOCONFIG["dbtableprefix"] = getenv('NEXTCLOUD_TABLE_PREFIX');
+        }
+        $AUTOCONFIG["directory"] = getenv('NEXTCLOUD_DATA_DIR') ?: "/var/www/html/data";
+    }
+{{- end }}
+{{- if index .Values.nextcloud.defaultConfigs "smtp.config.php" }}
+  smtp.config.php: |-
+    <?php
+    if (getenv('SMTP_HOST') && getenv('MAIL_FROM_ADDRESS') && getenv('MAIL_DOMAIN')) {
+      $CONFIG = array (
+        'mail_smtpmode' => 'smtp',
+        'mail_smtphost' => getenv('SMTP_HOST'),
+        'mail_smtpport' => getenv('SMTP_PORT') ?: (getenv('SMTP_SECURE') ? 465 : 25),
+        'mail_smtpsecure' => getenv('SMTP_SECURE') ?: '',
+        'mail_smtpauth' => getenv('SMTP_NAME') && getenv('SMTP_PASSWORD'),
+        'mail_smtpauthtype' => getenv('SMTP_AUTHTYPE') ?: 'LOGIN',
+        'mail_smtpname' => getenv('SMTP_NAME') ?: '',
+        'mail_smtppassword' => getenv('SMTP_PASSWORD') ?: '',
+        'mail_from_address' => getenv('MAIL_FROM_ADDRESS'),
+        'mail_domain' => getenv('MAIL_DOMAIN'),
+      );
+    }
+{{- end }}
+{{- end }}
 {{- end }}

--- a/stable/nextcloud/templates/cronjob.yaml
+++ b/stable/nextcloud/templates/cronjob.yaml
@@ -32,10 +32,16 @@ spec:
             app.kubernetes.io/managed-by: {{ .Release.Service }}
         spec:
           restartPolicy: Never
+          {{- if (default .Values.image.pullSecrets .Values.cronjob.image.pullSecrets) }}
+          imagePullSecrets:
+          {{- range (default .Values.image.pullSecrets .Values.cronjob.image.pullSecrets) }}
+            - name: {{ . }}
+          {{- end }}
+          {{- end }}
           containers:
             - name: {{ .Chart.Name }}
-              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              image: "{{ default .Values.image.repository .Values.cronjob.image.repository }}:{{ default .Values.image.tag .Values.cronjob.image.tag }}"
+              imagePullPolicy: {{ default .Values.image.pullPolicy .Values.cronjob.image.pullPolicy }}
               command: [ "curl" ]
               args:
                 - "--fail"

--- a/stable/nextcloud/templates/cronjob.yaml
+++ b/stable/nextcloud/templates/cronjob.yaml
@@ -51,16 +51,16 @@ spec:
                 - "http://{{ .Values.nextcloud.host }}/cron.php"
               {{- end }}
               resources:
-{{ toYaml .Values.resources | indent 16 }}
-    {{- with .Values.nodeSelector }}
+{{ toYaml (default .Values.resources .Values.cronjob.resources) | indent 16 }}
+    {{- with (default .Values.nodeSelector .Values.cronjob.nodeSelector) }}
           nodeSelector:
 {{ toYaml . | indent 12 }}
     {{- end }}
-    {{- with .Values.affinity }}
+    {{- with (default .Values.affinity .Values.cronjob.affinity) }}
           affinity:
 {{ toYaml . | indent 12 }}
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with (default .Values.tolerations .Values.cronjob.tolerations) }}
           tolerations:
 {{ toYaml . | indent 12 }}:
     {{- end }}

--- a/stable/nextcloud/templates/cronjob.yaml
+++ b/stable/nextcloud/templates/cronjob.yaml
@@ -22,8 +22,8 @@ spec:
   jobTemplate:
     metadata:
       labels:
-        app: {{ include "nextcloud.name" . }}
-        release: {{ .Release.Name }}
+        app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
     spec:
       template:
         metadata:

--- a/stable/nextcloud/templates/cronjob.yaml
+++ b/stable/nextcloud/templates/cronjob.yaml
@@ -45,6 +45,7 @@ spec:
               command: [ "curl" ]
               args:
                 - "--fail"
+                - "-L"
               {{- if .Values.ingress.tls }}
                 - "https://{{ .Values.nextcloud.host }}/cron.php"
               {{- else }}

--- a/stable/nextcloud/templates/deployment.yaml
+++ b/stable/nextcloud/templates/deployment.yaml
@@ -228,3 +228,6 @@ spec:
         configMap:
           name: {{ template "nextcloud.fullname" . }}-phpconfig
       {{- end }}
+      # Will mount configuration files as www-data (id: 33) for nextcloud
+      securityContext:
+        fsGroup: 33

--- a/stable/nextcloud/templates/deployment.yaml
+++ b/stable/nextcloud/templates/deployment.yaml
@@ -174,8 +174,11 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
         - name: nextcloud-data
-          mountPath: /var/www/html/
+          mountPath: /var/www/
           subPath: root
+        - name: nextcloud-data
+          mountPath: /var/www/html
+          subPath: html
         - name: nextcloud-data
           mountPath: {{ .Values.nextcloud.datadir }}
           subPath: data

--- a/stable/nextcloud/templates/deployment.yaml
+++ b/stable/nextcloud/templates/deployment.yaml
@@ -193,6 +193,11 @@ spec:
           mountPath: /var/www/html/config/{{ $key }}
           subPath: {{ $key }}
         {{- end }}
+        {{- range $key, $value := .Values.nextcloud.phpConfigs }}
+        - name: nextcloud-phpconfig
+          mountPath: /usr/local/etc/php/conf.d/{{ $key }}
+          subPath: {{ $key }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -217,4 +222,9 @@ spec:
       - name: nextcloud-config
         configMap:
           name: {{ template "nextcloud.fullname" . }}-config
+      {{- end }}
+      {{- if .Values.nextcloud.phpConfigs }}
+      - name: nextcloud-phpconfig
+        configMap:
+          name: {{ template "nextcloud.fullname" . }}-phpconfig
       {{- end }}

--- a/stable/nextcloud/templates/deployment.yaml
+++ b/stable/nextcloud/templates/deployment.yaml
@@ -199,6 +199,13 @@ spec:
           mountPath: /var/www/html/config/{{ $key }}
           subPath: {{ $key }}
         {{- end }}
+        {{- range $key, $value := .Values.nextcloud.defaultConfigs }}
+        {{- if $value }}
+        - name: nextcloud-config
+          mountPath: /var/www/html/config/{{ $key }}
+          subPath: {{ $key }}
+        {{- end }}
+        {{- end }}
         {{- range $key, $value := .Values.nextcloud.phpConfigs }}
         - name: nextcloud-phpconfig
           mountPath: /usr/local/etc/php/conf.d/{{ $key }}

--- a/stable/nextcloud/templates/deployment.yaml
+++ b/stable/nextcloud/templates/deployment.yaml
@@ -199,11 +199,13 @@ spec:
           mountPath: /var/www/html/config/{{ $key }}
           subPath: {{ $key }}
         {{- end }}
+        {{- if .Values.nextcloud.configs }}
         {{- range $key, $value := .Values.nextcloud.defaultConfigs }}
         {{- if $value }}
         - name: nextcloud-config
           mountPath: /var/www/html/config/{{ $key }}
           subPath: {{ $key }}
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- range $key, $value := .Values.nextcloud.phpConfigs }}

--- a/stable/nextcloud/templates/deployment.yaml
+++ b/stable/nextcloud/templates/deployment.yaml
@@ -189,6 +189,9 @@ spec:
           mountPath: /var/www/html/custom_apps
           subPath: custom_apps
         - name: nextcloud-data
+          mountPath: /var/www/tmp
+          subPath: tmp
+        - name: nextcloud-data
           mountPath: /var/www/html/themes
           subPath: themes
         {{- range $key, $value := .Values.nextcloud.configs }}

--- a/stable/nextcloud/templates/nextcloud-pvc.yaml
+++ b/stable/nextcloud/templates/nextcloud-pvc.yaml
@@ -4,6 +4,15 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "nextcloud.fullname" . }}-nextcloud
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.persistence.annotations | indent 4 }}
+{{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/stable/nextcloud/templates/php-config.yaml
+++ b/stable/nextcloud/templates/php-config.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.nextcloud.phpConfigs -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nextcloud.fullname" . }}-phpconfig
+  labels:
+    app.kubernetes.io/name: {{ include "nextcloud.name" . }}
+    helm.sh/chart: {{ include "nextcloud.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+{{- range $key, $value := .Values.nextcloud.phpConfigs }}
+  {{ $key }}: |-
+{{ $value | indent 4 }}
+{{- end }}
+{{- end }}

--- a/stable/nextcloud/values.yaml
+++ b/stable/nextcloud/values.yaml
@@ -201,7 +201,9 @@ service:
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##
 persistence:
+  # Nextcloud Data (/var/www/html)
   enabled: false
+  annotations: {}
   ## nextcloud data Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning

--- a/stable/nextcloud/values.yaml
+++ b/stable/nextcloud/values.yaml
@@ -75,6 +75,9 @@ nextcloud:
       authtype: LOGIN
       name: user
       password: pass
+  # PHP Configuration files
+  # Will be injected in /usr/local/etc/php/conf.d
+  phpConfigs: {}
   # Extra config files created in /var/www/html/config/
   # ref: https://docs.nextcloud.com/server/15/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-config-php-file
   configs: {}

--- a/stable/nextcloud/values.yaml
+++ b/stable/nextcloud/values.yaml
@@ -175,7 +175,7 @@ redis:
 cronjob:
   enabled: false
   # Nexcloud image is used as default but only curl is needed
-  # image:
+  image: {}
     # repository: nextcloud
     # tag: 16.0.3-apache
     # pullPolicy: IfNotPresent

--- a/stable/nextcloud/values.yaml
+++ b/stable/nextcloud/values.yaml
@@ -200,7 +200,7 @@ cronjob:
     # requests:
     #  cpu: 100m
     #  memory: 128Mi
-  
+
   # If not set, nextcloud deployment one will be set
   # nodeSelector: {}
 

--- a/stable/nextcloud/values.yaml
+++ b/stable/nextcloud/values.yaml
@@ -78,6 +78,24 @@ nextcloud:
   # PHP Configuration files
   # Will be injected in /usr/local/etc/php/conf.d
   phpConfigs: {}
+  # Default config files
+  # IMPORTANT: Will be used only if you put extra configs, otherwise default will come from nextcloud itself
+  # Default confgurations can be found here: https://github.com/nextcloud/docker/tree/master/16.0/apache/config
+  defaultConfigs:
+    # To protect /var/www/html/config
+    .htaccess: true
+    # Redis default configuration
+    redis.config.php: true
+    # Apache configuration for rewrite urls
+    apache-pretty-urls.config.php: true
+    # Define APCu as local cache
+    apcu.config.php: true
+    # Apps directory configs
+    apps.config.php: true
+    # Used for auto configure database
+    autoconfig.php: true
+    # SMTP default configuration
+    smtp.config.php: true
   # Extra config files created in /var/www/html/config/
   # ref: https://docs.nextcloud.com/server/15/admin_manual/configuration_server/config_sample_php_parameters.html#multiple-config-php-file
   configs: {}

--- a/stable/nextcloud/values.yaml
+++ b/stable/nextcloud/values.yaml
@@ -170,6 +170,27 @@ cronjob:
   annotations: {}
   failedJobsHistoryLimit: 5
   successfulJobsHistoryLimit: 2
+  # If not set, nextcloud deployment one will be set
+  # resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+  
+  # If not set, nextcloud deployment one will be set
+  # nodeSelector: {}
+
+  # If not set, nextcloud deployment one will be set
+  # tolerations: []
+
+  # If not set, nextcloud deployment one will be set
+  # affinity: {}
 
 service:
   type: ClusterIP

--- a/stable/nextcloud/values.yaml
+++ b/stable/nextcloud/values.yaml
@@ -156,6 +156,13 @@ redis:
 ##
 cronjob:
   enabled: false
+  # Nexcloud image is used as default but only curl is needed
+  # image:
+    # repository: nextcloud
+    # tag: 16.0.3-apache
+    # pullPolicy: IfNotPresent
+    # pullSecrets:
+    #   - myRegistrKeySecretName
   # Every 15 minutes
   # Note: Setting this to any any other value than 15 minutes might
   #  cause issues with how nextcloud background jobs are executed


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR will add flexibility and allow more configuration for nextcloud deployments:
- Allow to put extra php configs
- Put all default configuration if custom configurations are set
  - For this particular case, if one extra config is set, the rsync exclude will prevent the first copy of all default configurations files.
- Allow to have annotations on pvc
- Cronjob follow redirect for cases like having https but not managed by the ingress controller (AWS ELB for example)
- Image, affinity, tolerations and resources can be changed just for cronjob instead of using nextcloud deployment one
- Change mount path to allow the creation of a tmp directory in volume instead of using the /tmp which is on Kubernetes nodes (large files upload can be in trouble when using the /tmp)
- Use the fs group of www-data (33) for mounted files

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
