### PR TITLE
[stable/datadog] Add an option to reference an existing clusterAgent.token 

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.32.1
+version: 1.32.2
 appVersion: 6.12.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -298,6 +298,7 @@ helm install --name <RELEASE_NAME> \
 | `kube-state-metrics.serviceAccount.name`                   | If not set & create is true, use template fullname                                    |                                            |
 | `clusterAgent.enabled`                   | Use the cluster-agent for cluster metrics (Kubernetes 1.10+ only)                         | `false`                                     |
 | `clusterAgent.token`                     | A cluster-internal secret for agent-to-agent communication. Must be 32+ characters a-zA-Z | Generates a random value                    |
+| `clusterAgent.tokenExistingSecret`                     | If set, use the secret with a provided name instead of creating a new one | `nil`                    |
 | `clusterAgent.containerName`             | The container name for the Cluster Agent                                                  | `cluster-agent`                             |
 | `clusterAgent.image.repository`          | The image repository for the cluster-agent                                                | `datadog/cluster-agent`                     |
 | `clusterAgent.image.tag`                 | The image tag to pull                                                                     | `1.2.0`                                     |

--- a/stable/datadog/templates/NOTES.txt
+++ b/stable/datadog/templates/NOTES.txt
@@ -44,13 +44,13 @@ Create an application key at https://app.datadoghq.com/account/settings#api
     {{- end }}
   {{- end }}
 
-  {{- if not .Values.clusterAgent.token }}
+  {{- if and (not .Values.clusterAgent.token) (not .Values.clusterAgent.tokenExistingSecret) }}
 
 ##############################################################################
 ####               INFO: You did not set a clusterAgent.token            ####
 ##############################################################################
 
-Because you enabled the Cluster Agent but did not provide a token, a random token was generated.
+Because you enabled the Cluster Agent but did not either provide a token or a reference to an existing token via '{{ .Values.clusterAgent.tokenExistingSecret }}', a random token was generated.
 This token is used to secure the communication between the Agents and the Cluster Agent.
 
 Make sure to recreate all pods on upgrade (with the --recreate-pods flag) to ensure all

--- a/stable/datadog/templates/_helpers.tpl
+++ b/stable/datadog/templates/_helpers.tpl
@@ -52,8 +52,11 @@ Return secret name to be used based on provided values.
 Return secret name to be used based on provided values.
 */}}
 {{- define "clusterAgent.tokenSecretName" -}}
-{{- $fullName := include "datadog.fullname" . -}}
-{{- default $fullName .Values.clusterAgent.tokenExistingSecret | quote -}}
+{{- if not .Values.clusterAgent.tokenExistingSecret -}}
+{{- include "datadog.fullname" . -}}-cluster-agent
+{{- else -}}
+{{- .Values.clusterAgent.tokenExistingSecret -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/datadog/templates/_helpers.tpl
+++ b/stable/datadog/templates/_helpers.tpl
@@ -49,6 +49,14 @@ Return secret name to be used based on provided values.
 {{- end -}}
 
 {{/*
+Return secret name to be used based on provided values.
+*/}}
+{{- define "clusterAgent.tokenSecretName" -}}
+{{- $fullName := include "datadog.fullname" . -}}
+{{- default $fullName .Values.clusterAgent.tokenExistingSecret | quote -}}
+{{- end -}}
+
+{{/*
 Return the appropriate apiVersion for RBAC APIs.
 */}}
 {{- define "rbac.apiVersion" -}}

--- a/stable/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/stable/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -40,7 +40,7 @@ spec:
           - name: DD_CLUSTER_AGENT_AUTH_TOKEN
             valueFrom:
               secretKeyRef:
-                name: {{ if not .Values.clusterAgent.tokenExistingSecret }}{{ template "datadog.fullname" . }}-cluster-agent{{ else }}"{{ .Values.clusterAgent.tokenExistingSecret }}"{{ end }}
+                name: {{ template "clusterAgent.tokenSecretName" . }}
                 key: token
           - name: DD_CLUSTER_AGENT_ENABLED
             value: {{ .Values.clusterAgent.enabled | quote }}

--- a/stable/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/stable/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -40,7 +40,7 @@ spec:
           - name: DD_CLUSTER_AGENT_AUTH_TOKEN
             valueFrom:
               secretKeyRef:
-                name: {{ template "datadog.fullname" . }}-cluster-agent
+                name: {{ if not .Values.clusterAgent.tokenExistingSecret }}{{ template "datadog.fullname" . }}-cluster-agent{{ else }}"{{ .Values.clusterAgent.tokenExistingSecret }}"{{ end }}
                 key: token
           - name: DD_CLUSTER_AGENT_ENABLED
             value: {{ .Values.clusterAgent.enabled | quote }}

--- a/stable/datadog/templates/agent-secret.yaml
+++ b/stable/datadog/templates/agent-secret.yaml
@@ -18,4 +18,5 @@ data:
   token: {{ randAlphaNum 32 | b64enc | quote }}
   {{ end }}
 {{- end }}
+
 {{ end }}

--- a/stable/datadog/templates/agent-secret.yaml
+++ b/stable/datadog/templates/agent-secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.clusterAgent.tokenExistingSecret }}
 {{- if .Values.clusterAgent.enabled -}}
 
 apiVersion: v1
@@ -17,3 +18,4 @@ data:
   token: {{ randAlphaNum 32 | b64enc | quote }}
   {{ end }}
 {{- end }}
+{{ end }}

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -116,7 +116,7 @@ spec:
           - name: DD_CLUSTER_AGENT_AUTH_TOKEN
             valueFrom:
               secretKeyRef:
-                name: {{ template "datadog.fullname" . }}-cluster-agent
+                name: {{ if not .Values.clusterAgent.tokenExistingSecret }}{{ template "datadog.fullname" . }}-cluster-agent{{ else }}"{{ .Values.clusterAgent.tokenExistingSecret }}"{{ end }}
                 key: token
           - name: DD_KUBE_RESOURCES_NAMESPACE
             value: {{ .Release.Namespace }}

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -116,7 +116,7 @@ spec:
           - name: DD_CLUSTER_AGENT_AUTH_TOKEN
             valueFrom:
               secretKeyRef:
-                name: {{ if not .Values.clusterAgent.tokenExistingSecret }}{{ template "datadog.fullname" . }}-cluster-agent{{ else }}"{{ .Values.clusterAgent.tokenExistingSecret }}"{{ end }}
+                name: {{ template "clusterAgent.tokenSecretName" . }}
                 key: token
           - name: DD_KUBE_RESOURCES_NAMESPACE
             value: {{ .Release.Namespace }}

--- a/stable/datadog/templates/container-agent.yaml
+++ b/stable/datadog/templates/container-agent.yaml
@@ -67,7 +67,7 @@
     - name: DD_CLUSTER_AGENT_AUTH_TOKEN
       valueFrom:
         secretKeyRef:
-          name: {{ template "datadog.fullname" . }}-cluster-agent
+          name: {{ if not .Values.clusterAgent.tokenExistingSecret }}{{ template "datadog.fullname" . }}-cluster-agent{{ else }}"{{ .Values.clusterAgent.tokenExistingSecret }}"{{ end }}
           key: token
     {{- end }}
     {{- if .Values.datadog.podLabelsAsTags }}

--- a/stable/datadog/templates/container-agent.yaml
+++ b/stable/datadog/templates/container-agent.yaml
@@ -67,7 +67,7 @@
     - name: DD_CLUSTER_AGENT_AUTH_TOKEN
       valueFrom:
         secretKeyRef:
-          name: {{ if not .Values.clusterAgent.tokenExistingSecret }}{{ template "datadog.fullname" . }}-cluster-agent{{ else }}"{{ .Values.clusterAgent.tokenExistingSecret }}"{{ end }}
+          name: {{ template "clusterAgent.tokenSecretName" . }}
           key: token
     {{- end }}
     {{- if .Values.datadog.podLabelsAsTags }}

--- a/stable/datadog/templates/container-agents.yaml
+++ b/stable/datadog/templates/container-agents.yaml
@@ -94,7 +94,7 @@
     - name: DD_CLUSTER_AGENT_AUTH_TOKEN
       valueFrom:
         secretKeyRef:
-          name: {{ template "datadog.fullname" . }}-cluster-agent
+          name: {{ if not .Values.clusterAgent.tokenExistingSecret }}{{ template "datadog.fullname" . }}-cluster-agent{{ else }}"{{ .Values.clusterAgent.tokenExistingSecret }}"{{ end }}
           key: token
     {{- end }}
     - name: KUBERNETES

--- a/stable/datadog/templates/container-agents.yaml
+++ b/stable/datadog/templates/container-agents.yaml
@@ -94,7 +94,7 @@
     - name: DD_CLUSTER_AGENT_AUTH_TOKEN
       valueFrom:
         secretKeyRef:
-          name: {{ if not .Values.clusterAgent.tokenExistingSecret }}{{ template "datadog.fullname" . }}-cluster-agent{{ else }}"{{ .Values.clusterAgent.tokenExistingSecret }}"{{ end }}
+          name: {{ template "clusterAgent.tokenSecretName" . }}
           key: token
     {{- end }}
     - name: KUBERNETES


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Implements an `clusterAgent.tokenExistingSecret` option similar to the implementation of datadog.apiKeyExistingSecret so that referencing an existing clusterAgent.token is possible

#### Which issue this PR fixes
  - fixes #16207

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
