### PR TITLE
[stable/nginx-ingress] replace ambiguous controller.headers option

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.14.0
+version: 1.15.0
 appVersion: 0.25.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.15.0
+version: 1.14.1
 appVersion: 0.25.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.14.1
+version: 1.15.0
 appVersion: 0.25.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -140,7 +140,9 @@ Parameter | Description | Default
 `controller.metrics.serviceMonitor.honorLabels` | honorLabels chooses the metric's labels on collisions with target labels. | `false`
 `controller.customTemplate.configMapName` | configMap containing a custom nginx template | `""`
 `controller.customTemplate.configMapKey` | configMap key containing the nginx template | `""`
-`controller.headers` | configMap key:value pairs containing the [custom headers](https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers) for Nginx | `{}`
+`controller.addHeaders` | configMap key:value pairs containing [custom headers](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#add-headers) added before sending response to the client | `{}`
+`controller.proxySetHeaders` | configMap key:value pairs containing [custom headers](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#proxy-set-headers) added before sending request to the backends| `{}`
+`controller.headers` | DEPRECATED, Use `controller.proxySetHeaders` instead. | `{}`
 `controller.updateStrategy` | allows setting of RollingUpdate strategy | `{}`
 `controller.configMapNamespace` | The nginx-configmap namespace name | `""`
 `controller.tcp.configMapNamespace` | The tcp-services-configmap namespace name | `""`

--- a/stable/nginx-ingress/ci/daemonset-headers-values.yaml
+++ b/stable/nginx-ingress/ci/daemonset-headers-values.yaml
@@ -1,0 +1,6 @@
+controller:
+  kind: DaemonSet
+  addHeaders:
+    X-Frame-Options: deny
+  proxySetHeaders:
+    X-Forwarded-Proto: https

--- a/stable/nginx-ingress/ci/deployment-headers-values.yaml
+++ b/stable/nginx-ingress/ci/deployment-headers-values.yaml
@@ -1,0 +1,5 @@
+controller:
+  addHeaders:
+    X-Frame-Options: deny
+  proxySetHeaders:
+    X-Forwarded-Proto: https

--- a/stable/nginx-ingress/templates/NOTES.txt
+++ b/stable/nginx-ingress/templates/NOTES.txt
@@ -62,3 +62,10 @@ If TLS is enabled for the Ingress, a Secret containing the certificate and key m
     tls.crt: <base64 encoded cert>
     tls.key: <base64 encoded key>
   type: kubernetes.io/tls
+
+{{- if .Values.controller.headers }}
+#################################################################################
+######   WARNING: `controller.headers` has been deprecated!                 #####
+######            It has been renamed to `controller.proxySetHeaders`.      #####
+#################################################################################
+{{- end }}

--- a/stable/nginx-ingress/templates/addheaders-configmap.yaml
+++ b/stable/nginx-ingress/templates/addheaders-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.controller.addHeaders }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.fullname" . }}-custom-add-headers
+data:
+{{ toYaml .Values.controller.addHeaders | indent 2 }}
+{{- end }}

--- a/stable/nginx-ingress/templates/controller-configmap.yaml
+++ b/stable/nginx-ingress/templates/controller-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.controller.config (or .Values.controller.proxySetHeaders .Values.controller.addHeaders) }}
+{{- if or .Values.controller.config (or (or .Values.controller.proxySetHeaders .Values.controller.headers) .Values.controller.addHeaders) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,9 +11,9 @@ metadata:
   name: {{ template "nginx-ingress.controller.fullname" . }}
 data:
 {{- if .Values.controller.addHeaders }}
-  proxy-set-headers: {{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-custom-add-headers
+  add-headers: {{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-custom-add-headers
 {{- end }}
-{{- if .Values.controller.proxySetHeaders }}
+{{- if or .Values.controller.proxySetHeaders .Values.controller.headers }}
   proxy-set-headers: {{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-custom-proxy-headers
 {{- end }}
 {{- if .Values.controller.config }}

--- a/stable/nginx-ingress/templates/controller-configmap.yaml
+++ b/stable/nginx-ingress/templates/controller-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.controller.headers .Values.controller.config }}
+{{- if or .Values.controller.config (or .Values.controller.proxySetHeaders .Values.controller.addHeaders) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,8 +10,11 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.controller.fullname" . }}
 data:
-{{- if .Values.controller.headers }}
-  proxy-set-headers: {{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-custom-headers
+{{- if .Values.controller.addHeaders }}
+  proxy-set-headers: {{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-custom-add-headers
+{{- end }}
+{{- if .Values.controller.proxySetHeaders }}
+  proxy-set-headers: {{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-custom-proxy-headers
 {{- end }}
 {{- if .Values.controller.config }}
 {{ toYaml .Values.controller.config | indent 2 }}

--- a/stable/nginx-ingress/templates/proxyheaders-configmap.yaml
+++ b/stable/nginx-ingress/templates/proxyheaders-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.headers }}
+{{- if .Values.controller.proxySetHeaders }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,7 +8,7 @@ metadata:
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.fullname" . }}-custom-headers
+  name: {{ template "nginx-ingress.fullname" . }}-custom-proxy-headers
 data:
-{{ toYaml .Values.controller.headers | indent 2 }}
+{{ toYaml .Values.controller.proxySetHeaders | indent 2 }}
 {{- end }}

--- a/stable/nginx-ingress/templates/proxyheaders-configmap.yaml
+++ b/stable/nginx-ingress/templates/proxyheaders-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.proxySetHeaders }}
+{{- if or .Values.controller.proxySetHeaders .Values.controller.headers }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,5 +10,9 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.fullname" . }}-custom-proxy-headers
 data:
+{{- if .Values.controller.proxySetHeaders }}
 {{ toYaml .Values.controller.proxySetHeaders | indent 2 }}
+{{ else if and .Values.controller.headers (not .Values.controller.proxySetHeaders) }}
+{{ toYaml .Values.controller.headers | indent 2 }}
+{{- end }}
 {{- end }}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -17,8 +17,12 @@ controller:
     https: 443
   # Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
   config: {}
-  # Will add custom header to Nginx https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers
-  headers: {}
+
+  # Will add custom headers before sending traffic to backends according to https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers
+  proxySetHeaders: {}
+
+  # Will add custom headers before sending response traffic to the client according to: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#add-headers
+  addHeaders: {}
 
   # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
   # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920


### PR DESCRIPTION
#### What this PR does / why we need it:

controller.headers is ambiguous because the headers can be added to the client response, or as the request is passed to the backend. Here are the relevant nginx-ingress configuration options:
- [add-headers](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#add-headers)
- [proxy-set-headers](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#proxy-set-headers)

This PR replaces the ambiguous config with two commands handling both use cases. 

#### Special notes for your reviewer:

First contribution, all feedback appreciated.

Specifically Looking for feedback on the best way to handle deprecating the option, as-is if someone is using that option it will stop working, hence the major version bump.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)