### PR TITLE
Comment for pushgateway incorrectly mentioned alertmanager

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 8.15.0
+version: 8.15.1
 appVersion: 2.11.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -923,7 +923,7 @@ pushgateway:
     ##
     size: 2Gi
 
-    ## alertmanager data Persistent Volume Storage Class
+    ## pushgateway data Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning
     ## If undefined (the default) or set to null, no storageClassName spec is
@@ -932,7 +932,7 @@ pushgateway:
     ##
     # storageClass: "-"
 
-    ## Subdirectory of alertmanager data Persistent Volume to mount
+    ## Subdirectory of pushgateway data Persistent Volume to mount
     ## Useful if the volume's root directory is not empty
     ##
     subPath: ""


### PR DESCRIPTION
#### What this PR does / why we need it:

Changes the comments for the `pushgateway` section to mention `pushgateway` instead of `alertmanager`.  When searching for `storageClass` in the chart the comments led you to believe you were in a different section.

#### Which issue this PR fixes

None

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed

I know this is trivial @mgoodness, everything in the chart works fine.   I didn't bump the version since there wasn't a functionality change.