### PR TITLE
[stable/nextcloud] Add insecure option for curl

### DIFF
--- a/stable/nextcloud/Chart.yaml
+++ b/stable/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nextcloud
-version: 1.7.0
+version: 1.7.1
 appVersion: 16.0.3
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/nextcloud/README.md
+++ b/stable/nextcloud/README.md
@@ -96,6 +96,7 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `cronjob.enabled`                                            | Whether to enable/disable cronjob                       | `false`                                                 |
 | `cronjob.schedule`                                           | Schedule for the CronJob                                | `*/15 * * * *`                                          |
 | `cronjob.annotations`                                        | Annotations to add to the cronjob                       | {}                                                      |
+| `cronjob.curlInsecure`                                       | Set insecure (-k) option to curl                        | false                                                   |
 | `cronjob.failedJobsHistoryLimit`                             | Specify the number of failed Jobs to keep               | `5`                                                     |
 | `cronjob.successfulJobsHistoryLimit`                         | Specify the number of completed Jobs to keep            | `2`                                                     |
 | `cronjob.resources`                                          | Cronjob Resources                                       | `nil`                                                   |

--- a/stable/nextcloud/templates/cronjob.yaml
+++ b/stable/nextcloud/templates/cronjob.yaml
@@ -44,6 +44,9 @@ spec:
               imagePullPolicy: {{ default .Values.image.pullPolicy .Values.cronjob.image.pullPolicy }}
               command: [ "curl" ]
               args:
+              {{- if .Values.cronjob.curlInsecure }}
+                - "-k"
+              {{- end }}
                 - "--fail"
                 - "-L"
               {{- if .Values.ingress.tls }}

--- a/stable/nextcloud/values.yaml
+++ b/stable/nextcloud/values.yaml
@@ -186,6 +186,8 @@ cronjob:
   #  cause issues with how nextcloud background jobs are executed
   schedule: "*/15 * * * *"
   annotations: {}
+  # Set curl's insecure option if you use e.g. self-signed certificates
+  curlInsecure: false
   failedJobsHistoryLimit: 5
   successfulJobsHistoryLimit: 2
   # If not set, nextcloud deployment one will be set


### PR DESCRIPTION
Signed-off-by: Aurélien Bertron <aurelienbertron@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Add `cronjob.curlInsecure` value. This is used to set the "insecure" option (-k) to curl in the cronjob. This prevents errors when using self-signed certificates in development configuration.

#### Which issue this PR fixes

  - fixes #16232 

#### Special notes for your reviewer:
Feel free to suggest a new name for this value as I am not sure it is clear enough for a user.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
