### PR TITLE
[stable/kiam] Permit passing annotations and labels to DaemonSets

### DIFF
--- a/stable/kiam/Chart.yaml
+++ b/stable/kiam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kiam
-version: 2.5.1
+version: 2.6.0
 appVersion: 3.3
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/stable/kiam/README.md
+++ b/stable/kiam/README.md
@@ -115,6 +115,8 @@ Parameter | Description | Default
 `agent.prometheus.syncInterval` | Agent Prometheus synchronization interval | `5s`
 `agent.podAnnotations` | Annotations to be added to agent pods | `{}`
 `agent.podLabels` | Labels to be added to agent pods | `{}`
+`agent.daemonsetAnnotations` | Annotations to be added to agent daemonset | `{}`
+`agent.daemonsetLabels` | Labels to be added to agent daemonset | `{}`
 `agent.priorityClassName` | Agent pods priority class name | `""`
 `agent.resources` | Agent container resources | `{}`
 `agent.serviceAnnotations` | Annotations to be added to agent service | `{}`
@@ -145,6 +147,8 @@ Parameter | Description | Default
 `server.prometheus.syncInterval` | Server Prometheus synchronization interval | `5s`
 `server.podAnnotations` | Annotations to be added to server pods | `{}`
 `server.podLabels` | Labels to be added to server pods | `{}`
+`server.daemonsetAnnotations` | Annotations to be added to server daemonset | `{}`
+`server.daemonsetLabels` | Labels to be added to server daemonset | `{}`
 `server.probes.serverAddress` | Address that readyness and liveness probes will hit | `127.0.0.1`
 `server.priorityClassName` | Server pods priority class name | `""`
 `server.resources` | Server container resources | `{}`

--- a/stable/kiam/templates/agent-daemonset.yaml
+++ b/stable/kiam/templates/agent-daemonset.yaml
@@ -8,6 +8,13 @@ metadata:
     component: "{{ .Values.agent.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+    {{- if .Values.agent.daemonsetLabels }}
+{{ toYaml .Values.agent.daemonsetLabels | indent 4 }}
+    {{- end }}
+  {{- if .Values.agent.daemonsetAnnotations }}
+  annotations:
+{{ toYaml .Values.agent.daemonsetAnnotations | indent 4 }}
+  {{- end }}
   name: {{ template "kiam.fullname" . }}-agent
 spec:
   selector:

--- a/stable/kiam/templates/server-daemonset.yaml
+++ b/stable/kiam/templates/server-daemonset.yaml
@@ -8,6 +8,13 @@ metadata:
     component: "{{ .Values.server.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+    {{- if .Values.server.daemonsetLabels }}
+{{ toYaml .Values.server.daemonsetLabels | indent 4 }}
+    {{- end }}
+  {{- if .Values.server.daemonsetAnnotations }}
+  annotations:
+{{ toYaml .Values.server.daemonsetAnnotations | indent 4 }}
+  {{- end }}
   name: {{ template "kiam.fullname" . }}-server
 spec:
   selector:

--- a/stable/kiam/values.yaml
+++ b/stable/kiam/values.yaml
@@ -42,6 +42,12 @@ agent:
   ## Labels to be added to pods
   ##
   podLabels: {}
+  ## Annotations to be added to daemonset
+  ##
+  daemonsetAnnotations: {}
+  ## Labels to be added to daemonset
+  ##
+  daemonsetLabels: {}
   ## Annotations to be added to service
   ##
   serviceAnnotations: {}
@@ -157,6 +163,12 @@ server:
   ## Labels to be added to pods
   ##
   podLabels: {}
+  ## Annotations to be added to daemonset
+  ##
+  daemonsetAnnotations: {}
+  ## Labels to be added to daemonset
+  ##
+  daemonsetLabels: {}
   ## Annotations to be added to service
   ##
   serviceAnnotations: {}


### PR DESCRIPTION


Signed-off-by: Steve Huff <shuff@vecna.org>
#### What this PR does / why we need it:
This PR adds new values `agent.daemonsetLabels`, `agent.daemonsetAnnotations`, `server.daemonsetLabels`, `server.daemonsetAnnotations` for controlling labels and annotations on the daemonsets themselves, not on the pods managed by the daemonsets.

This make it easier to use _e.g._
[Reloader](https://github.com/stakater/Reloader) to orchestrate rolling
replacements of kiam pods when their mTLS certificates are updated.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
