### PR TITLE
[stable/nats] Use bitnami/nats-exporter

### DIFF
--- a/stable/nats/Chart.yaml
+++ b/stable/nats/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nats
-version: 4.0.1
+version: 4.1.0
 appVersion: 2.0.2
 description: An open-source, cloud-native messaging system
 keywords:

--- a/stable/nats/README.md
+++ b/stable/nats/README.md
@@ -126,8 +126,8 @@ The following table lists the configurable parameters of the NATS chart and thei
 | `networkPolicy.allowExternal`        | Allow external connections                                                                   | `true`                                                        |
 | `metrics.enabled`                    | Enable Prometheus metrics via exporter side-car                                              | `false`                                                       |
 | `metrics.image.registry`             | Prometheus metrics exporter image registry                                                   | `docker.io`                                                   |
-| `metrics.image.repository`           | Prometheus metrics exporter image name                                                       | `synadia/prometheus-nats-exporter`                            |
-| `metrics.image.tag`                  | Prometheus metrics exporter image tag                                                        | `0.1.0`                                                       |
+| `metrics.image.repository`           | Prometheus metrics exporter image name                                                       | `bitnami/nats-exporter`                                       |
+| `metrics.image.tag`                  | Prometheus metrics exporter image tag                                                        | `{TAG_NAME}`                                                  |
 | `metrics.image.pullPolicy`           | Prometheus metrics image pull policy                                                         | `IfNotPresent`                                                |
 | `metrics.image.pullSecrets`          | Prometheus metrics image pull secrets                                                        | `[]` (does not add image pull secrets to deployed pods)       |
 | `metrics.port`                       | Prometheus metrics exporter port                                                             | `7777`                                                        |

--- a/stable/nats/values-production.yaml
+++ b/stable/nats/values-production.yaml
@@ -301,8 +301,8 @@ metrics:
   enabled: true
   image:
     registry: docker.io
-    repository: synadia/prometheus-nats-exporter
-    tag: 0.1.0
+    repository: bitnami/nats-exporter
+    tag: 0.5.0-debian-9-r3
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/stable/nats/values.yaml
+++ b/stable/nats/values.yaml
@@ -301,8 +301,8 @@ metrics:
   enabled: false
   image:
     registry: docker.io
-    repository: synadia/prometheus-nats-exporter
-    tag: 0.1.0
+    repository: bitnami/nats-exporter
+    tag: 0.5.0-debian-9-r3
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Signed-off-by: Andrés Bono <andresbonojimenez@gmail.com>

#### What this PR does / why we need it:

This PR substitutes the image for the NATS Prometheus exporter.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
