### PR TITLE
stable/percona-xtradb-cluster Add `tag` configuration for metricsExporter container

### DIFF
--- a/stable/percona-xtradb-cluster/Chart.yaml
+++ b/stable/percona-xtradb-cluster/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: percona-xtradb-cluster
-version: 1.0.0
+version: 1.0.1
 appVersion: 5.7.19
 description: free, fully compatible, enhanced, open source drop-in replacement for
   MySQL with Galera Replication (xtradb)

--- a/stable/percona-xtradb-cluster/README.md
+++ b/stable/percona-xtradb-cluster/README.md
@@ -82,6 +82,7 @@ The following table lists the configurable parameters of the Percona chart and t
 | `metricsExporter.enabled` | if set to true runs a [mysql metrics exporter](https://github.com/prometheus/mysqld_exporter) container in the pod | false |
 | `metricsExporter.commandOverrides` | Overrides default docker command for metrics exporter | `[]` |
 | `metricsExporter.argsOverrides`   | Overrides default docker args for metrics exporter     | `[]` |
+| `metricsExporter.tag`             | Specify a docker image tag for `prom/mysqld-exporter` metrics exporter docker image | `nil` |
 | `prometheus.operator.enabled`                  | Setting to true will create Prometheus-Operator specific resources | `false` |
 | `prometheus.operator.prometheusRule.enabled`   | Create default alerting rules                                      | `true`  |
 | `prometheus.operator.prometheusRule.labels`    | Labels to add to alerts                                            | `{}`    |

--- a/stable/percona-xtradb-cluster/templates/statefulset.yaml
+++ b/stable/percona-xtradb-cluster/templates/statefulset.yaml
@@ -134,7 +134,11 @@ spec:
       {{ end }}
       {{ if .Values.metricsExporter.enabled }}
       - name: metrics
+        {{- if .Values.metricsExporter.tag }}
+        image: prom/mysqld-exporter:{{ .Values.metricsExporter.tag }}
+        {{- else }}
         image: prom/mysqld-exporter
+        {{- end }}
         imagePullPolicy: IfNotPresent
 {{- if .Values.metricsExporter.commandOverrides }}
         command:


### PR DESCRIPTION
#### What this PR does / why we need it:

In the percona-xtradb-cluster chart, there is no method to pin the docker image of the `prom/mysqld-exporter` sidecar that is run in the pod if `metricsExporter.enabled` is set to `true`.

This PR adds an optional `metricsExporter.tag` setting, which allows us to specify a version of the `prom/mysql-exporter` docker image. It defaults to `nil` and will fallback to the current behaviour, where no docker image tag is specified.


#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
