### PR TITLE
[stable/redis-ha] Fix additionalAffinities indentation

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.7.2
+version: 3.7.3
 appVersion: 5.0.5
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/stable/redis-ha/templates/redis-ha-statefulset.yaml
@@ -51,7 +51,7 @@ spec:
     {{- end }}
     {{- else }}
     {{- if .Values.additionalAffinities }}
-    {{ toYaml .Values.additionalAffinities | indent 8 }}
+{{ toYaml .Values.additionalAffinities | indent 8 }}
     {{- end }}
         podAntiAffinity:
     {{- if .Values.hardAntiAffinity }}


### PR DESCRIPTION
#### What this PR does / why we need it:

When using this value, the identation was incorrectly set, leading to a helm error.

```
==> Linting redis-ha
[ERROR] templates/redis-ha-statefulset.yaml: unable to parse YAML
        error converting YAML to JSON: yaml: line 29: did not find expected key
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
