### PR TITLE
[stable/consul] add flag to support ipv6

### DIFF
--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: consul
 home: https://github.com/hashicorp/consul
-version: 3.8.0
+version: 3.8.1
 appVersion: 1.5.3
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/stable/consul/README.md
+++ b/stable/consul/README.md
@@ -74,6 +74,7 @@ The following table lists the configurable parameters of the consul chart and th
 | `test.rbac.serviceAccountName`          | Name of existed service account for test container    | ``                         |
 | `additionalLabels`      | Add labels to Pod and StatefulSet     | `{}`                                                       |
 | `lifecycle`             | Lifecycle configuration, in YAML, for StatefulSet | `nil`                                          |
+| `forceIpv6`             | force to listen on IPv6 address                                                                    |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/consul/templates/consul-statefulset.yaml
+++ b/stable/consul/templates/consul-statefulset.yaml
@@ -225,14 +225,22 @@ spec:
               -server \
               -bootstrap-expect=$( echo "$JOIN_PEERS" | wc -w ) \
               -disable-keyring-file \
+            {{- if .Values.forceIpv6 }}
+              -bind=:: \
+            {{- else }}
               -bind=0.0.0.0 \
+            {{- end }}
               -advertise=${POD_IP} \
               ${JOIN_LAN} \
               ${JOIN_WAN} \
             {{- if .Values.Gossip.Encrypt }}
               ${GOSSIP_KEY} \
             {{- end }}
+            {{- if .Values.forceIpv6 }}
+              -client=:: \
+            {{- else }}
               -client=0.0.0.0 \
+            {{- end }}
               -dns-port=${DNSPORT} \
               -http-port={{ .Values.HttpPort }}
       volumes:

--- a/stable/consul/values.yaml
+++ b/stable/consul/values.yaml
@@ -157,3 +157,4 @@ additionalLabels: {}
 #       - sh
 #       - -c
 #       - "sleep 60"
+forceIpv6: false


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Current chart hardcode IPv4 address (0.0.0.0) as bind and client address, the chart cannot be deployed to an IPv6-only environment.

#### Which issue this PR fixes

#### Special notes for your reviewer:
The new flag `forceIpv6` is default to false so it does not change default behavior of the chart, people who need IPv6 can change that to true to listen on `::`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
