### PR TITLE
[stable/prometheus-operator] Fix several issues

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -11,7 +11,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 6.5.0
+version: 6.6.0
 appVersion: 0.31.1
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -200,6 +200,9 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.admissionWebhooks.patch.image.tag` | Tag to use for the webhook integration jobs | `v1.0.0` |
 | `prometheusOperator.admissionWebhooks.patch.image.pullPolicy` | Image pull policy for the webhook integration jobs | `IfNotPresent` |
 | `prometheusOperator.admissionWebhooks.patch.priorityClassName` | Priority class for the webhook integration jobs | `nil` |
+| `prometheusOperator.admissionWebhooks.patch.podAnnotations` | Annotations for the webhook job pods | `nil` |
+| `prometheusOperator.admissionWebhooks.patch.nodeSelector` | Node selector for running admission hook patch jobs | `nil` |
+
 
 ### Prometheus
 | Parameter | Description | Default |

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -69,6 +69,13 @@ kubectl delete crd alertmanagers.monitoring.coreos.com
 
 ## Work-Arounds for Known Issues
 
+### Running on private GKE clusters
+When Google configure the control plane for private clusters, they automatically configure VPC peering between your Kubernetes cluster’s network and a separate Google managed project. In order to restrict what Google are able to access within your cluster, the firewall rules configured restrict access to your Kubernetes pods. This means that in order to use the webhook component with a GKE private cluster, you must configure an additional firewall rule to allow the GKE control plane access to your webhook pod.
+
+You can read more information on how to add firewall rules for the GKE control plane nodes in the [GKE docs](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules)
+
+Alternatively, you can disable the hooks by setting `prometheusOperator.admissionWebhooks.enabled=false`.
+
 ### Helm fails to create CRDs
 Due to a bug in helm, it is possible for the 4 CRDs that are created by this chart to fail to get fully deployed before Helm attempts to create resources that require them. This affects all versions of Helm with a [potential fix pending](https://github.com/helm/helm/pull/5112). In order to work around this issue when installing the chart you will need to make sure all 4 CRDs exist in the cluster first and disable their previsioning by the chart:
 

--- a/stable/prometheus-operator/ci/test-values.yaml
+++ b/stable/prometheus-operator/ci/test-values.yaml
@@ -949,9 +949,12 @@ prometheusOperator:
         repository: jettech/kube-webhook-certgen
         tag: v1.0.0
         pullPolicy: IfNotPresent
-    ## Provide a priority class name to the webhook patching job
-    ##
-    priorityClassName: ""
+      ## Provide a priority class name to the webhook patching job
+      ##
+      priorityClassName: ""
+      podAnnotations: {}
+      nodeSelector: {}
+
 
   ## Service account for Alertmanager to use.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/

--- a/stable/prometheus-operator/hack/sync_grafana_dashboards.py
+++ b/stable/prometheus-operator/hack/sync_grafana_dashboards.py
@@ -29,29 +29,29 @@ charts = [
         'source': 'https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml',
         'destination': '../templates/grafana/dashboards-1.14',
         'type': 'yaml',
-        'min_kubernetes': '1.14.0',
-        'max_kubernetes': '1.16.0'
+        'min_kubernetes': '1.14.0-0',
+        'max_kubernetes': '1.16.0-0'
     },
     {
         'source': 'https://raw.githubusercontent.com/etcd-io/etcd/master/Documentation/op-guide/grafana.json',
         'destination': '../templates/grafana/dashboards-1.14',
         'type': 'json',
-        'min_kubernetes': '1.14.0',
-        'max_kubernetes': '1.16.0'
+        'min_kubernetes': '1.14.0-0',
+        'max_kubernetes': '1.16.0-0'
     },
     {
         'source': 'https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/grafana-dashboardDefinitions.yaml',
         'destination': '../templates/grafana/dashboards',
         'type': 'yaml',
-        'min_kubernetes': '1.11.0',
-        'max_kubernetes': '1.14.0'
+        'min_kubernetes': '1.11.0-0',
+        'max_kubernetes': '1.14.0-0'
     },
     {
         'source': 'https://raw.githubusercontent.com/etcd-io/etcd/master/Documentation/op-guide/grafana.json',
         'destination': '../templates/grafana/dashboards',
         'type': 'json',
-        'min_kubernetes': '1.11.0',
-        'max_kubernetes': '1.14.0'
+        'min_kubernetes': '1.11.0-0',
+        'max_kubernetes': '1.14.0-0'
     },
 ]
 

--- a/stable/prometheus-operator/hack/sync_prometheus_rules.py
+++ b/stable/prometheus-operator/hack/sync_prometheus_rules.py
@@ -27,26 +27,26 @@ charts = [
     {
         'source': 'https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/prometheus-rules.yaml',
         'destination': '../templates/prometheus/rules-1.14',
-        'min_kubernetes': '1.14.0',
-        'max_kubernetes': '1.16.0'
+        'min_kubernetes': '1.14.0-0',
+        'max_kubernetes': '1.16.0-0'
     },
     {
         'source': 'https://raw.githubusercontent.com/etcd-io/etcd/master/Documentation/op-guide/etcd3_alert.rules.yml',
         'destination': '../templates/prometheus/rules-1.14',
-        'min_kubernetes': '1.14.0',
-        'max_kubernetes': '1.16.0'
+        'min_kubernetes': '1.14.0-0',
+        'max_kubernetes': '1.16.0-0'
     },
     {
         'source': 'https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml',
         'destination': '../templates/prometheus/rules',
-        'min_kubernetes': '1.11.0',
-        'max_kubernetes': '1.14.0'
+        'min_kubernetes': '1.11.0-0',
+        'max_kubernetes': '1.14.0-0'
     },
     {
         'source': 'https://raw.githubusercontent.com/etcd-io/etcd/master/Documentation/op-guide/etcd3_alert.rules.yml',
         'destination': '../templates/prometheus/rules',
-        'min_kubernetes': '1.11.0',
-        'max_kubernetes': '1.14.0'
+        'min_kubernetes': '1.11.0-0',
+        'max_kubernetes': '1.14.0-0'
     },
 ]
 

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/apiserver.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/apiserver.yaml
@@ -1,7 +1,7 @@
 # Generated from 'apiserver' from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled .Values.kubeApiServer.enabled }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled .Values.kubeApiServer.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/controller-manager.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/controller-manager.yaml
@@ -1,7 +1,7 @@
 # Generated from 'controller-manager' from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled .Values.kubeControllerManager.enabled }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled .Values.kubeControllerManager.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/etcd.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/etcd.yaml
@@ -1,7 +1,7 @@
 # Generated from 'etcd' from https://raw.githubusercontent.com/etcd-io/etcd/master/Documentation/op-guide/grafana.json
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled .Values.kubeEtcd.enabled }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled .Values.kubeEtcd.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-cluster-rsrc-use.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-cluster-rsrc-use.yaml
@@ -1,7 +1,7 @@
 # Generated from 'k8s-cluster-rsrc-use' from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-node-rsrc-use.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-node-rsrc-use.yaml
@@ -1,7 +1,7 @@
 # Generated from 'k8s-node-rsrc-use' from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-resources-cluster.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-resources-cluster.yaml
@@ -1,7 +1,7 @@
 # Generated from 'k8s-resources-cluster' from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-resources-namespace.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-resources-namespace.yaml
@@ -1,7 +1,7 @@
 # Generated from 'k8s-resources-namespace' from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-resources-pod.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-resources-pod.yaml
@@ -1,7 +1,7 @@
 # Generated from 'k8s-resources-pod' from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-resources-workload.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-resources-workload.yaml
@@ -1,7 +1,7 @@
 # Generated from 'k8s-resources-workload' from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-resources-workloads-namespace.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-resources-workloads-namespace.yaml
@@ -1,7 +1,7 @@
 # Generated from 'k8s-resources-workloads-namespace' from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/kubelet.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/kubelet.yaml
@@ -1,7 +1,7 @@
 # Generated from 'kubelet' from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled .Values.kubelet.enabled }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled .Values.kubelet.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/nodes.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/nodes.yaml
@@ -1,7 +1,7 @@
 # Generated from 'nodes' from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/persistentvolumesusage.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/persistentvolumesusage.yaml
@@ -1,7 +1,7 @@
 # Generated from 'persistentvolumesusage' from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/pods.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/pods.yaml
@@ -1,7 +1,7 @@
 # Generated from 'pods' from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/prometheus-remote-write.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/prometheus-remote-write.yaml
@@ -1,7 +1,7 @@
 # Generated from 'prometheus-remote-write' from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/prometheus.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/prometheus.yaml
@@ -1,7 +1,7 @@
 # Generated from 'prometheus' from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/proxy.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/proxy.yaml
@@ -1,7 +1,7 @@
 # Generated from 'proxy' from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled .Values.kubeProxy.enabled }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled .Values.kubeProxy.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/scheduler.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/scheduler.yaml
@@ -1,7 +1,7 @@
 # Generated from 'scheduler' from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled .Values.kubeScheduler.enabled }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled .Values.kubeScheduler.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/statefulset.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/statefulset.yaml
@@ -1,7 +1,7 @@
 # Generated from 'statefulset' from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards/etcd.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards/etcd.yaml
@@ -1,7 +1,7 @@
 # Generated from 'etcd' from https://raw.githubusercontent.com/etcd-io/etcd/master/Documentation/op-guide/grafana.json
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled .Values.kubeEtcd.enabled }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled .Values.kubeEtcd.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards/k8s-cluster-rsrc-use.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards/k8s-cluster-rsrc-use.yaml
@@ -1,7 +1,7 @@
 # Generated from 'k8s-cluster-rsrc-use' from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards/k8s-node-rsrc-use.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards/k8s-node-rsrc-use.yaml
@@ -1,7 +1,7 @@
 # Generated from 'k8s-node-rsrc-use' from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards/k8s-resources-cluster.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards/k8s-resources-cluster.yaml
@@ -1,7 +1,7 @@
 # Generated from 'k8s-resources-cluster' from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards/k8s-resources-namespace.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards/k8s-resources-namespace.yaml
@@ -1,7 +1,7 @@
 # Generated from 'k8s-resources-namespace' from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards/k8s-resources-pod.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards/k8s-resources-pod.yaml
@@ -1,7 +1,7 @@
 # Generated from 'k8s-resources-pod' from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards/k8s-resources-workload.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards/k8s-resources-workload.yaml
@@ -1,7 +1,7 @@
 # Generated from 'k8s-resources-workload' from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards/k8s-resources-workloads-namespace.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards/k8s-resources-workloads-namespace.yaml
@@ -1,7 +1,7 @@
 # Generated from 'k8s-resources-workloads-namespace' from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards/nodes.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards/nodes.yaml
@@ -1,7 +1,7 @@
 # Generated from 'nodes' from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards/persistentvolumesusage.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards/persistentvolumesusage.yaml
@@ -1,7 +1,7 @@
 # Generated from 'persistentvolumesusage' from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards/pods.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards/pods.yaml
@@ -1,7 +1,7 @@
 # Generated from 'pods' from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/grafana/dashboards/statefulset.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards/statefulset.yaml
@@ -1,7 +1,7 @@
 # Generated from 'statefulset' from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/grafana-dashboardDefinitions.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.grafana.enabled .Values.grafana.defaultDashboardsEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
@@ -14,6 +14,10 @@ spec:
   template:
     metadata:
       name:  {{ template "prometheus-operator.fullname" . }}-admission-create
+{{- with .Values.prometheusOperator.admissionWebhooks.patch.podAnnotations }}
+      annotations:
+{{ toYaml .  | indent 8 }}
+{{- end }}
       labels:
         app: {{ template "prometheus-operator.name" $ }}-admission-create
 {{- include "prometheus-operator.labels" $ | indent 8 }}
@@ -32,6 +36,10 @@ spec:
             - --secret-name={{ template "prometheus-operator.fullname" . }}-admission
       restartPolicy: OnFailure
       serviceAccountName: {{ template "prometheus-operator.fullname" . }}-admission
+      {{- with .Values.prometheusOperator.admissionWebhooks.patch.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 2000

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -14,6 +14,10 @@ spec:
   template:
     metadata:
       name:  {{ template "prometheus-operator.fullname" . }}-admission-patch
+{{- with .Values.prometheusOperator.admissionWebhooks.patch.podAnnotations }}
+      annotations:
+{{ toYaml .  | indent 8 }}
+{{- end }}
       labels:
         app: {{ template "prometheus-operator.name" $ }}-admission-patch
 {{- include "prometheus-operator.labels" $ | indent 8 }}
@@ -33,6 +37,10 @@ spec:
             - --patch-failure-policy={{ .Values.prometheusOperator.admissionWebhooks.failurePolicy }}
       restartPolicy: OnFailure
       serviceAccountName: {{ template "prometheus-operator.fullname" . }}-admission
+      {{- with .Values.prometheusOperator.admissionWebhooks.patch.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 2000

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/alertmanager.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/alertmanager.rules.yaml
@@ -1,7 +1,7 @@
 # Generated from 'alertmanager.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.alertmanager }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.alertmanager }}
 {{- $operatorJob := printf "%s-%s" (include "prometheus-operator.fullname" .) "operator" }}
 {{- $alertmanagerJob := printf "%s-%s" (include "prometheus-operator.fullname" .) "alertmanager" }}
 {{- $namespace := .Release.Namespace }}

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/etcd.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/etcd.yaml
@@ -1,7 +1,7 @@
 # Generated from 'etcd' group from https://raw.githubusercontent.com/etcd-io/etcd/master/Documentation/op-guide/etcd3_alert.rules.yml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.kubeEtcd.enabled .Values.defaultRules.rules.etcd }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.kubeEtcd.enabled .Values.defaultRules.rules.etcd }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/general.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/general.rules.yaml
@@ -1,7 +1,7 @@
 # Generated from 'general.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.general }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.general }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/k8s.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/k8s.rules.yaml
@@ -1,7 +1,7 @@
 # Generated from 'k8s.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.k8s }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.k8s }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/kube-apiserver.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/kube-apiserver.rules.yaml
@@ -1,7 +1,7 @@
 # Generated from 'kube-apiserver.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.kubeApiServer.enabled .Values.defaultRules.rules.kubeApiserver }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.kubeApiServer.enabled .Values.defaultRules.rules.kubeApiserver }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/kube-prometheus-node-alerting.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/kube-prometheus-node-alerting.rules.yaml
@@ -1,7 +1,7 @@
 # Generated from 'kube-prometheus-node-alerting.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubePrometheusNodeAlerting }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubePrometheusNodeAlerting }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/kube-prometheus-node-recording.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/kube-prometheus-node-recording.rules.yaml
@@ -1,7 +1,7 @@
 # Generated from 'kube-prometheus-node-recording.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubePrometheusNodeRecording }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubePrometheusNodeRecording }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/kube-scheduler.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/kube-scheduler.rules.yaml
@@ -1,7 +1,7 @@
 # Generated from 'kube-scheduler.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.kubeScheduler.enabled .Values.defaultRules.rules.kubeScheduler }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.kubeScheduler.enabled .Values.defaultRules.rules.kubeScheduler }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/kubernetes-absent.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/kubernetes-absent.yaml
@@ -1,7 +1,7 @@
 # Generated from 'kubernetes-absent' group from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesAbsent }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesAbsent }}
 {{- $operatorJob := printf "%s-%s" (include "prometheus-operator.fullname" .) "operator" }}
 {{- $prometheusJob := printf "%s-%s" (include "prometheus-operator.fullname" .) "prometheus" }}
 {{- $alertmanagerJob := printf "%s-%s" (include "prometheus-operator.fullname" .) "alertmanager" }}

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/kubernetes-apps.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/kubernetes-apps.yaml
@@ -1,7 +1,7 @@
 # Generated from 'kubernetes-apps' group from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.kubeStateMetrics.enabled .Values.defaultRules.rules.kubernetesApps }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.kubeStateMetrics.enabled .Values.defaultRules.rules.kubernetesApps }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/kubernetes-resources.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/kubernetes-resources.yaml
@@ -1,7 +1,7 @@
 # Generated from 'kubernetes-resources' group from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesResources }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesResources }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/kubernetes-storage.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/kubernetes-storage.yaml
@@ -1,7 +1,7 @@
 # Generated from 'kubernetes-storage' group from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesStorage }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesStorage }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/kubernetes-system.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/kubernetes-system.yaml
@@ -1,7 +1,7 @@
 # Generated from 'kubernetes-system' group from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesSystem }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesSystem }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/node-network.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/node-network.yaml
@@ -1,7 +1,7 @@
 # Generated from 'node-network' group from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.network }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.network }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/node-time.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/node-time.yaml
@@ -1,7 +1,7 @@
 # Generated from 'node-time' group from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.time }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.time }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/node.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/node.rules.yaml
@@ -1,7 +1,7 @@
 # Generated from 'node.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.nodeExporter.enabled .Values.defaultRules.rules.node }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.nodeExporter.enabled .Values.defaultRules.rules.node }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/prometheus-operator.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/prometheus-operator.yaml
@@ -1,7 +1,7 @@
 # Generated from 'prometheus-operator' group from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.prometheusOperator }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.prometheusOperator }}
 {{- $operatorJob := printf "%s-%s" (include "prometheus-operator.fullname" .) "operator" }}
 {{- $namespace := .Release.Namespace }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/prometheus.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/prometheus.yaml
@@ -1,7 +1,7 @@
 # Generated from 'prometheus' group from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create }}
+{{- if and (semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.16.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create }}
 {{- $prometheusJob := printf "%s-%s" (include "prometheus-operator.fullname" .) "prometheus" }}
 {{- $namespace := .Release.Namespace }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}

--- a/stable/prometheus-operator/templates/prometheus/rules/alertmanager.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/alertmanager.rules.yaml
@@ -1,7 +1,7 @@
 # Generated from 'alertmanager.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.alertmanager }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.alertmanager }}
 {{- $operatorJob := printf "%s-%s" (include "prometheus-operator.fullname" .) "operator" }}
 {{- $alertmanagerJob := printf "%s-%s" (include "prometheus-operator.fullname" .) "alertmanager" }}
 {{- $namespace := .Release.Namespace }}

--- a/stable/prometheus-operator/templates/prometheus/rules/etcd.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/etcd.yaml
@@ -1,7 +1,7 @@
 # Generated from 'etcd' group from https://raw.githubusercontent.com/etcd-io/etcd/master/Documentation/op-guide/etcd3_alert.rules.yml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.kubeEtcd.enabled .Values.defaultRules.rules.etcd }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.kubeEtcd.enabled .Values.defaultRules.rules.etcd }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules/general.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/general.rules.yaml
@@ -1,7 +1,7 @@
 # Generated from 'general.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.general }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.general }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules/k8s.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/k8s.rules.yaml
@@ -1,7 +1,7 @@
 # Generated from 'k8s.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.k8s }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.k8s }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules/kube-apiserver.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/kube-apiserver.rules.yaml
@@ -1,7 +1,7 @@
 # Generated from 'kube-apiserver.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.kubeApiServer.enabled .Values.defaultRules.rules.kubeApiserver }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.kubeApiServer.enabled .Values.defaultRules.rules.kubeApiserver }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules/kube-prometheus-node-alerting.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/kube-prometheus-node-alerting.rules.yaml
@@ -1,7 +1,7 @@
 # Generated from 'kube-prometheus-node-alerting.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubePrometheusNodeAlerting }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubePrometheusNodeAlerting }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules/kube-prometheus-node-recording.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/kube-prometheus-node-recording.rules.yaml
@@ -1,7 +1,7 @@
 # Generated from 'kube-prometheus-node-recording.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubePrometheusNodeRecording }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubePrometheusNodeRecording }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules/kube-scheduler.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/kube-scheduler.rules.yaml
@@ -1,7 +1,7 @@
 # Generated from 'kube-scheduler.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.kubeScheduler.enabled .Values.defaultRules.rules.kubeScheduler }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.kubeScheduler.enabled .Values.defaultRules.rules.kubeScheduler }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules/kubernetes-absent.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/kubernetes-absent.yaml
@@ -1,7 +1,7 @@
 # Generated from 'kubernetes-absent' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesAbsent }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesAbsent }}
 {{- $operatorJob := printf "%s-%s" (include "prometheus-operator.fullname" .) "operator" }}
 {{- $prometheusJob := printf "%s-%s" (include "prometheus-operator.fullname" .) "prometheus" }}
 {{- $alertmanagerJob := printf "%s-%s" (include "prometheus-operator.fullname" .) "alertmanager" }}

--- a/stable/prometheus-operator/templates/prometheus/rules/kubernetes-apps.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/kubernetes-apps.yaml
@@ -1,7 +1,7 @@
 # Generated from 'kubernetes-apps' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.kubeStateMetrics.enabled .Values.defaultRules.rules.kubernetesApps }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.kubeStateMetrics.enabled .Values.defaultRules.rules.kubernetesApps }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules/kubernetes-resources.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/kubernetes-resources.yaml
@@ -1,7 +1,7 @@
 # Generated from 'kubernetes-resources' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesResources }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesResources }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules/kubernetes-storage.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/kubernetes-storage.yaml
@@ -1,7 +1,7 @@
 # Generated from 'kubernetes-storage' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesStorage }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesStorage }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules/kubernetes-system.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/kubernetes-system.yaml
@@ -1,7 +1,7 @@
 # Generated from 'kubernetes-system' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesSystem }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesSystem }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules/node-network.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/node-network.yaml
@@ -1,7 +1,7 @@
 # Generated from 'node-network' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.network }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.network }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules/node-time.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/node-time.yaml
@@ -1,7 +1,7 @@
 # Generated from 'node-time' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.time }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.time }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules/node.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/node.rules.yaml
@@ -1,7 +1,7 @@
 # Generated from 'node.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.nodeExporter.enabled .Values.defaultRules.rules.node }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.nodeExporter.enabled .Values.defaultRules.rules.node }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule
 metadata:

--- a/stable/prometheus-operator/templates/prometheus/rules/prometheus-operator.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/prometheus-operator.yaml
@@ -1,7 +1,7 @@
 # Generated from 'prometheus-operator' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.prometheusOperator }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.prometheusOperator }}
 {{- $operatorJob := printf "%s-%s" (include "prometheus-operator.fullname" .) "operator" }}
 {{- $namespace := .Release.Namespace }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}

--- a/stable/prometheus-operator/templates/prometheus/rules/prometheus.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/prometheus.rules.yaml
@@ -1,7 +1,7 @@
 # Generated from 'prometheus.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
-{{- if and (semverCompare ">=1.11.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.prometheus }}
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.prometheus }}
 {{- $prometheusJob := printf "%s-%s" (include "prometheus-operator.fullname" .) "prometheus" }}
 {{- $namespace := .Release.Namespace }}
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -949,9 +949,12 @@ prometheusOperator:
         repository: jettech/kube-webhook-certgen
         tag: v1.0.0
         pullPolicy: IfNotPresent
-    ## Provide a priority class name to the webhook patching job
-    ##
-    priorityClassName: ""
+      ## Provide a priority class name to the webhook patching job
+      ##
+      priorityClassName: ""
+      podAnnotations: {}
+      nodeSelector: {}
+
 
   ## Service account for Alertmanager to use.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/


### PR DESCRIPTION
#### What this PR does / why we need it:
- Adds annotations for admission hooks management jobs, which allows disabling istio auto-injection
- Adds node selector for admission hooks management jobs, which allows running them in mixed node clusters
- Fixes rules not being provisioned on GKE due to it having a pre-release semver
- Adds documentation for requirements in private GKE clusters

#### Which issue this PR fixes
 - fixes #16237
 - fixes #16147
 - fixes #16263

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
