### PR TITLE
[stable/elasticsearch] add forceIpv6 flag so to be able to run in IPv6 env

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.31.0
+version: 1.31.1
 appVersion: 6.8.2
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/stable/elasticsearch/README.md
+++ b/stable/elasticsearch/README.md
@@ -178,6 +178,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `serviceAccounts.data.name`          | Name of the data service account to use or create                   | `{{ elasticsearch.data.fullname }}`                 |
 | `testFramework.image`                | `test-framework` image repository.                                  | `dduportal/bats`                                    |
 | `testFramework.tag`                  | `test-framework` image tag.                                         | `0.4.0`                                             |
+| `forceIpv6`                          | force to use IPv6 address to listen if set to true                  | `false`                                             |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/elasticsearch/templates/configmap.yaml
+++ b/stable/elasticsearch/templates/configmap.yaml
@@ -21,7 +21,11 @@ data:
 {{- end }}
     node.name: ${HOSTNAME}
 
+{{- if .Values.forceIpv6 }}
+    network.host: "::"
+{{- else }}
     network.host: 0.0.0.0
+{{- end }}
 
 {{- if hasPrefix "2." .Values.appVersion }}
     # see https://github.com/kubernetes/kubernetes/issues/3595

--- a/stable/elasticsearch/values.yaml
+++ b/stable/elasticsearch/values.yaml
@@ -313,3 +313,5 @@ chownInitContainer:
   enabled: true
 ## Additional init containers
 extraInitContainers: |
+
+forceIpv6: false


### PR DESCRIPTION
Signed-off-by: Hang Xie <7977860+hangxie@users.noreply.github.com>

#### What this PR does / why we need it:
Current chart hardcode IPv4 address (0.0.0.0) as `network.host`, the chart cannot be deployed to an IPv6-only environment.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
