### PR TITLE
[stable/airflow] add support for secrets on webserver

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 4.0.2
+version: 4.0.3
 appVersion: 1.10.3
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -356,6 +356,8 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `web.resources`                          | custom resource configuration for web pod               | `{}`                      |
 | `web.initialStartupDelay`                | amount of time webserver pod should sleep before initializing webserver             | `60`  |
 | `web.initialDelaySeconds`                | initial delay on livenessprobe before checking if webserver is available    | `360` |
+| `web.secretsDir`                         | directory in which to mount secrets on webserver nodes  | /var/airflow/secrets      |
+| `web.secrets`                            | secrets to mount as volumes on webserver nodes          | []                        |
 | `scheduler.resources`                    | custom resource configuration for scheduler pod         | `{}`                      |
 | `workers.enabled`                        | enable workers                                          | `true`                    |
 | `workers.replicas`                       | number of workers pods to launch                        | `1`                       |

--- a/stable/airflow/templates/deployments-web.yaml
+++ b/stable/airflow/templates/deployments-web.yaml
@@ -92,6 +92,12 @@ spec:
           volumeMounts:
             - name: scripts
               mountPath: /usr/local/scripts
+          {{- $secretsDir := .Values.web.secretsDir -}}
+          {{- range .Values.web.secrets }}
+            - name: {{ . }}-volume
+              readOnly: true
+              mountPath: {{ $secretsDir }}/{{ . }}
+          {{- end }}
           {{- if .Values.persistence.enabled }}
             - name: dags-data
               mountPath: {{ .Values.dags.path }}
@@ -169,6 +175,11 @@ spec:
           configMap:
             name: {{ template "airflow.fullname" . }}-scripts
             defaultMode: 0755
+        {{- range .Values.web.secrets }}
+        - name: {{ . }}-volume
+          secret:
+            secretName: {{ . }}
+        {{- end }}
         - name: dags-data
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -215,6 +215,12 @@ web:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+  ##
+  ## Directory in which to mount secrets on webserver nodes.
+  secretsDir: /var/airflow/secrets
+  ##
+  ## Secrets which will be mounted as a file at `secretsDir/<secret name>`.
+  secrets: []
 
 ##
 ## Workers configuration


### PR DESCRIPTION
Signed-off-by: Marcin Szymanski <ms32035@gmail.com>

#### What this PR does / why we need it:

In some cases Kubernetes secrets are also needed on the webserver. For example, custom plugins can use them. This PR adds support for mounting secrets on the webserver too

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
