### PR TITLE
[incubator/kafka] Revise the zookeeper child chart dependency to 2.0.0 

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.16.4
+version: 0.18.0
 appVersion: 5.0.1
 keywords:
 - kafka

--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.18.0
+version: 0.17.0
 appVersion: 5.0.1
 keywords:
 - kafka

--- a/incubator/kafka/requirements.lock
+++ b/incubator/kafka/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: zookeeper
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  version: 1.3.1
-digest: sha256:999c6b2e0886316ebf1709a44523fe87ee63cf09db66949babbcc1c6d5210723
-generated: 2019-05-24T09:49:23.731997103+02:00
+  version: 2.0.0
+digest: sha256:a564a1ed1f76137e5562d5fb598f45998812fa166e94fc1ba44a2f7774df920d
+generated: 2019-08-13T14:56:29.724627+01:00

--- a/incubator/kafka/requirements.yaml
+++ b/incubator/kafka/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: zookeeper
-  version: 1.3.1
+  version: 2.0.0
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
   condition: kafka.zookeeper.enabled,zookeeper.enabled


### PR DESCRIPTION
Signed-off-by: Kealan Murphy <kealan.murphy@aspect.com>

#### What this PR does / why we need it:
This PR upgrades the Zookeeper chart to version 2.0.0 this brings the Zookeeper version up to 3.5.5 and makes use of a maintained image compared to the previous sample image from google (gcr.io/google_samples/k8szk:v3)  which is no longer maintained. Please refer to https://github.com/helm/charts/pull/11343 for details of the change to zookeeper 3.5.5

#### Which issue this PR fixes

#### Special notes for your reviewer:
I have tested a clean install and basic cluster functionality, upgrades do not work this is a breaking change! 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
