### PR TITLE
[stable/datadog] Enforce Kubernetes Autodiscovery as Default

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.32.2
+version: 1.32.3
 appVersion: 6.12.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/container-agents.yaml
+++ b/stable/datadog/templates/container-agents.yaml
@@ -98,7 +98,7 @@
           key: token
     {{- end }}
     - name: KUBERNETES
-      value: "yes"
+      value: "true"
     {{- if .Values.datadog.podLabelsAsTags }}
     - name: DD_KUBERNETES_POD_LABELS_AS_TAGS
       value: '{{ toJson .Values.datadog.podLabelsAsTags }}'

--- a/stable/datadog/templates/containers-common-env.yaml
+++ b/stable/datadog/templates/containers-common-env.yaml
@@ -21,5 +21,5 @@
   value: {{ .Values.datadog.tags | quote }}
 {{- end }}
 - name: KUBERNETES
-  value: "yes"
+  value: "true"
 {{- end -}}

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -83,7 +83,7 @@ spec:
             value: {{ .Values.datadog.apmEnabled | quote }}
           {{- end }}
           - name: KUBERNETES
-            value: "yes"
+            value: "true"
           {{- if .Values.datadog.collectEvents }}
           - name: KUBERNETES_COLLECT_EVENTS
             value: "yes"


### PR DESCRIPTION
Signed-off-by: Jonathan M Reiter <unfathomablej@gmail.com>

#### What this PR does / why we need it:
This fixes a bad env var value that prevents Kubernetes Autodiscovery from working.

#### Which issue this PR fixes
  - fixes #16229

#### Special notes for your reviewer:
None!

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
