### PR TITLE
[stable/rabbitmq] fixes external metric port issue

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.3.0
+version: 6.3.1
 appVersion: 3.7.17
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -130,7 +130,7 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `metrics.serviceMonitor.relabellings`| Specify Metric Relabellings to add to the scrape endpoint                      | `nil`                     |
 | `metrics.serviceMonitor.honorLabels` | honorLabels chooses the metric's labels on collisions with target labels.      | `false`                   |
 | `metrics.serviceMonitor.additionalLabels`| Used to pass Labels that are required by the Installed Prometheus Operator | `{}`                      |
-| `metrics.port`                       | Prometheus metrics exporter port                 | `9090`                                                  |
+| `metrics.port`                       | Prometheus metrics exporter port                 | `9419`                                                  |
 | `metrics.env`                        | Exporter [configuration environment variables](https://github.com/kbudde/rabbitmq_exporter#configuration) | `{}` |
 | `metrics.resources`                  | Exporter resource requests/limit                 | `nil`                                                   |
 | `metrics.capabilities`               | Exporter: Comma-separated list of extended [scraping capabilities supported by the target RabbitMQ server](https://github.com/kbudde/rabbitmq_exporter#extended-rabbitmq-capabilities) | `bert,no_sort` |

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -256,7 +256,7 @@ spec:
         {{- end }}
         ports:
         - name: metrics
-          containerPort: {{ .Values.metrics.port }}
+          containerPort: 9090
         livenessProbe:
           httpGet:
             path: /metrics

--- a/stable/rabbitmq/templates/svc.yaml
+++ b/stable/rabbitmq/templates/svc.yaml
@@ -42,8 +42,8 @@ spec:
     targetPort: stats
 {{- if .Values.metrics.enabled }}
   - name: metrics
-    port: 9090
-    targetPort: metrics
+    port: {{ .Values.metrics.port }}
+    targetPort: 9090
 {{- end }}
   selector:
     app: {{ template "rabbitmq.name" . }}

--- a/stable/rabbitmq/values-production.yaml
+++ b/stable/rabbitmq/values-production.yaml
@@ -312,7 +312,7 @@ metrics:
   ## ref: https://github.com/kbudde/rabbitmq_exporter#configuration
   env: {}
   ## Metrics exporter port
-  port: 9090
+  port: 9419
   ## Comma-separated list of extended scraping capabilities supported by the target RabbitMQ server
   ## ref: https://github.com/kbudde/rabbitmq_exporter#extended-rabbitmq-capabilities
   capabilities: "bert,no_sort"

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -308,7 +308,7 @@ metrics:
   ## ref: https://github.com/kbudde/rabbitmq_exporter#configuration
   env: {}
   ## Metrics exporter port
-  port: 9090
+  port: 9419
   ## Comma-separated list of extended scraping capabilities supported by the target RabbitMQ server
   ## ref: https://github.com/kbudde/rabbitmq_exporter#extended-rabbitmq-capabilities
   capabilities: "bert,no_sort"


### PR DESCRIPTION
#### What this PR does / why we need it:
- It fixes a bug to set the external metric port
- plus changes the default external metric port from `9090` _(which is originally underused by the Prometheus server)_ to `9419` _(which is the default port used by [prometheus-rabbitmq-exporter]( https://github.com/helm/charts/blob/master/stable/prometheus-rabbitmq-exporter/values.yaml#L52))_

#### Special notes for your reviewer:
Right now, exposing metric port is not working due to hardcoded `9090` expose in here https://github.com/bitnami/bitnami-docker-rabbitmq-exporter/blob/master/0/debian-9/Dockerfile#L15

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
