### PR TITLE
[stable/neo4j] Added resources to replica deployment and HPA.

### DIFF
--- a/stable/neo4j/Chart.yaml
+++ b/stable/neo4j/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: neo4j
 home: https://www.neo4j.com
-version: 1.1.0
+version: 1.2.0
 appVersion: 3.4.5
 description: Neo4j is the world's leading graph database
 icon: http://info.neo4j.com/rs/773-GON-065/images/neo4j_logo.png

--- a/stable/neo4j/README.md
+++ b/stable/neo4j/README.md
@@ -73,6 +73,10 @@ their default values.
 | `core.persistentVolume.subPath`       | Subdirectory of the volume to mount                                                                                                     | `nil`                                           |
 | `core.persistentVolume.annotations`   | Persistent Volume Claim annotations                                                                                                     | `{}`                                            |
 | `readReplica.numberOfServers`         | Number of machines in READ_REPLICA mode                                                                                                 | `0`                                             |
+| `readReplica.autoscaling.enabled`  | Enable horizontal pod autoscaler  | `false`  |
+| `readReplica.autoscaling.targetAverageUtilization`  | Target CPU utilization  | `70`  |
+| `readReplica.autoscaling.minReplicas` | Min replicas for autoscaling  | `1`  |
+| `readReplica.autoscaling.maxReplicas`  | Max replicas for autoscaling  | `3` |
 | `readReplica.initContainers`          | Init containers to add to the replica pod. Example use case is a script that installs the APOC library                                  | `{}`                                            |
 | `resources`                           | Resources required (e.g. CPU, memory)                                                                                                   | `{}`                                            |
 | `clusterDomain`                       | Cluster domain                                                                                                                          | `cluster.local`                                 |

--- a/stable/neo4j/templates/core-statefulset.yaml
+++ b/stable/neo4j/templates/core-statefulset.yaml
@@ -112,6 +112,7 @@ spec:
 {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 6 }}
+{{- end }}
   {{- if .Values.core.persistentVolume.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/stable/neo4j/templates/core-statefulset.yaml
+++ b/stable/neo4j/templates/core-statefulset.yaml
@@ -101,6 +101,17 @@ spec:
         {{- end }}
         - name: plugins
           emptyDir: {}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 6 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 6 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 6 }}
   {{- if .Values.core.persistentVolume.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/stable/neo4j/templates/readreplicas-deployment.yaml
+++ b/stable/neo4j/templates/readreplicas-deployment.yaml
@@ -86,6 +86,7 @@ spec:
 {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 6 }}
+{{- end }}
       volumes:
         - name: plugins
           emptyDir: {}

--- a/stable/neo4j/templates/readreplicas-deployment.yaml
+++ b/stable/neo4j/templates/readreplicas-deployment.yaml
@@ -66,6 +66,8 @@ spec:
         volumeMounts:
         - name: plugins
           mountPath: /plugins
+        resources:
+{{ toYaml .Values.readReplica.resources | indent 10 }}
 {{- if .Values.core.sidecarContainers }}
 {{ toYaml .Values.core.sidecarContainers | indent 6 }}
 {{- end }}

--- a/stable/neo4j/templates/readreplicas-deployment.yaml
+++ b/stable/neo4j/templates/readreplicas-deployment.yaml
@@ -75,6 +75,17 @@ spec:
       initContainers:
 {{ toYaml .Values.readReplica.initContainers | indent 6 }}
 {{- end }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 6 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 6 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 6 }}
       volumes:
         - name: plugins
           emptyDir: {}

--- a/stable/neo4j/templates/readreplicas-hpa.yaml
+++ b/stable/neo4j/templates/readreplicas-hpa.yaml
@@ -3,6 +3,9 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "neo4j.name" . }}
+  chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  heritage: {{ .Release.Service }}
+  release: {{ .Release.Name }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/stable/neo4j/templates/readreplicas-hpa.yaml
+++ b/stable/neo4j/templates/readreplicas-hpa.yaml
@@ -1,0 +1,16 @@
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "neo4j.name" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "neo4j.name" . }}
+  minReplicas: {{ .Values.readReplica.minReplicas }}
+  maxReplicas: {{ .Values.readReplica.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: {{ .Values.readReplica.targetAverageUtilization }}

--- a/stable/neo4j/templates/readreplicas-hpa.yaml
+++ b/stable/neo4j/templates/readreplicas-hpa.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.readReplica.autoscaling.enabled }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -7,10 +8,11 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ template "neo4j.name" . }}
-  minReplicas: {{ .Values.readReplica.minReplicas }}
-  maxReplicas: {{ .Values.readReplica.maxReplicas }}
+  minReplicas: {{ .Values.readReplica.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.readReplica.autoscaling.maxReplicas }}
   metrics:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: {{ .Values.readReplica.targetAverageUtilization }}
+      targetAverageUtilization: {{ .Values.readReplica.autoscaling.targetAverageUtilization }}
+{{- end }}

--- a/stable/neo4j/values.yaml
+++ b/stable/neo4j/values.yaml
@@ -96,9 +96,11 @@ readReplica:
   # requests:
   #   cpu: 100m
   #   memory: 512Mi
-  targetAverageUtilization: 70
-  minReplicas: 0
-  maxReplicas: 3
+  autoscaling:
+    enabled: false
+    targetAverageUtilization: 70
+    minReplicas: 1
+    maxReplicas: 3
 
   numberOfServers: 0
   ## Pass extra environment variables to the Neo4j container.

--- a/stable/neo4j/values.yaml
+++ b/stable/neo4j/values.yaml
@@ -89,6 +89,17 @@ core:
 
 # Read Replicas
 readReplica:
+  resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 512Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 512Mi
+  targetAverageUtilization: 70
+  minReplicas: 0
+  maxReplicas: 3
+
   numberOfServers: 0
   ## Pass extra environment variables to the Neo4j container.
   ##

--- a/stable/neo4j/values.yaml
+++ b/stable/neo4j/values.yaml
@@ -15,6 +15,18 @@ podDisruptionBudget: {}
   # minAvailable: 2
   # maxUnavailable: 1
 
+## Node labels for pod assignment
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+## Tolerations for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+## Affinity for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
 # Use password authentication
 authEnabled: true
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Adding resources and HPA to read replica deployment.

#### Which issue this PR fixes
Without resources it cannot scale properly and it might take all the resources of the node, because there are no limits. Also without Horizontal Pod Autoscaler for deployment it cannot scale in case of higher load.

@mneedham 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
