### PR TITLE
[stable/helm-exporter] Support scrapeTimeout to avoid timeouts

### DIFF
--- a/stable/helm-exporter/Chart.yaml
+++ b/stable/helm-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.4.0"
 description: Exports helm release stats to prometheus
 name: helm-exporter
-version: 0.3.0
+version: 0.3.1
 home: https://github.com/sstarcher/helm-exporter
 sources:
 - https://github.com/sstarcher/helm-exporter

--- a/stable/helm-exporter/templates/servicemonitor.yaml
+++ b/stable/helm-exporter/templates/servicemonitor.yaml
@@ -21,6 +21,9 @@ spec:
     {{- with .Values.serviceMonitor.interval }}
     interval: {{ . }}
     {{- end }}
+    {{- with .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/stable/helm-exporter/values.yaml
+++ b/stable/helm-exporter/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: sstarcher/helm-exporter
-  tag: 0.4.0
+  tag: 0.4.2
   pullPolicy: Always
 
 # To override default tiller namespace name or to provide the multiple tiller namespaces like "kube-system,dev"

--- a/stable/helm-exporter/values.yaml
+++ b/stable/helm-exporter/values.yaml
@@ -34,6 +34,7 @@ serviceMonitor:
   # Specifies whether a ServiceMonitor should be created
   create: false
   interval:
+  scrapeTimeout:
   namespace:
   additionalLabels: {}
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
The metrics endpoint can takes rather long to responds (> 20 seconds) on some cluster.
This PR makes the `scrapeTimeout` value configurable to avoid timeouts in such cases.
It also update the chart to use latest image 0.4.2 instead of 0.4.0.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
