### PR TITLE
[stable/metallb] Fix helm warnings

### DIFF
--- a/stable/metallb/Chart.yaml
+++ b/stable/metallb/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.11.1
+version: 0.11.2
 name: metallb
 appVersion: 0.8.1
 description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters

--- a/stable/metallb/values.yaml
+++ b/stable/metallb/values.yaml
@@ -17,7 +17,7 @@ existingConfigMap: metallb-config
 #
 # Refer to https://metallb.universe.tf/configuration/ for
 # available options.
-configInline:
+configInline: {}
 
 rbac:
   # create specifies whether to install and use RBAC rules.


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixed helm warnings about `configInline` not being a table (when set).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
