### PR TITLE
[stable/mssql-linux] Added support for SQL Agent and loadBalancerIP

### DIFF
--- a/stable/mssql-linux/Chart.yaml
+++ b/stable/mssql-linux/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: SQL Server 2017 Linux Helm Chart
 name: mssql-linux
-version: 0.9.0
+version: 0.10.0
 appVersion: 14.0.3023.8
 home: https://hub.docker.com/r/microsoft/mssql-server-linux/
 icon: https://img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE1I4Dx

--- a/stable/mssql-linux/README.md
+++ b/stable/mssql-linux/README.md
@@ -101,6 +101,7 @@ The configuration parameters in this section control the resources requested and
 | nodeSelector     | Node labels for pod assignment                                                                 | `{}`                             |
 | service.headless   | Allows you to setup a headless service  | `false`  |
 | service.type     | Service Type                                                                                   | `ClusterIP`                      |
+| service.loadBalancerIP     | Loadbalancer IP                                                                                   | `nil`                      |
 | service.port     | Service Port                                                                                   | `1433`                           |
 | service.annotations | Kubernetes service annotations                                                              | `{}`                             |
 | service.labels   | Kubernetes service labels                                                                      | `{}`                             |
@@ -111,6 +112,7 @@ The configuration parameters in this section control the resources requested and
 | collation        | Default collation for SQL Server                                                               | `SQL_Latin1_General_CP1_CI_AS`   |
 | lcid             | Default languages for SQL Server                                                               | `1033`                           |
 | hadr             | Enable Availability Group                                                                      | `0`                              |
+| agent.enabled    | Enable Agent                                                                                   | `false`                          |
 | schedulerName    | Name of the k8s scheduler (other than default)                                                 | `nil`                            |
 | persistence.enabled | Persist the Data and Log files for SQL Server                                               | `false`                          |
 | persistence.existingDataClaim | Identify an existing Claim to be used for the Data Directory                      | `Commented Out`                  |

--- a/stable/mssql-linux/templates/deployment.yaml
+++ b/stable/mssql-linux/templates/deployment.yaml
@@ -72,6 +72,8 @@ spec:
               value: /mssql-data/master/mastlog.ldf
             - name: MSSQL_ENABLE_HADR
               value: "{{ .Values.hadr }}"
+            - name: MSSQL_AGENT_ENABLED
+              value: {{ .Values.agent.enabled | quote }}
             {{ if .Values.resources.limits.memory }}
             - name: MSSQL_MEMORY_LIMIT_MB
               valueFrom:

--- a/stable/mssql-linux/templates/service.yaml
+++ b/stable/mssql-linux/templates/service.yaml
@@ -21,6 +21,9 @@ spec:
   {{- else }}
   type: {{ .Values.service.type }}
   {{- end }}
+  {{- if (and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP))) }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   ports:
   - name: mssql
     port: {{ .Values.service.port }}

--- a/stable/mssql-linux/values.yaml
+++ b/stable/mssql-linux/values.yaml
@@ -5,6 +5,8 @@ edition:
 collation: SQL_Latin1_General_CP1_CI_AS
 lcid: 1033
 hadr: 0
+agent:
+  enabled: false
 # Override sapassword in templates/secret.yaml
 # sapassword: "MyStrongPassword1234"
 existingSecret: ""
@@ -30,6 +32,7 @@ service:
   port: 1433
   annotations: {}
   labels: {}
+  loadBalancerIP:
 deployment:
   annotations: {}
   labels: {}


### PR DESCRIPTION
## What this PR does / why we need it:
Added support for SQL Agent and loadBalancerIP

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
