### PR TITLE
[stable/reloader] Fix multiple small issues

### DIFF
--- a/stable/reloader/Chart.yaml
+++ b/stable/reloader/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: reloader
 description: Reloader chart that runs on kubernetes
-version: 1.1.1
+version: 1.1.2
 appVersion: "v0.0.29"
 keywords:
   - Reloader

--- a/stable/reloader/README.md
+++ b/stable/reloader/README.md
@@ -74,21 +74,22 @@ Update the `values.yaml` and set the following properties
 
 | Key           | Description                                                               | Example                            | Default Value                      |
 |---------------|---------------------------------------------------------------------------|------------------------------------|------------------------------------|
-| watchGlobally          | Option to watch configmap and secrets in all namespaces                                                | `true`                        | `true`                        |
-| matchLabels          | Additional match Labels for selector                                                | `{}`                        | `{}`                        |
-| deployment.annotations          | Annotations for deployment                                                | `{}`                        | `{}`                        |
-| deployment.labels          | Labels for deployment                                                | `provider`                        | `provider`                        |
-| deployment.image.name          | Image name for reloader                                                | `stakater/reloader`                        | `stakater/reloader`                        |
-| deployment.image.tag          | Image tag for reloader                                                | `v0.0.29`                        | `v0.0.29`                        |
-| deployment.image.pullPolicy          | Image pull policy for reloader                                                | `IfNotPresent`                        | `IfNotPresent`                        |
-| deployment.env.open          | Additional key value pair as environment variables                                                | `STORAGE: local`                        | ``                        |
-| deployment.env.secret          | Additional Key value pair as environment variables. It gets the values based on keys from default reloader secret if any                                               | `BASIC_AUTH_USER: test`                        | ``                        |
-| deployment.env.field          | Additional environment variables to expose pod information to containers.                                               | `POD_IP: status.podIP`                        | ``                        |
-| rbac.enabled          | Option to create rbac                                               | `true`                        | `true`                        |
-| rbac.labels          | Additional labels for rbac                                               | `{}`                        | `{}`                        |
-| serviceAccount.create          | Option to create serviceAccount                                               | `true`                        | `true`                        |
-| serviceAccount.name          | Name of serviceAccount                                               | `reloader`                        | `reloader`                        |
-| custom_annotations          | Optional flags to pass to the Reloader entrypoint           | `{}`          | `{}`          |
+| reloader.watchGlobally          | Option to watch configmap and secrets in all namespaces                                                | `true`                        | `true`                        |
+| reloader.matchLabels          | Additional match Labels for selector                                                | `{}`                        | `{}`                        |
+| reloader.deployment.annotations          | Annotations for deployment                                                | `{}`                        | `{}`                        |
+| reloader.deployment.labels          | Labels for deployment                                                | `provider`                        | `provider`                        |
+| reloader.deployment.image.name          | Image name for reloader                                                | `stakater/reloader`                        | `stakater/reloader`                        |
+| reloader.deployment.image.tag          | Image tag for reloader                                                | `v0.0.29`                        | `v0.0.29`                        |
+| reloader.deployment.image.pullPolicy          | Image pull policy for reloader                                                | `IfNotPresent`                        | `IfNotPresent`                        |
+| reloader.deployment.env.open          | Additional key value pair as environment variables                                                | `STORAGE: local`                        | ``                        |
+| reloader.deployment.env.secret          | Additional Key value pair as environment variables. It gets the values based on keys from default reloader secret if any                        | `BASIC_AUTH_USER: test`                        | ``                        |
+| reloader.deployment.env.field          | Additional environment variables to expose pod information to containers.                                               | `POD_IP: status.podIP`                        | ``                        |
+| reloader.rbac.enabled          | Option to create rbac                                               | `true`                        | `true`                        |
+| reloader.rbac.labels          | Additional labels for rbac                                               | `{}`                        | `{}`                        |
+| reloader.serviceAccount.create          | Option to create serviceAccount                                               | `true`                        | `true`                        |
+| reloader.serviceAccount.name          | Name of serviceAccount                                               | `reloader`                        | `reloader`                        |
+| reloader.custom_annotations          | Optional flags to pass to the Reloader entrypoint           | `{}`          | `{}`          |
+| reloader.nodeSelector          | Optional node labels for pod assignment           | `{}`          | `{}`          |
 ## Deploying to Kubernetes
 
 You can deploy Reloader by following methods:

--- a/stable/reloader/templates/deployment.yaml
+++ b/stable/reloader/templates/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
 {{- if .Values.reloader.matchLabels }}
 {{ toYaml .Values.reloader.matchLabels | indent 4 }}
 {{- end }}
-  name: {{ template "reloader-name" . }}
+  name: {{ template "reloader-fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
@@ -88,3 +88,7 @@ spec:
           {{- end }}
         {{- end }}
       serviceAccountName: {{ template "serviceAccountName" . }}
+      {{- if .Values.reloader.nodeSelector }}
+      nodeSelector:
+      {{ toYaml .Values.reloader.nodeSelector | indent 8 }}
+      {{- end }}

--- a/stable/reloader/templates/role.yaml
+++ b/stable/reloader/templates/role.yaml
@@ -11,7 +11,7 @@ metadata:
 {{- if .Values.reloader.matchLabels }}
 {{ toYaml .Values.reloader.matchLabels | indent 4 }}
 {{- end }}
-  name: {{ template "reloader-name" . }}-role
+  name: {{ template "reloader-fullname" . }}-role
   namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:

--- a/stable/reloader/templates/rolebinding.yaml
+++ b/stable/reloader/templates/rolebinding.yaml
@@ -17,7 +17,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "reloader-name" . }}-role
+  name: {{ template "reloader-fullname" . }}-role
 subjects:
   - kind: ServiceAccount
     name: {{ template "serviceAccountName" . }}

--- a/stable/reloader/templates/rolebinding.yaml
+++ b/stable/reloader/templates/rolebinding.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- if .Values.reloader.matchLabels }}
 {{ toYaml .Values.reloader.matchLabels | indent 4 }}
 {{- end }}
-  name: {{ template "reloader-name" . }}-role-binding
+  name: {{ template "reloader-fullname" . }}-role-binding
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/reloader/values.yaml
+++ b/stable/reloader/values.yaml
@@ -28,10 +28,11 @@ reloader:
     labels: {}
     # The name of the ServiceAccount to use.
     # If not set and create is true, a name is generated using the fullname template
-    name: reloader
+    name:
   # Optional flags to pass to the Reloader entrypoint
   # Example:
   #   custom_annotations:
   #     configmap: "my.company.com/configmap"
   #     secret: "my.company.com/secret"
   custom_annotations: {}
+  nodeSelector: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
- Added nodeSelector for deployment
- Fixed `README` to properly indicate that all values are coming from the `reloader` section
- Fixed service account name to fallback to the chart fullname for the name uniformity of deployed resources when not explicitly set
- Fixed role and role binding to use the chart fullname for the name uniformity of deployed resources

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
