### PR TITLE
[stable/pomerium] Version bump to 0.2.1

### DIFF
--- a/stable/pomerium/Chart.yaml
+++ b/stable/pomerium/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: pomerium
-version: 1.3.0
-appVersion: 0.2.0
+version: 1.3.1
+appVersion: 0.2.1
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo.svg
 description: Pomerium is an identity-aware access proxy.

--- a/stable/pomerium/values.yaml
+++ b/stable/pomerium/values.yaml
@@ -115,7 +115,7 @@ extraVolumes: {}
 
 image:
   repository: "pomerium/pomerium"
-  tag: "v0.2.0"
+  tag: "v0.2.1"
   pullPolicy: "IfNotPresent"
 
 metrics:


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates pomerium to latest 0.2 release.

Addresses  CVE-2019-9512, CVE-2019-9514 and CVE-2019-14809.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
