### PR TITLE
[incubator/vault]: use nodeport and enable custom statuscodes

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.18.15
+version: 0.19.0
 appVersion: 1.1.2
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -96,6 +96,8 @@ The following table lists the configurable parameters of the Vault chart and the
 | `vaultExporter.pullPolicy`        | Image pull policy that sould be used     | `IfNotPresent`                      |
 | `vaultExporter.vaultAddress`      | Vault address that exporter should use   | `127.0.0.1:8200`                    |
 | `vaultExporter.tlsCAFile`         | Vault TLS CA certificate mount path      | `/vault/tls/ca.crt`                 |
+| `readiness.statuscodes`           | A map of statuscode arguments to use in readiness check      | `{}`            |
+| `liveness.statuscodes`            | A map of statuscode arguments to use in liveness check       | `{}`            |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -70,7 +70,12 @@ spec:
             path: /v1/sys/health?standbyok=true&
               {{- if .Values.vault.liveness.aliveIfUninitialized -}}uninitcode=204&{{- end }}
               {{- if .Values.vault.liveness.aliveIfSealed -}}sealedcode=204&{{- end }}
-            port: {{ .Values.service.port }}
+              {{- if .Values.vault.liveness.statuscodes -}}
+                {{- range $type, $code := .Values.vault.liveness.statuscodes -}}
+                {{- $type }}={{ $code }}&
+                {{- end }}
+              {{- end }}
+            port: api
             scheme: {{ if .Values.vault.config.listener.tcp.tls_disable -}}HTTP{{- else -}}HTTPS{{- end }}
           initialDelaySeconds: {{ .Values.vault.liveness.initialDelaySeconds }}
           periodSeconds: {{ .Values.vault.liveness.periodSeconds }}
@@ -81,7 +86,12 @@ spec:
               {{- if .Values.vault.readiness.readyIfSealed -}}sealedcode=204&{{- end }}
               {{- if .Values.vault.readiness.readyIfStandby -}}standbycode=204&{{- end }}
               {{- if .Values.vault.readiness.readyIfUninitialized -}}uninitcode=204&{{- end }}
-            port: {{ .Values.service.port }}
+              {{- if .Values.vault.readiness.statuscodes -}}
+                {{- range $type, $code := .Values.vault.readiness.statuscodes -}}
+                {{- $type }}={{ $code }}&
+                {{- end }}
+              {{- end }}
+            port: api
             scheme: {{ if .Values.vault.config.listener.tcp.tls_disable -}}HTTP{{- else -}}HTTPS{{- end }}
           initialDelaySeconds: {{ .Values.vault.readiness.initialDelaySeconds }}
           periodSeconds: {{ .Values.vault.readiness.periodSeconds }}

--- a/incubator/vault/templates/ingress.yaml
+++ b/incubator/vault/templates/ingress.yaml
@@ -1,6 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "vault.fullname" . -}}
-{{- $servicePort := .Values.service.externalPort -}}
+{{- $servicePort := "api" -}}
+{{- if .Values.service.clusterExternalPort }}
+{{- $servicePort = "cluster" -}}
+{{- end }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/incubator/vault/templates/service.yaml
+++ b/incubator/vault/templates/service.yaml
@@ -26,15 +26,21 @@ spec:
     {{- end }}
   {{- end }}
   ports:
-  - port: {{ .Values.service.externalPort }}
+  - name: api
     protocol: TCP
+    port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.port }}
-    name: api
+    {{ if eq "NodePort" .Values.service.type }}
+    nodePort: {{ .Values.service.externalPort }}
+    {{ end }}
   {{- if .Values.service.clusterExternalPort }}
-  - port: {{ .Values.service.clusterExternalPort }}
+  - name: cluster
     protocol: TCP
+    port: {{ .Values.service.clusterExternalPort }}
     targetPort: {{ .Values.service.clusterPort }}
-    name: cluster
+    {{ if eq "NodePort" .Values.service.type }}
+    nodePort: {{ .Values.service.clusterExternalPort }}
+    {{ end }}
   {{- end }}
   selector:
     app: {{ template "vault.name" . }}

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -204,12 +204,22 @@ vault:
     aliveIfSealed: true
     initialDelaySeconds: 30
     periodSeconds: 10
+    statuscodes: {}
+    # sealedcode: 200
+    # standbycode: 200
+    # uninitcode: 200
+
   readiness:
     readyIfSealed: false
     readyIfStandby: true
     readyIfUninitialized: true
     initialDelaySeconds: 10
     periodSeconds: 10
+    statuscodes: {}
+    # sealedcode: 200
+    # standbycode: 200
+    # uninitcode: 200
+
   ## Use an existing config in a named ConfigMap
   # existingConfigName: vault-cm
   config:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR enables you to use nodePort service types with vault.
It also enables you to set custom statuscode values if required. 
In addition, I tweaked to probes to use the port by name.
All three of these are required to be able to deploy vault as a globally loadbalanced service.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x ] Chart Version bumped
- [x ] Variables are documented in the README.md
- [ x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
