### PR TITLE
[stable/nfs-server-provisioner] fix deployment when not creating storage class

### DIFF
--- a/stable/nfs-server-provisioner/Chart.yaml
+++ b/stable/nfs-server-provisioner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.2.1-k8s1.12
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 0.3.0
+version: 0.3.1
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/stable/nfs-server-provisioner/templates/storageclass.yaml
+++ b/stable/nfs-server-provisioner/templates/storageclass.yaml
@@ -17,7 +17,6 @@ reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
 {{ if .Values.storageClass.allowVolumeExpansion }}
 allowVolumeExpansion: {{ .Values.storageClass.allowVolumeExpansion }}
 {{ end }}
-{{ end -}}
 {{- with .Values.storageClass.parameters }}
 parameters:
 {{ toYaml . | indent 2 }}
@@ -26,3 +25,4 @@ parameters:
 mountOptions:
 {{ toYaml . | indent 2 }}
 {{- end }}
+{{ end -}}


### PR DESCRIPTION
Signed-off-by: Tomas Ostasevicius <t.ostasevicius@gmail.com>

tagging @kiall for review, thanks!

#### What this PR does / why we need it:

With the current chart, if `.Values.storageClass.create` is `false`, the `parameters` and `mountOptions` were still rendered in the template, thus making the chart undeployable (since the manifest is not complete).

This PR simply moves the `else` clause of the `.Values.storageClass.create` to the end of the file, so that the rendered template is completely empty (no-op), and the deployment succeeds.

#### Which issue this PR fixes
(I did not create an issue for this, as the fix is trivial)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
