### PR TITLE
[stable/opa] Adding ability to specify bootstrap policies through values.yaml

### DIFF
--- a/stable/opa/Chart.yaml
+++ b/stable/opa/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - opa
 - admission control
 - policy
-version: 1.7.0
+version: 1.8.0
 home: https://www.openpolicyagent.org
 icon: https://raw.githubusercontent.com/open-policy-agent/opa/master/logo/logo.png
 sources:

--- a/stable/opa/README.md
+++ b/stable/opa/README.md
@@ -86,3 +86,4 @@ Reference](https://www.openpolicyagent.org/docs/configuration.html).
 | `priorityClassName` | The name of the priorityClass for the pods. | Unset |
 | `prometheus.enabled` | Flag to expose the `/metrics` endpoint to be scraped. | `false` | 
 | `annotations` | Annotations to be added to the deployment template. | `{}` |
+| `bootstrapPolicies` | Bootstrap policies to be loaded during OPA startup. | `{}` |

--- a/stable/opa/templates/deployment.yaml
+++ b/stable/opa/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
 {{- end }}
-{{- if .Values.authz.enabled }}
+{{- if or .Values.authz.enabled .Values.bootstrapPolicies}}
       initContainers:
         - name: initpolicy
           image: {{ .Values.mgmt.image }}:{{ .Values.mgmt.imageTag }}
@@ -41,9 +41,10 @@ spec:
           - /bin/sh
           - -c
           - |
-            tr -dc 'A-F0-9' < /dev/urandom | dd bs=1 count=32 2>/dev/null > /authz/mgmt-token
-            TOKEN=`cat /authz/mgmt-token`
-            cat > /authz/authz.rego <<EOF
+{{- if .Values.authz.enabled }}
+            tr -dc 'A-F0-9' < /dev/urandom | dd bs=1 count=32 2>/dev/null > /bootstrap/mgmt-token
+            TOKEN=`cat /bootstrap/mgmt-token`
+            cat > /bootstrap/authz.rego <<EOF
             package system.authz
             default allow = false
             # Allow anonymous access to the default policy decision.
@@ -57,10 +58,17 @@ spec:
 {{- end }}
             allow { input.identity == "$TOKEN" }
             EOF
-          volumeMounts:
-            - name: authz
-              mountPath: /authz
 {{- end }}
+{{- range $policyName, $policy := .Values.bootstrapPolicies }}
+            cat > /bootstrap/{{ $policyName }}.rego <<EOF
+{{ $policy | indent 12 }}
+            EOF
+{{- end }}
+          volumeMounts:
+            - name: bootstrap
+              mountPath: /bootstrap
+{{- end }}
+
       containers:
         - name: opa
           image: {{ .Values.image }}:{{ .Values.imageTag }}
@@ -81,13 +89,15 @@ spec:
 {{- if .Values.authz.enabled }}
             - "--authentication=token"
             - "--authorization=basic"
-            - "/authz/authz.rego"
             - "--ignore=.*"
 {{- end }}
 {{- if .Values.prometheus.enabled }}
             - "--insecure-addr=0.0.0.0:8181"
 {{- else if .Values.mgmt.enabled }}
             - "--insecure-addr=127.0.0.1:8181"
+{{- end }}
+{{- if or .Values.authz.enabled .Values.bootstrapPolicies }}
+            - "/bootstrap"
 {{- end }}
           volumeMounts:
             - name: certs
@@ -98,10 +108,10 @@ spec:
               readOnly: true
               mountPath: /config
 {{- end }}
-{{- if .Values.authz.enabled }}
-            - name: authz
+{{- if or .Values.authz.enabled .Values.bootstrapPolicies }}
+            - name: bootstrap
               readOnly: true
-              mountPath: /authz
+              mountPath: /bootstrap
 {{- end }}
           readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 12 }}
@@ -115,7 +125,7 @@ spec:
 {{ toYaml .Values.mgmt.resources | indent 12 }}
           args:
 {{- if .Values.authz.enabled }}
-            - --opa-auth-token-file=/authz/mgmt-token
+            - --opa-auth-token-file=/bootstrap/mgmt-token
 {{- end }}
             - --opa-url=http://127.0.0.1:8181/v1
             - --replicate-path={{ .Values.mgmt.replicate.path }}
@@ -130,11 +140,11 @@ spec:
 {{- range .Values.mgmt.replicate.cluster }}
             - --replicate-cluster={{ . }}
 {{- end }}
-{{- if .Values.authz.enabled }}
+{{- if or .Values.authz.enabled .Values.bootstrapPolicies }}
           volumeMounts:
-            - name: authz
+            - name: bootstrap
               readOnly: true
-              mountPath: /authz
+              mountPath: /bootstrap
 {{- end }}
 {{- end }}
 {{- if .Values.sar.enabled }}
@@ -158,8 +168,8 @@ spec:
           secret:
             secretName: {{ template "opa.fullname" . }}-config
 {{- end }}
-{{- if .Values.authz.enabled }}
-        - name: authz
+{{- if or .Values.authz.enabled .Values.bootstrapPolicies}}
+        - name: bootstrap
           emptyDir: {}
 {{- end }}
       nodeSelector:

--- a/stable/opa/values.yaml
+++ b/stable/opa/values.yaml
@@ -25,6 +25,17 @@ prometheus:
 annotations:
   {}
 
+# Bootstrap policies to load upon startup
+# Define policies in the form of:
+# <policyName> : |-
+#   <regoBody>
+# For example, to mask the entire input body in the decision logs:
+# bootstrapPolicies:
+#   log: |-
+#     package system.log
+#     mask["/input"]
+bootstrapPolicies: {}
+
 # To enforce mutating policies, change to MutatingWebhookConfiguration.
 admissionControllerKind: ValidatingWebhookConfiguration
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Adding ability to define additional bootstrap policies loaded upon OPA startup, in addition to the authz policy. For example, log masking policies to be loaded as soon as OPA starts up instead of being loaded by opa-mgmt.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
