### PR TITLE
Update values.yaml

### DIFF
--- a/stable/redis-ha/values.yaml
+++ b/stable/redis-ha/values.yaml
@@ -3,7 +3,7 @@
 ##
 image:
   repository: redis
-  tag: 5.0.5-alpine
+  tag: 5.0.5
   pullPolicy: IfNotPresent
 ## replicas number for each component
 replicas: 3


### PR DESCRIPTION
Fix `Error: failed to start container "redis-ha": Error response from daemon: oci runtime error: container_linux.go:262: starting container process caused "exec: \"/bin/bash\": stat /bin/bash: no such file or directory"` error.

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Checklist

- [x] Chart Version bumped
- [x] Variables are documented in the README.md

