### PR TITLE
[stable/chart] New prom alert that adds client to KubeAPIErrorsHigh

### DIFF
--- a/stable/prometheus-operator/templates/prometheus/rules/kubernetes-system.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/kubernetes-system.yaml
@@ -124,6 +124,17 @@ spec:
       for: 10m
       labels:
         severity: warning
+    - alert: KubeAPIErrorsHighByClient
+      annotations:
+        message: API server is returning errors for {{`{{ $value }}`}}% of requests for {{`{{ $labels.verb }}`}} {{`{{ $labels.resource }}`}} {{`{{ $labels.subresource }}`}} by {{`{{$labels.client}}`}}.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorshigh
+      expr: |-
+        sum(rate(apiserver_request_count{job="apiserver",code=~"^(?:5..)$"}[5m])) by (client,resource,subresource,verb)
+          /
+        sum(rate(apiserver_request_count{job="apiserver"}[5m])) by (client,resource,subresource,verb) * 100 > 5
+      for: 10m
+      labels:
+        severity: warning
     - alert: KubeClientCertificateExpiration
       annotations:
         message: A client certificate used to authenticate to the apiserver is expiring in less than 7.0 days.


### PR DESCRIPTION
Signed-off-by: Ryan Shatford <evilmonkey@gmail.com>

#### What this PR does / why we need it:
Add the client who is making the api requests to fail to the k8s cluster to the prometheus alert. The previous alerts that fired told me nothing about who was making the requests that failed, so troubleshooting was nearly impossible without digging into the metrics and pulling out what i needed with hours of work.

#### Which issue this PR fixes
None

#### Special notes for your reviewer:
I find the fact that there are 3 alerts with the same name frustrating. I endeavored to break that practice with this review, but am not beholden to this opinion.

#### Checklist
- [x ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x ] Title of the PR starts with chart name (e.g. `[stable/chart]`)
