### PR TITLE
[stable/oauth2-proxy] add extraEnv to set extra environment variables in container

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 0.14.0
+version: 0.14.1
 apiVersion: v1
 appVersion: 3.2.0
 home: http://www.videntity.com/

--- a/stable/oauth2-proxy/README.md
+++ b/stable/oauth2-proxy/README.md
@@ -52,6 +52,7 @@ Parameter | Description | Default
 `config.google.serviceAccountJson` | google service account json contents | `""`
 `config.google.existingConfig` | existing Kubernetes configmap to use for the service account file. See [google secret template](https://github.com/helm/charts/blob/master/stable/oauth2-proxy/templates/google-secret.yaml) for the required values | `nil`
 `extraArgs` | key:value list of extra arguments to give the binary | `{}`
+`extraEnv` | key:value list of extra environment variables to give the binary | `[]`
 `htpasswdFile.enabled` | enable htpasswd-file option | `false`
 `htpasswdFile.entries` | list of [SHA encrypted user:passwords](https://pusher.github.io/oauth2_proxy/configuration#command-line-options) | `{}`
 `htpasswdFile.existingSecret` | existing Kubernetes secret to use for OAuth2 htpasswd file` | `""`

--- a/stable/oauth2-proxy/templates/deployment.yaml
+++ b/stable/oauth2-proxy/templates/deployment.yaml
@@ -81,6 +81,9 @@ spec:
             secretKeyRef:
               name:  {{ template "oauth2-proxy.secretName" . }}
               key: cookie-secret
+        {{- if .Values.extraEnv }}
+{{ toYaml .Values.extraEnv | indent 8 }}
+        {{- end }}
         ports:
           - containerPort: 4180
             name: http

--- a/stable/oauth2-proxy/values.yaml
+++ b/stable/oauth2-proxy/values.yaml
@@ -40,6 +40,7 @@ image:
   # - name: myRegistryKeySecretName
 
 extraArgs: {}
+extraEnv: []
 
 # To authorize individual email addresses
 # That is part of extraArgs but since this needs special treatment we need to do a separate section


### PR DESCRIPTION
Signed-off-by: Hang Xie <7977860+hangxie@users.noreply.github.com>

#### What this PR does / why we need it:
We need to set proxy environment variable for outbound traffic in our deployment, it seems adding a generic value `extraEnv` is a common pattern in other charts.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
