### PR TITLE
[stable/jenkins] add option to disable XML configuration

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.5.3
+version: 1.5.4
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -1,6 +1,6 @@
 # Jenkins Helm Chart
 
-Jenkins master and slave cluster utilizing the Jenkins Kubernetes plugin
+Jenkins master and agent cluster utilizing the Jenkins Kubernetes plugin
 
 * https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin
 
@@ -131,6 +131,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.jenkinsUrlProtocol`       | Set protocol for JenkinsLocationConfiguration.xml | Set to `https` if `Master.ingress.tls`, `http` otherwise |
 | `master.JCasC.enabled`            | Wheter Jenkins Configuration as Code is enabled or not | `false`                 |
 | `master.JCasC.configScripts`      | List of Jenkins Config as Code scripts | False                                   |
+| `master.enableXmlConfig`          | enables configuration done via XML files | `false`                               |
 | `master.sidecars.configAutoReload` | Jenkins Config as Code auto-reload settings |                                   |
 | `master.sidecars.configAutoReload.enabled` | Jenkins Config as Code auto-reload settings (Attention: rbac needs to be enabled otherwise the sidecar can't read the config map) | `false`                                                      |
 | `master.sidecars.configAutoReload.image` | Image which triggers the reload | `shadwell/k8s-sidecar:0.0.2`            |
@@ -187,13 +188,13 @@ Some third-party systems, e.g. GitHub, use HTML-formatted data in their payload 
 | `agent.privileged`         | Agent privileged container                      | `false`                |
 | `agent.resources`          | Resources allocation (Requests and Limits)      | `{requests: {cpu: 200m, memory: 256Mi}, limits: {cpu: 200m, memory: 256Mi}}`|
 | `agent.volumes`            | Additional volumes                              | `nil`                  |
-| `agent.envVars`            | Environment variables for the slave Pod         | Not set                |
+| `agent.envVars`            | Environment variables for the agent Pod         | Not set                |
 | `agent.command`            | Executed command when side container starts     | Not set                |
 | `agent.args`               | Arguments passed to executed command            | Not set                |
 | `agent.sideContainerName`  | Side container name in agent                    | jnlp                   |
 | `agent.TTYEnabled`         | Allocate pseudo tty to the side container       | false                  |
 | `agent.containerCap`       | Maximum number of agent                         | 10                     |
-| `agent.podName`            | slave Pod base name                             | Not set                |
+| `agent.podName`            | Agent Pod base name                             | Not set                |
 | `agent.idleMinutes`        | Allows the Pod to remain active for reuse       | 0                      |
 | `agent.yamlTemplate`       | The raw yaml of a Pod API Object to merge into the agent spec | Not set                |
 

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -12,6 +12,7 @@ metadata:
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
     "app.kubernetes.io/component": "{{ .Values.master.componentName }}"
 data:
+{{- if .Values.master.enableXmlConfig }}
   config.xml: |-
     <?xml version='1.0' encoding='UTF-8'?>
     <hudson>
@@ -211,7 +212,9 @@ data:
       <enabled>false</enabled>
 {{- end }}
     </jenkins.CLI>
+{{- end }}
   apply_config.sh: |-
+{{- if .Values.master.enableXmlConfig }}
     mkdir -p /usr/share/jenkins/ref/secrets/;
     echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch;
 {{- if .Values.master.overwriteConfig }}
@@ -232,6 +235,7 @@ data:
     yes n | cp -i /var/jenkins_config/{{- $key }} /var/jenkins_home;
   {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- if .Values.master.overwritePlugins }}
     # remove all plugins from shared volume
@@ -270,6 +274,7 @@ data:
     cp -v /var/jenkins_config/*.yaml /var/jenkins_home/casc_configs
   {{- end }}
 {{- end }}
+{{- if .Values.master.enableXmlConfig }}
 {{- if .Values.master.credentialsXmlSecret }}
     yes n | cp -i /var/jenkins_credentials/credentials.xml /var/jenkins_home;
 {{- end }}
@@ -281,6 +286,7 @@ data:
       mkdir -p /var/jenkins_home/jobs/$job
       yes {{ if not .Values.master.overwriteJobs }}n{{ end }} | cp -i /var/jenkins_jobs/$job /var/jenkins_home/jobs/$job/config.xml
     done
+{{- end }}
 {{- end }}
 {{- range $key, $val := .Values.master.initScripts }}
   init{{ $key }}.groovy: |-

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -126,6 +126,7 @@ spec:
               {{- end }}
             - mountPath: /var/jenkins_config
               name: jenkins-config
+            {{- if .Values.master.enabledXmlConfig }}
             {{- if .Values.master.credentialsXmlSecret }}
             - mountPath: /var/jenkins_credentials
               name: jenkins-credentials
@@ -141,14 +142,17 @@ spec:
               name: jenkins-jobs
               readOnly: true
             {{- end }}
+            {{- end }}
             {{- if .Values.master.installPlugins }}
             - mountPath: /usr/share/jenkins/ref/plugins
               name: plugins
             - mountPath: /var/jenkins_plugins
               name: plugin-dir
             {{- end }}
+            {{- if .Values.master.enableXmlConfig }}
             - mountPath: /usr/share/jenkins/ref/secrets/
               name: secrets-dir
+            {{- end }}
       containers:
         - name: jenkins
 {{- if .Values.master.imageTag }}
@@ -251,6 +255,7 @@ spec:
             - mountPath: /var/jenkins_config
               name: jenkins-config
               readOnly: true
+            {{- if .Values.master.enableXmlConfig }}
             {{- if .Values.master.credentialsXmlSecret }}
             - mountPath: /var/jenkins_credentials
               name: jenkins-credentials
@@ -266,14 +271,17 @@ spec:
               name: jenkins-jobs
               readOnly: true
             {{- end }}
+            {{- end }}
             {{- if .Values.master.installPlugins }}
             - mountPath: /usr/share/jenkins/ref/plugins/
               name: plugin-dir
               readOnly: false
             {{- end }}
+            {{- if .Values.master.enableXmlConfig }}
             - mountPath: /usr/share/jenkins/ref/secrets/
               name: secrets-dir
               readOnly: false
+            {{- end }}
             {{- if and (.Values.master.JCasC.enabled) (.Values.master.sidecars.configAutoReload.enabled) }}
             - name: sc-config-volume
               mountPath: {{ .Values.master.sidecars.configAutoReload.folder | default "/var/jenkins_home/casc_configs" | quote }}
@@ -340,6 +348,7 @@ spec:
       - name: jenkins-config
         configMap:
           name: {{ template "jenkins.fullname" . }}
+      {{- if .Values.master.enableXmlConfig }}
       {{- if .Values.master.credentialsXmlSecret }}
       - name: jenkins-credentials
         secret:
@@ -355,12 +364,15 @@ spec:
         configMap:
           name: {{ template "jenkins.fullname" . }}-jobs
       {{- end }}
+      {{- end }}
       {{- if .Values.master.installPlugins }}
       - name: plugin-dir
         emptyDir: {}
       {{- end }}
+      {{- if .Values.master.enableXmlConfig }}
       - name: secrets-dir
         emptyDir: {}
+      {{- end }}
       - name: jenkins-home
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -30,6 +30,10 @@ master:
   numExecutors: 0
   # configAutoReload requires UseSecurity is set to true:
   useSecurity: true
+
+  # enables configuration done directly via XML files
+  # People who want to configure Jenkins via https://github.com/jenkinsci/configuration-as-code-plugin only can set it to false
+  enableXmlConfig: true
   # Allows to configure different SecurityRealm using Jenkins XML
   securityRealm: |-
     <securityRealm class="hudson.security.LegacySecurityRealm"/>
@@ -120,8 +124,8 @@ master:
       enabled: true
       proxyCompatability: true
   cli: false
-  # Kubernetes service type for the JNLP slave service
-  # slaveListenerServiceType is the Kubernetes Service type for the JNLP slave service,
+  # Kubernetes service type for the JNLP agent service
+  # slaveListenerServiceType is the Kubernetes Service type for the JNLP agent service,
   # either 'LoadBalancer', 'NodePort', or 'ClusterIP'
   # Note if you set this to 'LoadBalancer', you *must* define annotations to secure it. By default
   # this will be an external load balancer and allowing inbound 0.0.0.0/0, a HUGE
@@ -130,7 +134,7 @@ master:
   slaveListenerServiceAnnotations: {}
   slaveKubernetesNamespace:
 
-  # Example of 'LoadBalancer' type of slave listener with annotations securing it
+  # Example of 'LoadBalancer' type of agent listener with annotations securing it
   # slaveListenerServiceType: LoadBalancer
   # slaveListenerServiceAnnotations:
   #   service.beta.kubernetes.io/aws-load-balancer-internal: "True"
@@ -195,7 +199,7 @@ master:
   # etc.  Best reference is https://<jenkins_url>/configuration-as-code/reference.  The example below creates a welcome message:
   JCasC:
     enabled: false
-    pluginVersion: "1.25"
+    pluginVersion: "1.27"
     # it's only used when plugin version is <=1.18 for later version the
     # configuration as code support plugin is no longer needed
     supportPluginVersion: "1.18"
@@ -365,14 +369,14 @@ agent:
       memory: "256Mi"
   # You may want to change this to true while testing a new image
   alwaysPullImage: false
-  # Controls how slave pods are retained after the Jenkins build completes
+  # Controls how agent pods are retained after the Jenkins build completes
   # Possible values: Always, Never, OnFailure
   podRetention: "Never"
   # You can define the volumes that you want to mount for this container
   # Allowed types are: ConfigMap, EmptyDir, HostPath, Nfs, Pod, Secret
   # Configure the attributes as they appear in the corresponding Java class for that type
   # https://github.com/jenkinsci/kubernetes-plugin/tree/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes
-  # Pod-wide ennvironment, these vars are visible to any container in the slave pod
+  # Pod-wide ennvironment, these vars are visible to any container in the agent pod
   envVars:
   # - name: PATH
   #   value: /usr/local/bin


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR adds the possibility to disable Jenkins configuration which is currently done via XML files. 
It allows to configure Jenkins differently e.g. by using the [Jenkins Configuration as Code Plugin](https://github.com/jenkinsci/configuration-as-code-plugin). Disabling the XML configuration allows one to check if all needed configuration is done via the new configuration mechanism.

In a future PR I want to add an option to have a minimal default configuration just via the configuration as code plugin. This way we can over time improve the configuration as code config to include options currently done via XML files. The benefits I see here are:

- it encourages people to configure Jenkins via code
- it allows updating configurations
  Currently templating XMLs is a one time task. Once it's done configuration changes via values.yaml have no effect unless you explicitly overwrite the XML files again.

From my point of view this should be an opt-in feature for the time being until all configuration options currently supported by the chart are supported. There are probably things which can't be ported e.g. supplying custom xml snippet e.g. `securityRealm`, `authorizationStrategy`. One could think about deprecating those in a major version bump when making the configuration as code configuration the default for the chart (if we want that).


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
I also added two minor improvements:
- configuration as code plugin has been updated to 1.27
- documentation was updated to replace "slave" with "agent" in the documentation

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
