### PR TITLE
[stable/sumologic-fluentd] Fix template syntax

### DIFF
--- a/stable/sumologic-fluentd/Chart.yaml
+++ b/stable/sumologic-fluentd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sumologic-fluentd
-version: 1.1.0
+version: 1.1.1
 appVersion: 2.3.0
 description: Sumologic Log Collector
 keywords:

--- a/stable/sumologic-fluentd/templates/daemonset.yaml
+++ b/stable/sumologic-fluentd/templates/daemonset.yaml
@@ -227,18 +227,18 @@ spec:
           configMap:
             name: {{ template "sumologic-fluentd.fluentdUserConfig.fullname" . }}
         {{- end }}
-{{- if .Values.tolerations }}
+    {{- if .Values.tolerations }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
-{{- end }}
-{{- if .Values.nodeSelector }}
+    {{- end }}
+    {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
-{{- end }}
-{{ if .Values.affinity }}
+    {{- end }}
+    {{ if .Values.affinity }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
-{{- end }}
+    {{- end }}
   updateStrategy:
     type: "{{ .Values.updateStrategy }}"
-{{- end }}
+    {{- end }}

--- a/stable/sumologic-fluentd/templates/daemonset.yaml
+++ b/stable/sumologic-fluentd/templates/daemonset.yaml
@@ -227,18 +227,18 @@ spec:
           configMap:
             name: {{ template "sumologic-fluentd.fluentdUserConfig.fullname" . }}
         {{- end }}
-    {{- if .Values.tolerations }}
+{{- if .Values.tolerations }}
       tolerations:
-    {{ toYaml .Values.tolerations | indent 8 }}
-    {{- end }}
-    {{- if .Values.nodeSelector }}
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- end }}
+{{- if .Values.nodeSelector }}
       nodeSelector:
-    {{ toYaml .Values.nodeSelector | indent 8 }}
-    {{- end }}
-    {{ if .Values.affinity }}
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{ if .Values.affinity }}
       affinity:
-    {{ toYaml .Values.affinity | indent 8 }}
-    {{- end }}
+{{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
   updateStrategy:
     type: "{{ .Values.updateStrategy }}"
 {{- end }}


### PR DESCRIPTION
### What this PR does / why we need it:
Fixes erroneous indentation in the DaemonSet template that made the
chart fail if affinity was defined.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
