### PR TITLE
Add .gitattributes to fix language stats bar

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.tpl linguist-language=Text
+*.tpl linguist-language=Go

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.tpl linguist-language=Text


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Fixes the Github Language stats bar, in which currently language of files with extension `tpl` are being recognised as Smarty, which are actually just text files. It makes the smarty files being shown as 86.7% of the codebase

After the commit, the text files are ignored in the final stats by Github Linguist:
```github-linguist --breakdown
59.54%  Shell
25.44%  Python
8.80%   Go
4.48%   Dockerfile
1.72%   Makefile
0.01%   HTML
```