### PR TITLE
[stable/chart] Update Grafana due to kiwigrid/k8s-sidecar crashing

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -11,7 +11,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 6.6.1
+version: 6.7.1
 appVersion: 0.31.1
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/requirements.lock
+++ b/stable/prometheus-operator/requirements.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 2.0.0
 - name: prometheus-node-exporter
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.5.1
+  version: 1.5.2
 - name: grafana
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 3.7.3
-digest: sha256:d218557e23680982931e04a9fae4f308d0ce75a6515cc83ee9e5dadda65fbbb0
-generated: 2019-07-24T09:09:34.838754406-07:00
+  version: 3.8.3
+digest: sha256:17bccb51e69893d2fa5d1c647e6f092a08e00dab0a6f22a47e8dba1eb7192e7e
+generated: "2019-08-16T00:07:19.618996-07:00"

--- a/stable/prometheus-operator/requirements.yaml
+++ b/stable/prometheus-operator/requirements.yaml
@@ -11,6 +11,6 @@ dependencies:
     condition: nodeExporter.enabled
 
   - name: grafana
-    version: 3.7.*
+    version: 3.8.*
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: grafana.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR fixes the Grafana sidecar process that keeps crashing "[Sidecar v0.0.18 crashes with API Server Error](https://github.com/kiwigrid/k8s-sidecar/issues/37)"

#### Which issue this PR fixes

"[Sidecar v0.0.18 crashes with API Server Error](https://github.com/kiwigrid/k8s-sidecar/issues/37)"

```
Containers:
  grafana-sc-dashboard:
    Container ID:   docker://74b97cae028f9706925c99ffb846dba2abf325547d1f0fb965ac95f4f0262ba4
    Image:          kiwigrid/k8s-sidecar:0.0.18
    Image ID:       docker-pullable://kiwigrid/k8s-sidecar@sha256:6eb52513d59efcbbb37999f494bd0d647571c76362166d8bb9081f3a067c09e8
    Port:           <none>
    Host Port:      <none>
    State:          Running
      Started:      Thu, 15 Aug 2019 23:25:24 -0700
    Last State:     Terminated
      Reason:       Error
      Exit Code:    1
      Started:      Thu, 15 Aug 2019 22:55:06 -0700
      Finished:     Thu, 15 Aug 2019 23:25:23 -0700
    Ready:          True
    Restart Count:  111  <---- Constant restarts due to old k8s library (Seems to be fixed in 0.1.20)
    Environment:
      LABEL:     grafana_dashboard
      FOLDER:    /tmp/dashboards
      RESOURCE:  both
    Mounts:
      /tmp/dashboards from sc-dashboard-volume (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from prometheus-grafana-token-czjvw (ro)
```

#### Special notes for your reviewer:

This has been tested on v1.13.7-gke.8
 
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
