### PR TITLE
[stable/kiam] reset gatewayTimeoutCreation to project default

### DIFF
--- a/stable/kiam/Chart.yaml
+++ b/stable/kiam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kiam
-version: 2.5.1
+version: 2.5.2
 appVersion: 3.3
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/stable/kiam/values.yaml
+++ b/stable/kiam/values.yaml
@@ -107,7 +107,7 @@ agent:
 
   ## Timeout when creating the kiam gateway
   ##
-  gatewayTimeoutCreation: 50ms
+  gatewayTimeoutCreation: 1s
 
   ## Base64-encoded PEM values for agent's CA certificate(s), certificate and private key
   ##
@@ -222,7 +222,7 @@ server:
 
   ## Timeout when creating the kiam gateway
   ##
-  gatewayTimeoutCreation: 50ms
+  gatewayTimeoutCreation: 1s
 
   ## Server probe configuration
   probes:


### PR DESCRIPTION
### What this PR does / why we need it:
The Helm chart default of 50ms can cause pods to restart randomly on
start-up, exacerbated by any CPU throttling or resource limits. The
[default set in the project manifests](https://github.com/uswitch/kiam/blob/04e66a7203457ada3b2dfb2efd0e9fdc50ea9260/deploy/agent.yaml#L56) is 1s.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
