### PR TITLE
[stable/stackdriver-exporter] Add support for Prometheus Operator ServiceMonitor

### DIFF
--- a/stable/stackdriver-exporter/Chart.yaml
+++ b/stable/stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: stackdriver-exporter
-version: 1.1.1
+version: 1.2.0
 appVersion: 0.6.0
 home: https://www.stackdriver.com/
 sources:

--- a/stable/stackdriver-exporter/README.md
+++ b/stable/stackdriver-exporter/README.md
@@ -85,6 +85,10 @@ Parameter                           | Description                               
 `affinity`                          | Pod affinity                                                                    | `{}`
 `nodeSelector`                      | Node labels for pod assignment												  | `{}`
 `tolerations`                       | Node taints to tolerate (requires Kubernetes >=1.6) 							  | `[]`
+`serviceMonitor.enabled`            | if `true`, creates a Prometheus Operator ServiceMonitor                         | `false`
+`serviceMonitor.namespace`          | Namespace which Prometheus is running in                                        | `monitoring`
+`serviceMonitor.interval`           | How frequently to scrape metrics (not set: fall back to Prometheus' default)    |  `nil`
+`serviceMonitor.honorLabels`        | if `true`, label conflicts are resolved by keeping label values from the scraped data | `true`
 
 
 

--- a/stable/stackdriver-exporter/README.md
+++ b/stable/stackdriver-exporter/README.md
@@ -86,7 +86,7 @@ Parameter                           | Description                               
 `nodeSelector`                      | Node labels for pod assignment												  | `{}`
 `tolerations`                       | Node taints to tolerate (requires Kubernetes >=1.6) 							  | `[]`
 `serviceMonitor.enabled`            | if `true`, creates a Prometheus Operator ServiceMonitor                         | `false`
-`serviceMonitor.namespace`          | Namespace which Prometheus is running in                                        | `monitoring`
+`serviceMonitor.namespace`          | Namespace where you want to create the ServiceMonitor                           | `monitoring`
 `serviceMonitor.interval`           | How frequently to scrape metrics (not set: fall back to Prometheus' default)    |  `nil`
 `serviceMonitor.honorLabels`        | if `true`, label conflicts are resolved by keeping label values from the scraped data | `true`
 

--- a/stable/stackdriver-exporter/templates/servicemonitor.yaml
+++ b/stable/stackdriver-exporter/templates/servicemonitor.yaml
@@ -24,4 +24,4 @@ spec:
       app: {{ template "stackdriver-exporter.name" . }}
       release: "{{ .Release.Name }}"
       heritage: "{{ .Release.Service }}"
-{{- end -}}
+{{- end }}

--- a/stable/stackdriver-exporter/templates/servicemonitor.yaml
+++ b/stable/stackdriver-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "prometheus-pushgateway.name" .  }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    chart: {{ template "stackdriver-exporter.chart" . }}
+    app: {{ template "stackdriver-exporter.name" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  endpoints:
+  - port: http
+    {{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    {{- end }}
+    honorLabels: {{ .Values.serviceMonitor.honorLabels }}
+  selector:
+    matchLabels:
+      chart: {{ template "stackdriver-exporter.chart" . }}
+      app: {{ template "stackdriver-exporter.name" . }}
+      release: "{{ .Release.Name }}"
+      heritage: "{{ .Release.Service }}"
+{{- end -}}

--- a/stable/stackdriver-exporter/values.yaml
+++ b/stable/stackdriver-exporter/values.yaml
@@ -91,6 +91,4 @@ serviceMonitor:
   # fallback to the prometheus default unless specified
   # interval: 10s
   ## Defaults to what's used if you follow CoreOS [Prometheus Install Instructions](https://github.com/helm/charts/tree/master/stable/prometheus-operator#tldr)
-  # Retain the job and instance labels of the metrics pushed to the Pushgateway
-  # [Scraping Pushgateway](https://github.com/prometheus/pushgateway#configure-the-pushgateway-as-a-target-to-scrape)
   honorLabels: true

--- a/stable/stackdriver-exporter/values.yaml
+++ b/stable/stackdriver-exporter/values.yaml
@@ -83,3 +83,14 @@ serviceAccount:
   # If not set and create is false, 'default' is used
   # If not set and create is true, a name is generated using the fullname template
   name:
+
+# Enable this if you're using https://github.com/coreos/prometheus-operator
+serviceMonitor:
+  enabled: false
+  namespace: monitoring
+  # fallback to the prometheus default unless specified
+  # interval: 10s
+  ## Defaults to what's used if you follow CoreOS [Prometheus Install Instructions](https://github.com/helm/charts/tree/master/stable/prometheus-operator#tldr)
+  # Retain the job and instance labels of the metrics pushed to the Pushgateway
+  # [Scraping Pushgateway](https://github.com/prometheus/pushgateway#configure-the-pushgateway-as-a-target-to-scrape)
+  honorLabels: true


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This adds an optional ServiceMonitor object to work with the Prometheus Operator

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
