### PR TITLE
[stable/kafka-manager] configurable liveness and readiness probes

### DIFF
--- a/stable/kafka-manager/Chart.yaml
+++ b/stable/kafka-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka-manager
-version: 2.1.6
+version: 2.2.0
 appVersion: 1.3.3.22
 kubeVersion: "^1.8.0-0"
 description: A tool for managing Apache Kafka.

--- a/stable/kafka-manager/README.md
+++ b/stable/kafka-manager/README.md
@@ -42,6 +42,8 @@ Parameter | Description | Default
 --------- | ----------- | -------
 `serviceAccount.create` | If true, create a service account for kafka-manager | `true`
 `serviceAccount.name` | Name of the service account to create or use | `{{ kafka-manager.fullname }}`
+`livenessProbe` | Liveness probe configurations | `{ "httpGet": { "path": "/api/health", "port": "kafka-manager" }, "initialDelaySeconds": 60, "timeoutSeconds": 30, "failureThreshold": 10 }`
+`readinessProbe` | Readiness probe configurations | `{ "httpGet": { "path": "/api/health", "port": "kafka-manager" } }`
 `image.repository` | Container image repository | `zenko/kafka-manager`
 `image.tag` | Container image tag | `1.3.3.22`
 `image.pullPolicy` | Container image pull policy | `IfNotPresent`

--- a/stable/kafka-manager/templates/deployment.yaml
+++ b/stable/kafka-manager/templates/deployment.yaml
@@ -52,13 +52,9 @@ spec:
                   name: {{ template "kafka-manager.fullname" . }}
                   key: basicAuthPassword
           livenessProbe:
-            httpGet:
-              path: /api/health
-              port: kafka-manager
+{{ toYaml .Values.livenessProbe | indent 12 }}
           readinessProbe:
-            httpGet:
-              path: /api/health
-              port: kafka-manager
+{{ toYaml .Values.readinessProbe | indent 12 }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/stable/kafka-manager/values.yaml
+++ b/stable/kafka-manager/values.yaml
@@ -12,6 +12,19 @@ serviceAccount:
   ##
   name: ""
 
+livenessProbe:
+  httpGet:
+    path: /api/health
+    port: kafka-manager
+  initialDelaySeconds: 60
+  timeoutSeconds: 30
+  failureThreshold: 10
+
+readinessProbe:
+  httpGet:
+    path: /api/health
+    port: kafka-manager
+
 ## Specs for the Kafka-manager image
 ##
 image:


### PR DESCRIPTION
Signed-off-by: moody <moody.saada@agolo.com>

#### What this PR does / why we need it:
Make probes configurable

#### Which issue this PR fixes
  - fixes #16377 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
