### PR TITLE
[stable/minecraft-server] adds server backup instructions

### DIFF
--- a/stable/minecraft/Chart.yaml
+++ b/stable/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 1.1.0
+version: 1.1.1
 appVersion: 1.14.4
 home: https://minecraft.net/
 description: Minecraft server

--- a/stable/minecraft/README.md
+++ b/stable/minecraft/README.md
@@ -63,3 +63,13 @@ By default a PersistentVolumeClaim is created and mounted for saves but not mods
 you can change the values.yaml to disable persistence under the sub-sections under `persistence`.
 
 > *"An emptyDir volume is first created when a Pod is assigned to a Node, and exists as long as that Pod is running on that node. When a Pod is removed from a node for any reason, the data in the emptyDir is deleted forever."*
+
+## Backups
+
+You can backup the state of your minecraft server to your local machine via the `kubectl cp` command.  
+
+```
+NAMESPACE=default
+POD_ID=lionhope-387ff8d-sdis9
+kubectl cp ${NAMESPACE}/${POD_ID}:/data .
+```

--- a/stable/minecraft/README.md
+++ b/stable/minecraft/README.md
@@ -71,5 +71,8 @@ You can backup the state of your minecraft server to your local machine via the 
 ```
 NAMESPACE=default
 POD_ID=lionhope-387ff8d-sdis9
+kubectl exec ${NAMESPACE}/${POD_ID} rcon-cli save-off
+kubectl exec ${NAMESPACE}/${POD_ID} rcon-cli save-all
 kubectl cp ${NAMESPACE}/${POD_ID}:/data .
+kubectl exec ${NAMESPACE}/${POD_ID} rcon-cli save-on
 ```

--- a/stable/minecraft/README.md
+++ b/stable/minecraft/README.md
@@ -71,8 +71,8 @@ You can backup the state of your minecraft server to your local machine via the 
 ```
 NAMESPACE=default
 POD_ID=lionhope-387ff8d-sdis9
-kubectl exec ${NAMESPACE}/${POD_ID} rcon-cli save-off
-kubectl exec ${NAMESPACE}/${POD_ID} rcon-cli save-all
+kubectl exec --namespace ${NAMESPACE} ${POD_ID} rcon-cli save-off
+kubectl exec --namespace ${NAMESPACE} ${POD_ID} rcon-cli save-all
 kubectl cp ${NAMESPACE}/${POD_ID}:/data .
-kubectl exec ${NAMESPACE}/${POD_ID} rcon-cli save-on
+kubectl exec --namespace ${NAMESPACE} ${POD_ID} rcon-cli save-on
 ```


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This adds backup instructions to the readme for minecraft-server.  This is needed because stateful services such as this one should not be deployed without some kind of backup strategy in mind up front.  

#### Which issue this PR fixes
The PR was automatically closed for this issue by the bot.  

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
