### PR TITLE
[stable/home-assistant] Allow user to specify command in git-sync container

### DIFF
--- a/stable/home-assistant/Chart.yaml
+++ b/stable/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.95.4
 description: Home Assistant
 name: home-assistant
-version: 0.9.4
+version: 0.9.5
 keywords:
 - home-assistant
 - hass

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -42,7 +42,14 @@ spec:
       - name: git-sync
         image: "{{ .Values.git.image.repository }}:{{ .Values.git.image.tag }}"
         imagePullPolicy: {{ .Values.git.image.pullPolicy }}
+        {{- if .Values.git.command }}
+        command:
+          {{- range .Values.git.command }}
+          - {{ . | quote }}
+          {{- end }}
+        {{- else }}
         command: ['sh', '-c', '[ "$(ls {{ .Values.git.syncPath }})" ] || git clone {{ .Values.git.repo }} {{ .Values.git.syncPath }}']
+        {{- end }}
         volumeMounts:
         - mountPath: /config
           name: config

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -90,6 +90,9 @@ git:
     tag: x86_64-0.3.1
     pullPolicy: IfNotPresent
 
+  ## Specify the command that runs in the git-sync container to pull in configuration.
+  # command: []
+
   # repo:
   secret: git-creds
   syncPath: /config


### PR DESCRIPTION
#### What this PR does / why we need it:

This allows a user to specify the command that runs in the git-sync container. There are a few scenarios where the user may want to add additional git params, or also extend functionality of the git-sync feature

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
