### PR TITLE
[stable/prometheus] Added /nodes/metrics permission to prometheus server

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 9.1.0
+version: 9.1.1
 appVersion: 2.11.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/server-clusterrole.yaml
+++ b/stable/prometheus/templates/server-clusterrole.yaml
@@ -22,6 +22,7 @@ rules:
     resources:
       - nodes
       - nodes/proxy
+      - nodes/metrics
       - services
       - endpoints
       - pods


### PR DESCRIPTION
Signed-off-by: Micah Hausler <hausler.m@gmail.com>

#### What this PR does / why we need it:

This change allows prometheus to scrape nodes directly, instead of
proxying all requests through the API server. Technically, this is not granting any additional access, as Prometheus can already access `/metrics` and `/metrics/cadvisor` over the APIserver's proxy.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
