### PR TITLE
[stable/datadog] adds podAnnotations to DataDog deployments

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.33.0
+version: 1.33.1
 appVersion: 6.13.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -292,6 +292,7 @@ helm install --name <RELEASE_NAME> \
 | `deployment.affinity`                    | Node / Pod affinities                                                                     | `{}`                                        |
 | `deployment.tolerations`                 | List of node taints to tolerate                                                           | `[]`                                        |
 | `deployment.priorityClassName`           | Which Priority Class to associate with the deployment                                     | `nil`                                       |
+| `deployment.podAnnotations`               | Annotations to add to the Deployment's Pods                                                | `nil`                                       |
 | `kubeStateMetrics.enabled`               | If true, create kube-state-metrics                                                        | `true`                                      |
 | `kube-state-metrics.rbac.create`         | If true, create & use RBAC resources for kube-state-metrics                               | `true`                                      |
 | `kube-state-metrics.serviceAccount.create`                 | If true, create & use serviceAccount                                    | `true`                                      |

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
         checksum/autoconf-config: {{ tpl (toYaml .Values.datadog.autoconf) . | sha256sum }}
         checksum/confd-config: {{ tpl (toYaml .Values.datadog.confd) . | sha256sum }}
         checksum/checksd-config: {{ tpl (toYaml .Values.datadog.checksd) . | sha256sum }}
+      {{- if .Values.daemonset.podAnnotations }}
+{{ toYaml .Values.daemonset.podAnnotations | indent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.datadog.securityContext }}
       securityContext:

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -630,6 +630,12 @@ deployment:
   #
   # priorityClassName:
 
+  ## @param podAnnotations - list of key:value strings - optional
+  ## Annotations to add to the Deployment's Pods
+  #
+  # podAnnotations:
+  #   <POD_ANNOTATION>: '[{"key": "<KEY>", "value": "<VALUE>"}]'
+
 clusterchecksDeployment:
 
   ## @param enabled - boolean - required


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds support for podAnnotations on deployment pods. Daemonsets already support this. Current use-case is for Istio annotations on our dogstatsd deployment.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
