### PR TITLE
[stable/kube-state-metrics] Add honorlabel parameter

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - monitoring
 - prometheus
 - kubernetes
-version: 2.3.0
+version: 2.3.1
 appVersion: 1.7.2
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -65,3 +65,4 @@ $ helm install stable/kube-state-metrics
 | `prometheus.monitor.enabled`            | Set this to `true` to create ServiceMonitor for Prometheus operator                   | `false`                                    |
 | `prometheus.monitor.additionalLabels`   | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`                                       |
 | `prometheus.monitor.namespace`          | Namespace where servicemonitor resource should be created                             | `the same namespace as kube-state-metrics` |
+| `prometheus.monitor.honorLabels`        | Honor metric labels                                                                   | `false`                                    |

--- a/stable/kube-state-metrics/templates/servicemonitor.yaml
+++ b/stable/kube-state-metrics/templates/servicemonitor.yaml
@@ -18,4 +18,7 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   endpoints:
     - port: http
+      {{- if .Values.prometheus.monitor.honorLabels }}
+      honorLabels: true
+      {{- end }}
 {{- end }}

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -38,6 +38,7 @@ prometheus:
     enabled: false
     additionalLabels: {}
     namespace: ""
+    honorLabels: false
 
 ## Specify if a Pod Security Policy for kube-state-metrics must be created
 ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Adds parameter to enable honorLabel field on the servicemonitor.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
