### PR TITLE
[stable/kong] wrapped KONG_ADMIN_GUI_AUTH_CONF with quotes and default its according value to empty object 

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.15.1
+version: 0.15.2
 appVersion: 1.2

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -103,7 +103,7 @@ spec:
         - name: KONG_ADMIN_GUI_AUTH
           value: {{ .Values.enterprise.rbac.admin_gui_auth | default "basic-auth" }}
         - name: KONG_ADMIN_GUI_AUTH_CONF
-          value: {{ toJson .Values.enterprise.rbac.admin_gui_auth_conf | default "" }}
+          value: {{ toJson .Values.enterprise.rbac.admin_gui_auth_conf }}
         - name: KONG_ADMIN_GUI_SESSION_CONF
           valueFrom:
             secretKeyRef:

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -103,7 +103,7 @@ spec:
         - name: KONG_ADMIN_GUI_AUTH
           value: {{ .Values.enterprise.rbac.admin_gui_auth | default "basic-auth" }}
         - name: KONG_ADMIN_GUI_AUTH_CONF
-          value: {{ toJson .Values.enterprise.rbac.admin_gui_auth_conf }}
+          value: '{{ toJson .Values.enterprise.rbac.admin_gui_auth_conf }}'
         - name: KONG_ADMIN_GUI_SESSION_CONF
           valueFrom:
             secretKeyRef:

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -229,7 +229,7 @@ enterprise:
     # The key value must be a secret configuration, following the example at https://docs.konghq.com/enterprise/0.35-x/kong-manager/authentication/sessions/
     session_conf_secret: you-must-create-an-rbac-session-conf-secret
     # Set to the appropriate plugin config JSON if not using basic-auth
-     admin_gui_auth_conf: {}
+    admin_gui_auth_conf: {}
   smtp:
     enabled: false
     portal_emails_from: none@example.com

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -229,7 +229,7 @@ enterprise:
     # The key value must be a secret configuration, following the example at https://docs.konghq.com/enterprise/0.35-x/kong-manager/authentication/sessions/
     session_conf_secret: you-must-create-an-rbac-session-conf-secret
     # Set to the appropriate plugin config JSON if not using basic-auth
-    # admin_gui_auth_conf: ''
+     admin_gui_auth_conf: ''
   smtp:
     enabled: false
     portal_emails_from: none@example.com

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -229,7 +229,7 @@ enterprise:
     # The key value must be a secret configuration, following the example at https://docs.konghq.com/enterprise/0.35-x/kong-manager/authentication/sessions/
     session_conf_secret: you-must-create-an-rbac-session-conf-secret
     # Set to the appropriate plugin config JSON if not using basic-auth
-     admin_gui_auth_conf: ''
+     admin_gui_auth_conf: {}
   smtp:
     enabled: false
     portal_emails_from: none@example.com


### PR DESCRIPTION
#16087 ## What this PR does / why we need it:

Fix the admin_gui_auth_conf failing to be parsed because of missing quotes in deployment manifest

#### Which issue this PR fixes
No issues raised


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
