### PR TITLE
[stable/distributed-tensorflow] Add custom variable to set number of training steps.

### DIFF
--- a/stable/distributed-tensorflow/Chart.yaml
+++ b/stable/distributed-tensorflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for running distributed TensorFlow on Kubernetes
 name: distributed-tensorflow
-version: 0.1.1
+version: 0.1.2
 appVersion: 1.6.0
 sources:
 - https://github.com/tensorflow/tensorflow

--- a/stable/distributed-tensorflow/README.md
+++ b/stable/distributed-tensorflow/README.md
@@ -24,13 +24,13 @@ This chart will create a TensorFlow cluster, and distribute a computation graph 
   ```
 
 * To install with custom values via file:
-  
+
   ```
   $ helm install  --values values.yaml  --name mnist  incubator/distributed-tensorflow
   ```
-  
+
   Below is an example of the custom value file values.yaml with GPU support.
-  
+
   ```
   worker:
     number: 2
@@ -40,7 +40,7 @@ This chart will create a TensorFlow cluster, and distribute a computation graph 
       tag: 1.6.0-gpu
     port: 9090
     gpuCount: 1
-  
+
   ps:
     number: 2
     podManagementPolicy: Parallel
@@ -49,11 +49,12 @@ This chart will create a TensorFlow cluster, and distribute a computation graph 
       tag: 1.6.0
       pullPolicy: IfNotPresent
     port: 8080
-  
+
   # optimize for training
   hyperparams:
     batchsize: 20
     learningrate: 0.001
+    trainsteps: 10000
   ```
 
 > Notice: you can check the details of docker image from [Docker hub](https://hub.docker.com/r/cheyang/distributed-tf/)

--- a/stable/distributed-tensorflow/templates/statefulset-ps.yaml
+++ b/stable/distributed-tensorflow/templates/statefulset-ps.yaml
@@ -1,5 +1,6 @@
 {{- $lr := .Values.hyperparams.learningrate -}}
 {{- $batchsize := .Values.hyperparams.batchsize -}}
+{{- $trainsteps := .Values.hyperparams.trainsteps -}}
 
 apiVersion: apps/v1beta2
 kind: StatefulSet
@@ -44,6 +45,8 @@ spec:
         - {{ $lr | quote }}
         - --batch_size
         - {{ $batchsize | quote }}
+        - --train_steps
+        - {{ $trainsteps | quote }}
         env:
         - name: WORKER_HOSTS
           valueFrom:
@@ -61,7 +64,7 @@ spec:
               fieldPath: metadata.name
         - name: JOB_NAME
           value: ps
-       {{- if .Values.ps.env }}            
+       {{- if .Values.ps.env }}
        {{- range $key, $value := .Values.ps.env }}
         - name: "{{ $key }}"
           value: "{{ $value }}"

--- a/stable/distributed-tensorflow/templates/statefulset-worker.yaml
+++ b/stable/distributed-tensorflow/templates/statefulset-worker.yaml
@@ -1,5 +1,6 @@
 {{- $lr := .Values.hyperparams.learningrate -}}
 {{- $batchsize := .Values.hyperparams.batchsize -}}
+{{- $trainsteps := .Values.hyperparams.trainsteps -}}
 
 apiVersion: apps/v1beta2
 kind: StatefulSet
@@ -48,6 +49,8 @@ spec:
         - {{ $lr | quote }}
         - --batch_size
         - {{ $batchsize | quote }}
+        - --train_steps
+        - {{ $trainsteps | quote }}
         env:
         - name: WORKER_HOSTS
           valueFrom:
@@ -65,7 +68,7 @@ spec:
               fieldPath: metadata.name
         - name: JOB_NAME
           value: worker
-       {{- if .Values.worker.env }}            
+       {{- if .Values.worker.env }}
        {{- range $key, $value := .Values.worker.env }}
         - name: "{{ $key }}"
           value: "{{ $value }}"

--- a/stable/distributed-tensorflow/values.yaml
+++ b/stable/distributed-tensorflow/values.yaml
@@ -22,3 +22,4 @@ ps:
 hyperparams:
   batchsize: 20
   learningrate: 0.001
+  trainsteps: 0


### PR DESCRIPTION
By default script run in cheyang/distributed-tensorflow container
runs with flag train_steps set to 0 which means that
script will be running inifitely,

However, it's to possible to set this flag to fixed number
which will make script to run only passed number of training
steps and stop.

This change adds custom variable in hyperparams that lets user set
custom value for training steps.

Although, I deleted some trailing whitespaces from files that I've changed.

Signed-off-by: Szymon Krasuski <krasuski.szymon.piotr@gmail.com>
-->

#### What this PR does / why we need it:
Adds custom variable in hyperparams to let user have more control on script running in container.

#### Which issue this PR fixes
-

#### Special notes for your reviewer:
-

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
