### PR TITLE
[stable/sealed-secrets] Create service.name value

### DIFF
--- a/stable/sealed-secrets/Chart.yaml
+++ b/stable/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.3.3
+version: 1.3.4
 appVersion: 0.8.1
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/stable/sealed-secrets/README.md
+++ b/stable/sealed-secrets/README.md
@@ -42,7 +42,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | **resources** | CPU/Memory resource requests/limits | `{}` |
 | **crd.create** | `true` if crd resources should be created | `true` |
 | **crd.keep** | `true` if the sealed secret CRD should be kept when the chart is deleted | `true` |
-|**networkPolicy** | Whether to create a network policy that allows access to the service | `false`|
+| **networkPolicy** | Whether to create a network policy that allows access to the service | `false` |
+| **service.name** | The name of the service to create for the controller. If this is changed `kubeseal` commands will need to be passed this name | `"sealed-secrets-controller"` |
 
 - In the case that **serviceAccount.create** is `false` and **rbac.create** is `true` it is expected for a service account with the name **serviceAccount.name** to exist _in the same namespace as this chart_ before installation.
 - If **serviceAccount.create** is `true` there cannot be an existing service account with the name **serviceAccount.name**.

--- a/stable/sealed-secrets/templates/NOTES.txt
+++ b/stable/sealed-secrets/templates/NOTES.txt
@@ -29,10 +29,15 @@ kubectl create -f mysealedsecret.[json|yaml]
 Running 'kubectl get secret secret-name -o [json|yaml]' will show the decrypted secret that was generated from the sealed secret.
 
 Both the SealedSecret and generated Secret must have the same name and namespace.
-
 {{ if not (eq .Release.Namespace "kube-system") }}
 --------------------------------------------------------------------------------------------------
 
 Please Note: Since this chart was not installed in the kube-system namespace all kubeseal commands must pass the option `--controller-namespace {{ .Release.Namespace }}`
+
+{{ end }}
+{{ if not (eq .Values.service.name "sealed-secrets-controller") }}
+--------------------------------------------------------------------------------------------------
+
+Please Note: Since this chart was installed with a custom service name all kubeseal commands must pass the option `--controller-name {{ .Values.service.name }}`
 
 {{ end }}

--- a/stable/sealed-secrets/templates/NOTES.txt
+++ b/stable/sealed-secrets/templates/NOTES.txt
@@ -4,7 +4,7 @@ You should now be able to create sealed secrets.
 
 GOOS=$(go env GOOS)
 GOARCH=$(go env GOARCH)
-wget https://github.com/bitnami-labs/sealed-secrets/releases/download/$release/kubeseal-$GOOS-$GOARCH
+wget https://github.com/bitnami-labs/sealed-secrets/releases/download/{{ .Values.image.tag }}/kubeseal-$GOOS-$GOARCH
 sudo install -m 755 kubeseal-$GOOS-$GOARCH /usr/local/bin/kubeseal
 
 2. Create a sealed secret file

--- a/stable/sealed-secrets/templates/service.yaml
+++ b/stable/sealed-secrets/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "sealed-secrets.fullname" . }}
+  name: {{ .Values.service.name }}
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
     helm.sh/chart: {{ template "sealed-secrets.chart" . }}

--- a/stable/sealed-secrets/values.yaml
+++ b/stable/sealed-secrets/values.yaml
@@ -29,3 +29,6 @@ crd:
   keep: true
 
 networkPolicy: false
+
+service:
+  name: sealed-secrets-controller


### PR DESCRIPTION
#### What this PR does / why we need it:

Addresses https://github.com/helm/charts/issues/15161. This makes the default service name the one that is expected by `kubeseal` and adds to the `NOTES.txt` the required CLI option to be passed in the case you decide to change this name.

Tested locally with `kubeseal` in both the default and custom name cases. Also reinstalled `kubeseal` using the updated instructions in `NOTES.txt` to make sure that is copy-pastable.

#### Which issue this PR fixes
  - fixes #15161, fixes #11258

#### Special notes for your reviewer:

Super minor point, should this be a minor version bump rather than a patch version bump? It will change the way people interact with the chart using `kubeseal` (IMO for the better)

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
