### PR TITLE
[stable/prometheus-pushgateway] make port name configurable

### DIFF
--- a/stable/prometheus-pushgateway/Chart.yaml
+++ b/stable/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.9.1"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.0.1
+version: 1.0.2
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/stable/prometheus-pushgateway/README.md
+++ b/stable/prometheus-pushgateway/README.md
@@ -55,6 +55,7 @@ The following table lists the configurable parameters of the pushgateway chart a
 | `service.type`              | Service type                                                                                                                  | `ClusterIP`                       |
 | `service.port`              | The service port                                                                                                              | `9091`                            |
 | `service.targetPort`        | The target port of the container                                                                                              | `9091`                            |
+| `service.name`              | The service port name                                                                                                         | `http`                            |
 | `serviceLabels`             | Labels for service                                                                                                            | `{}`                              |
 | `serviceAccount.create`     | Specifies whether a service account should be created.                                                                        | `true`                            |
 | `serviceAccount.name`       | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |                                   |

--- a/stable/prometheus-pushgateway/templates/deployment.yaml
+++ b/stable/prometheus-pushgateway/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
 {{ toYaml .Values.extraArgs | indent 12 }}
         {{- end }}
           ports:
-            - name: metrics
+            - name: {{ .Values.service.name }}
               containerPort: 9091
               protocol: TCP
           livenessProbe:

--- a/stable/prometheus-pushgateway/templates/service.yaml
+++ b/stable/prometheus-pushgateway/templates/service.yaml
@@ -10,7 +10,7 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
-      name: http
+      name: {{ .Values.service.name }}
   selector:
     app: {{ template "prometheus-pushgateway.name" . }}
     release: {{ .Release.Name }}

--- a/stable/prometheus-pushgateway/values.yaml
+++ b/stable/prometheus-pushgateway/values.yaml
@@ -10,6 +10,7 @@ service:
   type: ClusterIP
   port: 9091
   targetPort: 9091
+  name: http
 
 # Optional pod annotations
 podAnnotations: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows configuring the port name of the pushgateway

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
