### PR TITLE
[stable/prometheus-operator] Ignore coredns version

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -11,7 +11,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 6.7.2
+version: 6.7.3
 appVersion: 0.31.1
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/hack/sync_prometheus_rules.py
+++ b/stable/prometheus-operator/hack/sync_prometheus_rules.py
@@ -37,7 +37,7 @@ charts = [
         'max_kubernetes': '1.16.0-0'
     },
     {
-        'source': 'https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml',
+        'source': 'https://raw.githubusercontent.com/coreos/kube-prometheus/da959c643657c7d2aac6f5ddd68582a949283c49/manifests/prometheus-rules.yaml',
         'destination': '../templates/prometheus/rules',
         'min_kubernetes': '1.11.0-0',
         'max_kubernetes': '1.14.0-0'

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/alertmanager.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/alertmanager.rules.yaml
@@ -26,7 +26,7 @@ spec:
     - alert: AlertmanagerConfigInconsistent
       annotations:
         message: The configuration of the instances of the Alertmanager cluster `{{`{{$labels.service}}`}}` are out of sync.
-      expr: count_values("config_hash", alertmanager_config_hash{job="{{ $alertmanagerJob }}",namespace="{{ $namespace }}"}) BY (service) / ON(service) GROUP_LEFT() label_replace(prometheus_operator_spec_replicas{job="{{ $operatorJob }}",namespace="{{ $namespace }}",controller="alertmanager"}, "service", "$1", "name", "(.*)") != 1
+      expr: count_values("config_hash", alertmanager_config_hash{job="{{ $alertmanagerJob }}",namespace="{{ $namespace }}"}) BY (service) / ON(service) GROUP_LEFT() label_replace(max(prometheus_operator_spec_replicas{job="{{ $operatorJob }}",namespace="{{ $namespace }}",controller="alertmanager"}) by (name, job, namespace, controller), "service", "$1", "name", "(.*)") != 1
       for: 5m
       labels:
         severity: critical

--- a/stable/prometheus-operator/templates/prometheus/rules/alertmanager.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/alertmanager.rules.yaml
@@ -1,4 +1,4 @@
-# Generated from 'alertmanager.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
+# Generated from 'alertmanager.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/da959c643657c7d2aac6f5ddd68582a949283c49/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
 {{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.alertmanager }}
@@ -26,7 +26,7 @@ spec:
     - alert: AlertmanagerConfigInconsistent
       annotations:
         message: The configuration of the instances of the Alertmanager cluster `{{`{{$labels.service}}`}}` are out of sync.
-      expr: count_values("config_hash", alertmanager_config_hash{job="{{ $alertmanagerJob }}",namespace="{{ $namespace }}"}) BY (service) / ON(service) GROUP_LEFT() label_replace(prometheus_operator_spec_replicas{job="{{ $operatorJob }}",namespace="{{ $namespace }}",controller="alertmanager"}, "service", "$1", "name", "(.*)") != 1
+      expr: count_values("config_hash", alertmanager_config_hash{job="{{ $alertmanagerJob }}",namespace="{{ $namespace }}"}) BY (service) / ON(service) GROUP_LEFT() label_replace(max(prometheus_operator_spec_replicas{job="{{ $operatorJob }}",namespace="{{ $namespace }}",controller="alertmanager"}) by (name, job, namespace, controller), "service", "$1", "name", "(.*)") != 1
       for: 5m
       labels:
         severity: critical

--- a/stable/prometheus-operator/templates/prometheus/rules/general.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/general.rules.yaml
@@ -1,4 +1,4 @@
-# Generated from 'general.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
+# Generated from 'general.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/da959c643657c7d2aac6f5ddd68582a949283c49/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
 {{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.general }}

--- a/stable/prometheus-operator/templates/prometheus/rules/k8s.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/k8s.rules.yaml
@@ -1,4 +1,4 @@
-# Generated from 'k8s.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
+# Generated from 'k8s.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/da959c643657c7d2aac6f5ddd68582a949283c49/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
 {{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.k8s }}
@@ -20,29 +20,36 @@ spec:
   groups:
   - name: k8s.rules
     rules:
-    - expr: sum(rate(container_cpu_usage_seconds_total{job="kubelet", image!="", container_name!=""}[5m])) by (namespace)
+    - expr: sum(rate(container_cpu_usage_seconds_total{job="kubelet", image!="", container!="POD"}[5m])) by (namespace)
       record: namespace:container_cpu_usage_seconds_total:sum_rate
-    - expr: sum(container_memory_usage_bytes{job="kubelet", image!="", container_name!=""}) by (namespace)
+    - expr: |-
+        sum by (namespace, pod, container) (
+          rate(container_cpu_usage_seconds_total{job="kubelet", image!="", container!="POD"}[5m])
+        )
+      record: namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
+    - expr: sum(container_memory_usage_bytes{job="kubelet", image!="", container!="POD"}) by (namespace)
       record: namespace:container_memory_usage_bytes:sum
     - expr: |-
-        sum by (namespace, pod_name, container_name) (
-          rate(container_cpu_usage_seconds_total{job="kubelet", image!="", container_name!=""}[5m])
+        sum by (namespace, label_name) (
+            sum(container_memory_usage_bytes{job="kubelet",image!="", container!="POD"}) by (pod, namespace)
+          * on (namespace, pod)
+            group_left(label_name) kube_pod_labels{job="kube-state-metrics"}
         )
-      record: namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate
+      record: namespace:container_memory_usage_bytes:sum
     - expr: |-
-        sum by(namespace) (
-            kube_pod_container_resource_requests_memory_bytes{job="kube-state-metrics"}
-          * on (endpoint, instance, job, namespace, pod, service)
-            group_left(phase) (kube_pod_status_phase{phase=~"^(Pending|Running)$"} == 1)
+        sum by (namespace, label_name) (
+            sum(kube_pod_container_resource_requests_memory_bytes{job="kube-state-metrics"} * on (endpoint, instance, job, namespace, pod, service) group_left(phase) (kube_pod_status_phase{phase=~"^(Pending|Running)$"} == 1)) by (namespace, pod)
+          * on (namespace, pod)
+            group_left(label_name) kube_pod_labels{job="kube-state-metrics"}
         )
-      record: namespace_name:kube_pod_container_resource_requests_memory_bytes:sum
+      record: namespace:kube_pod_container_resource_requests_memory_bytes:sum
     - expr: |-
-        sum by (namespace) (
-            kube_pod_container_resource_requests_cpu_cores{job="kube-state-metrics"}
-          * on (endpoint, instance, job, namespace, pod, service)
-            group_left(phase) (kube_pod_status_phase{phase=~"^(Pending|Running)$"} == 1)
+        sum by (namespace, label_name) (
+            sum(kube_pod_container_resource_requests_cpu_cores{job="kube-state-metrics"} * on (endpoint, instance, job, namespace, pod, service) group_left(phase) (kube_pod_status_phase{phase=~"^(Pending|Running)$"} == 1)) by (namespace, pod)
+          * on (namespace, pod)
+            group_left(label_name) kube_pod_labels{job="kube-state-metrics"}
         )
-      record: namespace_name:kube_pod_container_resource_requests_cpu_cores:sum
+      record: namespace:kube_pod_container_resource_requests_cpu_cores:sum
     - expr: |-
         sum(
           label_replace(

--- a/stable/prometheus-operator/templates/prometheus/rules/kube-apiserver.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/kube-apiserver.rules.yaml
@@ -1,4 +1,4 @@
-# Generated from 'kube-apiserver.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
+# Generated from 'kube-apiserver.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/da959c643657c7d2aac6f5ddd68582a949283c49/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
 {{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.kubeApiServer.enabled .Values.defaultRules.rules.kubeApiserver }}
@@ -20,16 +20,16 @@ spec:
   groups:
   - name: kube-apiserver.rules
     rules:
-    - expr: histogram_quantile(0.99, sum(rate(apiserver_request_latencies_bucket{job="apiserver"}[5m])) without(instance, pod)) / 1e+06
+    - expr: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver"}[5m])) without(instance, pod))
       labels:
         quantile: '0.99'
-      record: cluster_quantile:apiserver_request_latencies:histogram_quantile
-    - expr: histogram_quantile(0.9, sum(rate(apiserver_request_latencies_bucket{job="apiserver"}[5m])) without(instance, pod)) / 1e+06
+      record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+    - expr: histogram_quantile(0.9, sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver"}[5m])) without(instance, pod))
       labels:
         quantile: '0.9'
-      record: cluster_quantile:apiserver_request_latencies:histogram_quantile
-    - expr: histogram_quantile(0.5, sum(rate(apiserver_request_latencies_bucket{job="apiserver"}[5m])) without(instance, pod)) / 1e+06
+      record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+    - expr: histogram_quantile(0.5, sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver"}[5m])) without(instance, pod))
       labels:
         quantile: '0.5'
-      record: cluster_quantile:apiserver_request_latencies:histogram_quantile
+      record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
 {{- end }}

--- a/stable/prometheus-operator/templates/prometheus/rules/kube-prometheus-node-alerting.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/kube-prometheus-node-alerting.rules.yaml
@@ -1,4 +1,4 @@
-# Generated from 'kube-prometheus-node-alerting.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
+# Generated from 'kube-prometheus-node-alerting.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/da959c643657c7d2aac6f5ddd68582a949283c49/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
 {{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubePrometheusNodeAlerting }}
@@ -22,14 +22,14 @@ spec:
     rules:
     - alert: NodeDiskRunningFull
       annotations:
-        message: Device {{`{{ $labels.device }}`}} of node-exporter {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} will be full within the next 24 hours.
+        message: Device {{`{{ $labels.device }}`}} on node {{`{{ $labels.instance }}`}} will be full within the next 24 hours.
       expr: '(node:node_filesystem_usage: > 0.85) and (predict_linear(node:node_filesystem_avail:[6h], 3600 * 24) < 0)'
       for: 30m
       labels:
         severity: warning
     - alert: NodeDiskRunningFull
       annotations:
-        message: Device {{`{{ $labels.device }}`}} of node-exporter {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} will be full within the next 2 hours.
+        message: Device {{`{{ $labels.device }}`}} on node {{`{{ $labels.instance }}`}} will be full within the next 2 hours.
       expr: '(node:node_filesystem_usage: > 0.85) and (predict_linear(node:node_filesystem_avail:[30m], 3600 * 2) < 0)'
       for: 10m
       labels:

--- a/stable/prometheus-operator/templates/prometheus/rules/kube-prometheus-node-recording.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/kube-prometheus-node-recording.rules.yaml
@@ -1,4 +1,4 @@
-# Generated from 'kube-prometheus-node-recording.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
+# Generated from 'kube-prometheus-node-recording.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/da959c643657c7d2aac6f5ddd68582a949283c49/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
 {{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubePrometheusNodeRecording }}

--- a/stable/prometheus-operator/templates/prometheus/rules/kube-scheduler.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/kube-scheduler.rules.yaml
@@ -1,4 +1,4 @@
-# Generated from 'kube-scheduler.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
+# Generated from 'kube-scheduler.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/da959c643657c7d2aac6f5ddd68582a949283c49/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
 {{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.kubeScheduler.enabled .Values.defaultRules.rules.kubeScheduler }}
@@ -20,40 +20,40 @@ spec:
   groups:
   - name: kube-scheduler.rules
     rules:
-    - expr: histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+    - expr: histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: '0.99'
-      record: cluster_quantile:scheduler_e2e_scheduling_latency:histogram_quantile
-    - expr: histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+      record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+    - expr: histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: '0.99'
-      record: cluster_quantile:scheduler_scheduling_algorithm_latency:histogram_quantile
-    - expr: histogram_quantile(0.99, sum(rate(scheduler_binding_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+      record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
+    - expr: histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: '0.99'
-      record: cluster_quantile:scheduler_binding_latency:histogram_quantile
-    - expr: histogram_quantile(0.9, sum(rate(scheduler_e2e_scheduling_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+      record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
+    - expr: histogram_quantile(0.9, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: '0.9'
-      record: cluster_quantile:scheduler_e2e_scheduling_latency:histogram_quantile
-    - expr: histogram_quantile(0.9, sum(rate(scheduler_scheduling_algorithm_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+      record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+    - expr: histogram_quantile(0.9, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: '0.9'
-      record: cluster_quantile:scheduler_scheduling_algorithm_latency:histogram_quantile
-    - expr: histogram_quantile(0.9, sum(rate(scheduler_binding_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+      record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
+    - expr: histogram_quantile(0.9, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: '0.9'
-      record: cluster_quantile:scheduler_binding_latency:histogram_quantile
-    - expr: histogram_quantile(0.5, sum(rate(scheduler_e2e_scheduling_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+      record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
+    - expr: histogram_quantile(0.5, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: '0.5'
-      record: cluster_quantile:scheduler_e2e_scheduling_latency:histogram_quantile
-    - expr: histogram_quantile(0.5, sum(rate(scheduler_scheduling_algorithm_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+      record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+    - expr: histogram_quantile(0.5, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: '0.5'
-      record: cluster_quantile:scheduler_scheduling_algorithm_latency:histogram_quantile
-    - expr: histogram_quantile(0.5, sum(rate(scheduler_binding_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+      record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
+    - expr: histogram_quantile(0.5, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: '0.5'
-      record: cluster_quantile:scheduler_binding_latency:histogram_quantile
+      record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
 {{- end }}

--- a/stable/prometheus-operator/templates/prometheus/rules/kubernetes-absent.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/kubernetes-absent.yaml
@@ -1,4 +1,4 @@
-# Generated from 'kubernetes-absent' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
+# Generated from 'kubernetes-absent' group from https://raw.githubusercontent.com/coreos/kube-prometheus/da959c643657c7d2aac6f5ddd68582a949283c49/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
 {{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesAbsent }}

--- a/stable/prometheus-operator/templates/prometheus/rules/kubernetes-apps.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/kubernetes-apps.yaml
@@ -1,4 +1,4 @@
-# Generated from 'kubernetes-apps' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
+# Generated from 'kubernetes-apps' group from https://raw.githubusercontent.com/coreos/kube-prometheus/da959c643657c7d2aac6f5ddd68582a949283c49/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
 {{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.kubeStateMetrics.enabled .Values.defaultRules.rules.kubernetesApps }}
@@ -32,7 +32,7 @@ spec:
       annotations:
         message: Pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} has been in a non-ready state for longer than an hour.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
-      expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"}) > 0
+      expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Failed|Pending|Unknown"}) > 0
       for: 1h
       labels:
         severity: critical

--- a/stable/prometheus-operator/templates/prometheus/rules/kubernetes-resources.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/kubernetes-resources.yaml
@@ -1,4 +1,4 @@
-# Generated from 'kubernetes-resources' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
+# Generated from 'kubernetes-resources' group from https://raw.githubusercontent.com/coreos/kube-prometheus/da959c643657c7d2aac6f5ddd68582a949283c49/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
 {{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesResources }}
@@ -25,11 +25,11 @@ spec:
         message: Cluster has overcommitted CPU resource requests for Pods and cannot tolerate node failure.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuovercommit
       expr: |-
-        sum(namespace_name:kube_pod_container_resource_requests_cpu_cores:sum)
+        sum(namespace:kube_pod_container_resource_requests_cpu_cores:sum)
           /
-        sum(node:node_num_cpu:sum)
+        sum(kube_node_status_allocatable_cpu_cores)
           >
-        (count(node:node_num_cpu:sum)-1) / count(node:node_num_cpu:sum)
+        (count(kube_node_status_allocatable_cpu_cores)-1) / count(kube_node_status_allocatable_cpu_cores)
       for: 5m
       labels:
         severity: warning
@@ -38,13 +38,13 @@ spec:
         message: Cluster has overcommitted memory resource requests for Pods and cannot tolerate node failure.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememovercommit
       expr: |-
-        sum(namespace_name:kube_pod_container_resource_requests_memory_bytes:sum)
+        sum(namespace:kube_pod_container_resource_requests_memory_bytes:sum)
           /
-        sum(node_memory_MemTotal_bytes)
+        sum(kube_node_status_allocatable_memory_bytes)
           >
-        (count(node:node_num_cpu:sum)-1)
+        (count(kube_node_status_allocatable_memory_bytes)-1)
           /
-        count(node:node_num_cpu:sum)
+        count(kube_node_status_allocatable_memory_bytes)
       for: 5m
       labels:
         severity: warning
@@ -55,7 +55,7 @@ spec:
       expr: |-
         sum(kube_resourcequota{job="kube-state-metrics", type="hard", resource="cpu"})
           /
-        sum(node:node_num_cpu:sum)
+        sum(kube_node_status_allocatable_cpu_cores)
           > 1.5
       for: 5m
       labels:
@@ -67,7 +67,7 @@ spec:
       expr: |-
         sum(kube_resourcequota{job="kube-state-metrics", type="hard", resource="memory"})
           /
-        sum(node_memory_MemTotal_bytes{job="node-exporter"})
+        sum(kube_node_status_allocatable_memory_bytes{job="node-exporter"})
           > 1.5
       for: 5m
       labels:
@@ -86,12 +86,12 @@ spec:
         severity: warning
     - alert: CPUThrottlingHigh
       annotations:
-        message: '{{`{{ printf "%0.0f" $value }}`}}% throttling of CPU in namespace {{`{{ $labels.namespace }}`}} for container {{`{{ $labels.container_name }}`}} in pod {{`{{ $labels.pod_name }}`}}.'
+        message: '{{`{{ printf "%0.0f" $value }}`}}% throttling of CPU in namespace {{`{{ $labels.namespace }}`}} for container {{`{{ $labels.container }}`}} in pod {{`{{ $labels.pod }}`}}.'
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-cputhrottlinghigh
       expr: |-
-        100 * sum(increase(container_cpu_cfs_throttled_periods_total{container_name!="", }[5m])) by (container_name, pod_name, namespace)
+        100 * sum(increase(container_cpu_cfs_throttled_periods_total{container!="", }[5m])) by (container, pod, namespace)
           /
-        sum(increase(container_cpu_cfs_periods_total{}[5m])) by (container_name, pod_name, namespace)
+        sum(increase(container_cpu_cfs_periods_total{}[5m])) by (container, pod, namespace)
           > 25
       for: 15m
       labels:

--- a/stable/prometheus-operator/templates/prometheus/rules/kubernetes-storage.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/kubernetes-storage.yaml
@@ -1,4 +1,4 @@
-# Generated from 'kubernetes-storage' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
+# Generated from 'kubernetes-storage' group from https://raw.githubusercontent.com/coreos/kube-prometheus/da959c643657c7d2aac6f5ddd68582a949283c49/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
 {{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesStorage }}

--- a/stable/prometheus-operator/templates/prometheus/rules/kubernetes-system.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/kubernetes-system.yaml
@@ -1,4 +1,4 @@
-# Generated from 'kubernetes-system' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
+# Generated from 'kubernetes-system' group from https://raw.githubusercontent.com/coreos/kube-prometheus/da959c643657c7d2aac6f5ddd68582a949283c49/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
 {{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.kubernetesSystem }}
@@ -32,7 +32,7 @@ spec:
       annotations:
         message: There are {{`{{ $value }}`}} different semantic versions of Kubernetes components running.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeversionmismatch
-      expr: count(count by (gitVersion) (label_replace(kubernetes_build_info{job!="kube-dns"},"gitVersion","$1","gitVersion","(v[0-9]*.[0-9]*.[0-9]*).*"))) > 1
+      expr: count(count by (gitVersion) (label_replace(kubernetes_build_info{job!~"kube-dns|coredns"},"gitVersion","$1","gitVersion","(v[0-9]*.[0-9]*.[0-9]*).*"))) > 1
       for: 1h
       labels:
         severity: warning
@@ -68,7 +68,7 @@ spec:
       annotations:
         message: The API server has a 99th percentile latency of {{`{{ $value }}`}} seconds for {{`{{ $labels.verb }}`}} {{`{{ $labels.resource }}`}}.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapilatencyhigh
-      expr: cluster_quantile:apiserver_request_latencies:histogram_quantile{job="apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > 1
+      expr: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{job="apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > 1
       for: 10m
       labels:
         severity: warning
@@ -76,7 +76,7 @@ spec:
       annotations:
         message: The API server has a 99th percentile latency of {{`{{ $value }}`}} seconds for {{`{{ $labels.verb }}`}} {{`{{ $labels.resource }}`}}.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapilatencyhigh
-      expr: cluster_quantile:apiserver_request_latencies:histogram_quantile{job="apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > 4
+      expr: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{job="apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > 4
       for: 10m
       labels:
         severity: critical
@@ -85,9 +85,9 @@ spec:
         message: API server is returning errors for {{`{{ $value }}`}}% of requests.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorshigh
       expr: |-
-        sum(rate(apiserver_request_count{job="apiserver",code=~"^(?:5..)$"}[5m]))
+        sum(rate(apiserver_request_total{job="apiserver",code=~"^(?:5..)$"}[5m]))
           /
-        sum(rate(apiserver_request_count{job="apiserver"}[5m])) * 100 > 3
+        sum(rate(apiserver_request_total{job="apiserver"}[5m])) * 100 > 3
       for: 10m
       labels:
         severity: critical
@@ -96,9 +96,9 @@ spec:
         message: API server is returning errors for {{`{{ $value }}`}}% of requests.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorshigh
       expr: |-
-        sum(rate(apiserver_request_count{job="apiserver",code=~"^(?:5..)$"}[5m]))
+        sum(rate(apiserver_request_total{job="apiserver",code=~"^(?:5..)$"}[5m]))
           /
-        sum(rate(apiserver_request_count{job="apiserver"}[5m])) * 100 > 1
+        sum(rate(apiserver_request_total{job="apiserver"}[5m])) * 100 > 1
       for: 10m
       labels:
         severity: warning
@@ -107,9 +107,9 @@ spec:
         message: API server is returning errors for {{`{{ $value }}`}}% of requests for {{`{{ $labels.verb }}`}} {{`{{ $labels.resource }}`}} {{`{{ $labels.subresource }}`}}.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorshigh
       expr: |-
-        sum(rate(apiserver_request_count{job="apiserver",code=~"^(?:5..)$"}[5m])) by (resource,subresource,verb)
+        sum(rate(apiserver_request_total{job="apiserver",code=~"^(?:5..)$"}[5m])) by (resource,subresource,verb)
           /
-        sum(rate(apiserver_request_count{job="apiserver"}[5m])) by (resource,subresource,verb) * 100 > 10
+        sum(rate(apiserver_request_total{job="apiserver"}[5m])) by (resource,subresource,verb) * 100 > 10
       for: 10m
       labels:
         severity: critical
@@ -118,9 +118,9 @@ spec:
         message: API server is returning errors for {{`{{ $value }}`}}% of requests for {{`{{ $labels.verb }}`}} {{`{{ $labels.resource }}`}} {{`{{ $labels.subresource }}`}}.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorshigh
       expr: |-
-        sum(rate(apiserver_request_count{job="apiserver",code=~"^(?:5..)$"}[5m])) by (resource,subresource,verb)
+        sum(rate(apiserver_request_total{job="apiserver",code=~"^(?:5..)$"}[5m])) by (resource,subresource,verb)
           /
-        sum(rate(apiserver_request_count{job="apiserver"}[5m])) by (resource,subresource,verb) * 100 > 5
+        sum(rate(apiserver_request_total{job="apiserver"}[5m])) by (resource,subresource,verb) * 100 > 5
       for: 10m
       labels:
         severity: warning

--- a/stable/prometheus-operator/templates/prometheus/rules/node-network.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/node-network.yaml
@@ -1,4 +1,4 @@
-# Generated from 'node-network' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
+# Generated from 'node-network' group from https://raw.githubusercontent.com/coreos/kube-prometheus/da959c643657c7d2aac6f5ddd68582a949283c49/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
 {{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.network }}

--- a/stable/prometheus-operator/templates/prometheus/rules/node-time.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/node-time.yaml
@@ -1,4 +1,4 @@
-# Generated from 'node-time' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
+# Generated from 'node-time' group from https://raw.githubusercontent.com/coreos/kube-prometheus/da959c643657c7d2aac6f5ddd68582a949283c49/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
 {{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.time }}
@@ -23,7 +23,7 @@ spec:
     - alert: ClockSkewDetected
       annotations:
         message: Clock skew detected on node-exporter {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}}. Ensure NTP is configured correctly on this host.
-      expr: abs(node_timex_offset_seconds{job="node-exporter"}) > 0.03
+      expr: abs(node_timex_offset_seconds{job="node-exporter"}) > 0.05
       for: 2m
       labels:
         severity: warning

--- a/stable/prometheus-operator/templates/prometheus/rules/node.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/node.rules.yaml
@@ -1,4 +1,4 @@
-# Generated from 'node.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
+# Generated from 'node.rules' group from https://raw.githubusercontent.com/coreos/kube-prometheus/da959c643657c7d2aac6f5ddd68582a949283c49/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
 {{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.nodeExporter.enabled .Values.defaultRules.rules.node }}

--- a/stable/prometheus-operator/templates/prometheus/rules/prometheus-operator.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/prometheus-operator.yaml
@@ -1,4 +1,4 @@
-# Generated from 'prometheus-operator' group from https://raw.githubusercontent.com/coreos/kube-prometheus/release-0.1/manifests/prometheus-rules.yaml
+# Generated from 'prometheus-operator' group from https://raw.githubusercontent.com/coreos/kube-prometheus/da959c643657c7d2aac6f5ddd68582a949283c49/manifests/prometheus-rules.yaml
 # Do not change in-place! In order to change this file first read following link:
 # https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
 {{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create .Values.defaultRules.rules.prometheusOperator }}

--- a/stable/prometheus-operator/templates/prometheus/rules/prometheus.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/prometheus.yaml
@@ -1,0 +1,191 @@
+# Generated from 'prometheus' group from https://raw.githubusercontent.com/coreos/kube-prometheus/da959c643657c7d2aac6f5ddd68582a949283c49/manifests/prometheus-rules.yaml
+# Do not change in-place! In order to change this file first read following link:
+# https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack
+{{- if and (semverCompare ">=1.11.0-0" .Capabilities.KubeVersion.GitVersion) (semverCompare "<1.14.0-0" .Capabilities.KubeVersion.GitVersion) .Values.defaultRules.create }}
+{{- $prometheusJob := printf "%s-%s" (include "prometheus-operator.fullname" .) "prometheus" }}
+{{- $namespace := .Release.Namespace }}
+apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
+kind: PrometheusRule
+metadata:
+  name: {{ printf "%s-%s" (include "prometheus-operator.fullname" .) "prometheus" | trunc 63 | trimSuffix "-" }}
+  labels:
+    app: {{ template "prometheus-operator.name" . }}
+{{ include "prometheus-operator.labels" . | indent 4 }}
+{{- if .Values.defaultRules.labels }}
+{{ toYaml .Values.defaultRules.labels | indent 4 }}
+{{- end }}
+{{- if .Values.defaultRules.annotations }}
+  annotations:
+{{ toYaml .Values.defaultRules.annotations | indent 4 }}
+{{- end }}
+spec:
+  groups:
+  - name: prometheus
+    rules:
+    - alert: PrometheusBadConfig
+      annotations:
+        description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} has failed to reload its configuration.
+        summary: Failed Prometheus configuration reload.
+      expr: |-
+        # Without max_over_time, failed scrapes could create false negatives, see
+        # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+        max_over_time(prometheus_config_last_reload_successful{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m]) == 0
+      for: 10m
+      labels:
+        severity: critical
+    - alert: PrometheusNotificationQueueRunningFull
+      annotations:
+        description: Alert notification queue of Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} is running full.
+        summary: Prometheus alert notification queue predicted to run full in less than 30m.
+      expr: |-
+        # Without min_over_time, failed scrapes could create false negatives, see
+        # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+        (
+          predict_linear(prometheus_notifications_queue_length{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m], 60 * 30)
+        >
+          min_over_time(prometheus_notifications_queue_capacity{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m])
+        )
+      for: 15m
+      labels:
+        severity: warning
+    - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
+      annotations:
+        description: '{{`{{ printf "%.1f" $value }}`}}% errors while sending alerts from Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} to Alertmanager {{`{{$labels.alertmanager}}`}}.'
+        summary: Prometheus has encountered more than 1% errors sending alerts to a specific Alertmanager.
+      expr: |-
+        (
+          rate(prometheus_notifications_errors_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m])
+        /
+          rate(prometheus_notifications_sent_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m])
+        )
+        * 100
+        > 1
+      for: 15m
+      labels:
+        severity: warning
+    - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
+      annotations:
+        description: '{{`{{ printf "%.1f" $value }}`}}% minimum errors while sending alerts from Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} to any Alertmanager.'
+        summary: Prometheus encounters more than 3% errors sending alerts to any Alertmanager.
+      expr: |-
+        min without(alertmanager) (
+          rate(prometheus_notifications_errors_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m])
+        /
+          rate(prometheus_notifications_sent_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m])
+        )
+        * 100
+        > 3
+      for: 15m
+      labels:
+        severity: critical
+    - alert: PrometheusNotConnectedToAlertmanagers
+      annotations:
+        description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} is not connected to any Alertmanagers.
+        summary: Prometheus is not connected to any Alertmanagers.
+      expr: |-
+        # Without max_over_time, failed scrapes could create false negatives, see
+        # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+        max_over_time(prometheus_notifications_alertmanagers_discovered{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m]) < 1
+      for: 10m
+      labels:
+        severity: warning
+    - alert: PrometheusTSDBReloadsFailing
+      annotations:
+        description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} has detected {{`{{$value | humanize}}`}} reload failures over the last 3h.
+        summary: Prometheus has issues reloading blocks from disk.
+      expr: increase(prometheus_tsdb_reloads_failures_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[3h]) > 0
+      for: 4h
+      labels:
+        severity: warning
+    - alert: PrometheusTSDBCompactionsFailing
+      annotations:
+        description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} has detected {{`{{$value | humanize}}`}} compaction failures over the last 3h.
+        summary: Prometheus has issues compacting blocks.
+      expr: increase(prometheus_tsdb_compactions_failed_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[3h]) > 0
+      for: 4h
+      labels:
+        severity: warning
+    - alert: PrometheusTSDBWALCorruptions
+      annotations:
+        description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} has detected {{`{{$value | humanize}}`}} corruptions of the write-ahead log (WAL) over the last 3h.
+        summary: Prometheus is detecting WAL corruptions.
+      expr: increase(tsdb_wal_corruptions_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[3h]) > 0
+      for: 4h
+      labels:
+        severity: warning
+    - alert: PrometheusNotIngestingSamples
+      annotations:
+        description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} is not ingesting samples.
+        summary: Prometheus is not ingesting samples.
+      expr: rate(prometheus_tsdb_head_samples_appended_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m]) <= 0
+      for: 10m
+      labels:
+        severity: warning
+    - alert: PrometheusDuplicateTimestamps
+      annotations:
+        description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} is dropping {{`{{$value | humanize}}`}} samples/s with different values but duplicated timestamp.
+        summary: Prometheus is dropping samples with duplicate timestamps.
+      expr: rate(prometheus_target_scrapes_sample_duplicate_timestamp_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m]) > 0
+      for: 10m
+      labels:
+        severity: warning
+    - alert: PrometheusOutOfOrderTimestamps
+      annotations:
+        description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} is dropping {{`{{$value | humanize}}`}} samples/s with timestamps arriving out of order.
+        summary: Prometheus drops samples with out-of-order timestamps.
+      expr: rate(prometheus_target_scrapes_sample_out_of_order_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m]) > 0
+      for: 10m
+      labels:
+        severity: warning
+    - alert: PrometheusRemoteStorageFailures
+      annotations:
+        description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} failed to send {{`{{ printf "%.1f" $value }}`}}% of the samples to queue {{`{{$labels.queue}}`}}.
+        summary: Prometheus fails to send samples to remote storage.
+      expr: |-
+        (
+          rate(prometheus_remote_storage_failed_samples_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m])
+        /
+          (
+            rate(prometheus_remote_storage_failed_samples_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m])
+          +
+            rate(prometheus_remote_storage_succeeded_samples_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m])
+          )
+        )
+        * 100
+        > 1
+      for: 15m
+      labels:
+        severity: critical
+    - alert: PrometheusRemoteWriteBehind
+      annotations:
+        description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} remote write is {{`{{ printf "%.1f" $value }}`}}s behind for queue {{`{{$labels.queue}}`}}.
+        summary: Prometheus remote write is behind.
+      expr: |-
+        # Without max_over_time, failed scrapes could create false negatives, see
+        # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+        (
+          max_over_time(prometheus_remote_storage_highest_timestamp_in_seconds{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m])
+        - on(job, instance) group_right
+          max_over_time(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m])
+        )
+        > 120
+      for: 15m
+      labels:
+        severity: critical
+    - alert: PrometheusRuleFailures
+      annotations:
+        description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} has failed to evaluate {{`{{ printf "%.0f" $value }}`}} rules in the last 5m.
+        summary: Prometheus is failing rule evaluations.
+      expr: increase(prometheus_rule_evaluation_failures_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m]) > 0
+      for: 15m
+      labels:
+        severity: critical
+    - alert: PrometheusMissingRuleEvaluations
+      annotations:
+        description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} has missed {{`{{ printf "%.0f" $value }}`}} rule group evaluations in the last 5m.
+        summary: Prometheus is missing rule evaluations due to slow rule group evaluation.
+      expr: increase(prometheus_rule_group_iterations_missed_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m]) > 0
+      for: 15m
+      labels:
+        severity: warning
+{{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it

When [prometheus-operator](https://github.com/helm/charts/blob/f63198f2142c0bb4be83e85bedc806e0601d3202/stable/prometheus-operator/templates/alertmanager/rules/kubernetes-system.yaml#L33) was copied from coreos the was a rule that didn't applied to Google Cloud managed kubernetes cluster.

It seem that the job `kube-dns` is called `coredns` in Google Cloud, here are my metrics in prometheus:

```
kubernetes_build_info{buildDate="1970-01-01T00:00:00Z",compiler="gc",endpoint="http-metrics",gitCommit="$Format:%H$",gitTreeState="not a git tree",gitVersion="v1.5.2-beta.0+$Format:%h$",goVersion="go1.10.3",instance="10.0.0.7:10055",job="coredns",major="1",minor="5+",namespace="kube-system",platform="linux/amd64",pod="kube-dns-78d5dcc986-7b6cs",service="prometheus-coredns"} | 1
-- | --
kubernetes_build_info{buildDate="1970-01-01T00:00:00Z",compiler="gc",endpoint="http-metrics",gitCommit="$Format:%H$",gitTreeState="not a git tree",gitVersion="v1.5.2-beta.0+$Format:%h$",goVersion="go1.10.3",instance="10.0.2.130:10055",job="coredns",major="1",minor="5+",namespace="kube-system",platform="linux/amd64",pod="kube-dns-78d5dcc986-wwrpj",service="prometheus-coredns"} | 1
```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
