### PR TITLE
[stable/datadog] Istio injection should be disabled for the Datadog Agent pod

### DIFF
--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -22,6 +22,7 @@ spec:
         checksum/autoconf-config: {{ tpl (toYaml .Values.datadog.autoconf) . | sha256sum }}
         checksum/confd-config: {{ tpl (toYaml .Values.datadog.confd) . | sha256sum }}
         checksum/checksd-config: {{ tpl (toYaml .Values.datadog.checksd) . | sha256sum }}
+        sidecar.istio.io/inject: "false"
       {{- if .Values.daemonset.podAnnotations }}
 {{ toYaml .Values.daemonset.podAnnotations | indent 8 }}
       {{- end }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -18,7 +18,7 @@ image:
   ## Define the Agent version to use.
   ## Use 6.13.0-jmx to enable jmx fetch collection
   #
-  tag: 6.13.0
+  tag: 6.14.0
 
   ## @param pullPolicy - string - required
   ## The Kubernetes pull policy.


### PR DESCRIPTION
Signed-off-by: Saverio Proto <zioproto@gmail.com>

#### What this PR does / why we need it:

This PR adds a metadata annotation to the datadog-agent daemonset, in order to disable istio injection for the pods in this daemon set.
This is recommended by the datadog documentation, when installing the Istio integration.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
