### PR TITLE
[stable/concourse] baggageclaim warning only on worker deployments

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 8.2.2
+version: 8.2.3
 appVersion: 5.4.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/NOTES.txt
+++ b/stable/concourse/templates/NOTES.txt
@@ -35,6 +35,7 @@
   {{- end }}
 * If this is your first time using Concourse, follow the tutorials at https://concourse-ci.org/tutorials.html
 
+{{- if .Values.worker.enabled }}
 {{- if .Values.concourse.worker.baggageclaim.driver }}
 {{- if contains "naive" .Values.concourse.worker.baggageclaim.driver }}
 
@@ -48,6 +49,7 @@ This is the default for compatibility reasons, but is very space inefficient, an
 
 Please see https://github.com/concourse/concourse/issues/1230 and https://github.com/concourse/concourse/issues/1966 for background.
 
+{{- end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Only alert about the worker baggageclaim driver default if workers are enabled; e.g., don't warn me if it's a web-only deployment

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #16341

#### Special notes for your reviewer:

This seriously isn't a big deal and if you don't want to merge it, we can just reject this PR outright and leave it as-is.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
