### PR TITLE
[stable/concourse] [wip] web hardAntiAffinity

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 8.2.3
+version: 8.3.0
 appVersion: 5.4.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 8.2.2
+version: 8.2.3
 appVersion: 5.4.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -167,6 +167,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.datadog.prefix` | Prefix for emitted metrics | `"concourse.ci"` |
 | `web.enabled` | Enable or disable the web component | `true` |
 | `web.env` | Configure additional environment variables for the web containers | `[]` |
+| `web.hardAntiAffinity` | Should the web pods be forced (as opposed to preferred) to be on different nodes? | `false` |
 | `web.ingress.annotations` | Concourse Web Ingress annotations | `{}` |
 | `web.ingress.enabled` | Enable Concourse Web Ingress | `false` |
 | `web.ingress.hosts` | Concourse Web Ingress Hostnames | `[]` |

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -1089,10 +1089,29 @@ spec:
             - name: auth-keys
               mountPath: {{ .Values.web.authSecretsPath | quote }}
               readOnly: true
-{{- if .Values.web.additionalAffinities }}
+
       affinity:
+{{- if .Values.web.additionalAffinities }}
 {{ toYaml .Values.web.additionalAffinities | indent 8 }}
 {{- end }}
+        podAntiAffinity:
+          {{- if .Values.web.hardAntiAffinity }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: {{ template "concourse.web.fullname" . }}
+                release: {{ .Release.Name | quote }}
+            topologyKey: kubernetes.io/hostname
+          {{- else }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: {{ template "concourse.web.fullname" . }}
+                  release: {{ .Release.Name | quote }}
+          {{- end }}
       volumes:
 {{- if .Values.web.additionalVolumes }}
 {{ toYaml .Values.web.additionalVolumes | indent 8 }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1313,6 +1313,13 @@ web:
   ##
   additionalVolumeMounts:
 
+  ## Whether the web pods should be forced to run on separate nodes.
+  ## This is accomplished by setting their AntiAffinity with requiredDuringSchedulingIgnoredDuringExecution as opposed to preferred
+  ## If false, it's *preferred* they be on separate nodes as opposed to forced
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature
+  ##
+  hardAntiAffinity: false
+
   ## Additional affinities to add to the web pods.
   ##
   ## Example:


### PR DESCRIPTION
#### What this PR does / why we need it:

Ability to configure whether the web pods should be forced (or preferred) to be on different nodes

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #15681

#### Special notes for your reviewer:

Open question: if `web.hardAntiAffinity: false`, this still _prefers_ to schedule the web pods on separate nodes, and there's no way to turn that off (this is also how `workers.hardAntiAffinity` works, too). Are we okay with that...? E.g., is there a reason someone wouldn't want to have the web nodes try to be on different hosts? 

And if someone specifies `podAntiAffinity` under `additionalAffinities`, it'll blow up due to a duplicate key. I believe this is already the case with `worker.hardAntiAffinity`, but nonetheless it's worth pointing out:

```yml
web:
  hardAntiAffinity: false
  additionalAffinities:
    podAntiAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector:
          matchLabels:
            app: concourse-web-web
            release: "concourse-web"
        topologyKey: kubernetes.io/hostname
```

would result in...

```yml
      affinity:
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchLabels:
                app: concourse-web-web
                release: concourse-web
            topologyKey: kubernetes.io/hostname
        
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - weight: 100
            podAffinityTerm:
              topologyKey: kubernetes.io/hostname
              labelSelector:
                matchLabels:
                  app: concourse-web-web
                  release: "concourse-web"
```

... which is maybe okay?

I'm not sure what the best course of action is, because it's hard for me to imagine needing an affinity other than "try not to clump up onto a single host"? This same logic applies to the concourse workers. But I'll leave this decision up to someone else.

This might also be slightly problematic since the `web` pods use a `deployment`, which won't take too kindly to having `hardAntiAffinity` on while trying to do a rolling upgrade? Haven't thought about this too much though, it might be fine.

Also please let me know if you'd like any doc changed, formatting, etc.

And finally, please keep in mind I haven't tested this in a real production environment yet, just on a local machine, so I need to get around to doing that at some point.

TL;DR, don't merge this yet, haven't tested this in prod or deeply thought through implications

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
