### PR TITLE
[stable/nginx-ingress] Fix incompatible types comparison

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.17.0
+version: 1.17.1
 appVersion: 0.25.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/controller-poddisruptionbudget.yaml
+++ b/stable/nginx-ingress/templates/controller-poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if gt .Values.controller.replicaCount 1.0 }}
+{{- if gt (.Values.controller.replicaCount | int) 1 }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/stable/nginx-ingress/templates/default-backend-poddisruptionbudget.yaml
+++ b/stable/nginx-ingress/templates/default-backend-poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if gt .Values.defaultBackend.replicaCount 1.0 }}
+{{- if gt (.Values.defaultBackend.replicaCount | int) 1 }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
Signed-off-by: Trevor Wood <Trevor.G.Wood@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Resolves an incomatible types error when using the default values of chart with the latest version of Helm.

#### Which issue this PR fixes
  - Fixes #15691

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
