### PR TITLE
[stable/jenkins] enable xml config misspelling

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.5.5
+version: 1.5.6
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -126,7 +126,7 @@ spec:
               {{- end }}
             - mountPath: /var/jenkins_config
               name: jenkins-config
-            {{- if .Values.master.enabledXmlConfig }}
+            {{- if .Values.master.enableXmlConfig }}
             {{- if .Values.master.credentialsXmlSecret }}
             - mountPath: /var/jenkins_credentials
               name: jenkins-credentials


### PR DESCRIPTION
Signed-off-by: Daniel Fenert <daniel.fenert@g2a.com>

#### What this PR does / why we need it:
Misspelling in template (enabledXmlConfig -> enableXmlConfig)

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
