### PR TITLE
[stable/elasticsearch-curator] Remove duplicated labels key

### DIFF
--- a/stable/elasticsearch-curator/Chart.yaml
+++ b/stable/elasticsearch-curator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "5.5.4"
 description: A Helm chart for Elasticsearch Curator
 name: elasticsearch-curator
-version: 2.0.0
+version: 2.0.1
 home: https://github.com/elastic/curator
 keywords:
 - curator

--- a/stable/elasticsearch-curator/templates/psp.yml
+++ b/stable/elasticsearch-curator/templates/psp.yml
@@ -3,7 +3,6 @@ apiVersion: extensions/v1beta1
 kind: PodSecurityPolicy
 metadata:
   labels:
-  labels:
     app: {{ template "elasticsearch-curator.name" . }}
     chart: {{ template "elasticsearch-curator.chart" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Remove unnecessary duplicated labels key on the pod security policy template for the elasticsearch-curator chart.

#### Which issue this PR fixes
  - fixes #16481 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
