### PR TITLE
[stable/fluentd] Support higher termination grace period

### DIFF
--- a/stable/fluentd/Chart.yaml
+++ b/stable/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Fluentd Elasticsearch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd
-version: 2.0.1
+version: 2.0.2
 appVersion: v2.4.0
 home: https://www.fluentd.org/
 sources:

--- a/stable/fluentd/README.md
+++ b/stable/fluentd/README.md
@@ -77,6 +77,7 @@ Parameter | Description | Default
 `autoscaling.minReplicas` | Set minimum number of replicas | `2`
 `autoscaling.maxReplicas` | Set maximum number of replicas | `5`
 `autoscaling.metrics` | metrics used for autoscaling | See [values.yaml](values.yaml)
+`terminationGracePeriodSeconds` | Optional duration in seconds the pod needs to terminate gracefully | `30`
 `metrics.enabled`                         | Set this to `true` to enable Prometheus metrics HTTP endpoint                         | `false`
 `metrics.service.port`                    | Prometheus metrics HTTP endpoint port                                                 | `24231`
 `metrics.serviceMonitor.enabled`          | Set this to `true` to create ServiceMonitor for Prometheus operator                   | `false`

--- a/stable/fluentd/templates/deployment.yaml
+++ b/stable/fluentd/templates/deployment.yaml
@@ -38,6 +38,7 @@ spec:
         - name: {{ $pullSecret }}
       {{- end }}
 {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/fluentd/values.yaml
+++ b/stable/fluentd/values.yaml
@@ -186,3 +186,7 @@ autoscaling:
         target:
           type: Utilization
           averageUtilization: 60
+
+# Consider to set higher value when using in conjuction with autoscaling
+# Full description about this field: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#pod-v1-core
+terminationGracePeriodSeconds: 30


### PR DESCRIPTION
#### What this PR does / why we need it:
During fluentd scale in, we might need additional time to flush the buffer

#### Which issue this PR fixes
  - fixes #16509

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
