### PR TITLE
[stable/jenkins] Fix: Always mount jenkins-secrets volume if secretsFilesSecret is set

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -6,6 +6,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.5.8
+
+Fixed an issue when master.enableXmlConfig is set to false: Always mount jenkins-secrets volume if secretsFilesSecret is set (#16512)
+
 ## 1.5.7
 
 added initial changelog (#16324)

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.5.7
+version: 1.5.8
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -214,9 +214,9 @@ data:
     </jenkins.CLI>
 {{- end }}
   apply_config.sh: |-
-{{- if .Values.master.enableXmlConfig }}
     mkdir -p /usr/share/jenkins/ref/secrets/;
     echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch;
+{{- if .Values.master.enableXmlConfig }}
 {{- if .Values.master.overwriteConfig }}
     cp /var/jenkins_config/config.xml /var/jenkins_home;
     cp /var/jenkins_config/jenkins.CLI.xml /var/jenkins_home;
@@ -278,15 +278,15 @@ data:
 {{- if .Values.master.credentialsXmlSecret }}
     yes n | cp -i /var/jenkins_credentials/credentials.xml /var/jenkins_home;
 {{- end }}
-{{- if .Values.master.secretsFilesSecret }}
-    yes n | cp -i /var/jenkins_secrets/* /usr/share/jenkins/ref/secrets/;
-{{- end }}
 {{- if .Values.master.jobs }}
     for job in $(ls /var/jenkins_jobs); do
       mkdir -p /var/jenkins_home/jobs/$job
       yes {{ if not .Values.master.overwriteJobs }}n{{ end }} | cp -i /var/jenkins_jobs/$job /var/jenkins_home/jobs/$job/config.xml
     done
 {{- end }}
+{{- end }}
+{{- if .Values.master.secretsFilesSecret }}
+    yes n | cp -i /var/jenkins_secrets/* /usr/share/jenkins/ref/secrets/;
 {{- end }}
 {{- range $key, $val := .Values.master.initScripts }}
   init{{ $key }}.groovy: |-

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -215,8 +215,8 @@ data:
 {{- end }}
   apply_config.sh: |-
     mkdir -p /usr/share/jenkins/ref/secrets/;
-    echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch;
 {{- if .Values.master.enableXmlConfig }}
+    echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch;
 {{- if .Values.master.overwriteConfig }}
     cp /var/jenkins_config/config.xml /var/jenkins_home;
     cp /var/jenkins_config/jenkins.CLI.xml /var/jenkins_home;

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -132,26 +132,24 @@ spec:
               name: jenkins-credentials
               readOnly: true
             {{- end }}
-            {{- if .Values.master.secretsFilesSecret }}
-            - mountPath: /var/jenkins_secrets
-              name: jenkins-secrets
-              readOnly: true
-            {{- end }}
             {{- if .Values.master.jobs }}
             - mountPath: /var/jenkins_jobs
               name: jenkins-jobs
               readOnly: true
             {{- end }}
+            - mountPath: /usr/share/jenkins/ref/secrets/
+              name: secrets-dir
+            {{- end }}
+            {{- if .Values.master.secretsFilesSecret }}
+            - mountPath: /var/jenkins_secrets
+              name: jenkins-secrets
+              readOnly: true
             {{- end }}
             {{- if .Values.master.installPlugins }}
             - mountPath: /usr/share/jenkins/ref/plugins
               name: plugins
             - mountPath: /var/jenkins_plugins
               name: plugin-dir
-            {{- end }}
-            {{- if .Values.master.enableXmlConfig }}
-            - mountPath: /usr/share/jenkins/ref/secrets/
-              name: secrets-dir
             {{- end }}
       containers:
         - name: jenkins
@@ -261,25 +259,23 @@ spec:
               name: jenkins-credentials
               readOnly: true
             {{- end }}
-            {{- if .Values.master.secretsFilesSecret }}
-            - mountPath: /var/jenkins_secrets
-              name: jenkins-secrets
-              readOnly: true
-            {{- end }}
             {{- if .Values.master.jobs }}
             - mountPath: /var/jenkins_jobs
               name: jenkins-jobs
               readOnly: true
             {{- end }}
+            - mountPath: /usr/share/jenkins/ref/secrets/
+              name: secrets-dir
+              readOnly: false
+            {{- end }}
+            {{- if or .Values.master.secretsFilesSecret }}
+            - mountPath: /var/jenkins_secrets
+              name: jenkins-secrets
+              readOnly: true
             {{- end }}
             {{- if .Values.master.installPlugins }}
             - mountPath: /usr/share/jenkins/ref/plugins/
               name: plugin-dir
-              readOnly: false
-            {{- end }}
-            {{- if .Values.master.enableXmlConfig }}
-            - mountPath: /usr/share/jenkins/ref/secrets/
-              name: secrets-dir
               readOnly: false
             {{- end }}
             {{- if and (.Values.master.JCasC.enabled) (.Values.master.sidecars.configAutoReload.enabled) }}
@@ -354,23 +350,21 @@ spec:
         secret:
           secretName: {{ .Values.master.credentialsXmlSecret }}
       {{- end }}
-      {{- if .Values.master.secretsFilesSecret }}
-      - name: jenkins-secrets
-        secret:
-          secretName: {{ .Values.master.secretsFilesSecret }}
-      {{- end }}
       {{- if .Values.master.jobs }}
       - name: jenkins-jobs
         configMap:
           name: {{ template "jenkins.fullname" . }}-jobs
       {{- end }}
+      - name: secrets-dir
+        emptyDir: {}
+      {{- end }}
+      {{- if .Values.master.secretsFilesSecret }}
+      - name: jenkins-secrets
+        secret:
+          secretName: {{ .Values.master.secretsFilesSecret }}
       {{- end }}
       {{- if .Values.master.installPlugins }}
       - name: plugin-dir
-        emptyDir: {}
-      {{- end }}
-      {{- if .Values.master.enableXmlConfig }}
-      - name: secrets-dir
         emptyDir: {}
       {{- end }}
       - name: jenkins-home


### PR DESCRIPTION
#### What this PR does / why we need it:
If secretsFilesSecret is set we should always mount `/var/jenkins_secrets` not depending on enableXmlConfig being set to true.

#### Which issue this PR fixes
  - Reference #16477 

#### Special notes for your reviewer:
Tuned config.yaml to match and also moved `secrets-dir` up to get rid of a conditional.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
