### PR TITLE
[stable/sealed-secrets] Add securityContext.runAsUser as value

### DIFF
--- a/stable/sealed-secrets/Chart.yaml
+++ b/stable/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.3.4
+version: 1.4.0
 appVersion: 0.8.1
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/stable/sealed-secrets/README.md
+++ b/stable/sealed-secrets/README.md
@@ -57,6 +57,7 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 | **crd.create** | `true` if crd resources should be created | `true` |
 | **crd.keep** | `true` if the sealed secret CRD should be kept when the chart is deleted | `true` |
 |**networkPolicy** | Whether to create a network policy that allows access to the service | `false`|
+|**securityContext.runAsUser** | Defines under which user the operator Pod and its containers/processes run | `1001`|
 
 - In the case that **serviceAccount.create** is `false` and **rbac.create** is `true` it is expected for a service account with the name **serviceAccount.name** to exist _in the same namespace as this chart_ before installation.
 - If **serviceAccount.create** is `true` there cannot be an existing service account with the name **serviceAccount.name**.

--- a/stable/sealed-secrets/templates/deployment.yaml
+++ b/stable/sealed-secrets/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
-            runAsUser: 1001
+            runAsUser: {{ .Values.securityContext.runAsUser }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:

--- a/stable/sealed-secrets/values.yaml
+++ b/stable/sealed-secrets/values.yaml
@@ -29,3 +29,7 @@ crd:
   keep: true
 
 networkPolicy: false
+
+securityContext:
+  # securityContext.runAsUser defines under which user the operator Pod and its containers/processes run.
+  runAsUser: 1001


### PR DESCRIPTION
Enables customization of the securityContext.runAsUser field of the operator Pod. This is required to run this Pod in OpenShift without adding PSPs/SCCs.

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)

@stefanprodan @olib963 
