### PR TITLE
[stable/chart] Add Chart to deploy Couchbase Cluster

### DIFF
--- a/stable/couchbase-cluster/Chart.yaml
+++ b/stable/couchbase-cluster/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+name: couchbase-cluster
+description: Couchbase Server is a NoSQL document database with a distributed architecture for performance, scalability, and availability. It enables developers to build applications easier and faster by leveraging the power of SQL with the flexibility of JSON.
+version: 1.0.0
+appVersion: 1.2.0
+keywords:
+- couchbase
+- database
+- nosql
+- cluster
+- replication
+home: https://www.couchbase.com
+icon: https://couchbase-partners.github.io/helm-charts/assets/img/CB_Logomark_220.png
+sources:
+- https://github.com/couchbase/docker/tree/master/enterprise/couchbase-server
+maintainers:
+- name: tahmmee
+  email: tahmmee@gmail.com

--- a/stable/couchbase-cluster/OWNERS
+++ b/stable/couchbase-cluster/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- tahmmee
+- spjmurray
+- danielma82
+reviewers:
+- tahmmee
+- spjmurray
+- danielma82

--- a/stable/couchbase-cluster/OWNERS
+++ b/stable/couchbase-cluster/OWNERS
@@ -1,8 +1,0 @@
-approvers:
-- tahmmee
-- spjmurray
-- danielma82
-reviewers:
-- tahmmee
-- spjmurray
-- danielma82

--- a/stable/couchbase-cluster/templates/NOTES.txt
+++ b/stable/couchbase-cluster/templates/NOTES.txt
@@ -1,0 +1,6 @@
+1. Get couchbase cluster status
+  kubectl describe --namespace {{ .Release.Namespace }} couchbasecluster {{ (include "couchbase-cluster.clustername" .) }}
+
+2. Connect to Admin console
+  kubectl port-forward --namespace {{ .Release.Namespace }} {{ printf "%s-0000" (include "couchbase-cluster.clustername" .) }} 8091:8091
+  # open http://localhost:8091

--- a/stable/couchbase-cluster/templates/_helpers.tpl
+++ b/stable/couchbase-cluster/templates/_helpers.tpl
@@ -1,0 +1,111 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "couchbase-cluster.name" -}}
+{{- default .Chart.Name .Values.couchbaseCluster.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "couchbase-cluster.fullname" -}}
+{{- printf "%s-%s" .Release.Name (include "couchbase-cluster.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "couchbase-cluster.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the username of the Admin user.
+*/}}
+{{- define "couchbase-cluster.username" -}}
+  {{ .Values.couchbaseCluster.username | b64enc | quote }}
+{{- end -}}
+
+{{/*
+Create the password of the Admin user.
+*/}}
+{{- define "couchbase-cluster.password" -}}
+  {{ .Values.couchbaseCluster.password | b64enc | quote }}
+{{- end -}}
+
+
+{{/*
+Create secret for couchbase cluster.
+*/}}
+{{- define "couchbase-cluster.secret.name" -}}
+{{- default (include "couchbase-cluster.fullname" .) .Values.couchbaseCluster.authSecretOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Generate cluster name from chart name or use user value
+*/}}
+{{- define "couchbase-cluster.clustername" -}}
+  {{ default (include "couchbase-cluster.fullname" .) .Values.couchbaseCluster.name }}
+{{- end -}}
+
+{{/*
+Name of tls operator secret
+*/}}
+{{- define  "couchbase-cluster.secret.tls-operator" -}}
+{{- $fullname := printf "%s-operator-tls" (include "couchbase-cluster.fullname" .) -}}
+{{- default $fullname .Values.couchbaseTLS.ServerSecret | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Name of tls server secret
+*/}}
+{{- define  "couchbase-cluster.secret.tls-server" -}}
+{{- $fullname := printf "%s-server-tls" (include "couchbase-cluster.fullname" .) -}}
+{{- default $fullname .Values.couchbaseTLS.ServerSecret | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Generate certificates for couchbase-cluster
+*/}}
+{{- define "couchbase-cluster.gen-certs" -}}
+{{- $expiration := (.Values.couchbaseTLS.expiration | int) -}}
+{{- if (or (empty .Values.couchbaseTLS.cert) (empty .Values.couchbaseTLS.key)) -}}
+{{- $ca :=  genCA "couchbase-cluster-ca" $expiration -}}
+{{- template "couchbase-cluster.gen-client-tls" (dict "RootScope" . "CA" $ca) -}}
+{{- else -}}
+{{- $ca :=  buildCustomCert (.Values.couchbaseTLS.cert | b64enc) (.Values.couchbaseTLS.key | b64enc) -}}
+{{- template "couchbase-cluster.gen-client-tls" (dict "RootScope" . "CA" $ca) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate client key and cert from CA
+*/}}
+{{- define "couchbase-cluster.gen-client-tls" -}}
+{{- $clustername := (include "couchbase-cluster.clustername" .RootScope) -}}
+{{- $altNames :=  list (printf "*.%s.%s.svc" $clustername .RootScope.Release.Namespace) -}}
+{{- if .RootScope.Values.couchbaseCluster.dns -}}
+{{- $extendedAltNames := append $altNames (printf "*.%s.%s" $clustername .RootScope.Values.couchbaseCluster.dns.domain) -}}
+{{- template "couchbase-cluster.internal.gen-client-tls" (dict "RootScope" .RootScope "CA" .CA "AltNames" $extendedAltNames) -}}
+{{- else -}}
+{{- template "couchbase-cluster.internal.gen-client-tls" (dict "RootScope" .RootScope "CA" .CA "AltNames" $altNames) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate client key and cert from CA and altNames
+*/}}
+{{- define "couchbase-cluster.internal.gen-client-tls" -}}
+{{- $expiration := (.RootScope.Values.couchbaseTLS.expiration | int) -}}
+{{- $cert := genSignedCert ( include "couchbase-cluster.fullname" .RootScope) nil .AltNames $expiration .CA -}}
+{{- $clientCert := default $cert.Cert .RootScope.Values.couchbaseTLS.operatorSecret.cert | b64enc -}}
+{{- $clientKey := default $cert.Key .RootScope.Values.couchbaseTLS.operatorSecret.key | b64enc -}}
+caCert: {{ .CA.Cert | b64enc }}
+clientCert: {{ $clientCert }}
+clientKey: {{ $clientKey }}
+{{- end -}}

--- a/stable/couchbase-cluster/templates/couchbase-admin-secret.yaml
+++ b/stable/couchbase-cluster/templates/couchbase-admin-secret.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "couchbase-cluster.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "couchbase-cluster.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "couchbase-cluster.chart" . }}
+
+type: Opaque
+data:
+  username: {{ template "couchbase-cluster.username" . }}
+  password: {{ template "couchbase-cluster.password" . }}

--- a/stable/couchbase-cluster/templates/couchbase-cluster-secret.yaml
+++ b/stable/couchbase-cluster/templates/couchbase-cluster-secret.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.couchbaseTLS.create }}
+{{ $tls := fromYaml ( include "couchbase-cluster.gen-certs" . ) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "couchbase-cluster.secret.tls-operator" . }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "couchbase-cluster.chart" . }}
+data:
+  ca.crt: {{ $tls.caCert }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "couchbase-cluster.secret.tls-server" . }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "couchbase-cluster.chart" . }}
+data:
+  chain.pem: {{ $tls.clientCert }}
+  pkey.key: {{ $tls.clientKey }}
+{{- end -}}

--- a/stable/couchbase-cluster/templates/couchbase-cluster.yaml
+++ b/stable/couchbase-cluster/templates/couchbase-cluster.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: "couchbase.com/v1"
+kind: "CouchbaseCluster"
+metadata:
+  name: {{ template "couchbase-cluster.clustername" . }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "couchbase-cluster.chart" . }}
+spec:
+  baseImage: {{ .Values.couchbaseCluster.baseImage }}
+  version: {{ .Values.couchbaseCluster.version }}
+  authSecret: {{ template "couchbase-cluster.secret.name" . }}
+  exposeAdminConsole: {{ .Values.couchbaseCluster.exposeAdminConsole }}
+  adminConsoleServices: {{ .Values.couchbaseCluster.adminConsoleServices }}
+  exposedFeatures: {{ .Values.couchbaseCluster.exposedFeatures }}
+  adminConsoleServiceType: {{ .Values.couchbaseCluster.adminConsoleServiceType }}
+  exposedFeatureServiceType: {{ .Values.couchbaseCluster.exposedFeatureServiceType }}
+  logRetentionTime: {{ .Values.couchbaseCluster.logRetentionTime }}
+  logRetentionCount: {{ .Values.couchbaseCluster.logRetentionCount }}
+{{- if .Values.couchbaseCluster.dns }}
+  dns:
+    domain: {{ .Values.couchbaseCluster.dns.domain }}
+{{- end }}
+{{- if .Values.couchbaseCluster.platform }}
+  platform: {{ .Values.couchbaseCluster.platform }}
+{{- end }}
+  cluster:
+{{ toYaml .Values.couchbaseCluster.cluster | indent 4 }}
+  buckets:
+  {{- range $bucket, $config := .Values.couchbaseCluster.buckets }}
+  -
+{{ toYaml $config | indent 4 }}
+  {{- end }}
+  servers:
+  {{- range $server, $config := .Values.couchbaseCluster.servers }}
+  - name: {{ $server }}
+{{ toYaml $config | indent 4 }}
+  {{- end }}
+{{- if .Values.couchbaseTLS.create }}
+  tls:
+    static:
+      member:
+        serverSecret: {{ template "couchbase-cluster.secret.tls-server" . }}
+      operatorSecret: {{ template "couchbase-cluster.secret.tls-operator" . }}
+{{- end }}
+  securityContext:
+{{ toYaml .Values.couchbaseCluster.securityContext | indent 4 }}
+  volumeClaimTemplates:
+{{ toYaml .Values.couchbaseCluster.volumeClaimTemplates | indent 4 }}

--- a/stable/couchbase-cluster/values.yaml
+++ b/stable/couchbase-cluster/values.yaml
@@ -40,11 +40,7 @@ couchbaseCluster:
   logRetentionTime: 604800s
   # The maximum number of log volumes that can be kept after their associated pods have been deleted.
   logRetentionCount: 20
-  # Uncomment these 2 lines for specifying the dynamic DNS configuration to use when exposing services
-  #dns:
-  # domain:  example.domain.com
-  # Indicates which underlying cloud platform the Kubernetes cluster is running.
-  # The Value must be one of aws, gce or azure
+  # The cloud platform
   platform:
   # Cluster wide settings for nodes and services
   cluster:

--- a/stable/couchbase-cluster/values.yaml
+++ b/stable/couchbase-cluster/values.yaml
@@ -1,0 +1,141 @@
+# Default values for couchbase-cluster.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# couchbaseCluster config
+couchbaseCluster:
+  # create flag to deploy couchbase cluster
+  create: true
+  # name of the cluster. defaults to name of chart release
+  name: ""
+  # username of the cluster admin.
+  username: "Administrator"
+  # password of the cluster admin.
+  password: "password"
+  # authSecretOverride is name of secret to use instead of using
+  # the default secret with username and password specified above
+  authSecretOverride: ""
+  # BaseImage is the base couchbase image name that will be used to launch
+  # couchbase clusters. This is useful for private registries, etc.
+  baseImage: "couchbase/server"
+  # Version is the expected version of the couchbase cluster
+  version: "enterprise-6.0.1"
+  # Option to expose admin console
+  exposeAdminConsole: true
+  # Option to expose admin console
+  adminConsoleServices:
+    - data
+  # Specific services to use when exposing ui
+  exposedFeatures:
+    - xdcr
+  # Defines how the admin console service is exposed.
+  # Allowed values are NodePort and LoadBalancer.
+  # If this field is LoadBalancer then you must also define a spec.dns.domain.
+  adminConsoleServiceType: NodePort
+  # Defines how the per Couchbase node ports are exposed.
+  # Allowed values are NodePort and LoadBalancer.
+  # If this field is LoadBalancer then you must also define a spec.dns.domain.
+  exposedFeatureServiceType: NodePort
+  # The retention period that log volumes are kept for after their associated pods have been deleted.
+  logRetentionTime: 604800s
+  # The maximum number of log volumes that can be kept after their associated pods have been deleted.
+  logRetentionCount: 20
+  # Uncomment these 2 lines for specifying the dynamic DNS configuration to use when exposing services
+  #dns:
+  # domain:  example.domain.com
+  # Indicates which underlying cloud platform the Kubernetes cluster is running.
+  # The Value must be one of aws, gce or azure
+  platform:
+  # Cluster wide settings for nodes and services
+  cluster:
+    # The amount of memory that should be allocated to the data service
+    dataServiceMemoryQuota: 256
+    # The amount of memory that should be allocated to the index service
+    indexServiceMemoryQuota: 256
+    # The amount of memory that should be allocated to the search service
+    searchServiceMemoryQuota: 256
+    # The amount of memory that should be allocated to the eventing service
+    eventingServiceMemoryQuota: 256
+    # The amount of memory that should be allocated to the analytics service
+    analyticsServiceMemoryQuota: 1024
+    # The index storage mode to use for secondary indexing
+    indexStorageSetting: memory_optimized
+    # Timeout that expires to trigger the auto failover.
+    autoFailoverTimeout: 120
+    # The number of failover events we can tolerate
+    autoFailoverMaxCount: 3
+    # Whether to auto failover if disk issues are detected
+    autoFailoverOnDataDiskIssues: true
+    # How long to wait for transient errors before failing over a faulty disk
+    autoFailoverOnDataDiskIssuesTimePeriod: 120
+    # Whether to enable failing over a server group
+    autoFailoverServerGroup: false
+
+  # cluster buckets
+  buckets:
+    # The default bucket
+    default:
+      # Name of the bucket
+      name: default
+      # The type of bucket to use
+      type: couchbase
+      # The amount of memory that should be allocated to the bucket
+      memoryQuota: 128
+      # The number of bucket replicates
+      replicas: 1
+      # The priority when compared to other buckets
+      ioPriority: high
+      # The bucket eviction policy which determines behavior during expire and high mem usage
+      evictionPolicy: fullEviction
+      # The bucket's conflict resolution mechanism; which is to be used if a conflict occurs during Cross Data-Center Replication (XDCR). Sequence-based and timestamp-based mechanisms are supported.
+      conflictResolution: seqno
+      # The enable flush option denotes wether the data in the bucket can be flushed
+      enableFlush: true
+      # Enable Index replica specifies whether or not to enable view index replicas for this bucket.
+      enableIndexReplica: false
+      # data compression mode for the bucket to run in [off, passive, active]
+      compressionMode: "passive"
+  servers:
+    # Name for the server configuration. It must be unique.
+    all_services:
+      # Size of the couchbase cluster.
+      size: 3
+      # The services to run on nodes
+      services:
+        - data
+        - index
+        - query
+        - search
+        - eventing
+        - analytics
+      # ServerGroups define the set of availability zones we want to distribute pods over.
+      serverGroups: []
+      # Pod defines the policy to create pod for the couchbase pod.
+      pod: {}
+  # Security Context for all pods
+  securityContext: {}
+  # VolumeClaimTemplates define the desired characteristics of a volume
+  # that can be requested and claimed by a pod.
+  volumeClaimTemplates: []
+
+# couchbaseTLS can be used to override the Certs that will be used
+# to sign the keys used by the nodes.
+couchbaseTLS:
+  # disable if manually creating certs
+  # provide cert and key via --set-file
+  create: false
+  # A base64 encoded PEM format certificate for the CA
+  cert:
+  # A base64 encoded PEM format private key for the CA
+  key:
+  # Expiry time of CA in days for generated certs
+  expiration: 365
+  # OperatorSecret is the secret containing TLS certs used by operator
+  operatorSecret:
+    name: ""
+    # PEM format certificate for operator (auto-generated)
+    # override via --set-file
+    cert:
+    # PEM format private key for operator (auto-generated)
+    # override via --set-file
+    key:


### PR DESCRIPTION
Signed-off-by: Tommie McAfee <tommie@couchbase.com>

#### What this PR does / why we need it:
The Chart helps Kubernetes administrators to deploy and manage a Couchbase Cluster.
Manual deployment of the cluster requires the creation of the following resources which are automatically (and optionally) installed by this chart:

==> v1/Secret                              
tailored-shark-couchbase-cluster 

==> v1/CouchbaseCluster
tailored-shark-couchbase-cluster  

The chart is also very helpful for auto-generating TLS to secure client communication with couchbase cluster  `--set couchbaseTLS.create=true`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
