### PR TITLE
[stable/fluentd] fix wrong indentation caused to emptyDir usage instead of pvc

### DIFF
--- a/stable/fluentd/Chart.yaml
+++ b/stable/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Fluentd Elasticsearch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd
-version: 2.0.0
+version: 2.0.1
 appVersion: v2.4.0
 home: https://www.fluentd.org/
 sources:

--- a/stable/fluentd/templates/deployment.yaml
+++ b/stable/fluentd/templates/deployment.yaml
@@ -97,23 +97,14 @@ spec:
         - name: config-volume-{{ template "fluentd.fullname" . }}
           configMap:
             name: {{ template "fluentd.fullname" . }}
-        - name: buffer
-          {{- if and .Values.persistence.enabled (not .Values.autoscaling.enabled) }}
+        {{- if and .Values.persistence.enabled (not .Values.autoscaling.enabled) }}
+        - name: buffer          
           persistentVolumeClaim:
-            claimName: {{ template "fluentd.fullname" . }}
-          {{- else if and .Values.persistence.enabled (.Values.autoscaling.enabled) }}
-          volumeClaimTemplates:
-          - metadata:
-              name: buffer
-            spec:
-              accessModes: [{{ .Values.persistence.accessMode | quote }}]
-              storageClassName: {{ .Values.persistence.storageClass }} 
-              resources:
-                requests:
-                  storage: {{ .Values.persistence.size }}        
-          {{- else }}
+            claimName: {{ template "fluentd.fullname" . }}       
+        {{- else if (not .Values.persistence.enabled) }}
+        - name: buffer  
           emptyDir: {}
-          {{- end }}
+        {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -126,3 +117,14 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+{{- if and .Values.persistence.enabled (.Values.autoscaling.enabled) }}
+  volumeClaimTemplates:
+  - metadata:
+      name: buffer
+    spec:
+      accessModes: [{{ .Values.persistence.accessMode }}]
+      storageClassName: {{ .Values.persistence.storageClass }} 
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size }}
+{{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Due to the wrong indentation, a pvc request has been ignored and emptyDir was used instead

#### Which issue this PR fixes
  - fixes #16528

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
