### PR TITLE
[stable/mongodb] Fix 'storageClass' macros

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 7.2.1
+version: 7.2.2
 appVersion: 4.0.12
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/templates/_helpers.tpl
+++ b/stable/mongodb/templates/_helpers.tpl
@@ -202,25 +202,25 @@ but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else 
 {{- if .Values.global -}}
     {{- if .Values.global.storageClass -}}
         {{- if (eq "-" .Values.global.storageClass) -}}
-            {{- printf "\"\"" -}}
+            {{- printf "storageClassName: \"\"" -}}
         {{- else }}
-            {{- printf "%s" .Values.global.storageClass -}}
+            {{- printf "storageClassName: %s" .Values.global.storageClass -}}
         {{- end -}}
     {{- else -}}
         {{- if .Values.persistence.storageClass -}}
               {{- if (eq "-" .Values.persistence.storageClass) -}}
-                  {{- printf "\"\"" -}}
+                  {{- printf "storageClassName: \"\"" -}}
               {{- else }}
-                  {{- printf "%s" .Values.persistence.storageClass -}}
+                  {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
               {{- end -}}
         {{- end -}}
     {{- end -}}
 {{- else -}}
     {{- if .Values.persistence.storageClass -}}
         {{- if (eq "-" .Values.persistence.storageClass) -}}
-            {{- printf "\"\"" -}}
+            {{- printf "storageClassName: \"\"" -}}
         {{- else }}
-            {{- printf "%s" .Values.persistence.storageClass -}}
+            {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/stable/mongodb/templates/pvc-standalone.yaml
+++ b/stable/mongodb/templates/pvc-standalone.yaml
@@ -16,5 +16,5 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
-  storageClassName: {{ include "mongodb.storageClass" . }}
+  {{ include "mongodb.storageClass" . }}
 {{- end }}

--- a/stable/mongodb/templates/statefulset-primary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-primary-rs.yaml
@@ -281,7 +281,7 @@ spec:
         resources:
           requests:
             storage: {{ .Values.persistence.size | quote }}
-        storageClassName: {{ include "mongodb.storageClass" . }}
+        {{ include "mongodb.storageClass" . }}
 {{- else }}
         - name: datadir
           emptyDir: {}

--- a/stable/mongodb/templates/statefulset-secondary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-secondary-rs.yaml
@@ -255,7 +255,7 @@ spec:
         resources:
           requests:
             storage: {{ .Values.persistence.size | quote }}
-        storageClassName: {{ include "mongodb.storageClass" . }}
+        {{ include "mongodb.storageClass" . }}
 {{- else }}
         - name: datadir
           emptyDir: {}


### PR DESCRIPTION
Signed-off-by: Alejandro Moreno <amoreno@bitnami.com>

#### What this PR does / why we need it:

At #16434 we introduced a new macro that allows us to use a `global.storageClass` parameter to overwrite any other **storageClassName** used on other parameters.

Despite new **PVCs** and **Statefulsets** generated are syntactically correct (PVC manifests generate exactly the same PVC in the K8s cluster), we introduce a backwards incompatibility since Helm includes some "sanity checks" to ensure immutable objects do not change their specs during an upgrade (see the error below):

```console
Error: UPGRADE FAILED: PersistentVolumeClaim "xxxxx" is invalid: spec: Forbidden: is immutable after creation except resources.requests for bound claims
```

This error is a consequence of the change below introduced in the PR (when no **storagleClass** is provided):

```diff
kind: PersistentVolumeClaim
...
    requests:
      storage: "8Gi"
+   storageClassName: 
```

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
