### PR TITLE
[stable/odoo] Fix 'storageClass' macros

### DIFF
--- a/stable/odoo/Chart.yaml
+++ b/stable/odoo/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: odoo
-version: 10.1.1
+version: 10.1.2
 appVersion: 12.0.20190815
 description: A suite of web based open source business apps.
 home: https://www.odoo.com/

--- a/stable/odoo/templates/_helpers.tpl
+++ b/stable/odoo/templates/_helpers.tpl
@@ -101,25 +101,25 @@ but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else 
 {{- if .Values.global -}}
     {{- if .Values.global.storageClass -}}
         {{- if (eq "-" .Values.global.storageClass) -}}
-            {{- printf "\"\"" -}}
+            {{- printf "storageClassName: \"\"" -}}
         {{- else }}
-            {{- printf "%s" .Values.global.storageClass -}}
+            {{- printf "storageClassName: %s" .Values.global.storageClass -}}
         {{- end -}}
     {{- else -}}
         {{- if .Values.persistence.storageClass -}}
               {{- if (eq "-" .Values.persistence.storageClass) -}}
-                  {{- printf "\"\"" -}}
+                  {{- printf "storageClassName: \"\"" -}}
               {{- else }}
-                  {{- printf "%s" .Values.persistence.storageClass -}}
+                  {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
               {{- end -}}
         {{- end -}}
     {{- end -}}
 {{- else -}}
     {{- if .Values.persistence.storageClass -}}
         {{- if (eq "-" .Values.persistence.storageClass) -}}
-            {{- printf "\"\"" -}}
+            {{- printf "storageClassName: \"\"" -}}
         {{- else }}
-            {{- printf "%s" .Values.persistence.storageClass -}}
+            {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/stable/odoo/templates/pvc.yaml
+++ b/stable/odoo/templates/pvc.yaml
@@ -14,5 +14,5 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
-  storageClassName: {{ include "odoo.storageClass" . }}
+  {{ include "odoo.storageClass" . }}
 {{- end -}}


### PR DESCRIPTION
Signed-off-by: Alejandro Moreno <amoreno@bitnami.com>

#### What this PR does / why we need it:

At #16418 we introduced a new macro that allows us to use a `global.storageClass` parameter to overwrite any other **storageClassName** used on other parameters.

Despite new **PVCs** and **Statefulsets** generated are syntactically correct (PVC manifests generate exactly the same PVC in the K8s cluster), we introduce a backwards incompatibility since Helm includes some "sanity checks" to ensure immutable objects do not change their specs during an upgrade (see the error below):

```console
Error: UPGRADE FAILED: PersistentVolumeClaim "xxxxx" is invalid: spec: Forbidden: is immutable after creation except resources.requests for bound claims
```

This error is a consequence of the change below introduced in the PR (when no **storagleClass** is provided):

```diff
kind: PersistentVolumeClaim
...
    requests:
      storage: "8Gi"
+   storageClassName: 
```

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
