### PR TITLE
[stable/orangehrm] Fix 'storageClass' macros

### DIFF
--- a/stable/orangehrm/Chart.yaml
+++ b/stable/orangehrm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: orangehrm
-version: 6.1.1
+version: 6.1.2
 appVersion: 4.3.2-0
 description: OrangeHRM is a free HR management system that offers a wealth of modules
   to suit the needs of your business.

--- a/stable/orangehrm/requirements.lock
+++ b/stable/orangehrm/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.7.2
+  version: 6.8.2
 digest: sha256:a363428d6463718a9523a88c70e485218373e315f2979cb1bb17b034ec2be96a
-generated: "2019-07-25T09:26:32.03089+02:00"
+generated: "2019-08-22T17:49:48.731564+02:00"

--- a/stable/orangehrm/templates/_helpers.tpl
+++ b/stable/orangehrm/templates/_helpers.tpl
@@ -130,25 +130,25 @@ but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else 
 {{- if .Values.global -}}
     {{- if .Values.global.storageClass -}}
         {{- if (eq "-" .Values.global.storageClass) -}}
-            {{- printf "\"\"" -}}
+            {{- printf "storageClassName: \"\"" -}}
         {{- else }}
-            {{- printf "%s" .Values.global.storageClass -}}
+            {{- printf "storageClassName: %s" .Values.global.storageClass -}}
         {{- end -}}
     {{- else -}}
         {{- if .Values.persistence.orangehrm.storageClass -}}
               {{- if (eq "-" .Values.persistence.orangehrm.storageClass) -}}
-                  {{- printf "\"\"" -}}
+                  {{- printf "storageClassName: \"\"" -}}
               {{- else }}
-                  {{- printf "%s" .Values.persistence.orangehrm.storageClass -}}
+                  {{- printf "storageClassName: %s" .Values.persistence.orangehrm.storageClass -}}
               {{- end -}}
         {{- end -}}
     {{- end -}}
 {{- else -}}
     {{- if .Values.persistence.orangehrm.storageClass -}}
         {{- if (eq "-" .Values.persistence.orangehrm.storageClass) -}}
-            {{- printf "\"\"" -}}
+            {{- printf "storageClassName: \"\"" -}}
         {{- else }}
-            {{- printf "%s" .Values.persistence.orangehrm.storageClass -}}
+            {{- printf "storageClassName: %s" .Values.persistence.orangehrm.storageClass -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/stable/orangehrm/templates/orangehrm-pvc.yaml
+++ b/stable/orangehrm/templates/orangehrm-pvc.yaml
@@ -14,5 +14,5 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.orangehrm.size | quote }}
-  storageClassName: {{ include "orangehrm.storageClass" . }}
+  {{ include "orangehrm.storageClass" . }}
 {{- end -}}


### PR DESCRIPTION
Signed-off-by: Alejandro Moreno <amoreno@bitnami.com>

#### What this PR does / why we need it:

At #16416 we introduced a new macro that allows us to use a `global.storageClass` parameter to overwrite any other **storageClassName** used on other parameters.

Despite new **PVCs** and **Statefulsets** generated are syntactically correct (PVC manifests generate exactly the same PVC in the K8s cluster), we introduce a backwards incompatibility since Helm includes some "sanity checks" to ensure immutable objects do not change their specs during an upgrade (see the error below):

```console
Error: UPGRADE FAILED: PersistentVolumeClaim "xxxxx" is invalid: spec: Forbidden: is immutable after creation except resources.requests for bound claims
```

This error is a consequence of the change below introduced in the PR (when no **storagleClass** is provided):

```diff
kind: PersistentVolumeClaim
...
    requests:
      storage: "8Gi"
+   storageClassName: 
```

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
