### PR TITLE
[stable/postgresql] Fix 'storageClass' macros

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 6.3.1
+version: 6.3.2
 appVersion: 11.5.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/_helpers.tpl
+++ b/stable/postgresql/templates/_helpers.tpl
@@ -325,25 +325,25 @@ but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else 
 {{- if .Values.global -}}
     {{- if .Values.global.storageClass -}}
         {{- if (eq "-" .Values.global.storageClass) -}}
-            {{- printf "\"\"" -}}
+            {{- printf "storageClassName: \"\"" -}}
         {{- else }}
-            {{- printf "%s" .Values.global.storageClass -}}
+            {{- printf "storageClassName: %s" .Values.global.storageClass -}}
         {{- end -}}
     {{- else -}}
         {{- if .Values.persistence.storageClass -}}
               {{- if (eq "-" .Values.persistence.storageClass) -}}
-                  {{- printf "\"\"" -}}
+                  {{- printf "storageClassName: \"\"" -}}
               {{- else }}
-                  {{- printf "%s" .Values.persistence.storageClass -}}
+                  {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
               {{- end -}}
         {{- end -}}
     {{- end -}}
 {{- else -}}
     {{- if .Values.persistence.storageClass -}}
         {{- if (eq "-" .Values.persistence.storageClass) -}}
-            {{- printf "\"\"" -}}
+            {{- printf "storageClassName: \"\"" -}}
         {{- else }}
-            {{- printf "%s" .Values.persistence.storageClass -}}
+            {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/stable/postgresql/templates/statefulset-slaves.yaml
+++ b/stable/postgresql/templates/statefulset-slaves.yaml
@@ -232,6 +232,6 @@ spec:
         resources:
           requests:
             storage: {{ .Values.persistence.size | quote }}
-        storageClassName: {{ include "postgresql.storageClass" . }}
+        {{ include "postgresql.storageClass" . }}
 {{- end }}
 {{- end }}

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -332,5 +332,5 @@ spec:
         resources:
           requests:
             storage: {{ .Values.persistence.size | quote }}
-        storageClassName: {{ include "postgresql.storageClass" . }}
+        {{ include "postgresql.storageClass" . }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Alejandro Moreno <amoreno@bitnami.com>

#### What this PR does / why we need it:

At #16423 we introduced a new macro that allows us to use a `global.storageClass` parameter to overwrite any other **storageClassName** used on other parameters.

Despite new **PVCs** and **Statefulsets** generated are syntactically correct (PVC manifests generate exactly the same PVC in the K8s cluster), we introduce a backwards incompatibility since Helm includes some "sanity checks" to ensure immutable objects do not change their specs during an upgrade (see the error below):

```console
Error: UPGRADE FAILED: PersistentVolumeClaim "xxxxx" is invalid: spec: Forbidden: is immutable after creation except resources.requests for bound claims
```

This error is a consequence of the change below introduced in the PR (when no **storagleClass** is provided):

```diff
kind: PersistentVolumeClaim
...
    requests:
      storage: "8Gi"
+   storageClassName: 
```

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
