### PR TITLE
[stable/wordpress] Fix 'storageClass' macros

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 7.2.1
+version: 7.2.2
 appVersion: 5.2.2
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/requirements.lock
+++ b/stable/wordpress/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.7.2
+  version: 6.8.2
 digest: sha256:2ee24c91cd38aab43cd1985a7aaf24cbd0994ab5fd48e5f76eba17c3cffbaea1
-generated: "2019-07-25T09:28:23.800378+02:00"
+generated: "2019-08-22T16:21:04.606347+02:00"

--- a/stable/wordpress/templates/_helpers.tpl
+++ b/stable/wordpress/templates/_helpers.tpl
@@ -136,25 +136,25 @@ but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else 
 {{- if .Values.global -}}
     {{- if .Values.global.storageClass -}}
         {{- if (eq "-" .Values.global.storageClass) -}}
-            {{- printf "\"\"" -}}
+            {{- printf "storageClassName: \"\"" -}}
         {{- else }}
-            {{- printf "%s" .Values.global.storageClass -}}
+            {{- printf "storageClassName: %s" .Values.global.storageClass -}}
         {{- end -}}
     {{- else -}}
         {{- if .Values.persistence.storageClass -}}
               {{- if (eq "-" .Values.persistence.storageClass) -}}
-                  {{- printf "\"\"" -}}
+                  {{- printf "storageClassName: \"\"" -}}
               {{- else }}
-                  {{- printf "%s" .Values.persistence.storageClass -}}
+                  {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
               {{- end -}}
         {{- end -}}
     {{- end -}}
 {{- else -}}
     {{- if .Values.persistence.storageClass -}}
         {{- if (eq "-" .Values.persistence.storageClass) -}}
-            {{- printf "\"\"" -}}
+            {{- printf "storageClassName: \"\"" -}}
         {{- else }}
-            {{- printf "%s" .Values.persistence.storageClass -}}
+            {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/stable/wordpress/templates/pvc.yaml
+++ b/stable/wordpress/templates/pvc.yaml
@@ -14,5 +14,5 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
-  storageClassName: {{ include "wordpress.storageClass" . }}
+  {{ include "wordpress.storageClass" . }}
 {{- end -}}


### PR DESCRIPTION
Signed-off-by: Alejandro Moreno <amoreno@bitnami.com>

#### What this PR does / why we need it:

At #16431 we introduced a new macro that allows us to use a `global.storageClass` parameter to overwrite any other **storageClassName** used on other parameters.

Despite new **PVCs** and **Statefulsets** generated are syntactically correct (PVC manifests generate exactly the same PVC in the K8s cluster), we introduce a backwards incompatibility since Helm includes some "sanity checks" to ensure immutable objects do not change their specs during an upgrade (see the error below):

```console
Error: UPGRADE FAILED: PersistentVolumeClaim "xxxxx" is invalid: spec: Forbidden: is immutable after creation except resources.requests for bound claims
```

This error is a consequence of the change below introduced in the PR (when no **storagleClass** is provided):

```diff
kind: PersistentVolumeClaim
...
    requests:
      storage: "8Gi"
+   storageClassName: 
```

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
