### PR TITLE
[stable/kiam] Use correct port when generating certificates

### DIFF
--- a/stable/kiam/Chart.yaml
+++ b/stable/kiam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kiam
-version: 2.5.1
+version: 2.5.2
 appVersion: 3.3
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/stable/kiam/templates/_helpers.tpl
+++ b/stable/kiam/templates/_helpers.tpl
@@ -101,7 +101,7 @@ Generate certificates for kiam server and agent
 {{.Values.agent.tlsCerts.keyFileName }}: {{ $cert.Key | b64enc }}
 {{- end -}}
 {{- define "kiam.server.gen-certs" -}}
-{{- $altNames := list (include "kiam.server.fullname" .) (printf "%s:%d" (include "kiam.server.fullname" .) .Values.server.service.port) (printf "127.0.0.1:%d" .Values.server.service.targetPort) -}}
+{{- $altNames := list (include "kiam.server.fullname" .) (printf "%s:%d" (include "kiam.server.fullname" .) (int64 .Values.server.service.port)) (printf "127.0.0.1:%d" (int64 .Values.server.service.targetPort)) -}}
 {{- $ca := .ca | default (genCA "kiam-ca" 365) -}}
 {{- $_ := set . "ca" $ca -}}
 {{- $cert := genSignedCert "Kiam Server" (list "127.0.0.1") $altNames 365 $ca -}}


### PR DESCRIPTION
The datatype of `.Values.server.service.port` is float64 by default. So `printf "127.0.0.1:%d" .Values.server.service.targetPort` will be evaluated into below:

    127.0.0.1:%!d(float64=443)

We need to cast `.Values.server.service.port` into integer type before using it.

Reference:
  https://helm.sh/docs/chart_best_practices/#make-types-clear

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
