### PR TITLE
[incubator/cassandra] add service monitor

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cassandra
-version: 0.13.1
+version: 0.13.2
 appVersion: 3.11.3
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/README.md
+++ b/incubator/cassandra/README.md
@@ -157,6 +157,7 @@ The following table lists the configurable parameters of the Cassandra chart and
 | `backup.destination`                 | Destination to store backup artifacts           | `s3://bucket/cassandra`                                    |
 | `backup.google.serviceAccountSecret` | Secret containing credentials if GCS is used as destination |                                                |
 | `exporter.enabled`                   | Enable Cassandra exporter                       | `false`                                                    |
+| `exporter.servicemonitor`            | Enable ServiceMonitor for exporter              | `true`                                                    |
 | `exporter.image.repo`                | Exporter image repository                       | `criteord/cassandra_exporter`                              |
 | `exporter.image.tag`                 | Exporter image tag                              | `2.0.2`                                                    |
 | `exporter.port`                      | Exporter port                                   | `5556`                                                     |

--- a/incubator/cassandra/templates/service.yaml
+++ b/incubator/cassandra/templates/service.yaml
@@ -11,6 +11,11 @@ spec:
   clusterIP: None
   type: {{ .Values.service.type }}
   ports:
+    {{- if .Values.exporter.enabled }}
+  - name: metrics
+    port: 5556
+    targetPort: {{ .Values.exporter.port }}
+    {{- end }}
   - name: intra
     port: 7000
     targetPort: 7000

--- a/incubator/cassandra/templates/servicemonitor.yaml
+++ b/incubator/cassandra/templates/servicemonitor.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.exporter.enabled .Values.exporter.servicemonitor }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "cassandra.fullname" . }}
+  name: hello-prometheus-scraping
+  labels:
+    app: {{ template "cassandra.name" . }}
+    chart: {{ template "cassandra.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  jobLabel: {{ template "cassandra.name" . }}
+  endpoints:
+  - port: metrics
+    interval: 10s
+  selector:
+    matchLabels:
+    app: {{ template "cassandra.name" . }}
+  namespaceSelector:
+    any: true
+{{- end }}

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -211,6 +211,8 @@ backup:
 ## Cassandra exported configuration
 ## ref: https://github.com/criteo/cassandra_exporter
 exporter:
+  # If exporter is enabled this will create a ServiceMonitor by default as well
+  servicemonitor: true
   enabled: false
   image:
     repo: criteord/cassandra_exporter


### PR DESCRIPTION
#### What this PR does / why we need it:

This adds an optional ServiceMonitor which is enabled by default when the exporter is enabled

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
