### PR TITLE
[stable/sonatype-nexus] adding ACM cert annotations and LoadBalancer source IP whitelisting support

### DIFF
--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 1.19.0
+version: 1.19.1
 appVersion: 3.17.0-01
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 1.19.1
+version: 1.20.0
 appVersion: 3.17.0-01
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/README.md
+++ b/stable/sonatype-nexus/README.md
@@ -146,6 +146,7 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `service.portName`                          | Service port name                | `nil`                                      |
 | `service.labels`                            | Service labels                   | `nil`                                      |
 | `service.annotations`                       | Service annotations              | `nil`                                      |
+| `service.loadBalancerSourceRanges`          | Service LoadBalancer source IP whitelist | `nil`                              |
 | `service.targetPort`                        | Service port                     | `nil`                                      |
 | `service.port`                              | Port for exposing service        | `nil`                                      |
 | `route.enabled`         | Set to true to create route for additional service | `false` |

--- a/stable/sonatype-nexus/templates/service.yaml
+++ b/stable/sonatype-nexus/templates/service.yaml
@@ -30,5 +30,11 @@ spec:
     app: {{ template "nexus.name" . }}
     release: {{ .Release.Name }}
   type: {{ .Values.service.serviceType }}
+  {{ if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- range .Values.service.loadBalancerSourceRanges }}
+    - {{ . }}
+    {{- end }}
+  {{ end }}
 {{- end}}
 

--- a/stable/sonatype-nexus/values.yaml
+++ b/stable/sonatype-nexus/values.yaml
@@ -35,7 +35,16 @@ nexus:
   service:
     type: NodePort
     # clusterIP: None
-  # annotations: {}
+  annotations:
+    ## When using LoadBalancer service type, use the following AWS certificate from ACM
+    ## https://aws.amazon.com/documentation/acm/
+    # service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "arn:aws:acm:eu-west-1:123456789:certificate/abc123-abc123-abc123-abc123"
+    # service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "https"
+    # service.beta.kubernetes.io/aws-load-balancer-backend-port: "https"
+  ## When using LoadBalancer service type, whitelist these source IP ranges
+  ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/
+  # loadBalancerSourceRanges:
+  #   - 192.168.1.10/32
   # labels: {}
   # securityContext:
   #   fsGroup: 2000

--- a/stable/sonatype-nexus/values.yaml
+++ b/stable/sonatype-nexus/values.yaml
@@ -35,7 +35,7 @@ nexus:
   service:
     type: NodePort
     # clusterIP: None
-  annotations: {}
+  # annotations: {}
     ## When using LoadBalancer service type, use the following AWS certificate from ACM
     ## https://aws.amazon.com/documentation/acm/
     # service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "arn:aws:acm:eu-west-1:123456789:certificate/abc123-abc123-abc123-abc123"

--- a/stable/sonatype-nexus/values.yaml
+++ b/stable/sonatype-nexus/values.yaml
@@ -35,7 +35,7 @@ nexus:
   service:
     type: NodePort
     # clusterIP: None
-  annotations:
+  annotations: {}
     ## When using LoadBalancer service type, use the following AWS certificate from ACM
     ## https://aws.amazon.com/documentation/acm/
     # service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "arn:aws:acm:eu-west-1:123456789:certificate/abc123-abc123-abc123-abc123"


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds ability to specify an AWS ACM certificate to provide SSL for the Nexus server.

#### Special notes for your reviewer:

Let me know if anything else is required/missing for this @rjkernick @tsiddique

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
