### PR TITLE
[stable/prometheus] Add usage of configFromSecret and configFileName for alertmanager-statefulset

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 9.1.0
+version: 9.1.1
 appVersion: 2.11.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/alertmanager-statefulset.yaml
+++ b/stable/prometheus/templates/alertmanager-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
           args:
-            - --config.file=/etc/config/alertmanager.yml
+            - --config.file=/etc/config/{{ .Values.alertmanager.configFileName }}
             - --storage.path={{ .Values.alertmanager.persistentVolume.mountPath }}
             - --cluster.advertise-address=$(POD_IP):6783
           {{- if .Values.alertmanager.statefulSet.headless.enableMeshPeer }}
@@ -115,8 +115,13 @@ spec:
     {{- end }}
       volumes:
         - name: config-volume
+          {{- if empty .Values.alertmanager.configFromSecret }}
           configMap:
             name: {{ if .Values.alertmanager.configMapOverrideName }}{{ .Release.Name }}-{{ .Values.alertmanager.configMapOverrideName }}{{- else }}{{ template "prometheus.alertmanager.fullname" . }}{{- end }}
+          {{- else }}
+          secret:
+            secretName: {{ .Values.alertmanager.configFromSecret }}
+          {{- end }}
       {{- range .Values.alertmanager.extraSecretMounts }}
         - name: {{ .name }}
           secret:


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds the ability to use the values .alertmanager.configFileName and alertmanager.configFromSecret for the alertmanager-statefulset which is already possible for the alertmanager-deployment.

#### Special notes for your reviewer:
Please let me know if anything else is required/missing for this @mgoodness @gianrubio

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
