### PR TITLE
stable/jenkins: Solve warning when supplying sidecar resources

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -6,6 +6,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.5.9
+
+Fixed a warning when sidecar resources are provided through a parent chart or override values
+
 ## 1.5.8
 
 Fixed an issue when master.enableXmlConfig is set to false: Always mount jenkins-secrets volume if secretsFilesSecret is set (#16512)

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.5.8
+version: 1.5.9
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -225,7 +225,7 @@ master:
       enabled: false
       image: shadwell/k8s-sidecar:0.0.2
       imagePullPolicy: IfNotPresent
-      resources:
+      resources: {}
         #   limits:
         #     cpu: 100m
         #     memory: 100Mi


### PR DESCRIPTION
#### What this PR does / why we need it:

The resources value is currently nil, but requires a map to be supplied. When overriding the value from a parent chart, a warning is produced because a map is applied to a value which was originally nil.

```
  Merging destination map for chart 'jenkins'. The destination item 'resources' is a table and ignoring the source 'resources' as it has a non-table value of: <nil>
```

Adding an empty map solves the warning and ensures the original intent.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)

@lachie83 @viglesiasce @maorfr @torstenwalter @mogaal 