### PR TITLE
[stable/redis-ha] Add network policy

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.7.1
+version: 3.8.0
 appVersion: 5.0.5
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/README.md
+++ b/stable/redis-ha/README.md
@@ -95,6 +95,8 @@ The following table lists the configurable parameters of the Redis chart and the
 | `sysctlImage.pullPolicy`                   | sysctlImage Init container pull policy                                                                         | `Always`                                             |
 | `sysctlImage.mountHostSys`                 | Mount the host `/sys` folder to `/host-sys`                                                                    | `false`                                              |
 | `schedulerName`                            | Alternate scheduler name                                                                                       | `nil`                                                |
+| `networkPolicy.enabled`                       | Enable NetworkPolicy                                                                                                                                | `false`                                                 |
+| `networkPolicy.allowExternal`                 | Don't require client label for connections                                                                                                          | `true`                                                  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/redis-ha/templates/redis-ha-netpol.yaml
+++ b/stable/redis-ha/templates/redis-ha-netpol.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: "{{ template "redis-ha.fullname" . }}"
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "redis-ha.name" . }}
+      release: "{{ .Release.Name }}"
+  ingress:
+    # Allow inbound connections
+    - ports:
+      - port: {{ .Values.redisPort }}
+      - port: {{ .Values.sentinel.port }}
+      {{- if not .Values.networkPolicy.allowExternal }}
+      from:
+    # From redis-ha client(s)
+      - podSelector:
+          matchLabels:
+            {{ template "redis-ha.fullname" . }}-client: "true"
+    # From fellow redis-ha pods
+      - podSelector:
+          matchLabels:
+            app: {{ template "redis-ha.name" . }}
+            release: "{{ .Release.Name }}"
+      {{- end }}
+    # Allow prometheus scrapes for metrics
+    - ports:
+      - port: {{ .Values.exporter.port }}
+{{- end }}

--- a/stable/redis-ha/values.yaml
+++ b/stable/redis-ha/values.yaml
@@ -213,3 +213,15 @@ hostPath:
   # change the owner of the hostPath folder to the user defined in the
   # security context
   chown: true
+
+networkPolicy:
+  ## Specifies whether a NetworkPolicy should be created
+  ##
+  enabled: false
+
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## client label will have network access to the port Redis is listening
+  ## on. When true, Redis will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  # allowExternal: true


### PR DESCRIPTION
Signed-off-by: Naseem <naseemkullah@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
Copied from other charts... this implementation seen in many charts and introduced here does not allow for the case of some pods from other namespace(s) as per https://github.com/ahmetb/kubernetes-network-policy-recipes/blob/master/07-allow-traffic-from-some-pods-in-another-namespace.md#allow-traffic-from-some-pods-in-another-namespace

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
