### PR TITLE
[stable/redmine] Add support for external databases

### DIFF
--- a/stable/redmine/Chart.yaml
+++ b/stable/redmine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redmine
-version: 12.1.1
+version: 12.2.0
 appVersion: 4.0.4
 description: A flexible project management web application.
 keywords:

--- a/stable/redmine/Chart.yaml
+++ b/stable/redmine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redmine
-version: 12.1.2
+version: 12.2.0
 appVersion: 4.0.4
 description: A flexible project management web application.
 keywords:

--- a/stable/redmine/README.md
+++ b/stable/redmine/README.md
@@ -82,10 +82,13 @@ The following table lists the configurable parameters of the Redmine chart and t
 | `mariadb.enabled`                   | Whether to deploy a MariaDB server to satisfy the applications database requirements     | `true`    |
 | `mariadb.rootUser.password`         | MariaDB admin password                     | `nil`                                                   |
 | `postgresql.enabled`                | Whether to deploy a PostgreSQL server to satisfy the applications database requirements  | `false`   |
-| `postgresql.postgresqlPassword`     | PostgreSQL admin password                  | `nil`                                                   |
+| `postgresql.postgresqlDatabase`     | PostgreSQL database                        | `bitnami_redmine`                                       |
+| `postgresql.postgresqlUsername`     | PostgreSQL user                            | `bn_redmine`                                            |
+| `postgresql.postgresqlPassword`     | PostgreSQL password                        | `nil`                                                   |
 | `externalDatabase.host`             | Host of the external database              | `localhost`                                             |
-| `externalDatabase.user`             | External db admin user                     | `root`                                                  |
-| `externalDatabase.password`         | Password for the admin user                | `""`                                                    |
+| `externalDatabase.name`             | Name of the external database              | `localhost`                                             |
+| `externalDatabase.user`             | External db user                           | `user`                                                  |
+| `externalDatabase.password`         | Password for the db user                   | `""`                                                    |
 | `externalDatabase.port`             | Database port number                       | `3306`                                                  |
 | `service.type`                      | Kubernetes Service type                    | `LoadBalancer`                                          |
 | `service.port`                      | Service HTTP port                          | `80`                                                    |

--- a/stable/redmine/requirements.lock
+++ b/stable/redmine/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.7.2
+  version: 6.8.2
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.2.0
+  version: 6.3.2
 digest: sha256:ee162ec03d9c5f09b7cab23f9fc3d98481694ff8295405c6089ea9dd7470d7fa
-generated: "2019-07-25T09:18:23.784977+02:00"
+generated: 2019-08-26T14:06:38.677666682Z

--- a/stable/redmine/templates/deployment.yaml
+++ b/stable/redmine/templates/deployment.yaml
@@ -52,11 +52,15 @@ spec:
         - name: REDMINE_DB_MYSQL
         {{- if .Values.mariadb.enabled }}
           value: {{ template "redmine.mariadb.fullname" . }}
+        - name: REDMINE_DB_NAME
+          value: {{ .Values.mariadb.db.name | quote }}
+        - name: REDMINE_DB_USERNAME
+          value: {{ .Values.mariadb.db.user | quote }}
         - name: REDMINE_DB_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "redmine.mariadb.fullname" . }}
-              key: mariadb-root-password
+              key: mariadb-password
         {{- else }}
           value: {{ .Values.externalDatabase.host | quote }}
         {{- end }}
@@ -64,6 +68,10 @@ spec:
         - name: REDMINE_DB_POSTGRES
         {{- if .Values.postgresql.enabled }}
           value: {{ template "redmine.postgresql.fullname" . }}
+        - name: REDMINE_DB_NAME
+          value: {{ .Values.postgresql.postgresqlDatabase | quote }}
+        - name: REDMINE_DB_USERNAME
+          value: {{ .Values.postgresql.postgresqlUsername | quote }}
         - name: REDMINE_DB_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -74,11 +82,10 @@ spec:
         {{- end }}
         {{- end }}
         {{- if or (and .Values.databaseType.mariadb (not .Values.mariadb.enabled)) (and .Values.databaseType.postgresql (not .Values.postgresql.enabled)) }}
+        - name: REDMINE_DB_NAME
+          value: {{ .Values.externalDatabase.name | quote }}
         - name: REDMINE_DB_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: {{ printf "%s-%s" .Release.Name "externaldb" }}
-              key: db-admin-user
+          value: {{ .Values.externalDatabase.user | quote }}
         - name: REDMINE_DB_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/stable/redmine/values.yaml
+++ b/stable/redmine/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/redmine
-  tag: 4.0.4-debian-9-r22
+  tag: 4.0.4-debian-9-r70
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/stable/redmine/values.yaml
+++ b/stable/redmine/values.yaml
@@ -96,7 +96,7 @@ mariadb:
   db:
     name: bitnami_redmine
     user: bn_redmine
-    ## If the password is not specified, mariadb will generates a random password
+    ## If the password is not specified, mariadb will generate a random password
     ##
     # password:
 
@@ -131,9 +131,14 @@ mariadb:
 postgresql:
   ## Whether to deploy a PostgreSQL server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
   enabled: false
-  ## PostgreSQL admin password
-  ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#setting-the-root-password-on-first-run
+
+  ## Create a database and a database user
+  ## ref: https://github.com/bitnami/bitnami-docker-postgresql/#creating-a-database-on-first-run
   ##
+  postgresqlDatabase: bitnami_redmine
+  postgresqlUsername: bn_redmine
+  ##
+  ## If the password is not specified, postgresql will generate a random password
   # postgresqlPassword:
 
   ## Enable persistence using Persistent Volume Claims
@@ -164,10 +169,13 @@ externalDatabase:
   ## Database host
   host: localhost
 
-  ## Database Admin User
-  user: root
+  ## Database name
+  name: database
 
-  ## Database Admin Password
+  ## Database User
+  user: user
+
+  ## Database Password
   password: ""
 
   ## Database port number (use 5432 when using PostgreSQL)


### PR DESCRIPTION
Signed-off-by: Alejandro Moreno <amoreno@bitnami.com>

#### What this PR does / why we need it:
This PR adds support for external databases without having to give the application root permissions to the database server. This is done using an updated version of the `bitnami/redmine` container that supports this feature.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
