### PR TITLE
[stable/airflow] Option to specify postgres/redis secret key

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 4.0.5
+version: 4.0.6
 appVersion: 1.10.3
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -408,7 +408,8 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `serviceAccount.create`                  | create a service account                                | `true`                    |
 | `serviceAccount.name`                    | the service account name                                | ``                        |
 | `postgresql.enabled`                     | create a postgres server                                | `true`                    |
-| `postgresql.existingSecret`              | The name of an existing secret with a key `postgres-password` to use as the password  | `nil` |
+| `postgresql.existingSecret`              | The name of an existing secret with a key named `postgresql.existingSecretKey` to use as the password  | `nil` |
+| `postgresql.existingSecretKey`           | The name of the key containing the password in the secret named `postgresql.existingSecret`  | `postgres-password` |
 | `postgresql.uri`                         | full URL to custom postgres setup                       | (undefined)               |
 | `postgresql.postgresHost`                | PostgreSQL Hostname                                     | (undefined)               |
 | `postgresql.postgresUser`                | PostgreSQL User                                         | `postgres`                |
@@ -418,7 +419,8 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `postgresql.persistance.storageClass`    | Persistant class                                        | (undefined)               |
 | `postgresql.persistance.accessMode`      | Access mode                                             | `ReadWriteOnce`           |
 | `redis.enabled`                          | Create a Redis cluster                                  | `true`                    |
-| `redis.existingSecret`                   | The name of an existing secret with a key `redis-password` to use as the password  | `nil` |
+| `redis.existingSecret`                   | The name of an existing secret with a key named `redis.existingSecretKey` to use as the password  | `nil` |
+| `redis.existingSecretKey`                | The name of the key containing the password in the secret named `redis.existingSecret`  | `redis-password` |
 | `redis.redisHost`                        | Redis Hostname                                          | (undefined)               |
 | `redis.password`                         | Redis password                                          | `airflow`                 |
 | `redis.master.persistence.enabled`       | Enable Redis PVC                                        | `false`                   |

--- a/stable/airflow/templates/_helpers.tpl
+++ b/stable/airflow/templates/_helpers.tpl
@@ -104,14 +104,14 @@ The key names for postgres and redis are fixed, which is consistent with the sub
     valueFrom:
       secretKeyRef:
         name: {{ default (include "airflow.postgresql.fullname" .) .Values.postgresql.existingSecret }}
-        key: postgres-password
+        key: {{ .Values.postgresql.existingSecretKey }}
   {{- end }}
   {{- if or .Values.redis.existingSecret .Values.redis.enabled }}
   - name: REDIS_PASSWORD
     valueFrom:
       secretKeyRef:
         name: {{ default (include "airflow.redis.fullname" .) .Values.redis.existingSecret }}
-        key: redis-password
+        key: {{ .Values.redis.existingSecretKey }}
   {{- end }}
   {{- if .Values.airflow.extraEnv }}
 {{ toYaml .Values.airflow.extraEnv | indent 2 }}

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -493,8 +493,10 @@ postgresql:
 
   ##
   ## The name of an existing secret that contains the postgres password.
-  ## Note that the secret must have a key called postgres-password.
   existingSecret:
+
+  ## Name of the key containing the secret.
+  existingSecretKey: postgres-password
 
   ##
   ## If you are bringing your own PostgreSQL, you should set postgresHost and
@@ -538,8 +540,10 @@ redis:
 
   ##
   ## The name of an existing secret that contains the redis password.
-  ## Note that the secret must have a key called redis-password.
   existingSecret:
+
+  ## Name of the key containing the secret.
+  existingSecretKey: redis-password
 
   ##
   ## If you are bringing your own redis, you can set the host in redisHost.


### PR DESCRIPTION
#### What this PR does / why we need it:
Give an option to specify the key containing the passwords for `postgres` and `redis` in the existing secrets instead of having a hardcoded value, `postgres-password` and `redis-password` respectively.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
