### PR TITLE
[stable/rocketchat]  Fix broken NOTES.txt labels

### DIFF
--- a/stable/rocketchat/Chart.yaml
+++ b/stable/rocketchat/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rocketchat
-version: 1.1.9
+version: 1.1.10
 appVersion: 1.3.1
 description: Prepare to take off with the ultimate chat platform, experience the next level of team communications
 keywords:

--- a/stable/rocketchat/templates/NOTES.txt
+++ b/stable/rocketchat/templates/NOTES.txt
@@ -4,15 +4,15 @@ Rocket.Chat can be accessed via port 80 on the following DNS name from within yo
 
 You can easily connect to the remote instance from your browser. Forward the webserver port to localhost:8888
 
-- kubectl port-forward --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "rocketchat.name" . }},release={{ .Release.Name }}" -o jsonpath='{ .items[0].metadata.name }') 8888:3000
+- kubectl port-forward --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "rocketchat.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath='{ .items[0].metadata.name }') 8888:3000
 
 You can also connect to the container running Rocket.Chat. To open a shell session in the pod run the following:
 
-- kubectl exec -i -t --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "rocketchat.name" . }},release={{ .Release.Name }}" -o jsonpath='{.items[0].metadata.name}') /bin/sh
+- kubectl exec -i -t --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "rocketchat.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath='{.items[0].metadata.name}') /bin/sh
 
 To trail the logs for the Rocket.Chat pod run the following:
 
-- kubectl logs -f --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "rocketchat.name" . }},release={{ .Release.Name }}" -o jsonpath='{ .items[0].metadata.name }')
+- kubectl logs -f --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "rocketchat.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath='{ .items[0].metadata.name }')
 
 {{- if .Values.ingress.enabled }}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Since the change in label names in #13619 , the instruction in NOTES.txt has been broken .  

This PR updates the instructions to use the modified label name.

#### Which issue this PR fixes

Problem introduced with #13619

#### Special notes for your reviewer:

@sreug  @verwilst @geekgonecrazy  please review 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
