### PR TITLE
[stable/apm-server] Use a non-root user

### DIFF
--- a/stable/apm-server/Chart.yaml
+++ b/stable/apm-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: The server receives data from the Elastic APM agents and stores the data into a datastore like Elasticsearch
 icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.svg
 name: apm-server
-version: 2.1.4
+version: 2.1.5
 appVersion: 7.0.0
 home: https://www.elastic.co/solutions/apm
 sources:

--- a/stable/apm-server/README.md
+++ b/stable/apm-server/README.md
@@ -75,7 +75,9 @@ The following table lists the configurable parameters of the apm-server chart an
 | `nodeSelector`                      | Node labels for pod assignment     | `{}`                                      |
 | `tolerations`                       | List of node taints to tolerate    | `[]`                                      |
 | `affinity`                          | Node/Pod affinities                | None                                      |
-| `autoscaling` | HorizontalPodAutoscaler for the deployment | `{}` |
+| `autoscaling`                       | HorizontalPodAutoscaler for the deployment | `{}` |
+| `runAsUser`                         | User id to use when running the pod | 1000 |
+| `runAsGroup`                        | Group id to use when running the pod | 1000 |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/apm-server/templates/daemonset.yaml
+++ b/stable/apm-server/templates/daemonset.yaml
@@ -29,7 +29,18 @@ spec:
         {{-  range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value }}
         {{- end }}
-    spec:
+    spec:      
+{{- if .Values.runAsUser }}
+      initContainers:
+      - name: busybox
+        image: busybox:1.31.0
+        command: ['sh','-c']
+        args: 
+        - chown {{.Values.runAsUser}}:{{default 1000 .Values.runAsGroup}} -R /usr/share/apm-server
+        volumeMounts:
+        - name: data
+          mountPath: /usr/share/apm-server/data
+{{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -62,7 +73,8 @@ spec:
             port: http
           initialDelaySeconds: 60
         securityContext:
-          runAsUser: 0
+          runAsUser: {{ default 1000 .Values.runAsUser }}
+          runAsGroup: {{ default 1000 .Values.runAsGroup }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:

--- a/stable/apm-server/templates/deployment.yaml
+++ b/stable/apm-server/templates/deployment.yaml
@@ -31,6 +31,17 @@ spec:
         {{ $key }}: {{ $value }}
         {{- end }}
     spec:
+{{- if .Values.runAsUser }}
+      initContainers:
+      - name: busybox
+        image: busybox:1.31.0
+        command: ['sh','-c']
+        args: 
+        - chown {{.Values.runAsUser}}:{{default 1000 .Values.runAsGroup}} -R /usr/share/apm-server
+        volumeMounts:
+        - name: data
+          mountPath: /usr/share/apm-server/data
+{{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -64,7 +75,8 @@ spec:
             port: http
           initialDelaySeconds: 60
         securityContext:
-          runAsUser: 0
+          runAsUser: {{ default 1000 .Values.runAsUser }}
+          runAsGroup: {{ default 1000 .Values.runAsGroup }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:

--- a/stable/apm-server/values.yaml
+++ b/stable/apm-server/values.yaml
@@ -135,6 +135,10 @@ config:
 plugins: []
   # - kinesis.so
 
+# User used to run the container. 1000 = apm-server
+runAsUser: 1000
+runAsGroup: 1000
+
 # Additional container arguments
 extraArgs: []
   # - -d


### PR DESCRIPTION
#### What this PR does / why we need it:
The chart for apm-server force the container to run as root, which goes against security best-practices. This PR allow to specify a non-root user (by default: 1000/apm-server) and run with it.


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #16044 

#### Special notes for your reviewer:

The use of an init container has been needed to set rights on the RW volumes.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)

Signed-off-by: Clément Loiselet