### PR TITLE
[stable/graylog] Support graylog.ingress.extraPaths

### DIFF
--- a/stable/graylog/Chart.yaml
+++ b/stable/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: graylog
 home: https://www.graylog.org
-version: 1.3.3
+version: 1.3.4
 appVersion: 3.0.2-2
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:

--- a/stable/graylog/README.md
+++ b/stable/graylog/README.md
@@ -94,7 +94,7 @@ graylog:
 
 ## Configuration
 
-The following table lists the configurable parameters of the Cassandra chart and their default values.
+The following table lists the configurable parameters of the Graylog chart and their default values.
 
 | Parameter                               | Description                                                                                                                                           | Default                               |
 |-----------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
@@ -124,6 +124,7 @@ The following table lists the configurable parameters of the Cassandra chart and
 | `graylog.ingress.annotations`           | Graylog Ingress annotations                                                                                                                           | `{}`                                  |
 | `graylog.ingress.hosts`                 | Graylog Ingress host names                                                                                                                            | `[]`                                  |
 | `graylog.ingress.tls`                   | Graylog Ingress TLS configuration (YAML)                                                                                                              | `[]`                                  |
+| `graylog.ingress.extraPaths`            | Ingress extra paths to prepend to every host configuration. Useful when configuring [custom actions with AWS ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/#actions). | `[]`                                  |
 | `graylog.input`                         | Graylog Input configuration (YAML) Sees #Input section for detail                                                                                     | `{}`                                  |
 | `graylog.metrics.enabled`               | If true, add Prometheus annotations to pods                                                                                                           | `false`                               |
 | `graylog.geoip.enabled`                 | If true, Maxmind Geoip Lite will be installed to ${GRAYLOG_HOME}/etc/GeoLite2-City.mmdb                                                               | `false`                               |

--- a/stable/graylog/templates/ingress.yaml
+++ b/stable/graylog/templates/ingress.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.graylog.ingress.enabled -}}
+{{- $extraPaths := .Values.graylog.ingress.extraPaths -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -20,6 +21,9 @@ spec:
     - host: {{ . }}
       http:
         paths:
+          {{ if $extraPaths }}
+{{ toYaml $extraPaths | indent 10 }}
+          {{- end }}
           - backend:
               serviceName: {{ template "graylog.fullname" $ }}-web
               servicePort: graylog

--- a/stable/graylog/values.yaml
+++ b/stable/graylog/values.yaml
@@ -146,6 +146,13 @@ graylog:
     hosts: []
     #   - graylog.yourdomain.com
 
+    ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+    extraPaths: []
+    # - path: /*
+    #   backend:
+    #     serviceName: ssl-redirect
+    #     servicePort: use-annotation
+
     ## Graylog server Ingress TLS configuration
     ## Secrets must be manually created in the namespace
     ##


### PR DESCRIPTION
#### What this PR does / why we need it:

Adding ingress.extraPaths configuration to allow users to prepend additional paths to every host. This is required when working with aws-alb-ingress-controller and configuring ssl redirection (see https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/tasks/ssl_redirect/).

#### Special notes for your reviewer:

Inspired on this PR (which was not closed yet): #15080

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
