### PR TITLE
[stable/graylog] Updating the rolling update strategy to type RollingUpdate

### DIFF
--- a/stable/graylog/Chart.yaml
+++ b/stable/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: graylog
 home: https://www.graylog.org
-version: 1.3.2
+version: 1.3.3
 appVersion: 3.0.2-2
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:

--- a/stable/graylog/Chart.yaml
+++ b/stable/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: graylog
 home: https://www.graylog.org
-version: 1.3.1
+version: 1.3.2
 appVersion: 3.0.2-2
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:

--- a/stable/graylog/README.md
+++ b/stable/graylog/README.md
@@ -86,7 +86,7 @@ Set the following values in `values.yaml`
 
 ```yaml
 graylog:
-  tolerations: 
+  tolerations:
     - key: graylog
       value: "true"
       operator: "Equal"
@@ -114,7 +114,7 @@ The following table lists the configurable parameters of the Cassandra chart and
 | `graylog.service.master.annotations`    | Graylog Master Service annotations                                                                                                                    | `{}`                                  |
 | `graylog.podAnnotations`                | Kubernetes Pod annotations                                                                                                                            | `{}`                                  |
 | `graylog.terminationGracePeriodSeconds` | Pod termination grace period                                                                                                                          | `120`                                 |
-| `graylog.updateStrategy`                | Update Strategy of the StatefulSet                                                                                                                    | `OnDelete`                            |
+| `graylog.updateStrategy`                | Update Strategy of the StatefulSet                                                                                                                    | `RollingUpdate`                           |
 | `graylog.persistence.enabled`           | Use a PVC to persist data                                                                                                                             | `true`                                |
 | `graylog.persistence.storageClass`      | Storage class of backing PVC                                                                                                                          | `nil` (uses storage class annotation) |
 | `graylog.persistence.accessMode`        | Use volume as ReadOnly or ReadWrite                                                                                                                   | `ReadWriteOnce`                       |

--- a/stable/graylog/values.yaml
+++ b/stable/graylog/values.yaml
@@ -171,9 +171,9 @@ graylog:
   # heapSize: "1024g"
 
   ## RollingUpdate update strategy
-  ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   ##
-  updateStrategy: OnDelete
+  updateStrategy: RollingUpdate
   ## Graylog server pod termination grace period
   ##
   terminationGracePeriodSeconds: 120


### PR DESCRIPTION
## What this PR does / why we need it:
The current rolling update strategy is `onDelete` which is a legacy rolling strategy type for Kubernetes version prior to 1.6 (https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#on-delete).  This causes problems when deploying it out on newer Kubernetes version.

Setting the type to a more reasonable mondern default


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
