### PR TITLE
stable/sumologic-fluentd - Updated chart readme

### DIFF
--- a/stable/sumologic-fluentd/Chart.yaml
+++ b/stable/sumologic-fluentd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sumologic-fluentd
-version: 1.1.0
+version: 1.1.1
 appVersion: 2.3.0
 description: Sumologic Log Collector
 keywords:

--- a/stable/sumologic-fluentd/README.md
+++ b/stable/sumologic-fluentd/README.md
@@ -74,7 +74,7 @@ The following table lists the configurable parameters of the sumologic-fluentd c
 | `sumologic.sourceName` | Set the sumo `_sourceName` | `%{namespace}.%{pod}.%{container}` |
 | `sumologic.sourceHost` | Set the sumo `_sourceHost` | `Nil` |
 | `sumologic.sourceCategory` | Set the sumo `_sourceCategory` | `%{namespace}/%{pod_name}` |
-| `sumologic.sourceCategoryPrefix` | Define a prefix, for `_sourceCategory` | `Nil` |
+| `sumologic.sourceCategoryPrefix` | Define a prefix, for `_sourceCategory` | `kubernetes/` |
 | `sumologic.sourceCategoryReplaceDash` | Used to replace `-` with another character | `/` |
 | `sumologic.logFormat` | Format to post logs, into sumo (`json`, `json_merge`, or `text`) | `json` |
 | `sumologic.kubernetesMeta` | Include or exclude kubernetes metadata, with `json` format | `true` |

--- a/stable/sumologic-fluentd/values.yaml
+++ b/stable/sumologic-fluentd/values.yaml
@@ -67,8 +67,8 @@ sumologic:
   ## Set the _sourceCategory metadata field in SumoLogic. (Default "%{namespace}/%{pod_name}")
   sourceCategory: ""
 
-  ## Set the prefix, for _sourceCategory metadata. (Default nil)
-  sourceCategoryPrefix: ""
+  ## Set the prefix, for _sourceCategory metadata. (Default kubernetes/)
+  sourceCategoryPrefix: "kubernetes/"
 
   ## Used to replace - with another character. (default /)
   sourceCategoryReplaceDash: ""


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR updates the readme for the `stable/sumologic-fluentd` chart to accurately reflect the default value of `sumologic.sourceCategoryPrefix`.

#### Special notes for your reviewer:
I found this particular discrepancy after reading [this article](https://support.sumologic.com/hc/en-us/articles/360016337874-We-are-not-seeing-Kubernetes-logs-in-Sumo-Logic-under-the-expected-sourceCategory) , which in turn references [this repo](https://github.com/SumoLogic/fluentd-kubernetes-sumologic) where this is documented. Tried specifying a blank value for this to see if I could just avoid setting the prefix, but unfortunately it is set to `kubernetes/` even when manually specified as blank. Not sure if there's documentation somewhere on how to omit the setting altogether, but would be worth mentioning in the readme if possible, as it seems odd to me that it would be required.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Variables are documented in the README.md
- [x] Chart version bump
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)

cc: @flah00 @frankreno @darend @bendrucker 