### PR TITLE
[stable/rocketchat]  correct mongodb to single node oplog enabled by default 

### DIFF
--- a/stable/rocketchat/Chart.yaml
+++ b/stable/rocketchat/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rocketchat
-version: 1.1.10
+version: 1.1.11
 appVersion: 1.3.1
 description: Prepare to take off with the ultimate chat platform, experience the next level of team communications
 keywords:

--- a/stable/rocketchat/values.yaml
+++ b/stable/rocketchat/values.yaml
@@ -73,7 +73,15 @@ mongodb:
 
   replicaSet:
     enabled: true
-    # key:
+    replicas:
+      secondary: 0
+      arbiter: 0
+    pdb:
+      minAvailable:
+        secondary: 0
+        arbiter: 0
+
+   # key:
 
   persistence:
     enabled: true


### PR DESCRIPTION
### What this PR does / why we need it:

Prior modifications to the chart (in order to enforce mongo oplog for version 1.x+ )  creates a  mongodb replicaset consisting of 3x mongo instances.   This has unnecessarily tripled the resource requirement to deploy the default basic chart.  

This PR corrects the situation and starts a single mongodb instance with oplog enabled. Significantly reducing the minimal deploy resource requirements.

#### Special notes for your reviewer:

please review and test   @geekgonecrazy 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
