### PR TITLE
[stable/sonarqube] Add deployment strategy support and use LTS image

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 2.1.4
-appVersion: 7.8
+version: 2.2.0
+appVersion: 7.9
 keywords:
   - coverage
   - security

--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -40,7 +40,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | Parameter                                   | Description                               | Default                                    |
 | ------------------------------------------  | ----------------------------------------  | -------------------------------------------|
 | `image.repository`                          | image repository                          | `sonarqube`                                |
-| `image.tag`                                 | `sonarqube` image tag.                    | `7.8-community`                                        |
+| `image.tag`                                 | `sonarqube` image tag.                    | `7.9-community`                                        |
 | `image.pullPolicy`                          | Image pull policy                         | `IfNotPresent`                             |
 | `image.pullSecret`                          | imagePullSecret to use for private repository      |                                   |
 | `command`                                   | command to run in the container           | `nil` (need to be set prior to 6.7.6, and 7.4)      |

--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -39,8 +39,10 @@ The following table lists the configurable parameters of the Sonarqube chart and
 
 | Parameter                                   | Description                               | Default                                    |
 | ------------------------------------------  | ----------------------------------------  | -------------------------------------------|
+| `replicaCount`                              | Number of replicas deployed               | `1`                                        |
+| `deploymentStrategy`                        | Deployment strategy                       | `{}`                                       |
 | `image.repository`                          | image repository                          | `sonarqube`                                |
-| `image.tag`                                 | `sonarqube` image tag.                    | `7.9-community`                                        |
+| `image.tag`                                 | `sonarqube` image tag.                    | `7.9-community`                            |
 | `image.pullPolicy`                          | Image pull policy                         | `IfNotPresent`                             |
 | `image.pullSecret`                          | imagePullSecret to use for private repository      |                                   |
 | `command`                                   | command to run in the container           | `nil` (need to be set prior to 6.7.6, and 7.4)      |

--- a/stable/sonarqube/templates/deployment.yaml
+++ b/stable/sonarqube/templates/deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+{{- if .Values.deploymentStrategy }}
+  strategy:
+{{ toYaml .Values.deploymentStrategy | indent 4 }}
+{{- end }}
   template:
     metadata:
       labels:
@@ -193,7 +197,7 @@ spec:
       {{- end }}
       {{- if .Values.sonarSecretKey }}
       - name: secret
-        secret: 
+        secret:
           secretName: {{ .Values.sonarSecretKey }}
           items:
           - key: sonar-secret.txt

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -2,9 +2,13 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 replicaCount: 1
+
+ # This will use the default deployment strategy unless it is overriden
+deploymentStrategy: {}
+
 image:
   repository: sonarqube
-  tag: 7.8-community
+  tag: 7.9-community
   # If using a private repository, the name of the imagePullSecret to use
   # pullSecret: my-repo-secret
 


### PR DESCRIPTION
Signed-off-by: Steve Hipwell <steve.hipwell@gmail.com>

#### What this PR does / why we need it:
This merge request enables the customisation of the deployment strategy as well as updating the default image to the 7.9 current LTS deployment. The default deployment strategy hasn't been modified so as to ensure compatibility, but a rolling strategy would better suit a single replica deployment like this.

#### Special notes for your reviewer:
n/a

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/chart]`)
