### PR TITLE
[stable/gatekeeper] Add Gatekeeper chart

### DIFF
--- a/stable/gatekeeper/.helmignore
+++ b/stable/gatekeeper/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/gatekeeper/Chart.yaml
+++ b/stable/gatekeeper/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+appVersion: "3.0.4-beta.1"
+description: Gatekeeper - Policy Controller for Kubernetes
+name: gatekeeper
+version: 0.2.0
+home: https://github.com/open-policy-agent/gatekeeper
+icon: https://www.openpolicyagent.org/img/opa-logo.svg
+maintainers:
+- email: jimmidyson@gmail.com
+  name: jimmidyson
+sources:
+- https://github.com/open-policy-agent/gatekeeper
+tillerVersion: '>=2.10.0'

--- a/stable/gatekeeper/README.md
+++ b/stable/gatekeeper/README.md
@@ -1,0 +1,58 @@
+# Gatekeeper
+
+[Gatekeeper](https://github.com/open-policy-agent/gatekeeper/), the Policy Controller for
+Kubernetes.
+
+## Prerequisites
+
+- Kubernetes 1.15 (or newer) for validating and mutating webhook admission
+  controller support.
+
+## Overview
+
+This helm chart installs Gatekeeper as a [Kubernetes admission
+controller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/).
+Gatekeeper is a validating (mutating TBA) webhook that enforces CRD-based policies executed by [Open
+Policy Agent](https://github.com/open-policy-agent/opa), a policy engine for Cloud Native
+environments hosted by [CNCF](https://www.cncf.io) as an incubation-level project.
+
+## Kick the tires
+
+If you just want to see something run, install the chart without any
+configuration.
+
+```bash
+helm install stable/gatekeeper
+```
+
+You can then follow the instructions
+[here](https://github.com/open-policy-agent/gatekeeper/#how-to-use-gatekeeper) to learn how to use
+Gatekeeper.
+
+## Configuration
+
+All configuration settings are contained and described in
+[values.yaml](values.yaml).
+
+| Parameter                                             | Description                                                                  | Default             |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------- |
+| port                                                  | Port for gateekeper pod to listen on                                         | 8443                |
+| securityContext.runAsUser                             | Run as user for gatekeeper pod                                               |                     |
+| securityContext.fsGroup                               | FS group for gatekeeper pod                                                  |                     |
+| service.annotations                                   | Service annotations                                                          |                     |
+| service.type                                          | Service type                                                                 | "ClusterIP"         |
+| service.port                                          | Service port                                                                 | 443                 |
+| rbac.create                                           | Create RBAC resources                                                        | true                |
+| serviceAccount.create                                 | Create service account                                                       | true                |
+| serviceAccount.name                                   | Service account name (if not specified, will be generated from release name) |                     |
+| priorityClassName                                     | Pod priority class name                                                      |                     |
+| resources                                             | Pod resources                                                                |                     |
+| admissionControllerFailurePolicy                      | Admission controller failure policy                                          | "Ignore"            |
+| admissionControllerNamespaceSelector.matchExpressions | Admission controller namespace selector expressions                          | []                  |
+| admissionControllerObjectSelector.matchExpressions    | Admission controller object selector expressions                             | []                  |
+| admissionControllerObjectSelector.matchLabels         | Admission controller object label selector                                   | []                  |
+| webhook.apiGroups                                     | Webhook rules API groups                                                     | [""]                |
+| webhook.apiVersions                                   | Webhook rules API versions                                                   | ["*"]               |
+| webhook.operations                                    | Webhook rules operations                                                     | ["CREATE","UPDATE"] |
+| webhook.resources                                     | Webhook rules resources                                                      | ["pods"]            |
+| webhook.scope                                         | Webhook rules scope                                                          | "Namespaced"        |

--- a/stable/gatekeeper/templates/NOTES.txt
+++ b/stable/gatekeeper/templates/NOTES.txt
@@ -1,0 +1,13 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get {{ .Release.Name }}
+
+You can read more about Gatekeeper at:
+
+https://github.com/open-policy-agent/gatekeeper
+https://kubernetes.io/blog/2019/08/06/opa-gatekeeper-policy-and-governance-for-kubernetes/

--- a/stable/gatekeeper/templates/_helpers.tpl
+++ b/stable/gatekeeper/templates/_helpers.tpl
@@ -1,0 +1,74 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gatekeeper.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "gatekeeper.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "gatekeeper.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Add Helm metadata to selector labels specifically for deployments/daemonsets/statefulsets/\s.
+*/}}
+{{- define "gatekeeper.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gatekeeper.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "gatekeeper.commonLabels" -}}
+{{- include "gatekeeper.selectorLabels" . }}
+helm.sh/chart: {{ include "gatekeeper.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "gatekeeper.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ default (include "gatekeeper.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+{{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the image tag to use
+*/}}
+{{- define "gatekeeper.imageTag" -}}
+{{- if .Values.image.tag -}}
+{{ .Values.image.tag }}
+{{- else -}}
+v{{ .Chart.AppVersion }}
+{{- end -}}
+{{- end -}}

--- a/stable/gatekeeper/templates/clusterrole.yaml
+++ b/stable/gatekeeper/templates/clusterrole.yaml
@@ -1,0 +1,152 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "gatekeeper.fullname" . }}-role
+  labels:
+    {{- include "gatekeeper.commonLabels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - config.gatekeeper.sh
+  resources:
+  - configs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - config.gatekeeper.sh
+  resources:
+  - configs/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - constraints.gatekeeper.sh
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - templates.gatekeeper.sh
+  resources:
+  - constrainttemplates
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - templates.gatekeeper.sh
+  resources:
+  - constrainttemplates/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - constraints.gatekeeper.sh
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+{{- end -}}

--- a/stable/gatekeeper/templates/clusterrolebinding.yaml
+++ b/stable/gatekeeper/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "gatekeeper.fullname" . }}-rolebinding
+  labels:
+    {{- include "gatekeeper.commonLabels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "gatekeeper.fullname" . }}-role
+subjects:
+- kind: ServiceAccount
+  name: {{ template "gatekeeper.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/stable/gatekeeper/templates/config-crd.yaml
+++ b/stable/gatekeeper/templates/config-crd.yaml
@@ -1,0 +1,109 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: configs.config.gatekeeper.sh
+  labels:
+    {{- include "gatekeeper.commonLabels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: crd-install
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  group: config.gatekeeper.sh
+  names:
+    kind: Config
+    plural: configs
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            sync:
+              description: Configuration for syncing k8s objects
+              properties:
+                syncOnly:
+                  description: If non-empty, only entries on this list will be replicated
+                    into OPA
+                  items:
+                    properties:
+                      group:
+                        type: string
+                      kind:
+                        type: string
+                      version:
+                        type: string
+                    type: object
+                  type: array
+              type: object
+            validation:
+              description: Configuration for validation
+              properties:
+                traces:
+                  description: List of requests to trace. Both "user" and "kinds"
+                    must be specified
+                  items:
+                    properties:
+                      dump:
+                        description: Also dump the state of OPA with the trace. Set
+                          to `All` to dump everything.
+                        type: string
+                      kind:
+                        description: Only trace requests of the following GroupVersionKind
+                        properties:
+                          group:
+                            type: string
+                          kind:
+                            type: string
+                          version:
+                            type: string
+                        type: object
+                      user:
+                        description: Only trace requests from the specified user
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          type: object
+        status:
+          properties:
+            byPod:
+              description: List of statuses as seen by individual pods
+              items:
+                properties:
+                  allFinalizers:
+                    description: List of Group/Version/Kinds with finalizers
+                    items:
+                      properties:
+                        group:
+                          type: string
+                        kind:
+                          type: string
+                        version:
+                          type: string
+                      type: object
+                    type: array
+                  id:
+                    description: a unique identifier for the pod that wrote the status
+                    type: string
+                type: object
+              type: array
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/stable/gatekeeper/templates/constraint-template-crd.yaml
+++ b/stable/gatekeeper/templates/constraint-template-crd.yaml
@@ -1,0 +1,96 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: constrainttemplates.templates.gatekeeper.sh
+  labels:
+    {{- include "gatekeeper.commonLabels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: crd-install
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  group: templates.gatekeeper.sh
+  names:
+    kind: ConstraintTemplate
+    plural: constrainttemplates
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            crd:
+              properties:
+                spec:
+                  properties:
+                    names:
+                      properties:
+                        kind:
+                          type: string
+                      type: object
+                    validation:
+                      type: object
+                  type: object
+              type: object
+            targets:
+              items:
+                properties:
+                  rego:
+                    type: string
+                  target:
+                    type: string
+                type: object
+              type: array
+          type: object
+        status:
+          properties:
+            byPod:
+              items:
+                properties:
+                  errors:
+                    items:
+                      properties:
+                        code:
+                          type: string
+                        location:
+                          type: string
+                        message:
+                          type: string
+                      required:
+                      - code
+                      - message
+                      type: object
+                    type: array
+                  id:
+                    description: a unique identifier for the pod that wrote the status
+                    type: string
+                type: object
+              type: array
+            created:
+              type: boolean
+          type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+  - name: v1alpha1
+    served: true
+    storage: false
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/stable/gatekeeper/templates/deployment.yaml
+++ b/stable/gatekeeper/templates/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "gatekeeper.fullname" . }}
+  labels:
+    {{- include "gatekeeper.commonLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "gatekeeper.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gatekeeper.commonLabels" . | nindent 8 }}
+    spec:
+      serviceAccount: {{ template "gatekeeper.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      {{- if or (.Values.securityContext.runAsUser) (.Values.securityContext.fsGroup) }}
+      securityContext:
+        {{- if .Values.securityContext.runAsUser }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        {{- end }}
+        {{- if .Values.securityContext.fsGroup }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        {{- end }}
+      {{- end }}
+      containers:
+      - args:
+        - --auditInterval=30
+        - --port={{ .Values.port }}
+        - --enable-manual-deploy
+        command:
+        - /root/manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: {{ .Values.image.name }}:{{ include "gatekeeper.imageTag" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        name: manager
+        ports:
+        - containerPort: {{ .Values.port }}
+          name: http
+          protocol: TCP
+        resources:
+          {{ toYaml .Values.resources | nindent 10 }}
+        volumeMounts:
+        - mountPath: /certs
+          name: cert
+          readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: {{ template "gatekeeper.fullname" . }}-webhook-server-secret
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}

--- a/stable/gatekeeper/templates/service.yaml
+++ b/stable/gatekeeper/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "gatekeeper.fullname" . }}
+  labels:
+    {{- include "gatekeeper.commonLabels" . | nindent 4 }}
+{{- if .Values.service.annotations }}
+  annotations:
+    {{ toYaml .Values.service.annotations | nindent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.port }}
+    targetPort: http
+    protocol: TCP
+    name: http
+{{- if and  .Values.service.nodePort (eq "NodePort" .Values.service.type) }}
+    nodePort: {{ .Values.service.nodePort }}
+{{- end }}
+  selector:
+    {{- include "gatekeeper.selectorLabels" . | nindent 4 }}

--- a/stable/gatekeeper/templates/serviceaccount.yaml
+++ b/stable/gatekeeper/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "gatekeeper.serviceAccountName" . }}
+  labels:
+    {{- include "gatekeeper.commonLabels" . | nindent 4 }}
+{{- end -}}

--- a/stable/gatekeeper/templates/tests/test-connection.yaml
+++ b/stable/gatekeeper/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "gatekeeper.fullname" . }}-test-connection
+  labels:
+    {{- include "gatekeeper.commonLabels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ include "gatekeeper.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/stable/gatekeeper/templates/validatingwebhook.yaml
+++ b/stable/gatekeeper/templates/validatingwebhook.yaml
@@ -1,0 +1,64 @@
+{{- $serviceName := include "gatekeeper.fullname" . }}
+{{- $ca := genCA ( printf "%s-ca" $serviceName ) 3650 }}
+{{- $altName1 := printf "%s.%s" $serviceName .Release.Namespace }}
+{{- $altName2 := printf "%s.%s.svc" $serviceName .Release.Namespace }}
+{{- $cert := genSignedCert $serviceName nil (list $altName1 $altName2) 3650 $ca }}
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ template "gatekeeper.fullname" . }}
+  labels:
+    {{- include "gatekeeper.commonLabels" . | nindent 4 }}
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    caBundle: {{ b64enc $ca.Cert }}
+    service:
+      name: {{ template "gatekeeper.fullname" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /v1/admit
+      port: {{ .Values.service.port }}
+  failurePolicy: {{ .Values.admissionControllerFailurePolicy }}
+  matchPolicy: Exact
+  name: validation.gatekeeper.sh
+  {{- with .Values.admissionControllerNamespaceSelector }}
+  namespaceSelector:
+    {{ toYaml . | nindent 4 }}
+  {{ end }}
+  objectSelector:
+    matchExpressions:
+    - {key: app.kubernetes.io/name, operator: NotIn, values: ["{{ include "gatekeeper.name" . }}"]}
+    - {key: app.kubernetes.io/instance, operator: NotIn, values: ["{{ .Release.Name }}"]}
+    {{- with .Values.admissionControllerObjectSelector.matchExpressions }}
+    {{ toYaml . | nindent 4 }}
+    {{ end }}
+    {{- with .Values.admissionControllerObjectSelector.matchLabels }}
+    matchLabels:
+    {{ toYaml . | nindent 4 }}
+    {{ end }}
+  rules:
+  - apiGroups:
+    {{ toYaml .Values.webhook.apiGroups | nindent 4 }}
+    apiVersions:
+    {{ toYaml .Values.webhook.apiVersions | nindent 4 }}
+    operations:
+    {{ toYaml .Values.webhook.operations | nindent 4 }}
+    resources:
+    {{ toYaml .Values.webhook.resources | nindent 4 }}
+    scope: {{ .Values.webhook.scope }}
+  sideEffects: None
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "gatekeeper.fullname" . }}-webhook-server-secret
+  labels:
+    {{- include "gatekeeper.commonLabels" . | nindent 4 }}
+type: Opaque
+data:
+  cert.pem: {{ b64enc $cert.Cert }}
+  key.pem: {{ b64enc $cert.Key }}
+  ca-cert.pem: {{ b64enc $ca.Cert }}
+

--- a/stable/gatekeeper/values.yaml
+++ b/stable/gatekeeper/values.yaml
@@ -1,0 +1,95 @@
+# Default values for gatekeeper.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+## Provide a name in place of prometheus-operator for `app:` labels
+##
+nameOverride: ""
+
+## Provide a name to substitute for the full names of resources
+##
+fullnameOverride: ""
+
+## Labels to apply to all resources
+##
+commonLabels: {}
+# scmhash: abc123
+# myLabel: aakkmd
+
+image:
+  # image.name is the name of the Gatekeeper container image.
+  name: quay.io/open-policy-agent/gatekeeper
+  # image.tag is the tag name of the Gatekeeper container image.
+  tag:
+  # image.pullPolicy specifies when to pull the image.
+  pullPolicy: IfNotPresent
+
+port: 8443
+
+securityContext: {}
+  # runAsUser: 65534
+  # fsGroup: 0
+
+service:
+  annotations: {}
+  type: ClusterIP
+  port: 443
+
+  # For nodeport, specify the following:
+  #   type: NodePort
+  #   nodePort: <port-number>
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+priorityClassName:
+
+resources: {}
+  # limits:
+  #   cpu: 1
+  #   memory: 500Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 300Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# To _fail closed_ on failures, change to Fail. During initial testing, we
+# recommend leaving the failure policy as Ignore.
+admissionControllerFailurePolicy: Ignore
+
+# Adds a namespace selector to the admission controller webhook
+admissionControllerNamespaceSelector:
+  matchExpressions:
+  - {key: validation.gatekeeper.sh/disable-validation, operator: NotIn, values: ["true"]}
+
+# Adds an object selector to the admission controller webhook
+admissionControllerObjectSelector:
+  matchExpressions: []
+  # - {key: foo, operator: NotIn, values: ["bar"]}
+  matchLabels: []
+  # - foo: bar
+
+webhook:
+  apiGroups:
+  - ""
+  apiVersions:
+  - "*"
+  operations:
+  - CREATE
+  - UPDATE
+  resources:
+  - pods
+  scope: Namespaced


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds [Gatekeeper](https://github.com/open-policy-agent/gatekeeper/) chart to install Gatekeeper,
the Policy Controller for Kubernetes.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)