### PR TITLE
[stable/elasticsearch-curator] curator fails with "requests_aws4auth"…

### DIFF
--- a/stable/elasticsearch-curator/Chart.yaml
+++ b/stable/elasticsearch-curator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "5.5.4"
 description: A Helm chart for Elasticsearch Curator
 name: elasticsearch-curator
-version: 2.0.1
+version: 2.0.2
 home: https://github.com/elastic/curator
 keywords:
 - curator

--- a/stable/elasticsearch-curator/README.md
+++ b/stable/elasticsearch-curator/README.md
@@ -42,7 +42,7 @@ their default values.
 |          Parameter                   |                         Description                         |                   Default                    |
 | :----------------------------------- | :---------------------------------------------------------- | :------------------------------------------- |
 | `image.pullPolicy`                   | Container pull policy                                       | `IfNotPresent`                               |
-| `image.repository`                   | Container image to use                                      | `untergeek/curator`                          |
+| `image.repository`                   | Container image to use                                      | `bobrik/curator`                             |
 | `image.tag`                          | Container image tag to deploy                               | `5.7.6`                                      |
 | `hooks`                              | Whether to run job on selected hooks                        | `{ "install": false, "upgrade": false }`     |
 | `cronjob.schedule`                   | Schedule for the CronJob                                    | `0 1 * * *`                                  |
@@ -56,7 +56,7 @@ their default values.
 | `envFromSecrets`                     | Environment variables from secrets to the cronjob container | {}                                           |
 | `envFromSecrets.*.from.secret`       | - `secretKeyRef.name` used for environment variable         |                                              |
 | `envFromSecrets.*.from.key`          | - `secretKeyRef.key` used for environment variable          |                                              |
-| `command`                            | Command to execute                                          | ["/curator/curator"]                         |
+| `command`                            | Command to execute                                          | ["/usr/bin/curator"]                         |
 | `configMaps.action_file_yml`           | Contents of the Curator action_file.yml                      | See values.yaml                              |
 | `configMaps.config_yml`                | Contents of the Curator config.yml (overrides config)         | See values.yaml                              |
 | `resources`                          | Resource requests and limits                                | {}                                           |

--- a/stable/elasticsearch-curator/values.yaml
+++ b/stable/elasticsearch-curator/values.yaml
@@ -30,7 +30,7 @@ psp:
   create: false
 
 image:
-  repository: untergeek/curator
+  repository: bobrik/curator
   tag: 5.7.6
   pullPolicy: IfNotPresent
 
@@ -41,7 +41,7 @@ hooks:
 # run curator in dry-run mode
 dryrun: false
 
-command: ["/curator/curator"]
+command: ["/usr/bin/curator"]
 env: {}
 
 configMaps:


### PR DESCRIPTION
… python module error #16672

 The docker image being used is untergeek/curator:5.7.6.
 It doesn't cleanup indices and fails with error above.
 On top of that, it has no associated Dockerfile or Git repository
 which is on the face of quite unsafe.
 The new image bobrik/curator:5.7.6 works fine and widely used.
 It has Dockerfile associated with it and github repo.

Signed-off-by: Divyang Patel <divyang.jp@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #16672

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
