### PR TITLE
[stable/redis-ha] Add tolerations to HAProxy deployment.

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.7.4
+version: 3.7.5
 appVersion: 5.0.5
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/redis-haproxy-deployment.yaml
+++ b/stable/redis-ha/templates/redis-haproxy-deployment.yaml
@@ -33,6 +33,8 @@ spec:
       serviceAccountName: {{ template "redis-ha.serviceAccountName" . }}-haproxy
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
       initContainers:
       - name: config-init
         image: {{ .Values.haproxy.image.repository }}:{{ .Values.haproxy.image.tag }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Recently merged PR #15305 added HAProxy always pointing to master node of Redis. However, HAProxy pods did not inherit the tolerations defined in chart configurations and hence they were not schedulable in our k8s cluster.

The expected behavior is to apply the same tolerations as are applied to other pods (taken from chart configuration).

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
