### PR TITLE
fix #16690 - stable/prometheus - fails with empty clusterrole ruleset

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 9.4.0
+version: 9.4.1
 appVersion: 2.13.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/alertmanager-clusterrole.yaml
+++ b/stable/prometheus/templates/alertmanager-clusterrole.yaml
@@ -15,5 +15,7 @@ rules:
     - use
     resourceNames:
     - {{ template "prometheus.alertmanager.fullname" . }}
+{{- else }}
+  []
 {{- end }}
 {{- end }}

--- a/stable/prometheus/templates/pushgateway-clusterrole.yaml
+++ b/stable/prometheus/templates/pushgateway-clusterrole.yaml
@@ -15,5 +15,7 @@ rules:
     - use
     resourceNames:
     - {{ template "prometheus.pushgateway.fullname" . }}
+{{- else }}
+  []
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Till Adam <lxmail@web.de>

#### What this PR does / why we need it:

#### Which issue this PR fixes

fixes #16690

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
