### PR TITLE
[incubator/fluentd-cloudwatch] hostNetwork should be toggleable, per …

### DIFF
--- a/incubator/fluentd-cloudwatch/Chart.yaml
+++ b/incubator/fluentd-cloudwatch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-cloudwatch
-version: 0.10.2
+version: 0.10.3
 appVersion: v1.3.3-debian-cloudwatch-1.0
 description: A Fluentd CloudWatch Helm chart for Kubernetes.
 home: https://www.fluentd.org/

--- a/incubator/fluentd-cloudwatch/templates/daemonset.yaml
+++ b/incubator/fluentd-cloudwatch/templates/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
       - name: {{ template "fluentd-cloudwatch.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-        #hostNetwork: {{ default false .Values.hostNetwork }}
+        hostNetwork: {{ default false .Values.hostNetwork }}
         env:
         - name: AWS_REGION
           value: {{ .Values.awsRegion }}

--- a/incubator/fluentd-cloudwatch/templates/daemonset.yaml
+++ b/incubator/fluentd-cloudwatch/templates/daemonset.yaml
@@ -32,11 +32,11 @@ spec:
               mountPath: /config-volume
             - name: config
               mountPath: /etc/fluentd
+      hostNetwork: {{ default false .Values.hostNetwork }}
       containers:
       - name: {{ template "fluentd-cloudwatch.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-        hostNetwork: {{ default false .Values.hostNetwork }}
         env:
         - name: AWS_REGION
           value: {{ .Values.awsRegion }}

--- a/incubator/fluentd-cloudwatch/values.yaml
+++ b/incubator/fluentd-cloudwatch/values.yaml
@@ -21,7 +21,7 @@ resources: {}
 #    cpu: 100m
 #    memory: 200Mi
 
-# hostNetwork: false
+hostNetwork: false
 
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/


### PR DESCRIPTION
…documentation

Signed-off-by: Daniel Tahara <daniel.tahara@carbonlighthouse.com>

#### What this PR does / why we need it:
Uncomments out `hostNetwork` in daemonset configuration. This has been commented out since the initial commit, which means the documented behavior is incorrect.

#### Which issue this PR fixes
  - fixes https://github.com/helm/charts/issues/16676

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)