### PR TITLE
[stable/drone] bump drone version - CVE-2019-9512 and CVE-2019-9514

### DIFF
--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 2.0.7
-appVersion: 1.2
+version: 2.1.0
+appVersion: 1.3.1
 description: Drone is a Continuous Delivery system built on container technology
 keywords:
 - continuous-delivery

--- a/stable/drone/README.md
+++ b/stable/drone/README.md
@@ -55,10 +55,10 @@ The following table lists the configurable parameters of the drone charts and th
 | Parameter                   | Description                                                                                   | Default                     |
 |-----------------------------|-----------------------------------------------------------------------------------------------|-----------------------------|
 | `images.server.repository`  | Drone **server** image                                                                        | `docker.io/drone/drone`     |
-| `images.server.tag`         | Drone **server** image tag                                                                    | `1.2`                       |
+| `images.server.tag`         | Drone **server** image tag                                                                    | `1.3.1`                       |
 | `images.server.pullPolicy`  | Drone **server** image pull policy                                                            | `IfNotPresent`              |
 | `images.agent.repository`   | Drone **agent** image                                                                         | `docker.io/drone/agent`     |
-| `images.agent.tag`          | Drone **agent** image tag                                                                     | `1.2`                       |
+| `images.agent.tag`          | Drone **agent** image tag                                                                     | `1.3.1`                       |
 | `images.agent.pullPolicy`   | Drone **agent** image pull policy                                                             | `IfNotPresent`              |
 | `images.dind.repository`    | Docker **dind** image                                                                         | `docker.io/library/docker`  |
 | `images.dind.tag`           | Docker **dind** image tag                                                                     | `18.06.1-ce-dind`           |

--- a/stable/drone/values.yaml
+++ b/stable/drone/values.yaml
@@ -4,7 +4,7 @@ images:
   ##
   server:
     repository: "docker.io/drone/drone"
-    tag: 1.2
+    tag: 1.3.1
     pullPolicy: IfNotPresent
 
   ## The official drone (agent) image, change tag to use a different version.
@@ -12,7 +12,7 @@ images:
   ##
   agent:
     repository: "docker.io/drone/agent"
-    tag: 1.2
+    tag: 1.3.1
     pullPolicy: IfNotPresent
 
   ## The official docker (dind) image, change tag to use a different version.


### PR DESCRIPTION
Signed-off-by: Rauny Brandão <rauny@hotmart.com>

#### What this PR does / why we need it:
Bump drone server and agent to the latest version

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
