### PR TITLE
[stable/ambassador] Bump Ambassador Pro version

### DIFF
--- a/stable/ambassador/Chart.yaml
+++ b/stable/ambassador/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.76.0
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 3.3.2
+version: 3.4.2
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/stable/ambassador/templates/ambassador-pro-license-key-secret.yaml
+++ b/stable/ambassador/templates/ambassador-pro-license-key-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.pro.licenseKey.secret -}}
+{{- if and .Values.pro.enabled .Values.pro.licenseKey.secret -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/ambassador/templates/deployment.yaml
+++ b/stable/ambassador/templates/deployment.yaml
@@ -93,7 +93,11 @@ spec:
             {{- toYaml .Values.prometheusExporter.resources | nindent 12 }}
         {{- end }}
         - name: {{ .Chart.Name }}
+          {{- if and .Values.pro.enabled (gt .Values.pro.image.tag "0.6.0") }}
+          image: "{{ .Values.pro.image.repository }}:amb-core-{{ .Values.pro.image.tag }}"
+          {{ else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             {{- range .Values.service.ports }}
@@ -110,6 +114,17 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            {{- if and .Values.pro.enabled (gt .Values.pro.image.tag "0.6.0") }}
+            - name: AMBASSADOR_LICENSE_KEY
+            {{- if .Values.pro.licenseKey.secret }}
+              valueFrom:
+                secretKeyRef:
+                  name: ambassador-pro-license-key
+                  key: key
+            {{ else }}
+              value: {{ .Values.pro.licenseKey.value }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.prometheusExporter.enabled }}
             - name: STATSD_ENABLED
               value: "true"
@@ -159,7 +174,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
         {{- if .Values.pro.enabled }}
         - name: ambassador-pro
-          image: "{{ .Values.pro.image.repository }}:{{ .Values.pro.image.tag }}"
+          image: "{{ .Values.pro.image.repository }}:amb-sidecar-{{ .Values.pro.image.tag }}"
           ports:
           - name: grpc-auth
             containerPort: {{ .Values.pro.ports.auth }}

--- a/stable/ambassador/values.yaml
+++ b/stable/ambassador/values.yaml
@@ -225,7 +225,7 @@ pro:
   logLevel: info
   licenseKey:
     value:
-    secret: false
+    secret: true
   # Ambassador Pro environment variables can be found at https://www.getambassador.io/reference/pro/environment
   # For consistency, AMBASSADOR_ID is copied over from the Ambassador env above and will be ignored if set here.
   env:

--- a/stable/ambassador/values.yaml
+++ b/stable/ambassador/values.yaml
@@ -217,7 +217,7 @@ pro:
   enabled: false
   image:
     repository: quay.io/datawire/ambassador_pro
-    tag: amb-sidecar-0.6.0
+    tag: 0.7.0
   # As of Ambassador Pro 0.6.0, both the RateLimitService and AuthService use the same port
   ports:
     auth: 8500


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Upgrades the version of Ambassador Pro to 0.7.0

Ambassador Pro 0.7.0 introduces Ambassador certified builds which require a license key and to pull the image from the ambassador_pro repository.

This change has been made in a backwards compatible way so Ambassador Pro < 0.7.0 will still use Ambassador OSS repository.

#### Special notes for your reviewer:

I believe this is backwards compatible but please review the `templates/deployment.yaml` file to make sure I didn't miss a way this is not.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
