### PR TITLE
[stable/home-assistant] Bump timeouts images

### DIFF
--- a/stable/home-assistant/Chart.yaml
+++ b/stable/home-assistant/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.95.4
+appVersion: 0.98.0
 description: Home Assistant
 name: home-assistant
-version: 0.9.5
+version: 0.9.6
 keywords:
 - home-assistant
 - hass

--- a/stable/home-assistant/README.md
+++ b/stable/home-assistant/README.md
@@ -36,7 +36,7 @@ The following tables lists the configurable parameters of the Home Assistant cha
 | Parameter                  | Description                         | Default                                                 |
 |----------------------------|-------------------------------------|---------------------------------------------------------|
 | `image.repository`         | Image repository | `homeassistant/home-assistant` |
-| `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/homeassistant/home-assistant/tags/).| `0.95.4`|
+| `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/homeassistant/home-assistant/tags/).| `0.98.0`|
 | `image.pullPolicy`         | Image pull policy | `IfNotPresent` |
 | `image.pullSecrets`        | Secrets to use when pulling the image | `[]` |
 | `strategyType`             | Specifies the strategy used to replace old Pods by new ones | `Recreate` |
@@ -69,7 +69,7 @@ The following tables lists the configurable parameters of the Home Assistant cha
 | `extraEnvSecrets`   | Extra env vars to pass to the home-assistant container from k8s secrets - see `values.yaml` for an example | `{}` |
 | `configurator.enabled`     | Enable the optional [configuration UI](https://github.com/danielperna84/hass-configurator) | `false` |
 | `configurator.image.repository`         | Image repository | `billimek/hass-configurator-docker` |
-| `configurator.image.tag`                | Image tag | `x86_64-0.3.0`|
+| `configurator.image.tag`                | Image tag | `0.3.5-x86_64`|
 | `configurator.image.pullPolicy`         | Image pull policy | `IfNotPresent` |
 | `configurator.hassApiUrl`               | Home Assistant API URL (e.g. 'http://home-assistant:8123/api/') - will auto-configure to proper URL if not set | ``|
 | `configurator.hassApiPassword`          | Home Assistant API Password | `` |
@@ -100,7 +100,7 @@ The following tables lists the configurable parameters of the Home Assistant cha
 | `configurator.service.loadBalancerSourceRanges`   | Loadbalancer client IP restriction range for the configurator UI | `[]` |
 | `vscode.enabled`                  | Enable the optional [VS Code Server Sidecar](https://github.com/cdr/code-server) | `false` |
 | `vscode.image.repository`         | Image repository | `codercom/code-server` |
-| `vscode.image.tag`                | Image tag | `1.939`|
+| `vscode.image.tag`                | Image tag | `2.preview.11-vsc1.37.0`|
 | `vscode.image.pullPolicy`         | Image pull policy | `IfNotPresent` |
 | `vscode.hassConfig`               | Base path of the home assistant configuration files | `/config` |
 | `vscode.vscodePath`               | Base path of the VS Code configuration files | `/config/.vscode` |

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -77,16 +77,16 @@ spec:
             httpGet:
               path: /
               port: api
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
             failureThreshold: 5
-            timeoutSeconds: 5
+            timeoutSeconds: 10
           readinessProbe:
             httpGet:
               path: /
               port: api
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
             failureThreshold: 5
-            timeoutSeconds: 5
+            timeoutSeconds: 10
           env:
             {{- range $key, $value := .Values.extraEnv }}
             - name: {{ $key }}
@@ -205,6 +205,7 @@ spec:
             {{- if .Values.vscode.vscodePath }}
             - --extensions-dir={{ .Values.vscode.vscodePath }}
             - --user-data-dir={{ .Values.vscode.vscodePath }}
+            - {{ .Values.vscode.hassConfig }}
             {{- end }}
           ports:
             - name: vscode

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: homeassistant/home-assistant
-  tag: 0.95.4
+  tag: 0.98.0
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -87,7 +87,7 @@ git:
   ##
   image:
     repository: causticlab/hass-configurator-docker
-    tag: x86_64-0.3.1
+    tag: 0.3.5-x86_64
     pullPolicy: IfNotPresent
 
   ## Specify the command that runs in the git-sync container to pull in configuration.
@@ -109,7 +109,7 @@ configurator:
   ##
   image:
     repository: causticlab/hass-configurator-docker
-    tag: x86_64-0.3.1
+    tag: 0.3.5-x86_64
     pullPolicy: IfNotPresent
 
   ## URL for the home assistant API endpoint
@@ -182,7 +182,7 @@ vscode:
   ##
   image:
     repository: codercom/code-server
-    tag: 1.939
+    tag: 2.preview.11-vsc1.37.0
     pullPolicy: IfNotPresent
 
   ## VSCode password


### PR DESCRIPTION
#### What this PR does / why we need it:

* Bump Home Assistant to 0.98.0
* Bump configurator to 0.3.5
* Bump vs code server to 2.preview.11-vsc1.37.0
* Increase default probe timeouts to account for longer home assistant
startup time

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
