### PR TITLE
[stable/kube2iam] corrects labels in notes to new format

### DIFF
--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kube2iam
-version: 2.0.1
+version: 2.0.2
 appVersion: 0.10.7
 description: Provide IAM credentials to pods based on annotations.
 keywords:

--- a/stable/kube2iam/templates/NOTES.txt
+++ b/stable/kube2iam/templates/NOTES.txt
@@ -1,6 +1,6 @@
 To verify that kube2iam has started, run:
 
-  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "kube2iam.name" . }},release={{ .Release.Name }}"
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ template "kube2iam.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"
 
 Add an iam.amazonaws.com/role annotation to your pods with the role you want them to assume.
 


### PR DESCRIPTION
Signed-off-by: Dennis Webb <dennis@bluesentryit.com>

#### What this PR does / why we need it:
Notes displayed after installing chart displayed the wrong labels for verifying the pods were running. This corrects that to use the newer labels.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
