### PR TITLE
[stable/rabbitmq] Fix `enabled_plugins` default value syntax error

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.4.2
+version: 6.4.3
 appVersion: 3.7.17
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -65,7 +65,7 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `rabbitmq.existingPasswordSecret`    | Existing secret with RabbitMQ credentials        | `nil`                                                   |
 | `rabbitmq.erlangCookie`              | Erlang cookie                                    | _random 32 character long alphanumeric string_          |
 | `rabbitmq.existingErlangSecret`      | Existing secret with RabbitMQ Erlang cookie      | `nil`                                                   |
-| `rabbitmq.plugins`                   | List of plugins to enable                        | `rabbitmq_management rabbitmq_peer_discovery_k8s`       |
+| `rabbitmq.plugins`                   | List of plugins to enable                        | `[rabbitmq_management,rabbitmq_peer_discovery_k8s].`    |
 | `rabbitmq.extraPlugins`              | Extra plugings to enable                         | `nil`                                                   |
 | `rabbitmq.clustering.address_type`   | Switch clustering mode                           | `ip` or `hostname`                                      |
 | `rabbitmq.clustering.k8s_domain`     | Customize internal k8s cluster domain            | `cluster.local`                                         |

--- a/stable/rabbitmq/values-production.yaml
+++ b/stable/rabbitmq/values-production.yaml
@@ -104,7 +104,7 @@ rabbitmq:
   onlineSchedulers: 1
 
   ## Plugins to enable
-  plugins: "rabbitmq_management rabbitmq_peer_discovery_k8s"
+  plugins: "[rabbitmq_management,rabbitmq_peer_discovery_k8s]."
 
   ## Extra plugins to enable
   ## Use this instead of `plugins` to add new plugins

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -104,7 +104,7 @@ rabbitmq:
   onlineSchedulers: 1
 
   ## Plugins to enable
-  plugins: "rabbitmq_management rabbitmq_peer_discovery_k8s"
+  plugins: "[rabbitmq_management,rabbitmq_peer_discovery_k8s]."
 
   ## Extra plugins to enable
   ## Use this instead of `plugins` to add new plugins


### PR DESCRIPTION
#### What this PR does / why we need it:

This fixes syntax error on `enabled_plugins` file. `enabled_plugins` file content needs to be formatted JSON-ish array notation with period(.)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)

@desaintmartin 