### PR TITLE
[stable/influxdb] Add support for Azure to backup job

### DIFF
--- a/stable/influxdb/Chart.yaml
+++ b/stable/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 1.3.4
+version: 1.4.0
 appVersion: 1.7.6
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/stable/influxdb/templates/backup-cronjob.yaml
+++ b/stable/influxdb/templates/backup-cronjob.yaml
@@ -25,12 +25,14 @@ spec:
           volumes:
           - name: backups
             emptyDir: {}
+          {{- if and .Values.backup.gcs }}
           - name: google-cloud-key
             secret:
               secretName: {{ .Values.backup.gcs.serviceAccountSecret | quote }}
+          {{- end }}
           initContainers:
           - name: influxdb-backup
-            image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             volumeMounts:
             - name: backups
               mountPath: /backups
@@ -41,6 +43,7 @@ spec:
             - |
               influxd backup -host {{ template "influxdb.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.config.rpc.bind_address }} -portable /backups/backup_$(date +%Y%m%d_%H%M%S)
           containers:
+          {{- if .Values.backup.gcs}}
           - name: gsutil-cp
             image: google/cloud-sdk:alpine
             command:
@@ -59,7 +62,34 @@ spec:
               - name: SRC_URL
                 value: /backups
               - name: DST_URL
-                value: {{ .Values.backup.destination}}
+                value: {{ .Values.gcs.backup.destination}}
               - name: KEY_FILE
                 value: /var/secrets/google/key.json
+          {{- end }}
+          {{- if .Values.backup.azure }}
+          - name: azure-cli
+            image: microsoft/azure-cli
+            command:
+            - /bin/sh
+            args:
+            - '-c'
+            - |
+              az storage container create --name "$DST_CONTAINER"
+              az storage blob upload-batch --destination "$DST_CONTAINER" --destination-path "$DST_PATH" --source "$SRC_URL"
+            volumeMounts:
+            - name: backups
+              mountPath: /backups
+            env:
+              - name: SRC_URL
+                value: /backups
+              - name: DST_CONTAINER
+                value: {{ .Values.backup.azure.destination_container }}
+              - name: DST_PATH
+                value: {{ .Values.backup.azure.destination_path }}
+              - name: AZURE_STORAGE_CONNECTION_STRING
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ .Values.backup.azure.storageAccountSecret }}
+                    key: connection-string
+          {{- end }}
 {{- end }}

--- a/stable/influxdb/values.yaml
+++ b/stable/influxdb/values.yaml
@@ -280,7 +280,17 @@ backup:
   enabled: false
   schedule: "0 0 * * *"
   annotations: {}
-  destination: gs://bucket/influxdb
-  # Google Cloud Storage
-  gcs:
-    serviceAccountSecret: influxdb-backup-key
+
+  ## Google Cloud Storage
+  ## Secret is expected to have key stored in `key.json` field
+  # gcs:
+  #    serviceAccountSecret: influxdb-backup-key
+  #    destination: gs://bucket/influxdb
+
+  ## Azure
+  ## Secret is expected to have connection string stored in `connection-string` field
+  ## Existing container will be used or private one withing storage account will be created.
+  # azure:
+  #   storageAccountSecret: influxdb-backup-azure-key
+  #   destination_container: influxdb-container
+  #   destination_path: ""


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Hey, @Aisuko you reviewed  the PR https://github.com/helm/charts/pull/14134 that added GCP based backup cronjob, it also mentioned adding support for other storage providers in the future and so this PR implements Azure.

#### Checklist

- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)


