### PR TITLE
[stable/external-dns] Added ServiceAccount annotations

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.5.6
+version: 2.6.0
 appVersion: 0.5.16
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -142,6 +142,7 @@ The following table lists the configurable parameters of the external-dns chart 
 | `service.annotations`              | Annotations to add to service                                                                            | `{}`                                                     |
 | `rbac.create`                      | Wether to create & use RBAC resources or not                                                             | `false`                                                  |
 | `rbac.serviceAccountName`          | ServiceAccount (ignored if rbac.create == true)                                                          | `default`                                                |
+| `rbac.serviceAccountAnnotations`   | Additional Service Account annotations                                                                   | `{}`                                                     |
 | `rbac.apiVersion`                  | Version of the RBAC API                                                                                  | `v1beta1`                                                |
 | `rbac.pspEnabled`                  | PodSecurityPolicy                                                                                        | `false`                                                  |
 | `resources`                        | CPU/Memory resource requests/limits.                                                                     | `{}`                                                     |

--- a/stable/external-dns/templates/serviceaccount.yaml
+++ b/stable/external-dns/templates/serviceaccount.yaml
@@ -4,4 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ template "external-dns.fullname" . }}
   labels: {{ include "external-dns.labels" . | nindent 4 }}
+  {{- if .Values.rbac.serviceAccountAnnotations }}
+  annotations: {{ toYaml .Values.rbac.serviceAccountAnnotations | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/stable/external-dns/values-production.yaml
+++ b/stable/external-dns/values-production.yaml
@@ -111,7 +111,7 @@ coredns:
   ## If enabled all the values under this key must hold a valid data
   ##
   etcdTLS:
-    ## Enable or disable secure communication and client authentication to the etcd cluster 
+    ## Enable or disable secure communication and client authentication to the etcd cluster
     ##
     enabled: true
     ## Name of the existing secret containing cert files for client communication
@@ -329,6 +329,9 @@ rbac:
   ## https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
   ##
   serviceAccountName: default
+  ## Annotations for the Service Account
+  ##
+  serviceAccountAnnotations: {}
   ## RBAC API version
   ##
   apiVersion: v1beta1

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -329,6 +329,9 @@ rbac:
   ## https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
   ##
   serviceAccountName: default
+  ## Annotations for the Service Account
+  ##
+  serviceAccountAnnotations: {}
   ## RBAC API version
   ##
   apiVersion: v1beta1


### PR DESCRIPTION
Signed-off-by: Micah Hausler <mhausler@amazon.com>

#### What this PR does / why we need it:

Adds support for configurable service account annotations. This will be used for AWS's IAM for Service Accounts (aws/containers-roadmap#23).

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

This is a non-breaking change that will facilitate IAM for Service Accounts once kubernetes-incubator/external-dns#1172 lands in a release

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
