### PR TITLE
[stable/external-dns] - update RBAC permission when crd.create=true

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.5.5
+version: 2.5.6
 appVersion: 0.5.16
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/templates/clusterrole.yaml
+++ b/stable/external-dns/templates/clusterrole.yaml
@@ -40,4 +40,12 @@ rules:
   - get
   - list
   - watch
+{{- if .Values.crd.create }}
+- apiGroups:
+  - externaldns.k8s.io
+  resources:
+  - dnsendpoints/status
+  verbs:
+  - update
+{{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
Adding `update` permission for `dnsendpoints/status` resource when `rbac.create` and `crd.create` are true to prevent log message and to let the controller mark the record as up to date:

```
"Could not update ObservedGeneration of the CRD: dnsendpoints.externaldns.k8s.io \"examplednsrecord\" is forbidden: User \"system:serviceaccount:kube-system:external-dns\" cannot update resource \"dnsendpoints/status\" in API group \"externaldns.k8s.io\" in the namespace ..."
```

#### Which issue this PR fixes
* fixes #16735 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ x] Chart Version bumped
- [ x] Variables are documented in the README.md
- [ x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
