### PR TITLE
[stable/jenkins] add support for gcs in backup cronjob

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -6,6 +6,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.6.0
+
+Add support for Google Cloud Storage for backup CronJob (migrating from nuvo/kube-tasks to maorfr/kube-tasks)
+
 ## 1.5.9
 
 Fixed a warning when sidecar resources are provided through a parent chart or override values

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.5.9
+version: 1.6.0
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based
@@ -9,7 +9,7 @@ description: Open source continuous integration server. It supports multiple SCM
 sources:
 - https://github.com/jenkinsci/jenkins
 - https://github.com/jenkinsci/docker-jnlp-slave
-- https://github.com/nuvo/kube-tasks
+- https://github.com/maorfr/kube-tasks
 - https://github.com/jenkinsci/configuration-as-code-plugin
 maintainers:
 - name: lachie83

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -372,8 +372,8 @@ Adds a backup CronJob for jenkins, along with required RBAC resources.
 | `backup.enabled`                       | Enable the use of a backup CronJob                     | `false`                           |
 | `backup.schedule`                      | Schedule to run jobs                                   | `0 2 * * *`                       |
 | `backup.annotations`                   | Backup pod annotations                                 | iam.amazonaws.com/role: `jenkins` |
-| `backup.image.repo`                    | Backup image repository                                | `nuvo/kube-tasks`                 |
-| `backup.image.tag`                     | Backup image tag                                       | `0.1.2`                           |
+| `backup.image.repo`                    | Backup image repository                                | `maorfr/kube-tasks`               |
+| `backup.image.tag`                     | Backup image tag                                       | `0.2.0`                           |
 | `backup.extraArgs`                     | Additional arguments for kube-tasks                    | `[]`                              |
 | `backup.existingSecret`                | Environment variables to add to the cronjob container  | {}                                |
 | `backup.existingSecret.*`              | Specify the secret name containing the AWS credentials | `jenkinsaws`                      |
@@ -381,13 +381,13 @@ Adds a backup CronJob for jenkins, along with required RBAC resources.
 | `backup.existingSecret.*.awssecretkey` | `secretKeyRef.key` used for `AWS_SECRET_ACCESS_KEY`    | `jenkins_aws_secret_key`          |
 | `backup.env`                           | Backup environment variables                           | AWS_REGION: `us-east-1`           |
 | `backup.resources`                     | Backup CPU/Memory resource requests/limits             | Memory: `1Gi`, CPU: `1`           |
-| `backup.destination`                   | Destination to store backup artifacts                  | `s3://nuvo-jenkins-data/backup`   |
+| `backup.destination`                   | Destination to store backup artifacts                  | `s3://jenkins-data/backup`        |
 
 ### Restore from backup
 
-To restore a backup, you can use the `kube-tasks` underlying tool called [skbn](https://github.com/nuvo/skbn), which copies files from cloud storage to Kubernetes.
+To restore a backup, you can use the `kube-tasks` underlying tool called [skbn](https://github.com/maorfr/skbn), which copies files from cloud storage to Kubernetes.
 The best way to do it would be using a `Job` to copy files from the desired backup tag to the Jenkins pod.
-See the [skbn in-cluster example](https://github.com/nuvo/skbn/tree/master/examples/in-cluster) for more details.
+See the [skbn in-cluster example](https://github.com/maorfr/skbn/tree/master/examples/in-cluster) for more details.
 
 
 ## Run Jenkins as non root user

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -470,7 +470,7 @@ serviceAccountAgent:
   annotations: {}
 
 ## Backup cronjob configuration
-## Ref: https://github.com/nuvo/kube-tasks
+## Ref: https://github.com/maorfr/kube-tasks
 backup:
   # Backup must use RBAC
   # So by enabling backup you are enabling RBAC specific for backup
@@ -485,10 +485,10 @@ backup:
     # Can also be done using environment variables
     iam.amazonaws.com/role: "jenkins"
   image:
-    repository: "nuvo/kube-tasks"
-    tag: "0.1.2"
+    repository: "maorfr/kube-tasks"
+    tag: "0.2.0"
   # Additional arguments for kube-tasks
-  # Ref: https://github.com/nuvo/kube-tasks#simple-backup
+  # Ref: https://github.com/maorfr/kube-tasks#simple-backup
   extraArgs: []
   # Add existingSecret for AWS credentials
   existingSecret: {}
@@ -511,8 +511,8 @@ backup:
       memory: 1Gi
       cpu: 1
   # Destination to store the backup artifacts
-  # Supported cloud storage services: AWS S3, Minio S3, Azure Blob Storage
+  # Supported cloud storage services: AWS S3, Minio S3, Azure Blob Storage, Google Cloud Storage
   # Additional support can added. Visit this repository for details
-  # Ref: https://github.com/nuvo/skbn
-  destination: "s3://nuvo-jenkins-data/backup"
+  # Ref: https://github.com/maorfr/skbn
+  destination: "s3://jenkins-data/backup"
 checkDeprecation: true


### PR DESCRIPTION
Signed-off-by: Maor Friedman <maor.friedman@redhat.com>

#### What this PR does / why we need it:
Add support for Google Cloud Storage in backup CronJob in Jenkins.

#### Special notes for your reviewer:
migrating from nuvo/kube-tasks to maorfr/kube-tasks due to inactivity.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
