### PR TITLE
[stable/couchdb] Add annotations in stateFulSet

### DIFF
--- a/stable/couchdb/Chart.yaml
+++ b/stable/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: couchdb
-version: 2.2.0
+version: 2.2.1
 appVersion: 2.3.1
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/stable/couchdb/README.md
+++ b/stable/couchdb/README.md
@@ -125,6 +125,7 @@ A variety of other parameters are also configurable. See the comments in the
 | `persistentVolume.storageClass` | Default for the Kube cluster           |
 | `podManagementPolicy`           | Parallel                               |
 | `affinity`                      |                                        |
+| `podAnnotations`                |                                        |
 | `resources`                     |                                        |
 | `service.annotations`           |                                        |
 | `service.enabled`               | true                                   |

--- a/stable/couchdb/templates/statefulset.yaml
+++ b/stable/couchdb/templates/statefulset.yaml
@@ -18,6 +18,10 @@ spec:
     metadata:
       labels:
 {{ include "couchdb.ss.selector" . | indent 8 }}
+{{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
     spec:
       {{- if .Values.schedulerName }}
       schedulerName: "{{ .Values.schedulerName }}"

--- a/stable/couchdb/values.yaml
+++ b/stable/couchdb/values.yaml
@@ -80,6 +80,9 @@ affinity:
   #             - couchdb
   #       topologyKey: "kubernetes.io/hostname"
 
+## Optional Annotations
+podAnnotations: {}
+
 ## A StatefulSet requires a headless Service to establish the stable network
 ## identities of the Pods, and that Service is created automatically by this
 ## chart without any additional configuration. The Service block below refers


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
This PR add capabilities to put annotations four couchdb statefulset. It's usefull for example to add Velero annotations.

#### Which issue this PR fixes
No

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
