### PR TITLE
[stable/dex] Add support to always display login screen

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: dex
-version: 2.1.1
-appVersion: 2.17.0
+version: 2.2.0
+appVersion: 2.18.0
 description: CoreOS Dex
 keywords:
 - dex

--- a/stable/dex/README.md
+++ b/stable/dex/README.md
@@ -73,6 +73,7 @@ Parameters introduced starting from v2
 | `config.grpc.tlsKey` | Maps to the dex config `grpc.tlsKey` param | `/etc/dex/tls/grpc/server/tls.key` |
 | `config.issuer` | Maps to the dex config `issuer` param | `http://dex.io:8080` |
 | `config.logger` | Maps to the dex config `logger` dict param | `{"level": "debug"}` |
+| `config.oauth2.alwaysShowLoginScreen` | Maps to the dex config `oauth2.alwaysShowLoginScreen` param | `false` |
 | `config.oauth2.skipApprovalScreen` | Maps to the dex config `oauth2.skipApprovalScreen` param | `true` |
 | `config.staticClients` | Maps to the dex config `staticClients` list param | `""` |
 | `config.staticPasswords` | Maps to the dex config `staticPasswords` list param | `""` |

--- a/stable/dex/templates/secret.yaml
+++ b/stable/dex/templates/secret.yaml
@@ -31,8 +31,7 @@ stringData:
     connectors:
 {{ toYaml .connectors | indent 4 }}
     {{- end }}
-    oauth2:
-    {{ toYaml .oauth2 | indent 2 }}
+    oauth2: {{ toYaml .oauth2 | nindent 6 }}
     {{- if .staticClients }}
     staticClients:
 {{ toYaml .staticClients | indent 4 }}

--- a/stable/dex/values.yaml
+++ b/stable/dex/values.yaml
@@ -4,7 +4,7 @@
 # name: value
 
 image: quay.io/dexidp/dex
-imageTag: "v2.17.0"
+imageTag: "v2.18.0"
 imagePullPolicy: "IfNotPresent"
 
 inMiniKube: false
@@ -166,6 +166,7 @@ config:
 #      redirectURI: https://dex.minikube.local:5556/callback
 #      org: kubernetes
   oauth2:
+    alwaysShowLoginScreen: false
     skipApprovalScreen: true
 
 #  staticClients:


### PR DESCRIPTION
#### What this PR does / why we need it:

The current indentation of the OAuth2 configuration block doesn't allow
for extra properties to be added. This allows to enable the new
configuration that will always display the login screen, even though
only one connector is defined.

The default value (disabled) is also added to the values file for
documentation.

See also: https://github.com/dexidp/dex/releases/tag/v2.18.0
See also: https://github.com/dexidp/dex/pull/1505

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
