### PR TITLE
[stable/kong] bump up Kong to 1.3

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.16.1
-appVersion: 1.2
+version: 0.17.0
+appVersion: 1.3

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -61,7 +61,7 @@ and their default values.
 | Parameter                          | Description                                                                           | Default             |
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
 | image.repository                   | Kong image                                                                            | `kong`              |
-| image.tag                          | Kong image version                                                                    | `1.2`               |
+| image.tag                          | Kong image version                                                                    | `1.3`               |
 | image.pullPolicy                   | Image pull policy                                                                     | `IfNotPresent`      |
 | image.pullSecrets                  | Image pull secrets                                                                    | `null`              |
 | replicaCount                       | Kong instance count                                                                   | `1`                 |
@@ -183,7 +183,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```console
 $ helm install stable/kong --name my-release \
-  --set=image.tag=1.2,env.database=cassandra,cassandra.enabled=true
+  --set=image.tag=1.3,env.database=cassandra,cassandra.enabled=true
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -4,7 +4,7 @@
 image:
   repository: kong
   # repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  tag: 1.2
+  tag: 1.3
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Kong Ingress Controller 0.5 is compatible with Kong 1.3 as well.

Signed-off-by: Harry Bagdi <harrybagdi@gmail.com>