### PR TITLE
[stable/elasticsearch-exporter] Add ability to use existing secrets for SSL certs

### DIFF
--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 1.9.0
+version: 1.10.0
 appVersion: 1.1.0
 home: https://github.com/justwatchcom/elasticsearch_exporter
 sources:

--- a/stable/elasticsearch-exporter/README.md
+++ b/stable/elasticsearch-exporter/README.md
@@ -61,6 +61,7 @@ Parameter | Description | Default
 `service.annotations` | Annotations on the http service | `{}`
 `service.labels` | Additional labels for the service definition | `{}`
 `env` | Extra environment variables passed to pod | `{}`
+`secretMounts` |  list of secrets and their paths to mount inside the pod | `[]`
 `affinity` | Affinity rules | `{}`
 `es.uri` | address of the Elasticsearch node to connect to | `localhost:9200`
 `es.all` | if `true`, query stats for all nodes in the cluster, rather than just the node we connect to | `true`
@@ -69,10 +70,14 @@ Parameter | Description | Default
 `es.cluster_settings` | if true, query stats for cluster settings | `true`
 `es.snapshots` | if true, query stats for snapshots in the cluster | `true`
 `es.timeout` | timeout for trying to get stats from Elasticsearch | `30s`
-`es.ssl.enabled` | If true, a secure connection to E cluster is used | `false`
-`es.ssl.client.ca.pem` | PEM that contains trusted CAs used for setting up secure Elasticsearch connection |
+`es.ssl.enabled` | If true, a secure connection to Elasticsearch cluster is used | `false`
+`es.ssl.useExistingSecrets` | If true, certs from secretMounts will be used | `false`
+`es.ssl.ca.pem` | PEM that contains trusted CAs used for setting up secure Elasticsearch connection |
+`es.ssl.ca.pemPath` | Path of ca pem file which should match a secretMount path |
 `es.ssl.client.pem` | PEM that contains the client cert to connect to Elasticsearch |
+`es.ssl.client.pemPath` | Path of client pem file which should match a secretMount path |
 `es.ssl.client.key` | Private key for client auth when connecting to Elasticsearch |
+`es.ssl.client.keyPath` | Path of client key file which should match a secretMount path |
 `web.path` | path under which to expose metrics | `/metrics`
 `serviceMonitor.enabled` | If true, a ServiceMonitor CRD is created for a prometheus operator | `false`
 `serviceMonitor.namespace` | If set, the ServiceMonitor will be installed in a different namespace  | `""`

--- a/stable/elasticsearch-exporter/templates/cert-secret.yaml
+++ b/stable/elasticsearch-exporter/templates/cert-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.es.ssl.enabled }}
+{{- if and .Values.es.ssl.enabled (eq .Values.es.ssl.useExistingSecrets false) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/elasticsearch-exporter/templates/deployment.yaml
+++ b/stable/elasticsearch-exporter/templates/deployment.yaml
@@ -74,9 +74,9 @@ spec:
                     "--es.ssl-skip-verify",
                     {{- end }}
                     {{- if .Values.es.ssl.enabled }}
-                    "--es.ca=/ssl/ca.pem",
-                    "--es.client-cert=/ssl/client.pem",
-                    "--es.client-private-key=/ssl/client.key",
+                    "--es.ca={{.Values.es.ssl.ca.path | default "/ssl/ca.pem" }}",
+                    "--es.client-cert={{.Values.es.ssl.client.pemPath | default "/ssl/client.pem" }}",
+                    "--es.client-private-key={{.Values.es.ssl.client.keyPath | default "/ssl/client.key" }}",
                     {{- end }}
                     "--web.listen-address=:{{ .Values.service.httpPort }}",
                     "--web.telemetry-path={{ .Values.web.path }}"]
@@ -116,9 +116,16 @@ spec:
             initialDelaySeconds: 10
             timeoutSeconds: 10
           volumeMounts:
-            {{- if .Values.es.ssl.enabled }}
+            {{- if and .Values.es.ssl.enabled (eq .Values.es.ssl.useExistingSecrets false) }}
             - mountPath: /ssl
               name: ssl
+            {{- end }}
+            {{- range .Values.secretMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .path }}
+              {{- if .subPath }}
+              subPath: {{ .subPath }}
+              {{- end }}
             {{- end }}
 {{- if .Values.nodeSelector }}
       nodeSelector:
@@ -133,8 +140,13 @@ spec:
 {{ toYaml .Values.affinity | indent 8 }}
 {{- end }}
       volumes:
-        {{- if .Values.es.ssl.enabled }}
+        {{- if and .Values.es.ssl.enabled (eq .Values.es.ssl.useExistingSecrets false) }}
         - name: ssl
           secret:
             secretName: {{ template "elasticsearch-exporter.fullname" . }}-cert
+        {{- end }}
+        {{- range .Values.secretMounts }}
+        - name: {{ .name }}
+        secret:
+          secretName: {{ .secretName }}
         {{- end }}

--- a/stable/elasticsearch-exporter/values.yaml
+++ b/stable/elasticsearch-exporter/values.yaml
@@ -53,6 +53,19 @@ service:
 ##   KEY_2: value2
 # env:
 
+# A list of secrets and their paths to mount inside the pod
+# This is useful for mounting certificates for security
+secretMounts: []
+#  - name: ca
+#    secretName: elastic-ca
+#    path: /ssl/ca.pem
+#  - name: elastic-client-pem
+#    secretName: elastic-client-pem
+#    path: /ssl/client.pem
+#  - name: elastic-client-key
+#    secretName: elastic-client-key
+#    path: /ssl/client.key
+
 es:
   ## Address (host and port) of the Elasticsearch node we should connect to.
   ## This could be a local node (localhost:9200, for instance), or the address
@@ -97,22 +110,33 @@ es:
     ##
     enabled: false
 
+    ## If true, certs from secretMounts will be need to be referenced instead of certs below
+    ##
+    useExistingSecrets: false
+
     ca:
 
       ## PEM that contains trusted CAs used for setting up secure Elasticsearch connection
       ##
       # pem:
 
+      # Path of ca pem file which should match a secretMount path
+      # pemPath: /ssl/ca.pem
     client:
 
       ## PEM that contains the client cert to connect to Elasticsearch.
       ##
       # pem:
 
+      # Path of client pem file which should match a secretMount path
+      # pemPath: /ssl/client.pem
+
       ## Private key for client auth when connecting to Elasticsearch
       ##
       # key:
 
+      # Path of client key file which should match a secretMount path
+      # keyPath: /ssl/client.key
 web:
   ## Path under which to expose metrics.
   ##


### PR DESCRIPTION
Adds the option to import existing secrets and to reference their paths in the deployment command

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
