### PR TITLE
[stable/home-assistant] Support zigbee, zwave, host-configs, and other host mounts

### DIFF
--- a/stable/home-assistant/Chart.yaml
+++ b/stable/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.98.0
 description: Home Assistant
 name: home-assistant
-version: 0.9.6
+version: 0.9.7
 keywords:
 - home-assistant
 - hass

--- a/stable/home-assistant/README.md
+++ b/stable/home-assistant/README.md
@@ -57,14 +57,20 @@ The following tables lists the configurable parameters of the Home Assistant cha
 | `persistence.enabled`      | Use persistent volume to store data | `true` |
 | `persistence.size`         | Size of persistent volume claim | `5Gi` |
 | `persistence.existingClaim`| Use an existing PVC to persist data | `nil` |
+| `persistence.hostPath`| The path to the config directory on the host, instead of a PVC | `nil` |
 | `persistence.storageClass` | Type of persistent volume claim | `-` |
 | `persistence.accessMode`  | Persistence access modes | `ReadWriteMany` |
 | `git.enabled`                  | Use git-sync in init container | `false` |
-| `git.secret`                   | Git secret to use for git-sync | `git-creds` | 
+| `git.secret`                   | Git secret to use for git-sync | `git-creds` |
 | `git.syncPath`                 | Git sync path | `/config` |
 | `git.keyPath`                  | Git ssh key path | `/root/.ssh` |
 | `zwave.enabled`                  | Enable zwave host device passthrough. Also enables privileged container mode. | `false` |
 | `zwave.device`                  | Device to passthrough to guest | `ttyACM0` |
+| `hostMounts`        | Array of host directories to mount; can be used for devices | [] |
+| `hostMounts.name`   | Name of the volume | `nil` |
+| `hostMounts.hostPath` | The path on the host machine | `nil` |
+| `hostMounts.mountPath` | The path at which to mount (optional; assumed same as hostPath) | `nil` |
+| `hostMounts.type` | The type to mount (optional, i.e., `Directory`) | `nil` |
 | `extraEnv`          | Extra ENV vars to pass to the home-assistant container | `{}` |
 | `extraEnvSecrets`   | Extra env vars to pass to the home-assistant container from k8s secrets - see `values.yaml` for an example | `{}` |
 | `configurator.enabled`     | Enable the optional [configuration UI](https://github.com/danielperna84/hass-configurator) | `false` |

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -106,6 +106,14 @@ spec:
           - mountPath: /dev/ttyACM0
             name: ttyacm
           {{- end }}
+          {{- range .Values.hostMounts }}
+          {{- if .mountPath }}
+          - mountPath: {{ .mountPath }}
+          {{- else }}
+          - mountPath: {{ .hostPath }}
+          {{- end }}
+            name: {{ .name }}
+          {{- end }}
           {{- if .Values.git.enabled }}
           - mountPath: {{ .Values.git.keyPath }}
             name: git-secret
@@ -121,7 +129,7 @@ spec:
           {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-          {{- if .Values.zwave.enabled }}
+          {{- if or .Values.zwave.enabled (.Values.hostMounts) }}
           securityContext:
             privileged: true
           {{- end }}
@@ -241,8 +249,14 @@ spec:
       volumes:
       - name: config
       {{- if .Values.persistence.enabled }}
+        {{- if .Values.persistence.hostPath }}
+        hostPath:
+          path: {{.Values.persistence.hostPath}}
+          type: Directory
+        {{- else }}
         persistentVolumeClaim:
           claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "home-assistant.fullname" . }}{{- end }}
+        {{- end }}
       {{- else }}
         emptyDir: {}
       {{ end }}
@@ -250,6 +264,14 @@ spec:
       - name: ttyacm
         hostPath:
           path: /dev/{{.Values.zwave.device}}
+      {{- end }}
+      {{- range .Values.hostMounts }}
+      - name: {{ .name }}
+        hostPath:
+          path: {{.hostPath}}
+          {{- if .type }}
+          type: {{ .type }}
+          {{- end }}
       {{- end }}
       {{- if .Values.git.enabled }}
       - name: git-secret

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -102,6 +102,8 @@ zwave:
   enabled: false
   device: ttyACM0
 
+deviceMounts: []
+
 configurator:
   enabled: false
 

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -54,6 +54,9 @@ persistence:
   ## If you want to reuse an existing claim, you can pass the name of the PVC using
   ## the existingClaim variable
   # existingClaim: your-claim
+  ##
+  ## If you want to use a volume on the host machine instead of a PVC:
+  # hostPath: /path/to/the/config/folder
   accessMode: ReadWriteOnce
   size: 5Gi
 
@@ -102,7 +105,11 @@ zwave:
   enabled: false
   device: ttyACM0
 
-deviceMounts: []
+# Mount devices or folders from the host machine. Can be used for USB device mounting.
+hostMounts: []
+  # Example
+  # - name: zha
+  #   hostPath: /dev/serial/by-id/usb-Silicon_Labs_HubZ_Smart_Home_Controller_6120245D-if01-port0
 
 configurator:
   enabled: false


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Home Assistant cannot currently support anything but a single `zwave` device, and it is highly opinionated about where that device will be mounted. Instead, this allows users to arbitrarily mount anything from the host machine (including `zigbee` USB sticks, configuration volumes, etc.)

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
This PR is backwards compatible with the old `zwave` style config, but is intended to replace it.

@billimek sample helm config (working with my Home Assistant installation):
```
hostMounts:
  - name: zha
    hostPath: /dev/serial/by-id/usb-Silicon_Labs_HubZ_Smart_Home_Controller_6120245D-if01-port0
  - name: zwave
    hostPath: /dev/serial/by-id/usb-Silicon_Labs_HubZ_Smart_Home_Controller_6120245D-if00-port0
    mountPath: /dev/ttyACM0

persistence:
  hostPath: /home/zaneclaes/home-assistant
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
