### PR TITLE
stable/oauth2-proxy Fix Google credentials

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 1.1.0
+version: 1.1.1
 apiVersion: v1
 appVersion: 4.0.0
 home: http://www.videntity.com/

--- a/stable/oauth2-proxy/templates/deployment.yaml
+++ b/stable/oauth2-proxy/templates/deployment.yaml
@@ -140,7 +140,7 @@ spec:
 {{- if and .adminEmail (or .serviceAccountJson .existingSecret) }}
       - name: google-secret
         secret:
-          secretName: {{ if .existingSecret }}{{ .existingSecret }}{{ else }} {{ template "oauth2-proxy.secretName" . }}{{ end }}
+          secretName: {{ if .existingSecret }}{{ .existingSecret }}{{ else }} {{ template "oauth2-proxy.fullname" $ }}-google{{ end }}
 {{- end }}
 {{- end }}
 

--- a/stable/oauth2-proxy/templates/google-secret.yaml
+++ b/stable/oauth2-proxy/templates/google-secret.yaml
@@ -10,5 +10,5 @@ metadata:
   name: {{ template "oauth2-proxy.fullname" . }}-google
 type: Opaque
 data:
-  service-account.json: {{ .serviceAccountJson }}
+  service-account.json: {{ .Values.config.google.serviceAccountJson | b64enc }}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:
Chart installation fails when google admin mail and credentials json are provided.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
