### PR TITLE
[stable/metabase] Increase livenessProbe timeout from 5 to 30 seconds

### DIFF
--- a/stable/metabase/Chart.yaml
+++ b/stable/metabase/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 0.8.0
+version: 0.8.1
 appVersion: v0.32.9
 maintainers:
 - name: pmint93

--- a/stable/metabase/templates/deployment.yaml
+++ b/stable/metabase/templates/deployment.yaml
@@ -108,7 +108,7 @@ spec:
               path: /
               port: {{ .Values.service.internalPort }}
             initialDelaySeconds: 120
-            timeoutSeconds: 5
+            timeoutSeconds: 30
             failureThreshold: 6
           readinessProbe:
             httpGet:


### PR DESCRIPTION
#### What this PR does / why we need it:

Increase `livenessProbe.timeoutSeconds` from 5 to 30. We give our metabase pod 6 CPU cores but still often the `livenessProbe` will fail and the pod will be restarted by k8s.

This happens on the hour due to the sync/analyze metadata process.

By setting this value hire the metabase pod completes the sync/analyze process without being restarted.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
