### PR TITLE
[stable/mongo-replicaset] use bitnami/mongodb-exporter

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.9.7
+version: 3.10.0
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.9.6
+version: 3.9.7
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -66,12 +66,14 @@ The following table lists the configurable parameters of the mongodb chart and t
 | `init.resources`                    | Pod resource requests and limits (for init containers)                    | `{}`                                                |
 | `init.timeout`                      | The amount of time in seconds to wait for bootstrap to finish             | `900`                                               |
 | `metrics.enabled`                   | Enable Prometheus compatible metrics for pods and replicasets             | `false`                                             |
-| `metrics.image.repository`          | Image name for metrics exporter                                           | `bitnami/mongodb-exporter`                         |
-| `metrics.image.tag`                 | Image tag for metrics exporter                                            | `0.9.0-debian-9-r2`                                             |
+| `metrics.image.repository`          | Image name for metrics exporter                                           | `bitnami/mongodb-exporter`                          |
+| `metrics.image.tag`                 | Image tag for metrics exporter                                            | `0.9.0-debian-9-r2`                                 |
 | `metrics.image.pullPolicy`          | Image pull policy for metrics exporter                                    | `IfNotPresent`                                      |
 | `metrics.port`                      | Port for metrics exporter                                                 | `9216`                                              |
 | `metrics.path`                      | URL Path to expose metics                                                 | `/metrics`                                          |
 | `metrics.resources`                 | Metrics pod resource requests and limits                                  | `{}`                                                |
+| `metrics.securityContext.fsGroup`   | Group ID for the metrics container                                        | `1001`                                              |
+| `metrics.securityContext.runAsUser` | User ID for the metrics container                                         | `1001`                                              |
 | `metrics.socketTimeout`             | Time to wait for a non-responding socket                                  | `3s`                                                |
 | `metrics.syncTimeout`               | Time an operation with this session will wait before returning an error   | `1m`                                                |
 | `metrics.prometheusServiceDiscovery`| Adds annotations for Prometheus ServiceDiscovery                          | `true`                                              |

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -67,7 +67,7 @@ The following table lists the configurable parameters of the mongodb chart and t
 | `init.timeout`                      | The amount of time in seconds to wait for bootstrap to finish             | `900`                                               |
 | `metrics.enabled`                   | Enable Prometheus compatible metrics for pods and replicasets             | `false`                                             |
 | `metrics.image.repository`          | Image name for metrics exporter                                           | `bitnami/mongodb-exporter`                         |
-| `metrics.image.tag`                 | Image tag for metrics exporter                                            | `0.6.1`                                             |
+| `metrics.image.tag`                 | Image tag for metrics exporter                                            | `0.9.0-debian-9-r2`                                             |
 | `metrics.image.pullPolicy`          | Image pull policy for metrics exporter                                    | `IfNotPresent`                                      |
 | `metrics.port`                      | Port for metrics exporter                                                 | `9216`                                              |
 | `metrics.path`                      | URL Path to expose metics                                                 | `/metrics`                                          |

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -66,7 +66,7 @@ The following table lists the configurable parameters of the mongodb chart and t
 | `init.resources`                    | Pod resource requests and limits (for init containers)                    | `{}`                                                |
 | `init.timeout`                      | The amount of time in seconds to wait for bootstrap to finish             | `900`                                               |
 | `metrics.enabled`                   | Enable Prometheus compatible metrics for pods and replicasets             | `false`                                             |
-| `metrics.image.repository`          | Image name for metrics exporter                                           | `ssalaues/mongodb-exporter`                         |
+| `metrics.image.repository`          | Image name for metrics exporter                                           | `bitnami/mongodb-exporter`                         |
 | `metrics.image.tag`                 | Image tag for metrics exporter                                            | `0.6.1`                                             |
 | `metrics.image.pullPolicy`          | Image pull policy for metrics exporter                                    | `IfNotPresent`                                      |
 | `metrics.port`                      | Port for metrics exporter                                                 | `9216`                                              |

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -72,6 +72,7 @@ The following table lists the configurable parameters of the mongodb chart and t
 | `metrics.port`                      | Port for metrics exporter                                                 | `9216`                                              |
 | `metrics.path`                      | URL Path to expose metics                                                 | `/metrics`                                          |
 | `metrics.resources`                 | Metrics pod resource requests and limits                                  | `{}`                                                |
+| `metrics.securityContext.enabled`   | Enable security context                                                   | `true`                                              |
 | `metrics.securityContext.fsGroup`   | Group ID for the metrics container                                        | `1001`                                              |
 | `metrics.securityContext.runAsUser` | User ID for the metrics container                                         | `1001`                                              |
 | `metrics.socketTimeout`             | Time to wait for a non-responding socket                                  | `3s`                                                |

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -49,7 +49,7 @@ spec:
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
-        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}        
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
     {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       initContainers:
@@ -278,6 +278,11 @@ spec:
               containerPort: {{ .Values.metrics.port  }}
           resources:
 {{ toYaml .Values.metrics.resources | indent 12 }}
+          {{- if .Values.securityContext.enabled }}
+          securityContext:
+            runAsUser: {{ .Values.metrics.securityContext.runAsUser }}
+            fsGroup: {{ .Values.metrics.securityContext.fsGroup }}
+          {{- end }}
           livenessProbe:
             exec:
               command:

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -249,7 +249,7 @@ spec:
             {{- end }}
               --mongodb.socket-timeout={{ .Values.metrics.socketTimeout }}
               --mongodb.sync-timeout={{ .Values.metrics.syncTimeout }}
-              --web.metrics-path={{ .Values.metrics.path }}
+              --web.telemetry-path={{ .Values.metrics.path }}
               --web.listen-address=:{{ .Values.metrics.port }}
           volumeMounts:
           {{- if and (.Values.tls.enabled) }}
@@ -278,7 +278,7 @@ spec:
               containerPort: {{ .Values.metrics.port  }}
           resources:
 {{ toYaml .Values.metrics.resources | indent 12 }}
-          {{- if .Values.securityContext.enabled }}
+          {{- if .Values.metrics.securityContext.enabled }}
           securityContext:
             runAsUser: {{ .Values.metrics.securityContext.runAsUser }}
             fsGroup: {{ .Values.metrics.securityContext.fsGroup }}

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -234,23 +234,23 @@ spec:
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
           command:
             - sh
-            - -ec
+            - -c
             - >-
               /bin/mongodb_exporter
             {{- if .Values.auth.enabled }}
-              -mongodb.uri mongodb://$METRICS_USER:$METRICS_PASSWORD@localhost:{{ .Values.port }}
+              --mongodb.uri mongodb://$METRICS_USER:$METRICS_PASSWORD@localhost:{{ .Values.port }}
             {{- else }}
-              -mongodb.uri mongodb://localhost:{{ .Values.port }}
+              --mongodb.uri mongodb://localhost:{{ .Values.port }}
             {{- end }}
             {{- if .Values.tls.enabled }}
-              -mongodb.tls
-              -mongodb.tls-ca=/ca/tls.crt
-              -mongodb.tls-cert=/work-dir/mongo.pem
+              --mongodb.tls
+              --mongodb.tls-ca=/ca/tls.crt
+              --mongodb.tls-cert=/work-dir/mongo.pem
             {{- end }}
-              -mongodb.socket-timeout={{ .Values.metrics.socketTimeout }}
-              -mongodb.sync-timeout={{ .Values.metrics.syncTimeout }}
-              -web.metrics-path={{ .Values.metrics.path }}
-              -web.listen-address=:{{ .Values.metrics.port }}
+              --mongodb.socket-timeout={{ .Values.metrics.socketTimeout }}
+              --mongodb.sync-timeout={{ .Values.metrics.syncTimeout }}
+              --web.metrics-path={{ .Values.metrics.path }}
+              --web.listen-address=:{{ .Values.metrics.port }}
           volumeMounts:
           {{- if and (.Values.tls.enabled) }}
             - name: ca

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -52,8 +52,8 @@ extraVars: {}
 metrics:
   enabled: false
   image:
-    repository: ssalaues/mongodb-exporter
-    tag: 0.6.1
+    repository: bitnami/mongodb-exporter
+    tag: 0.9.0-debian-9-r2
     pullPolicy: IfNotPresent
   port: 9216
   path: "/metrics"

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -62,6 +62,7 @@ metrics:
   prometheusServiceDiscovery: true
   resources: {}
   securityContext:
+    enabled: true
     runAsUser: 1001
     fsGroup: 1001
 

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -61,6 +61,9 @@ metrics:
   syncTimeout: 1m
   prometheusServiceDiscovery: true
   resources: {}
+  securityContext:
+    runAsUser: 1001
+    fsGroup: 1001
 
 # Annotations to be added to MongoDB pods
 podAnnotations: {}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

In the current chart the `ssalaues/mongodb-exporter` exporter crashes after every scrape with a nil pointer exception. So my solution would be to use the `bitnami/mongodb-exporter` which is already used for the `stable/mongodb` chart.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)