### PR TITLE
[stable/cluster-autoscaler] Allow individual envs from secrets

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 4.0.1
+version: 4.1.0
 appVersion: 1.13.7
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/README.md
+++ b/stable/cluster-autoscaler/README.md
@@ -148,8 +148,9 @@ Parameter | Description | Default
 `extraArgs` | additional container arguments | `{}`
 `podDisruptionBudget` | Pod disruption budget | `maxUnavailable: 1`
 `extraEnv` | additional container environment variables | `{}`
-`envFromConfigMap` |  additional container environment variables from a configmap | `[]`
-`envFromSecret` | additional container environment variables from secret | `nil`
+`envFromConfigMap` | additional container environment variables from a configmap | `{}`
+`envFromSecret` | secret name containing keys that will be exposed as envs | `nil`
+`extraEnvSecrets` | additional container environment variables from a secret | `{}`
 `nodeSelector` | node labels for pod assignment | `{}`
 `podAnnotations` | annotations to add to each pod | `{}`
 `deployment.apiVersion` | apiVersion for the deployment | `extensions/v1beta1`

--- a/stable/cluster-autoscaler/templates/deployment.yaml
+++ b/stable/cluster-autoscaler/templates/deployment.yaml
@@ -149,6 +149,13 @@ spec:
                   name: {{ default (include "cluster-autoscaler.fullname" $) $value.name }}
                   key: {{ required "Must specify key!" $value.key }}
           {{- end }}
+          {{- range $key, $value := .Values.extraEnvSecrets }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "cluster-autoscaler.fullname" $) $value.name }}
+                  key: {{ required "Must specify key!" $value.key }}
+          {{- end }}
           {{- if .Values.envFromSecret }}
           envFrom:
             - secretRef:


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:

Previously the `envFromSecret` config accepted a single secret name and all keys from this secret would be exposed as envs, using the same key name as the env name.

This commit changes the `envFromSecret` config to be a map in the format:
```
envFromSecret:
  <env var name>:
    name: <secret name>
    key: <secret key>
```
This adds more flexibility by allowing to expose selected keys from a secret and also allowing for a different name for the env variable. The new behavior is identical to the existing `envFromConfigMap` config.

#### Special notes for your reviewer:

This is a breaking change, that's why I bumped the version to `4.0.0`. If a breaking change is not wanted it would be possible to add a new config value instead of replacing the behavior of the old one. However, this could be confusing due to similar config values with different behaviors.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
