### PR TITLE
Change copyright to "The Helm Authors"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright The Helm Authors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
This was identified by a community member that the license in the charts repo did not contain a copyright author. This hasn't been changed since the project was first introduced 4 years ago.

This fixes the copyright to be in line with other projects in the Helm project such as chartmuseum and Helm itself.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>