### PR TITLE
[stable/datadog] allow for setting annotations on cluster checks pod

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.38.7
+version: 1.38.8
 appVersion: 6.14.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -370,6 +370,7 @@ helm install --name <RELEASE_NAME> \
 | `clusterchecksDeployment.rbac.dedicated`                 | If true, use dedicated RBAC resources for clusterchecks agent's pods                          | `false`                                     |
 | `clusterchecksDeployment.rbac.serviceAccount`            | existing ServiceAccount to use (ignored if rbac.create=true) for clusterchecks                | `default`                                   |
 | `clusterchecksDeployment.strategy`                       | Which update strategy to deploy the Cluster Checks Deployment                                 | RollingUpdate with 0 maxUnavailable, 1 maxSurge |
+| `clusterchecksDeployment.podAnnotations`                 | Annotations to add to pods of the Cluster Check Deployment                                    | `nil`                                       |
 | `systemProbe.enabled`                  | If both this flag and `daemonset.useDedicatedContainers` are true, enable system probe collection 	        | `false`                                           |
 | `systemProbe.seccompRoot`              | Seccomp root directory for system-probe                                                                    | `/var/lib/kubelet/seccomp`                        |
 | `systemProbe.debugPort`                | The port to expose pprof and expvar for system-probe agent, it is not enabled if the value is set to 0     | `0`                                               |

--- a/stable/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/stable/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -38,6 +38,10 @@ spec:
       labels:
         app: {{ template "datadog.fullname" . }}-clusterchecks
       name: {{ template "datadog.fullname" . }}-clusterchecks
+      {{- if .Values.clusterchecksDeployment.podAnnotations }}
+      annotations:
+{{ toYaml .Values.clusterchecksDeployment.podAnnotations | indent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.clusterchecksDeployment.rbac.dedicated }}
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "datadog.fullname" . }}-cluster-checks{{ else }}"{{ .Values.clusterchecksDeployment.rbac.serviceAccountName }}"{{ end }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -832,3 +832,10 @@ clusterchecksDeployment:
   # env:
   #   - name: <ENV_VAR_NAME>
   #     value: <ENV_VAR_VALUE>
+  
+  ## @param podAnnotations - list of key:value strings - optional
+  ## Annotations to add to the cluster-agents's pod(s)
+  #
+  # podAnnotations:
+  #   key: "value"
+

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -832,10 +832,9 @@ clusterchecksDeployment:
   # env:
   #   - name: <ENV_VAR_NAME>
   #     value: <ENV_VAR_VALUE>
-  
+
   ## @param podAnnotations - list of key:value strings - optional
   ## Annotations to add to the cluster-agents's pod(s)
   #
   # podAnnotations:
   #   key: "value"
-

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -422,7 +422,7 @@ clusterAgent:
   #     maxUnavailable: 0
 
   ## @param podAnnotations - list of key:value strings - optional
-  ## Annotations to add to the cluster-agents's pod(s)
+  ## Annotations to add to pods of the Cluster Check Deployment
   #
   # podAnnotations:
   #   key: "value"


### PR DESCRIPTION
Signed-off-by: Joe Hohertz <joe@viafoura.com>

@hkaj 
@irabinovitch 
@CharlyF 
@mfpierre 
@clamoriniere 
@xlucas 

#### What this PR does / why we need it:

simply allows specifying podAnnotation for clusterChecks deployment, as is allowed for other components.

#### Which issue this PR fixes

none known

#### Special notes for your reviewer:

none

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
