### PR TITLE
stable/kong: Add ability to add secrets as a volume in Kong. 

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.18.4
+version: 0.18.5
 appVersion: 1.3

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -114,6 +114,7 @@ and their default values.
 | serviceMonitor.enabled             | Create ServiceMonitor for Prometheus Operator                                         | false               |
 | serviceMonitor.interval            | Scrapping interval                                                                    | 10s                 |
 | serviceMonitor.namespace           | Where to create ServiceMonitor                                                        |                     |
+| secretVolume                       | Mount given secret as a volume in Kong container to override default certs and keys.  |                   |
 
 ### Admin/Proxy listener override
 

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -114,7 +114,7 @@ and their default values.
 | serviceMonitor.enabled             | Create ServiceMonitor for Prometheus Operator                                         | false               |
 | serviceMonitor.interval            | Scrapping interval                                                                    | 10s                 |
 | serviceMonitor.namespace           | Where to create ServiceMonitor                                                        |                     |
-| secretVolume                       | Mount given secret as a volume in Kong container to override default certs and keys.  |                   |
+| secretVolumes                      | Mount given secrets as a volume in Kong container to override default certs and keys. | `[]`                |
 
 ### Admin/Proxy listener override
 

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -250,6 +250,10 @@ spec:
           - name: kong-custom-dbless-config-volume
             mountPath: /kong_dbless/
           {{- end }}
+          {{ if .Values.secretVolume }}
+          - name: secret-volume
+            mountPath: /etc/secrets
+          {{- end }}
         readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 10 }}
         livenessProbe:
@@ -278,4 +282,10 @@ spec:
             {{- else }}
             name: {{ template "kong.dblessConfig.fullname" . }}
             {{- end }}
+{{- end }}
+
+{{ if .Values.secretVolume }}
+        - name: secret-volume
+          secret:
+            secretName: {{ .Values.secretVolume }}
 {{- end }}

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -250,9 +250,9 @@ spec:
           - name: kong-custom-dbless-config-volume
             mountPath: /kong_dbless/
           {{- end }}
-          {{ if .Values.secretVolume }}
-          - name: secret-volume
-            mountPath: /etc/secrets
+          {{- range .Values.secretVolumes }}
+          - name:  {{ . }}
+            mountPath: /etc/secrets/{{ . }}
           {{- end }}
         readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 10 }}
@@ -284,8 +284,8 @@ spec:
             {{- end }}
 {{- end }}
 
-{{ if .Values.secretVolume }}
-        - name: secret-volume
+{{- range $secretVolume := .Values.secretVolumes }}
+        - name: {{ . }}
           secret:
-            secretName: {{ .Values.secretVolume }}
+            secretName: {{ . }}
 {{- end }}

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -420,6 +420,10 @@ dblessConfig:
       #     paths:
       #     - "/example"
 
+# Inject specified secrets as a volume in Kong Container at path /etc/secrets
+# This can be used to override default SSL certificatees
+secretVolume: ""
+
 serviceMonitor:
   # Specifies whether ServiceMonitor for Prometheus operator should be created
   enabled: false

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -420,9 +420,14 @@ dblessConfig:
       #     paths:
       #     - "/example"
 
-# Inject specified secrets as a volume in Kong Container at path /etc/secrets
-# This can be used to override default SSL certificatees
-secretVolume: ""
+# Inject specified secrets as a volume in Kong Container at path /etc/secrets/{secret-name}/
+# This can be used to override default SSL certificates
+# Example configuration
+# secretVolumes:
+# - kong-proxy-tls
+# - kong-admin-tls
+secretVolumes: []
+
 
 serviceMonitor:
   # Specifies whether ServiceMonitor for Prometheus operator should be created


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

#### What this PR does / why we need it:
Add ability to add secrets as a volume in Kong. This is useful to override default ADMIN and Proxy certs and keys. For e.g.

- We can create a tls secret consisting of keys and certificates:
```bash
kubectl create secret tls  kong-ssl-secrets \
  --key=tls-key.pem \
  --cert=tls-cert-bundle.pem
```

- Pass it as parameter to helm chart to override default kong ssl certs:

```yaml
secretVolume: 'kong-ssl-secrets'
env:
  ssl_cert: /etc/secrets/tls.crt
  ssl_cert_key: /etc/secrets/tls.key
```

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
