### PR TITLE
[stable/jenkins] display error when admin user does not exist.

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -6,6 +6,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.6.1
+
+Print error message when `master.sidecars.configAutoReload.enabled` is `true`, but the admin user can't be found to configure the SSH key.
+
 ## 1.6.0
 
 Add support for Google Cloud Storage for backup CronJob (migrating from nuvo/kube-tasks to maorfr/kube-tasks)

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.6.0
+version: 1.6.1
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -301,15 +301,16 @@ data:
     User user = User.get("{{ .Values.master.adminUser | default "admin" }}", false)
     if (user == null) {
       System.err.println("ERROR: user '{{ .Values.master.adminUser | default "admin" }}' not found! Can't configure SSH key which is needed to reload JCasC config!")
+    } else {
+      String sshKeyString = new File('/var/jenkins_home/key.pub').text
+      keys_param = new org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl(sshKeyString)
+      user.addProperty(keys_param)
+      def inst = Jenkins.getInstance()
+      def sshDesc = inst.getDescriptor("org.jenkinsci.main.modules.sshd.SSHD")
+      sshDesc.setPort({{ .Values.master.sidecars.configAutoReload.sshTcpPort | default 1044 }})
+      sshDesc.getActualPort()
+      sshDesc.save()
     }
-    String sshKeyString = new File('/var/jenkins_home/key.pub').text
-    keys_param = new org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl(sshKeyString)
-    user.addProperty(keys_param)
-    def inst = Jenkins.getInstance()
-    def sshDesc = inst.getDescriptor("org.jenkinsci.main.modules.sshd.SSHD")
-    sshDesc.setPort({{ .Values.master.sidecars.configAutoReload.sshTcpPort | default 1044 }})
-    sshDesc.getActualPort()
-    sshDesc.save()
   {{- else }}
 # Only add config to this script if we aren't auto-reloading otherwise the pod will restart upon each config change:
 {{- range $key, $val := .Values.master.JCasC.configScripts }}

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -297,13 +297,14 @@ data:
   init-add-ssh-key-to-admin.groovy: |-
     import jenkins.security.*
     import hudson.model.User
-    import jenkins.security.ApiTokenProperty
     import jenkins.model.Jenkins
-    User u = User.get("{{ .Values.master.adminUser | default "admin" }}")
-    ApiTokenProperty t = u.getProperty(ApiTokenProperty.class)
+    User user = User.get("{{ .Values.master.adminUser | default "admin" }}", false)
+    if (user == null) {
+      System.err.println("ERROR: user '{{ .Values.master.adminUser | default "admin" }}' not found! Can't configure SSH key which is needed to reload JCasC config!")
+    }
     String sshKeyString = new File('/var/jenkins_home/key.pub').text
     keys_param = new org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl(sshKeyString)
-    u.addProperty(keys_param)
+    user.addProperty(keys_param)
     def inst = Jenkins.getInstance()
     def sshDesc = inst.getDescriptor("org.jenkinsci.main.modules.sshd.SSHD")
     sshDesc.setPort({{ .Values.master.sidecars.configAutoReload.sshTcpPort | default 1044 }})


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

#### What this PR does / why we need it:

Print an error message when `master.sidecars.configAutoReload.enabled` is `true`, but the admin user which is needed to configure the SSH key does not exist.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

`User.get("username", false)` => `false` indicates that the user should not be created if it does not exist.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
