### PR TITLE
[stable/velero] Fix Restic DaemonSet template syntax

### DIFF
--- a/stable/velero/Chart.yaml
+++ b/stable/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.1.0
 description: A Helm chart for velero
 name: velero
-version: 2.1.5
+version: 2.1.6
 home: https://github.com/heptio/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/stable/velero/templates/restic-daemonset.yaml
+++ b/stable/velero/templates/restic-daemonset.yaml
@@ -78,13 +78,13 @@ spec:
             - name: VELERO_SCRATCH_DIR
               value: /scratch
             {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp")) }}
-              {{- if eq $provider "aws" }}
-              - name: AWS_SHARED_CREDENTIALS_FILE
-                value: /credentials/cloud
-              {{- else }}
-              - name: GOOGLE_APPLICATION_CREDENTIALS
-                value: /credentials/cloud
-              {{- end }}
+            {{- if eq $provider "aws" }}
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              value: /credentials/cloud
+            {{- else }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /credentials/cloud
+            {{- end }}
             {{- end }}
             {{- if eq $provider "minio" }}
             - name: AWS_SHARED_CREDENTIALS_FILE


### PR DESCRIPTION
#### What this PR does / why we need it:

Using Restic is currently not possible:
```
YAML parse error on velero/templates/restic-daemonset.yaml: error converting YAML to JSON: yaml: line 62: did not find expected key
```

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
