### PR TITLE
[stable/rabbitmq-ha] Update entrypoint and args to support always setting erlang cookie

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.15
-version: 1.32.0
+version: 1.33.0
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -83,6 +83,16 @@ spec:
         - name: {{ .Chart.Name }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+                set -x &&
+                echo $RABBITMQ_ERLANG_COOKIE > /var/lib/rabbitmq/.erlang.cookie &&
+                chown rabbitmq:rabbitmq /var/lib/rabbitmq/.erlang.cookie &&
+                chmod 600 /var/lib/rabbitmq/.erlang.cookie &&
+                docker-entrypoint.sh rabbitmq-server
           ports:
             - name: epmd
               protocol: TCP


### PR DESCRIPTION
#### What this PR does / why we need it:
So we've been having a sporadic issue on our infrastructure where for reasons we don't fully understand yet the erlang cookie can change. Looking at the code the cookie is only set once at first start. What I've done is add some shell script in before the entrypoint which essentially forcibly sets the erlang cookie to what the environmental variable is.

I did initially investigate mounting the configmap directly but had little success.

#### Special notes for your reviewer:

I understand that this is a slightly hacky approach to achieving this goal but right now anyway I'm struggling to think of a better strategy. I'm open to other ideas, and naturally we do need to get to the bottom of the problem our end where rabbitmq can even crash in such a way that it loses (or changes) its erlang cookie.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
