### PR TITLE
[stable/sentry] Bump dependencies and allow dependency naming

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 3.0.3
+version: 3.1.0
 appVersion: 9.1.2
 keywords:
   - debugging

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -122,11 +122,11 @@ Parameter                                            | Description              
 `ingress.path`                                       | path to address your Sentry installation                                                                   | `/`
 `ingress.tls`                                        | Ingress TLS configuration                                                                                  | `[]`
 `postgresql.enabled`                                 | Deploy postgres server (see below)                                                                         | `true`
-`postgresql.postgresDatabase`                        | Postgres database name                                                                                     | `sentry`
-`postgresql.postgresUser`                            | Postgres username                                                                                          | `sentry`
-`postgresql.postgresHost`                            | External postgres host                                                                                     | `nil`
-`postgresql.postgresPassword`                        | External postgres password                                                                                 | `nil`
-`postgresql.postgresPort`                            | External postgres port                                                                                     | `5432`
+`postgresql.postgresqlDatabase`                      | Postgres database name                                                                                     | `sentry`
+`postgresql.postgresqlUsername`                      | Postgres username                                                                                          | `postgres`
+`postgresql.postgresqlHost`                          | External postgres host                                                                                     | `nil`
+`postgresql.postgresqlPassword`                      | External postgres password                                                                                 | `nil`
+`postgresql.postgresqlPort`                          | External postgres port                                                                                     | `5432`
 `redis.enabled`                                      | Deploy redis server (see below)                                                                            | `true`
 `redis.host`                                         | External redis host                                                                                        | `nil`
 `redis.password`                                     | External redis password                                                                                    | `nil`
@@ -188,7 +188,7 @@ $ helm install --name my-release -f values.yaml stable/sentry
 
 ## PostgresSQL
 
-By default, PostgreSQL is installed as part of the chart. To use an external PostgreSQL server set `postgresql.enabled` to `false` and then set `postgresql.postgresHost` and `postgresql.postgresPassword`. The other options (`postgresql.postgresDatabase`, `postgresql.postgresUser` and `postgresql.postgresPort`) may also want changing from their default values.
+By default, PostgreSQL is installed as part of the chart. To use an external PostgreSQL server set `postgresql.enabled` to `false` and then set `postgresql.postgresHost` and `postgresql.postgresqlPassword`. The other options (`postgresql.postgresqlDatabase`, `postgresql.postgresqlUsername` and `postgresql.postgresqlPort`) may also want changing from their default values.
 
 ## Redis
 

--- a/stable/sentry/requirements.lock
+++ b/stable/sentry/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.18.0
+  version: 6.5.0
 - name: redis
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 3.8.1

--- a/stable/sentry/requirements.lock
+++ b/stable/sentry/requirements.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 6.5.0
 - name: redis
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 3.8.1
-digest: sha256:2e645b00617ba18fb9c6b03eb0b1a7b6c1c0b6272f654fc455ef623faeeba0df
-generated: 2019-01-30T14:20:03.270355538+01:00
+  version: 9.3.2
+digest: sha256:ec1c090ef960c117f69fb79617eacfa01ee787312a5f00a1d5a3bfe97ae00ef6
+generated: "2019-10-20T12:47:31.239466+01:00"

--- a/stable/sentry/requirements.yaml
+++ b/stable/sentry/requirements.yaml
@@ -4,6 +4,6 @@ dependencies:
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: postgresql.enabled
   - name: redis
-    version: 3.8.1
+    version: 9.3.2
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: redis.enabled

--- a/stable/sentry/requirements.yaml
+++ b/stable/sentry/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: postgresql
-    version: 0.18.0
+    version: 6.5.0
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: postgresql.enabled
   - name: redis

--- a/stable/sentry/templates/_helpers.tpl
+++ b/stable/sentry/templates/_helpers.tpl
@@ -29,13 +29,31 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "sentry.postgresql.fullname" -}}
-{{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.postgresql.fullnameOverride -}}
+{{- .Values.postgresql.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.postgresql.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name "sentry-postgresql" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 {{- define "sentry.redis.fullname" -}}
-{{- printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.redis.fullnameOverride -}}
+{{- .Values.redis.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.redis.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name "sentry-redis" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 {{- define "sentry.smtp.fullname" -}}
-{{- printf "%s-%s" .Release.Name "smtp" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name "sentry-smtp" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/stable/sentry/templates/_helpers.tpl
+++ b/stable/sentry/templates/_helpers.tpl
@@ -45,7 +45,7 @@ Set postgres host
 {{- if .Values.postgresql.enabled -}}
 {{- template "sentry.postgresql.fullname" . -}}
 {{- else -}}
-{{- .Values.postgresql.postgresHost | quote -}}
+{{- .Values.postgresql.postgresqlHost | quote -}}
 {{- end -}}
 {{- end -}}
 
@@ -67,7 +67,7 @@ Set postgres port
 {{- if .Values.postgresql.enabled -}}
     "5432"
 {{- else -}}
-{{- default "5432" .Values.postgresql.postgresPort | quote -}}
+{{- default "5432" .Values.postgresql.postgresqlPort | quote -}}
 {{- end -}}
 {{- end -}}
 

--- a/stable/sentry/templates/cron-deployment.yaml
+++ b/stable/sentry/templates/cron-deployment.yaml
@@ -60,9 +60,9 @@ spec:
               name: {{ template "sentry.fullname" . }}
               key: sentry-secret
         - name: SENTRY_DB_USER
-          value: {{ default "sentry" .Values.postgresql.postgresUser | quote }}
+          value: {{ default "sentry" .Values.postgresql.postgresqlUsername | quote }}
         - name: SENTRY_DB_NAME
-          value: {{ default "sentry" .Values.postgresql.postgresDatabase | quote }}
+          value: {{ default "sentry" .Values.postgresql.postgresqlDatabase | quote }}
         - name: SENTRY_DB_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -71,7 +71,7 @@ spec:
             {{- else }}
               name: {{ template "sentry.postgresql.secret" . }}
             {{- end }}
-              key: postgres-password
+              key: postgresql-password
         - name: SENTRY_POSTGRES_HOST
           value: {{ template "sentry.postgresql.host" . }}
         - name: SENTRY_POSTGRES_PORT

--- a/stable/sentry/templates/hooks/db-init.job.yaml
+++ b/stable/sentry/templates/hooks/db-init.job.yaml
@@ -47,9 +47,9 @@ spec:
               name: {{ template "sentry.fullname" . }}
               key: sentry-secret
         - name: SENTRY_DB_USER
-          value: {{ default "sentry" .Values.postgresql.postgresUser | quote }}
+          value: {{ default "sentry" .Values.postgresql.postgresqlUsername | quote }}
         - name: SENTRY_DB_NAME
-          value: {{ default "sentry" .Values.postgresql.postgresDatabase | quote }}
+          value: {{ default "sentry" .Values.postgresql.postgresqlDatabase | quote }}
         - name: SENTRY_DB_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -58,7 +58,7 @@ spec:
             {{- else }}
               name: {{ template "sentry.postgresql.secret" . }}
             {{- end }}
-              key: postgres-password
+              key: postgresql-password
         - name: SENTRY_POSTGRES_HOST
           value: {{ template "sentry.postgresql.host" . }}
         - name: SENTRY_POSTGRES_PORT

--- a/stable/sentry/templates/hooks/user-create.job.yaml
+++ b/stable/sentry/templates/hooks/user-create.job.yaml
@@ -47,9 +47,9 @@ spec:
               name: {{ template "sentry.fullname" . }}
               key: sentry-secret
         - name: SENTRY_DB_USER
-          value: {{ default "sentry" .Values.postgresql.postgresUser | quote }}
+          value: {{ default "sentry" .Values.postgresql.postgresqlUsername | quote }}
         - name: SENTRY_DB_NAME
-          value: {{ default "sentry" .Values.postgresql.postgresDatabase | quote }}
+          value: {{ default "sentry" .Values.postgresql.postgresqlDatabase | quote }}
         - name: SENTRY_DB_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -58,7 +58,7 @@ spec:
             {{- else }}
               name: {{ template "sentry.postgresql.secret" . }}
             {{- end }}
-              key: postgres-password
+              key: postgresql-password
         - name: SENTRY_POSTGRES_HOST
           value: {{ template "sentry.postgresql.host" . }}
         - name: SENTRY_POSTGRES_PORT

--- a/stable/sentry/templates/secrets.yaml
+++ b/stable/sentry/templates/secrets.yaml
@@ -23,7 +23,7 @@ data:
   user-password: {{ randAlphaNum 16 | b64enc | quote }}
   {{ end }}
   {{ if not .Values.postgresql.enabled }}
-  postgres-password: {{ .Values.postgresql.postgresPassword | default "" | b64enc | quote }}
+  postgresql-password: {{ .Values.postgresql.postgresqlPassword | default "" | b64enc | quote }}
   {{ end }}
   {{ if and (not .Values.redis.enabled) (.Values.redis.password) }}
   redis-password: {{ .Values.redis.password | default "" | b64enc | quote }}

--- a/stable/sentry/templates/web-deployment.yaml
+++ b/stable/sentry/templates/web-deployment.yaml
@@ -59,9 +59,9 @@ spec:
               name: {{ template "sentry.fullname" . }}
               key: sentry-secret
         - name: SENTRY_DB_USER
-          value: {{ default "sentry" .Values.postgresql.postgresUser | quote }}
+          value: {{ default "sentry" .Values.postgresql.postgresqlUsername | quote }}
         - name: SENTRY_DB_NAME
-          value: {{ default "sentry" .Values.postgresql.postgresDatabase | quote }}
+          value: {{ default "sentry" .Values.postgresql.postgresqlDatabase | quote }}
         - name: SENTRY_DB_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -70,7 +70,7 @@ spec:
             {{- else }}
               name: {{ template "sentry.postgresql.secret" . }}
             {{- end }}
-              key: postgres-password
+              key: postgresql-password
         - name: SENTRY_POSTGRES_HOST
           value: {{ template "sentry.postgresql.host" . }}
         - name: SENTRY_POSTGRES_PORT

--- a/stable/sentry/templates/workers-deployment.yaml
+++ b/stable/sentry/templates/workers-deployment.yaml
@@ -69,9 +69,9 @@ spec:
               name: {{ template "sentry.fullname" . }}
               key: sentry-secret
         - name: SENTRY_DB_USER
-          value: {{ default "sentry" .Values.postgresql.postgresUser | quote }}
+          value: {{ default "sentry" .Values.postgresql.postgresqlUsername | quote }}
         - name: SENTRY_DB_NAME
-          value: {{ default "sentry" .Values.postgresql.postgresDatabase | quote }}
+          value: {{ default "sentry" .Values.postgresql.postgresqlDatabase | quote }}
         - name: SENTRY_DB_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -80,7 +80,7 @@ spec:
             {{- else }}
               name: {{ template "sentry.postgresql.secret" . }}
             {{- end }}
-              key: postgres-password
+              key: postgresql-password
         - name: SENTRY_POSTGRES_HOST
           value: {{ template "sentry.postgresql.host" . }}
         - name: SENTRY_POSTGRES_PORT

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -188,6 +188,7 @@ ingress:
 
 postgresql:
   enabled: true
+  nameOverride: sentry-postgresql
   postgresqlDatabase: sentry
   postgresqlUsername: postgres
   # Only used when internal PG is disabled
@@ -197,6 +198,7 @@ postgresql:
 
 redis:
   enabled: true
+  nameOverride: sentry-redis
   # Only used when internal redis is disabled
   # host: redis
   # Just omit the password field if your redis cluster doesn't use password

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -188,15 +188,12 @@ ingress:
 
 postgresql:
   enabled: true
-  postgresDatabase: sentry
-  postgresUser: sentry
+  postgresqlDatabase: sentry
+  postgresqlUsername: postgres
   # Only used when internal PG is disabled
-  # postgresHost: postgres
-  # postgresPassword: postgres
-  # postgresPort: 5432
-  imageTag: "9.6"
-  persistence:
-    enabled: true
+  # postgresqlHost: postgres
+  # postgresqlPassword: postgres
+  # postgresqlPort: 5432
 
 redis:
   enabled: true


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:

These charts have been updated a lot, since we've introduced
these dependencies.

It mainly introduces new version of Postgres and doesn't seem to break
the general functionality. It does introduce some template changes and
fixes a single problem, where policy has an empty value and causes
kubernetes to fall out in persistant volume claim.

```yaml
  annotations:
    "helm.sh/resource-policy":
```

We can also benefit from not having Persistent Volumes.

Whilst being here, it would be nice to bump redis too.

On separate note:

It may be a case, when a user would like to install two different
instances of postgres or redis in the same namespace with a single
release. This would cause one of the instances being overwritten by the
other and lead to unwanted behaviour.

Adding this support and prefixing sentry's dependencies, may solve that
problem, and doesn't really strike as a bad practice.

#### Special notes for your reviewer:

Only briefly tested.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
