### PR TITLE
[stable/nginx-ingress] Add substitution for containerPorts from values

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.19.1
+version: 1.19.2
 appVersion: 0.25.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.19.2
+version: 1.20.0
 appVersion: 0.25.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -1,5 +1,6 @@
 {{- if or (eq .Values.controller.kind "DaemonSet") (eq .Values.controller.kind "Both") }}
 {{- $useHostPort := .Values.controller.daemonset.useHostPort -}}
+{{- $hostPorts := .Values.controller.daemonset.hostPorts -}}
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -120,18 +121,14 @@ spec:
             successThreshold: {{ .Values.controller.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.controller.livenessProbe.failureThreshold }}
           ports:
-            - name: http
-              containerPort: {{ .Values.controller.containerPort.http }}
+          {{- range $key, $value := .Values.controller.containerPort }}
+            - name: {{ $key }}
+              containerPort: {{ $value }}
               protocol: TCP
-              {{- if .Values.controller.daemonset.useHostPort }}
-              hostPort: {{ .Values.controller.daemonset.hostPorts.http }}
+              {{- if $useHostPort }}
+              hostPort: {{ index $hostPorts $key | default $value }}
               {{- end }}
-            - name: https
-              containerPort: {{ .Values.controller.containerPort.https }}
-              protocol: TCP
-              {{- if .Values.controller.daemonset.useHostPort }}
-              hostPort: {{ .Values.controller.daemonset.hostPorts.https }}
-              {{- end }}
+          {{- end }}    
           {{- if .Values.controller.metrics.enabled }}
             - name: metrics
               containerPort: 10254

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -120,12 +120,11 @@ spec:
             successThreshold: {{ .Values.controller.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.controller.livenessProbe.failureThreshold }}
           ports:
-            - name: http
-              containerPort: {{ .Values.controller.containerPort.http }}
+          {{- range $key, $value := .Values.controller.containerPort }}
+            - name: {{ $key }}
+              containerPort: {{ $value }}
               protocol: TCP
-            - name: https
-              containerPort: {{ .Values.controller.containerPort.https }}
-              protocol: TCP
+          {{- end }} 
           {{- if .Values.controller.metrics.enabled }}
             - name: metrics
               containerPort: 10254

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -15,6 +15,7 @@ controller:
   containerPort:
     http: 80
     https: 443
+
   # Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
   config: {}
 


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Use key-value range from .Values.controller.containerPort definition instead of mapping 1to1 http and https ports.

It allows passing extra configuration to nginx-ingress, such as validation-webhook with its own port, and define this port in values.
Without this option it’s not possible because of hardcoded http and https ports in deployment/daemonset templates.

Does not break anything.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
