### PR TITLE
[stable/prometheus-operator] walCompression of wrong type

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -10,7 +10,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 6.9.2
+version: 6.9.3
 appVersion: 0.32.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/templates/prometheus-operator/crd-prometheus.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/crd-prometheus.yaml
@@ -2440,7 +2440,7 @@ spec:
               type: string
             walCompression:
               description: Enable compression of the write-ahead log using Snappy.
-              type: bool
+              type: boolean
             routePrefix:
               description: The route prefix Prometheus registers HTTP handlers for.
                 This is useful, if using ExternalURL and a proxy is rewriting HTTP

--- a/stable/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/stable/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -71,7 +71,7 @@ spec:
   retentionSize: {{ .Values.prometheus.prometheusSpec.retentionSize | quote }}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.walCompression }}
-  walCompression: {{ .Values.prometheus.prometheusSpec.walCompression | quote }}
+  walCompression: {{ .Values.prometheus.prometheusSpec.walCompression }}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.routePrefix }}
   routePrefix: {{ .Values.prometheus.prometheusSpec.routePrefix | quote  }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix `walCompression` type.

#### Which issue this PR fixes
  - fixes #17043

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
