### PR TITLE
[stable/atlantis] Fix typo on `values.yml` for `environmentSecrets`

### DIFF
--- a/stable/atlantis/Chart.yaml
+++ b/stable/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.8.2"
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 3.8.1
+version: 3.8.2
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/stable/atlantis/values.yaml
+++ b/stable/atlantis/values.yaml
@@ -202,7 +202,7 @@ environmentSecrets: []
 #   - name: THE_ENV_VAR
 #     secretKeyRef:
 #       name: the_k8s_secret_name
-#       value: the_key_of_the_value_in_the_secret
+#       key: the_key_of_the_value_in_the_secret
 
 # Optionally specify google service account credentials as Kubernetes secrets. If you are using the terraform google provider you can specify the credentials as "${file("/var/secrets/some-secret-name/key.json")}".
 googleServiceAccountSecrets: []


### PR DESCRIPTION
* should be `key` and not `value` in `stable/atlantis/values.yaml`
* per `.secretKeyRef.key` references in `stable/atlantis/templates/statefulset.yaml`

Signed-off-by: Eddie Ramirez <eddieramirez@me.com>

#### What this PR does / why we need it:

- fixes documentaiton

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)