### PR TITLE
[stable/mongodb] Use persistence.existingClaim when running in StatefulSet

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 7.2.8
+version: 7.2.9
 appVersion: 4.0.12
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/templates/statefulset-primary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-primary-rs.yaml
@@ -68,7 +68,8 @@ spec:
       {{- if .Values.extraInitContainers }}
 {{ tpl .Values.extraInitContainers . | indent 6}}
       {{- end }}
-      {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
+      {{- $needsVolumePermissions := and .Values.volumePermissions.enabled (and ( and .Values.peristence.enabled (not .Values.persistence.existingClaim) ) .Values.securityContext.enabled) }}
+      {{- if $needsVolumePermissions }}
       - name: volume-permissions
         image: {{ template "mongodb.volumePermissions.image" . }}
         imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
@@ -265,7 +266,17 @@ spec:
           configMap:
             name: {{ template "mongodb.fullname" . }}
         {{- end }}
-{{- if .Values.persistence.enabled }}
+        {{- if not .Values.persisntence.enabled }}
+        - name: datadir
+          emptyDir: {}
+        {{- else }}
+        {{- if .Values.persistence.existingClaim }}
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim }}
+        {{- end }}
+        {{- end }}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
   volumeClaimTemplates:
     - metadata:
         name: datadir

--- a/stable/mongodb/templates/statefulset-primary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-primary-rs.yaml
@@ -293,8 +293,5 @@ spec:
           requests:
             storage: {{ .Values.persistence.size | quote }}
         {{ include "mongodb.storageClass" . }}
-{{- else }}
-        - name: datadir
-          emptyDir: {}
 {{- end }}
 {{- end }}

--- a/stable/mongodb/templates/statefulset-primary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-primary-rs.yaml
@@ -68,7 +68,7 @@ spec:
       {{- if .Values.extraInitContainers }}
 {{ tpl .Values.extraInitContainers . | indent 6}}
       {{- end }}
-      {{- $needsVolumePermissions := and .Values.volumePermissions.enabled (and ( and .Values.peristence.enabled (not .Values.persistence.existingClaim) ) .Values.securityContext.enabled) }}
+      {{- $needsVolumePermissions := and .Values.volumePermissions.enabled (and ( and .Values.persistence.enabled (not .Values.persistence.existingClaim) ) .Values.securityContext.enabled) }}
       {{- if $needsVolumePermissions }}
       - name: volume-permissions
         image: {{ template "mongodb.volumePermissions.image" . }}
@@ -266,7 +266,7 @@ spec:
           configMap:
             name: {{ template "mongodb.fullname" . }}
         {{- end }}
-        {{- if not .Values.persisntence.enabled }}
+        {{- if not .Values.persistence.enabled }}
         - name: datadir
           emptyDir: {}
         {{- else }}


### PR DESCRIPTION
This PR updates stable/mongodb StatefulSet definition to support `persistence.existingClaim` settings, analogous to stable/redis.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
