### PR TITLE
[stable/airflow] Quote command line parameters in create connection script

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 4.0.7
+version: 4.0.8
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/templates/secret-connections.yaml
+++ b/stable/airflow/templates/secret-connections.yaml
@@ -1,12 +1,12 @@
 {{- define "connections.script" }}
   #!/bin/sh -e
   {{- range .Values.airflow.connections }}
-  airflow connections --add --conn_type {{ .type }} --conn_id {{ .id }} 
+  airflow connections --add --conn_type {{ .type }} --conn_id {{ .id }}
   {{- if .uri }} --conn_uri {{ .uri | quote }} {{ end -}}
-  {{- if .host }} --conn_host {{ .host }} {{ end -}}
-  {{- if .login }} --conn_login {{ .login }} {{ end -}}
-  {{- if .password }} --conn_password {{ .password }} {{ end -}}
-  {{- if .schema }} --conn_schema {{ .schema }} {{ end -}}
+  {{- if .host }} --conn_host {{ .host | quote }} {{ end -}}
+  {{- if .login }} --conn_login {{ .login | quote }} {{ end -}}
+  {{- if .password }} --conn_password {{ .password | quote }} {{ end -}}
+  {{- if .schema }} --conn_schema {{ .schema | quote }} {{ end -}}
   {{- if .port }} --conn_port {{ .port }} {{ end -}}
   {{- if .extra }} --conn_extra {{ .extra | quote }} {{ end -}}
   {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
In some cases when we create Airflow connection on Pod start we would like to pass parameters that contain special characters and we need to quote them. I quoted all string parameters to make this script more universal.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
