### PR TITLE
[stable/grafana] Support statefulset as persistence option

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 3.8.11
+version: 3.8.12
 appVersion: 6.3.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -61,6 +61,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `extraContainers`                         | Sidecar containers to add to the grafana pod  | `{}` |
 | `schedulerName`                           | Name of the k8s scheduler (other than default) | `nil`                                                  |
 | `persistence.enabled`                     | Use persistent volume to store data           | `false`                                                 |
+| `persistence.type`                        | Type of persistence (`pvc` or `statefulset`)  | `false`                                                 |
 | `persistence.size`                        | Size of persistent volume claim               | `10Gi`                                                  |
 | `persistence.existingClaim`               | Use an existing PVC to persist data           | `nil`                                                   |
 | `persistence.storageClassName`            | Type of persistent volume claim               | `nil`                                                   |

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -38,7 +38,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `securityContext`                         | Deployment securityContext                    | `{"runAsUser": 472, "fsGroup": 472}`                    |
 | `priorityClassName`                       | Name of Priority Class to assign pods         | `nil`                                                   |
 | `image.repository`                        | Image repository                              | `grafana/grafana`                                       |
-| `image.tag`                               | Image tag (`Must be >= 5.0.0`)                | `6.3.4`                                                 |
+| `image.tag`                               | Image tag (`Must be >= 5.0.0`)                | `6.3.5`                                                 |
 | `image.pullPolicy`                        | Image pull policy                             | `IfNotPresent`                                          |
 | `image.pullSecrets`                       | Image pull secrets                            | `{}`                                                    |
 | `service.type`                            | Kubernetes service type                       | `ClusterIP`                                             |

--- a/stable/grafana/templates/_pod.tpl
+++ b/stable/grafana/templates/_pod.tpl
@@ -1,0 +1,355 @@
+{{- define "grafana.pod" -}}
+{{- if .Values.schedulerName }}
+schedulerName: "{{ .Values.schedulerName }}"
+{{- end }}
+serviceAccountName: {{ template "grafana.serviceAccountName" . }}
+{{- if .Values.schedulerName }}
+schedulerName: "{{ .Values.schedulerName }}"
+{{- end }}
+{{- if .Values.securityContext }}
+securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+{{- end }}
+{{- if .Values.priorityClassName }}
+priorityClassName: {{ .Values.priorityClassName }}
+{{- end }}
+{{- if ( or .Values.persistence.enabled .Values.dashboards .Values.sidecar.datasources.enabled .Values.extraInitContainers) }}
+initContainers:
+{{- end }}
+{{- if ( and .Values.persistence.enabled .Values.initChownData.enabled ) }}
+  - name: init-chown-data
+    image: "{{ .Values.initChownData.image.repository }}:{{ .Values.initChownData.image.tag }}"
+    imagePullPolicy: {{ .Values.initChownData.image.pullPolicy }}
+    securityContext:
+      runAsUser: 0
+    command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsUser }}", "/var/lib/grafana"]
+    resources:
+{{ toYaml .Values.initChownData.resources | indent 12 }}
+    volumeMounts:
+      - name: storage
+        mountPath: "/var/lib/grafana"
+{{- if .Values.persistence.subPath }}
+        subPath: {{ .Values.persistence.subPath }}
+{{- end }}
+{{- end }}
+{{- if .Values.dashboards }}
+  - name: download-dashboards
+    image: "{{ .Values.downloadDashboardsImage.repository }}:{{ .Values.downloadDashboardsImage.tag }}"
+    imagePullPolicy: {{ .Values.downloadDashboardsImage.pullPolicy }}
+    command: ["/bin/sh"]
+    args: [ "-c", "mkdir -p /var/lib/grafana/dashboards/default && /bin/sh /etc/grafana/download_dashboards.sh" ]
+    env:
+{{- range $key, $value := .Values.downloadDashboards.env }}
+      - name: "{{ $key }}"
+        value: "{{ $value }}"
+{{- end }}
+    volumeMounts:
+      - name: config
+        mountPath: "/etc/grafana/download_dashboards.sh"
+        subPath: download_dashboards.sh
+      - name: storage
+        mountPath: "/var/lib/grafana"
+{{- if .Values.persistence.subPath }}
+        subPath: {{ .Values.persistence.subPath }}
+{{- end }}
+    {{- range .Values.extraSecretMounts }}
+      - name: {{ .name }}
+        mountPath: {{ .mountPath }}
+        readOnly: {{ .readOnly }}
+    {{- end }}
+{{- end }}
+{{- if .Values.sidecar.datasources.enabled }}
+  - name: {{ template "grafana.name" . }}-sc-datasources
+    image: "{{ .Values.sidecar.image }}"
+    imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+    env:
+      - name: METHOD
+        value: LIST
+      - name: LABEL
+        value: "{{ .Values.sidecar.datasources.label }}"
+      - name: FOLDER
+        value: "/etc/grafana/provisioning/datasources"
+      - name: RESOURCE
+        value: "both"
+      {{- if .Values.sidecar.datasources.searchNamespace }}
+      - name: NAMESPACE
+        value: "{{ .Values.sidecar.datasources.searchNamespace }}"
+      {{- end }}
+      {{- if .Values.sidecar.skipTlsVerify }}
+      - name: SKIP_TLS_VERIFY
+        value: "{{ .Values.sidecar.skipTlsVerify }}"
+      {{- end }}
+    resources:
+{{ toYaml .Values.sidecar.resources | indent 12 }}
+    volumeMounts:
+      - name: sc-datasources-volume
+        mountPath: "/etc/grafana/provisioning/datasources"
+{{- end}}
+{{- if .Values.extraInitContainers }}
+{{ toYaml .Values.extraInitContainers | indent 8 }}
+{{- end }}
+{{- if .Values.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+{{- end}}
+{{- end }}
+containers:
+{{- if .Values.sidecar.dashboards.enabled }}
+  - name: {{ template "grafana.name" . }}-sc-dashboard
+    image: "{{ .Values.sidecar.image }}"
+    imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+    env:
+      - name: LABEL
+        value: "{{ .Values.sidecar.dashboards.label }}"
+      - name: FOLDER
+        value: "{{ .Values.sidecar.dashboards.folder }}{{- with .Values.sidecar.dashboards.defaultFolderName }}/{{ . }}{{- end }}"
+      - name: RESOURCE
+        value: "both"
+      {{- if .Values.sidecar.dashboards.searchNamespace }}
+      - name: NAMESPACE
+        value: "{{ .Values.sidecar.dashboards.searchNamespace }}"
+      {{- end }}
+      {{- if .Values.sidecar.skipTlsVerify }}
+      - name: SKIP_TLS_VERIFY
+        value: "{{ .Values.sidecar.skipTlsVerify }}"
+      {{- end }}
+    resources:
+{{ toYaml .Values.sidecar.resources | indent 12 }}
+    volumeMounts:
+      - name: sc-dashboard-volume
+        mountPath: {{ .Values.sidecar.dashboards.folder | quote }}
+{{- end}}
+  - name: {{ .Chart.Name }}
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+    imagePullPolicy: {{ .Values.image.pullPolicy }}
+  {{- if .Values.command }}
+    command:
+    {{- range .Values.command }}
+      - {{ . }}
+    {{- end }}
+  {{- end}}
+    volumeMounts:
+      - name: config
+        mountPath: "/etc/grafana/grafana.ini"
+        subPath: grafana.ini
+      {{- if not .Values.admin.existingSecret }}
+      - name: ldap
+        mountPath: "/etc/grafana/ldap.toml"
+        subPath: ldap.toml
+      {{- end }}
+      {{- range .Values.extraConfigmapMounts }}
+      - name: {{ .name }}
+        mountPath: {{ .mountPath }}
+        subPath: {{ .subPath | default "" }}
+        readOnly: {{ .readOnly }}
+      {{- end }}
+      - name: storage
+        mountPath: "/var/lib/grafana"
+{{- if .Values.persistence.subPath }}
+        subPath: {{ .Values.persistence.subPath }}
+{{- end }}
+{{- if .Values.dashboards }}
+{{- range $provider, $dashboards := .Values.dashboards }}
+{{- range $key, $value := $dashboards }}
+{{- if (or (hasKey $value "json") (hasKey $value "file")) }}
+      - name: dashboards-{{ $provider }}
+        mountPath: "/var/lib/grafana/dashboards/{{ $provider }}/{{ $key }}.json"
+        subPath: "{{ $key }}.json"
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}
+{{- if .Values.dashboardsConfigMaps }}
+{{- range keys .Values.dashboardsConfigMaps }}
+      - name: dashboards-{{ . }}
+        mountPath: "/var/lib/grafana/dashboards/{{ . }}"
+{{- end }}
+{{- end }}
+{{- if .Values.datasources }}
+      - name: config
+        mountPath: "/etc/grafana/provisioning/datasources/datasources.yaml"
+        subPath: datasources.yaml
+{{- end }}
+{{- if .Values.notifiers }}
+      - name: config
+        mountPath: "/etc/grafana/provisioning/notifiers/notifiers.yaml"
+        subPath: notifiers.yaml
+{{- end }}
+{{- if .Values.dashboardProviders }}
+      - name: config
+        mountPath: "/etc/grafana/provisioning/dashboards/dashboardproviders.yaml"
+        subPath: dashboardproviders.yaml
+{{- end }}
+{{- if .Values.sidecar.dashboards.enabled }}
+      - name: sc-dashboard-volume
+        mountPath: {{ .Values.sidecar.dashboards.folder | quote }}
+      - name: sc-dashboard-provider
+        mountPath: "/etc/grafana/provisioning/dashboards/sc-dashboardproviders.yaml"
+        subPath: provider.yaml
+{{- end}}
+{{- if .Values.sidecar.datasources.enabled }}
+      - name: sc-datasources-volume
+        mountPath: "/etc/grafana/provisioning/datasources"
+{{- end}}
+    {{- range .Values.extraSecretMounts }}
+      - name: {{ .name }}
+        mountPath: {{ .mountPath }}
+        readOnly: {{ .readOnly }}
+    {{- end }}
+    {{- range .Values.extraVolumeMounts }}
+      - name: {{ .name }}
+        mountPath: {{ .mountPath }}
+        subPath: {{ .subPath | default "" }}
+        readOnly: {{ .readOnly }}
+    {{- end }}
+    {{- range .Values.extraEmptyDirMounts }}
+      - name: {{ .name }}
+        mountPath: {{ .mountPath }}
+    {{- end }}
+    ports:
+      - name: service
+        containerPort: {{ .Values.service.port }}
+        protocol: TCP
+      - name: grafana
+        containerPort: 3000
+        protocol: TCP
+    env:
+      {{- if not .Values.env.GF_SECURITY_ADMIN_USER }}
+      - name: GF_SECURITY_ADMIN_USER
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Values.admin.existingSecret | default (include "grafana.fullname" .) }}
+            key: {{ .Values.admin.userKey | default "admin-user" }}
+      {{- end }}
+      {{- if not .Values.env.GF_SECURITY_ADMIN_PASSWORD }}
+      - name: GF_SECURITY_ADMIN_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Values.admin.existingSecret | default (include "grafana.fullname" .) }}
+            key: {{ .Values.admin.passwordKey | default "admin-password" }}
+      {{- end }}
+      {{- if .Values.plugins }}
+      - name: GF_INSTALL_PLUGINS
+        valueFrom:
+          configMapKeyRef:
+            name: {{ template "grafana.fullname" . }}
+            key: plugins
+      {{- end }}
+      {{- if .Values.smtp.existingSecret }}
+      - name: GF_SMTP_USER
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Values.smtp.existingSecret }}
+            key: {{ .Values.smtp.userKey | default "user" }}
+      - name: GF_SMTP_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Values.smtp.existingSecret }}
+            key: {{ .Values.smtp.passwordKey | default "password" }}
+      {{- end }}
+{{- range $key, $value := .Values.env }}
+      - name: "{{ $key }}"
+        value: "{{ $value }}"
+{{- end }}
+    {{- if .Values.envFromSecret }}
+    envFrom:
+      - secretRef:
+          name: {{ .Values.envFromSecret }}
+    {{- end }}
+    livenessProbe:
+{{ toYaml .Values.livenessProbe | indent 12 }}
+    readinessProbe:
+{{ toYaml .Values.readinessProbe | indent 12 }}
+    resources:
+{{ toYaml .Values.resources | indent 12 }}
+{{- if .Values.extraContainers }}
+{{ toYaml .Values.extraContainers | indent 8}}
+{{- end }}
+{{- with .Values.nodeSelector }}
+nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+volumes:
+  - name: config
+    configMap:
+      name: {{ template "grafana.fullname" . }}
+{{- range .Values.extraConfigmapMounts }}
+  - name: {{ .name }}
+    configMap:
+      name: {{ .configMap }}
+{{- end }}
+  {{- if .Values.dashboards }}
+    {{- range keys .Values.dashboards }}
+  - name: dashboards-{{ . }}
+    configMap:
+      name: {{ template "grafana.fullname" $ }}-dashboards-{{ . }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.dashboardsConfigMaps }}
+    {{ $root := . }}
+    {{- range $provider, $name := .Values.dashboardsConfigMaps }}
+  - name: dashboards-{{ $provider }}
+    configMap:
+      name: {{ tpl $name $root }}
+    {{- end }}
+  {{- end }}
+  {{- if not .Values.admin.existingSecret }}
+  - name: ldap
+    secret:
+      {{- if .Values.ldap.existingSecret }}
+      secretName: {{ .Values.ldap.existingSecret }}
+      {{- else }}
+      secretName: {{ template "grafana.fullname" . }}
+      {{- end }}
+      items:
+        - key: ldap-toml
+          path: ldap.toml
+  {{- end }}
+{{- if and .Values.persistence.enabled (eq .Values.persistence.type "pvc") }}
+  - name: storage
+    persistentVolumeClaim:
+      claimName: {{ .Values.persistence.existingClaim | default (include "grafana.fullname" .) }}
+{{- else if and .Values.persistence.enabled (eq .Values.persistence.type "statefulset") }}
+# nothing
+{{- else }}
+  - name: storage
+    emptyDir: {}
+{{- end -}}
+{{- if .Values.sidecar.dashboards.enabled }}
+  - name: sc-dashboard-volume
+    emptyDir: {}
+{{- if .Values.sidecar.dashboards.enabled }}
+  - name: sc-dashboard-provider
+    configMap:
+      name: {{ template "grafana.fullname" . }}-config-dashboards
+{{- end }}
+{{- end }}
+{{- if .Values.sidecar.datasources.enabled }}
+  - name: sc-datasources-volume
+    emptyDir: {}
+{{- end -}}
+{{- range .Values.extraSecretMounts }}
+  - name: {{ .name }}
+    secret:
+      secretName: {{ .secretName }}
+      defaultMode: {{ .defaultMode }}
+{{- end }}
+{{- range .Values.extraVolumeMounts }}
+  - name: {{ .name }}
+    persistentVolumeClaim:
+      claimName: {{ .existingClaim }}
+{{- end }}
+{{- range .Values.extraEmptyDirMounts }}
+  - name: {{ .name }}
+    emptyDir: {}
+{{- end -}}
+{{- end }}

--- a/stable/grafana/templates/pvc.yaml
+++ b/stable/grafana/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.persistence.type "pvc")}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/stable/grafana/templates/statefulset.yaml
+++ b/stable/grafana/templates/statefulset.yaml
@@ -38,7 +38,7 @@ spec:
       {{- include "grafana.pod" . | nindent 6 }}
   volumeClaimTemplates:
   - metadata:
-    name: storage
+      name: storage
     spec:
       accessModes: {{ .Values.persistence.accessModes }}
       storageClassName: {{ .Values.persistence.storageClassName }}

--- a/stable/grafana/templates/statefulset.yaml
+++ b/stable/grafana/templates/statefulset.yaml
@@ -1,6 +1,6 @@
-{{ if (or (not .Values.persistence.enabled) (eq .Values.persistence.type "pvc")) }}
-apiVersion: apps/v1beta2
-kind: Deployment
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.persistence.type "statefulset")}}
+apiVersion: apps/v1
+kind: StatefulSet
 metadata:
   name: {{ template "grafana.fullname" . }}
   namespace: {{ .Release.Namespace }}
@@ -9,9 +9,6 @@ metadata:
     chart: {{ template "grafana.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- if .Values.labels }}
-{{ toYaml .Values.labels | indent 4 }}
-{{- end }}
 {{- with .Values.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
@@ -22,10 +19,6 @@ spec:
     matchLabels:
       app: {{ template "grafana.name" . }}
       release: {{ .Release.Name }}
-{{- with .Values.deploymentStrategy }}
-  strategy:
-{{ toYaml . | trim | indent 4 }}
-{{- end }}
   template:
     metadata:
       labels:
@@ -43,4 +36,13 @@ spec:
 {{- end }}
     spec:
       {{- include "grafana.pod" . | nindent 6 }}
+  volumeClaimTemplates:
+  - metadata:
+    name: storage
+    spec:
+      accessModes: {{ .Values.persistence.accessModes }}
+      storageClassName: {{ .Values.persistence.storageClassName }}
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size }} 
 {{- end }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -171,6 +171,7 @@ extraContainers: |
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##
 persistence:
+  type: pvc # pvc or statefulset
   enabled: false
   # storageClassName: default
   accessModes:

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -171,7 +171,7 @@ extraContainers: |
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##
 persistence:
-  type: pvc # pvc or statefulset
+  type: pvc
   enabled: false
   # storageClassName: default
   accessModes:


### PR DESCRIPTION
#### Is this a new chart
no

#### What this PR does / why we need it:
You will lose your snapshots and dashboards in case of accidentally deleted PVC (e.g. helm --purge) except if you use an external database. 
An external database is not an option for lot of applications so I propose to use statefulset as option guarantees nothing happens with PV with data. 

#### Special notes for your reviewer:
no

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)

#### Reviewers
@zanhsieh @rtluckie @maorfr