### PR TITLE
[stable/etcd-operator] Fix Tolerations to be a list

### DIFF
--- a/stable/etcd-operator/Chart.yaml
+++ b/stable/etcd-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: CoreOS etcd-operator Helm chart for Kubernetes
 name: etcd-operator
-version: 0.9.0
+version: 0.9.1
 appVersion: 0.9.4
 home: https://github.com/coreos/etcd-operator
 icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png

--- a/stable/etcd-operator/values.yaml
+++ b/stable/etcd-operator/values.yaml
@@ -91,7 +91,7 @@ backupOperator:
   ## e.g., analytics: true
   commandArgs: {}
   securityContext: {}
-  tolerations: {}
+  tolerations: []
 
 # restore spec
 restoreOperator:
@@ -118,7 +118,7 @@ restoreOperator:
   ## e.g., analytics: true
   commandArgs: {}
   securityContext: {}
-  tolerations: {}
+  tolerations: []
 
 ## etcd-cluster specific values
 etcdCluster:
@@ -154,4 +154,4 @@ etcdCluster:
     ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
     nodeSelector: {}
     securityContext: {}
-    tolerations: {}
+    tolerations: []


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix regression introduced in https://github.com/helm/charts/pull/16085

Tolerations  (https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
 should be a `[]`, not `{}`.

#### Error log from etcd-operator:
```
E0911 13:06:03.699355       1 reflector.go:134] github.com/coreos/etcd-operator/pkg/controller/informer.go:78: Failed to list *v1beta2.EtcdCluster: v1beta2.EtcdClusterList.Items: []v1beta2.EtcdCluster: v1beta2.EtcdCluster.Spec: v1beta2.ClusterSpec.Pod: v1beta2.PodPolicy.Tolerations: []v1.Toleration: decode slice: expect [ or n, but found {, error found in #10 byte of ...|rations":{}},"size":|..., bigger context ...|ry":"128Mi"}},"securityContext":{},"tolerations":{}},"size":3,"version":"3.2.25"}}],"kind":"EtcdClus|...
```