### PR TITLE
[stable/dex] Support frontend config values

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 2.2.0
+version: 2.3.0
 appVersion: 2.18.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/README.md
+++ b/stable/dex/README.md
@@ -67,6 +67,7 @@ Parameters introduced starting from v2
 | `certs.web.pod.annotations` | Annotations for the pod created by the `web-certs` job | `{}` |
 | `config.connectors` | Maps to the dex config `connectors` dict param | `{}` |
 | `config.enablePasswordDB` | Maps to the dex config `enablePasswordDB` param | `true` |
+| `config.frontend` | Maps to the dex config `frontend` dict param | `""` |
 | `config.grpc.address` | dex grpc listen address | `127.0.0.1` |
 | `config.grpc.tlsCert` | Maps to the dex config `grpc.tlsCert` param | `/etc/dex/tls/grpc/server/tls.crt` |
 | `config.grpc.tlsClientCA` | Maps to the dex config `grpc.tlsClientCA` param | `/etc/dex/tls/grpc/ca/tls.crt` |

--- a/stable/dex/templates/secret.yaml
+++ b/stable/dex/templates/secret.yaml
@@ -41,4 +41,7 @@ stringData:
     staticPasswords:
 {{ toYaml .staticPasswords | indent 4 }}
     {{- end }}
+    {{- if .frontend }}
+    frontend: {{ toYaml .frontend | nindent 6 }}
+    {{- end }}
     {{- end }}

--- a/stable/dex/values.yaml
+++ b/stable/dex/values.yaml
@@ -183,3 +183,6 @@ config:
 #     hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
 #     username: "admin"
 #     userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+
+# frontend:
+#   logoURL: https://example.com/yourlogo.png


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No 

#### What this PR does / why we need it:
Allows end users to override the `frontend` configuration values in dex, to allow customization of the web UI.

My immediate use case is for custom logo images, but this PR takes a general approach and passes through any config values under `frontend` directly to dex's `frontend` configuration.

#### Special notes for your reviewer:

Tested on a local cluster, logo was overridden in UI as expected.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
