### PR TITLE
[stable/concourse] Concourse v5.6.0

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: concourse
-version: 8.2.5
-appVersion: 5.5.0
+version: 8.2.6
+appVersion: 5.6.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479
 keywords:

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -83,7 +83,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `imageDigest` | Specific image digest to use in place of a tag. | `nil` |
 | `imagePullPolicy` | Concourse image pull policy | `IfNotPresent` |
 | `imagePullSecrets` | Array of imagePullSecrets in the namespace for pulling images | `[]` |
-| `imageTag` | Concourse image version | `5.5.0` |
+| `imageTag` | Concourse image version | `5.6.0` |
 | `image` | Concourse image | `concourse/concourse` |
 | `nameOverride` | Provide a name in place of `concourse` for `app:` labels | `nil` |
 | `persistence.enabled` | Enable Concourse persistence using Persistent Volume Claims | `true` |

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -71,6 +71,14 @@ spec:
             - name: CONCOURSE_ENABLE_LIDAR
               value: {{ .Values.concourse.web.enableLidar | quote }}
             {{- end }}
+            {{- if .Values.concourse.web.lidarScannerInterval }}
+            - name: CONCOURSE_LIDAR_SCANNER_INTERVAL
+              value: {{ .Values.concourse.web.lidarScannerInterval | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.lidarCheckerInterval }}
+            - name: CONCOURSE_LIDAR_CHECKER_INTERVAL
+              value: {{ .Values.concourse.web.lidarCheckerInterval | quote }}
+            {{- end }}
             {{- if .Values.concourse.web.enableBuildAuditing }}
             - name: CONCOURSE_ENABLE_BUILD_AUDITING
               value: {{ .Values.concourse.web.enableBuildAuditing | quote }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -107,6 +107,10 @@ spec:
             - name: CONCOURSE_ENABLE_VOLUME_AUDITING
               value: {{ .Values.concourse.web.enableVolumeAuditing | quote }}
             {{- end }}
+            {{- if .Values.concourse.web.enableRedactSecrets }}
+            - name: CONCOURSE_ENABLE_REDACT_SECRETS
+              value: {{ .Values.concourse.web.enableRedactSecrets | quote }}
+            {{- end }}
             {{- if .Values.concourse.web.secretRetryAttempts }}
             - name: CONCOURSE_SECRET_RETRY_ATTEMPTS
               value: {{ .Values.concourse.web.secretRetryAttempts | quote }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -267,6 +267,10 @@ spec:
             - name: CONCOURSE_LOG_DB_QUERIES
               value: {{ .Values.concourse.web.logDbQueries | quote }}
             {{- end }}
+            {{- if .Values.concourse.web.logClusterName }}
+            - name: CONCOURSE_LOG_CLUSTER_NAME
+              value: {{ .Values.concourse.web.logClusterName | quote }}
+            {{- end }}
             {{- if .Values.concourse.web.buildTrackerInterval }}
             - name: CONCOURSE_BUILD_TRACKER_INTERVAL
               value: {{ .Values.concourse.web.buildTrackerInterval | quote  }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -123,6 +123,10 @@ spec:
             - name: CONCOURSE_SECRET_CACHE_DURATION
               value: {{ .Values.concourse.web.secretCacheDuration | quote }}
             {{- end }}
+            {{- if .Values.concourse.web.secretCacheDurationNotFound }}
+            - name: CONCOURSE_SECRET_CACHE_DURATION_NOTFOUND
+              value: {{ .Values.concourse.web.secretCacheDurationNotFound | quote }}
+            {{- end }}
             {{- if .Values.concourse.web.secretCacheEnabled }}
             - name: CONCOURSE_SECRET_CACHE_ENABLED
               value: {{ .Values.concourse.web.secretCacheEnabled | quote }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -67,6 +67,10 @@ spec:
             - name: CONCOURSE_ENABLE_GLOBAL_RESOURCES
               value: {{ .Values.concourse.web.enableGlobalResources | quote }}
             {{- end }}
+            {{- if .Values.concourse.web.enableLidar }}
+            - name: CONCOURSE_ENABLE_LIDAR
+              value: {{ .Values.concourse.web.enableLidar | quote }}
+            {{- end }}
             {{- if .Values.concourse.web.enableBuildAuditing }}
             - name: CONCOURSE_ENABLE_BUILD_AUDITING
               value: {{ .Values.concourse.web.enableBuildAuditing | quote }}
@@ -637,6 +641,10 @@ spec:
             {{- if .Values.concourse.web.gc.missingGracePeriod }}
             - name: CONCOURSE_GC_MISSING_GRACE_PERIOD
               value: {{ .Values.concourse.web.gc.missingGracePeriod | quote }}
+            {{- end }}
+            {{- if .Values.concourse.web.gc.checkRecyclePeriod }}
+            - name: CONCOURSE_GC_CHECK_RECYCLE_PERIOD
+              value: {{ .Values.concourse.web.gc.checkRecyclePeriod | quote }}
             {{- end }}
             {{- if .Values.concourse.web.syslog.enabled }}
             {{- if .Values.concourse.web.syslog.hostname }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -244,6 +244,11 @@ concourse:
     ##
     logDbQueries: false
 
+    ## Log cluster name.
+    ##
+    logClusterName: false
+
+
     ## Interval on which to run build tracking.
     ##
     buildTrackerInterval: 10s

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -105,6 +105,10 @@ concourse:
     ##
     enableVolumeAuditing: false
 
+    ## Enable redacting secrets in build logs.
+    ##
+    enableRedactSecrets: false
+
     ## The number of attempts secret will be retried to be fetched,
     ## in case a retryable error happens.
     ##

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -128,6 +128,11 @@ concourse:
     ##
     secretCacheDuration:
 
+    ## If the cache is enabled, secret not found responses will be cached for
+    ## this duration.
+    ##
+    secretCacheDurationNotFound:
+
     ## If the cache is enabled, expired items will be removed on this internal.
     ##
     secretCachePurgeInterval:

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -69,6 +69,15 @@ concourse:
     ##
     enableLidar: false
 
+    ## Interval on which the resource scanner will run to see if new checks need
+    ## to be scheduled.
+    ##
+    lidarScannerInterval: 1m
+
+    ## Interval on which the resource checker runs any scheduled checks.
+    ##
+    lidarCheckerInterval: 10s
+
     ## Enable auditing for all api requests connected to builds.
     ##
     enableBuildAuditing: false

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -67,16 +67,16 @@ concourse:
 
     ## The Future™ of resource checking.
     ##
-    enableLidar: false
+    enableLidar:
 
     ## Interval on which the resource scanner will run to see if new checks need
     ## to be scheduled.
     ##
-    lidarScannerInterval: 1m
+    lidarScannerInterval:
 
     ## Interval on which the resource checker runs any scheduled checks.
     ##
-    lidarCheckerInterval: 10s
+    lidarCheckerInterval:
 
     ## Enable auditing for all api requests connected to builds.
     ##
@@ -116,7 +116,7 @@ concourse:
 
     ## Enable redacting secrets in build logs.
     ##
-    enableRedactSecrets: false
+    enableRedactSecrets:
 
     ## The number of attempts secret will be retried to be fetched,
     ## in case a retryable error happens.
@@ -255,7 +255,7 @@ concourse:
 
     ## Log cluster name.
     ##
-    logClusterName: false
+    logClusterName:
 
 
     ## Interval on which to run build tracking.
@@ -649,7 +649,7 @@ concourse:
 
       ## Period after which to reap checks that are completed.
       ##
-      checkRecyclePeriod: 6h
+      checkRecyclePeriod:
 
     syslog:
       ## Enables the emission of build logs to external log ingesters through

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -65,6 +65,10 @@ concourse:
     ##
     enableGlobalResources: true
 
+    ## The Future™ of resource checking.
+    ##
+    enableLidar: false
+
     ## Enable auditing for all api requests connected to builds.
     ##
     enableBuildAuditing: false
@@ -619,6 +623,10 @@ concourse:
       ## went missing from the worker.
       ##
       missingGracePeriod: 5m
+
+      ## Period after which to reap checks that are completed.
+      ##
+      checkRecyclePeriod: 6h
 
     syslog:
       ## Enables the emission of build logs to external log ingesters through

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -19,7 +19,7 @@ image: concourse/concourse
 ##      of `concourse/concourse`.
 ## Ref: https://hub.docker.com/r/concourse/concourse/tags/
 ##
-imageTag: "5.5.0"
+imageTag: "5.6.0"
 
 ## Specific image digest to use in place of a tag.
 ## Ref: https://kubernetes.io/docs/concepts/configuration/overview/#container-images


### PR DESCRIPTION
#### What this PR does / why we need it:
* upgrades Concourse to v5.6.0
* adds new configuration parameters for v5.6.0

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
