### PR TITLE
[stable/elasticsearch-exporter] Fix spacing issue in volume mount

### DIFF
--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 1.10.0
+version: 1.10.1
 appVersion: 1.1.0
 home: https://github.com/justwatchcom/elasticsearch_exporter
 sources:

--- a/stable/elasticsearch-exporter/README.md
+++ b/stable/elasticsearch-exporter/README.md
@@ -73,7 +73,7 @@ Parameter | Description | Default
 `es.ssl.enabled` | If true, a secure connection to Elasticsearch cluster is used | `false`
 `es.ssl.useExistingSecrets` | If true, certs from secretMounts will be used | `false`
 `es.ssl.ca.pem` | PEM that contains trusted CAs used for setting up secure Elasticsearch connection |
-`es.ssl.ca.pemPath` | Path of ca pem file which should match a secretMount path |
+`es.ssl.ca.path` | Path of ca pem file which should match a secretMount path |
 `es.ssl.client.pem` | PEM that contains the client cert to connect to Elasticsearch |
 `es.ssl.client.pemPath` | Path of client pem file which should match a secretMount path |
 `es.ssl.client.key` | Private key for client auth when connecting to Elasticsearch |

--- a/stable/elasticsearch-exporter/templates/deployment.yaml
+++ b/stable/elasticsearch-exporter/templates/deployment.yaml
@@ -147,6 +147,6 @@ spec:
         {{- end }}
         {{- range .Values.secretMounts }}
         - name: {{ .name }}
-        secret:
-          secretName: {{ .secretName }}
+          secret:
+            secretName: {{ .secretName }}
         {{- end }}

--- a/stable/elasticsearch-exporter/values.yaml
+++ b/stable/elasticsearch-exporter/values.yaml
@@ -56,15 +56,9 @@ service:
 # A list of secrets and their paths to mount inside the pod
 # This is useful for mounting certificates for security
 secretMounts: []
-#  - name: ca
-#    secretName: elastic-ca
-#    path: /ssl/ca.pem
-#  - name: elastic-client-pem
-#    secretName: elastic-client-pem
-#    path: /ssl/client.pem
-#  - name: elastic-client-key
-#    secretName: elastic-client-key
-#    path: /ssl/client.key
+#  - name: elastic-certs
+#    secretName: elastic-certs
+#    path: /ssl
 
 es:
   ## Address (host and port) of the Elasticsearch node we should connect to.
@@ -121,7 +115,7 @@ es:
       # pem:
 
       # Path of ca pem file which should match a secretMount path
-      # pemPath: /ssl/ca.pem
+      # path: /ssl/ca.pem
     client:
 
       ## PEM that contains the client cert to connect to Elasticsearch.


### PR DESCRIPTION
Update spacing issue in deployment, fixed README, and updated values to have a better example.

The previous revision had incorrect the key 'es.ssl.ca.pemPath' in the README and in the values.yaml. This PR fixes those two files to be the correct key described in the deployment.yaml 'es.ssl.ca.path'

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
