### PR TITLE
[stable/prometheus-operator] Add 10m timeout, don't clean up to delete hooks

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -10,7 +10,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 6.11.0
+version: 6.11.1
 appVersion: 0.32.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/clusterrole.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/clusterrole.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-timeout": "600"
   labels:
     app: {{ template "prometheus-operator.name" $ }}-admission
 {{- include "prometheus-operator.labels" $ | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/clusterrole.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/clusterrole.yaml
@@ -5,7 +5,7 @@ metadata:
   name:  {{ template "prometheus-operator.fullname" . }}-admission
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-delete-timeout": "600"
   labels:
     app: {{ template "prometheus-operator.name" $ }}-admission

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/clusterrolebinding.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/clusterrolebinding.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-timeout": "600"
   labels:
     app: {{ template "prometheus-operator.name" $ }}-admission
 {{- include "prometheus-operator.labels" $ | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/clusterrolebinding.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
   name:  {{ template "prometheus-operator.fullname" . }}-admission
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-delete-timeout": "600"
   labels:
     app: {{ template "prometheus-operator.name" $ }}-admission

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
@@ -5,7 +5,7 @@ metadata:
   name:  {{ template "prometheus-operator.fullname" . }}-admission-create
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-delete-timeout": "600"
   labels:
     app: {{ template "prometheus-operator.name" $ }}-admission-create

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-timeout": "600"
   labels:
     app: {{ template "prometheus-operator.name" $ }}-admission-create
 {{- include "prometheus-operator.labels" $ | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-timeout": "600"
   labels:
     app: {{ template "prometheus-operator.name" $ }}-admission-patch
 {{- include "prometheus-operator.labels" $ | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -5,7 +5,7 @@ metadata:
   name:  {{ template "prometheus-operator.fullname" . }}-admission-patch
   annotations:
     "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-delete-timeout": "600"
   labels:
     app: {{ template "prometheus-operator.name" $ }}-admission-patch

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/psp.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/psp.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-timeout": "600"
   labels:
     app: {{ template "prometheus-operator.name" . }}-admission
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/psp.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/psp.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "prometheus-operator.fullname" . }}-admission
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-delete-timeout": "600"
   labels:
     app: {{ template "prometheus-operator.name" . }}-admission

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/role.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/role.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-timeout": "600"
   labels:
     app: {{ template "prometheus-operator.name" $ }}-admission
 {{- include "prometheus-operator.labels" $ | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/role.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/role.yaml
@@ -5,7 +5,7 @@ metadata:
   name:  {{ template "prometheus-operator.fullname" . }}-admission
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-delete-timeout": "600"
   labels:
     app: {{ template "prometheus-operator.name" $ }}-admission

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/rolebinding.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/rolebinding.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-timeout": "600"
   labels:
     app: {{ template "prometheus-operator.name" $ }}-admission
 {{- include "prometheus-operator.labels" $ | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/rolebinding.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/rolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
   name:  {{ template "prometheus-operator.fullname" . }}-admission
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-delete-timeout": "600"
   labels:
     app: {{ template "prometheus-operator.name" $ }}-admission

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/serviceaccount.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/serviceaccount.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-timeout": "600"
   labels:
     app: {{ template "prometheus-operator.name" $ }}-admission
 {{- include "prometheus-operator.labels" $ | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/serviceaccount.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   name:  {{ template "prometheus-operator.fullname" . }}-admission
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-delete-timeout": "600"
   labels:
     app: {{ template "prometheus-operator.name" $ }}-admission


### PR DESCRIPTION
#### What this PR does / why we need it:
Some clusters seem to be very slow at handling deletes. Increasing the timeout to a very high value should be perfectly fine

#### Which issue this PR fixes
  - fixes #15977
  - fixes https://github.com/helm/helm/issues/6130

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
