### PR TITLE
[stable/redis] Fix svc for redis with sentinel

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 9.1.9
+version: 9.1.10
 appVersion: 5.0.5
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/redis-with-sentinel-svc.yaml
+++ b/stable/redis/templates/redis-with-sentinel-svc.yaml
@@ -8,14 +8,14 @@ metadata:
     chart: {{ template "redis.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-{{- if .Values.master.service.annotations }}
+{{- if .Values.sentinel.service.annotations }}
   annotations:
-{{ toYaml .Values.master.service.annotations | indent 4 }}
+{{ toYaml .Values.sentinel.service.annotations | indent 4 }}
 {{- end }}
 spec:
-  type: {{ .Values.master.service.type }}
-  {{ if eq .Values.master.service.type "LoadBalancer" -}} {{ if .Values.master.service.loadBalancerIP -}}
-  loadBalancerIP: {{ .Values.master.service.loadBalancerIP }}
+  type: {{ .Values.sentinel.service.type }}
+  {{ if eq .Values.sentinel.service.type "LoadBalancer" -}} {{ if .Values.sentinel.service.loadBalancerIP -}}
+  loadBalancerIP: {{ .Values.sentinel.service.loadBalancerIP }}
   {{ end -}}
   {{- end -}}
   ports:


### PR DESCRIPTION
Signed-off-by: Alejandro Moreno <amoreno@bitnami.com>

#### What this PR does / why we need it:
Fixes the `redis-with-sentinel-svc.yaml` to use the values from `sentinel` instead of `master`.

#### Which issue this PR fixes
  - fixes #17040 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
