### PR TITLE
[stable/datadog] correct volumes template

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.33.0
+version: 1.33.1
 appVersion: 6.13.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -208,7 +208,7 @@ datadog:
   #
   # volumes:
   #   - hostPath:
-  #     path: <HOST_PATH>
+  #       path: <HOST_PATH>
   #     name: <VOLUME_NAME>
 
   ## @param volumeMounts - list of objects - optional


### PR DESCRIPTION
#### What this PR does / why we need it:

Avoid potential volume mounting errors.

#### Which issue this PR fixes

The current volumes template section in `values.yaml` misses a tabulation, which may lead to a volume mount failure if users uncomment and use the template.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
