### PR TITLE
[stable/cluster-overprovisioner] Add app.kubernetes.io/fleetName label

### DIFF
--- a/stable/cluster-overprovisioner/Chart.yaml
+++ b/stable/cluster-overprovisioner/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: Installs the a deployment that overprovisions the cluster
 name: cluster-overprovisioner
 home: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler
-version: 0.2.3
+version: 0.2.4
 maintainers:
 - name: max-rocket-internet
   email: max.williams@deliveryhero.com

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -34,25 +34,25 @@ Some thought or experimentation is required to set `deployment.resources` and `d
 
 The following table lists the configurable parameters for this chart and their default values.
 
-| Parameter                          | Description                                       | Default           |
-| -----------------------------------|---------------------------------------------------|-------------------|
-| `priorityClassOverprovision.name`  | Name of the overprovision priorityClass           | `overprovision`   |
-| `priorityClassOverprovision.value` | Priority value of the overprovision priorityClass | `-1`              |
-| `priorityClassDefault.enabled`     | If true, enable default priorityClass             | `true`            |
-| `priorityClassDefault.name`        | Name of the default priorityClass                 | `default`         |
-| `priorityClassDefault.value`       | Priority value of the default priorityClass       | `0`               |
-| `image.repository`                 | Image repository                                  | `k8s.gcr.io/pause`|
-| `image.tag`                        | Image tag                                         | `3.1`             |
-| `image.pullPolicy`                 | Container pull policy                             | `IfNotPresent`    |
-| `fullnameOverride`                 | Override the fullname of the chart                | `nil`             |
-| `nameOverride`                     | Override the name of the chart                    | `nil`             |
-| `deployments`                      | Define optional additional deployments            | `[]`              |
-| `deployments[].name`               | Name for additional deployments                   | ``                |
-| `deployments[].replicaCount`       | Number of replicas                                | `1`               |
-| `deployments[].resources`          | Resources for the overprovision pods              | `{}`              |
-| `deployments[].affinity`           | Map of node/pod affinities                        | `{}`              |
-| `deployments[].nodeSelector`       | Node labels for pod assignment                    | `{}`              |
-| `deployments[].tolerations`        | Optional deployment tolerations                   | `[]`              |
+| Parameter                          | Description                                                                                                             | Default           |
+| -----------------------------------|------------------------------------------------------------------------------------------------------------------------ |-------------------|
+| `priorityClassOverprovision.name`  | Name of the overprovision priorityClass                                                                                 | `overprovision`   |
+| `priorityClassOverprovision.value` | Priority value of the overprovision priorityClass                                                                       | `-1`              |
+| `priorityClassDefault.enabled`     | If true, enable default priorityClass                                                                                   | `true`            |
+| `priorityClassDefault.name`        | Name of the default priorityClass                                                                                       | `default`         |
+| `priorityClassDefault.value`       | Priority value of the default priorityClass                                                                             | `0`               |
+| `image.repository`                 | Image repository                                                                                                        | `k8s.gcr.io/pause`|
+| `image.tag`                        | Image tag                                                                                                               | `3.1`             |
+| `image.pullPolicy`                 | Container pull policy                                                                                                   | `IfNotPresent`    |
+| `fullnameOverride`                 | Override the fullname of the chart                                                                                      | `nil`             |
+| `nameOverride`                     | Override the name of the chart                                                                                          | `nil`             |
+| `deployments`                      | Define optional additional deployments                                                                                  | `[]`              |
+| `deployments[].name`               | Name for additional deployments (will be added as app.kubernetes.io/fleetName, so you can match it with affinity rules) | ``                |
+| `deployments[].replicaCount`       | Number of replicas                                                                                                      | `1`               |
+| `deployments[].resources`          | Resources for the overprovision pods                                                                                    | `{}`              |
+| `deployments[].affinity`           | Map of node/pod affinities                                                                                              | `{}`              |
+| `deployments[].nodeSelector`       | Node labels for pod assignment                                                                                          | `{}`              |
+| `deployments[].tolerations`        | Optional deployment tolerations                                                                                         | `[]`              |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -34,25 +34,25 @@ Some thought or experimentation is required to set `deployment.resources` and `d
 
 The following table lists the configurable parameters for this chart and their default values.
 
-| Parameter                          | Description                                                                                                             | Default           |
-| -----------------------------------|------------------------------------------------------------------------------------------------------------------------ |-------------------|
-| `priorityClassOverprovision.name`  | Name of the overprovision priorityClass                                                                                 | `overprovision`   |
-| `priorityClassOverprovision.value` | Priority value of the overprovision priorityClass                                                                       | `-1`              |
-| `priorityClassDefault.enabled`     | If true, enable default priorityClass                                                                                   | `true`            |
-| `priorityClassDefault.name`        | Name of the default priorityClass                                                                                       | `default`         |
-| `priorityClassDefault.value`       | Priority value of the default priorityClass                                                                             | `0`               |
-| `image.repository`                 | Image repository                                                                                                        | `k8s.gcr.io/pause`|
-| `image.tag`                        | Image tag                                                                                                               | `3.1`             |
-| `image.pullPolicy`                 | Container pull policy                                                                                                   | `IfNotPresent`    |
-| `fullnameOverride`                 | Override the fullname of the chart                                                                                      | `nil`             |
-| `nameOverride`                     | Override the name of the chart                                                                                          | `nil`             |
-| `deployments`                      | Define optional additional deployments                                                                                  | `[]`              |
-| `deployments[].name`               | Name for additional deployments (will be added as app.kubernetes.io/fleetName, so you can match it with affinity rules) | ``                |
-| `deployments[].replicaCount`       | Number of replicas                                                                                                      | `1`               |
-| `deployments[].resources`          | Resources for the overprovision pods                                                                                    | `{}`              |
-| `deployments[].affinity`           | Map of node/pod affinities                                                                                              | `{}`              |
-| `deployments[].nodeSelector`       | Node labels for pod assignment                                                                                          | `{}`              |
-| `deployments[].tolerations`        | Optional deployment tolerations                                                                                         | `[]`              |
+| Parameter                          | Description                                                                                                                     | Default           |
+| -----------------------------------|-------------------------------------------------------------------------------------------------------------------------------- |-------------------|
+| `priorityClassOverprovision.name`  | Name of the overprovision priorityClass                                                                                         | `overprovision`   |
+| `priorityClassOverprovision.value` | Priority value of the overprovision priorityClass                                                                               | `-1`              |
+| `priorityClassDefault.enabled`     | If true, enable default priorityClass                                                                                           | `true`            |
+| `priorityClassDefault.name`        | Name of the default priorityClass                                                                                               | `default`         |
+| `priorityClassDefault.value`       | Priority value of the default priorityClass                                                                                     | `0`               |
+| `image.repository`                 | Image repository                                                                                                                | `k8s.gcr.io/pause`|
+| `image.tag`                        | Image tag                                                                                                                       | `3.1`             |
+| `image.pullPolicy`                 | Container pull policy                                                                                                           | `IfNotPresent`    |
+| `fullnameOverride`                 | Override the fullname of the chart                                                                                              | `nil`             |
+| `nameOverride`                     | Override the name of the chart                                                                                                  | `nil`             |
+| `deployments`                      | Define optional additional deployments                                                                                          | `[]`              |
+| `deployments[].name`               | Name for additional deployments (will be added as label cluster-over-provisioner-name, so you can match it with affinity rules) | ``                |
+| `deployments[].replicaCount`       | Number of replicas                                                                                                              | `1`               |
+| `deployments[].resources`          | Resources for the overprovision pods                                                                                            | `{}`              |
+| `deployments[].affinity`           | Map of node/pod affinities                                                                                                      | `{}`              |
+| `deployments[].nodeSelector`       | Node labels for pod assignment                                                                                                  | `{}`              |
+| `deployments[].tolerations`        | Optional deployment tolerations                                                                                                 | `[]`              |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:

--- a/stable/cluster-overprovisioner/templates/deployments.yaml
+++ b/stable/cluster-overprovisioner/templates/deployments.yaml
@@ -16,7 +16,7 @@ metadata:
   name: "{{ $fullname }}-{{ .name }}"
   labels:
     app.kubernetes.io/name: {{ $name }}
-    app.kubernetes.io/fleetName: {{ .name }}
+    cluster-overprovisioner-name: {{ .name }}
     helm.sh/chart: {{ $chart }}
     app.kubernetes.io/instance: {{ $relName }}
     app.kubernetes.io/managed-by: {{ $relService }}
@@ -25,13 +25,13 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ $name }}
-      app.kubernetes.io/fleetName: {{ .name }}
+      cluster-overprovisioner-name: {{ .name }}
       app.kubernetes.io/instance: {{ $relName }}
   template:
     metadata:
       labels:
         app.kubernetes.io/name: {{ $name }}
-        app.kubernetes.io/fleetName: {{ .name }}
+        cluster-overprovisioner-name: {{ .name }}
         app.kubernetes.io/instance: {{ $relName }}
     spec:
       priorityClassName: {{ $priorityClassName }}

--- a/stable/cluster-overprovisioner/templates/deployments.yaml
+++ b/stable/cluster-overprovisioner/templates/deployments.yaml
@@ -16,6 +16,7 @@ metadata:
   name: "{{ $fullname }}-{{ .name }}"
   labels:
     app.kubernetes.io/name: {{ $name }}
+    app.kubernetes.io/fleetName: {{ .name }}
     helm.sh/chart: {{ $chart }}
     app.kubernetes.io/instance: {{ $relName }}
     app.kubernetes.io/managed-by: {{ $relService }}
@@ -24,11 +25,13 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ $name }}
+      app.kubernetes.io/fleetName: {{ .name }}
       app.kubernetes.io/instance: {{ $relName }}
   template:
     metadata:
       labels:
         app.kubernetes.io/name: {{ $name }}
+        app.kubernetes.io/fleetName: {{ .name }}
         app.kubernetes.io/instance: {{ $relName }}
     spec:
       priorityClassName: {{ $priorityClassName }}


### PR DESCRIPTION
Signed-off-by: Koen van Ingen <koenvaningen@gmail.com>

#### What this PR does / why we need it:
When deploying multiple overprovisioning fleets, it's currently not possible to match on a specific fleet when using affinity/antiaffinity.

#### Which issue this PR fixes
- This PR adds a label (`app.kubernetes.io/fleetName`) allows to match on a specific
overprovisioning deployment with matchExpressions/matchLabels in
affinity rules. The fleetName label will be unique per deployment fleet.

#### Special notes for your reviewer:
- @max-rocket-internet
- @mmingorance-dh

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
