### PR TITLE
[incubator/vault] Add support for prometheus operator

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.20.0
+version: 0.21.0
 appVersion: 1.1.2
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -96,16 +96,17 @@ The following table lists the configurable parameters of the Vault chart and the
 | `vaultExporter.pullPolicy`        | Image pull policy that sould be used     | `IfNotPresent`                      |
 | `vaultExporter.vaultAddress`      | Vault address that exporter should use   | `127.0.0.1:8200`                    |
 | `vaultExporter.tlsCAFile`         | Vault TLS CA certificate mount path      | `/vault/tls/ca.crt`                 |
-| `vaultExporter.serviceMonitor.enabled`    | Specifies whether a Prometheus ServiceMonitor should be created | `false`|
-| `vaultExporter.serviceMonitor.additionalLabels`| Additional labels for Service Monitor | `{}`                                |
-| `vaultExporter.serviceMonitor.interval`   | Prometheus scrape interval       | `10s`                               |
-| `vaultExporter.serviceMonitor.jobLabel`   | Prometheus job label             | `vault-exporter`                    |
-| `vaultExporter.alerts.enabled`            | Specifies whether a Prometheus Alert Rule should be created                  | `false`          |
-| `vaultExporter.alerts.defaultRules.vaultUp`           | Specifies whether the vaultUp rule should be included            | `true`           |
-| `vaultExporter.alerts.defaultRules.vaultUninitialized`| Specifies whether the vaultUninitialized rule should be included | `true`           |
-| `vaultExporter.alerts.defaultRules.vaultSealed`       | Specifies whether the vaulSealed rule should be included         | `true`           |
-| `vaultExporter.alerts.defaultRules.vaultStandby`      | Specifies whether the vaultStandy rule should be included        | `false`          |
-| `vaultExporter.alerts.extraRules`                     | Custom extra rules                                               | `[]`             |
+| `serviceMonitor.enabled`          | Specifies whether a Prometheus ServiceMonitor should be created | `false`|
+| `serviceMonitor.additionalLabels` | Additional labels for Service Monitor    | `{}`                                |
+| `serviceMonitor.podPortName`      | Name of the port of the pod to scrape    | `metrics`                           |
+| `serviceMonitor.interval`         | Prometheus scrape interval               | `10s`                               |
+| `serviceMonitor.jobLabel`         | Prometheus job label                     | `vault-exporter`                    |
+| `prometheusRules.enabled`         | Specifies whether a Prometheus Alert Rule should be created                     | `false`          |
+| `prometheusRules.defaultRules.vaultUp`           | Specifies whether the vaultUp rule should be included            | `true`           |
+| `prometheusRules.defaultRules.vaultUninitialized`| Specifies whether the vaultUninitialized rule should be included | `true`           |
+| `prometheusRules.defaultRules.vaultSealed`       | Specifies whether the vaulSealed rule should be included         | `true`           |
+| `prometheusRules.defaultRules.vaultStandby`      | Specifies whether the vaultStandy rule should be included        | `false`          |
+| `prometheusRules.extraRules`                     | Custom extra rules                                               | `[]`             |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
@@ -152,6 +153,27 @@ serviceMonitor:
     prometheus-scraper: "default"
   interval: 10s
   jobLabel: "vault-exporter"
+```
+
+If you do not want to use the default vaultExporter container, but use your own, you can declare it in the `vault.extraContainer` part. But you have to expose a __named__ port for the metrics and set this name in the `serviceMonitor.podPortName`. For exmaple:
+
+```yaml
+vaultExporter:
+  enabled: false
+
+serviceMonitor:
+  enabled: true
+  additionalLabels:
+    prometheus-scraper: "default"
+  podPortName: "metricPort"
+
+vault:
+  extraContainer:
+  - name: my-vault-exporter
+    image: my-vault-exporter:latest
+    ports:
+    - containerPort: 8080
+      name: metricPort
 ```
 
 If you want to add Prometheus alerting rules you can simply enable the alerts and disabling/enabling

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -180,7 +180,7 @@ If you want to add Prometheus alerting rules you can simply enable the alerts an
 the defaults rules you want to use. You can add as many custom rules as you want. For example:
 
 ```yaml
-  alerts:
+  prometheusRules:
     enabled: true
     defaultRules:
       vaultUp: true

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -148,7 +148,7 @@ with an extraLabel corresponding to your Prometheus scraper label selector. For 
 ```yaml
 serviceMonitor:
   enabled: true
-  extraLabels:
+  additionalLabels:
     prometheus-scraper: "default"
   interval: 10s
   jobLabel: "vault-exporter"

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -96,6 +96,16 @@ The following table lists the configurable parameters of the Vault chart and the
 | `vaultExporter.pullPolicy`        | Image pull policy that sould be used     | `IfNotPresent`                      |
 | `vaultExporter.vaultAddress`      | Vault address that exporter should use   | `127.0.0.1:8200`                    |
 | `vaultExporter.tlsCAFile`         | Vault TLS CA certificate mount path      | `/vault/tls/ca.crt`                 |
+| `vaultExporter.serviceMonitor.enabled`    | Specifies whether a Prometheus ServiceMonitor should be created | `false`|
+| `vaultExporter.serviceMonitor.additionalLabels`| Additional labels for Service Monitor | `{}`                                |
+| `vaultExporter.serviceMonitor.interval`   | Prometheus scrape interval       | `10s`                               |
+| `vaultExporter.serviceMonitor.jobLabel`   | Prometheus job label             | `vault-exporter`                    |
+| `vaultExporter.alerts.enabled`            | Specifies whether a Prometheus Alert Rule should be created                  | `false`          |
+| `vaultExporter.alerts.defaultRules.vaultUp`           | Specifies whether the vaultUp rule should be included            | `true`           |
+| `vaultExporter.alerts.defaultRules.vaultUninitialized`| Specifies whether the vaultUninitialized rule should be included | `true`           |
+| `vaultExporter.alerts.defaultRules.vaultSealed`       | Specifies whether the vaulSealed rule should be included         | `true`           |
+| `vaultExporter.alerts.defaultRules.vaultStandby`      | Specifies whether the vaultStandy rule should be included        | `false`          |
+| `vaultExporter.alerts.extraRules`                     | Custom extra rules                                               | `[]`             |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
@@ -131,6 +141,39 @@ your needs.
 
 If your Vault is set up with TLS make sure to specify the CA certificate path properly.
 This is done through the parameter `vaultExporter.tlsCAFile`.
+
+If you want to use the exporter with the Prometheus Operator you can simply enable the ServiceMonitor
+with an extraLabel corresponding to your Prometheus scraper label selector. For example:
+
+```yaml
+serviceMonitor:
+  enabled: true
+  extraLabels:
+    prometheus-scraper: "default"
+  interval: 10s
+  jobLabel: "vault-exporter"
+```
+
+If you want to add Prometheus alerting rules you can simply enable the alerts and disabling/enabling
+the defaults rules you want to use. You can add as many custom rules as you want. For example:
+
+```yaml
+  alerts:
+    enabled: true
+    defaultRules:
+      vaultUp: true
+      vaultUninitialized: true
+      vaultSealed: true
+      vaultStandby: false
+    extraRules:
+    - alert: VaultHTTPErrorRateIsHigh
+      annotations:
+        description: The ingress is failing more than %15 of the requests for 5m
+      expr: sum(rate(nginx_ingress_controller_requests{ingress="vault",status!~"[4-5].*"}[2m])) by (ingress) / sum(rate(nginx_ingress_controller_requests{ingress="vault"}[2m])) by (ingress) < 0.85
+      for: 5m
+      labels:
+        severity: critical
+```
 
 ## Using Vault
 

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -178,6 +178,9 @@ spec:
         - name: {{ .secretName | replace "." "-"}}
           mountPath: {{ .mountPath }}
         {{- end }}
+        ports:
+        - containerPort: 9410
+          name: metrics
       {{- end }}
       {{- if .Values.affinity }}
       affinity:

--- a/incubator/vault/templates/prometheusrules.yaml
+++ b/incubator/vault/templates/prometheusrules.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.vaultExporter.alerts.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "vault.fullname" . }}
+  labels:
+    app: {{ template "vault.name" . }}
+    chart: {{ template "vault.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.vaultExporter.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.vaultExporter.serviceMonitor.additionalLabels | indent 4 }}
+{{- end }}
+spec:
+  groups:
+  # Adapted from https://github.com/bosh-prometheus/prometheus-boshrelease/blob/master/jobs/vault_alerts/templates/vault.alerts.yml
+  - name: vault.rules
+    rules:
+      {{- if .Values.vaultExporter.alerts.defaultRules.vaultUp }}
+      - alert: VaultUp
+        expr: vault_up{app="{{ template "vault.name" . }}", release="{{ .Release.Name }}"} == 0
+        for: 10m
+        labels:
+          service: vault
+          severity: critical
+        annotations:
+          summary: "Vault instance {{`{{$labels.pod_name}}`}} is down"
+          description: "The Vault instance {{`{{$labels.pod_name}}`}} has been down for the last 10m"
+      {{- end }}
+
+      {{- if .Values.vaultExporter.alerts.defaultRules.vaultUninitialized }}
+      - alert: VaultUninitialized
+        expr: vault_initialized{app="{{ template "vault.name" . }}", release="{{ .Release.Name }}"} == 0
+        for: 10m
+        labels:
+          service: vault
+          severity: critical
+        annotations:
+          summary: "Vault instance {{`{{$labels.pod_name}}`}} is uninitialized"
+          description: "The Vault instance {{`{{$labels.pod_name}}`}} has been uninitialized for the last 10m"
+      {{- end }}
+
+      {{- if .Values.vaultExporter.alerts.defaultRules.vaultSealed }}
+      - alert: VaultSealed
+        expr: vault_sealed{app="{{ template "vault.name" . }}", release="{{ .Release.Name }}"} == 1
+        for: 5m
+        labels:
+          service: vault
+          severity: critical
+        annotations:
+          summary: "Vault instance {{`{{$labels.pod_name}}`}} is sealed"
+          description: "The Vault instance {{`{{$labels.pod_name}}`}} has been sealed for the last 5m"
+      {{- end }}
+
+      {{- if .Values.vaultExporter.alerts.defaultRules.vaultStandby }}
+      - alert: VaultStandby
+        expr: vault_standby{app="{{ template "vault.name" . }}", release="{{ .Release.Name }}"} == 1
+        for: 10m
+        labels:
+          service: vault
+          severity: critical
+        annotations:
+          summary: "Vault instance {{`{{$labels.pod_name}}`}} is in standby mode"
+          description: "The Vault instance {{`{{$labels.pod_name}}`}} has been in standby mode for the last 10m"
+      {{- end }}
+{{- if .Values.vaultExporter.alerts.extraRules }}
+{{ toYaml .Values.vaultExporter.alerts.extraRules | indent 6 }}
+{{- end }}
+{{- end -}}

--- a/incubator/vault/templates/prometheusrules.yaml
+++ b/incubator/vault/templates/prometheusrules.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.vaultExporter.alerts.enabled -}}
+{{- if .Values.prometheusRules.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -8,15 +8,15 @@ metadata:
     chart: {{ template "vault.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- if .Values.vaultExporter.serviceMonitor.additionalLabels }}
-{{ toYaml .Values.vaultExporter.serviceMonitor.additionalLabels | indent 4 }}
+{{- if .Values.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
 {{- end }}
 spec:
   groups:
   # Adapted from https://github.com/bosh-prometheus/prometheus-boshrelease/blob/master/jobs/vault_alerts/templates/vault.alerts.yml
   - name: vault.rules
     rules:
-      {{- if .Values.vaultExporter.alerts.defaultRules.vaultUp }}
+      {{- if .Values.prometheusRules.defaultRules.vaultUp }}
       - alert: VaultUp
         expr: vault_up{app="{{ template "vault.name" . }}", release="{{ .Release.Name }}"} == 0
         for: 10m
@@ -28,7 +28,7 @@ spec:
           description: "The Vault instance {{`{{$labels.pod_name}}`}} has been down for the last 10m"
       {{- end }}
 
-      {{- if .Values.vaultExporter.alerts.defaultRules.vaultUninitialized }}
+      {{- if .Values.prometheusRules.defaultRules.vaultUninitialized }}
       - alert: VaultUninitialized
         expr: vault_initialized{app="{{ template "vault.name" . }}", release="{{ .Release.Name }}"} == 0
         for: 10m
@@ -40,7 +40,7 @@ spec:
           description: "The Vault instance {{`{{$labels.pod_name}}`}} has been uninitialized for the last 10m"
       {{- end }}
 
-      {{- if .Values.vaultExporter.alerts.defaultRules.vaultSealed }}
+      {{- if .Values.prometheusRules.defaultRules.vaultSealed }}
       - alert: VaultSealed
         expr: vault_sealed{app="{{ template "vault.name" . }}", release="{{ .Release.Name }}"} == 1
         for: 5m
@@ -52,7 +52,7 @@ spec:
           description: "The Vault instance {{`{{$labels.pod_name}}`}} has been sealed for the last 5m"
       {{- end }}
 
-      {{- if .Values.vaultExporter.alerts.defaultRules.vaultStandby }}
+      {{- if .Values.prometheusRules.defaultRules.vaultStandby }}
       - alert: VaultStandby
         expr: vault_standby{app="{{ template "vault.name" . }}", release="{{ .Release.Name }}"} == 1
         for: 10m
@@ -63,7 +63,7 @@ spec:
           summary: "Vault instance {{`{{$labels.pod_name}}`}} is in standby mode"
           description: "The Vault instance {{`{{$labels.pod_name}}`}} has been in standby mode for the last 10m"
       {{- end }}
-{{- if .Values.vaultExporter.alerts.extraRules }}
-{{ toYaml .Values.vaultExporter.alerts.extraRules | indent 6 }}
+{{- if .Values.prometheusRules.extraRules }}
+{{ toYaml .Values.prometheusRules.extraRules | indent 6 }}
 {{- end }}
 {{- end -}}

--- a/incubator/vault/templates/service.yaml
+++ b/incubator/vault/templates/service.yaml
@@ -30,10 +30,10 @@ spec:
     protocol: TCP
     targetPort: {{ .Values.service.port }}
     name: api
-  {{- if .Values.vaultExporter.serviceMonitor.enabled }}
+  {{- if .Values.serviceMonitor.enabled }}
   - port: 9410
     protocol: TCP
-    targetPort: metrics
+    targetPort: {{ .Values.serviceMonitor.podPortName }}
     name: metrics
   {{- end }}
   {{- if .Values.service.clusterExternalPort }}

--- a/incubator/vault/templates/service.yaml
+++ b/incubator/vault/templates/service.yaml
@@ -30,6 +30,12 @@ spec:
     protocol: TCP
     targetPort: {{ .Values.service.port }}
     name: api
+  {{- if .Values.vaultExporter.serviceMonitor.enabled }}
+  - port: 9410
+    protocol: TCP
+    targetPort: metrics
+    name: metrics
+  {{- end }}
   {{- if .Values.service.clusterExternalPort }}
   - port: {{ .Values.service.clusterExternalPort }}
     protocol: TCP

--- a/incubator/vault/templates/servicemonitor.yaml
+++ b/incubator/vault/templates/servicemonitor.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.vaultExporter.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "vault.fullname" . }}
+  labels:
+    app: {{ template "vault.name" . }}
+    chart: {{ template "vault.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.vaultExporter.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.vaultExporter.serviceMonitor.additionalLabels | indent 4 }}
+{{- end }}
+spec:
+  endpoints:
+  - port: "metrics"
+    interval: {{ .Values.vaultExporter.serviceMonitor.interval }}
+    honorLabels: true
+  jobLabel: {{ .Values.vaultExporter.serviceMonitor.jobLabel}}
+  selector:
+    matchLabels:
+      app: {{ template "vault.name" . }}
+      release: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+{{- end -}}

--- a/incubator/vault/templates/servicemonitor.yaml
+++ b/incubator/vault/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.vaultExporter.serviceMonitor.enabled -}}
+{{- if .Values.serviceMonitor.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -8,15 +8,15 @@ metadata:
     chart: {{ template "vault.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- if .Values.vaultExporter.serviceMonitor.additionalLabels }}
-{{ toYaml .Values.vaultExporter.serviceMonitor.additionalLabels | indent 4 }}
+{{- if .Values.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
 {{- end }}
 spec:
   endpoints:
   - port: "metrics"
-    interval: {{ .Values.vaultExporter.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
     honorLabels: true
-  jobLabel: {{ .Values.vaultExporter.serviceMonitor.jobLabel}}
+  jobLabel: {{ .Values.serviceMonitor.jobLabel}}
   selector:
     matchLabels:
       app: {{ template "vault.name" . }}

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -16,6 +16,36 @@ vaultExporter:
   pullPolicy: IfNotPresent
   vaultAddress: 127.0.0.1:8200
   # tlsCAFile: /vault/tls/ca.crt
+
+  # Prometheus operator Service Monitor:
+  serviceMonitor:
+    enabled: false
+    additionalLabels: {}
+      # prometheus-scraper: "default"
+    interval: 10s
+    jobLabel: "vault-exporter"
+  # Prometheus operator Rules:
+  alerts:
+    enabled: false
+    defaultRules:
+      # Triggered when pod is not up
+      vaultUp: true
+      # Triggered when vault is not initialzed
+      vaultUninitialized: true
+      # Triggered when vault is sealed
+      vaultSealed: true
+      # Triggered when vault is in standby mode
+      vaultStandby: false
+    extraRules: []
+    # - alert: VaultStandby
+    #   expr: vault_standby{app="vault", release="vault"} == 1
+    #   for: 1m
+    #   labels:
+    #     service: vault
+    #     severity: critical
+    #   annotations:
+    #     summary: "Vault instance {{$labels.pod_name}} is in standby mode"
+
 consulAgent:
   repository: consul
   tag: 1.4.0

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -17,34 +17,35 @@ vaultExporter:
   vaultAddress: 127.0.0.1:8200
   # tlsCAFile: /vault/tls/ca.crt
 
-  # Prometheus operator Service Monitor:
-  serviceMonitor:
-    enabled: false
-    additionalLabels: {}
-      # prometheus-scraper: "default"
-    interval: 10s
-    jobLabel: "vault-exporter"
-  # Prometheus operator Rules:
-  alerts:
-    enabled: false
-    defaultRules:
-      # Triggered when pod is not up
-      vaultUp: true
-      # Triggered when vault is not initialzed
-      vaultUninitialized: true
-      # Triggered when vault is sealed
-      vaultSealed: true
-      # Triggered when vault is in standby mode
-      vaultStandby: false
-    extraRules: []
-    # - alert: VaultStandby
-    #   expr: vault_standby{app="vault", release="vault"} == 1
-    #   for: 1m
-    #   labels:
-    #     service: vault
-    #     severity: critical
-    #   annotations:
-    #     summary: "Vault instance {{$labels.pod_name}} is in standby mode"
+# Prometheus operator Service Monitor:
+serviceMonitor:
+  enabled: false
+  additionalLabels: {}
+    # prometheus-scraper: "default"
+  podPortName: "metrics"
+  interval: 10s
+  jobLabel: "vault-exporter"
+# Prometheus operator Rules:
+prometheusRules:
+  enabled: false
+  defaultRules:
+    # Triggered when pod is not up
+    vaultUp: true
+    # Triggered when vault is not initialzed
+    vaultUninitialized: true
+    # Triggered when vault is sealed
+    vaultSealed: true
+    # Triggered when vault is in standby mode
+    vaultStandby: false
+  extraRules: []
+  # - alert: VaultStandby
+  #   expr: vault_standby{app="vault", release="vault"} == 1
+  #   for: 1m
+  #   labels:
+  #     service: vault
+  #     severity: critical
+  #   annotations:
+  #     summary: "Vault instance {{$labels.pod_name}} is in standby mode"
 
 consulAgent:
   repository: consul


### PR DESCRIPTION
Signed-off-by: Alexandre Ledit <alexandre.ledit@easymile.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR add support for Prometheus Operator. It allows to create a ServiceMonitor resource for Prometheus to automatically scrape the vault-exporter. It also can create a PrometheusRules resource with some default rules, and custom ones.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
 - None

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
