### PR TITLE
[stable/logstash] Add the option to create secrets

### DIFF
--- a/stable/logstash/Chart.yaml
+++ b/stable/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 2.2.0
+version: 2.2.1
 appVersion: 7.1.1
 sources:
 - https://www.docker.elastic.co

--- a/stable/logstash/README.md
+++ b/stable/logstash/README.md
@@ -110,6 +110,7 @@ The following table lists the configurable parameters of the chart and its defau
 | `persistence.size`              | Size for PVCs                                      | `2Gi`                                            |
 | `volumeMounts`                  | Volume mounts to configure for logstash container  | (see `values.yaml`)                              |
 | `volumes`                       | Volumes to configure for logstash container        | []                                               |
+| `secrets`                       | Secrets to create and mount to logstash container  | {}
 | `terminationGracePeriodSeconds` | Duration the pod needs to terminate gracefully     | `30`                                             |
 | `exporter.logstash`             | Prometheus logstash-exporter settings              | (see `values.yaml`)                              |
 | `exporter.logstash.enabled`     | Enables Prometheus logstash-exporter               | `false`                                          |

--- a/stable/logstash/README.md
+++ b/stable/logstash/README.md
@@ -110,7 +110,7 @@ The following table lists the configurable parameters of the chart and its defau
 | `persistence.size`              | Size for PVCs                                      | `2Gi`                                            |
 | `volumeMounts`                  | Volume mounts to configure for logstash container  | (see `values.yaml`)                              |
 | `volumes`                       | Volumes to configure for logstash container        | []                                               |
-| `secrets`                       | Secrets to create and mount to logstash container  | {}
+| `secrets`                       | Secrets to create and mount to logstash container  | {}                                               |
 | `terminationGracePeriodSeconds` | Duration the pod needs to terminate gracefully     | `30`                                             |
 | `exporter.logstash`             | Prometheus logstash-exporter settings              | (see `values.yaml`)                              |
 | `exporter.logstash.enabled`     | Enables Prometheus logstash-exporter               | `false`                                          |

--- a/stable/logstash/templates/secret.yaml
+++ b/stable/logstash/templates/secret.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.secrets -}}
+apiVersion: v1
+kind: Secret
+type: Opaque
+
+metadata:
+  name: {{ template "logstash.fullname" . }}-secrets
+  labels:
+    app: {{ template "logstash.name" . }}
+    chart: {{ template "logstash.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+{{- range $key, $value := .Values.secrets }}
+  {{ $key }}: {{ $value | b64enc }}
+{{- end }}
+{{- end -}}

--- a/stable/logstash/templates/statefulset.yaml
+++ b/stable/logstash/templates/statefulset.yaml
@@ -96,6 +96,11 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:
 {{ toYaml .Values.volumeMounts | indent 12 }}
+{{- if .Values.secrets }}
+            - name: secrets
+              mountPath: /usr/share/logstash/secrets
+              readOnly: true
+{{- end }}
 
 {{- if .Values.exporter.logstash.enabled }}
         ## logstash-exporter
@@ -153,6 +158,12 @@ spec:
         - name: pipeline
           configMap:
             name: {{ template "logstash.fullname" . }}-pipeline
+    {{- if .Values.secrets }}
+        - name: secrets
+          secret:
+            defaultMode: 0400
+            secretName: {{ template "logstash.fullname" . }}-secrets
+    {{- end }}
     {{- with .Values.volumes }}
 {{ toYaml . | indent 8 }}
     {{- end }}

--- a/stable/logstash/values.yaml
+++ b/stable/logstash/values.yaml
@@ -183,6 +183,14 @@ volumes: []
   #   hostPath:
   #     path: /tmp
 
+secrets: {}
+  # json_key_file.json: |-
+  #   "sensitive": {
+  #     "data": "password"
+  #     }
+  #   }
+  # e.g. for https://www.elastic.co/guide/en/logstash/master/plugins-outputs-google_bigquery.html#plugins-outputs-google_bigquery-json_key_file
+
 exporter:
   logstash:
     enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:
Add the possibility to store sensitive information in secrets and mount them to container.
This could be used for plugins that require to specify file with cloud provider credentials to not put it in configmaps. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
