### PR TITLE
[stable/node-problem-detector] Add relabelings to include node label in metrics

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-problem-detector
-version: "1.5.2"
+version: "1.6.0"
 appVersion: v0.7.0
 home: https://github.com/kubernetes/node-problem-detector
 description: Installs the node-problem-detector daemonset for monitoring extra attributes on nodes

--- a/stable/node-problem-detector/templates/servicemonitor.yaml
+++ b/stable/node-problem-detector/templates/servicemonitor.yaml
@@ -23,4 +23,13 @@ spec:
   - port: exporter
     path: /metrics
     interval: 60s
+    relabelings:
+    - action: replace
+      targetLabel: node
+      sourceLabels:
+        - __meta_kubernetes_pod_node_name
+    - action: replace
+      targetLabel: host_ip
+      sourceLabels:
+        - __meta_kubernetes_pod_host_ip
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Patrick Harböck <patrick.harboeck@tngtech.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Since #16125 node-problem-detector exposes metrics via a prometheus-operator ServiceMonitor.
These metrics did not include any labels to identify the relevant node.

This PR adds the necessary relabeling rules to include these labels (as suggested in https://github.com/kubernetes/node-problem-detector/issues/332).

#### Which issue this PR fixes
  - fixes https://github.com/kubernetes/node-problem-detector/issues/332

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
