### PR TITLE
[stable/sonarqube] Adds ability to set sysctl init container image from values.

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 2.2.0
+version: 2.2.1
 appVersion: 7.9
 keywords:
   - coverage

--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 2.2.1
+version: 2.3.0
 appVersion: 7.9
 keywords:
   - coverage

--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -94,7 +94,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `tolerations`                               | List of node taints to tolerate           | `[]`                                       |
 | `plugins.install`                           | List of plugins to install                | `[]`                                       |
 | `plugins.resources`                         | Plugin Pod resource requests & limits     | `{}`                                       |
-| `plugins.initContainerImage`                | Change init container image               | `[]`                                       |
+| `plugins.initContainerImage`                | Change init container image               | `joosthofman/wget:1.0`                     |
 | `plugins.deleteDefaultPlugins`              | Remove default plugins and use plugins.install list | `[]`                             |
 | `podLabels`                                 | Map of labels to add to the pods          | `{}`                                       |
 

--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -95,6 +95,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `plugins.install`                           | List of plugins to install                | `[]`                                       |
 | `plugins.resources`                         | Plugin Pod resource requests & limits     | `{}`                                       |
 | `plugins.initContainerImage`                | Change init container image               | `joosthofman/wget:1.0`                     |
+| `plugins.initSysctlContainerImage`          | Change init sysctl container image        | `busybox:1.31`                             |
 | `plugins.deleteDefaultPlugins`              | Remove default plugins and use plugins.install list | `[]`                             |
 | `podLabels`                                 | Map of labels to add to the pods          | `{}`                                       |
 

--- a/stable/sonarqube/templates/deployment.yaml
+++ b/stable/sonarqube/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
 {{ toYaml .Values.securityContext | indent 8 }}
       initContainers:
         - name: init-sysctl
-          image: busybox:1.31
+          image: {{ default "busybox:1.31" .Values.plugins.initSysctlContainerImage }}
           command:
           - sysctl
           - -w


### PR DESCRIPTION
Signed-off-by: Nicolaas Hyatt <nhyatt@smoothnet.org>

#### What this PR does / why we need it:

This pull request adds support to set the sysctl init container image from the values.yaml file to identify a container repository.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)

#### Mentions
@rjkernick
@tsiddique