### PR TITLE
[stable/grafana] Fix indentation of pod template

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 3.8.12
+version: 3.8.13
 appVersion: 6.3.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/_pod.tpl
+++ b/stable/grafana/templates/_pod.tpl
@@ -8,7 +8,7 @@ schedulerName: "{{ .Values.schedulerName }}"
 {{- end }}
 {{- if .Values.securityContext }}
 securityContext:
-{{ toYaml .Values.securityContext | indent 8 }}
+{{ toYaml .Values.securityContext | indent 2 }}
 {{- end }}
 {{- if .Values.priorityClassName }}
 priorityClassName: {{ .Values.priorityClassName }}
@@ -24,7 +24,7 @@ initContainers:
       runAsUser: 0
     command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsUser }}", "/var/lib/grafana"]
     resources:
-{{ toYaml .Values.initChownData.resources | indent 12 }}
+{{ toYaml .Values.initChownData.resources | indent 6 }}
     volumeMounts:
       - name: storage
         mountPath: "/var/lib/grafana"
@@ -80,13 +80,13 @@ initContainers:
         value: "{{ .Values.sidecar.skipTlsVerify }}"
       {{- end }}
     resources:
-{{ toYaml .Values.sidecar.resources | indent 12 }}
+{{ toYaml .Values.sidecar.resources | indent 6 }}
     volumeMounts:
       - name: sc-datasources-volume
         mountPath: "/etc/grafana/provisioning/datasources"
 {{- end}}
 {{- if .Values.extraInitContainers }}
-{{ toYaml .Values.extraInitContainers | indent 8 }}
+{{ toYaml .Values.extraInitContainers | indent 2 }}
 {{- end }}
 {{- if .Values.image.pullSecrets }}
 imagePullSecrets:
@@ -115,7 +115,7 @@ containers:
         value: "{{ .Values.sidecar.skipTlsVerify }}"
       {{- end }}
     resources:
-{{ toYaml .Values.sidecar.resources | indent 12 }}
+{{ toYaml .Values.sidecar.resources | indent 6 }}
     volumeMounts:
       - name: sc-dashboard-volume
         mountPath: {{ .Values.sidecar.dashboards.folder | quote }}
@@ -258,25 +258,25 @@ containers:
           name: {{ .Values.envFromSecret }}
     {{- end }}
     livenessProbe:
-{{ toYaml .Values.livenessProbe | indent 12 }}
+{{ toYaml .Values.livenessProbe | indent 6 }}
     readinessProbe:
-{{ toYaml .Values.readinessProbe | indent 12 }}
+{{ toYaml .Values.readinessProbe | indent 6 }}
     resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.resources | indent 6 }}
 {{- if .Values.extraContainers }}
-{{ toYaml .Values.extraContainers | indent 8}}
+{{ toYaml .Values.extraContainers | indent 2}}
 {{- end }}
 {{- with .Values.nodeSelector }}
 nodeSelector:
-{{ toYaml . | indent 8 }}
+{{ toYaml . | indent 2 }}
 {{- end }}
 {{- with .Values.affinity }}
 affinity:
-{{ toYaml . | indent 8 }}
+{{ toYaml . | indent 2 }}
 {{- end }}
 {{- with .Values.tolerations }}
 tolerations:
-{{ toYaml . | indent 8 }}
+{{ toYaml . | indent 2 }}
 {{- end }}
 volumes:
   - name: config


### PR DESCRIPTION
Signed-off-by: Ramon Rüttimann <ramon.ruettimann@gmail.com>

#### What this PR does / why we need it:
It fixes the indentation on the pod template that gets added to the deployment.
The last commit to this Chart has extracted the pod template (`_pod.tpl`) from the `deployment.yaml`, but did not correct the indentation (as the template gets indented 6 spaces, plus the original x indents in the `_pod.tpl`).
This causes the chart to render incorrectly and fail as a YAML syntax error.

@zanhsieh 
@rtluckie 
@maorfr 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
