### PR TITLE
[stable/prometheus-pushgateway] Add configurable ServiceMonitor

### DIFF
--- a/stable/prometheus-pushgateway/Chart.yaml
+++ b/stable/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.9.1"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.0.1
+version: 1.0.3
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/stable/prometheus-pushgateway/README.md
+++ b/stable/prometheus-pushgateway/README.md
@@ -64,9 +64,9 @@ The following table lists the configurable parameters of the pushgateway chart a
 | `podLabels`                 | Labels for pod                                                                                                                | `{}`                              |
 | `serviceAccountLabels`      | Labels for service account                                                                                                    | `{}`                              |
 | `serviceMonitor.enabled`    | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)                        | `false`                           |
-| `serviceMonitor.namespace`  | Namespace which Prometheus is running in                                                                                      | `monitoring`                      |
-| `serviceMonitor.interval`   | How frequently to scrape metrics (use by default, falling back to Prometheus' default)                                        |  `nil`                            |
-| `serviceMonitor.selector`   | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install                    | `{ prometheus: kube-prometheus }` |
+| `serviceMonitor.labels`     | Labels for serviceMonitor                                                                                                     | `{}`                              |
+| `serviceMonitor.interval`   | How frequently to scrape metrics (use by default, falling back to Prometheus' default)                                        | `''`                              |
+| `serviceMonitor.selector`   | Pushgateway service monitor selector, matches against service labels                                                          | `{}`                              |
 | `serviceMonitor.honorLabels`| if `true`, label conflicts are resolved by keeping label values from the scraped data                                         | `true`                            |
 | `podDisruptionBudget`       | If set, create a PodDisruptionBudget with the items in this map set in the spec                                               | ``                                |
 

--- a/stable/prometheus-pushgateway/templates/servicemonitor.yaml
+++ b/stable/prometheus-pushgateway/templates/servicemonitor.yaml
@@ -3,13 +3,9 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-pushgateway.name" .  }}
-  {{- if .Values.serviceMonitor.namespace }}
-  namespace: {{ .Values.serviceMonitor.namespace }}
-  {{- end }}
+  namespace: {{ .Release.Namespace }}
   labels:
-    {{- range $key, $value := .Values.serviceMonitor.selector }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
+{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.serviceMonitor.labels) . }}
 spec:
   endpoints:
   - port: http
@@ -18,6 +14,11 @@ spec:
     {{- end }}
     honorLabels: {{ .Values.serviceMonitor.honorLabels }}
   selector:
+    {{- if .Values.serviceMonitor.selector }}
+    {{ toYaml .Values.serviceMonitor.selector }}
+    {{- else }}
     matchLabels:
       app: {{ template "prometheus-pushgateway.name" . }}
+      release: {{ .Release.Name }}
+    {{- end -}}
 {{- end -}}

--- a/stable/prometheus-pushgateway/values.yaml
+++ b/stable/prometheus-pushgateway/values.yaml
@@ -95,14 +95,16 @@ affinity: {}
 # Enable this if you're using https://github.com/coreos/prometheus-operator
 serviceMonitor:
   enabled: false
-  namespace: monitoring
-  # fallback to the prometheus default unless specified
-  # interval: 10s
-  ## Defaults to what's used if you follow CoreOS [Prometheus Install Instructions](https://github.com/helm/charts/tree/master/stable/prometheus-operator#tldr)
-  ## [Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#prometheus-operator-1)
-  ## [Kube Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#exporters)
-  selector:
-    prometheus: kube-prometheus
+  # Optional serviceMonitor labels
+  labels: {}
+  # Prometheus scrape_interval matching the regex [0-9]+(ms|[smhdwy])
+  # Uses the Prometheus server's default scrape_interval if not specified
+  interval: ''
+  # Label selector used by the serviceMonitor to match against the Pushgateway
+  # service. Defaults to this chart's release and app (fullname) if not specified.
+  # see [metav1.LabelSelector documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#labelselector-v1-meta)
+  # for details
+  selector: {}
   # Retain the job and instance labels of the metrics pushed to the Pushgateway
   # [Scraping Pushgateway](https://github.com/prometheus/pushgateway#configure-the-pushgateway-as-a-target-to-scrape)
   honorLabels: true


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR fixes a bug in which ServiceMonitors scrape all releases, regardless of whether those releases have ServiceMonitors enabled. Instead, a flexible selector configuration is introduced with the default selector matching only the service in the same release as the selector itself.

I've also done some minor cleanup in the ServiceMonitor.

#### Which issue this PR fixes
  - fixes #17138 
  - changes the `serviceMonitor.selector` variable so that it applies to the serviceMonitor's selector, not its labels. `serviceMonitor.labels` has been added, and are merged into the defaultLabels and applied to the serviceMonitor
  - removes `serviceMonitor.namespace`, which (unless I'm mistaken) does not provide functionality, and breaks the [technical requirement](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements) that the chart must launch with default values; the current default causes the chart to break if the `monitoring` namespace does not exist.
  - minor cleanup on the `serviceMonitor.interval` variable's default value

#### Special notes for your reviewer:
* Version bumped to `1.0.3` so as to not conflict with #17128 which is related.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
