### PR TITLE
Fix `output.scheme` notation

### DIFF
--- a/stable/fluentd/Chart.yaml
+++ b/stable/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Fluentd Elasticsearch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd
-version: 2.2.0
+version: 2.2.1
 appVersion: v2.4.0
 home: https://www.fluentd.org/
 sources:

--- a/stable/fluentd/README.md
+++ b/stable/fluentd/README.md
@@ -48,7 +48,7 @@ Parameter | Description | Default
 `configMaps` | Fluentd configuration | See [values.yaml](values.yaml)
 `output.host` | output host | `elasticsearch-client.default.svc.cluster.local`
 `output.port` | output port | `9200`
-`output.scheme` | output port | `http`
+`output.scheme` | output scheme | `http`
 `output.sslVersion` | output ssl version | `TLSv1`
 `output.buffer_chunk_limit` | output buffer chunk limit | `2M`
 `output.buffer_queue_limit` | output buffer queue limit | `8`


### PR DESCRIPTION
This looks like a copy-paste typo. I updated the description to match the related key.

I bumped the chart minor version as no code has changed.