### PR TITLE
[stable/rabbitmq-ha] Only set the nodePort for NodePort service type

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.15
-version: 1.33.0
+version: 1.32.1
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.15
-version: 1.32.0
+version: 1.33.0
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/templates/service.yaml
+++ b/stable/rabbitmq-ha/templates/service.yaml
@@ -40,17 +40,23 @@ spec:
     - name: http
       protocol: TCP
       port: {{ .Values.rabbitmqManagerPort }}
+      {{- if eq .Values.service.type "NodePort" }}
       nodePort: {{ .Values.service.managerNodePort }}
+      {{- end }}
       targetPort: http
     - name: amqp
       protocol: TCP
       port: {{ .Values.rabbitmqNodePort }}
+      {{- if eq .Values.service.type "NodePort" }}
       nodePort: {{ .Values.service.amqpNodePort }}
+      {{- end }}
       targetPort: amqp
     - name: epmd
       protocol: TCP
       port: {{ .Values.rabbitmqEpmdPort }}
+      {{- if eq .Values.service.type "NodePort" }}
       nodePort: {{ .Values.service.epmdNodePort }}
+      {{- end }}
       targetPort: epmd
     {{- if .Values.rabbitmqSTOMPPlugin.enabled }}
     - name: stomp-tcp

--- a/stable/rabbitmq-ha/templates/service.yaml
+++ b/stable/rabbitmq-ha/templates/service.yaml
@@ -40,21 +40,21 @@ spec:
     - name: http
       protocol: TCP
       port: {{ .Values.rabbitmqManagerPort }}
-      {{- if eq .Values.service.type "NodePort" }}
+      {{- if eq .Values.service.type "NodePort" "LoadBalancer" }}
       nodePort: {{ .Values.service.managerNodePort }}
       {{- end }}
       targetPort: http
     - name: amqp
       protocol: TCP
       port: {{ .Values.rabbitmqNodePort }}
-      {{- if eq .Values.service.type "NodePort" }}
+      {{- if eq .Values.service.type "NodePort" "LoadBalancer" }}
       nodePort: {{ .Values.service.amqpNodePort }}
       {{- end }}
       targetPort: amqp
     - name: epmd
       protocol: TCP
       port: {{ .Values.rabbitmqEpmdPort }}
-      {{- if eq .Values.service.type "NodePort" }}
+      {{- if eq .Values.service.type "NodePort" "LoadBalancer" }}
       nodePort: {{ .Values.service.epmdNodePort }}
       {{- end }}
       targetPort: epmd


### PR DESCRIPTION
#### What this PR does / why we need it:

This resolves an issue with older version of kubernetes that fails on
parsing the `null` value as it only expects integer values. (which
means that on older clusters the chart as is now fails to install)

```
...
failed: Service in version "v1" cannot be handled as a Service: v1.Service: Spec: v1.ServiceSpec: Ports: []v1.ServicePort: v1.ServicePort: NodePort: readUint32: unexpected character: �, parsing 304 ...odePort":n...
...
```

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)