### PR TITLE
[incubator/schema-registry] allow custom service annotations

### DIFF
--- a/incubator/schema-registry/Chart.yaml
+++ b/incubator/schema-registry/Chart.yaml
@@ -1,6 +1,6 @@
 name: schema-registry
 home: https://docs.confluent.io/current/schema-registry/docs/index.html
-version: 1.1.5
+version: 1.1.6
 appVersion: 5.0.1
 keywords:
   - confluent

--- a/incubator/schema-registry/README.md
+++ b/incubator/schema-registry/README.md
@@ -79,6 +79,7 @@ The following table lists the configurable parameters of the SchemaRegistry char
 | `sasl.scram.zookeeperClientPassword` | the sasl scram password to use to authenticate to zookeeper | `zookeeper-password` |
 | `resources` | CPU/Memory resource requests/limits | `{}` |
 | `servicePort` | The port on which the SchemaRegistry server will be exposed. | `8081` |
+| `service.annotations` | Additional annotations for the service | `{}` |
 | `service.labels` | Additional labels for the service | `{}` |
 | `overrideGroupId` | Group ID defaults to using Release Name so each release is its own Schema Registry worker group, it can be overridden | `{- .Release.Name -}}` |
 | `kafkaStore.overrideBootstrapServers` | Defaults to Kafka Servers in the same release, it can be overridden in case there was a separate release for Kafka Deploy | `{{- printf "PLAINTEXT://%s-kafka-headless:9092" .Release.Name }}`

--- a/incubator/schema-registry/templates/service.yaml
+++ b/incubator/schema-registry/templates/service.yaml
@@ -1,6 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
   name: {{ template "schema-registry.fullname" . }}
   labels:
     app: {{ template "schema-registry.name" . }}

--- a/incubator/schema-registry/values.yaml
+++ b/incubator/schema-registry/values.yaml
@@ -42,6 +42,8 @@ servicePort: 8081
 
 ## Provides schema registry service settings
 service:
+  ## Any annotations to add to the service
+  annotations: {}
   ## Any additional labels to add to the service
   labels: {}
 


### PR DESCRIPTION
Signed-off-by: S.Cavallo <smcavallo@hotmail.com>

#### Is this a new chart
no

#### What this PR does / why we need it:
Allows further customization of schema-registry service - adding annotations which can be used to allow service mesh, deployments, discovery by other custom tools

#### Which issue this PR fixes
n/a

#### Special notes for your reviewer:
following the pattern of setting annotations for services found in other helm/charts
Example usage.

```
## Provides schema registry service settings
service:
  ## Any annotations to add to the service
  annotations:
    getambassador.io/config: |
      ---
      apiVersion: ambassador/v1
      kind:  Mapping
      name: schema_uri_mapping
      prefix: /schema-registry
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X ] Chart Version bumped
- [X ] Variables are documented in the README.md
- [X ] Title of the PR starts with chart name (e.g. `[stable/chart]`)
