### PR TITLE
incubator/jaeger Support deadline override in cassandra schema job

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.13.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.13.0
+version: 0.13.1
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -249,6 +249,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `schema.image`                           | Image to setup cassandra schema     |  `jaegertracing/jaeger-cassandra-schema` |
 | `schema.mode`                            | Schema mode (prod or test)          |  `prod`                                  |
 | `schema.pullPolicy`                      | Schema image pullPolicy             |  `IfNotPresent`                          |
+| `schema.activeDeadlineSeconds`           | Deadline in seconds for cassandra schema creation job to complete |  `120`                            |
 | `serviceAccounts.agent.create`              | Create service account   |  `true`                                  |
 | `serviceAccounts.agent.name`              | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template  |  ``                                  |
 | `serviceAccounts.cassandraSchema.create`              | Create service account   |  `true`                                  |

--- a/incubator/jaeger/templates/cassandra-schema-job.yaml
+++ b/incubator/jaeger/templates/cassandra-schema-job.yaml
@@ -15,7 +15,7 @@ metadata:
 {{ toYaml .Values.schema.annotations | indent 4 }}
 {{- end }}
 spec:
-  activeDeadlineSeconds: 120
+  activeDeadlineSeconds: {{ .Values.schema.activeDeadlineSeconds }}
   template:
     metadata:
       name: {{ include "jaeger.fullname" . }}-cassandra-schema

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -88,6 +88,8 @@ schema:
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
+  # Deadline for cassandra schema creation job
+  activeDeadlineSeconds: 120
 
 # Begin: Override values on the Elasticsearch subchart to customize for Jaeger
 elasticsearch:


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:

With the default `activeDeadlineSeconds` of 120, in our cluster the jaeger-cassandra pods may not be available quickly enough for the job to complete. After its 120 second deadline, the job is aborted and will not be retried. We would like to increase this deadline in our configuration so that this chart may fully install without manual intervention.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
