### PR TITLE
[stable/datadog] Make deployment strategies configurable

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.33.0
+version: 1.34.0
 appVersion: 6.13.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -286,6 +286,7 @@ helm install --name <RELEASE_NAME> \
 | `daemonset.containers.traceAgent.resources.limits.memory`        | Memory resource limits for the trace-agent container                                   | `200Mi`                                       |
 | `daemonset.containers.traceAgent.resources.requests.memory`      | Memory resource requests for the trace-agent container                                 | `200Mi`                                       |
 | `daemonset.priorityClassName`            | Which Priority Class to associate with the daemonset                                      | `nil`                                       |
+| `daemonset.updateStrategy`               | Which update strategy to deploy the daemonset                                             | RollingUpdate with 10% maxUnavailable       |
 | `datadog.leaderElection`                 | Enable the leader Election feature                                                        | `false`                                     |
 | `datadog.leaderLeaseDuration`            | The duration for which a leader stays elected.                                            | 60 sec, 15 if Cluster Checks enabled        |
 | `datadog.collectEvents`                  | Enable Kubernetes event collection. Requires leader election.                             | `false`                                     |
@@ -317,6 +318,7 @@ helm install --name <RELEASE_NAME> \
 | `clusterAgent.tolerations`               | List of node taints to tolerate                                                           | `[]`                                        |
 | `clusterAgent.livenessProbe`             | Overrides the default liveness probe                                                      | http port 443 if external metrics enabled   |
 | `clusterAgent.readinessProbe`            | Overrides the default readiness probe                                                     | http port 443 if external metrics enabled   |
+| `clusterAgent.strategy`                  | Which update strategy to deploy the cluster-agent                                         | RollingUpdate with 10% maxUnavailable       |
 | `clusterchecksDeployment.enabled`        | Enable Datadog agent deployment dedicated for running Cluster Checks. It allows having different resources (Request/Limit) for Cluster Checks agent pods.  | `false` |
 | `clusterchecksDeployment.env`                            | Additional Datadog environment variables for Cluster Checks Deployment                        | `nil`                                       |
 | `clusterchecksDeployment.resources.requests.cpu`         | CPU resource requests                                                                         | `200m`                                      |
@@ -329,3 +331,4 @@ helm install --name <RELEASE_NAME> \
 | `clusterchecksDeployment.livenessProbe`                  | Overrides the default liveness probe                                                          | http port 5555                              |
 | `clusterchecksDeployment.rbac.dedicated`                  | If true, use dedicated RBAC resources for clusterchecks agent's pods                          | `false`                                     |
 | `clusterchecksDeployment.rbac.serviceAccount`            | existing ServiceAccount to use (ignored if rbac.create=true) for clusterchecks                | `default`                                   |
+| `clusterchecksDeployment.strategy`                       | Which update strategy to deploy the Cluster Checks Deployment                                 | RollingUpdate with 10% maxUnavailable       |

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -318,7 +318,7 @@ helm install --name <RELEASE_NAME> \
 | `clusterAgent.tolerations`               | List of node taints to tolerate                                                           | `[]`                                        |
 | `clusterAgent.livenessProbe`             | Overrides the default liveness probe                                                      | http port 443 if external metrics enabled   |
 | `clusterAgent.readinessProbe`            | Overrides the default readiness probe                                                     | http port 443 if external metrics enabled   |
-| `clusterAgent.strategy`                  | Which update strategy to deploy the cluster-agent                                         | RollingUpdate with 10% maxUnavailable       |
+| `clusterAgent.strategy`                  | Which update strategy to deploy the cluster-agent                                         | RollingUpdate with 0 maxUnavailable, 1 maxSurge |
 | `clusterchecksDeployment.enabled`        | Enable Datadog agent deployment dedicated for running Cluster Checks. It allows having different resources (Request/Limit) for Cluster Checks agent pods.  | `false` |
 | `clusterchecksDeployment.env`                            | Additional Datadog environment variables for Cluster Checks Deployment                        | `nil`                                       |
 | `clusterchecksDeployment.resources.requests.cpu`         | CPU resource requests                                                                         | `200m`                                      |
@@ -331,4 +331,4 @@ helm install --name <RELEASE_NAME> \
 | `clusterchecksDeployment.livenessProbe`                  | Overrides the default liveness probe                                                          | http port 5555                              |
 | `clusterchecksDeployment.rbac.dedicated`                  | If true, use dedicated RBAC resources for clusterchecks agent's pods                          | `false`                                     |
 | `clusterchecksDeployment.rbac.serviceAccount`            | existing ServiceAccount to use (ignored if rbac.create=true) for clusterchecks                | `default`                                   |
-| `clusterchecksDeployment.strategy`                       | Which update strategy to deploy the Cluster Checks Deployment                                 | RollingUpdate with 10% maxUnavailable       |
+| `clusterchecksDeployment.strategy`                       | Which update strategy to deploy the Cluster Checks Deployment                                 | RollingUpdate with 0 maxUnavailable, 1 maxSurge |

--- a/stable/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/stable/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 1
-      maxUnavailable: 1
+      maxUnavailable: 0
 {{- end }}
   template:
     metadata:

--- a/stable/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/stable/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -16,7 +16,8 @@ spec:
 {{- else }}
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: "10%"
+      maxSurge: 1
+      maxUnavailable: 1
 {{- end }}
   template:
     metadata:

--- a/stable/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/stable/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -10,6 +10,14 @@ metadata:
     heritage: {{ .Release.Service | quote }}
 spec:
   replicas: {{ .Values.clusterchecksDeployment.replicas }}
+  strategy:
+{{- if .Values.clusterchecksDeployment.strategy }}
+{{ toYaml .Values.clusterchecksDeployment.strategy | indent 4 }}
+{{- else }}
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "10%"
+{{- end }}
   template:
     metadata:
       labels:

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -16,7 +16,8 @@ spec:
 {{- else }}
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: "10%"
+      maxSurge: 1
+      maxUnavailable: 0
 {{- end }}
   selector:
     matchLabels:

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -10,6 +10,14 @@ metadata:
     heritage: {{ .Release.Service | quote }}
 spec:
   replicas: {{ .Values.clusterAgent.replicas }}
+  strategy:
+{{- if .Values.clusterAgent.strategy }}
+{{ toYaml .Values.clusterAgent.strategy | indent 4 }}
+{{- else }}
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "10%"
+{{- end }}
   selector:
     matchLabels:
       app: {{ template "datadog.fullname" . }}-cluster-agent

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -131,6 +131,12 @@ spec:
 {{ toYaml .Values.daemonset.nodeSelector | indent 8 }}
       {{- end }}
   updateStrategy:
-    type: {{ default "RollingUpdate" .Values.daemonset.updateStrategy | quote }}
+{{- if .Values.daemonset.updateStrategy }}
+{{ toYaml .Values.daemonset.updateStrategy | indent 4 }}
+{{- else }}
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "10%"
+{{- end }}
 {{ end }}
 {{ end }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -367,7 +367,8 @@ clusterAgent:
   # strategy:
   #   type: RollingUpdate
   #   rollingUpdate:
-  #     maxUnavailable: 10%
+  #     maxSurge: 1
+  #     maxUnavailable: 0
 
   ## @param podAnnotations - list of key:value strings - optional
   ## Annotations to add to the cluster-agents's pod(s)
@@ -691,7 +692,8 @@ clusterchecksDeployment:
   # strategy:
   #   type: RollingUpdate
   #   rollingUpdate:
-  #     maxUnavailable: 10%
+  #     maxSurge: 1
+  #     maxUnavailable: 1
 
   ## @param nodeSelector - object - optional
   ## Allow the ClusterChecks Deployment to schedule on selected nodes

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -208,7 +208,7 @@ datadog:
   #
   # volumes:
   #   - hostPath:
-  #     path: <HOST_PATH>
+  #       path: <HOST_PATH>
   #     name: <VOLUME_NAME>
 
   ## @param volumeMounts - list of objects - optional
@@ -359,6 +359,15 @@ clusterAgent:
   # livenessProbe:
   #   exec:
   #     command: ["/bin/true"]
+
+  ## @param strategy - string - optional
+  ## Allow the Cluster Agent deployment to perform a rolling update on helm update
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  #
+  # strategy:
+  #   type: RollingUpdate
+  #   rollingUpdate:
+  #     maxUnavailable: 10%
 
   ## @param podAnnotations - list of key:value strings - optional
   ## Annotations to add to the cluster-agents's pod(s)
@@ -567,7 +576,10 @@ daemonset:
   ## Allow the DaemonSet to perform a rolling update on helm update
   ## ref: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
   #
-  # updateStrategy: RollingUpdate
+  # updateStrategy:
+  #   type: RollingUpdate
+  #   rollingUpdate:
+  #     maxUnavailable: 10%
 
   ## @param priorityClassName - string - optional
   ## Sets PriorityClassName if defined.
@@ -672,8 +684,17 @@ clusterchecksDeployment:
   #
   # affinity:
 
+  ## @param strategy - string - optional
+  ## Allow the ClusterChecks deployment to perform a rolling update on helm update
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  #
+  # strategy:
+  #   type: RollingUpdate
+  #   rollingUpdate:
+  #     maxUnavailable: 10%
+
   ## @param nodeSelector - object - optional
-  ## Allow the ClusterChecks Deploument to schedule on selected nodes
+  ## Allow the ClusterChecks Deployment to schedule on selected nodes
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   #
   # nodeSelector: {}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -580,7 +580,7 @@ daemonset:
   # updateStrategy:
   #   type: RollingUpdate
   #   rollingUpdate:
-  #     maxUnavailable: 10%
+  #     maxUnavailable: "10%"
 
   ## @param priorityClassName - string - optional
   ## Sets PriorityClassName if defined.

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -693,7 +693,7 @@ clusterchecksDeployment:
   #   type: RollingUpdate
   #   rollingUpdate:
   #     maxSurge: 1
-  #     maxUnavailable: 1
+  #     maxUnavailable: 0
 
   ## @param nodeSelector - object - optional
   ## Allow the ClusterChecks Deployment to schedule on selected nodes


### PR DESCRIPTION
#### What this PR does / why we need it:
offers the possibility to configure the deployment strategies of Agent, ClusterAgent, ClusterChecks

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
