### PR TITLE
[stable/redis] Allow creating a cluster without initial slave replicas

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 9.1.10
+version: 9.1.11
 appVersion: 5.0.5
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/configmap.yaml
+++ b/stable/redis/templates/configmap.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: {{ template "redis.fullname" . }}
   labels:
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "redis.fullname" . }}
 data:
   redis.conf: |-
 {{- if .Values.configmap }}

--- a/stable/redis/templates/headless-svc.yaml
+++ b/stable/redis/templates/headless-svc.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   type: ClusterIP
   clusterIP: None
@@ -21,4 +21,4 @@ spec:
 {{- end }}
   selector:
     app: {{ template "redis.name" . }}
-    release: "{{ .Release.Name }}"
+    release: {{ .Release.Name }}

--- a/stable/redis/templates/health-configmap.yaml
+++ b/stable/redis/templates/health-configmap.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: {{ template "redis.fullname" . }}-health
   labels:
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "redis.fullname" . }}-health
 data:
   ping_readiness_local.sh: |-
 {{- if .Values.usePasswordFile }}

--- a/stable/redis/templates/metrics-svc.yaml
+++ b/stable/redis/templates/metrics-svc.yaml
@@ -6,12 +6,11 @@ metadata:
   labels:
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
-{{- if .Values.metrics.service.annotations }}
-  annotations:
-{{ toYaml .Values.metrics.service.annotations | indent 4 }}
-{{- end }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- if .Values.metrics.service.annotations }}
+  annotations: {{ toYaml .Values.metrics.service.annotations | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.metrics.service.type }}
   {{ if eq .Values.metrics.service.type "LoadBalancer" -}} {{ if .Values.metrics.service.loadBalancerIP -}}

--- a/stable/redis/templates/networkpolicy.yaml
+++ b/stable/redis/templates/networkpolicy.yaml
@@ -2,18 +2,18 @@
 kind: NetworkPolicy
 apiVersion: {{ template "networkPolicy.apiVersion" . }}
 metadata:
-  name: "{{ template "redis.fullname" . }}"
+  name: {{ template "redis.fullname" . }}
   labels:
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   podSelector:
     matchLabels:
       app: {{ template "redis.name" . }}
-      release: "{{ .Release.Name }}"
-  {{- if ge .Values.cluster.slaveCount 1.0 }}
+      release: {{ .Release.Name }}
+  {{- if .Values.cluster.enabled }}
   policyTypes:
     - Ingress
     - Egress
@@ -27,8 +27,8 @@ spec:
       to:
       - podSelector:
           matchLabels:
-            release: "{{ .Release.Name }}"
             app: {{ template "redis.name" . }}
+            release: {{ .Release.Name }}
   {{- end }}
   ingress:
     # Allow inbound connections
@@ -45,16 +45,16 @@ spec:
       {{- if .Values.metrics.enabled }}
       - podSelector:
           matchLabels:
-            release: "{{ .Release.Name }}"
-            role: metrics
             app: {{ template "redis.name" . }}
+            release: {{ .Release.Name }}
+            role: metrics
       {{- end }}
-      {{- if ge .Values.cluster.slaveCount 1.0 }}
+      {{- if .Values.cluster.enabled }}
       - podSelector:
           matchLabels:
-            release: "{{ .Release.Name }}"
-            role: slave
             app: {{ template "redis.name" . }}
+            release: {{ .Release.Name }}
+            role: slave
       {{- end }}
       {{- end }}
     {{- if .Values.metrics.enabled }}

--- a/stable/redis/templates/redis-master-statefulset.yaml
+++ b/stable/redis/templates/redis-master-statefulset.yaml
@@ -5,29 +5,28 @@ metadata:
   labels:
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   selector:
     matchLabels:
-      release: "{{ .Release.Name }}"
-      role: master
       app: {{ template "redis.name" . }}
+      release: {{ .Release.Name }}
+      role: master
   serviceName: {{ template "redis.fullname" . }}-headless
   template:
     metadata:
       labels:
-        release: "{{ .Release.Name }}"
-        chart: {{ template "redis.chart" . }}
-        role: master
         app: {{ template "redis.name" . }}
+        chart: {{ template "redis.chart" . }}
+        release: {{ .Release.Name }}
+        role: master
 {{- if .Values.master.podLabels }}
 {{ toYaml .Values.master.podLabels | indent 8 }}
 {{- end }}
 {{- if and .Values.metrics.enabled .Values.metrics.podLabels }}
 {{ toYaml .Values.metrics.podLabels | indent 8 }}
 {{- end }}
-
       annotations:
         checksum/health: {{ include (print $.Template.BasePath "/health-configmap.yaml") . | sha256sum }}
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
@@ -376,10 +375,10 @@ spec:
     - metadata:
         name: redis-data
         labels:
-          app: "{{ template "redis.name" . }}"
-          component: "master"
-          release: {{ .Release.Name | quote }}
-          heritage: {{ .Release.Service | quote }}
+          app: {{ template "redis.name" . }}
+          release: {{ .Release.Name }}
+          heritage: {{ .Release.Service }}
+          component: master
       spec:
         accessModes:
         {{- range .Values.master.persistence.accessModes }}

--- a/stable/redis/templates/redis-master-svc.yaml
+++ b/stable/redis/templates/redis-master-svc.yaml
@@ -6,11 +6,10 @@ metadata:
   labels:
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 {{- if .Values.master.service.annotations }}
-  annotations:
-{{ toYaml .Values.master.service.annotations | indent 4 }}
+  annotations: {{ toYaml .Values.master.service.annotations | nindent 4 }}
 {{- end }}
 spec:
   type: {{ .Values.master.service.type }}
@@ -27,6 +26,6 @@ spec:
     {{- end }}
   selector:
     app: {{ template "redis.name" . }}
-    release: "{{ .Release.Name }}"
+    release: {{ .Release.Name }}
     role: master
 {{- end }}

--- a/stable/redis/templates/redis-role.yaml
+++ b/stable/redis/templates/redis-role.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 rules:
 {{ toYaml .Values.rbac.role.rules }}
 {{- end -}}

--- a/stable/redis/templates/redis-rolebinding.yaml
+++ b/stable/redis/templates/redis-rolebinding.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/stable/redis/templates/redis-serviceaccount.yaml
+++ b/stable/redis/templates/redis-serviceaccount.yaml
@@ -6,6 +6,6 @@ metadata:
   labels:
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 {{- end -}}

--- a/stable/redis/templates/redis-slave-statefulset.yaml
+++ b/stable/redis/templates/redis-slave-statefulset.yaml
@@ -6,29 +6,27 @@ metadata:
   labels:
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
 {{- if .Values.slave.updateStrategy }}
   strategy:
 {{ toYaml .Values.slave.updateStrategy | indent 4 }}
 {{- end }}
-{{- if .Values.cluster.slaveCount }}
   replicas: {{ .Values.cluster.slaveCount }}
-{{- end }}
   serviceName: {{ template "redis.fullname" . }}-headless
   selector:
     matchLabels:
-        release: "{{ .Release.Name }}"
-        role: slave
-        app: {{ template "redis.name" . }}
+      app: {{ template "redis.name" . }}
+      release: {{ .Release.Name }}
+      role: slave
   template:
     metadata:
       labels:
-        release: "{{ .Release.Name }}"
+        app: {{ template "redis.name" . }}
+        release: {{ .Release.Name }}
         chart: {{ template "redis.chart" . }}
         role: slave
-        app: {{ template "redis.name" . }}
       {{- if .Values.slave.podLabels }}
 {{ toYaml .Values.slave.podLabels | indent 8 }}
       {{- end }}
@@ -394,10 +392,10 @@ spec:
     - metadata:
         name: redis-data
         labels:
-          app: "{{ template "redis.name" . }}"
-          component: "slave"
-          release: {{ .Release.Name | quote }}
-          heritage: {{ .Release.Service | quote }}
+          app: {{ template "redis.name" . }}
+          release: {{ .Release.Name }}
+          heritage: {{ .Release.Service }}
+          component: slave
       spec:
         accessModes:
         {{- range .Values.slave.persistence.accessModes }}

--- a/stable/redis/templates/redis-slave-svc.yaml
+++ b/stable/redis/templates/redis-slave-svc.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 {{- if .Values.slave.service.annotations }}
   annotations:
 {{ toYaml .Values.slave.service.annotations | indent 4 }}
@@ -27,6 +27,6 @@ spec:
     {{- end }}
   selector:
     app: {{ template "redis.name" . }}
-    release: "{{ .Release.Name }}"
+    release: {{ .Release.Name }}
     role: slave
 {{- end }}

--- a/stable/redis/templates/redis-with-sentinel-svc.yaml
+++ b/stable/redis/templates/redis-with-sentinel-svc.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 {{- if .Values.sentinel.service.annotations }}
   annotations:
 {{ toYaml .Values.sentinel.service.annotations | indent 4 }}
@@ -33,5 +33,5 @@ spec:
     {{- end }}
   selector:
     app: {{ template "redis.name" . }}
-    release: "{{ .Release.Name }}"
+    release: {{ .Release.Name }}
 {{- end }}

--- a/stable/redis/values-production.yaml
+++ b/stable/redis/values-production.yaml
@@ -17,7 +17,7 @@ image:
   ## Bitnami Redis image tag
   ## ref: https://github.com/bitnami/bitnami-docker-redis#supported-tags-and-respective-dockerfile-links
   ##
-  tag: 5.0.5-debian-9-r124
+  tag: 5.0.5-debian-9-r138
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -56,7 +56,7 @@ sentinel:
     ## Bitnami Redis image tag
     ## ref: https://github.com/bitnami/bitnami-docker-redis-sentinel#supported-tags-and-respective-dockerfile-links
     ##
-    tag: 5.0.5-debian-9-r119
+    tag: 5.0.5-debian-9-r131
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -443,7 +443,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/redis-exporter
-    tag: 1.1.0-debian-9-r16
+    tag: 1.1.1-debian-9-r10
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -17,7 +17,7 @@ image:
   ## Bitnami Redis image tag
   ## ref: https://github.com/bitnami/bitnami-docker-redis#supported-tags-and-respective-dockerfile-links
   ##
-  tag: 5.0.5-debian-9-r124
+  tag: 5.0.5-debian-9-r138
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -56,7 +56,7 @@ sentinel:
     ## Bitnami Redis image tag
     ## ref: https://github.com/bitnami/bitnami-docker-redis-sentinel#supported-tags-and-respective-dockerfile-links
     ##
-    tag: 5.0.5-debian-9-r119
+    tag: 5.0.5-debian-9-r131
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -443,7 +443,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/redis-exporter
-    tag: 1.1.0-debian-9-r16
+    tag: 1.1.1-debian-9-r10
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR allows releasing the chart without any slave replica (despite configuring it with the master-slave cluster configuration). This way, the user can have a initial cluster with just one master pod with the ability to be scaled in the future like this:

```
$ kubectl get pods
NAME             READY   STATUS    RESTARTS   AGE
redis-master-0   1/1     Running   0          62s
$ kubectl get sts
NAME           READY   AGE
redis-master   1/1     65s
redis-slave    0/0     65s
$ kubectl scale sts redis-slave --replicas 2
statefulset.apps/redis-slave scaled
```

The PR also adapts the **networkpolicy** so it adapts the ingress/egress rules based on the parameter `cluster.enabled` instead of the number of slave replicas.

#### Which issue this PR fixes

  - fixes #17142 

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
