### PR TITLE
[stable/sysdig] Allow the DaemonSet to schedule using affinity rules

### DIFF
--- a/stable/sysdig/CHANGELOG.md
+++ b/stable/sysdig/CHANGELOG.md
@@ -3,6 +3,12 @@
 This file documents all notable changes to Sysdig Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.4.16
+
+### Minor changes
+
+* Allow the DaemonSet to schedule using affinity rules
+
 ## v1.4.15
 
 ### Minor changes

--- a/stable/sysdig/Chart.yaml
+++ b/stable/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.4.15
+version: 1.4.16
 appVersion: 0.92.1
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/stable/sysdig/README.md
+++ b/stable/sysdig/README.md
@@ -52,6 +52,7 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `serviceAccount.create`         | Create serviceAccount                                                  | `true`                                      |
 | `serviceAccount.name`           | Use this value as serviceAccountName                                   | ` `                                         |
 | `daemonset.updateStrategy.type` | The updateStrategy for updating the daemonset                          | `RollingUpdate`                             |
+| `daemonset.affinity`            | Node affinities                                                        | `nil`                                       |
 | `ebpf.enabled`                  | Enable eBPF support for Sysdig instead of `sysdig-probe` kernel module | `false`                                     |
 | `ebpf.settings.mountEtcVolume`  | Needed to detect which kernel version are running in Google COS        | `true`                                      |
 | `sysdig.accessKey`              | Your Sysdig Monitor Access Key                                         | `Nil` You must provide your own key         |

--- a/stable/sysdig/templates/daemonset.yaml
+++ b/stable/sysdig/templates/daemonset.yaml
@@ -26,6 +26,10 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       terminationGracePeriodSeconds: 5
+      {{- if .Values.daemonset.affinity }}
+      affinity:
+{{ toYaml .Values.daemonset.affinity | indent 8 }}
+      {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}

--- a/stable/sysdig/values.yaml
+++ b/stable/sysdig/values.yaml
@@ -45,6 +45,9 @@ daemonset:
     type: RollingUpdate
   ## Extra environment variables that will be pass onto deployment pods
   env: {}
+  ## Allow the DaemonSet to schedule using affinity rules
+  # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  # affinity: {}
 
 # If is behind a proxy you can set the proxy server
 proxy:


### PR DESCRIPTION


#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

#### What this PR does / why we need it:

Allow the DaemonSet to schedule ussing affinity rules

Heavily inspired by
https://github.com/helm/charts/blob/master/stable/signalsciences.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

@lachie83 @bencer @nestorsalceda

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
