### PR TITLE
[stable/datadog] Add possibility to extract node labels as metric tags

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.34.0
+version: 1.35.0
 appVersion: 6.13.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -175,7 +175,13 @@ For more details, please refer to [the documentation](https://docs.datadoghq.com
 
 ### Kubernetes Labels and Annotations
 
-To map Kubernetes pod labels and annotations to Datadog tags, provide a dictionary with kubernetes labels/annotations as keys and Datadog tags key as values in your [datadog-values.yaml](values.yaml) file:
+To map Kubernetes node labels and pod labels and annotations to Datadog tags, provide a dictionary with kubernetes labels/annotations as keys and Datadog tags key as values in your [datadog-values.yaml](values.yaml) file:
+
+```yaml
+nodeLabelsAsTags:
+  beta.kubernetes.io/instance-type: aws_instance_type
+  kubernetes.io/role: kube_role
+```
 
 ```yaml
 podAnnotationsAsTags:
@@ -248,6 +254,7 @@ helm install --name <RELEASE_NAME> \
 | `datadog.dogStatsDSocketPath`            | Custom path to the socket, has to be located in the `/var/run/datadog` folder path        | `/var/run/datadog/dsd.socket`               |
 | `datadog.volumes`                        | Additional volumes for the daemonset or deployment                                        | `nil`                                       |
 | `datadog.volumeMounts`                   | Additional volumeMounts for the daemonset or deployment                                   | `nil`                                       |
+| `datadog.nodeLabelsAsTags`               | Kubernetes Node Labels to Datadog Tags mapping                                            | `nil`                                       |
 | `datadog.podAnnotationsAsTags`           | Kubernetes Annotations to Datadog Tags mapping                                            | `nil`                                       |
 | `datadog.podLabelsAsTags`                | Kubernetes Labels to Datadog Tags mapping                                                 | `nil`                                       |
 | `datadog.resources.requests.cpu`         | CPU resource requests                                                                     | `200m`                                      |

--- a/stable/datadog/templates/container-agent.yaml
+++ b/stable/datadog/templates/container-agent.yaml
@@ -70,6 +70,10 @@
           name: {{ template "clusterAgent.tokenSecretName" . }}
           key: token
     {{- end }}
+    {{- if .Values.datadog.nodeLabelsAsTags }}
+    - name: DD_KUBERNETES_NODE_LABELS_AS_TAGS
+      value: '{{ toJson .Values.datadog.nodeLabelsAsTags }}'
+    {{- end }}
     {{- if .Values.datadog.podLabelsAsTags }}
     - name: DD_KUBERNETES_POD_LABELS_AS_TAGS
       value: '{{ toJson .Values.datadog.podLabelsAsTags }}'

--- a/stable/datadog/templates/container-agents.yaml
+++ b/stable/datadog/templates/container-agents.yaml
@@ -99,6 +99,10 @@
     {{- end }}
     - name: KUBERNETES
       value: "yes"
+    {{- if .Values.datadog.nodeLabelsAsTags }}
+    - name: DD_KUBERNETES_NODE_LABELS_AS_TAGS
+      value: '{{ toJson .Values.datadog.nodeLabelsAsTags }}'
+    {{- end }}
     {{- if .Values.datadog.podLabelsAsTags }}
     - name: DD_KUBERNETES_POD_LABELS_AS_TAGS
       value: '{{ toJson .Values.datadog.podLabelsAsTags }}'

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -99,6 +99,14 @@ datadog:
   #
   logLevel: INFO
 
+  ## @param nodeLabelsAsTags - list of key:value strings - optional
+  ## Provide a mapping of Kubernetes Node Labels to Datadog Tags.
+  #
+  # nodeLabelsAsTags:
+  #   beta.kubernetes.io/instance-type: aws-instance-type
+  #   kubernetes.io/role: kube_role
+  #   <KUBERNETES_NODE_LABEL>: <DATADOG_TAG_KEY>
+
   ## @param podLabelsAsTags - list of key:value strings - optional
   ## Provide a mapping of Kubernetes Labels to Datadog Tags.
   #


### PR DESCRIPTION
Signed-off-by: Javi Polo <javipolo@drslump.org>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
NO

#### What this PR does / why we need it:
This PR adds the environment variable DD_KUBERNETES_NODE_LABELS_AS_TAGS to allow datadog to map host labels into metric tags. It's basically the same thing that podLabelsAsTags is doing already, but on a node level

#### Which issue this PR fixes
NONE

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
