### PR TITLE
[stable/filebeat] Add Filebeat config volume mount to init container

### DIFF
--- a/stable/filebeat/Chart.yaml
+++ b/stable/filebeat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart to collect Kubernetes logs with filebeat
 icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.svg
 name: filebeat
-version: 3.1.0
+version: 3.1.1
 appVersion: 7.0.1
 home: https://www.elastic.co/products/beats/filebeat
 sources:

--- a/stable/filebeat/templates/daemonset.yaml
+++ b/stable/filebeat/templates/daemonset.yaml
@@ -49,6 +49,11 @@ spec:
           -E output.logstash.enabled=false
           -E output.file.enabled=false
           -E output.elasticsearch.hosts=[{{- range $index, $host := .Values.indexTemplateLoad }}{{ if $index }}, {{ end }}{{ $host | quote }}{{- end }}]
+        volumeMounts:
+        - name: filebeat-config
+          mountPath: /usr/share/filebeat/filebeat.yml
+          readOnly: true
+          subPath: filebeat.yml
 {{- end }}
 {{- if .Values.extraInitContainers }}
 {{ toYaml .Values.extraInitContainers | indent 6 }}


### PR DESCRIPTION
Allow init container to load ES template using credentials provisioned in the Filebeat config secret.

#### What this PR does / why we need it:

Allow Filebeat to load ES templates using credentials from the config secret.

#### Which issue this PR fixes

- fixes #17187 

#### Checklist

- [x] DCO
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name
