### PR TITLE
[incubator/sentry-kubernetes] Allow specifying priorityClassName

### DIFF
--- a/incubator/sentry-kubernetes/Chart.yaml
+++ b/incubator/sentry-kubernetes/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for sentry-kubernetes (https://github.com/getsentry/sentry-kubernetes)
 name: sentry-kubernetes
-version: 0.2.1
+version: 0.2.2
 appVersion: latest
 icon: https://sentry-brand.storage.googleapis.com/sentry-glyph-white.png
 home: https://github.com/getsentry/sentry-kubernetes

--- a/incubator/sentry-kubernetes/README.md
+++ b/incubator/sentry-kubernetes/README.md
@@ -15,7 +15,7 @@ The following table lists the configurable parameters of the sentry-kubernetes c
 | Parameter               | Description                                                                                                                 | Default                       |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
 | `sentry.dsn`            | Sentry dsn                                                                                                                  | Empty                         |
-| `existingSecret`        | Existing secret to read DSN from                                                                                           | Empty                         |
+| `existingSecret`        | Existing secret to read DSN from                                                                                            | Empty                         |
 | `sentry.environment`    | Sentry environment                                                                                                          | Empty                         |
 | `sentry.release`        | Sentry release                                                                                                              | Empty                         |
 | `sentry.logLevel`       | Sentry log level                                                                                                            | Empty                         |
@@ -24,3 +24,4 @@ The following table lists the configurable parameters of the sentry-kubernetes c
 | `rbac.create`           | If `true`, create and use RBAC resources                                                                                    | `true`                        |
 | `serviceAccount.name`   | Service account to be used. If not set and serviceAccount.create is `true`, a name is generated using the fullname template | ``                            |
 | `serviceAccount.create` | If true, create a new service account                                                                                       | `true`                        |
+| `priorityClassName`     | pod priorityClassName                                                                                                       | Empty                         |

--- a/incubator/sentry-kubernetes/templates/deployment.yaml
+++ b/incubator/sentry-kubernetes/templates/deployment.yaml
@@ -16,6 +16,9 @@ spec:
         app: {{ template "sentry-kubernetes.name" . }}
         release: {{.Release.Name }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/incubator/sentry-kubernetes/values.yaml
+++ b/incubator/sentry-kubernetes/values.yaml
@@ -27,3 +27,6 @@ serviceAccount:
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
+
+# Set priorityCLassName in deployment
+# priorityClassName: ""


### PR DESCRIPTION
#### Checklist

Adds configurable `priorityClassName` to Sentry Kuberenetes. This is needed for environments that support `priorityClassName` and needed prioritized scheduling for pods.

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
