### PR TITLE
[stable/external-dns] Remove status section from DNSEndpoints CRD

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.6.2
+version: 2.6.3
 appVersion: 0.5.17
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/templates/crd.yaml
+++ b/stable/external-dns/templates/crd.yaml
@@ -61,9 +61,4 @@ spec:
               type: integer
           type: object
   version: v1alpha1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
 {{- end }}


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
As of k8s 1.11, backwards incompatible changes have been made to the `status` section of a CRD definition:
* conditions can no longer be null
* storedVersions is now required

This PR removes the `status` section from the external-dns DNSEndpoint CRD, making the CRD compatible with k8s >= 1.11 and backward compatible with k8s 1.10.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
