### PR TITLE
[stable/node-red] add support for extra environment variables

### DIFF
--- a/stable/node-red/Chart.yaml
+++ b/stable/node-red/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.20.7
 description: Node-RED is flow-based programming for the Internet of Things
 name: node-red
-version: 1.3.1
+version: 1.3.2
 keywords:
   - nodered
   - node-red

--- a/stable/node-red/README.md
+++ b/stable/node-red/README.md
@@ -44,6 +44,7 @@ The following tables lists the configurable parameters of the Node-RED chart and
 | `strategyType`                     | Specifies the strategy used to replace old Pods by new ones             | `Recreate`                |
 | `flows`                            | Default flows configuration                                             | `flows.json`              |
 | `nodeOptions`                      | Node.js runtime arguments                                               | ``                        |
+| `extraEnvs`                        | Extra environment variables which will be appended to the env           | `[]`                      |
 | `timezone`                         | Default timezone                                                        | `UTC`                     |
 | `service.type`                     | Kubernetes service type for the GUI                                     | `ClusterIP`               |
 | `service.port`                     | Kubernetes port where the GUI is exposed                                | `1880`                    |

--- a/stable/node-red/templates/deployment.yaml
+++ b/stable/node-red/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               value: "{{ .Values.nodeOptions }}"
             - name: TZ
               value: "{{ .Values.timezone }}"
-          {{- with .Values.tolerations }}
+          {{- with .Values.extraEnvs }}
 {{ toYaml .Values.extraEnvs | indent 12 }}
           {{- end }}
           volumeMounts:

--- a/stable/node-red/templates/deployment.yaml
+++ b/stable/node-red/templates/deployment.yaml
@@ -44,6 +44,9 @@ spec:
               value: "{{ .Values.nodeOptions }}"
             - name: TZ
               value: "{{ .Values.timezone }}"
+          {{- with .Values.tolerations }}
+{{ toYaml .Values.extraEnvs | indent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               mountPath: /data

--- a/stable/node-red/values.yaml
+++ b/stable/node-red/values.yaml
@@ -15,6 +15,7 @@ fullnameOverride: ""
 
 flows: "flows.json"
 # nodeOptions: ""
+extraEnvs: []
 timezone: "UTC"
 
 service:


### PR DESCRIPTION
Allow extra environment variables to be set.

#### What this PR does / why we need it:

By allowing extra environment variables, setting node properties can be handy.

#### Checklist
* [x]  DCO
* [x]  Chart Version bumped
* [x]  Variables are documented in the README.md
* [x]  Title of the PR starts with chart name
