### PR TITLE
[incubator/kube-downscaler] enabling users to define security context 

### DIFF
--- a/incubator/kube-downscaler/Chart.yaml
+++ b/incubator/kube-downscaler/Chart.yaml
@@ -1,6 +1,6 @@
 name: kube-downscaler
 apiVersion: v1
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.6
 description: A Helm chart for kube-downscaler
 home: https://github.com/hjacobs/kube-downscaler

--- a/incubator/kube-downscaler/README.md
+++ b/incubator/kube-downscaler/README.md
@@ -57,6 +57,7 @@ The following tables lists the configurable parameters of the kube-downscaler ch
 | `resources`               | downscaler pod resource requests & limits                                                            | `{}`                      |
 | `rbac.create`             | If true, create & use RBAC resources                                                                 | `false`                   |
 | `rbac.serviceAccountName` | ServiceAccount downscaler will use (ignored if rbac.create=true)                                     | `default`                 |
+| `securityContext`         | downscaler pod security context                                                                      | `{}`                      |
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 

--- a/incubator/kube-downscaler/templates/deployment.yaml
+++ b/incubator/kube-downscaler/templates/deployment.yaml
@@ -40,6 +40,10 @@ spec:
             {{ if .Values.debug.enable }}- --debug{{end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.securityContext }}
+          securityContext:
+{{ toYaml . | indent 12 }}
+    {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/incubator/kube-downscaler/values.yaml
+++ b/incubator/kube-downscaler/values.yaml
@@ -42,6 +42,8 @@ tolerations: []
 
 affinity: {}
 
+securityContext: {}
+
 podLabels: {}
 
 podAnnotations: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR enables users to define a security context for the kube downscaler pod

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
