### PR TITLE
[stable/node-red] fix for templating error of extraEnvs

### DIFF
--- a/stable/node-red/Chart.yaml
+++ b/stable/node-red/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.20.7
 description: Node-RED is flow-based programming for the Internet of Things
 name: node-red
-version: 1.3.2
+version: 1.3.3
 keywords:
   - nodered
   - node-red

--- a/stable/node-red/templates/deployment.yaml
+++ b/stable/node-red/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
             - name: TZ
               value: "{{ .Values.timezone }}"
           {{- with .Values.extraEnvs }}
-{{ toYaml .Values.extraEnvs | indent 12 }}
+{{ toYaml . | indent 12 }}
           {{- end }}
           volumeMounts:
             - name: data


### PR DESCRIPTION
Template of extraEnvs is done using with clause, but still referencing .Values.extraEnvs

#### What this PR does / why we need it:

using .Values.extraEnvs inside with clause was wrong.
it causes the error below.

```
Error: render error in "node-red/templates/deployment.yaml": template: node-red/templates/deployment.yaml:48:17: executing "node-red/templates/deployment.yaml" at <.Values.extraEnvs>: can't evaluate field Values in type []interface {}
```

#### Checklist
* [x]  DCO
* [x]  Chart Version bumped
* [x]  Variables are documented in the README.md
* [x]  Title of the PR starts with chart name
