### PR TITLE
[stable/kong] Allow hosts to be optional for kong ingress resources

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.18.1
+version: 0.18.2
 appVersion: 1.3

--- a/stable/kong/ci/ingress-with-hosts.yaml
+++ b/stable/kong/ci/ingress-with-hosts.yaml
@@ -1,0 +1,13 @@
+admin:
+  ingress:
+    enabled: true
+    hosts: ["test.com", "test2.com"]
+    annotations: {}
+    path: /
+
+proxy:
+  ingress:
+    enabled: true
+    hosts: ["test.com", "test2.com"]
+    annotations: {}
+    path: /

--- a/stable/kong/ci/ingress-without-hosts.yaml
+++ b/stable/kong/ci/ingress-without-hosts.yaml
@@ -1,0 +1,13 @@
+admin:
+  ingress:
+    enabled: true
+    hosts: []
+    annotations: {}
+    path: /
+
+proxy:
+  ingress:
+    enabled: true
+    hosts: []
+    annotations: {}
+    path: /

--- a/stable/kong/templates/ingress-admin.yaml
+++ b/stable/kong/templates/ingress-admin.yaml
@@ -2,6 +2,7 @@
 {{- $serviceName := include "kong.fullname" . -}}
 {{- $servicePort := .Values.admin.servicePort -}}
 {{- $path := .Values.admin.ingress.path -}}
+{{- $hosts_count := len .Values.admin.ingress.hosts -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -17,6 +18,14 @@ metadata:
     {{- end }}
 spec:
   rules:
+    {{- if eq $hosts_count 0 }}
+    - http:
+        paths:
+          - path: {{ $path }}
+            backend:
+              serviceName: {{ $serviceName }}-admin
+              servicePort: {{ $servicePort }}
+    {{ else -}}
     {{- range $host := .Values.admin.ingress.hosts }}
     - host: {{ $host }}
       http:
@@ -25,6 +34,7 @@ spec:
             backend:
               serviceName: {{ $serviceName }}-admin
               servicePort: {{ $servicePort }}
+    {{- end -}}
     {{- end -}}
   {{- if .Values.admin.ingress.tls }}
   tls:

--- a/stable/kong/templates/ingress-manager.yaml
+++ b/stable/kong/templates/ingress-manager.yaml
@@ -3,6 +3,7 @@
 {{- $serviceName := include "kong.fullname" . -}}
 {{- $servicePort := include "kong.ingress.servicePort" .Values.manager -}}
 {{- $path := .Values.manager.ingress.path -}}
+{{- $hosts_count := len .Values.manager.ingress.hosts -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -18,6 +19,14 @@ metadata:
     {{- end }}
 spec:
   rules:
+    {{- if eq $hosts_count 0 }}
+    - http:
+        paths:
+          - path: {{ $path }}
+            backend:
+              serviceName: {{ $serviceName }}-manager
+              servicePort: {{ $servicePort }}
+    {{ else -}}
     {{- range $host := .Values.manager.ingress.hosts }}
     - host: {{ $host }}
       http:
@@ -26,6 +35,7 @@ spec:
             backend:
               serviceName: {{ $serviceName }}-manager
               servicePort: {{ $servicePort }}
+    {{- end -}}
     {{- end -}}
   {{- if .Values.manager.ingress.tls }}
   tls:

--- a/stable/kong/templates/ingress-portal-api.yaml
+++ b/stable/kong/templates/ingress-portal-api.yaml
@@ -3,6 +3,7 @@
 {{- $serviceName := include "kong.fullname" . -}}
 {{- $servicePort := include "kong.ingress.servicePort" .Values.portalapi -}}
 {{- $path := .Values.portalapi.ingress.path -}}
+{{- $hosts_count := len .Values.portalapi.ingress.hosts -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -18,6 +19,14 @@ metadata:
     {{- end }}
 spec:
   rules:
+    {{- if eq $hosts_count 0 }}
+    - http:
+        paths:
+          - path: {{ $path }}
+            backend:
+              serviceName: {{ $serviceName }}-portalapi
+              servicePort: {{ $servicePort }}
+    {{ else -}}
     {{- range $host := .Values.portalapi.ingress.hosts }}
     - host: {{ $host }}
       http:
@@ -26,6 +35,7 @@ spec:
             backend:
               serviceName: {{ $serviceName }}-portalapi
               servicePort: {{ $servicePort }}
+    {{- end -}}
     {{- end -}}
   {{- if .Values.portalapi.ingress.tls }}
   tls:

--- a/stable/kong/templates/ingress-portal.yaml
+++ b/stable/kong/templates/ingress-portal.yaml
@@ -3,6 +3,7 @@
 {{- $serviceName := include "kong.fullname" . -}}
 {{- $servicePort := include "kong.ingress.servicePort" .Values.portal -}}
 {{- $path := .Values.portal.ingress.path -}}
+{{- $hosts_count := len .Values.portal.ingress.hosts -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -18,6 +19,14 @@ metadata:
     {{- end }}
 spec:
   rules:
+    {{- if eq $hosts_count 0 }}
+    - http:
+        paths:
+          - path: {{ $path }}
+            backend:
+              serviceName: {{ $serviceName }}-portal
+              servicePort: {{ $servicePort }}
+    {{ else -}}
     {{- range $host := .Values.portal.ingress.hosts }}
     - host: {{ $host }}
       http:
@@ -26,6 +35,7 @@ spec:
             backend:
               serviceName: {{ $serviceName }}-portal
               servicePort: {{ $servicePort }}
+    {{- end -}}
     {{- end -}}
   {{- if .Values.portal.ingress.tls }}
   tls:

--- a/stable/kong/templates/ingress-proxy.yaml
+++ b/stable/kong/templates/ingress-proxy.yaml
@@ -2,6 +2,7 @@
 {{- $serviceName := include "kong.fullname" . -}}
 {{- $servicePort := include "kong.ingress.servicePort" .Values.proxy -}}
 {{- $path := .Values.proxy.ingress.path -}}
+{{- $hosts_count := len .Values.proxy.ingress.hosts -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -17,6 +18,14 @@ metadata:
     {{- end }}
 spec:
   rules:
+    {{- if eq $hosts_count 0 }}
+    - http:
+        paths:
+          - path: {{ $path }}
+            backend:
+              serviceName: {{ $serviceName }}-proxy
+              servicePort: {{ $servicePort }}
+    {{ else -}}
     {{- range $host := .Values.proxy.ingress.hosts }}
     - host: {{ $host }}
       http:
@@ -25,6 +34,7 @@ spec:
             backend:
               serviceName: {{ $serviceName }}-proxy
               servicePort: {{ $servicePort }}
+    {{- end -}}
     {{- end -}}
   {{- if .Values.proxy.ingress.tls }}
   tls:


### PR DESCRIPTION
Signed-off-by: Mark Freebairn <mark_freebairn@hotmail.com>

#### What this PR does / why we need it:
This change allows the hosts array to be empty for kong ingress resources so that the ingress resource can be created without a host (see bullet 1 here: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules).
This is required when not using hosts directly in the ingress resource (for example, if you use an external-dns annotation to create dns records and associate them with your ingress instead).

Using the following yaml values in the values.yaml file:
``` 
admin:
  ingress:
    # Enable/disable exposure using ingress.
    enabled: true
    hosts: []
    # Map of ingress annotations.
    annotations: {}
    # Ingress path.
    path: /
```
Would currently produce the following output:
```
# Source: kong/templates/ingress-admin.yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: release-name-kong-admin
  labels:
    app: kong
    chart: "kong-0.18.1"
    release: "release-name"
    heritage: "Tiller"
  annotations:
spec:
  rules:
```

Whereas after the change in this PR it will output:
```
# Source: kong/templates/ingress-admin.yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: release-name-kong-admin
  labels:
    app: kong
    chart: "kong-0.18.1"
    release: "release-name"
    heritage: "Tiller"
  annotations:
spec:
  rules:
    - http:
        paths:
          - path: /
            backend:
              serviceName: release-name-kong-admin
              servicePort: 8444
```

I have also tested the behaviour with hosts array having 1 & multiple entries, e.g. when `hosts: ["test.com", "test2.com"]`:
```
# Source: kong/templates/ingress-admin.yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: release-name-kong-admin
  labels:
    app: kong
    chart: "kong-0.18.1"
    release: "release-name"
    heritage: "Tiller"
  annotations:
spec:
  rules:
    - host: test.com
      http:
        paths:
          - path: /
            backend:
              serviceName: release-name-kong-admin
              servicePort: 8444
    - host: test2.com
      http:
        paths:
          - path: /
            backend:
              serviceName: release-name-kong-admin
              servicePort: 8444
```

#### Which issue this PR fixes
  - fixes #17216

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
