### PR TITLE
[stable/traefik] Add env values to the storeconfig job

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.78.1
+version: 1.78.2
 appVersion: 1.7.14
 
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support

--- a/stable/traefik/templates/storeconfig-job.yaml
+++ b/stable/traefik/templates/storeconfig-job.yaml
@@ -30,6 +30,10 @@ spec:
             name: config
           - mountPath: /acme
             name: acme
+          {{- if .Values.env }}
+          env:
+{{ toYaml .Values.env | indent 12 }}
+          {{- end }}
       volumes:
       - name: config
         configMap:


### PR DESCRIPTION
Signed-off-by: Alexandre Amiche <aamiche@livingactor.com>

#### Is this a new chart
No

#### What this PR does / why we need it:

Add environment variables from Values when available to the storeconfig job. Useful when using a KV store like Consul that needs a token from env for authentication.

#### Which issue this PR fixes
  - fixes #17220

#### Checklist
- [x ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x ] Chart Version bumped
- [x ] Title of the PR starts with chart name (e.g. `[stable/chart]`)
