### PR TITLE
[incubator/jaeger] Update hotrod-ing.yaml

### DIFF
--- a/incubator/jaeger/templates/hotrod-ing.yaml
+++ b/incubator/jaeger/templates/hotrod-ing.yaml
@@ -22,12 +22,12 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          - path: /
+          - path: {{ default "/" $path }}
             backend:
               serviceName: {{ $serviceName }}-hotrod
               servicePort: {{ $servicePort }}
     {{- end -}}
-  {{- if .Values.hotrod.ingress.tls }}
+  {{ - if .Values.hotrod.ingress.tls }}
   tls:
 {{ toYaml .Values.hotrod.ingress.tls | indent 4 }}
   {{- end -}}


### PR DESCRIPTION
new variable $path, but with default value "/"

#### What this PR does / why we need it:
more flexible ingress values

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
