### PR TITLE
[incubator/jaeger] Specified a longer activeDeadlineSeconds

### DIFF
--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -89,7 +89,7 @@ schema:
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
   # Deadline for cassandra schema creation job
-  activeDeadlineSeconds: 120
+  activeDeadlineSeconds: 600
 
 # Begin: Override values on the Elasticsearch subchart to customize for Jaeger
 elasticsearch:


### PR DESCRIPTION
It was too sharp for cassandra to run with default values.

#### What this PR does / why we need it:
Better user experience.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
