### PR TITLE
[stable/sentry] feat: support initialDelaySeconds

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 2.1.1
+version: 2.1.2
 appVersion: 9.1.1
 keywords:
   - debugging

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -76,6 +76,7 @@ Parameter                                            | Description              
 `web.affinity`                                       | Affinity settings for web pod assignment                                                                   | `{}`
 `web.schedulerName`                                  | Name of an alternate scheduler for web pod                                                                 | `nil`
 `web.tolerations`                                    | Toleration labels for web pod assignment                                                                   | `[]`
+`web.probeInitialDelaySeconds`                       | The number of seconds before the probe doing healthcheck                                          | `50`
 `cron.podAnnotations`                                | Cron pod annotations                                                                                       | `{}`
 `cron.podLabels`                                     | Worker pod extra labels                                                                                    | `{}`
 `cron.replicacount`                                  | Amount of cron pods to run                                                                                 | `1`

--- a/stable/sentry/templates/web-deployment.yaml
+++ b/stable/sentry/templates/web-deployment.yaml
@@ -131,7 +131,7 @@ spec:
             path: /_health/
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
-          initialDelaySeconds: 50
+          initialDelaySeconds: {{ .Values.web.probeInitialDelaySeconds }}
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 2
@@ -141,7 +141,7 @@ spec:
             path: /_health/
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
-          initialDelaySeconds: 50
+          initialDelaySeconds: {{ .Values.web.probeInitialDelaySeconds }}
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 2

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -27,6 +27,7 @@ web:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  probeInitialDelaySeconds: 50
   ## Use an alternate scheduler, e.g. "stork".
   ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
   ##


### PR DESCRIPTION
#### What this PR does / why we need it:
The application takes sometimes a lot more than 50 seconds to start.

#### Which issue this PR fixes
Makes initialDelaySeconds editable

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
