### PR TITLE
[stable/memcached] Allow Memcached priorityClassName usage

### DIFF
--- a/stable/memcached/Chart.yaml
+++ b/stable/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 2.10.0
+version: 2.10.1
 appVersion: 1.5.12
 description: Free & open source, high-performance, distributed memory object caching
   system.

--- a/stable/memcached/README.md
+++ b/stable/memcached/README.md
@@ -63,6 +63,7 @@ The following table lists the configurable parameters of the Memcached chart and
 | `securityContext.fsGroup`  | Group ID for the container | `1001`                                                       |
 | `securityContext.runAsUser`| User ID for the container  | `1001`                                                       |
 | `updateStrategy.type`      | Update strategy for the StatefulSet/Deployment | `RollingUpdate`                          |
+| `priorityClassName  `      | Specifies the pod's priority class name        | Un-set                                   |
 
 The above parameters map to `memcached` params. For more information please refer to the [Memcached documentation](https://github.com/memcached/memcached/wiki/ConfiguringServer).
 

--- a/stable/memcached/templates/statefulset.yaml
+++ b/stable/memcached/templates/statefulset.yaml
@@ -14,7 +14,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   {{- if .Values.priorityClassName -}}
   priorityClassName: "{{ .Values.priorityClassName }}"
-  {{- end -}} }}
+  {{- end -}}
   template:
     metadata:
       labels:

--- a/stable/memcached/templates/statefulset.yaml
+++ b/stable/memcached/templates/statefulset.yaml
@@ -12,6 +12,9 @@ spec:
   serviceName: {{ template "memcached.fullname" . }}
   {{- end }}
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.priorityClassName -}}
+  priorityClassName: "{{ .Values.priorityClassName }}"
+  {{- end -}} }}
   template:
     metadata:
       labels:

--- a/stable/memcached/templates/statefulset.yaml
+++ b/stable/memcached/templates/statefulset.yaml
@@ -14,7 +14,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   {{- if .Values.priorityClassName -}}
   priorityClassName: "{{ .Values.priorityClassName }}"
-  {{- end -}}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/stable/memcached/values.yaml
+++ b/stable/memcached/values.yaml
@@ -103,3 +103,6 @@ extraVolumes: |
 
 # To be added to the server pod(s)
 podAnnotations: {}
+
+## Set pod priority class
+# priorityClassName: ""


### PR DESCRIPTION
#### Purpose
Allows the Memcached charts users to set the priorityClassName parameter

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
