### PR TITLE
[stable/rabbitmq-ha] Move prometheus annotations to pods

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.15
-version: 1.32.2
+version: 1.32.3
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/templates/service.yaml
+++ b/stable/rabbitmq-ha/templates/service.yaml
@@ -1,15 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-{{- if or .Values.service.annotations (and .Values.prometheus.exporter.enabled (not .Values.prometheus.operator.enabled)) }}
+{{- if or .Values.service.annotations }}
   annotations:
-{{- end }}
-{{- if .Values.service.annotations }}
 {{ toYaml .Values.service.annotations | indent 4 }}
-{{- end }}
-{{- if and .Values.prometheus.exporter.enabled (not .Values.prometheus.operator.enabled) }}
-    prometheus.io/scrape: "true"
-    prometheus.io/port: {{ .Values.prometheus.exporter.port | quote }}
 {{- end }}
   name: {{ template "rabbitmq-ha.fullname" . }}
   namespace: {{ .Release.Namespace }}

--- a/stable/rabbitmq-ha/templates/service.yaml
+++ b/stable/rabbitmq-ha/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-{{- if or .Values.service.annotations }}
+{{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -29,6 +29,10 @@ spec:
         {{- if not .Values.existingConfigMap }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
+        {{- if and .Values.prometheus.exporter.enabled (not .Values.prometheus.operator.enabled) }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .Values.prometheus.exporter.port | quote }}
+        {{- end }}
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
This pull request moves the prometheus scraping annotations to the statefulset pods. This is to populate the metrics with pod metadata.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
