### PR TITLE
[stable/chart/kong]: Add role access to api group networking.k8s.io for the Ingress controller

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.18.0
+version: 0.18.1
 appVersion: 1.3

--- a/stable/kong/templates/controller-cluster-role.yaml
+++ b/stable/kong/templates/controller-cluster-role.yaml
@@ -35,6 +35,7 @@ rules:
       - watch
   - apiGroups:
       - "extensions"
+      - "networking.k8s.io"
     resources:
       - ingresses
     verbs:
@@ -50,6 +51,7 @@ rules:
         - patch
   - apiGroups:
       - "extensions"
+      - "networking.k8s.io"
     resources:
       - ingresses/status
     verbs:


### PR DESCRIPTION
@hbagdi @shashiranjan84 

#### What this PR does / why we need it:
This fixes a bug where the Kong ingress controller isn't allowed to access ingress resources when the api group is "networking.k8s.io".

This should probably have been done when the following feature was added to KongKong (feat: add support for networking.k8s.io/v1beta1 Ingress API #369):  https://github.com/Kong/kubernetes-ingress-controller/issues/349.

#### Which issue this PR fixes
Failed to list *v1beta1.Ingress: ingresses.networking.k8s.io is forbidden: User "system:serviceaccount:ingress-kong:ingress-kong" cannot list resource "ingresses" in API group "networking.k8s.io" at the cluster scope

And a similar error message related to updating Ingress status.

The problem was encountered and solved on a K8s cluster running Kubernetes v.1.15.3.
#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
