### PR TITLE
[stable/redis-ha] Removing hostPort on HAProxy deployment

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.7.8
+version: 3.7.9
 appVersion: 5.0.5
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/redis-haproxy-deployment.yaml
+++ b/stable/redis-ha/templates/redis-haproxy-deployment.yaml
@@ -77,11 +77,9 @@ spec:
         ports:
         - name: redis
           containerPort: {{ default "6379" .Values.redis.port }}
-          hostPort: 6379
         {{- if .Values.haproxy.readOnly.enabled }}
         - name: readonlyport
           containerPort: {{ default "6380" .Values.haproxy.readOnly.port }}
-          hostPort: 6380
         {{- end }}
         resources:
 {{ toYaml .Values.haproxy.resources | indent 10 }}


### PR DESCRIPTION
Signed-off-by: Aaron Layfield <aaron.layfield@gmail.com>

#### What this PR does / why we need it:
Removed the hostPort requirement on the HAProxy deployment. Seems unecessary 
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #17239

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
