### PR TITLE
[stable/redis-ha] Added support for custom Redis ports

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.7.8
+version: 3.7.9
 appVersion: 5.0.5
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/redis-ha-configmap.yaml
+++ b/stable/redis-ha/templates/redis-ha-configmap.yaml
@@ -13,6 +13,7 @@ data:
 {{ tpl .Values.redis.customConfig . | indent 4 }}
 {{- else }}
     dir "/data"
+    port {{ .Values.redis.port }}
     {{- range $key, $value := .Values.redis.config }}
     {{ $key }} {{ $value }}
     {{- end }}
@@ -179,12 +180,12 @@ data:
     # decide redis backend to use
     #master
     frontend ft_redis_master
-      bind *:6379
+      bind *:{{ $root.Values.redis.port }}
       use_backend bk_redis_master
     {{ if .Values.haproxy.readOnly.enabled }}
     #slave
     frontend ft_redis_slave
-      bind *:6380
+      bind *:{{ .Values.haproxy.readOnly.port }}
       use_backend bk_redis_slave
     {{- end }} 
     # Check all redis servers to see if they think they are master
@@ -204,7 +205,7 @@ data:
       tcp-check expect string +OK
       {{- range $i := until $replicas }}
       use-server R{{ $i }} if { srv_is_up(R{{ $i }}) } { nbsrv(check_if_redis_is_master_{{ $i }}) ge 2 }
-      server R{{ $i }} {{ $fullName }}-announce-{{ $i }}:6379 check inter 1s fall 1 rise 1
+      server R{{ $i }} {{ $fullName }}-announce-{{ $i }}:{{ $root.Values.redis.port }} check inter 1s fall 1 rise 1
       {{- end }}     
     {{ if .Values.haproxy.readOnly.enabled }}
     backend bk_redis_slave
@@ -222,7 +223,7 @@ data:
       tcp-check send QUIT\r\n
       tcp-check expect string +OK
       {{- range $i := until $replicas }}
-      server R{{ $i }} {{ $fullName }}-announce-{{ $i }}:6379 check inter 1s fall 1 rise 1
+      server R{{ $i }} {{ $fullName }}-announce-{{ $i }}:{{ $root.Values.redis.port }} check inter 1s fall 1 rise 1
       {{- end }}
     {{- end }}
 {{- end }}

--- a/stable/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/stable/redis-ha/templates/redis-ha-statefulset.yaml
@@ -148,11 +148,11 @@ spec:
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
-        - redis-server
+        - redis-server 
         args:
         - /data/conf/redis.conf
-{{- if .Values.auth }}
         env:
+        {{- if .Values.auth }}
         - name: AUTH
           valueFrom:
             secretKeyRef:
@@ -162,7 +162,7 @@ spec:
               name: {{ template "redis-ha.fullname" . }}
             {{- end }}
               key: {{ .Values.authKey }}
-{{- end }}
+        {{- end }}
         livenessProbe:
           tcpSocket:
             port: {{ .Values.redis.port }}
@@ -216,7 +216,7 @@ spec:
         {{- end }}
         env:
           - name: REDIS_ADDR
-            value: redis://localhost:6379
+            value: redis://localhost:{{ .Values.redis.port }}
         {{- if .Values.auth }}
           - name: REDIS_PASSWORD
             valueFrom:

--- a/stable/redis-ha/templates/redis-haproxy-deployment.yaml
+++ b/stable/redis-ha/templates/redis-haproxy-deployment.yaml
@@ -77,11 +77,9 @@ spec:
         ports:
         - name: redis
           containerPort: {{ default "6379" .Values.redis.port }}
-          hostPort: 6379
         {{- if .Values.haproxy.readOnly.enabled }}
         - name: readonlyport
           containerPort: {{ default "6380" .Values.haproxy.readOnly.port }}
-          hostPort: 6380
         {{- end }}
         resources:
 {{ toYaml .Values.haproxy.resources | indent 10 }}


### PR DESCRIPTION
Signed-off-by: Aaron Layfield <aaron.layfield@gmail.com>

#### What this PR does / why we need it:
Added support for Redis / HAProxy to support actually changing the Redis port and exposing it. 

#### Which issue this PR fixes
  - fixes #16858
  - fixes #17239

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
