### PR TITLE
[stable/postgresql] display secretName template generated by helper

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 6.3.7
+version: 6.3.8
 appVersion: 11.5.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/NOTES.txt
+++ b/stable/postgresql/templates/NOTES.txt
@@ -8,7 +8,7 @@ PostgreSQL can be accessed via port {{ template "postgresql.port" . }} on the fo
 {{- end }}
 To get the password for "{{ template "postgresql.username" . }}" run:
 
-    export POSTGRES_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "postgresql.fullname" . }}{{ end }} -o jsonpath="{.data.postgresql-password}" | base64 --decode)
+    export POSTGRES_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "postgresql.secretName" . }} -o jsonpath="{.data.postgresql-password}" | base64 --decode)
 
 To connect to your database run the following command:
 


### PR DESCRIPTION
Signed-off-by: Hugo Cortes <contact@hugocortes.dev>

#### What this PR does / why we need it:
Uses the secret name generated by the [_helpers.tpl](https://github.com/helm/charts/blob/master/stable/postgresql/templates/_helpers.tpl#L198) when outputting `kubectl` command to get secret.

#### Which issue this PR fixes
Postgres secret can be set by one of following variables:
* `global.postgresql.existingSecret`
* `existingSecret`
* or simply the chart name

Previous if/else check omitted the `global.postgresql.existingSecret` value.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
