### PR TITLE
[stable/external-dns] Update psp apiVersion to 'policy/v1beta1' - Mandatory for K8s 1.16

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.6.3
+version: 2.6.2
 appVersion: 0.5.17
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.6.2
+version: 2.6.4
 appVersion: 0.5.17
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -16,7 +16,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 
 ## Prerequisites
 
-- Kubernetes 1.14+
+- Kubernetes 1.8+ with Beta APIs enabled
 
 ## Installing the Chart
 

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -16,7 +16,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 
 ## Prerequisites
 
-- Kubernetes 1.8+ with Beta APIs enabled
+- Kubernetes 1.14+
 
 ## Installing the Chart
 

--- a/stable/external-dns/templates/_helpers.tpl
+++ b/stable/external-dns/templates/_helpers.tpl
@@ -207,6 +207,17 @@ external-dns: infoblox.wapiPassword
 {{- end -}}
 
 {{/*
+Return the appropriate apiVersion for PodSecurityPolicy.
+*/}}
+{{- define "podSecurityPolicy.apiVersion" -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "policy/v1beta1" -}}
+{{- else -}}
+{{- print "extensions/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Validate values of External DNS:
 - must provide the PowerDNS API URL when provider is "pdns"
 */}}

--- a/stable/external-dns/templates/psp.yaml
+++ b/stable/external-dns/templates/psp.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "external-dns.fullname" . }}

--- a/stable/external-dns/templates/psp.yaml
+++ b/stable/external-dns/templates/psp.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: policy/v1beta1
+apiVersion: {{ template "podSecurityPolicy.apiVersion" . }}
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "external-dns.fullname" . }}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

There are several deprecations in the API introduced in `K8s 1.16` (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#deprecations-and-removals) which affect our manifests. The following APIs are no longer served by default:

- All resources under `apps/v1beta1` and `apps/v1beta2` - use `apps/v1` instead
- **daemonsets**, **deployments**, **replicasets** resources under `extensions/v1beta1` - use `apps/v1` instead
- **networkpolicies** resources under `extensions/v1beta1` - use `networking.k8s.io/v1` instead
- **podsecuritypolicies** resources under `extensions/v1beta1` - use `policy/v1beta1` instead

This PR address the changes to be done for `stable/external-dns`.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)