### PR TITLE
[stable/logstash] Allow templating in elasticsearch host

### DIFF
--- a/stable/logstash/Chart.yaml
+++ b/stable/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 2.2.0
+version: 2.2.1
 appVersion: 7.1.1
 sources:
 - https://www.docker.elastic.co

--- a/stable/logstash/README.md
+++ b/stable/logstash/README.md
@@ -119,7 +119,7 @@ The following table lists the configurable parameters of the chart and its defau
 | `exporter.serviceMonitor.interval` | Interval at which metrics should be scraped | `10s`
 | `exporter.serviceMonitor.scrapeTimeout` | Timeout after which the scrape is ended | `10s`
 | `exporter.serviceMonitor.scheme` | Scheme to use for scraping | `http`
-| `elasticsearch.host`            | ElasticSearch hostname                             | `elasticsearch-client.default.svc.cluster.local` |
+| `elasticsearch.host`            | ElasticSearch hostname (passed through tpl)        | `elasticsearch-client.default.svc.cluster.local` |
 | `elasticsearch.port`            | ElasticSearch port                                 | `9200`                                           |
 | `config`                        | Logstash configuration key-values                  | (see `values.yaml`)                              |
 | `patterns`                      | Logstash patterns configuration                    | `nil`                                            |

--- a/stable/logstash/templates/statefulset.yaml
+++ b/stable/logstash/templates/statefulset.yaml
@@ -78,7 +78,7 @@ spec:
               value: {{ .Values.exporter.logstash.target.port | quote }}
             ## Elasticsearch output
             - name: ELASTICSEARCH_HOST
-              value: {{ .Values.elasticsearch.host | quote }}
+              value: {{ tpl (.Values.elasticsearch.host | toString) $ | quote }}
             - name: ELASTICSEARCH_PORT
               value: {{ .Values.elasticsearch.port | quote }}
             # Logstash Java Options


### PR DESCRIPTION
Signed-off-by: James Lucas <james@liquidstate.co.uk>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No, it's a tweak to an existing chart.

#### What this PR does / why we need it:
The default value for the elasticsearch host in the logstash chart does not include the release name prefix and it doesn't appear to be possible to override it in a generic way without passing the .values.yaml value through tpl.

#### Which issue this PR fixes
None

#### Special notes for your reviewer:
@christian-roggia @rendhalver I would also like to increase the dependency version in the elastic-stack chart to include this, but I don't think I can do that until the new version has been deployed?
I also considered changing the default value within logstash/.values.yaml but decided against it as it only makes sense when used as a sub chart, so thought it better to do that in the parent chart's .values.yaml?

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md (added note to say value is passed through tpl)
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
