### PR TITLE
[stable/mediawiki] Update deployment apiVersion to 'apps/v1' - Mandatory for K8s 1.16

### DIFF
--- a/stable/mediawiki/Chart.yaml
+++ b/stable/mediawiki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mediawiki
-version: 8.2.3
+version: 8.2.4
 appVersion: 1.33.0
 description: Extremely powerful, scalable software and a feature-rich wiki implementation that uses PHP to process and display data stored in a database.
 home: http://www.mediawiki.org/

--- a/stable/mediawiki/requirements.lock
+++ b/stable/mediawiki/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.8.7
+  version: 6.9.1
 digest: sha256:bc40726b74587ca4fc92cff01759b61882e7d1454d6ee74db11787ad0d16063b
-generated: 2019-09-09T04:08:26.653650555Z
+generated: "2019-09-20T15:10:37.826041+02:00"

--- a/stable/mediawiki/templates/deployment.yaml
+++ b/stable/mediawiki/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "mediawiki.fullname" . }}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

There are several deprecations in the API introduced in `K8s 1.16` (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#deprecations-and-removals) which affect our manifests. The following APIs are no longer served by default:

- All resources under `apps/v1beta1` and `apps/v1beta2` - use `apps/v1` instead
- **daemonsets**, **deployments**, **replicasets** resources under `extensions/v1beta1` - use `apps/v1` instead
- **networkpolicies** resources under `extensions/v1beta1` - use `networking.k8s.io/v1` instead
- **podsecuritypolicies** resources under `extensions/v1beta1` - use `policy/v1beta1` instead

This PR address the changes to be done for `stable/mediawiki`.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)