### PR TITLE
[stable/prestashop] Update deployment apiVersion to 'apps/v1' - Mandatory for K8s 1.16

### DIFF
--- a/stable/prestashop/Chart.yaml
+++ b/stable/prestashop/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prestashop
-version: 8.2.2
+version: 8.2.3
 appVersion: 1.7.6-1
 description: A popular open source ecommerce solution. Professional tools are easily accessible to increase online sales including instant guest checkout, abandoned cart reminders and automated Email marketing.
 keywords:

--- a/stable/prestashop/requirements.lock
+++ b/stable/prestashop/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.8.7
+  version: 6.9.1
 digest: sha256:a363428d6463718a9523a88c70e485218373e315f2979cb1bb17b034ec2be96a
-generated: 2019-09-09T07:51:39.161174728Z
+generated: "2019-09-20T15:25:01.318945+02:00"

--- a/stable/prestashop/templates/deployment.yaml
+++ b/stable/prestashop/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if include "prestashop.host" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "prestashop.fullname" . }}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

There are several deprecations in the API introduced in `K8s 1.16` (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#deprecations-and-removals) which affect our manifests. The following APIs are no longer served by default:

- All resources under `apps/v1beta1` and `apps/v1beta2` - use `apps/v1` instead
- **daemonsets**, **deployments**, **replicasets** resources under `extensions/v1beta1` - use `apps/v1` instead
- **networkpolicies** resources under `extensions/v1beta1` - use `networking.k8s.io/v1` instead
- **podsecuritypolicies** resources under `extensions/v1beta1` - use `policy/v1beta1` instead

This PR address the changes to be done for `stable/prestashop`.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)