### PR TITLE
[stable/testlink] Update deployment apiVersion to 'apps/v1' - Mandatory for K8s 1.16

### DIFF
--- a/stable/testlink/Chart.yaml
+++ b/stable/testlink/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: testlink
-version: 6.3.0
+version: 6.3.1
 appVersion: 1.9.19
 description: Web-based test management system that facilitates software quality assurance.
 icon: https://bitnami.com/assets/stacks/testlink/img/testlink-stack-220x234.png

--- a/stable/testlink/requirements.lock
+++ b/stable/testlink/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.8.5
+  version: 6.9.1
 digest: sha256:a363428d6463718a9523a88c70e485218373e315f2979cb1bb17b034ec2be96a
-generated: 2019-09-03T08:15:17.423352215Z
+generated: "2019-09-20T15:29:11.919802+02:00"

--- a/stable/testlink/templates/deployment.yaml
+++ b/stable/testlink/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "testlink.fullname" . }}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

There are several deprecations in the API introduced in `K8s 1.16` (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#deprecations-and-removals) which affect our manifests. The following APIs are no longer served by default:

- All resources under `apps/v1beta1` and `apps/v1beta2` - use `apps/v1` instead
- **daemonsets**, **deployments**, **replicasets** resources under `extensions/v1beta1` - use `apps/v1` instead
- **networkpolicies** resources under `extensions/v1beta1` - use `networking.k8s.io/v1` instead
- **podsecuritypolicies** resources under `extensions/v1beta1` - use `policy/v1beta1` instead

This PR address the changes to be done for `stable/testlink`.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)