### PR TITLE
[stable/nginx-ingress] Fixes compatibility with 1.16

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.21.0
+version: 1.22.0
 appVersion: 0.25.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
@@ -15,3 +15,4 @@ maintainers:
   - name: taharah
     email: Trevor.G.Wood@gmail.com
 engine: gotpl
+kubeVersion: ">=1.10.0-0"

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -15,11 +15,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "nginx-ingress.name" . }}
-      component: "{{ .Values.controller.name }}"
       release: {{ .Release.Name }}
-      {{- if .Values.controller.podLabels }}
-{{ toYaml .Values.controller.podLabels | indent 6}}
-      {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   updateStrategy:
 {{ toYaml .Values.controller.updateStrategy | indent 4 }}

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -1,7 +1,7 @@
 {{- if or (eq .Values.controller.kind "DaemonSet") (eq .Values.controller.kind "Both") }}
 {{- $useHostPort := .Values.controller.daemonset.useHostPort -}}
 {{- $hostPorts := .Values.controller.daemonset.hostPorts -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ .Values.controller.apiVersion }}
 kind: DaemonSet
 metadata:
   labels:
@@ -12,6 +12,14 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.controller.fullname" . }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "nginx-ingress.name" . }}
+      component: "{{ .Values.controller.name }}"
+      release: {{ .Release.Name }}
+      {{- if .Values.controller.podLabels }}
+{{ toYaml .Values.controller.podLabels | indent 6}}
+      {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   updateStrategy:
 {{ toYaml .Values.controller.updateStrategy | indent 4 }}
@@ -133,7 +141,7 @@ spec:
               {{- if $useHostPort }}
               hostPort: {{ index $hostPorts $key | default $value }}
               {{- end }}
-          {{- end }}    
+          {{- end }}
           {{- if .Values.controller.metrics.enabled }}
             - name: metrics
               containerPort: 10254

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if or (eq .Values.controller.kind "Deployment") (eq .Values.controller.kind "Both") }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ .Values.controller.apiVersion }}
 kind: Deployment
 metadata:
   labels:
@@ -10,6 +10,14 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.controller.fullname" . }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "nginx-ingress.name" . }}
+      component: "{{ .Values.controller.name }}"
+      release: {{ .Release.Name }}
+      {{- if .Values.controller.podLabels }}
+{{ toYaml .Values.controller.podLabels | indent 6 }}
+      {{- end }}
   replicas: {{ .Values.controller.replicaCount }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   strategy:
@@ -129,7 +137,7 @@ spec:
             - name: {{ $key }}
               containerPort: {{ $value }}
               protocol: TCP
-          {{- end }} 
+          {{- end }}
           {{- if .Values.controller.metrics.enabled }}
             - name: metrics
               containerPort: 10254

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -13,11 +13,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "nginx-ingress.name" . }}
-      component: "{{ .Values.controller.name }}"
       release: {{ .Release.Name }}
-      {{- if .Values.controller.podLabels }}
-{{ toYaml .Values.controller.podLabels | indent 6 }}
-      {{- end }}
   replicas: {{ .Values.controller.replicaCount }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   strategy:

--- a/stable/nginx-ingress/templates/controller-psp.yaml
+++ b/stable/nginx-ingress/templates/controller-psp.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podSecurityPolicy.enabled}}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "nginx-ingress.fullname" . }}

--- a/stable/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/stable/nginx-ingress/templates/default-backend-deployment.yaml
@@ -13,11 +13,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "nginx-ingress.name" . }}
-      component: "{{ .Values.defaultBackend.name }}"
       release: {{ .Release.Name }}
-      {{- if .Values.defaultBackend.podLabels }}
-{{ toYaml .Values.defaultBackend.podLabels | indent 6 }}
-      {{- end }}
   replicas: {{ .Values.defaultBackend.replicaCount }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:

--- a/stable/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/stable/nginx-ingress/templates/default-backend-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.defaultBackend.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ .Values.defaultBackend.apiVersion }}
 kind: Deployment
 metadata:
   labels:
@@ -10,6 +10,14 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "nginx-ingress.name" . }}
+      component: "{{ .Values.defaultBackend.name }}"
+      release: {{ .Release.Name }}
+      {{- if .Values.defaultBackend.podLabels }}
+{{ toYaml .Values.defaultBackend.podLabels | indent 6 }}
+      {{- end }}
   replicas: {{ .Values.defaultBackend.replicaCount }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -11,6 +11,9 @@ controller:
     runAsUser: 33
     allowPrivilegeEscalation: true
 
+  # Can be changed to old api for compatibility reasons: extensions/v1beta1
+  apiVersion: apps/v1
+
   # Configures the ports the nginx-controller listens on
   containerPort:
     http: 80
@@ -403,6 +406,9 @@ defaultBackend:
   ## If false, controller.defaultBackendService must be provided
   ##
   enabled: true
+
+  # Can be changed to old api for compatibility reasons: extensions/v1beta1
+  apiVersion: apps/v1
 
   name: default-backend
   image:


### PR DESCRIPTION
Signed-off-by: Rafael Grigorian <me@raffi.io>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Makes stable/nginx-ingress compatible with 1.16. A quick overview of deprecated APIs can be found on their blog post: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
