### PR TITLE
[stable/cluster-autoscaler] remove sslCertPath host mapping

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 3.4.0
+version: 4.0.0
 appVersion: 1.13.7
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/templates/deployment.yaml
+++ b/stable/cluster-autoscaler/templates/deployment.yaml
@@ -162,15 +162,12 @@ spec:
             - containerPort: 8085
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          {{- if eq .Values.cloudProvider "gce" }}
           volumeMounts:
-            - name: ssl-certs
-              mountPath: {{ .Values.sslCertPath }}
-              readOnly: true
-            {{- if eq .Values.cloudProvider "gce" }}
             - name: cloudconfig
               mountPath: {{ .Values.cloudConfigPath }}
               readOnly: true
-            {{- end }}
+          {{- end }}
     {{- if .Values.affinity }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
@@ -182,15 +179,12 @@ spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "cluster-autoscaler.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
+      {{- if eq .Values.cloudProvider "gce" }}
       volumes:
-        - name: ssl-certs
-          hostPath:
-            path: {{ .Values.sslCertHostPath }}
-        {{- if eq .Values.cloudProvider "gce" }}
         - name: cloudconfig
           hostPath:
             path: {{ .Values.cloudConfigPath }}
-        {{- end }}
+      {{- end }}
     {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}

--- a/stable/cluster-autoscaler/templates/podsecuritypolicy.yaml
+++ b/stable/cluster-autoscaler/templates/podsecuritypolicy.yaml
@@ -16,9 +16,8 @@ spec:
     - 'configMap'
     - 'secret'
     - 'hostPath'
-  allowedHostPaths:
-    - pathPrefix: {{ .Values.sslCertHostPath }}
 {{- if eq .Values.cloudProvider "gce" }}
+  allowedHostPaths:
     - pathPrefix: {{ .Values.cloudConfigPath }}
 {{- end }}
   hostNetwork: false

--- a/stable/cluster-autoscaler/values.yaml
+++ b/stable/cluster-autoscaler/values.yaml
@@ -48,9 +48,6 @@ azureUseManagedIdentityExtension: false
 # Currently only `gce`, `aws`, `azure` & `spotinst` are supported
 cloudProvider: aws
 
-sslCertPath: /etc/ssl/certs/ca-certificates.crt
-sslCertHostPath: /etc/ssl/certs/ca-certificates.crt
-
 # Configuration file for cloud provider
 cloudConfigPath: /etc/gce.conf
 


### PR DESCRIPTION
The certificates were added in https://github.com/kubernetes/autoscaler/pull/11#discussion_r113791551 and it shouldn't be necessary to reference the host itself.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
