### PR TITLE
[stable/cluster-autoscaler]: support annotations on the created svc acct

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 3.2.0
+version: 3.3.0
 appVersion: 1.13.1
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/README.md
+++ b/stable/cluster-autoscaler/README.md
@@ -157,6 +157,7 @@ Parameter | Description | Default
 `deployment.apiVersion` | apiVersion for the deployment | `extensions/v1beta1`
 `rbac.create` | If true, create & use RBAC resources | `false`
 `rbac.serviceAccountName` | existing ServiceAccount to use (ignored if rbac.create=true) | `default`
+`rbac.serviceAccount.annotations` | annotations to add to the service account (ignored if rbac.create=false) | `{}`
 `rbac.pspEnabled` | Must be used with `rbac.create` true. If true, creates & uses RBAC resources required in the cluster with [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) enabled. | `false`
 `replicaCount` | desired number of pods | `1`
 `priorityClassName` | priorityClassName | `nil`

--- a/stable/cluster-autoscaler/templates/serviceaccount.yaml
+++ b/stable/cluster-autoscaler/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations: {{ toYaml .Values.rbac.serviceAccount.annotations | nindent 4 }}
   labels:
 {{ include "cluster-autoscaler.labels" . | indent 4 }}
   name: {{ template "cluster-autoscaler.fullname" . }}

--- a/stable/cluster-autoscaler/values.yaml
+++ b/stable/cluster-autoscaler/values.yaml
@@ -118,6 +118,10 @@ rbac:
   ##
   serviceAccountName: default
 
+  serviceAccount:
+    # If rbac.create is true, apply these annotations to the generated service account
+    annotations: {}
+
 resources: {}
   # limits:
   #   cpu: 100m


### PR DESCRIPTION
#### What this PR does / why we need it:

The new [IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) feature that was recently released
by AWS depends on the ability to add annotations to the service account specifying the ARN
of the role that you want to be able to assume.

#### Which issue this PR fixes

Fixes #16944

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
