### PR TITLE
[stable/consul] Fixes compatibility with 1.16

### DIFF
--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: consul
 home: https://github.com/hashicorp/consul
-version: 3.8.1
+version: 3.8.2
 appVersion: 1.5.3
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/stable/consul/templates/consul-ingress.yaml
+++ b/stable/consul/templates/consul-ingress.yaml
@@ -2,7 +2,7 @@
 {{- $releaseName := .Release.Name -}}
 {{- $servicePort := .Values.HttpPort -}}
 {{- $serviceName := include "consul.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/stable/consul/templates/consul-statefulset.yaml
+++ b/stable/consul/templates/consul-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: "{{ template "consul.fullname" . }}"
@@ -156,7 +156,7 @@ spec:
               JOIN_LAN=""
               for THIS_PEER in $JOIN_PEERS; do
                   # Make sure we can resolve hostname and ping IP
-                  if PEER_IP="$(ping -c 1 $THIS_PEER | awk -F'[()]' '/PING/{print $2}')" && [ "$PEER_IP" != "" ]; then 
+                  if PEER_IP="$(ping -c 1 $THIS_PEER | awk -F'[()]' '/PING/{print $2}')" && [ "$PEER_IP" != "" ]; then
                     if [ "${PEER_IP}" != "${POD_IP}" ]; then
                       JOIN_LAN="${JOIN_LAN}${JOIN_LAN:+ } -retry-join=$THIS_PEER"
                     fi
@@ -187,7 +187,7 @@ spec:
               JOIN_WAN=""
               for THIS_PEER in $WAN_PEERS; do
                   # We don't care if we can ping the peer, but we do care that we can get its IP
-                  if PEER_IP="$( ( ping -c 1 $THIS_PEER || true ) | awk -F'[()]' '/PING/{print $2}')" && [ "$PEER_IP" != "" ]; then 
+                  if PEER_IP="$( ( ping -c 1 $THIS_PEER || true ) | awk -F'[()]' '/PING/{print $2}')" && [ "$PEER_IP" != "" ]; then
                     if [ "${PEER_IP}" != "${POD_IP}" ]; then
                       JOIN_WAN="${JOIN_WAN}${JOIN_WAN:+ } -retry-join-wan=$THIS_PEER"
                     fi


### PR DESCRIPTION
Signed-off-by: Rafael Grigorian <me@raffi.io>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Makes stable/consul compatible with 1.16. A quick overview of deprecated APIs can be found on their blog post: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
