### PR TITLE
[all charts] Charts compatible with kubernetes 1.16

### DIFF
--- a/incubator/artifactory/Chart.yaml
+++ b/incubator/artifactory/Chart.yaml
@@ -1,6 +1,6 @@
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 5.2.1
+version: 5.2.2
 appVersion: 5.2.0
 description: DEPRECATED Universal Repository Manager supporting all major packaging formats, build tools and CI servers.
 keywords:

--- a/incubator/artifactory/templates/deployment.yaml
+++ b/incubator/artifactory/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{template "fullname" .}}

--- a/incubator/azuremonitor-containers/Chart.yaml
+++ b/incubator/azuremonitor-containers/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 7.0.0-1
 description: Helm chart for deploying Azure Monitor container monitoring agent in Kubernetes
 name: azuremonitor-containers
-version: 2.0.0
+version: 2.0.1
 keywords:
   - monitoring
   - azuremonitor

--- a/incubator/azuremonitor-containers/templates/omsagent-daemonset.yaml
+++ b/incubator/azuremonitor-containers/templates/omsagent-daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if and (ne .Values.omsagent.secret.key "<your_workspace_key>") (ne .Values.omsagent.secret.wsid "<your_workspace_id>") (ne .Values.omsagent.env.clusterName "<your_cluster_name>")}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
  name: omsagent

--- a/incubator/azuremonitor-containers/templates/omsagent-deployment.yaml
+++ b/incubator/azuremonitor-containers/templates/omsagent-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if and (ne .Values.omsagent.secret.key "<your_workspace_key>") (ne .Values.omsagent.secret.wsid "<your_workspace_id>") (ne .Values.omsagent.env.clusterName "<your_cluster_name>")}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
  name: omsagent-rs

--- a/incubator/cassandra-reaper/Chart.yaml
+++ b/incubator/cassandra-reaper/Chart.yaml
@@ -5,7 +5,7 @@ name: cassandra-reaper
 home: http://cassandra-reaper.io/
 keywords:
   - cassandra
-version: 0.2.1
+version: 0.2.2
 maintainers:
   - name: kamsz
     email: kamil@szczygiel.io

--- a/incubator/cassandra-reaper/templates/deployment.yaml
+++ b/incubator/cassandra-reaper/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "cassandra-reaper.fullname" . }}

--- a/incubator/chartmuseum/Chart.yaml
+++ b/incubator/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Helm Chart Repository with support for Amazon S3 and Google Cloud Storage
 name: chartmuseum
-version: 1.1.1
+version: 1.1.2
 appVersion: 0.5.1
 home: https://github.com/chartmuseum/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/chartmuseum/master/logo.png

--- a/incubator/chartmuseum/templates/deployment.yaml
+++ b/incubator/chartmuseum/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "chartmuseum.fullname" . }}

--- a/incubator/check-mk/Chart.yaml
+++ b/incubator/check-mk/Chart.yaml
@@ -14,5 +14,5 @@ name: check-mk
 sources:
 - https://github.com/kubernetes/charts
 - http://git.mathias-kettner.de/git/
-version: 0.2.1
+version: 0.2.2
 appVersion: 1.4.0p26

--- a/incubator/check-mk/templates/deployment.yaml
+++ b/incubator/check-mk/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "check-mk.fullname" . }}

--- a/incubator/common/templates/_deployment.yaml
+++ b/incubator/common/templates/_deployment.yaml
@@ -1,5 +1,5 @@
 {{- define "common.deployment.tpl" -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 {{ template "common.metadata" . }}
 spec:

--- a/incubator/couchdb/Chart.yaml
+++ b/incubator/couchdb/Chart.yaml
@@ -3,7 +3,7 @@ name: couchdb
 # The CouchDB chart has been promoted to stable and so the incubator
 # version is deprecated.
 deprecated: true
-version: 1.3.1
+version: 1.3.2
 appVersion: 2.3.1
 description: DEPRECATED see stable version of chart
 home: https://couchdb.apache.org/

--- a/incubator/couchdb/templates/statefulset.yaml
+++ b/incubator/couchdb/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "couchdb.fullname" . }}

--- a/incubator/distribution/Chart.yaml
+++ b/incubator/distribution/Chart.yaml
@@ -9,6 +9,6 @@ name: distribution
 sources:
 - https://bintray.com/jfrog/product/distribution/view
 - https://github.com/JFrogDev
-version: 0.3.1
+version: 0.3.2
 appVersion: 1.0.0
 deprecated: true

--- a/incubator/distribution/templates/distribution-deployment.yaml
+++ b/incubator/distribution/templates/distribution-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "distribution.fullname" . }}

--- a/incubator/distribution/templates/distributor-deployment.yaml
+++ b/incubator/distribution/templates/distributor-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "distributor.fullname" . }}

--- a/incubator/drone/Chart.yaml
+++ b/incubator/drone/Chart.yaml
@@ -1,7 +1,7 @@
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 1.1.1
+version: 1.1.2
 appVersion: 0.8.5
 # The incubator/drone chart is deprecated and no longer maintained. Please use
 # the stable chart you can find at stable/drone.

--- a/incubator/drone/templates/deployment-agent.yaml
+++ b/incubator/drone/templates/deployment-agent.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "drone.fullname" . }}-agent

--- a/incubator/drone/templates/deployment-server.yaml
+++ b/incubator/drone/templates/deployment-server.yaml
@@ -1,5 +1,5 @@
 {{- if hasKey .Values.server.env "DRONE_PROVIDER" }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "drone.fullname" . }}-server

--- a/incubator/etcd/Chart.yaml
+++ b/incubator/etcd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: etcd
 home: https://github.com/coreos/etcd
-version: 0.7.3
+version: 0.7.4
 appVersion: 3.2.26
 description: Distributed reliable key-value store for the most critical data of a
   distributed system.

--- a/incubator/etcd/templates/statefulset.yaml
+++ b/incubator/etcd/templates/statefulset.yaml
@@ -1,7 +1,7 @@
 {{- $etcdPeerProtocol := include "etcd.peerProtocol" . }}
 {{- $etcdClientProtocol := include "etcd.clientProtocol" . }}
 {{- $etcdAuthOptions := include "etcd.authOptions" . }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "etcd.fullname" . }}

--- a/incubator/fluentd-cloudwatch/Chart.yaml
+++ b/incubator/fluentd-cloudwatch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-cloudwatch
-version: 0.10.2
+version: 0.10.3
 appVersion: v1.3.3-debian-cloudwatch-1.0
 description: A Fluentd CloudWatch Helm chart for Kubernetes.
 home: https://www.fluentd.org/

--- a/incubator/fluentd-cloudwatch/templates/daemonset.yaml
+++ b/incubator/fluentd-cloudwatch/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "fluentd-cloudwatch.fullname" . }}

--- a/incubator/fluentd-elasticsearch/Chart.yaml
+++ b/incubator/fluentd-elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-elasticsearch
-version: 2.0.7
+version: 2.0.8
 appVersion: 2.3.2
 home: https://www.fluentd.org/
 description: DEPRECATED! - A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/incubator/fluentd-elasticsearch/templates/pod-security-policy.yaml
+++ b/incubator/fluentd-elasticsearch/templates/pod-security-policy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podSecurityPolicy.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "fluentd-elasticsearch.fullname" . }}

--- a/incubator/gogs/Chart.yaml
+++ b/incubator/gogs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: 'Gogs: Go Git Service'
 name: gogs
-version: 0.7.10
+version: 0.7.11
 appVersion: 0.11.86
 home: https://gogs.io/
 icon: https://gogs.io/img/favicon.ico

--- a/incubator/gogs/templates/deployment.yaml
+++ b/incubator/gogs/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "gogs.fullname" . }}

--- a/incubator/goldfish/Chart.yaml
+++ b/incubator/goldfish/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Goldfish - Vault UI
 name: goldfish
-version: 0.2.7
+version: 0.2.8
 icon: https://github.com/Caiyeon/goldfish/blob/master/frontend/client/assets/logo@2x.png?raw=true
 home: https://vault-ui.io
 appVersion: 0.9.0

--- a/incubator/goldfish/templates/deployment.yaml
+++ b/incubator/goldfish/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ template "goldfish.fullname" . }}"

--- a/incubator/haproxy-ingress/Chart.yaml
+++ b/incubator/haproxy-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: haproxy-ingress
-version: 0.0.15
+version: 0.0.16
 appVersion: 0.7.2
 home: https://github.com/jcmoraisjr/haproxy-ingress
 description: Ingress controller implementation for haproxy loadbalancer.

--- a/incubator/haproxy-ingress/templates/controller-daemonset.yaml
+++ b/incubator/haproxy-ingress/templates/controller-daemonset.yaml
@@ -1,5 +1,5 @@
 {{ if eq .Values.controller.kind "DaemonSet" -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/incubator/haproxy-ingress/templates/controller-deployment.yaml
+++ b/incubator/haproxy-ingress/templates/controller-deployment.yaml
@@ -1,5 +1,5 @@
 {{ if eq .Values.controller.kind "Deployment" -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/incubator/haproxy-ingress/templates/controller-hpa.yaml
+++ b/incubator/haproxy-ingress/templates/controller-hpa.yaml
@@ -11,7 +11,7 @@ metadata:
   name: {{ template "haproxy-ingress.controller.fullname" . }}
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1beta2
+    apiVersion: apps/v1
     kind: Deployment
     name: {{ template "haproxy-ingress.controller.fullname" . }}
   minReplicas: {{ .Values.controller.autoscaling.minReplicas }}

--- a/incubator/haproxy-ingress/templates/default-backend-deployment.yaml
+++ b/incubator/haproxy-ingress/templates/default-backend-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.defaultBackend.enabled }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/incubator/haproxy-ingress/templates/psp.yaml
+++ b/incubator/haproxy-ingress/templates/psp.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.rbac.security.enable -}}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "haproxy-ingress.fullname" . }}

--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.18.2
+version: 0.18.3
 appVersion: 5.0.1
 keywords:
 - kafka

--- a/incubator/kafka/templates/deployment-kafka-exporter.yaml
+++ b/incubator/kafka/templates/deployment-kafka-exporter.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.prometheus.kafka.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kafka.fullname" . }}-exporter

--- a/incubator/keycloak-proxy/Chart.yaml
+++ b/incubator/keycloak-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "3.4.2.Final"
 description: Keycloak Proxy supports Single Sign-On with Keycloak
 name: keycloak-proxy
-version: 0.0.1
+version: 0.0.2
 keywords:
 - authentication
 - sso

--- a/incubator/keycloak-proxy/templates/deployment.yaml
+++ b/incubator/keycloak-proxy/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "keycloak-proxy.fullname" . }}

--- a/incubator/kube-registry-proxy/Chart.yaml
+++ b/incubator/kube-registry-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kube-registry-proxy
 home: https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/registry
-version: 0.3.1
+version: 0.3.2
 appVersion: 0.4
 description: Installs the kubernetes-registry-proxy cluster addon.
 maintainers:

--- a/incubator/kube-registry-proxy/templates/daemon.yaml
+++ b/incubator/kube-registry-proxy/templates/daemon.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "kube-registry-proxy.fullname" . }}

--- a/incubator/kubeless/Chart.yaml
+++ b/incubator/kubeless/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubeless
-version: 2.1.0
+version: 2.1.1
 appVersion: v1.0.4
 description: Kubeless is a Kubernetes-native serverless framework. It runs on top of your Kubernetes cluster and allows you to deploy small unit of code without having to build container images.
 icon: https://cloud.githubusercontent.com/assets/4056725/25480209/1d5bf83c-2b48-11e7-8db8-bcd650f31297.png

--- a/incubator/kubeless/templates/controller-deployment.yaml
+++ b/incubator/kubeless/templates/controller-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kubeless.fullname" . }}-controller-manager

--- a/incubator/kubeless/templates/ui-deployment.yaml
+++ b/incubator/kubeless/templates/ui-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ui.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kubeless.fullname" . }}-ui

--- a/incubator/kubewatch/Chart.yaml
+++ b/incubator/kubewatch/Chart.yaml
@@ -1,6 +1,6 @@
 deprecated: true  # moved to stable
 name: kubewatch
-version: 0.2.3
+version: 0.2.4
 appVersion: v0.0.3
 description: DEPRECATED Kubewatch notifies your slack rooms when changes to your cluster occur
 home: https://github.com/skippbox/kubewatch

--- a/incubator/kubewatch/templates/deployment.yaml
+++ b/incubator/kubewatch/templates/deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/incubator/logstash/Chart.yaml
+++ b/incubator/logstash/Chart.yaml
@@ -5,7 +5,7 @@ description: DEPRECATED Logstash is an open source, server-side data processing 
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 0.9.6
+version: 0.9.7
 appVersion: 6.4.2
 sources:
 - https://www.docker.elastic.co

--- a/incubator/logstash/templates/statefulset.yaml
+++ b/incubator/logstash/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "logstash.fullname" . }}

--- a/incubator/riemann/Chart.yaml
+++ b/incubator/riemann/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Riemann monitors distributed systems. Riemann aggregates events from your servers and applications with a powerful stream processing language.
 name: riemann
-version: 0.1.2
+version: 0.1.3
 appVersion: 0.2.14
 keywords:
 - riemann

--- a/incubator/riemann/templates/deployment.yaml
+++ b/incubator/riemann/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "riemann.fullname" . }}

--- a/incubator/schema-registry/Chart.yaml
+++ b/incubator/schema-registry/Chart.yaml
@@ -1,6 +1,6 @@
 name: schema-registry
 home: https://docs.confluent.io/current/schema-registry/docs/index.html
-version: 1.1.6
+version: 1.1.7
 appVersion: 5.0.1
 keywords:
   - confluent

--- a/incubator/schema-registry/templates/deployment.yaml
+++ b/incubator/schema-registry/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "schema-registry.fullname" . }}

--- a/incubator/sentry-kubernetes/Chart.yaml
+++ b/incubator/sentry-kubernetes/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for sentry-kubernetes (https://github.com/getsentry/sentry-kubernetes)
 name: sentry-kubernetes
-version: 0.2.2
+version: 0.2.3
 appVersion: latest
 icon: https://sentry-brand.storage.googleapis.com/sentry-glyph-white.png
 home: https://github.com/getsentry/sentry-kubernetes

--- a/incubator/sentry-kubernetes/templates/deployment.yaml
+++ b/incubator/sentry-kubernetes/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels: {{ include "sentry-kubernetes.labels" . | indent 4 }}

--- a/incubator/spring-cloud-data-flow/Chart.yaml
+++ b/incubator/spring-cloud-data-flow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: DEPRECATED Toolkit for building data processing pipelines.
 name: spring-cloud-data-flow
-version: 0.2.7
+version: 0.2.8
 appVersion: 1.6.2.RELEASE
 home: http://cloud.spring.io/spring-cloud-dataflow/
 sources:

--- a/incubator/spring-cloud-data-flow/templates/metrics-deployment-rabbit.yaml
+++ b/incubator/spring-cloud-data-flow/templates/metrics-deployment-rabbit.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "scdf.fullname" . }}-metrics

--- a/incubator/spring-cloud-data-flow/templates/server-deployment.yaml
+++ b/incubator/spring-cloud-data-flow/templates/server-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "scdf.fullname" . }}-server

--- a/incubator/spring-cloud-data-flow/templates/skipper-deployment.yaml
+++ b/incubator/spring-cloud-data-flow/templates/skipper-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "scdf.fullname" . }}-skipper

--- a/incubator/tensorflow-inception/Chart.yaml
+++ b/incubator/tensorflow-inception/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: tensorflow-inception
 home: https://github.com/kubernetes/charts
-version: 0.4.1
+version: 0.4.2
 appVersion: 1.4.0
 description: Open source software library for numerical computation using data flow graphs.
 icon: https://camo.githubusercontent.com/ee91ac3c9f5ad840ebf70b54284498fe0e6ddb92/68747470733a2f2f7777772e74656e736f72666c6f772e6f72672f696d616765732f74665f6c6f676f5f7472616e73702e706e67

--- a/incubator/tensorflow-inception/templates/tensorflow-inception.yaml
+++ b/incubator/tensorflow-inception/templates/tensorflow-inception.yaml
@@ -18,7 +18,7 @@ spec:
   type: {{ .Values.serviceType }}
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "tensorflow-inception.fullname" . }}

--- a/incubator/webpagetest-agent/Chart.yaml
+++ b/incubator/webpagetest-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: webpagetest-agent
-version: 0.2.0
+version: 0.2.1
 appVersion: "2018-01-23"
 home: https://www.webpagetest.org/
 icon: https://www.webpagetest.org/images/logo_wpt.png

--- a/incubator/webpagetest-agent/templates/deployment.yaml
+++ b/incubator/webpagetest-agent/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "webpagetest.fullname" . }}

--- a/incubator/webpagetest-server/Chart.yaml
+++ b/incubator/webpagetest-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: webpagetest-server
-version: 0.2.1
+version: 0.2.2
 appVersion: "2018-03-08"
 home: https://www.webpagetest.org/
 icon: https://www.webpagetest.org/images/logo_wpt.png

--- a/incubator/webpagetest-server/templates/deployment.yaml
+++ b/incubator/webpagetest-server/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "webpagetest.fullname" . }}

--- a/stable/acs-engine-autoscaler/Chart.yaml
+++ b/stable/acs-engine-autoscaler/Chart.yaml
@@ -5,7 +5,7 @@ deprecated: true
 description: DEPRECATED Scales worker nodes within agent pools
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: acs-engine-autoscaler
-version: 2.2.2
+version: 2.2.3
 appVersion: 2.1.1
 home: https://github.com/wbuchwalter/Kubernetes-acs-engine-autoscaler
 sources:

--- a/stable/acs-engine-autoscaler/templates/deployment.yaml
+++ b/stable/acs-engine-autoscaler/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.acsenginecluster.resourcegroup .Values.acsenginecluster.azurespappid .Values.acsenginecluster.azurespsecret .Values.acsenginecluster.azuresptenantid .Values.acsenginecluster.kubeconfigprivatekey .Values.acsenginecluster.clientprivatekey -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "acs-engine-autoscaler.fullname" . }}

--- a/stable/ark/Chart.yaml
+++ b/stable/ark/Chart.yaml
@@ -6,7 +6,7 @@ appVersion: 0.10.2
 deprecated: true
 description: DEPRECATED A Helm chart for ark
 name: ark
-version: 4.2.2
+version: 4.2.3
 home: https://github.com/heptio/ark
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/stable/ark/templates/deployment.yaml
+++ b/stable/ark/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.configuration.provider -}}
 {{- $provider := .Values.configuration.provider -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "ark.fullname" . }}

--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.4.1
+version: 0.4.2
 appVersion: 6.2.0
 description: DEPRECATED Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-node-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "artifactory-ha.node.name" . }}

--- a/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
+++ b/stable/artifactory-ha/templates/artifactory-primary-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "artifactory-ha.primary.name" . }}

--- a/stable/artifactory-ha/templates/nginx-deployment.yaml
+++ b/stable/artifactory-ha/templates/nginx-deployment.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.nginx.enabled -}}
 {{- $serviceName := include "artifactory-ha.fullname" . -}}
 {{- $servicePort := .Values.artifactory.externalPort -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "artifactory-ha.nginx.fullname" . }}

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.3.1
+version: 7.3.2
 appVersion: 6.1.0
 description: DEPRECATED Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/templates/artifactory-statefulset.yaml
+++ b/stable/artifactory/templates/artifactory-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "artifactory.fullname" . }}

--- a/stable/artifactory/templates/nginx-deployment.yaml
+++ b/stable/artifactory/templates/nginx-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.nginx.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "artifactory.nginx.fullname" . }}

--- a/stable/aws-iam-authenticator/Chart.yaml
+++ b/stable/aws-iam-authenticator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for aws-iam-authenticator
 name: aws-iam-authenticator
-version: 0.1.1
+version: 0.1.2
 home: https://github.com/kubernetes-sigs/aws-iam-authenticator
 maintainers:
   - name: plumdog

--- a/stable/aws-iam-authenticator/templates/daemonset.yaml
+++ b/stable/aws-iam-authenticator/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "aws-iam-authenticator.fullname" . }}

--- a/stable/bitcoind/Chart.yaml
+++ b/stable/bitcoind/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: bitcoind
-version: 0.2.2
+version: 0.2.3
 appVersion: 0.17.1
 description: Bitcoin is an innovative payment network and a new kind of money.
 keywords:

--- a/stable/bitcoind/templates/deployment.yaml
+++ b/stable/bitcoind/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "bitcoind.fullname" . }}

--- a/stable/bookstack/Chart.yaml
+++ b/stable/bookstack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.27.4-1
 description: BookStack is a simple, self-hosted, easy-to-use platform for organising and storing information.
 name: bookstack
-version: 1.1.1
+version: 1.1.2
 home: https://www.bookstackapp.com/
 icon: https://github.com/BookStackApp/website/blob/master/static/images/logo.png
 sources:

--- a/stable/bookstack/templates/podsecuritypolicy.yaml
+++ b/stable/bookstack/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podSecurityPolicy.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "bookstack.fullname" . }}

--- a/stable/buildkite/Chart.yaml
+++ b/stable/buildkite/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: DEPRECATED Agent for Buildkite
 name: buildkite
-version: 0.2.4
+version: 0.2.5
 appVersion: 3.0
 icon: https://github.com/buildkite/media/blob/master/marks/Buildkite%20-%20Mark%20-%20colour.png
 keywords:

--- a/stable/buildkite/templates/deployment.yaml
+++ b/stable/buildkite/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.agent.token }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "buildkite.fullname" . }}

--- a/stable/centrifugo/Chart.yaml
+++ b/stable/centrifugo/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 3.1.0
+version: 3.1.1
 appVersion: 2.1.0
 description: Centrifugo is a real-time messaging server.
 name: centrifugo

--- a/stable/centrifugo/templates/deployment.yaml
+++ b/stable/centrifugo/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "centrifugo.fullname" . }}

--- a/stable/chartmuseum/Chart.yaml
+++ b/stable/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 2.3.2
+version: 2.3.3
 appVersion: 0.8.2
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/helm/chartmuseum/master/logo2.png

--- a/stable/chartmuseum/templates/deployment.yaml
+++ b/stable/chartmuseum/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "chartmuseum.fullname" . }}

--- a/stable/chronograf/Chart.yaml
+++ b/stable/chronograf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: chronograf
-version: 1.1.0
+version: 1.1.1
 appVersion: 1.7.12
 description: Open-source web application written in Go and React.js that provides
   the tools to visualize your monitoring data and easily create alerting and automation

--- a/stable/chronograf/templates/deployment.yaml
+++ b/stable/chronograf/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "chronograf.fullname" . }}

--- a/stable/clamav/Chart.yaml
+++ b/stable/clamav/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.6"
 description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats.
 name: clamav
-version: 1.0.3
+version: 1.0.4
 home: https://www.clamav.net
 icon: https://www.clamav.net/assets/clamav-trademark.png
 maintainers:

--- a/stable/clamav/templates/deployment.yaml
+++ b/stable/clamav/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "clamav.fullname" . }}

--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 5.0.0
+version: 5.0.1
 appVersion: 1.13.7
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/README.md
+++ b/stable/cluster-autoscaler/README.md
@@ -164,7 +164,7 @@ Parameter | Description | Default
 `extraEnvSecrets` | additional container environment variables from a secret | `{}`
 `nodeSelector` | node labels for pod assignment | `{}`
 `podAnnotations` | annotations to add to each pod | `{}`
-`deployment.apiVersion` | apiVersion for the deployment | `extensions/v1beta1`
+`deployment.apiVersion` | apiVersion for the deployment | `apps/v1`
 `rbac.create` | If true, create & use RBAC resources | `false`
 `rbac.serviceAccountName` | existing ServiceAccount to use (ignored if rbac.create=true) | `default`
 `rbac.serviceAccountAnnotations` | Additional Service Account annotations	| `{}`

--- a/stable/cluster-autoscaler/templates/podsecuritypolicy.yaml
+++ b/stable/cluster-autoscaler/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "cluster-autoscaler.fullname" . }}

--- a/stable/cluster-autoscaler/values.yaml
+++ b/stable/cluster-autoscaler/values.yaml
@@ -102,7 +102,7 @@ podLabels: {}
 replicaCount: 1
 
 deployment:
-  apiVersion: "extensions/v1beta1"
+  apiVersion: "apps/v1"
 
 rbac:
   ## If true, create & use RBAC resources

--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 8.2.5
+version: 8.2.6
 appVersion: 5.5.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.web.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "concourse.web.fullname" . }}

--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: coredns
-version: 1.7.3
+version: 1.7.4
 appVersion: 1.6.3
 description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services
 keywords:

--- a/stable/coredns/templates/podsecuritypolicy.yaml
+++ b/stable/coredns/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnable }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "coredns.fullname" . }}

--- a/stable/coscale/Chart.yaml
+++ b/stable/coscale/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: coscale
-version: 1.0.0
+version: 1.0.1
 appVersion: 3.16.0
 description: CoScale Agent
 keywords:

--- a/stable/coscale/templates/daemonset.yaml
+++ b/stable/coscale/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if and (and .Values.coscale.appId .Values.coscale.accessToken) .Values.coscale.templateId -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "coscale.name" . }}

--- a/stable/couchdb/Chart.yaml
+++ b/stable/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: couchdb
-version: 2.2.0
+version: 2.2.1
 appVersion: 2.3.1
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/stable/couchdb/templates/statefulset.yaml
+++ b/stable/couchdb/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "couchdb.fullname" . }}

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.36.0
+version: 1.36.1
 appVersion: 6.13.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/stable/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -2,7 +2,7 @@
 {{- if .Capabilities.APIVersions.Has "apps/v1" }}
 apiVersion: apps/v1
 {{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 {{- else }}
 apiVersion: apps/v1
 {{- end }}

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -3,7 +3,7 @@
 {{- if .Capabilities.APIVersions.Has "apps/v1" }}
 apiVersion: apps/v1
 {{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 {{- else }}
 apiVersion: apps/v1
 {{- end }}

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -3,7 +3,7 @@
 {{- if .Capabilities.APIVersions.Has "apps/v1" }}
 apiVersion: apps/v1
 {{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 {{- else }}
 apiVersion: apps/v1
 {{- end }}

--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 2.3.1
+version: 2.3.2
 appVersion: 2.19.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/templates/deployment.yaml
+++ b/stable/dex/templates/deployment.yaml
@@ -6,7 +6,7 @@
 {{ $grpcCaBuiltName := printf "%s-ca" $fullname }}
 {{ $grpcCaSecretName := default $grpcCaBuiltName .Values.certs.grpc.secret.caName }}
 
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "dex.fullname" . }}

--- a/stable/distributed-tensorflow/Chart.yaml
+++ b/stable/distributed-tensorflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for running distributed TensorFlow on Kubernetes
 name: distributed-tensorflow
-version: 0.1.1
+version: 0.1.2
 appVersion: 1.6.0
 sources:
 - https://github.com/tensorflow/tensorflow

--- a/stable/distributed-tensorflow/templates/statefulset-ps.yaml
+++ b/stable/distributed-tensorflow/templates/statefulset-ps.yaml
@@ -1,7 +1,7 @@
 {{- $lr := .Values.hyperparams.learningrate -}}
 {{- $batchsize := .Values.hyperparams.batchsize -}}
 
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ .Release.Name }}-ps

--- a/stable/distributed-tensorflow/templates/statefulset-worker.yaml
+++ b/stable/distributed-tensorflow/templates/statefulset-worker.yaml
@@ -1,7 +1,7 @@
 {{- $lr := .Values.hyperparams.learningrate -}}
 {{- $batchsize := .Values.hyperparams.batchsize -}}
 
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ .Release.Name }}-worker

--- a/stable/distribution/Chart.yaml
+++ b/stable/distribution/Chart.yaml
@@ -9,7 +9,7 @@ name: distribution
 sources:
 - https://bintray.com/jfrog/product/distribution/view
 - https://github.com/JFrogDev
-version: 0.4.2
+version: 0.4.3
 appVersion: 1.1.0
 ## Deprecated following https://github.com/helm/charts/blob/master/PROCESSES.md#deprecating-a-chart
 ## Chart is now maintained in https://github.com/jfrog/charts

--- a/stable/distribution/templates/distribution-statefulset.yaml
+++ b/stable/distribution/templates/distribution-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "distribution.fullname" . }}

--- a/stable/distribution/templates/distributor-statefulset.yaml
+++ b/stable/distribution/templates/distributor-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "distributor.fullname" . }}

--- a/stable/dmarc2logstash/Chart.yaml
+++ b/stable/dmarc2logstash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0.3"
 description: Provides a POP3-polled DMARC XML report injector into Elasticsearch via Logstash and Filebeat
 name: dmarc2logstash
-version: 1.2.0
+version: 1.2.1
 home: https://github.com/jertel/dmarc2logstash
 sources:
 - https://github.com/jertel/dmarc2logstash

--- a/stable/dmarc2logstash/templates/deployment.yaml
+++ b/stable/dmarc2logstash/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.filebeat.logstash.host }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "dmarc2logstash.fullname" . }}

--- a/stable/docker-registry/Chart.yaml
+++ b/stable/docker-registry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Docker Registry
 name: docker-registry
-version: 1.8.2
+version: 1.8.3
 appVersion: 2.7.1
 home: https://hub.docker.com/_/registry/
 icon: https://hub.docker.com/public/images/logos/mini-logo.svg

--- a/stable/docker-registry/templates/deployment.yaml
+++ b/stable/docker-registry/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "docker-registry.fullname" . }}

--- a/stable/efs-provisioner/Chart.yaml
+++ b/stable/efs-provisioner/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: efs-provisioner
 description: A Helm chart for the AWS EFS external storage provisioner
-version: 0.7.0
+version: 0.7.1
 appVersion: v2.2.0-k8s1.12
 home: https://github.com/kubernetes-incubator/external-storage/tree/master/aws/efs
 sources:

--- a/stable/efs-provisioner/templates/deployment.yaml
+++ b/stable/efs-provisioner/templates/deployment.yaml
@@ -10,7 +10,7 @@ creates pods that will never enter a clean, running state.
 Omitting the deployment hacks around this limitation.
 */}}
 kind: Deployment
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: {{ template "efs-provisioner.fullname" . }}
   labels:

--- a/stable/elastabot/Chart.yaml
+++ b/stable/elastabot/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.1.0
 description: A Helm chart for Elastabot - a Slack bot companion for Elasticsearch and ElastAlert
 name: elastabot
-version: 1.2.0
+version: 1.2.1
 home: https://github.com/jertel/elastabot
 sources:
 - https://github.com/jertel/elastabot

--- a/stable/elastabot/templates/deployment.yaml
+++ b/stable/elastabot/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.elasticsearch.host }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "elastabot.fullname" . }}

--- a/stable/elasticsearch-curator/Chart.yaml
+++ b/stable/elasticsearch-curator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "5.5.4"
 description: A Helm chart for Elasticsearch Curator
 name: elasticsearch-curator
-version: 2.0.1
+version: 2.0.2
 home: https://github.com/elastic/curator
 keywords:
 - curator

--- a/stable/elasticsearch-curator/templates/psp.yml
+++ b/stable/elasticsearch-curator/templates/psp.yml
@@ -1,5 +1,5 @@
 {{- if .Values.psp.create }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   labels:

--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 1.10.1
+version: 1.10.2
 appVersion: 1.1.0
 home: https://github.com/justwatchcom/elasticsearch_exporter
 sources:

--- a/stable/elasticsearch-exporter/templates/deployment.yaml
+++ b/stable/elasticsearch-exporter/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "elasticsearch-exporter.fullname" . }}

--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.31.1
+version: 1.31.2
 appVersion: 6.8.2
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/stable/elasticsearch/templates/podsecuritypolicy.yaml
+++ b/stable/elasticsearch/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podSecurityPolicy.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "elasticsearch.fullname" . }}

--- a/stable/ethereum/Chart.yaml
+++ b/stable/ethereum/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ethereum
-version: 1.0.0
+version: 1.0.1
 appVersion: v1.7.3
 description: private Ethereum network Helm chart for Kubernetes
 keywords:

--- a/stable/ethereum/templates/bootnode.deployment.yaml
+++ b/stable/ethereum/templates/bootnode.deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2 
+apiVersion: apps/v1 
 kind: Deployment
 metadata:
   name: {{ template "ethereum.fullname" . }}-bootnode

--- a/stable/ethereum/templates/ethstats.deployment.yaml
+++ b/stable/ethereum/templates/ethstats.deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2 
+apiVersion: apps/v1 
 kind: Deployment
 metadata:
   name: {{ template "ethereum.fullname" . }}-ethstats

--- a/stable/ethereum/templates/geth-miner.deployment.yaml
+++ b/stable/ethereum/templates/geth-miner.deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2 
+apiVersion: apps/v1 
 kind: Deployment
 metadata:
   name: {{ template "ethereum.fullname" . }}-geth-miner

--- a/stable/ethereum/templates/geth-tx.deployment.yaml
+++ b/stable/ethereum/templates/geth-tx.deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2 
+apiVersion: apps/v1 
 kind: Deployment
 metadata:
   name: {{ template "ethereum.fullname" . }}-geth-tx

--- a/stable/factorio/Chart.yaml
+++ b/stable/factorio/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: factorio
-version: 1.0.0
+version: 1.0.1
 appVersion: 0.15.39
 description: Factorio dedicated server.
 keywords:

--- a/stable/factorio/templates/deployment.yaml
+++ b/stable/factorio/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "factorio.fullname" . }}

--- a/stable/falco/Chart.yaml
+++ b/stable/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: falco
-version: 1.0.8
+version: 1.0.9
 appVersion: 0.17.1
 description: Falco
 keywords:

--- a/stable/falco/templates/daemonset.yaml
+++ b/stable/falco/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "falco.fullname" . }}

--- a/stable/falco/templates/deployment.yaml
+++ b/stable/falco/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.fakeEventGenerator.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "falco.fullname" . }}-event-generator

--- a/stable/falco/templates/podsecuritypolicy.yaml
+++ b/stable/falco/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podSecurityPolicy.create}}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "falco.fullname" . }}

--- a/stable/filebeat/Chart.yaml
+++ b/stable/filebeat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart to collect Kubernetes logs with filebeat
 icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.svg
 name: filebeat
-version: 3.0.1
+version: 3.0.2
 appVersion: 7.0.1
 home: https://www.elastic.co/products/beats/filebeat
 sources:

--- a/stable/filebeat/templates/daemonset.yaml
+++ b/stable/filebeat/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "filebeat.fullname" . }}

--- a/stable/filebeat/templates/podsecuritypolicy.yaml
+++ b/stable/filebeat/templates/podsecuritypolicy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create -}}
 {{- if .Values.podSecurityPolicy.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "filebeat.fullname" . }}

--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.7.0
+version: 2.7.1
 appVersion: 1.2.2
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/daemonset.yaml
+++ b/stable/fluent-bit/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "fluent-bit.fullname" . }}

--- a/stable/fluentd-elasticsearch/Chart.yaml
+++ b/stable/fluentd-elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-elasticsearch
-version: 2.0.7
+version: 2.0.8
 appVersion: 2.3.2
 home: https://www.fluentd.org/
 description: DEPRECATED! - A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/stable/fluentd-elasticsearch/templates/pod-security-policy.yaml
+++ b/stable/fluentd-elasticsearch/templates/pod-security-policy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podSecurityPolicy.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "fluentd-elasticsearch.fullname" . }}

--- a/stable/g2/Chart.yaml
+++ b/stable/g2/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 deprecated: true
 description: DEPRECATED G2 by AppsCode - Gearman in Golang
 name: g2
-version: 0.3.3
+version: 0.3.4
 appVersion: 0.5.0
 home: https://github.com/appscode/g2
 icon: https://cdn.appscode.com/images/icon/g2.png

--- a/stable/g2/templates/deployment.yaml
+++ b/stable/g2/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "g2.fullname" . }}

--- a/stable/gangway/Chart.yaml
+++ b/stable/gangway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: An application that can be used to easily enable authentication flows via OIDC for a kubernetes cluster.
 name: gangway
-version: 0.1.6
+version: 0.1.7
 appVersion: 3.0.0
 home: https://github.com/heptiolabs/gangway
 sources:

--- a/stable/gangway/templates/deployment.yaml
+++ b/stable/gangway/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "gangway.fullname" . }}

--- a/stable/gcloud-endpoints/Chart.yaml
+++ b/stable/gcloud-endpoints/Chart.yaml
@@ -3,7 +3,7 @@ name: gcloud-endpoints
 # This Chart has been deprecated according to the process described in PROCESSES.md. Check that file to
 # see how to undeprecate this Chart.
 deprecated: true
-version: 0.1.2
+version: 0.1.3
 appVersion: "1"
 description: DEPRECATED Develop, deploy, protect and monitor your APIs with Google Cloud Endpoints.
 keywords:

--- a/stable/gcloud-endpoints/templates/deployment.yaml
+++ b/stable/gcloud-endpoints/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}

--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: gcloud-sqlproxy
-version: 0.6.1
+version: 0.6.2
 appVersion: 1.11
 description: DEPRECATED Google Cloud SQL Proxy
 keywords:

--- a/stable/gcloud-sqlproxy/templates/deployment.yaml
+++ b/stable/gcloud-sqlproxy/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if ne (index .Values.cloudsql.instances 0).instance "instance" }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "gcloud-sqlproxy.fullname" . }}

--- a/stable/gitlab-ce/Chart.yaml
+++ b/stable/gitlab-ce/Chart.yaml
@@ -1,6 +1,6 @@
 name: gitlab-ce
 deprecated: true
-version: 0.2.2
+version: 0.2.3
 appVersion: 9.4.1
 description: GitLab Community Edition
 keywords:

--- a/stable/gitlab-ce/templates/deployment.yaml
+++ b/stable/gitlab-ce/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if default "" .Values.externalUrl }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "gitlab-ce.fullname" . }}

--- a/stable/gitlab-ee/Chart.yaml
+++ b/stable/gitlab-ee/Chart.yaml
@@ -1,6 +1,6 @@
 name: gitlab-ee
 deprecated: true
-version: 0.2.2
+version: 0.2.3
 appVersion: 9.4.1
 description: GitLab Enterprise Edition
 keywords:

--- a/stable/gitlab-ee/templates/deployment.yaml
+++ b/stable/gitlab-ee/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if default "" .Values.externalUrl }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "gitlab-ee.fullname" . }}

--- a/stable/hackmd/Chart.yaml
+++ b/stable/hackmd/Chart.yaml
@@ -1,6 +1,6 @@
 name: hackmd
 apiVersion: v1
-version: "1.2.1"
+version: "1.2.2"
 appVersion: "1.3.0-alpine"
 description: Realtime collaborative markdown notes on all platforms.
 icon: https://hackmd.io/favicon.png

--- a/stable/hackmd/templates/deployment.yaml
+++ b/stable/hackmd/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "hackmd.fullname" . }}

--- a/stable/heapster/Chart.yaml
+++ b/stable/heapster/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Heapster enables Container Cluster Monitoring and Performance Analysis.
 name: heapster
-version: 1.0.1
+version: 1.0.2
 appVersion: 1.5.4
 home: https://github.com/kubernetes/heapster
 sources:

--- a/stable/heapster/templates/deployment.yaml
+++ b/stable/heapster/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "heapster.fullname" . }}

--- a/stable/hl-composer/Chart.yaml
+++ b/stable/hl-composer/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Hyperledger Composer REST Server chart
 name: hl-composer
-version: 1.0.12
+version: 1.0.13
 appVersion: 0.20.0
 keywords:
   - blockchain

--- a/stable/hl-composer/templates/hl-composer-cli-deployment.yaml
+++ b/stable/hl-composer/templates/hl-composer-cli-deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "hl-composer.fullname" . }}-cli

--- a/stable/hl-composer/templates/hl-composer-pg-deployment.yaml
+++ b/stable/hl-composer/templates/hl-composer-pg-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.pg.enabled -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "hl-composer.fullname" . }}-pg

--- a/stable/hl-composer/templates/hl-composer-rest-deployment.yaml
+++ b/stable/hl-composer/templates/hl-composer-rest-deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "hl-composer.fullname" . }}-rest

--- a/stable/horovod/Chart.yaml
+++ b/stable/horovod/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for deploying Horovod
 name: horovod
-version: 1.0.0
+version: 1.0.1
 appVersion: 0.12.1
 sources:
   - https://github.com/uber/horovod

--- a/stable/horovod/templates/statefulset.yaml
+++ b/stable/horovod/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "horovod.fullname" . }}

--- a/stable/influxdb/Chart.yaml
+++ b/stable/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 1.4.0
+version: 1.4.1
 appVersion: 1.7.6
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/stable/influxdb/templates/deployment.yaml
+++ b/stable/influxdb/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ template "influxdb.fullname" . }}"

--- a/stable/instana-agent/Chart.yaml
+++ b/stable/instana-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: instana-agent
-version: 1.0.13
+version: 1.0.14
 appVersion: 1.0
 description: Instana Agent for Kubernetes
 home: https://www.instana.com/

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.agent.key -}}
 {{- if or .Values.zone.name .Values.cluster.name -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "instana-agent.fullname" . }}

--- a/stable/janusgraph/Chart.yaml
+++ b/stable/janusgraph/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: Open source, scalable graph database.
 name: janusgraph
-version: 0.2.1
+version: 0.2.2
 home: http://janusgraph.org
 icon: https://raw.githubusercontent.com/JanusGraph/janusgraph/master/janusgraph.png
 sources:

--- a/stable/janusgraph/templates/deployment.yaml
+++ b/stable/janusgraph/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "janusgraph.fullname" . }}

--- a/stable/k8s-spot-rescheduler/Chart.yaml
+++ b/stable/k8s-spot-rescheduler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.2.0"
 description: A k8s-spot-rescheduler Helm chart for Kubernetes
 name: k8s-spot-rescheduler
-version: 0.4.2
+version: 0.4.3
 keywords:
   - spot
   - rescheduler

--- a/stable/k8s-spot-rescheduler/templates/deployment.yaml
+++ b/stable/k8s-spot-rescheduler/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "k8s-spot-rescheduler.fullname" . }}

--- a/stable/kapacitor/Chart.yaml
+++ b/stable/kapacitor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kapacitor
-version: 1.1.3
+version: 1.1.4
 appVersion: 1.5.2
 description: InfluxDB's native data processing engine. It can process both stream
   and batch data from InfluxDB.

--- a/stable/kapacitor/templates/deployment.yaml
+++ b/stable/kapacitor/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $bl := empty .Values.influxURL }}
 {{- if not $bl }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kapacitor.fullname" . }}

--- a/stable/keel/Chart.yaml
+++ b/stable/keel/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: keel
 description: DEPRECATED Open source, tool for automating Kubernetes deployment updates. Keel
   is stateless, robust and lightweight.
-version: 0.6.1
+version: 0.6.2
 appVersion: 0.9.5
 keywords:
 - kubernetes deployment

--- a/stable/keel/templates/deployment.yaml
+++ b/stable/keel/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "keel.fullname" . }}

--- a/stable/kiam/Chart.yaml
+++ b/stable/kiam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kiam
-version: 2.5.1
+version: 2.5.2
 appVersion: 3.3
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/stable/kiam/templates/agent-daemonset.yaml
+++ b/stable/kiam/templates/agent-daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.agent.enabled -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/stable/kiam/templates/server-daemonset.yaml
+++ b/stable/kiam/templates/server-daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.server.enabled -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.18.5
+version: 0.18.6
 appVersion: 1.3

--- a/stable/kong/templates/controller-deployment.yaml
+++ b/stable/kong/templates/controller-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if (and (.Values.ingressController.enabled) (not (eq .Values.env.database "off"))) }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ template "kong.fullname" . }}-controller"

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ template "kong.fullname" . }}"

--- a/stable/kube-lego/Chart.yaml
+++ b/stable/kube-lego/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: DEPRECATED Automatically requests certificates from Let's Encrypt
 name: kube-lego
-version: 0.4.2
+version: 0.4.3
 appVersion: v0.1.6
 # The kube-lego chart is deprecated and no longer maintained.
 deprecated: true

--- a/stable/kube-lego/templates/deployment.yaml
+++ b/stable/kube-lego/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/stable/kube-ops-view/Chart.yaml
+++ b/stable/kube-ops-view/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kube-ops-view
-version: 1.1.0
+version: 1.1.1
 appVersion: 0.11
 description: Kubernetes Operational View - read-only system dashboard for multiple
   K8s clusters

--- a/stable/kube-ops-view/templates/deployment.yaml
+++ b/stable/kube-ops-view/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kube-ops-view.fullname" . }}

--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kube2iam
-version: 2.0.1
+version: 2.0.2
 appVersion: 0.10.7
 description: Provide IAM credentials to pods based on annotations.
 keywords:

--- a/stable/kube2iam/templates/daemonset.yaml
+++ b/stable/kube2iam/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/stable/kubed/Chart.yaml
+++ b/stable/kubed/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 deprecated: true
 description: DEPRECATED Kubed by AppsCode - Kubernetes daemon
 name: kubed
-version: 0.3.3
+version: 0.3.4
 appVersion: 0.4.0
 home: https://github.com/appscode/kubed
 icon: https://cdn.appscode.com/images/icon/kubed.png

--- a/stable/kubed/templates/deployment.yaml
+++ b/stable/kubed/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kubed.fullname" . }}

--- a/stable/kuberos/Chart.yaml
+++ b/stable/kuberos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2018-07-03"
 description: An OIDC authentication helper for Kubernetes
 name: kuberos
-version: 0.2.1
+version: 0.2.2
 home: https://github.com/negz/kuberos
 sources:
   - https://github.com/negz/kuberos

--- a/stable/kuberos/templates/deployment.yaml
+++ b/stable/kuberos/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kuberos.fullname" . }}

--- a/stable/kured/Chart.yaml
+++ b/stable/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.2.0"
 description: A Helm chart for kured
 name: kured
-version: 1.3.1
+version: 1.3.2
 home: https://github.com/weaveworks/kured
 maintainers:
   - name: plumdog

--- a/stable/kured/templates/podsecuritypolicy.yaml
+++ b/stable/kured/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podSecurityPolicy.create}}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "kured.fullname" . }}

--- a/stable/lamp/Chart.yaml
+++ b/stable/lamp/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Modular and transparent LAMP stack chart supporting PHP-FPM, Release Cloning, LoadBalancer, Ingress, SSL and lots more!
 name: lamp
-version: 1.1.1
+version: 1.1.2
 appVersion: 7
 home: https://github.com/lead4good/helm-lamp-stack
 maintainers:

--- a/stable/lamp/templates/deployment.yaml
+++ b/stable/lamp/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "lamp.fullname" . }}

--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: locust
 description: A modern load testing framework
-version: 1.1.1
+version: 1.1.2
 appVersion: 0.9.0
 maintainers:
   - name: so0k

--- a/stable/locust/templates/master-deploy.yaml
+++ b/stable/locust/templates/master-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "locust.master" . }}

--- a/stable/locust/templates/worker-deploy.yaml
+++ b/stable/locust/templates/worker-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "locust.worker" . }}

--- a/stable/logdna-agent/Chart.yaml
+++ b/stable/logdna-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: logdna-agent
 description: Run this, get logs. All cluster containers. LogDNA collector agent daemonset for Kubernetes.
-version: 1.2.0
+version: 1.2.1
 appVersion: 1.5.6
 keywords:
 - logs

--- a/stable/logdna-agent/templates/daemonset.yaml
+++ b/stable/logdna-agent/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.logdna.key -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "logdna.name" . }}

--- a/stable/logstash/Chart.yaml
+++ b/stable/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 2.2.0
+version: 2.2.1
 appVersion: 7.1.1
 sources:
 - https://www.docker.elastic.co

--- a/stable/logstash/templates/statefulset.yaml
+++ b/stable/logstash/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "logstash.fullname" . }}

--- a/stable/luigi/Chart.yaml
+++ b/stable/luigi/Chart.yaml
@@ -18,5 +18,5 @@ keywords:
 - spark
 - kubernetes job manager
 name: luigi
-version: 2.7.5
+version: 2.7.6
 appVersion: 2.7.2

--- a/stable/luigi/templates/deployment.yaml
+++ b/stable/luigi/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "luigi.fullname" . }}

--- a/stable/magento/Chart.yaml
+++ b/stable/magento/Chart.yaml
@@ -3,7 +3,7 @@ name: magento
 # The Magento chart is deprecated and no longer maintained. For details on deprecation,
 # including how to un-deprecate a chart, see the PROCESSES.md file.
 deprecated: true
-version: 5.1.4
+version: 5.1.5
 appVersion: 2.3.1
 description: DEPRECATED A feature-rich flexible e-commerce solution. It includes transaction options, multi-store functionality, loyalty programs, product categorization and shopper filtering, promotion rules, and more.
 keywords:

--- a/stable/magento/templates/deployment.yaml
+++ b/stable/magento/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if and (include "magento.host" .) (or .Values.mariadb.enabled .Values.externalDatabase.host) -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "magento.fullname" . }}

--- a/stable/magic-ip-address/Chart.yaml
+++ b/stable/magic-ip-address/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to assign static IP addresses for node-local services
 name: magic-ip-address
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.9.0
 home: https://github.com/mumoshu/kube-magic-ip-address
 sources:

--- a/stable/magic-ip-address/templates/daemonset.yaml
+++ b/stable/magic-ip-address/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "magic-ip-address.fullname" . }}

--- a/stable/magic-namespace/Chart.yaml
+++ b/stable/magic-namespace/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: magic-namespace
-version: 0.5.2
+version: 0.5.3
 appVersion: 2.8.1
 home: https://github.com/kubernetes/charts/tree/master/stable/magic-namespace
 description: Elegantly enables a Tiller per namespace in RBAC-enabled clusters

--- a/stable/magic-namespace/templates/tiller-deployment.yaml
+++ b/stable/magic-namespace/templates/tiller-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.tiller.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: tiller-deploy

--- a/stable/mcrouter/Chart.yaml
+++ b/stable/mcrouter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mcrouter
 home: https://github.com/facebook/mcrouter
-version: 1.0.0
+version: 1.0.1
 appVersion: 0.36.0
 description: Mcrouter is a memcached protocol router for scaling memcached deployments.
 sources:

--- a/stable/mcrouter/templates/daemonset.yaml
+++ b/stable/mcrouter/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if eq .Values.controller "daemonset" }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "fullname" . }}

--- a/stable/metabase/Chart.yaml
+++ b/stable/metabase/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 0.8.1
+version: 0.8.2
 appVersion: v0.32.9
 maintainers:
 - name: pmint93

--- a/stable/metabase/templates/deployment.yaml
+++ b/stable/metabase/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "metabase.fullname" . }}

--- a/stable/metricbeat/Chart.yaml
+++ b/stable/metricbeat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart to collect Kubernetes logs with metricbeat
 icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.svg
 name: metricbeat
-version: 1.7.0
+version: 1.7.1
 appVersion: 6.7.0
 home: https://www.elastic.co/products/beats/metricbeat
 sources:

--- a/stable/metricbeat/templates/podsecuritypolicy.yaml
+++ b/stable/metricbeat/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "metricbeat.fullname" . }}

--- a/stable/metrics-server/Chart.yaml
+++ b/stable/metrics-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.3.5
 description: Metrics Server is a cluster-wide aggregator of resource usage data.
 name: metrics-server
-version: 2.8.6
+version: 2.8.7
 keywords:
 - metrics-server
 home: https://github.com/kubernetes-incubator/metrics-server

--- a/stable/metrics-server/templates/psp.yaml
+++ b/stable/metrics-server/templates/psp.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: privileged-{{ template "metrics-server.fullname" . }}

--- a/stable/minecraft/Chart.yaml
+++ b/stable/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 1.1.0
+version: 1.1.1
 appVersion: 1.14.4
 home: https://minecraft.net/
 description: Minecraft server

--- a/stable/minecraft/templates/deployment.yaml
+++ b/stable/minecraft/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if ne (printf "%s" .Values.minecraftServer.eula) "FALSE" }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "minecraft.fullname" . }}

--- a/stable/mssql-linux/Chart.yaml
+++ b/stable/mssql-linux/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: SQL Server 2017 Linux Helm Chart
 name: mssql-linux
-version: 0.10.0
+version: 0.10.1
 appVersion: 14.0.3023.8
 home: https://hub.docker.com/r/microsoft/mssql-server-linux/
 icon: https://img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE1I4Dx

--- a/stable/mssql-linux/templates/deployment.yaml
+++ b/stable/mssql-linux/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "mssql.fullname" . }}

--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mysql
-version: 1.3.2
+version: 1.3.3
 appVersion: 5.7.14
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "mysql.fullname" . }}

--- a/stable/neo4j/Chart.yaml
+++ b/stable/neo4j/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: neo4j
 home: https://www.neo4j.com
-version: 1.2.1
+version: 1.2.2
 appVersion: 3.4.5
 description: Neo4j is the world's leading graph database
 icon: http://info.neo4j.com/rs/773-GON-065/images/neo4j_logo.png

--- a/stable/neo4j/templates/core-statefulset.yaml
+++ b/stable/neo4j/templates/core-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: "apps/v1beta2"
+apiVersion: "apps/v1"
 kind: StatefulSet
 metadata:
   name: "{{ template "neo4j.core.fullname" . }}"

--- a/stable/newrelic-infrastructure/Chart.yaml
+++ b/stable/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 0.13.8
+version: 0.13.9
 appVersion: 1.9.4
 home: https://hub.docker.com/r/newrelic/infrastructure-k8s/
 source:

--- a/stable/newrelic-infrastructure/templates/daemonset.yaml
+++ b/stable/newrelic-infrastructure/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{ if and (or .Values.licenseKey (and .Values.customSecretName .Values.customSecretKey)) .Values.cluster }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels: {{ include "newrelic.labels" . | indent 4 }}

--- a/stable/newrelic-infrastructure/templates/podsecuritypolicy.yaml
+++ b/stable/newrelic-infrastructure/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: privileged-{{ template "newrelic.fullname" . }}

--- a/stable/nfs-client-provisioner/Chart.yaml
+++ b/stable/nfs-client-provisioner/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 3.1.0
 description: nfs-client is an automatic provisioner that used your *already configured* NFS server, automatically creating Persistent Volumes.
 name: nfs-client-provisioner
 home: https://github.com/kubernetes-incubator/external-storage/tree/master/nfs-client
-version: 1.2.6
+version: 1.2.7
 sources:
 - https://github.com/kubernetes-incubator/external-storage/tree/master/nfs-client
 maintainers:

--- a/stable/nfs-client-provisioner/templates/podsecuritypolicy.yaml
+++ b/stable/nfs-client-provisioner/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podSecurityPolicy.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "nfs-client-provisioner.fullname" . }}

--- a/stable/nfs-server-provisioner/Chart.yaml
+++ b/stable/nfs-server-provisioner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.2.1-k8s1.12
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 0.3.1
+version: 0.3.2
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/stable/nfs-server-provisioner/templates/statefulset.yaml
+++ b/stable/nfs-server-provisioner/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "nfs-provisioner.fullname" . }}

--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.22.1
+version: 1.22.2
 appVersion: 0.25.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-problem-detector
-version: "1.6.0"
+version: "1.6.1"
 appVersion: v0.7.0
 home: https://github.com/kubernetes/node-problem-detector
 description: Installs the node-problem-detector daemonset for monitoring extra attributes on nodes

--- a/stable/node-problem-detector/templates/psp.yaml
+++ b/stable/node-problem-detector/templates/psp.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "node-problem-detector.fullname" . }}

--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 0.15.0
+version: 0.15.1
 apiVersion: v1
 appVersion: 3.2.0
 home: http://www.videntity.com/

--- a/stable/oauth2-proxy/templates/deployment.yaml
+++ b/stable/oauth2-proxy/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/stable/openebs/Chart.yaml
+++ b/stable/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 1.2.2
+version: 1.2.3
 name: openebs
 appVersion: 1.2.0
 description: Containerized Storage for Containers

--- a/stable/openebs/templates/daemonset-ndm.yaml
+++ b/stable/openebs/templates/daemonset-ndm.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ndm.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "openebs.fullname" . }}-ndm

--- a/stable/openldap/Chart.yaml
+++ b/stable/openldap/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: openldap
 home: https://www.openldap.org
-version: 1.2.1
+version: 1.2.2
 appVersion: 2.4.47
 description: Community developed LDAP software
 icon: http://www.openldap.org/images/headers/LDAPworm.gif

--- a/stable/openldap/templates/deployment.yaml
+++ b/stable/openldap/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name:  {{ template "openldap.fullname" . }}

--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 3.13.10
+version: 3.13.11
 appVersion: 1.1.0
 maintainers:
 - name: jasongwartz

--- a/stable/openvpn/templates/openvpn-deployment.yaml
+++ b/stable/openvpn/templates/openvpn-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "openvpn.fullname" . }}

--- a/stable/orangehrm/Chart.yaml
+++ b/stable/orangehrm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: orangehrm
-version: 6.2.3
+version: 6.2.4
 appVersion: 4.3.3-0
 description: OrangeHRM is a free HR management system that offers a wealth of modules
   to suit the needs of your business.

--- a/stable/orangehrm/templates/deployment.yaml
+++ b/stable/orangehrm/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "orangehrm.fullname" . }}

--- a/stable/owncloud/Chart.yaml
+++ b/stable/owncloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: owncloud
-version: 6.2.4
+version: 6.2.5
 appVersion: 10.2.1
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/owncloud/README.md
+++ b/stable/owncloud/README.md
@@ -69,7 +69,7 @@ The following table lists the configurable parameters of the ownCloud chart and 
 | `ingress.secrets[0].name`           | TLS Secret Name                            | `nil`                                                   |
 | `ingress.secrets[0].certificate`    | TLS Secret Certificate                     | `nil`                                                   |
 | `ingress.secrets[0].key`            | TLS Secret Key                             | `nil`                                                   |
-| `networkPolicyApiVersion`           | The kubernetes network API version         | `extensions/v1beta1`                                    |
+| `networkPolicyApiVersion`           | The kubernetes network API version         | `apps/v1`                                    |
 | `owncloudHost`                      | ownCloud host to create application URLs   | `nil`                                                   |
 | `owncloudLoadBalancerIP`            | `loadBalancerIP` for the owncloud Service  | `nil`                                                   |
 | `owncloudUsername`                  | User of the application                    | `user`                                                  |

--- a/stable/owncloud/values.yaml
+++ b/stable/owncloud/values.yaml
@@ -37,7 +37,7 @@ image:
 
 ## For Kubernetes v1.4, v1.5 and v1.6, use 'extensions/v1beta1'
 ## For Kubernetes v1.7, use 'networking.k8s.io/v1'
-networkPolicyApiVersion: extensions/v1beta1
+networkPolicyApiVersion: apps/v1
 
 ## Configure the ingress resource that allows you to access the
 ## ownCloud installation. Set up the URL

--- a/stable/pachyderm/Chart.yaml
+++ b/stable/pachyderm/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - reproducibility
   - distributed
   - processing
-version: 0.2.1
+version: 0.2.2
 appVersion: 1.8.6
 home: "https://pachyderm.io"
 sources:

--- a/stable/pachyderm/templates/etcd_deployment.yaml
+++ b/stable/pachyderm/templates/etcd_deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: etcd

--- a/stable/pachyderm/templates/pachd_deployment.yaml
+++ b/stable/pachyderm/templates/pachd_deployment.yaml
@@ -1,6 +1,6 @@
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: pachd
   labels:

--- a/stable/percona-xtradb-cluster/Chart.yaml
+++ b/stable/percona-xtradb-cluster/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: percona-xtradb-cluster
-version: 1.0.2
+version: 1.0.3
 appVersion: 5.7.19
 description: free, fully compatible, enhanced, open source drop-in replacement for
   MySQL with Galera Replication (xtradb)

--- a/stable/percona-xtradb-cluster/templates/statefulset.yaml
+++ b/stable/percona-xtradb-cluster/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "percona-xtradb-cluster.fullname" . }}

--- a/stable/percona/Chart.yaml
+++ b/stable/percona/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: percona
-version: 1.1.0
+version: 1.1.1
 appVersion: 5.7.17
 description: free, fully compatible, enhanced, open source drop-in replacement for
   MySQL

--- a/stable/percona/templates/deployment.yaml
+++ b/stable/percona/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "percona.fullname" . }}

--- a/stable/presto/Chart.yaml
+++ b/stable/presto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.196
 description: Distributed SQL query engine for running interactive analytic queries
 name: presto
-version: 0.1.1
+version: 0.1.2
 home: https://prestodb.io
 icon: https://prestodb.io/static/presto.png
 sources:

--- a/stable/presto/templates/deployment-coordinator.yaml
+++ b/stable/presto/templates/deployment-coordinator.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "presto.coordinator" . }}

--- a/stable/presto/templates/deployment-worker.yaml
+++ b/stable/presto/templates/deployment-worker.yaml
@@ -1,5 +1,5 @@
 {{- if gt (int .Values.server.workers) 0 }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "presto.worker" . }}

--- a/stable/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/stable/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.4.10
+version: 0.4.11
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}

--- a/stable/prometheus-consul-exporter/Chart.yaml
+++ b/stable/prometheus-consul-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.4.0"
 description: A Helm chart for the Prometheus Consul Exporter
 name: prometheus-consul-exporter
-version: 0.1.4
+version: 0.1.5
 keywords:
   - metrics
   - consul

--- a/stable/prometheus-consul-exporter/templates/podsecuritypolicy.yaml
+++ b/stable/prometheus-consul-exporter/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-consul-exporter.fullname" . }}

--- a/stable/prometheus-couchdb-exporter/Chart.yaml
+++ b/stable/prometheus-couchdb-exporter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart to export the metrics from couchdb in Prometheus format.
 name: prometheus-couchdb-exporter
 home: https://github.com/gesellix/couchdb-prometheus-exporter
-version: 0.1.1
+version: 0.1.2
 keywords:
 - couchdb-exporter
 sources:

--- a/stable/prometheus-couchdb-exporter/templates/podsecuritypolicy.yaml
+++ b/stable/prometheus-couchdb-exporter/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-couchdb-exporter.fullname" . }}

--- a/stable/prometheus-node-exporter/Chart.yaml
+++ b/stable/prometheus-node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.18.0"
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 1.6.0
+version: 1.6.1
 home: https://github.com/prometheus/node_exporter/
 sources:
 - https://github.com/prometheus/node_exporter/

--- a/stable/prometheus-node-exporter/templates/daemonset.yaml
+++ b/stable/prometheus-node-exporter/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "prometheus-node-exporter.fullname" . }}

--- a/stable/prometheus-node-exporter/templates/psp.yaml
+++ b/stable/prometheus-node-exporter/templates/psp.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create }}
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}

--- a/stable/prometheus-postgres-exporter/Chart.yaml
+++ b/stable/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.1"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 0.7.2
+version: 0.7.3
 home: https://github.com/wrouesnel/postgres_exporter
 sources:
 - https://github.com/wrouesnel/postgres_exporter

--- a/stable/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/stable/prometheus-postgres-exporter/templates/deployment.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.config.datasource.passwordSecret .Values.config.datasource.password -}}
 {{ fail (printf "ERROR: only one of .Values.config.datasource.passwordSecret and .Values.config.datasource.password must be defined") }}
 {{- end -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}

--- a/stable/prometheus-postgres-exporter/templates/podsecuritypolicy.yaml
+++ b/stable/prometheus-postgres-exporter/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}

--- a/stable/prometheus-pushgateway/Chart.yaml
+++ b/stable/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.9.1"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.0.1
+version: 1.0.2
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/stable/prometheus-pushgateway/templates/deployment.yaml
+++ b/stable/prometheus-pushgateway/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "prometheus-pushgateway.fullname" . }}

--- a/stable/prometheus-redis-exporter/Chart.yaml
+++ b/stable/prometheus-redis-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.4
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 3.0.1
+version: 3.0.2
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/stable/prometheus-redis-exporter/templates/deployment.yaml
+++ b/stable/prometheus-redis-exporter/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "prometheus-redis-exporter.fullname" . }}

--- a/stable/prometheus-redis-exporter/templates/podsecuritypolicy.yaml
+++ b/stable/prometheus-redis-exporter/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-redis-exporter.fullname" . }}

--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 9.1.1
+version: 9.1.2
 appVersion: 2.11.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/alertmanager-deployment.yaml
+++ b/stable/prometheus/templates/alertmanager-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.alertmanager.enabled (not .Values.alertmanager.statefulSet.enabled) -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/stable/prometheus/templates/kube-state-metrics-deployment.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.kubeStateMetrics.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
 {{- if .Values.kubeStateMetrics.deploymentAnnotations }}

--- a/stable/prometheus/templates/node-exporter-daemonset.yaml
+++ b/stable/prometheus/templates/node-exporter-daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.nodeExporter.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
 {{- if .Values.nodeExporter.deploymentAnnotations }}

--- a/stable/prometheus/templates/node-exporter-podsecuritypolicy.yaml
+++ b/stable/prometheus/templates/node-exporter-podsecuritypolicy.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.nodeExporter.enabled .Values.rbac.create }}
 {{- if .Values.podSecurityPolicy.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus.nodeExporter.fullname" . }}

--- a/stable/prometheus/templates/pushgateway-deployment.yaml
+++ b/stable/prometheus/templates/pushgateway-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.pushgateway.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.server.enabled -}}
 {{- if not .Values.server.statefulSet.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
 {{- if .Values.server.deploymentAnnotations }}

--- a/stable/quassel/Chart.yaml
+++ b/stable/quassel/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.12.4
 description: Quassel IRC is a modern, cross-platform, distributed IRC client.
 name: quassel
-version: 0.2.9
+version: 0.2.10
 icon: https://avatars3.githubusercontent.com/u/2965670
 home: https://quassel-irc.org/
 maintainers:

--- a/stable/quassel/templates/deployment.yaml
+++ b/stable/quassel/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "quassel.fullname" . }}

--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.7.13
+version: 3.7.14
 appVersion: 5.0.5
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/redis-haproxy-deployment.yaml
+++ b/stable/redis-ha/templates/redis-haproxy-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.haproxy.enabled }}
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ template "redis-ha.fullname" . }}-haproxy
   labels:

--- a/stable/risk-advisor/Chart.yaml
+++ b/stable/risk-advisor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: risk-advisor
 description: Risk Advisor add-on module for Kubernetes
-version: 2.0.4
+version: 2.0.5
 appVersion: 1.0.0
 home: https://www.riskadvisory.net/
 sources:

--- a/stable/risk-advisor/templates/deployment.yaml
+++ b/stable/risk-advisor/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "risk-advisor.fullname" . }}

--- a/stable/rocketchat/Chart.yaml
+++ b/stable/rocketchat/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rocketchat
-version: 1.1.12
+version: 1.1.13
 appVersion: 1.3.1
 description: Prepare to take off with the ultimate chat platform, experience the next level of team communications
 keywords:

--- a/stable/rocketchat/templates/deployment.yaml
+++ b/stable/rocketchat/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "rocketchat.fullname" . }}

--- a/stable/satisfy/Chart.yaml
+++ b/stable/satisfy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: satisfy
-version: 1.0.0
+version: 1.0.1
 appVersion: "3.0.4"
 description: Composer repo hosting with Satisfy
 home: https://github.com/anapsix/docker-satisfy

--- a/stable/satisfy/templates/deployment.yaml
+++ b/stable/satisfy/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "satisfy.fullname" . }}

--- a/stable/schema-registry-ui/Chart.yaml
+++ b/stable/schema-registry-ui/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - Kafka
   - avro
   - schema-registry
-version: 0.4.0
+version: 0.4.1
 maintainers:
 - email: cristian04@gmail.com
   name: cristian04

--- a/stable/schema-registry-ui/templates/deployment.yaml
+++ b/stable/schema-registry-ui/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "schema-registry-ui.fullname" . }}

--- a/stable/sealed-secrets/Chart.yaml
+++ b/stable/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.4.0
+version: 1.4.1
 appVersion: 0.8.1
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/stable/sealed-secrets/templates/psp.yaml
+++ b/stable/sealed-secrets/templates/psp.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "sealed-secrets.fullname" . }}

--- a/stable/searchlight/Chart.yaml
+++ b/stable/searchlight/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 deprecated: true
 description: DEPRECATED Searchlight by AppsCode - Alerts for Kubernetes
 name: searchlight
-version: 0.3.3
+version: 0.3.4
 appVersion: 5.0.0
 home: https://github.com/appscode/searchlight
 icon: https://cdn.appscode.com/images/icon/searchlight.png

--- a/stable/searchlight/templates/deployment.yaml
+++ b/stable/searchlight/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "searchlight.fullname" . }}

--- a/stable/selenium/Chart.yaml
+++ b/stable/selenium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: selenium
-version: 1.0.8
+version: 1.0.9
 appVersion: 3.141.59
 description: Chart for selenium grid
 keywords:

--- a/stable/selenium/templates/chrome-deployment.yaml
+++ b/stable/selenium/templates/chrome-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if eq true .Values.chrome.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "selenium.chrome.fullname" . }}

--- a/stable/selenium/templates/chromeDebug-deployment.yaml
+++ b/stable/selenium/templates/chromeDebug-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if eq true .Values.chromeDebug.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "selenium.chromeDebug.fullname" . }}

--- a/stable/selenium/templates/firefox-deployment.yaml
+++ b/stable/selenium/templates/firefox-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if eq true .Values.firefox.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "selenium.firefox.fullname" . }}

--- a/stable/selenium/templates/firefoxDebug-deployment.yaml
+++ b/stable/selenium/templates/firefoxDebug-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if eq true .Values.firefoxDebug.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "selenium.firefoxDebug.fullname" . }}

--- a/stable/selenium/templates/hub-deployment.yaml
+++ b/stable/selenium/templates/hub-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "selenium.hub.fullname" . }}

--- a/stable/sematext-agent/Chart.yaml
+++ b/stable/sematext-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.0"
-version: 1.0.18
+version: 1.0.19
 description: Helm chart for deploying Sematext Agent to Kubernetes
 keywords:
   - sematext

--- a/stable/sematext-agent/templates/daemonset.yaml
+++ b/stable/sematext-agent/templates/daemonset.yaml
@@ -2,7 +2,7 @@
 {{- if .Capabilities.APIVersions.Has "apps/v1" }}
 apiVersion: apps/v1
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 {{- end }}
 kind: DaemonSet
 metadata:

--- a/stable/sematext-docker-agent/Chart.yaml
+++ b/stable/sematext-docker-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: sematext-docker-agent
 # This chart is deprecated and no longer maintained. Use stable/sematext-agent instead.
 # For details deprecation, including how to un-deprecate a chart see the PROCESSES.md file.
 deprecated: true
-version: 1.0.1
+version: 1.0.2
 appVersion: 1.31.53
 description: DEPRECATED Sematext Docker Agent
 keywords:

--- a/stable/sematext-docker-agent/templates/daemonset.yaml
+++ b/stable/sematext-docker-agent/templates/daemonset.yaml
@@ -1,8 +1,8 @@
 {{- if or (.Values.sematext.spmToken) (.Values.sematext.logseneToken) }}
 {{- if .Capabilities.APIVersions.Has "apps/v1beta2" }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 {{- end }}
 kind: DaemonSet
 metadata:

--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 3.0.1
+version: 3.0.2
 appVersion: 9.1.1
 keywords:
   - debugging

--- a/stable/sentry/templates/cron-deployment.yaml
+++ b/stable/sentry/templates/cron-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sentry.fullname" . }}-cron

--- a/stable/sentry/templates/metrics-deployment.yaml
+++ b/stable/sentry/templates/metrics-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.metrics.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sentry.fullname" . }}-metrics

--- a/stable/sentry/templates/web-deployment.yaml
+++ b/stable/sentry/templates/web-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sentry.fullname" . }}-web

--- a/stable/sentry/templates/workers-deployment.yaml
+++ b/stable/sentry/templates/workers-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sentry.fullname" . }}-worker

--- a/stable/signalfx-agent/Chart.yaml
+++ b/stable/signalfx-agent/Chart.yaml
@@ -7,7 +7,7 @@ deprecated: true
 description: DEPRECATED The SignalFx Kubernetes agent
 name: signalfx-agent
 appVersion: 3.6.1
-version: 0.3.1
+version: 0.3.2
 keywords:
 - monitoring
 - alerting

--- a/stable/signalfx-agent/templates/daemonset.yaml
+++ b/stable/signalfx-agent/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.clusterName .Values.signalFxAccessToken -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "signalfx-agent.fullname" . }}

--- a/stable/signalsciences/Chart.yaml
+++ b/stable/signalsciences/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: signalsciences
 home: https://signalsciences.com
 icon: https://dashboard.signalsciences.net/static/images/logo-icon-color.svg
-version: 1.0.0
+version: 1.0.1
 appVersion: 3.12.1
 description: SignalSciences is a web application firewall. This chart is the installable agent.
 keywords:

--- a/stable/signalsciences/templates/daemonset.yaml
+++ b/stable/signalsciences/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.daemonset.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name:  {{ template "signalsciences.fullname" . }}

--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 2.3.0
+version: 2.3.1
 appVersion: 7.9
 keywords:
   - coverage

--- a/stable/sonarqube/templates/deployment.yaml
+++ b/stable/sonarqube/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sonarqube.fullname" . }}

--- a/stable/spark/Chart.yaml
+++ b/stable/spark/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: spark
-version: 1.0.0
+version: 1.0.1
 appVersion: 1.5.1
 description: Fast and general-purpose cluster computing system.
 home: http://spark.apache.org

--- a/stable/spark/templates/spark-master-deployment.yaml
+++ b/stable/spark/templates/spark-master-deployment.yaml
@@ -31,7 +31,7 @@ spec:
     component: "{{ .Release.Name }}-{{ .Values.Master.Component }}"
   type: {{ .Values.Master.ServiceType }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "master-fullname" . }}

--- a/stable/spark/templates/spark-worker-deployment.yaml
+++ b/stable/spark/templates/spark-worker-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "worker-fullname" . }}

--- a/stable/spark/templates/spark-zeppelin-deployment.yaml
+++ b/stable/spark/templates/spark-zeppelin-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     component: "{{ .Release.Name }}-{{ .Values.Zeppelin.Component }}"
   type: {{ .Values.Zeppelin.ServiceType }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "zeppelin-fullname" . }}

--- a/stable/spartakus/Chart.yaml
+++ b/stable/spartakus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: spartakus
-version: 1.1.6
+version: 1.1.7
 appVersion: 1.0.0
 home: https://www.shdlr.com
 description: Collect information about Kubernetes clusters to help improve the project.

--- a/stable/spartakus/templates/deployment.yaml
+++ b/stable/spartakus/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/stable/spotify-docker-gc/Chart.yaml
+++ b/stable/spotify-docker-gc/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: spotify-docker-gc
 home: https://github.com/spotify/docker-gc
-version: 1.0.0
+version: 1.0.1
 appVersion: latest
 description: A simple Docker container and image garbage collection script.
 sources:

--- a/stable/spotify-docker-gc/templates/daemonset.yaml
+++ b/stable/spotify-docker-gc/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "name" . }}

--- a/stable/stackdriver-exporter/Chart.yaml
+++ b/stable/stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: stackdriver-exporter
-version: 1.2.1
+version: 1.2.2
 appVersion: 0.6.0
 home: https://www.stackdriver.com/
 sources:

--- a/stable/stackdriver-exporter/templates/deployment.yaml
+++ b/stable/stackdriver-exporter/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "stackdriver-exporter.fullname" . }}

--- a/stable/stolon/Chart.yaml
+++ b/stable/stolon/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stolon
-version: 1.2.0
+version: 1.2.1
 appVersion: 0.13.0
 description: Stolon - PostgreSQL cloud native High Availability.
 home: https://github.com/sorintlab/stolon

--- a/stable/stolon/templates/keeper-statefulset.yaml
+++ b/stable/stolon/templates/keeper-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "stolon.fullname" . }}-keeper

--- a/stable/stolon/templates/proxy-deployment.yaml
+++ b/stable/stolon/templates/proxy-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "stolon.fullname" . }}-proxy

--- a/stable/stolon/templates/sentinel-deployment.yaml
+++ b/stable/stolon/templates/sentinel-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "stolon.fullname" . }}-sentinel

--- a/stable/sumokube/Chart.yaml
+++ b/stable/sumokube/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sumokube
-version: 1.0.0
+version: 1.0.1
 appVersion: latest
 home: https://www.sumologic.com/
 description: Sumologic Log Collector

--- a/stable/sumokube/templates/daemonset.yaml
+++ b/stable/sumokube/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.sumologic.accessId .Values.sumologic.accessKey -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "fullname" . }}

--- a/stable/sumologic-fluentd/Chart.yaml
+++ b/stable/sumologic-fluentd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sumologic-fluentd
-version: 1.1.1
+version: 1.1.2
 appVersion: 2.3.0
 description: Sumologic Log Collector
 keywords:

--- a/stable/sumologic-fluentd/templates/daemonset.yaml
+++ b/stable/sumologic-fluentd/templates/daemonset.yaml
@@ -1,6 +1,6 @@
 {{- if (or (.Values.sumologic.collectorUrlExistingSecret) (.Values.sumologic.collectorUrl)) -}}
 # Sumologic collector URL is required
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "sumologic-fluentd.fullname" . }}

--- a/stable/sysdig/Chart.yaml
+++ b/stable/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.4.16
+version: 1.4.17
 appVersion: 0.92.1
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/stable/sysdig/templates/daemonset.yaml
+++ b/stable/sysdig/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.sysdig.accessKey }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "sysdig.fullname" . }}

--- a/stable/tensorflow-notebook/Chart.yaml
+++ b/stable/tensorflow-notebook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for tensorflow notebook and tensorboard
 name: tensorflow-notebook
-version: 0.1.2
+version: 0.1.3
 appVersion: 1.6.0
 sources:
   - https://github.com/tensorflow/tensorflow

--- a/stable/tensorflow-notebook/templates/deployment.yaml
+++ b/stable/tensorflow-notebook/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "tensorflow-notebook.fullname" . }}

--- a/stable/tensorflow-serving/Chart.yaml
+++ b/stable/tensorflow-serving/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: tensorflow-serving
 home: https://github.com/kubernetes/charts
-version: 1.0.0
+version: 1.0.1
 appVersion: 1.14.0
 description: TensorFlow Serving is an open-source software library for serving machine learning models.
 sources:

--- a/stable/tensorflow-serving/templates/deployment.yaml
+++ b/stable/tensorflow-serving/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $gpuCount := .Values.gpuCount -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "tensorflow-serving.fullname" . }}

--- a/stable/tomcat/Chart.yaml
+++ b/stable/tomcat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: tomcat
 description: Deploy a basic tomcat application server with sidecar as web archive container
 icon: http://tomcat.apache.org/res/images/tomcat.png
-version: 0.3.0
+version: 0.3.1
 appVersion: "7.0"
 home: https://github.com/yahavb
 maintainers:

--- a/stable/tomcat/templates/appsrv.yaml
+++ b/stable/tomcat/templates/appsrv.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "tomcat.fullname" . }}

--- a/stable/uchiwa/Chart.yaml
+++ b/stable/uchiwa/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: uchiwa
-version: 1.0.0
+version: 1.0.1
 appVersion: 0.22
 description: Dashboard for the Sensu monitoring framework
 keywords:

--- a/stable/uchiwa/templates/deployment.yaml
+++ b/stable/uchiwa/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "uchiwa.fullname" . }}

--- a/stable/unbound/Chart.yaml
+++ b/stable/unbound/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Unbound is a fast caching DNS resolver
 home: https://www.unbound.net/
 name: unbound
-version: 1.0.0
+version: 1.0.1
 appVersion: 1.6.7
 sources:
 - http://unbound.nlnetlabs.nl/svn/

--- a/stable/unbound/templates/deployment.yaml
+++ b/stable/unbound/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "unbound.fullname" . }}

--- a/stable/voyager/Chart.yaml
+++ b/stable/voyager/Chart.yaml
@@ -6,7 +6,7 @@ description: DEPRECATED Voyager by AppsCode - Secure Ingress Controller for Kube
 home: https://appscode.com/products/voyager/
 icon: https://cdn.appscode.com/images/icon/voyager.png
 name: voyager
-version: 3.2.4
+version: 3.2.5
 appVersion: 6.0.0
 sources:
   - https://github.com/appscode/voyager

--- a/stable/voyager/templates/deployment.yaml
+++ b/stable/voyager/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "voyager.fullname" . }}

--- a/stable/weave-cloud/Chart.yaml
+++ b/stable/weave-cloud/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 appVersion: "1.3.0"
 name: weave-cloud
-version: 0.3.3
+version: 0.3.4
 description: |
     Weave Cloud is a add-on to Kubernetes which provides Continuous Delivery, along with hosted Prometheus Monitoring and a visual dashboard for exploring & debugging microservices
 home: https://weave.works

--- a/stable/weave-cloud/templates/deployment.yaml
+++ b/stable/weave-cloud/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.agent.name }}

--- a/stable/weave-scope/Chart.yaml
+++ b/stable/weave-scope/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: weave-scope
-version: 1.1.5
+version: 1.1.6
 appVersion: 1.11.5
 description: A Helm chart for the Weave Scope cluster visualizer.
 keywords:

--- a/stable/weave-scope/charts/weave-scope-agent/templates/daemonset.yaml
+++ b/stable/weave-scope/charts/weave-scope-agent/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/stable/weave-scope/charts/weave-scope-cluster-agent/templates/deployment.yaml
+++ b/stable/weave-scope/charts/weave-scope-cluster-agent/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/stable/zeppelin/Chart.yaml
+++ b/stable/zeppelin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Web-based notebook that enables data-driven, interactive data analytics and collaborative documents with SQL, Scala and more.
 name: zeppelin
-version: 1.1.0
+version: 1.1.1
 appVersion: 0.7.2
 home: https://zeppelin.apache.org/
 sources:

--- a/stable/zeppelin/templates/deployment.yaml
+++ b/stable/zeppelin/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-zeppelin

--- a/stable/zetcd/Chart.yaml
+++ b/stable/zetcd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: CoreOS zetcd Helm chart for Kubernetes
 name: zetcd
-version: 0.1.9
+version: 0.1.10
 appVersion: 0.0.3
 home: https://github.com/coreos/zetcd
 sources:

--- a/stable/zetcd/templates/deployment.yaml
+++ b/stable/zetcd/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "zetcd.fullname" . }}


### PR DESCRIPTION
Replaces extensions/v1beta1 to policy/v1beta1 for PodSecurityPolicy.
```
sed -i 's@apiVersion: extensions/v1beta1@apiVersion: policy/v1beta1@' `find . -iregex ".*yaml\|.*yml" -exec awk '/kind:\s+PodSecurityPolicy/ {print FILENAME}' {} +`
````
Replaces extensions/v1beta1 to apps/v1 for Deployment, StatefulSet, ReplicaSet, DaemonSet
```
sed -i 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' `find . -iregex ".*yaml\|.*yml" -exec awk '/kind:\s+(Deployment|StatefulSet|ReplicaSet|DaemonSet)/ {print FILENAME}' {} +`
sed -i 's@apiVersion: apps/v1beta2@apiVersion: apps/v1@' `find . -iregex ".*yaml\|.*yml" -exec awk '/kind:\s+(Deployment|StatefulSet|ReplicaSet|DaemonSet)/ {print FILENAME}' {} +`
```

Manually modified after searching for rest of files containing extensions/v1beta1 except Ingress objects obtained from: "`egrep -rL 'kind:\s+Ingress' | xargs awk '/extensions\/v1beta1|apps\/v1beta2/ {print FILENAME}'`"
Manually modified files:
> modified:   stable/cluster-autoscaler/README.md
> modified:   stable/cluster-autoscaler/values.yaml
> 	modified:   stable/owncloud/README.md
> 	modified:   stable/owncloud/values.yaml
>      modified:   stable/neo4j/templates/core-statefulset.yaml

Changes based on https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
* NetworkPolicy resources will no longer be served from extensions/v1beta1 by default in v1.16. Migrate to the networking.k8s.io/v1 API, available since v1.8. Existing persisted data can be retrieved/updated via the networking.k8s.io/v1 API.
* PodSecurityPolicy resources will no longer be served from extensions/v1beta1 by default in v1.16. Migrate to the policy/v1beta1 API, available since v1.10. Existing persisted data can be retrieved/updated via the policy/v1beta1 API.
* DaemonSet, Deployment, StatefulSet, and ReplicaSet resources will no longer be served from extensions/v1beta1, apps/v1beta1, or apps/v1beta2 by default in v1.16. Migrate to the apps/v1 API, available since v1.9. Existing persisted data can be retrieved/updated via the apps/v1 API.

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Compatibility k8s v1.16

#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/chart]`)
