### PR TITLE
[stable/parse] Update deployment apiVersion to 'apps/v1' - Mandatory for K8s 1.16

### DIFF
--- a/stable/parse/Chart.yaml
+++ b/stable/parse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: parse
-version: 10.0.0
+version: 10.0.1
 appVersion: 3.9.0
 description: Parse is a platform that enables users to add a scalable and powerful backend to launch a full-featured app for iOS, Android, JavaScript, Windows, Unity, and more.
 keywords:

--- a/stable/parse/requirements.lock
+++ b/stable/parse/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mongodb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 7.2.8
+  version: 7.2.9
 digest: sha256:380fe3c8514cc2d19b28e5b1a79d83961fa9f9d7f438eba85425dbf8c0b89bbd
-generated: 2019-09-13T01:16:14.323259325Z
+generated: "2019-09-23T09:17:59.529409+02:00"

--- a/stable/parse/templates/dashboard-deployment.yaml
+++ b/stable/parse/templates/dashboard-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if and (include "parse.host" .) .Values.dashboard.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "parse.fullname" . }}-dashboard

--- a/stable/parse/templates/server-deployment.yaml
+++ b/stable/parse/templates/server-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "parse.fullname" . }}-server


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

There are several deprecations in the API introduced in `K8s 1.16` (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#deprecations-and-removals) which affect our manifests. The following APIs are no longer served by default:

- All resources under `apps/v1beta1` and `apps/v1beta2` - use `apps/v1` instead
- **daemonsets**, **deployments**, **replicasets** resources under `extensions/v1beta1` - use `apps/v1` instead
- **networkpolicies** resources under `extensions/v1beta1` - use `networking.k8s.io/v1` instead
- **podsecuritypolicies** resources under `extensions/v1beta1` - use `policy/v1beta1` instead

This PR address the changes to be done for `stable/parse`.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)