### PR TITLE
[stable/odoo] Update deployment apiVersion to 'apps/v1' - Mandatory for K8s 1.16

### DIFF
--- a/stable/odoo/Chart.yaml
+++ b/stable/odoo/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: odoo
-version: 11.1.5
+version: 11.1.6
 appVersion: 12.0.20190915
 description: A suite of web based open source business apps.
 home: https://www.odoo.com/

--- a/stable/odoo/requirements.lock
+++ b/stable/odoo/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.3.6
+  version: 6.3.9
 digest: sha256:3fb60c16194499f6ebb30080e98e402f6c6d0fcf1133b8b03c2a90224b3fc291
-generated: 2019-09-15T08:42:30.873014978Z
+generated: "2019-09-23T09:19:39.951279+02:00"

--- a/stable/odoo/templates/deployment.yaml
+++ b/stable/odoo/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "odoo.fullname" . }}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

There are several deprecations in the API introduced in `K8s 1.16` (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#deprecations-and-removals) which affect our manifests. The following APIs are no longer served by default:

- All resources under `apps/v1beta1` and `apps/v1beta2` - use `apps/v1` instead
- **daemonsets**, **deployments**, **replicasets** resources under `extensions/v1beta1` - use `apps/v1` instead
- **networkpolicies** resources under `extensions/v1beta1` - use `networking.k8s.io/v1` instead
- **podsecuritypolicies** resources under `extensions/v1beta1` - use `policy/v1beta1` instead

This PR address the changes to be done for `stable/odoo`.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)