### PR TITLE
[stable/sentry] Don't set sentry pods resources by default

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 2.2.0
+version: 2.3.0
 appVersion: 9.1.1
 keywords:
   - debugging

--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 2.3.0
+version: 3.0.0
 appVersion: 9.1.1
 keywords:
   - debugging

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -12,13 +12,13 @@ image:
 # How many web UI instances to run
 web:
   replicacount: 1
-  resources:
-    limits:
-      cpu: 500m
-      memory: 500Mi
-    requests:
-      cpu: 300m
-      memory: 300Mi
+  resources: {}
+    # limits:
+    #   cpu: 500m
+    #   memory: 500Mi
+    # requests:
+    #   cpu: 300m
+    #   memory: 300Mi
   env:
     - name: GITHUB_APP_ID
       value:
@@ -40,13 +40,13 @@ web:
 # How many cron instances to run
 cron:
   replicacount: 1
-  resources:
-    limits:
-      cpu: 200m
-      memory: 200Mi
-    requests:
-      cpu: 100m
-      memory: 100Mi
+  resources: {}
+    # limits:
+    #   cpu: 200m
+    #   memory: 200Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 100Mi
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -58,13 +58,13 @@ cron:
 # How many worker instances to run
 worker:
   replicacount: 2
-  resources:
-    limits:
-      cpu: 300m
-      memory: 500Mi
-    requests:
-      cpu: 100m
-      memory: 100Mi
+  resources: {}
+    # limits:
+    #   cpu: 300m
+    #   memory: 500Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 100Mi
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
I think sentry chart shouldn't set the resources values of the worker, web and cron pods by default.
This makes it very hard to override these values because of the way helm merge the values.
For example when I need to unset the values of cpu limit, I can't do that by simply using this:
```
resources:
    limits:
      # cpu: 500m
      memory: 500Mi
    requests:
      cpu: 300m
      memory: 300Mi
```
because the default value from the chart will be used.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
