### PR TITLE
[stable/oauth2-proxy] add annotations to the config secret

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 0.14.1
+version: 0.15.0
 apiVersion: v1
 appVersion: 3.2.0
 home: http://www.videntity.com/

--- a/stable/oauth2-proxy/README.md
+++ b/stable/oauth2-proxy/README.md
@@ -79,6 +79,7 @@ Parameter | Description | Default
 `readinessProbe.successThreshold` | number of successes | 1
 `replicaCount` | desired number of pods | `1`
 `resources` | pod resource requests & limits | `{}`
+`secretAnnotations` | annotations to add to the config secret | `{}`
 `service.port` | port for the service | `80`
 `service.type` | type of service | `ClusterIP`
 `service.clusterIP` | cluster ip address | `nil`

--- a/stable/oauth2-proxy/templates/secret.yaml
+++ b/stable/oauth2-proxy/templates/secret.yaml
@@ -2,6 +2,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  {{- if .Values.secretAnnotations }}
+  annotations:
+    {{ toYaml .Values.secretAnnotations | indent 4 }}
+  {{- end }}
   labels:
     app: {{ template "oauth2-proxy.name" . }}
     chart: {{ template "oauth2-proxy.chart" . }}

--- a/stable/oauth2-proxy/values.yaml
+++ b/stable/oauth2-proxy/values.yaml
@@ -125,6 +125,7 @@ readinessProbe:
 podAnnotations: {}
 podLabels: {}
 replicaCount: 1
+secretAnnotations: {}
 
 # Additionally authenticate against a htpasswd file. Entries must be created with "htpasswd -s" for SHA encryption.
 # Alternatively supply an existing secret which contains the required information.


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

This PR adds the ability to use annotations in the config secret that gets created. This is useful for us as we use a webhook to pull secrets from Vault into the secret allowing us to keep our secrets out of git i.e. https://github.com/banzaicloud/bank-vaults/blob/master/docs/mutating-webhook/README.md#getting-secret-data-from-vault-and-replace-it-in-sercret-data

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

N/A

#### Checklist

- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
