### PR TITLE
[stable/percona-xtradb-cluster] Minor version bump: Fix chart not being upgradable

### DIFF
--- a/stable/percona-xtradb-cluster/Chart.yaml
+++ b/stable/percona-xtradb-cluster/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: percona-xtradb-cluster
-version: 1.0.2
+version: 1.0.3
 appVersion: 5.7.19
 description: free, fully compatible, enhanced, open source drop-in replacement for
   MySQL with Galera Replication (xtradb)

--- a/stable/percona-xtradb-cluster/templates/statefulset.yaml
+++ b/stable/percona-xtradb-cluster/templates/statefulset.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ template "percona-xtradb-cluster.fullname" . }}
   labels:
     app: {{ template "percona-xtradb-cluster.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:


### PR DESCRIPTION
**What this PR does / why we need it:**

Major version bump: Fix chart not being upgradable by removing 'chart' label from spec.selector or spec.VolumeClaimTemplate.

**Special notes for your reviewer:**

See #7680 and #7803 for explanations