### PR TITLE
[stable/instana-agent] Add the ability to create a PodSecurityPolicy for the Instana Agent or use an existing one if specified

### DIFF
--- a/stable/instana-agent/Chart.yaml
+++ b/stable/instana-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: instana-agent
-version: 1.0.13
+version: 1.0.14
 appVersion: 1.0
 description: Instana Agent for Kubernetes
 home: https://www.instana.com/

--- a/stable/instana-agent/README.md
+++ b/stable/instana-agent/README.md
@@ -8,7 +8,7 @@ This chart adds the Instana Agent to all schedulable nodes (e.g. by default, not
 
 ## Prerequisites
 
-Kubernetes 1.8.x - 1.13.x
+Kubernetes 1.9.x - 1.14.x
 
 Working `helm` and `tiller`.
 
@@ -100,8 +100,8 @@ The following table lists the configurable parameters of the Instana chart and t
 | `agent.image.tag`                  | The image tag to pull                                                   | `1.0.17`                                                                                                    |
 | `agent.image.pullPolicy`           | Image pull policy                                                       | `IfNotPresent`                                                                                              |
 | `agent.leaderElectorPort`          | Instana leader elector sidecar port                                     | `42655`                                                                                                     |
-| `agent.endpointHost`               | Instana agent backend endpoint host                                     | `saas-us-west-2.instana.io`                                                                                 |
-| `agent.endpointPort`               | Instana agent backend endpoint port                                     | `443`                                                                                                       |
+| `agent.endpointHost`               | Instana Agent backend endpoint host                                     | `saas-us-west-2.instana.io`                                                                                 |
+| `agent.endpointPort`               | Instana Agent backend endpoint port                                     | `443`                                                                                                       |
 | `agent.downloadKey`                | Your Instana Download key                                               | `nil` You must provide your own download key                                                                |
 | `agent.mode`                       | Agent mode (Supported values are APM, INFRASTRUCTURE, AWS)              | `APM`                                                                                                       |
 | `agent.pod.annotations`            | Additional annotations to apply to the pod                              | `{}`                                                                                                        |
@@ -122,6 +122,8 @@ The following table lists the configurable parameters of the Instana chart and t
 | `rbac.create`                      | Whether RBAC resources should be created                                | `true`                                                                                                      |
 | `serviceAccount.create`            | Whether a ServiceAccount should be created                              | `true`                                                                                                      |
 | `serviceAccount.name`              | Name of the ServiceAccount to use                                       | `instana-agent`                                                                                             |
+| `podSecurityPolicy.enable`         | Whether a PodSecurityPolicy should be authorized for the Instana Agent pods. Requires `rbac.create` to be `true` as well. | `false` See [PodSecurityPolicy](https://docs.instana.io/quick_start/agent_setup/container/kubernetes/#podsecuritypolicy) for more details. |
+| `podSecurityPolicy.name`           | Name of an _existing_ PodSecurityPolicy to authorize for the Instana Agent pods. If not provided and `podSecurityPolicy.enable` is `true`, a PodSecurityPolicy will be created for you. | `nil` |
 
 ### Agent
 
@@ -130,4 +132,4 @@ To configure the agent, you can either:
 - edit the [config map](templates/configmap.yaml), or
 - provide the configuration via the `agent.configuration_yaml` parameter in [values.yaml](values.yaml)
 
-This configuration will be used for all instana agents on all nodes. Visit the [agent configuration documentation](https://docs.instana.io/quick_start/agent_configuration/#configuration) for more details on configuration options.
+This configuration will be used for all Instana Agents on all nodes. Visit the [agent configuration documentation](https://docs.instana.io/quick_start/agent_configuration/#configuration) for more details on configuration options.

--- a/stable/instana-agent/templates/_helpers.tpl
+++ b/stable/instana-agent/templates/_helpers.tpl
@@ -43,6 +43,15 @@ The name of the ServiceAccount used.
 {{- end -}}
 
 {{/*
+The name of the PodSecurityPolicy used.
+*/}}
+{{- define "instana-agent.podSecurityPolicyName" -}}
+{{- if .Values.podSecurityPolicy.enable -}}
+    {{ default (include "instana-agent.fullname" .) .Values.podSecurityPolicy.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Add Helm metadata to resource labels.
 */}}
 {{- define "instana-agent.commonLabels" -}}

--- a/stable/instana-agent/templates/clusterrole.yaml
+++ b/stable/instana-agent/templates/clusterrole.yaml
@@ -41,4 +41,11 @@ rules:
   resources:
     - "endpoints"
   verbs: ["create", "update", "patch"]
+{{- if .Values.podSecurityPolicy.enable}}
+- apiGroups: ["extensions"]
+  resources: ["podsecuritypolicies"]
+  verbs:     ["use"]
+  resourceNames:
+  - {{ template "instana-agent.podSecurityPolicyName" . }}
+{{- end -}}
 {{- end -}}

--- a/stable/instana-agent/templates/podsecuritypolicy.yaml
+++ b/stable/instana-agent/templates/podsecuritypolicy.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.rbac.create -}}
+{{- if (and .Values.podSecurityPolicy.enable (not .Values.podSecurityPolicy.name)) -}}
+kind: PodSecurityPolicy
+apiVersion: extensions/v1beta1
+metadata:
+  name: {{ template "instana-agent.podSecurityPolicyName" . }}
+  labels:
+    {{- include "instana-agent.commonLabels" . | nindent 4 }}
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  volumes:
+    - configMap
+    - downwardAPI
+    - emptyDir
+    - persistentVolumeClaim
+    - secret
+    - projected
+    - hostPath
+  allowedHostPaths:
+    - pathPrefix: "/dev"
+      readOnly: false
+    - pathPrefix:  "/run"
+      readOnly: false
+    - pathPrefix: "/var/run"
+      readOnly: false
+    - pathPrefix: "/sys"
+      readOnly: false
+    - pathPrefix: "/var/log"
+      readOnly: false
+    - pathPrefix: "/etc/machine-id"
+      readOnly: false
+  hostNetwork: true
+  hostPorts:
+    - min: 0
+      max: 65535
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: "RunAsAny"
+  seLinux:
+    rule: "RunAsAny"
+  supplementalGroups:
+    rule: "RunAsAny"
+  fsGroup:
+    rule: "RunAsAny"
+{{- end -}}
+{{- end -}}

--- a/stable/instana-agent/values.yaml
+++ b/stable/instana-agent/values.yaml
@@ -76,8 +76,16 @@ serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true
   # The name of the ServiceAccount to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If not set and `create` is true, a name is generated using the fullname template
   # name: instana-agent
+
+podSecurityPolicy:
+  # Specifies whether a PodSecurityPolicy should be authorized for the Instana Agent pods.
+  # Requires `rbac.create` to be `true` as well.
+  enable: false
+  # The name of an existing PodSecurityPolicy you would like to authorize for the Instana Agent pods.
+  # If not set and `enable` is true, a PodSecurityPolicy will be created with a name generated using the fullname template.
+  name: null
 
 cluster:
   # cluster.name represents the name that will be assigned to this cluster in Instana


### PR DESCRIPTION
#### What this PR does / why we need it:

Add the ability to create a PodSecurityPolicy for the Instana agent, or use an existing one if the user specifies its name. Some Kubernetes clusters require pods to have a PodSecurityPolicy in order to be accepted into the cluster.

#### Notes for the reviewer

The authorization of a PodSecurityPolicy for the Instana Agent pods is controlled via the `agent.podSecurityPolicy.enable` configuration. The user can either enable the creation of a new PodSecurityPolicy as defined in this helm chart by just switching `agent.podSecurityPolicy.enable` to `true`, or if they have an existing PodSecurityPolicy they would like to use, they can specify its name via `agent.podSecurityPolicy.name` in additional to setting `agent.podSecurityPolicy.enable` to `true`, in which case the helm chart will just link to that policy instead of creating a new one.

Note that `agent.rbac.create` also need to be `true` for it to work correctly.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
