### PR TITLE
[stable/jenkins] Comments out JCasC welcome message

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -6,6 +6,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.7.4
+
+Comments out JCasC example of jenkins.systemMessage so that it can be used by end users. Previously, an attempt to set systemMessage causes Jenkins to startup, citing duplicate JCasC settings for systemMessage [issue #13333](https://github.com/helm/charts/issues/13333)
+
 ## 1.7.2
 
 Update kubernetes-plugin to version 1.18.2 which fixes frequently encountered [JENKINS-59000](https://issues.jenkins-ci.org/plugins/servlet/mobile#issue/JENKINS-59000)

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.7.3
+version: 1.7.4
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -206,9 +206,9 @@ master:
     # configuration as code support plugin is no longer needed
     supportPluginVersion: "1.18"
     configScripts:
-      welcome-message: |
-        jenkins:
-          systemMessage: Welcome to our CI\CD server.  This Jenkins is configured and managed 'as code'.
+    # welcome-message: |
+    #   jenkins:
+    #     systemMessage: Welcome to our CI\CD server.  This Jenkins is configured and managed 'as code'.
 
   # Optionally specify additional init-containers
   customInitContainers: []


### PR DESCRIPTION
Allows users to override welcome-message as JCasC doesn't handle conflicting
configurations.
Fixes #13333

Signed-off-by: Weston Johnson <wes@futureprefect.com>


#### Is this a new chart
No

#### What this PR does / why we need it:
Comments out JCasC example of `jenkins.systemMessage` so that it can be used by end users. Currently, an attempt to set `systemMessage` fails Jenkins to startup, citing duplicate JCasC settings for `systemMessage`.

#### Which issue this PR fixes
  - fixes #13333

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
