### PR TITLE
[stable/metrics-server] bumped version to 0.3.5

### DIFF
--- a/stable/metrics-server/Chart.yaml
+++ b/stable/metrics-server/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.3.4
+appVersion: 0.3.5
 description: Metrics Server is a cluster-wide aggregator of resource usage data.
 name: metrics-server
-version: 2.8.5
+version: 2.8.6
 keywords:
 - metrics-server
 home: https://github.com/kubernetes-incubator/metrics-server

--- a/stable/metrics-server/values.yaml
+++ b/stable/metrics-server/values.yaml
@@ -28,7 +28,7 @@ hostNetwork:
 
 image:
   repository: gcr.io/google_containers/metrics-server-amd64
-  tag: v0.3.4
+  tag: v0.3.5
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
##  What this PR does / why we need it:
Upgrades version of metrics-server to 0.3.5

#### Which issue this PR fixes
None.

#### Special notes for your reviewer:
Tested on K8s v1.15.4
```
# helm ls -c metrics-server
NAME            REVISION        UPDATED                         STATUS          CHART                   APP VERSION     NAMESPACE
metrics-server  15              Mon Sep 23 21:02:46 2019        DEPLOYED        metrics-server-2.8.6    0.3.5           default

# kubectl top node
NAME                    CPU(cores)   CPU%   MEMORY(bytes)   MEMORY%
node1.internal   326m         20%    1017Mi          68%
node2.internal   233m         14%    932Mi           62%
node3.internal   166m         6%     1001Mi          67%
node4.internal   149m         5%     969Mi           64%
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
