### PR TITLE
[stable/sentry] Fix inconsistent SENTRY_SECRET_KEY among the pods when not set explicitly.

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 3.0.0
+version: 3.0.1
 appVersion: 9.1.1
 keywords:
   - debugging

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -66,6 +66,7 @@ Parameter                                            | Description              
 `image.tag`                                          | Sentry image tag                                                                                           | `9.1.1`
 `imagePullPolicy`                                    | Image pull policy                                                                                          | `IfNotPresent`
 `imagePullSecrets`                                   | Specify image pull secrets                                                                                 | `[]`
+`sentrySecret`                                       | Specify SENTRY_SECRET_KEY. If isn't specified it will be generated automatically.                          | `nil`
 `web.podAnnotations`                                 | Web pod annotations                                                                                        | `{}`
 `web.podLabels`                                      | Worker pod extra labels                                                                                    | `{}`
 `web.replicacount`                                   | Amount of web pods to run                                                                                  | `1`

--- a/stable/sentry/templates/cron-deployment.yaml
+++ b/stable/sentry/templates/cron-deployment.yaml
@@ -15,6 +15,7 @@ spec:
         metrics-enabled: {{ .Values.metrics.enabled | quote }}
         checksum/configYml: {{ .Values.config.configYml | sha256sum }}
         checksum/sentryConfPy: {{ .Values.config.sentryConfPy | sha256sum }}
+        checksum/secrets.yaml: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
       {{- if .Values.cron.podAnnotations }}
 {{ toYaml .Values.cron.podAnnotations | indent 8 }}
       {{- end }}

--- a/stable/sentry/templates/hooks/db-init.job.yaml
+++ b/stable/sentry/templates/hooks/db-init.job.yaml
@@ -18,6 +18,8 @@ spec:
   template:
     metadata:
       name: "{{ .Release.Name }}-db-init"
+      annotations:
+        checksum/secrets.yaml: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
       labels:
         app: {{ template "sentry.fullname" . }}
         release: "{{ .Release.Name }}"

--- a/stable/sentry/templates/hooks/user-create.job.yaml
+++ b/stable/sentry/templates/hooks/user-create.job.yaml
@@ -18,6 +18,8 @@ spec:
   template:
     metadata:
       name: "{{ .Release.Name }}-user-create"
+      annotations:
+        checksum/secrets.yaml: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
       labels:
         app: {{ template "sentry.fullname" . }}
         release: "{{ .Release.Name }}"

--- a/stable/sentry/templates/web-deployment.yaml
+++ b/stable/sentry/templates/web-deployment.yaml
@@ -15,6 +15,7 @@ spec:
         metrics-enabled: {{ .Values.metrics.enabled | quote }}
         checksum/configYml: {{ .Values.config.configYml | sha256sum }}
         checksum/sentryConfPy: {{ .Values.config.sentryConfPy | sha256sum }}
+        checksum/secrets.yaml: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
       {{- if .Values.web.podAnnotations }}
 {{ toYaml .Values.web.podAnnotations | indent 8 }}
       {{- end }}

--- a/stable/sentry/templates/workers-deployment.yaml
+++ b/stable/sentry/templates/workers-deployment.yaml
@@ -15,6 +15,7 @@ spec:
         metrics-enabled: {{ .Values.metrics.enabled | quote }}
         checksum/configYml: {{ .Values.config.configYml | sha256sum }}
         checksum/sentryConfPy: {{ .Values.config.sentryConfPy | sha256sum }}
+        checksum/secrets.yaml: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
       {{- if .Values.worker.podAnnotations }}
 {{ toYaml .Values.worker.podAnnotations | indent 8 }}
       {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Make Deployment and Job pods dependent on `secret.yaml` content (especially SENTRY_SECRET_KEY when it is not set explicitly) follow the Secret changes in sync. Symptoms were (after some deployments cannot log in, after some deployments cannot accept errors). Also, document the ability to set SENTRY_SECRET_KEY explicitly.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ x ] Chart Version bumped
- [ x ] Variables are documented in the README.md
- [ x ] Title of the PR starts with chart name (e.g. `[stable/chart]`)
