### PR TITLE
[stable/prometheus-operator] Only use job alpha feature if available

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -10,7 +10,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 6.11.0
+version: 6.11.1
 appVersion: 0.32.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
@@ -10,7 +10,10 @@ metadata:
     app: {{ template "prometheus-operator.name" $ }}-admission-create
 {{- include "prometheus-operator.labels" $ | indent 4 }}
 spec:
+  {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" -}}
+  # Alpha feature since k8s 1.12
   ttlSecondsAfterFinished: 0
+  {{- end -}}
   template:
     metadata:
       name:  {{ template "prometheus-operator.fullname" . }}-admission-create

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
@@ -10,10 +10,10 @@ metadata:
     app: {{ template "prometheus-operator.name" $ }}-admission-create
 {{- include "prometheus-operator.labels" $ | indent 4 }}
 spec:
-  {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" -}}
+  {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
   # Alpha feature since k8s 1.12
   ttlSecondsAfterFinished: 0
-  {{- end -}}
+  {{- end }}
   template:
     metadata:
       name:  {{ template "prometheus-operator.fullname" . }}-admission-create

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -10,7 +10,10 @@ metadata:
     app: {{ template "prometheus-operator.name" $ }}-admission-patch
 {{- include "prometheus-operator.labels" $ | indent 4 }}
 spec:
+  {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" -}}
+  # Alpha feature since k8s 1.12
   ttlSecondsAfterFinished: 0
+  {{- end -}}
   template:
     metadata:
       name:  {{ template "prometheus-operator.fullname" . }}-admission-patch

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -10,10 +10,10 @@ metadata:
     app: {{ template "prometheus-operator.name" $ }}-admission-patch
 {{- include "prometheus-operator.labels" $ | indent 4 }}
 spec:
-  {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" -}}
+  {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
   # Alpha feature since k8s 1.12
   ttlSecondsAfterFinished: 0
-  {{- end -}}
+  {{- end }}
   template:
     metadata:
       name:  {{ template "prometheus-operator.fullname" . }}-admission-patch


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
ttlSecondsAfterFinished requires alpha features. https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/

This PR only uses the feature if available.

#### Which issue this PR fixes
Fixes #17076

#### Special notes for your reviewer:
Hello! :)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
