### PR TITLE
[stable/nginx-ingress] Only use alpha features when available

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.22.0
+version: 1.22.1
 appVersion: 0.25.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -13,7 +13,10 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
+  {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" -}}
+  # Alpha feature since k8s 1.12
   ttlSecondsAfterFinished: 0
+  {{- end -}}
   template:
     metadata:
       name: {{ template "nginx-ingress.fullname" . }}-admission-create

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -13,10 +13,10 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
-  {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" -}}
+  {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
   # Alpha feature since k8s 1.12
   ttlSecondsAfterFinished: 0
-  {{- end -}}
+  {{- end }}
   template:
     metadata:
       name: {{ template "nginx-ingress.fullname" . }}-admission-create

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -13,7 +13,10 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
+  {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" -}}
+  # Alpha feature since k8s 1.12
   ttlSecondsAfterFinished: 0
+  {{- end -}}
   template:
     metadata:
       name:   {{ template "nginx-ingress.fullname" . }}-admission-patch

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -13,10 +13,10 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
-  {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" -}}
+  {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
   # Alpha feature since k8s 1.12
   ttlSecondsAfterFinished: 0
-  {{- end -}}
+  {{- end }}
   template:
     metadata:
       name:   {{ template "nginx-ingress.fullname" . }}-admission-patch


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
ttlSecondsAfterFinished requires alpha features. https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/

This PR only uses the feature if available.

#### Which issue this PR fixes
none yet

#### Special notes for your reviewer:
See also: https://github.com/helm/charts/pull/17387

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
