### PR TITLE
[stable/calico-aws] Add new chart

### DIFF
--- a/stable/calico-aws/.helmignore
+++ b/stable/calico-aws/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/calico-aws/Chart.yaml
+++ b/stable/calico-aws/Chart.yaml
@@ -1,0 +1,15 @@
+version: 0.1.0
+apiVersion: v1
+name: calico-aws
+appVersion: 1.5.3
+description: Unofficial implementation of Calico configuration for AWS EKS
+sources:
+  - https://github.com/aws/amazon-vpc-cni-k8s/blob/master/config/v1.5/aws-k8s-cni.yaml
+  - https://github.com/projectcalico/typha
+  - https://github.com/projectcalico/felix
+maintainers:
+  - name: gp42
+    url: https://github.com/gp42
+    email: gennadiy.potapov@gmail.com
+engine: gotpl
+icon: https://raw.githubusercontent.com/projectcalico/calico/master/images/felix_icon.png

--- a/stable/calico-aws/Chart.yaml
+++ b/stable/calico-aws/Chart.yaml
@@ -1,4 +1,4 @@
-version: 0.1.0
+version: 0.1.1
 apiVersion: v1
 name: calico-aws
 appVersion: 1.5.3

--- a/stable/calico-aws/README.md
+++ b/stable/calico-aws/README.md
@@ -1,0 +1,163 @@
+# Calico
+This helm chart installs [Calico] (https://www.projectcalico.org) network policy engine to AWS EKS.
+Please note that even though Project Calico supports many different configurations, this exact Helm Chart is made specifically to run Calico on AWS EKS.
+
+It is based on example calico implementation from AWS:
+https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.5/config/v1.5/calico.yaml
+
+Calico engine allows to use [Kubernetes Network Policies] (https://kubernetes.io/docs/concepts/services-networking/network-policies/) on AWS EKS.
+
+# Dependencies
+* Kubernetes 1.13 or later (may run on earlier versions, but not tested)
+* AWS EKS
+
+# Running
+You can run this Helm chart with default settings:
+```
+helm install --namespace kube-system .
+```
+
+This will create the following pods (together with other resources):
+ - [Typha] (https://github.com/projectcalico/typha)
+ - [Typha autoscaler] (https://github.com/kubernetes-incubator/cluster-proportional-autoscaler)
+ - [Calico Node (Felix)] (https://github.com/projectcalico/node)
+
+Uninstalling:
+```
+helm delete <release_name>
+```
+
+## Verify
+Follow the steps listed in [Kubernetes Network Policies] (https://kubernetes.io/docs/concepts/services-networking/network-policies/) documentation to make sure service works as expected.
+
+## Namespace
+Default setup is using built in priorityclasses (_system-cluster-critical_ and _system-node-critical_) which are currently restricted to _kube-system_ namespace.
+Follow [this github issue] (https://github.com/kubernetes/kubernetes/issues/76308) to see if anything has changed.
+
+It is possible to run typha in a custom namespace, in this case you either need to create a custom priority class:
+```
+priorityClassNode:
+  create: true
+priorityClassCluster:
+  create: true
+```
+Or set priorityClass name to null, to skip this setting completely:
+```
+priorityClassNode:
+  name: null
+priorityClassCluster:
+  name: null
+```
+
+##
+
+## Configuration
+Please refer to these documents and sources for information on Typha, Calico and autoscaler configuration parameters:
+- [Typha documentation] (https://docs.projectcalico.org/v3.7/reference/typha/configuration)
+- [Typha source] (https://github.com/projectcalico/typha/blob/master/pkg/config/config_params.go)
+- [Felix documentation] (https://docs.projectcalico.org/v3.7/reference/felix/configuration)
+- [Felix source] (https://github.com/projectcalico/felix/blob/master/config/config_params.go)
+- [Cluster propotional autoscaler] (https://github.com/kubernetes-incubator/cluster-proportional-autoscaler)
+
+### Parameters
+The following table summarizes chart configuration parameters.
+
+| Parameter | Description | Default |
+| ---       | ---         | ---     |
+| `serviceAccount.calico.create` | Create a service account for Typha and Calico node | `true` |
+| `serviceAccount.calico.name` | Provide a name of existing service account for Typha and Calico node (set `serviceAccount.calico.create` to `false`)| `null` |
+| `serviceAccount.calico.automountToken` | Automount Service Account token into Pod | `true` |
+| `serviceAccount.typhaCpha.create` | Create a service account for Typha autoscaler | `true` |
+| `serviceAccount.typhaCpha.name` | Provide a name of existing service account for Typha autoscaler (set `serviceAccount.typhaCpha.create` to `false`)| `null` |
+| `serviceAccount.typhaCpha.automountToken` | Automount Service Account token into Pod | `false` |
+| `priorityClassNode.name` | Priority Class name for Calico Node, priority class must exist | `system-node-critical` |
+| `priorityClassNode.create` | Create a custom priority class for Calico Node | `false` |
+| `priorityClassNode.nameSuffix` | Name suffix for a custom priority class | `node-high` |
+| `priorityClassNode.value` | Value for a custom priority class | `1001000` |
+| `priorityClassNode.labels` | Custom priority class extra labels | `{}` |
+| `priorityClassNode.annotations` | Custom priority class extra annotations | `{}` |
+| `priorityClassCluster.name` | Priority Class name for Typha, priority class must exist | `system-cluster-critical` |
+| `priorityClassCluster.create` | Create a custom priority class for Typha | `false` |
+| `priorityClassCluster.nameSuffix` | Name suffix for a custom priority class | `node-high` |
+| `priorityClassCluster.value` | Value for a custom priority class | `1000000` |
+| `priorityClassCluster.labels` | Custom priority class extra labels | `{}` |
+| `priorityClassCluster.annotations` | Custom priority class extra annotations | `{}` |
+| `calicoNode.image.registry` | Override standard Docker image registry | `quay.io` |
+| `calicoNode.image.name` | Override standard Docker image name | `calico/node` |
+| `calicoNode.image.tag` | Override standard Docker image tag | `v3.3.6` |
+| `calicoNode.image.pullPolicy` | Override standard Docker image pull policy | `IfNotPresent` |
+| `calicoNode.image.pullSecrets` | Provide docker secret name to pull images. Must be an array: `["docker-secret"]` | `null` |
+| `calicoNode.resources` | Resource configuration for Calico Node pods | `null` |
+| `calicoNode.annotations` | Extra annotations for Calico Node Daemonset | `{}` |
+| `calicoNode.labels` | Extra labels for Calico Node Daemonset | `{}` |
+| `calicoNode.podAnnotations` | Extra annotations for Calico Node pods | `{}` |
+| `calicoNode.podLabels` | Extra labels for Calico Node pods | `{}` |
+| `calicoNode.linuxOnly` | Run node pods only on Linux instances. OpenSource Calico supports only Linux | `true` |
+| `calicoNode.nodeSelector` | Node Selector configuration for Calico Node Daemonset | `null` |
+| `calicoNode.affinity` | Affinity configuration for Calico Node Daemonset | `null` |
+| `calicoNode.tolerations` | Tolerations configuration for Calico Node Daemonset | `null` |
+| `calicoNode.prometheusScrapeAnnotations` | Add prometheus scrape annotations to Calico Node | `true` |
+| `calicoNode.ports` | Port settings | see values.yaml |
+| `calicoNode.env` | Environment variables for Calico Node pods. Format is `ENV_VAR_NAME: "VALUE"`. Processed as a template, dynamic parameters are accepted. | see values.yaml |
+| `calicoNode.livenessProbe` | Liveness Probe for Calico Node pods. | see values.yaml |
+| `calicoNode.readinessProbe` | Readiness Probe for Calico Node pods. | see values.yaml |
+| `calicoNode.cert.create` | Create TLS certificate for Calico Node. Must provide cert parameters described below if set to `true` | `false` |
+| `calicoNode.cert.clientCertContents` | Contents of TLS cert for Calico Node for Node <--> Typha communication. PEM format | `""` |
+| `calicoNode.cert.clientKeyContents` | Contents of TLS cert key for Calico Node for Node <--> Typha communication. PEM format | `""` |
+| `calicoNode.cert.clientCAContents` | Contents of TLS Typha CA cert for Calico Node for Node <--> Typha communication used. PEM format | `""` |
+| `calicoNode.volumeMounts` | Custom volumeMounts for CalicoNode (may be used to mount existing certificates instead of creating) | `null` |
+| `calicoNode.volumes` | Custom volumes for Calico Node (may be used to mount existing certificates instead of creating) | `null` |
+| `typha.image.registry` | Override standard Docker image registry | `quay.io` |
+| `typha.image.name` | Override standard Docker image name | `calico/typha` |
+| `typha.image.tag` | Override standard Docker image tag | `v3.3.6` |
+| `typha.image.pullPolicy` | Override standard Docker image pull policy | `IfNotPresent` |
+| `typha.image.pullSecrets` | Provide docker secret name to pull images. Must be an array: `["docker-secret"]` | `null` |
+| `typha.resources` | Resource configuration for Typha pods | `null` |
+| `typha.annotations` | Extra annotations for Typha Deployment | `{}` |
+| `typha.labels` | Extra labels for Typha Deployment | `{}` |
+| `typha.podAnnotations` | Extra annotations for Typha pods | `{}` |
+| `typha.podLabels` | Extra labels for Typha pods | `{}` |
+| `typha.nodeSelector` | Node Selector configuration for Typha Deployment | `null` |
+| `typha.affinity` | Affinity configuration for Typha Deployment | `null` |
+| `typha.tolerations` | Tolerations configuration for Typha Deployment | `null` |
+| `typha.prometheusScrapeAnnotations` | Add prometheus scrape annotations to Typha | `true` |
+| `typha.ports` | Port settings | see values.yaml |
+| `typha.env` | Environment variables for Typha pods. Format is `ENV_VAR_NAME: "VALUE"`. Processed as a template, dynamic parameters are accepted. | see values.yaml |
+| `typha.livenessProbe` | Liveness Probe for Typha pods. | see values.yaml |
+| `typha.readinessProbe` | Readiness Probe for Typha pods. | see values.yaml |
+| `typha.serviceLabels` | Extra labels for Typha service. | `{}` |
+| `typha.serviceAnnotations` | Extra annotations for Typha service. | `{}` |
+| `typha.cert.create` | Create TLS certificate for Typha. Must provide cert parameters described below if set to `true` | `false` |
+| `typha.cert.clientCertContents` | Contents of TLS cert for Typha for Node <--> Typha communication. PEM format | `""` |
+| `typha.cert.clientKeyContents` | Contents of TLS cert key for Typha for Node <--> Typha communication. PEM format | `""` |
+| `typha.cert.clientCAContents` | Contents of TLS Node CA cert for Typha for Node <--> Typha communication used. PEM format | `""` |
+| `typha.volumeMounts` | Custom volumeMounts for Typha (may be used to mount existing certificates instead of creating) | `null` |
+| `typha.volumes` | Custom volumes for Typha (may be used to mount existing certificates instead of creating) | `null` |
+| `typhaCpha.image.registry` | Override standard Docker image registry | `k8s.gcr.io` |
+| `typhaCpha.image.name` | Override standard Docker image name | `cluster-propotional-autoscaler-amd64` |
+| `typhaCpha.image.tag` | Override standard Docker image tag | `1.1.2` |
+| `typhaCpha.image.pullPolicy` | Override standard Docker image pull policy | `IfNotPresent` |
+| `typhaCpha.image.pullSecrets` | Provide docker secret name to pull images. Must be an array: `["docker-secret"]` | `null` |
+| `typhaCpha.replicas` | Number of autoscaler replicas | `1` |
+| `typhaCpha.resources` | Resource configuration for Typha autoscaler pods | see values.yaml |
+| `typhaCpha.annotations` | Extra annotations for Typha autoscaler Deployment | `{}` |
+| `typhaCpha.labels` | Extra labels for Typha autoscaler Deployment | `{}` |
+| `typhaCpha.podAnnotations` | Extra annotations for Typha autoscaler pods | `{}` |
+| `typhaCpha.podLabels` | Extra labels for Typha autoscaler pods | `{}` |
+| `typhaCpha.nodeSelector` | Node Selector configuration for Typha autoscaler Deployment | `null` |
+| `typhaCpha.affinity` | Affinity configuration for Typha autoscaler Deployment | `null` |
+| `typhaCpha.tolerations` | Tolerations configuration for Typha autoscaler Deployment | `null` |
+| `typhaCpha.livenessProbe` | Liveness Probe for Typha autoscaler pods. | see values.yaml |
+| `typhaCpha.readinessProbe` | Readiness Probe for Typha autoscaler pods. | see values.yaml |
+| `typhaCpha.ladder` | Configuration for propotional autoscaler | see values.yaml |
+| `typhaCpha.args` | Arguments, passed to propotional autoscaler, format: `argument: "value"`. Processed as template, dynamic values are allowed. | see values.yaml |
+
+See `values.yaml` file for configuration notes. Specify parameters via helm `--set` flag:
+```
+helm install --namespace=kube-system --set serviceAccount.calico.name=foo .
+```
+Alternatively, create you own file with configuration overrides and supply it to helm:
+```
+helm install --namespace=kube-system -f value_overrides.yaml .
+```
+You can also add this chart to another chart as a dependency - add it to `requirements.yaml` file of a parent chart. More information [here] (https://helm.sh/docs/developing_charts/#chart-dependencies).

--- a/stable/calico-aws/README.md
+++ b/stable/calico-aws/README.md
@@ -31,7 +31,7 @@ helm delete <release_name>
 Follow the steps listed in [Kubernetes Network Policies] (https://kubernetes.io/docs/concepts/services-networking/network-policies/) documentation to make sure service works as expected.
 
 ## Namespace
-Default setup is using built in priorityclasses (_system-cluster-critical_ and _system-node-critical_) which are currently restricted to _kube-system_ namespace.
+Default setup is using built in priority classes (_system-cluster-critical_ and _system-node-critical_) which are currently restricted to _kube-system_ namespace.
 Follow [this github issue] (https://github.com/kubernetes/kubernetes/issues/76308) to see if anything has changed.
 
 It is possible to run typha in a custom namespace, in this case you either need to create a custom priority class:

--- a/stable/calico-aws/templates/NOTES.txt
+++ b/stable/calico-aws/templates/NOTES.txt
@@ -1,0 +1,12 @@
+Project Calico resources have been installed.
+
+Please perform the following checks:
+  * Check resource readiness
+  * Check Typha logs
+  * Check Calico node logs
+
+!!! Important Notice !!!
+This Helm Chart is designed to work on AWS EKS. Even though you can install it to other Kubernetes clusters, it will not perform network configuration.
+
+You can now create a network policy to verify your installation works as expected.
+Network Policies documentation: https://kubernetes.io/docs/concepts/services-networking/network-policies

--- a/stable/calico-aws/templates/_helpers.tpl
+++ b/stable/calico-aws/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "calico.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "calico.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "calico.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account for calico
+*/}}
+{{- define "calico.serviceAccountName.calico" -}}
+{{- if .Values.serviceAccount.calico.create -}}
+    {{ default (print (include "calico.fullname" .) "-node") .Values.serviceAccount.calico.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.calico.name }}
+{{- end -}}
+{{- end -}}
+
+{{- define "calico.serviceAccountName.calicoTest" -}}
+{{- if .Values.serviceAccount.calico.create -}}
+    {{ default (print (include "calico.fullname" .) "-test") .Values.serviceAccount.calico.nameTest }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.calico.nameTest }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account for typha autoscaler
+*/}}
+{{- define "calico.serviceAccountName.typhaCpha" -}}
+{{- if .Values.serviceAccount.typhaCpha.create -}}
+    {{ default (print (include "calico.fullname" .) "-typha-cpha") .Values.serviceAccount.typhaCpha.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.typhaCpha.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/calico-aws/templates/clusterrole-calico.yaml
+++ b/stable/calico-aws/templates/clusterrole-calico.yaml
@@ -1,0 +1,75 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "calico.fullname" . }}-node
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: [""]
+    resources:
+      - pods/status
+    verbs:
+      - patch
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: [""]
+    resources:
+      - services
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - endpoints
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups: ["extensions"]
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - networkpolicies
+    verbs:
+      - watch
+      - list
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - globalfelixconfigs
+      - felixconfigurations
+      - bgppeers
+      - globalbgpconfigs
+      - bgpconfigurations
+      - ippools
+      - globalnetworkpolicies
+      - globalnetworksets
+      - networkpolicies
+      - clusterinformations
+      - hostendpoints
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - watch

--- a/stable/calico-aws/templates/clusterrole-typha-cpha.yaml
+++ b/stable/calico-aws/templates/clusterrole-typha-cpha.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "calico.fullname" . }}-typha-cpha
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list"]

--- a/stable/calico-aws/templates/clusterrolebinding-calico.yaml
+++ b/stable/calico-aws/templates/clusterrolebinding-calico.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "calico.fullname" . }}-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "calico.fullname" . }}-node
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "calico.fullname" . }}-node
+    namespace: {{ .Release.Namespace }}

--- a/stable/calico-aws/templates/clusterrolebinding-typha-cpha.yaml
+++ b/stable/calico-aws/templates/clusterrolebinding-typha-cpha.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "calico.fullname" . }}-typha-cpha
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "calico.fullname" . }}-typha-cpha
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "calico.fullname" . }}-typha-cpha
+    namespace: {{ .Release.Namespace }}

--- a/stable/calico-aws/templates/cm-typha-cpha.yaml
+++ b/stable/calico-aws/templates/cm-typha-cpha.yaml
@@ -1,0 +1,12 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ template "calico.fullname" . }}-typha-cpha
+  labels:
+    app: {{ template "calico.name" . }}-typha-cpha
+    chart: {{ template "calico.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  ladder: |-
+{{ .Values.typhaCpha.ladder | indent 4 }}

--- a/stable/calico-aws/templates/customresourcedefinition.yaml
+++ b/stable/calico-aws/templates/customresourcedefinition.yaml
@@ -1,0 +1,160 @@
+# Create all the CustomResourceDefinitions needed for
+# Calico policy-only mode.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: felixconfigurations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: FelixConfiguration
+    plural: felixconfigurations
+    singular: felixconfiguration
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: bgpconfigurations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: BGPConfiguration
+    plural: bgpconfigurations
+    singular: bgpconfiguration
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: bgppeers.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: BGPPeer
+    plural: bgppeers
+    singular: bgppeer
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ippools.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: IPPool
+    plural: ippools
+    singular: ippool
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: hostendpoints.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: HostEndpoint
+    plural: hostendpoints
+    singular: hostendpoint
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterinformations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: ClusterInformation
+    plural: clusterinformations
+    singular: clusterinformation
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworkpolicies.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: GlobalNetworkPolicy
+    plural: globalnetworkpolicies
+    singular: globalnetworkpolicy
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworksets.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: GlobalNetworkSet
+    plural: globalnetworksets
+    singular: globalnetworkset
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networkpolicies.crd.projectcalico.org
+spec:
+  scope: Namespaced
+  group: crd.projectcalico.org
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: NetworkPolicy
+    plural: networkpolicies
+    singular: networkpolicy

--- a/stable/calico-aws/templates/daemonset-calico.yaml
+++ b/stable/calico-aws/templates/daemonset-calico.yaml
@@ -1,0 +1,181 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: {{ template "calico.fullname" . }}-node
+  labels:
+    app: {{ template "calico.name" . }}-node
+    chart: {{ template "calico.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- if .Values.calicoNode.labels }}
+{{ toYaml .Values.calicoNode.labels | indent 4 }}
+  {{- end }}
+{{- with .Values.calicoNode.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "calico.name" . }}-node
+      release: {{ .Release.Name }}
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "calico.name" . }}-node
+        chart: {{ template "calico.chart" . }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+      {{- with .Values.calicoNode.podLabels }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
+    {{- if or .Values.calicoNode.prometheusScrapeAnnotations .Values.calicoNode.podAnnotations }}
+      annotations:
+      {{- if .Values.calicoNode.prometheusScrapeAnnotations }}
+        prometheus.io/scrape: "true"
+        {{- with .Values.calicoNode.ports.metrics }}
+        prometheus.io/port: '{{ default "9091" .port }}'
+        {{- end }}
+      {{- end }}
+      {{- with .Values.calicoNode.podAnnotations }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
+    {{- end }}
+    spec:
+    {{- if .Values.priorityClassNode.create }}
+      priorityClassName: '{{ template "calico.fullname" . }}-{{ .Values.priorityClassNode.nameSuffix }}'
+    {{- else }}
+      {{- with .Values.priorityClassNode.name }}
+      priorityClassName: {{ . }}
+      {{- end }}
+    {{- end }}
+    {{- if or .Values.calicoNode.nodeSelector .Values.calicoNode.linuxOnly }}
+      nodeSelector:
+      {{- if .Values.calicoNode.linuxOnly }}
+        beta.kubernetes.io/os: linux
+      {{- end }}
+      {{- with .Values.calicoNode.nodeSelector }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
+    {{- end }}
+      tolerations:
+        # Make sure calico/node gets scheduled on all nodes.
+        - effect: NoSchedule
+          operator: Exists
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      {{- with .Values.calicoNode.tolerations }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
+    {{- with .Values.calicoNode.affinity }}
+      affinity:
+{{ tpl . $ | indent 8 }}
+    {{- end }}
+      hostNetwork: true
+      serviceAccountName: {{ template "calico.serviceAccountName.calico" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.calico.automountToken }}
+      # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
+      # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
+      terminationGracePeriodSeconds: 0
+    {{- if .Values.calicoNode.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.calicoNode.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
+      containers:
+        # Runs calico/node container on each Kubernetes node.  This
+        # container programs network policy and routes on each
+        # host.
+        - name: calico-node
+          image: "{{ .Values.calicoNode.image.registry }}/{{ .Values.calicoNode.image.name }}:{{ .Values.calicoNode.image.tag }}"
+          ports:
+            {{- range $k, $v := .Values.calicoNode.ports }}
+            - containerPort: {{ $v.port }}
+              name: {{ $k }}
+              protocol: {{ $v.protocol }}
+            {{- end }}
+          env:
+          {{- range $k, $v := .Values.calicoNode.env }}
+            - name: {{ $k }}
+              value: "{{ tpl $v $ }}"
+          {{- end }}
+            # Set based on the k8s node name.
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          securityContext:
+            privileged: true
+        {{- with .Values.calicoNode.livenessProbe }}
+          livenessProbe:
+{{ tpl . $ | indent 12 }}
+        {{- end }}
+        {{- with .Values.calicoNode.readinessProbe }}
+          readinessProbe:
+{{ tpl . $ | indent 12 }}
+        {{- end }}
+        {{- with .Values.calicoNode.resources }}
+          resources:
+{{ toYaml . | indent 12 }}
+        {{- end }}
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
+              readOnly: false
+          {{- with .Values.calicoNode.volumeMounts }}
+{{ toYaml . | indent 12 }}
+          {{- end }}
+        {{- if and .Values.calicoNode.cert.create }}
+            - name: cert
+              mountPath: "/etc/felix/cert.pem"
+              subPath: "cert.pem"
+              readOnly: true
+            - name: cert
+              mountPath: "/etc/felix/key.pem"
+              subPath: "key.pem"
+              readOnly: true
+            - name: cert
+              mountPath: "/etc/felix/ca.pem"
+              subPath: "ca.pem"
+              readOnly: true
+        {{- end }}
+      volumes:
+        # Used to ensure proper kmods are installed.
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+        - name: var-lib-calico
+          hostPath:
+            path: /var/lib/calico
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
+      {{- with .Values.calicoNode.volumes }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- if and .Values.calicoNode.cert.create }}
+        - name: cert
+          secret:
+            secretName: {{ template "calico.fullname" . }}-calico-cert
+      {{- end }}

--- a/stable/calico-aws/templates/deployment-typha-cpha.yaml
+++ b/stable/calico-aws/templates/deployment-typha-cpha.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "calico.fullname" . }}-typha-cpha
+  labels:
+    app: {{ template "calico.name" . }}-typha-cpha
+    chart: {{ template "calico.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- with .Values.typhaCpha.labels }}
+{{ toYaml . | indent 4 }}
+  {{- end }}
+{{- with .Values.typhaCpha.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "calico.name" . }}-typha-cpha
+      release: {{ .Release.Name }}
+  replicas: {{ .Values.typhaCpha.replicas }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "calico.name" . }}-typha-cpha
+        chart: {{ template "calico.chart" . }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+      {{- with .Values.typhaCpha.podLabels }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      annotations:
+    {{- with .Values.typhaCpha.podAnnotations }}
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    spec:
+    {{- if .Values.priorityClassCluster.create }}
+      priorityClassName: '{{ template "calico.fullname" . }}-{{ .Values.priorityClassCluster.nameSuffix }}'
+    {{- else }}
+      {{- with .Values.priorityClassCluster.name }}      
+      priorityClassName: {{ . }}
+      {{- end }}
+    {{- end }}
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      {{- with .Values.typhaCpha.nodeSelector }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
+    {{- with .Values.typhaCpha.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      serviceAccountName: {{ template "calico.serviceAccountName.typhaCpha" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.calico.automountToken }}
+    {{- if .Values.typhaCpha.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.typhaCpha.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
+      containers:
+        - image: "{{ .Values.typhaCpha.image.registry }}/{{ .Values.typhaCpha.image.name }}:{{ .Values.typhaCpha.image.tag }}"
+          name: autoscaler
+          command:
+            - /cluster-proportional-autoscaler
+          {{- with .Values.typhaCpha.args }}
+            {{- range $k, $v := . }}
+            - "--{{ $k }}={{ tpl $v $ }}"
+            {{- end }}
+          {{- end }}
+        {{- with .Values.typhaCpha.resources }}
+          resources:
+{{ toYaml . | indent 12 }}
+        {{- end }}
+        {{- with .Values.typhaCpha.livenessProbe }}
+          livenessProbe:
+{{ tpl . $ | indent 12 }}
+        {{- end }}
+        {{- with .Values.typhaCpha.readinessProbe }}
+          readinessProbe:
+{{ tpl . $ | indent 12 }}
+        {{- end }}

--- a/stable/calico-aws/templates/deployment-typha.yaml
+++ b/stable/calico-aws/templates/deployment-typha.yaml
@@ -1,0 +1,128 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "calico.fullname" . }}-typha
+  labels:
+    app: {{ template "calico.name" . }}-typha
+    chart: {{ template "calico.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.typha.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.typha.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "calico.name" . }}-typha
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "calico.name" . }}-typha
+        chart: {{ template "calico.chart" . }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+      {{- with .Values.typha.podLabels }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      {{- if .Values.typha.prometheusScrapeAnnotations }}
+        prometheus.io/scrape: "true"
+        {{- with .Values.typha.ports.metrics }}
+        prometheus.io/port: '{{ default "9093" .port }}'
+        {{- end }}
+      {{- end }}
+    {{- with .Values.typha.podAnnotations }}
+{{ toYaml . $ | indent 8 }}
+    {{- end }}
+    spec:
+    {{- if .Values.priorityClassCluster.create }}
+      priorityClassName: '{{ template "calico.fullname" . }}-{{ .Values.priorityClassCluster.nameSuffix }}'
+    {{- else }}
+      {{- with .Values.priorityClassCluster.name }}
+      priorityClassName: {{ . }}
+      {{- end }}
+    {{- end }}
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      {{- with .Values.typha.nodeSelector }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      tolerations:
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+      {{- with .Values.typha.tolerations }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      hostNetwork: true
+      serviceAccountName: {{ template "calico.serviceAccountName.calico" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.calico.automountToken }}
+    {{- if .Values.typha.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.typha.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
+      containers:
+        - image: "{{ .Values.typha.image.registry }}/{{ .Values.typha.image.name }}:{{ .Values.typha.image.tag }}"
+          name: calico-typha
+          ports:
+            {{- range $k, $v := .Values.typha.ports }}
+            - containerPort: {{ $v.port }}
+              name: {{ $k }}
+              protocol: {{ $v.protocol }}
+            {{- end }}
+          env:
+          {{- range $k, $v := .Values.typha.env }}
+            - name: {{ $k }}
+              value: "{{ tpl $v $ }}"
+          {{- end }}
+        {{- with .Values.typha.livenessProbe }}
+          livenessProbe:
+{{ tpl . $ | indent 12 }}
+        {{- end }}
+        {{- with .Values.typha.readinessProbe }}
+          readinessProbe:
+{{ tpl . $ | indent 12 }}
+        {{- end }}
+        {{- with .Values.typha.resources }}
+          resources:
+{{ toYaml . | indent 12 }}
+        {{- end }}
+        {{- if or .Values.typha.cert.create .Values.typha.volumeMounts }}
+          volumeMounts:
+          {{- with .Values.typha.volumeMounts }}
+{{ toYaml . | indent 12 }}
+          {{- end }}
+          {{- with .Values.typha.cert.create }}
+            - name: cert
+              mountPath: "/etc/typha/cert.pem"
+              subPath: "cert.pem"
+              readOnly: true
+            - name: cert
+              mountPath: "/etc/typha/key.pem"
+              subPath: "key.pem"
+              readOnly: true
+            - name: cert
+              mountPath: "/etc/typha/ca.pem"
+              subPath: "ca.pem"
+              readOnly: true
+          {{- end }}
+        {{- end }}
+    {{- if or .Values.typha.cert.create .Values.typha.volumes }}
+      volumes:
+      {{- with .Values.typha.volumes }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
+    {{- if and .Values.typha.cert.create }}
+        - name: cert
+          secret:
+            secretName: {{ template "calico.fullname" . }}-typha-cert
+    {{- end }}
+    {{- end }}

--- a/stable/calico-aws/templates/poddisruptionbudget-typha.yaml
+++ b/stable/calico-aws/templates/poddisruptionbudget-typha.yaml
@@ -1,0 +1,23 @@
+# This manifest creates a Pod Disruption Budget for Typha to allow K8s Cluster Autoscaler to evict
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "calico.fullname" . }}-typha
+  labels:
+    app: {{ template "calico.name" . }}-typha
+    chart: {{ template "calico.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- with .Values.typha.podDisruptionBudgetLabels }}
+{{ toYaml . | indent 6 }}
+  {{- end }}
+{{- with .Values.typha.podDisruptionBudgetAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: {{ template "calico.name" . }}-typha
+      release: {{ .Release.Name }}

--- a/stable/calico-aws/templates/poddisruptionbudget-typha.yaml
+++ b/stable/calico-aws/templates/poddisruptionbudget-typha.yaml
@@ -9,7 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   {{- with .Values.typha.podDisruptionBudgetLabels }}
-{{ toYaml . | indent 6 }}
+{{ toYaml . | indent 4 }}
   {{- end }}
 {{- with .Values.typha.podDisruptionBudgetAnnotations }}
   annotations:

--- a/stable/calico-aws/templates/priorityclass.yaml
+++ b/stable/calico-aws/templates/priorityclass.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.priorityClassNode.create }}
+---
+apiVersion: scheduling.k8s.io/v1beta1
+kind: PriorityClass
+metadata:
+  name: '{{ template "calico.fullname" . }}-{{ .Values.priorityClassNode.nameSuffix }}'
+  app: {{ template "calico.name" . }}
+  chart: {{ template "calico.chart" . }}
+  release: {{ .Release.Name }}
+  heritage: {{ .Release.Service }}
+{{- with .Values.priorityClassNode.labels }}
+{{ toYaml . | indent 2 }}
+{{- end }}
+{{- with .Values.priorityClassNode.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+value: {{ .Values.priorityClassNode.value }}
+globalDefault: {{ .Values.priorityClassNode.globalDefault }}
+description: "{{ .Values.priorityClassNode.description }}"
+{{- end }}
+
+{{- if .Values.priorityClassCluster.create }}
+---
+apiVersion: scheduling.k8s.io/v1beta1
+kind: PriorityClass
+metadata:
+  name: '{{ template "calico.fullname" . }}-{{ .Values.priorityClassCluster.nameSuffix }}'
+  app: {{ template "calico.name" . }}
+  chart: {{ template "calico.chart" . }}
+  release: {{ .Release.Name }}
+  heritage: {{ .Release.Service }}
+{{- with .Values.priorityClassCluster.labels }}
+{{ toYaml . | indent 2 }}
+{{- end }}
+{{- with .Values.priorityClassCluster.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+value: {{ .Values.priorityClassCluster.value }}
+globalDefault: {{ .Values.priorityClassCluster.globalDefault }}
+description: "{{ .Values.priorityClassCluster.description }}"
+{{- end }}

--- a/stable/calico-aws/templates/role-typha-cpha.yaml
+++ b/stable/calico-aws/templates/role-typha-cpha.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "calico.fullname" . }}-typha-cpha
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+  - apiGroups: ["extensions"]
+    resources: ["deployments/scale"]
+    verbs: ["get", "update"]

--- a/stable/calico-aws/templates/rolebinding-typha-cpha.yaml
+++ b/stable/calico-aws/templates/rolebinding-typha-cpha.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "calico.fullname" . }}-typha-cpha
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "calico.fullname" . }}-typha-cpha
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "calico.fullname" . }}-typha-cpha

--- a/stable/calico-aws/templates/sa-calico.yaml
+++ b/stable/calico-aws/templates/sa-calico.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.calico.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "calico.serviceAccountName.calico" . }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ template "calico.fullname" . }}
+{{- end }}

--- a/stable/calico-aws/templates/sa-typha-cpha.yaml
+++ b/stable/calico-aws/templates/sa-typha-cpha.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.typhaCpha.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "calico.serviceAccountName.typhaCpha" . }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ template "calico.fullname" . }}
+{{- end }}

--- a/stable/calico-aws/templates/secret-caliconode-cert.yaml
+++ b/stable/calico-aws/templates/secret-caliconode-cert.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.calicoNode.cert.create }}
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ template "calico.fullname" . }}-calico-cert
+  labels:
+    app: {{ template "calico.name" . }}-calico-cert
+    chart: {{ template "calico.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  cert.pem: {{ .Values.calicoNode.cert.clientCertContents | b64enc | quote }}
+  key.pem: {{ .Values.calicoNode.cert.clientKeyContents | b64enc | quote }}
+  ca.pem: {{ .Values.calicoNode.cert.serverCAContents | b64enc | quote }}
+{{- end }}

--- a/stable/calico-aws/templates/secret-typha-cert.yaml
+++ b/stable/calico-aws/templates/secret-typha-cert.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.typha.cert.create }}
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ template "calico.fullname" . }}-typha-cert
+  labels:
+    app: {{ template "calico.name" . }}-typha-cert
+    chart: {{ template "calico.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  cert.pem: {{ .Values.typha.cert.serverCertContents | b64enc | quote }}
+  key.pem: {{ .Values.typha.cert.serverKeyContents | b64enc | quote }}
+  ca.pem: {{ .Values.typha.cert.clientCAContents | b64enc | quote }}
+{{- end }}

--- a/stable/calico-aws/templates/service-typha.yaml
+++ b/stable/calico-aws/templates/service-typha.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "calico.fullname" . }}-typha
+  labels:
+    app: {{ template "calico.name" . }}-typha
+    chart: {{ template "calico.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- with .Values.typha.servicelabels }}
+{{ toYaml . | indent 4 }}
+  {{- end }}
+  {{- with .Values.typha.serviceAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+spec:
+  ports:
+    - port: {{ (index .Values.typha.ports "calico-typha").port }}
+      protocol: {{ (index .Values.typha.ports "calico-typha").protocol }}
+      targetPort: calico-typha
+      name: calico-typha
+  selector:
+    app: {{ template "calico.name" . }}-typha
+    release: {{ .Release.Name }}

--- a/stable/calico-aws/values.yaml
+++ b/stable/calico-aws/values.yaml
@@ -353,11 +353,3 @@ typhaCpha:
     logtostderr: "true"
     namespace: "{{ .Release.Namespace }}"
     v: "2"
-
-testFramework:
-  image:
-    registry: docker.io
-    name: busybox
-    tag: latest
-    pullPolicy: IfNotPresent
-    # pullSecrets:

--- a/stable/calico-aws/values.yaml
+++ b/stable/calico-aws/values.yaml
@@ -1,0 +1,363 @@
+## Pods Service Account
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+serviceAccount:
+  calico:
+    ## Specifies whether a ServiceAccount should be created
+    create: true
+    ## The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the redis-ha.fullname template
+    # name:
+    automountToken: true
+  typhaCpha:
+    ## Specifies whether a ServiceAccount for cluster autoscaler should be created
+    create: true
+    ## The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the redis-ha.fullname template
+    # name:
+    automountToken: false
+
+# node priority class
+priorityClassNode:
+  # Pod priorityClassName. Set to null to skip setting
+  name: system-node-critical
+  # Create a custom priorityClass
+  create: false
+  nameSuffix: node-high
+  value: 1001000
+  globalDefault: false
+  description: |
+    Custom PriorityClass for calico resources
+  labels: {}
+  annotations: {}
+
+# cluster priority class
+priorityClassCluster:
+  # Pod priorityClassName. Set to null to skip setting
+  name: system-cluster-critical
+  # Create a custom priorityClass
+  create: false
+  nameSuffix: cluster-high
+  value: 1000000
+  globalDefault: false
+  description: |
+    Custom PriorityClass for calico resources
+  labels: {}
+  annotations: {}
+
+calicoNode:
+  image:
+    registry: quay.io
+    name: calico/node
+    tag: v3.3.6
+    pullPolicy: IfNotPresent
+    # pullSecrets:
+
+  # Calico resources
+  # resources: {}
+
+  ## DaemonSet annotations
+  annotations: {}
+  ## DaemonSet labels
+  labels: {}
+  ## Pod annotations
+  podAnnotations: {}
+  ## Pod labels
+  podLabels: {}
+
+  ## OpenSource Calico only supports Linux
+  linuxOnly: true
+
+  ## Pod NodeSelector
+  # nodeSelector:
+
+  ## Node labels, affinity, and tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  # affinity: |
+
+  ## Pod tolerations
+  # tolerations:
+
+  ## Add prometheus annotations
+  ## prometheus.io/scrape
+  ## prometheus.io/port
+  ## You will also need to set these variables:
+  ## ref: https://docs.projectcalico.org/v3.7/reference/felix/configuration
+  ## FELIX_PROMETHEUSMETRICSENABLED
+  ## FELIX_PROMETHEUSMETRICSPORT
+  prometheusScrapeAnnotations: true
+
+  ports:
+    metrics:
+      port: 9091
+      protocol: TCP
+
+  ## Pod environment
+  ## dynamic values are allowed, like: FOO: "{{ .Values.bar }}"   
+  env:
+    # Use Kubernetes API as the backing datastore.
+    DATASTORE_TYPE: "kubernetes"
+    # Use eni not cali for interface prefix
+    FELIX_INTERFACEPREFIX: "eni"
+    # Enable felix info logging.
+    FELIX_LOGSEVERITYSCREEN: "info"
+    # Don't enable BGP.
+    CALICO_NETWORKING_BACKEND: "none"
+    # Cluster type to identify the deployment type
+    CLUSTER_TYPE: "k8s,ecs"
+    # Disable file logging so `kubectl logs` works.
+    CALICO_DISABLE_FILE_LOGGING: "true"
+    FELIX_TYPHAK8SSERVICENAME: '{{ template "calico.fullname" . }}-typha'
+    FELIX_TYPHAK8SNAMESPACE: '{{ .Release.Namespace }}'
+    # Set Felix endpoint to host default action to ACCEPT.
+    FELIX_DEFAULTENDPOINTTOHOSTACTION: "ACCEPT"
+    # This will make Felix honor AWS VPC CNI's mangle table
+    # rules.
+    FELIX_IPTABLESMANGLEALLOWACTION: "Return"
+    # Disable IPV6 on Kubernetes.
+    FELIX_IPV6SUPPORT: "false"
+    # Wait for the datastore.
+    WAIT_FOR_DATASTORE: "true"
+    FELIX_LOGSEVERITYSYS: "none"
+    FELIX_PROMETHEUSMETRICSENABLED: "true"
+    FELIX_PROMETHEUSMETRICSPORT: "{{ .Values.calicoNode.ports.metrics.port }}"
+    NO_DEFAULT_POOLS: "true"
+    FELIX_HEALTHENABLED: "true"
+    # No IP address needed
+    IP: ""
+    # Configure TLS - make sure to provide certificates via cert parameter or with a custom mount
+    # FELIX_TYPHACAFILE: '/etc/felix/ca.pem'
+    # FELIX_TYPHACERTFILE: '/etc/felix/cert.pem'
+    # FELIX_TYPHAKEYFILE: '/etc/felix/key.pem'
+    # FELIX_TYPHACN: 'yourcnhere'
+
+  ## Calico-node livenessProbe configuration
+  livenessProbe: |
+    httpGet:
+      path: /liveness
+      port: 9099
+      host: localhost
+    periodSeconds: 10
+    initialDelaySeconds: 10
+    failureThreshold: 6
+
+  # Calico-node readinessProbe configuration
+  readinessProbe: |
+    exec:
+      command:
+        - /bin/calico-node
+        - -felix-ready
+    periodSeconds: 10
+
+  ## Certificate configuration
+  ## Make sure to configure Typha and clients with environment variables accordingly
+  ## https://docs.projectcalico.org/v3.7/reference/typha/configuration
+  cert:
+    # create and mount certificate files from variables below
+    create: false
+    clientCertContents: ""
+    clientKeyContents: ""
+    serverCAContents: ""
+
+  ## Custom volumeMounts
+  # volumeMounts:
+
+  ## Custom volumes
+  # volumes:
+
+typha:
+  image:
+    registry: quay.io
+    name: calico/typha
+    tag: v3.3.6
+    pullPolicy: IfNotPresent
+    # pullSecrets:
+
+  # Typha resources
+  # resources: {}
+
+  ## Deployment annotations
+  annotations: {}
+  ## Deployment labels
+  labels: {}
+  ## Pod annotations
+  podAnnotations: {}
+  ## Pod labels
+  podLabels: {}
+
+  ## Pod NodeSelector
+  # nodeSelector:
+
+  ## Pod tolerations
+  # tolerations:
+
+  ## Node labels, affinity, and tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  # affinity: |
+
+  ## Add prometheus annotations
+  ## prometheus.io/scrape
+  ## prometheus.io/port
+  ## You will also need to set these variables:
+  ## TYPHA_PROMETHEUSMETRICSENABLED
+  ## TYPHA_PROMETHEUSMETRICSPORT
+  prometheusScrapeAnnotations: true
+
+  ports:
+    calico-typha:
+      port: 5473
+      protocol: TCP
+    metrics:
+      port: 9093
+      protocol: TCP
+    health:
+      port: 9098
+      protocol: TCP
+
+  ## Pod environment
+  ## dynamic values are allowed, like: FOO: "{{ .Values.bar }}"   
+  env:
+    # Use eni not cali for interface prefix
+    FELIX_INTERFACEPREFIX: "eni"
+    TYPHA_LOGFILEPATH: "none"
+    TYPHA_LOGSEVERITYSYS: "none"
+    TYPHA_LOGSEVERITYSCREEN: "info"
+    TYPHA_PROMETHEUSMETRICSENABLED: "true"
+    TYPHA_CONNECTIONREBALANCINGMODE: "kubernetes"
+    TYPHA_PROMETHEUSMETRICSPORT: "{{ .Values.typha.ports.metrics.port }}"
+    TYPHA_DATASTORETYPE: "kubernetes"
+    TYPHA_MAXCONNECTIONSLOWERLIMIT: "1"
+    TYPHA_HEALTHENABLED: "true"
+    TYPHA_HEALTHPORT: "{{ .Values.typha.ports.health.port }}"
+    TYPHA_K8SSERVICENAME: '{{ template "calico.fullname" . }}-typha'
+    TYPHA_K8SNAMESPACE: '{{ .Release.Namespace }}'
+    # This will make Felix honor AWS VPC CNI's mangle table
+    # rules.
+    FELIX_IPTABLESMANGLEALLOWACTION: "Return"
+    # Configure TLS - make sure to provide certificates via cert parameter or with a custom mount
+    # TYPHA_CAFILE: '/etc/typha/ca.pem'
+    # TYPHA_SERVERCERTFILE: '/etc/typha/cert.pem'
+    # TYPHA_SERVERKEYFILE: '/etc/typha/key.pem'
+    # TYPHA_CLIENTCN: 'addclientcnhere'
+
+  ## Typha livenessProve
+  livenessProbe: |
+    exec:
+      command:
+        - calico-typha
+        - check
+        - liveness
+    periodSeconds: 30
+    initialDelaySeconds: 30
+
+  ## Typha readinessProbe
+  readinessProbe: |
+    exec:
+      command:
+        - calico-typha
+        - check
+        - readiness
+    periodSeconds: 10
+
+  ## Additional labels and annotations for typha resources
+  podDisruptionBudgetLabels: {}
+  podDisruptionBudgetAnnotations: {}
+  serviceLabels: {}
+  serviceAnnotations: {}
+
+  ## Certificate configuration
+  ## Make sure to configure Typha and clients with environment variables accordingly
+  ## https://docs.projectcalico.org/v3.7/reference/typha/configuration
+  cert:
+    # create and mount certificate files from variables below
+    create: false
+    serverCertContents: ""
+    serverKeyContents: ""
+    clientCAContents: ""
+
+  ## Custom volumeMounts
+  # volumeMounts:
+
+  ## Custom volumes
+  # volumes:
+
+# Typha propotional cluster autoscaler
+typhaCpha:
+  image:
+    registry: k8s.gcr.io
+    name: cluster-proportional-autoscaler-amd64
+    tag: 1.1.2
+    pullPolicy: IfNotPresent
+    # pullSecrets:
+
+  replicas: 1
+
+  # Autoscaler resources
+  resources:
+    requests:
+      cpu: 10m
+    limits:
+      cpu: 10m
+
+  ## Deployment annotations
+  annotations: {}
+  ## Deployment labels
+  labels: {}
+  ## Pod annotations
+  podAnnotations: {}
+  ## Pod labels
+  podLabels: {}
+
+  ## Pod NodeSelector
+  # nodeSelector:
+
+  ## Node labels, affinity, and tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  # affinity: |
+
+  ## Pod tolerations
+  # tolerations:
+
+  ## Autoscaler livenessProbe configuration
+  # livenessProbe: |
+
+  # Autoscaler readinessProbe configuration
+  # readinessProbe: |
+
+  ladder: |
+    {
+      "coresToReplicas": [],
+      "nodesToReplicas":
+      [
+        [1, 1],
+        [10, 2],
+        [100, 3],
+        [250, 4],
+        [500, 5],
+        [1000, 6],
+        [1500, 7],
+        [2000, 8]
+      ]
+    }
+
+  ## Args for autoscaler pod
+  ## dynamic values are allowed, like: FOO: "{{ .Values.bar }}"   
+  args:
+    configmap: '{{ template "calico.fullname" . }}-typha-cpha'
+    target: 'deployment/{{ template "calico.fullname" . }}-typha'
+    logtostderr: "true"
+    namespace: "{{ .Release.Namespace }}"
+    v: "2"
+
+testFramework:
+  image:
+    registry: docker.io
+    name: busybox
+    tag: latest
+    pullPolicy: IfNotPresent
+    # pullSecrets:


### PR DESCRIPTION
#### Is this a new chart
This is a new Helm chart for running Project Calico on AWS EKS.

#### What this PR does / why we need it:
Calico is a common/widely used solution for managing network on AWS EKS, and it is missing from charts.

#### Special notes for your reviewer:
Based on: https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.5/config/v1.5/calico.yaml
Can run on any Kubernetes cluster, but useful work will only be done on AWS EKS.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
