### PR TITLE
[stable/kibana] Migrate APIs for Kibana 1.16

### DIFF
--- a/stable/kibana/Chart.yaml
+++ b/stable/kibana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kibana
-version: 3.2.3
+version: 3.2.4
 appVersion: 6.7.0
 description: Kibana is an open source data visualization plugin for Elasticsearch
 icon: https://raw.githubusercontent.com/elastic/kibana/master/src/ui/public/icons/kibana-color.svg

--- a/stable/kibana/templates/deployment.yaml
+++ b/stable/kibana/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -13,6 +13,10 @@ metadata:
 {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "kibana.name" . }}
+      release: {{ .Release.Name }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:
     metadata:

--- a/stable/kibana/templates/ingress.yaml
+++ b/stable/kibana/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "kibana.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   labels:


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
Migrate APIs for Kibana 1.16
See https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)

Signed-off-by: Johann Grabmann <johann@grabmann.eu>