### PR TITLE
[stable/mariadb] add support for mysql exporter extra args

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb
-version: 6.9.1
+version: 6.10.0
 appVersion: 10.3.18
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -164,6 +164,7 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `metrics.image.tag`                       | Exporter image tag                                  | `{TAG_NAME}`                                                      |
 | `metrics.image.pullPolicy`                | Exporter image pull policy                          | `IfNotPresent`                                                    |
 | `metrics.resources`                       | Exporter resource requests/limit                    | `nil`                                                             |
+| `metrics.extraArgs`                       | Extra args to be passed to mysqld_exporter          | `[]`                                                              |
 | `metrics.serviceMonitor.enabled`          | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)                    | `false`                                                             |
 | `metrics.serviceMonitor.namespace`        | Optional namespace which Prometheus is running in   | `nil`                                                             |
 | `metrics.serviceMonitor.interval`         | How frequently to scrape metrics (use by default, falling back to Prometheus' default)  | `nil`                                                             |

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -164,7 +164,8 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `metrics.image.tag`                       | Exporter image tag                                  | `{TAG_NAME}`                                                      |
 | `metrics.image.pullPolicy`                | Exporter image pull policy                          | `IfNotPresent`                                                    |
 | `metrics.resources`                       | Exporter resource requests/limit                    | `nil`                                                             |
-| `metrics.extraArgs`                       | Extra args to be passed to mysqld_exporter          | `[]`                                                              |
+| `metrics.extraArgs.master`                | Extra args to be passed to mysqld_exporter          | `[]`                                                              |
+| `metrics.extraArgs.slave`                 | Extra args to be passed to mysqld_exporter          | `[]`                                                              |
 | `metrics.serviceMonitor.enabled`          | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)                    | `false`                                                             |
 | `metrics.serviceMonitor.namespace`        | Optional namespace which Prometheus is running in   | `nil`                                                             |
 | `metrics.serviceMonitor.interval`         | How frequently to scrape metrics (use by default, falling back to Prometheus' default)  | `nil`                                                             |

--- a/stable/mariadb/templates/master-statefulset.yaml
+++ b/stable/mariadb/templates/master-statefulset.yaml
@@ -207,7 +207,15 @@ spec:
               name: {{ template "mariadb.fullname" . }}
             {{- end }}
               key: mariadb-root-password
-        command: [ 'sh', '-c', 'DATA_SOURCE_NAME="root:$MARIADB_ROOT_PASSWORD@(localhost:3306)/" /bin/mysqld_exporter' ]
+        command:
+          - sh
+          - -c
+          - >-
+            DATA_SOURCE_NAME="root:$MARIADB_ROOT_PASSWORD@(localhost:3306)/"
+            /bin/mysqld_exporter
+            {{- range .Values.metrics.extraArgs }}
+            {{ . }}
+            {{- end }}
         ports:
         - name: metrics
           containerPort: 9104

--- a/stable/mariadb/templates/master-statefulset.yaml
+++ b/stable/mariadb/templates/master-statefulset.yaml
@@ -213,7 +213,7 @@ spec:
           - >-
             DATA_SOURCE_NAME="root:$MARIADB_ROOT_PASSWORD@(localhost:3306)/"
             /bin/mysqld_exporter
-            {{- range .Values.metrics.extraArgs }}
+            {{- range .Values.metrics.extraArgs.master }}
             {{ . }}
             {{- end }}
         ports:

--- a/stable/mariadb/templates/slave-statefulset.yaml
+++ b/stable/mariadb/templates/slave-statefulset.yaml
@@ -190,7 +190,15 @@ spec:
               name: {{ template "mariadb.fullname" . }}
             {{- end }}
               key: mariadb-root-password
-        command: [ 'sh', '-c', 'DATA_SOURCE_NAME="root:$MARIADB_MASTER_ROOT_PASSWORD@(localhost:3306)/" /bin/mysqld_exporter' ]
+        command:
+          - sh
+          - -c
+          - >-
+            DATA_SOURCE_NAME="root:$MARIADB_ROOT_PASSWORD@(localhost:3306)/"
+            /bin/mysqld_exporter
+            {{- range .Values.metrics.extraArgs }}
+            {{ . }}
+            {{- end }}
         ports:
         - name: metrics
           containerPort: 9104

--- a/stable/mariadb/templates/slave-statefulset.yaml
+++ b/stable/mariadb/templates/slave-statefulset.yaml
@@ -196,7 +196,7 @@ spec:
           - >-
             DATA_SOURCE_NAME="root:$MARIADB_ROOT_PASSWORD@(localhost:3306)/"
             /bin/mysqld_exporter
-            {{- range .Values.metrics.extraArgs }}
+            {{- range .Values.metrics.extraArgs.slave }}
             {{ . }}
             {{- end }}
         ports:

--- a/stable/mariadb/values-production.yaml
+++ b/stable/mariadb/values-production.yaml
@@ -443,41 +443,43 @@ metrics:
   ## Extra args to be passed to mysqld_exporter
   ## ref: https://github.com/prometheus/mysqld_exporter/
   ##
-  extraArgs: []
-    # - --collect.auto_increment.columns
-    # - --collect.binlog_size
-    # - --collect.engine_innodb_status
-    # - --collect.engine_tokudb_status
-    # - --collect.global_status
-    # - --collect.global_variables
-    # - --collect.info_schema.clientstats
-    # - --collect.info_schema.innodb_metrics
-    # - --collect.info_schema.innodb_tablespaces
-    # - --collect.info_schema.innodb_cmp
-    # - --collect.info_schema.innodb_cmpmem
-    # - --collect.info_schema.processlist
-    # - --collect.info_schema.processlist.min_time
-    # - --collect.info_schema.query_response_time
-    # - --collect.info_schema.tables
-    # - --collect.info_schema.tables.databases
-    # - --collect.info_schema.tablestats
-    # - --collect.info_schema.userstats
-    # - --collect.perf_schema.eventsstatements
-    # - --collect.perf_schema.eventsstatements.digest_text_limit
-    # - --collect.perf_schema.eventsstatements.limit
-    # - --collect.perf_schema.eventsstatements.timelimit
-    # - --collect.perf_schema.eventswaits
-    # - --collect.perf_schema.file_events
-    # - --collect.perf_schema.file_instances
-    # - --collect.perf_schema.indexiowaits
-    # - --collect.perf_schema.tableiowaits
-    # - --collect.perf_schema.tablelocks
-    # - --collect.perf_schema.replication_group_member_stats
-    # - --collect.slave_status
-    # - --collect.slave_hosts
-    # - --collect.heartbeat
-    # - --collect.heartbeat.database
-    # - --collect.heartbeat.table
+  extraArgs:
+    master: []
+    slave: []
+      # - --collect.auto_increment.columns
+      # - --collect.binlog_size
+      # - --collect.engine_innodb_status
+      # - --collect.engine_tokudb_status
+      # - --collect.global_status
+      # - --collect.global_variables
+      # - --collect.info_schema.clientstats
+      # - --collect.info_schema.innodb_metrics
+      # - --collect.info_schema.innodb_tablespaces
+      # - --collect.info_schema.innodb_cmp
+      # - --collect.info_schema.innodb_cmpmem
+      # - --collect.info_schema.processlist
+      # - --collect.info_schema.processlist.min_time
+      # - --collect.info_schema.query_response_time
+      # - --collect.info_schema.tables
+      # - --collect.info_schema.tables.databases
+      # - --collect.info_schema.tablestats
+      # - --collect.info_schema.userstats
+      # - --collect.perf_schema.eventsstatements
+      # - --collect.perf_schema.eventsstatements.digest_text_limit
+      # - --collect.perf_schema.eventsstatements.limit
+      # - --collect.perf_schema.eventsstatements.timelimit
+      # - --collect.perf_schema.eventswaits
+      # - --collect.perf_schema.file_events
+      # - --collect.perf_schema.file_instances
+      # - --collect.perf_schema.indexiowaits
+      # - --collect.perf_schema.tableiowaits
+      # - --collect.perf_schema.tablelocks
+      # - --collect.perf_schema.replication_group_member_stats
+      # - --collect.slave_status
+      # - --collect.slave_hosts
+      # - --collect.heartbeat
+      # - --collect.heartbeat.database
+      # - --collect.heartbeat.table
 
   # Enable this if you're using https://github.com/coreos/prometheus-operator
   serviceMonitor:

--- a/stable/mariadb/values-production.yaml
+++ b/stable/mariadb/values-production.yaml
@@ -440,6 +440,45 @@ metrics:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9104"
 
+  ## Extra args to be passed to mysqld_exporter
+  ## ref: https://github.com/prometheus/mysqld_exporter/
+  ##
+  extraArgs: []
+    # - --collect.auto_increment.columns
+    # - --collect.binlog_size
+    # - --collect.engine_innodb_status
+    # - --collect.engine_tokudb_status
+    # - --collect.global_status
+    # - --collect.global_variables
+    # - --collect.info_schema.clientstats
+    # - --collect.info_schema.innodb_metrics
+    # - --collect.info_schema.innodb_tablespaces
+    # - --collect.info_schema.innodb_cmp
+    # - --collect.info_schema.innodb_cmpmem
+    # - --collect.info_schema.processlist
+    # - --collect.info_schema.processlist.min_time
+    # - --collect.info_schema.query_response_time
+    # - --collect.info_schema.tables
+    # - --collect.info_schema.tables.databases
+    # - --collect.info_schema.tablestats
+    # - --collect.info_schema.userstats
+    # - --collect.perf_schema.eventsstatements
+    # - --collect.perf_schema.eventsstatements.digest_text_limit
+    # - --collect.perf_schema.eventsstatements.limit
+    # - --collect.perf_schema.eventsstatements.timelimit
+    # - --collect.perf_schema.eventswaits
+    # - --collect.perf_schema.file_events
+    # - --collect.perf_schema.file_instances
+    # - --collect.perf_schema.indexiowaits
+    # - --collect.perf_schema.tableiowaits
+    # - --collect.perf_schema.tablelocks
+    # - --collect.perf_schema.replication_group_member_stats
+    # - --collect.slave_status
+    # - --collect.slave_hosts
+    # - --collect.heartbeat
+    # - --collect.heartbeat.database
+    # - --collect.heartbeat.table
+
   # Enable this if you're using https://github.com/coreos/prometheus-operator
   serviceMonitor:
     enabled: false

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -445,41 +445,43 @@ metrics:
   ## Extra args to be passed to mysqld_exporter
   ## ref: https://github.com/prometheus/mysqld_exporter/
   ##
-  extraArgs: []
-    # - --collect.auto_increment.columns
-    # - --collect.binlog_size
-    # - --collect.engine_innodb_status
-    # - --collect.engine_tokudb_status
-    # - --collect.global_status
-    # - --collect.global_variables
-    # - --collect.info_schema.clientstats
-    # - --collect.info_schema.innodb_metrics
-    # - --collect.info_schema.innodb_tablespaces
-    # - --collect.info_schema.innodb_cmp
-    # - --collect.info_schema.innodb_cmpmem
-    # - --collect.info_schema.processlist
-    # - --collect.info_schema.processlist.min_time
-    # - --collect.info_schema.query_response_time
-    # - --collect.info_schema.tables
-    # - --collect.info_schema.tables.databases
-    # - --collect.info_schema.tablestats
-    # - --collect.info_schema.userstats
-    # - --collect.perf_schema.eventsstatements
-    # - --collect.perf_schema.eventsstatements.digest_text_limit
-    # - --collect.perf_schema.eventsstatements.limit
-    # - --collect.perf_schema.eventsstatements.timelimit
-    # - --collect.perf_schema.eventswaits
-    # - --collect.perf_schema.file_events
-    # - --collect.perf_schema.file_instances
-    # - --collect.perf_schema.indexiowaits
-    # - --collect.perf_schema.tableiowaits
-    # - --collect.perf_schema.tablelocks
-    # - --collect.perf_schema.replication_group_member_stats
-    # - --collect.slave_status
-    # - --collect.slave_hosts
-    # - --collect.heartbeat
-    # - --collect.heartbeat.database
-    # - --collect.heartbeat.table
+  extraArgs:
+    master: []
+    slave: []
+      # - --collect.auto_increment.columns
+      # - --collect.binlog_size
+      # - --collect.engine_innodb_status
+      # - --collect.engine_tokudb_status
+      # - --collect.global_status
+      # - --collect.global_variables
+      # - --collect.info_schema.clientstats
+      # - --collect.info_schema.innodb_metrics
+      # - --collect.info_schema.innodb_tablespaces
+      # - --collect.info_schema.innodb_cmp
+      # - --collect.info_schema.innodb_cmpmem
+      # - --collect.info_schema.processlist
+      # - --collect.info_schema.processlist.min_time
+      # - --collect.info_schema.query_response_time
+      # - --collect.info_schema.tables
+      # - --collect.info_schema.tables.databases
+      # - --collect.info_schema.tablestats
+      # - --collect.info_schema.userstats
+      # - --collect.perf_schema.eventsstatements
+      # - --collect.perf_schema.eventsstatements.digest_text_limit
+      # - --collect.perf_schema.eventsstatements.limit
+      # - --collect.perf_schema.eventsstatements.timelimit
+      # - --collect.perf_schema.eventswaits
+      # - --collect.perf_schema.file_events
+      # - --collect.perf_schema.file_instances
+      # - --collect.perf_schema.indexiowaits
+      # - --collect.perf_schema.tableiowaits
+      # - --collect.perf_schema.tablelocks
+      # - --collect.perf_schema.replication_group_member_stats
+      # - --collect.slave_status
+      # - --collect.slave_hosts
+      # - --collect.heartbeat
+      # - --collect.heartbeat.database
+      # - --collect.heartbeat.table
 
   # Enable this if you're using https://github.com/coreos/prometheus-operator
   serviceMonitor:

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -442,6 +442,45 @@ metrics:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9104"
 
+  ## Extra args to be passed to mysqld_exporter
+  ## ref: https://github.com/prometheus/mysqld_exporter/
+  ##
+  extraArgs: []
+    # - --collect.auto_increment.columns
+    # - --collect.binlog_size
+    # - --collect.engine_innodb_status
+    # - --collect.engine_tokudb_status
+    # - --collect.global_status
+    # - --collect.global_variables
+    # - --collect.info_schema.clientstats
+    # - --collect.info_schema.innodb_metrics
+    # - --collect.info_schema.innodb_tablespaces
+    # - --collect.info_schema.innodb_cmp
+    # - --collect.info_schema.innodb_cmpmem
+    # - --collect.info_schema.processlist
+    # - --collect.info_schema.processlist.min_time
+    # - --collect.info_schema.query_response_time
+    # - --collect.info_schema.tables
+    # - --collect.info_schema.tables.databases
+    # - --collect.info_schema.tablestats
+    # - --collect.info_schema.userstats
+    # - --collect.perf_schema.eventsstatements
+    # - --collect.perf_schema.eventsstatements.digest_text_limit
+    # - --collect.perf_schema.eventsstatements.limit
+    # - --collect.perf_schema.eventsstatements.timelimit
+    # - --collect.perf_schema.eventswaits
+    # - --collect.perf_schema.file_events
+    # - --collect.perf_schema.file_instances
+    # - --collect.perf_schema.indexiowaits
+    # - --collect.perf_schema.tableiowaits
+    # - --collect.perf_schema.tablelocks
+    # - --collect.perf_schema.replication_group_member_stats
+    # - --collect.slave_status
+    # - --collect.slave_hosts
+    # - --collect.heartbeat
+    # - --collect.heartbeat.database
+    # - --collect.heartbeat.table
+
   # Enable this if you're using https://github.com/coreos/prometheus-operator
   serviceMonitor:
     enabled: false


### PR DESCRIPTION
Added support for mysql exporter extra arguments to be scraped by prometheus.
See https://github.com/prometheus/mysqld_exporter/