### PR TITLE
[stable/metallb] Add initContainer support to metallb speakers.

### DIFF
--- a/stable/metallb/Chart.yaml
+++ b/stable/metallb/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.11.2
+version: 0.12.0
 name: metallb
 appVersion: 0.8.1
 description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters

--- a/stable/metallb/templates/speaker.yaml
+++ b/stable/metallb/templates/speaker.yaml
@@ -34,6 +34,10 @@ spec:
       serviceAccountName: {{ template "metallb.speakerServiceAccountName" . }}
       terminationGracePeriodSeconds: 0
       hostNetwork: true
+{{- if gt (len .Values.speaker.initContainers) 0 }}
+      initContainers:
+{{ toYaml .Values.speaker.initContainers | indent 8 }}
+{{- end }}
       containers:
       - name: speaker
         image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag }}

--- a/stable/metallb/values.yaml
+++ b/stable/metallb/values.yaml
@@ -115,3 +115,4 @@ speaker:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  initContainers: []


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds support for adding custom initContainers to metallb speakers

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)