### PR TITLE
[stable/mariadb] fix wrong env variable in slave metrics container

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb
-version: 6.10.0
+version: 6.10.1
 appVersion: 10.3.18
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/templates/slave-statefulset.yaml
+++ b/stable/mariadb/templates/slave-statefulset.yaml
@@ -181,7 +181,7 @@ spec:
         image: {{ template "mariadb.metrics.image" . }}
         imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
         env:
-        - name: MARIADB_MASTER_ROOT_PASSWORD
+        - name: MARIADB_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
             {{- if .Values.existingSecret }}


### PR DESCRIPTION
In the slave statefulset, the metrics container uses an env variable that is not set.
The fix sets the expected env variable so that the metrics container can connect to the database to scrape the necessary tables.