### PR TITLE
[incubator/kafka] Wrong indentation fixed

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.18.0
+version: 0.18.1
 appVersion: 5.0.1
 keywords:
 - kafka

--- a/incubator/kafka/templates/service-brokers-external.yaml
+++ b/incubator/kafka/templates/service-brokers-external.yaml
@@ -62,7 +62,7 @@ spec:
   loadBalancerIP: {{ index $root.Values.external.loadBalancerIP $i }} 
   {{- end }}
   selector:
-    {{- include "kafka.broker.matchLabels" $root | nindent 6 }}
+    {{- include "kafka.broker.matchLabels" $root | nindent 4 }}
     statefulset.kubernetes.io/pod-name: {{ $responsiblePod | quote }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Seems the PR from yesterday contained a bug of the indentation of match labels for the external broker service. Sorry, should be fixed now.