### PR TITLE
[stable/cluster-autoscaler] Remove ClusterIP from default values.yaml

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 4.0.1
+version: 4.0.2
 appVersion: 1.13.7
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 4.1.1
+version: 5.0.0
 appVersion: 1.13.7
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/README.md
+++ b/stable/cluster-autoscaler/README.md
@@ -162,7 +162,6 @@ Parameter | Description | Default
 `dnsPolicy` | dnsPolicy | `nil`
 `resources` | pod resource requests & limits | `{}`
 `service.annotations` | annotations to add to service | none
-`service.clusterIP` | IP address to assign to service | `""`
 `service.externalIPs` | service external IP addresses | `[]`
 `service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`

--- a/stable/cluster-autoscaler/README.md
+++ b/stable/cluster-autoscaler/README.md
@@ -30,6 +30,17 @@ $ helm del --purge my-release
 Once the old release is deleted, the new 2.X release can be installed using the standard instructions.
 Note that autoscaling will not occur during the time between deletion and installation.
 
+## Upgrading from 4.X to 5.X
+
+In order to upgrade to chart version 5.X from <=4.X, deleting the old helm release first is required.
+
+```console
+$ helm del --purge my-release
+```
+
+Once the old release is deleted, the new 5.X release can be installed using the standard instructions.
+Note that autoscaling will not occur during the time between deletion and installation.
+
 ## Installing the Chart
 
 **By default, no deployment is created and nothing will autoscale**.

--- a/stable/cluster-autoscaler/values.yaml
+++ b/stable/cluster-autoscaler/values.yaml
@@ -135,7 +135,6 @@ priorityClassName: ""
 
 service:
   annotations: {}
-  clusterIP: ""
 
   ## List of IP addresses at which the service is available
   ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips


### PR DESCRIPTION
#### What this PR does / why we need it:
When using a gitops operator (ArgoCD) to deploy and manage the chart, syncing/updating the cluster-autoscaler service fails with:

```
kubectl failed exit status 1: The Service "cluster-autoscaler-aws-cluster-autoscaler" is invalid: spec.clusterIP: Invalid value: "": field is immutable
```

Since there is no way to add a parameter override, that would remove this value,
the only solution appears to be, to unset it on the default values.yaml of the chart.
Not sure why this was added to defaults in the first place?
I haven't seen other charts use it in this way.

#### Which issue this PR fixes

[argo-cd: #2150](https://github.com/argoproj/argo-cd/issues/2150)
[kubernetes: #11237](https://github.com/kubernetes/kubernetes/issues/11237)

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
