### PR TITLE
[stable/prometheus-pushgateway] adds ability to create annotations on service in prometheus-pushgateway

### DIFF
--- a/stable/prometheus-pushgateway/Chart.yaml
+++ b/stable/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.9.1"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.0.1
+version: 1.0.2
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/stable/prometheus-pushgateway/README.md
+++ b/stable/prometheus-pushgateway/README.md
@@ -55,6 +55,7 @@ The following table lists the configurable parameters of the pushgateway chart a
 | `service.type`              | Service type                                                                                                                  | `ClusterIP`                       |
 | `service.port`              | The service port                                                                                                              | `9091`                            |
 | `service.targetPort`        | The target port of the container                                                                                              | `9091`                            |
+| `service.annotations`       | Service annotations                                                                                                           | `{}`                              |
 | `serviceLabels`             | Labels for service                                                                                                            | `{}`                              |
 | `serviceAccount.create`     | Specifies whether a service account should be created.                                                                        | `true`                            |
 | `serviceAccount.name`       | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |                                   |

--- a/stable/prometheus-pushgateway/templates/service.yaml
+++ b/stable/prometheus-pushgateway/templates/service.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "prometheus-pushgateway.fullname" . }}
+{{- if .Values.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.ingress.annotations | indent 4}}
   labels:
 {{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.serviceLabels) .  }}
 spec:

--- a/stable/prometheus-pushgateway/templates/service.yaml
+++ b/stable/prometheus-pushgateway/templates/service.yaml
@@ -5,6 +5,7 @@ metadata:
 {{- if .Values.ingress.annotations }}
   annotations:
 {{ toYaml .Values.ingress.annotations | indent 4}}
+{{- end }}
   labels:
 {{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.serviceLabels) .  }}
 spec:

--- a/stable/prometheus-pushgateway/values.yaml
+++ b/stable/prometheus-pushgateway/values.yaml
@@ -11,6 +11,12 @@ service:
   port: 9091
   targetPort: 9091
 
+    ## Annotations.
+    ##
+    # annotations:
+    #   cloud.google.com/load-balancer-type: 'Internal'
+    #   service.beta.kubernetes.io/aws-load-balancer-internal: 'true'
+
 # Optional pod annotations
 podAnnotations: {}
 


### PR DESCRIPTION
Signed-off-by: David Sudia <dsudia@gmail.com>

#### Is this a new chart
No.

#### What this PR does / why we need it:
This adds the ability to create annotations on the service created by the stable/prometheus-pushgateway chart. We use internal load balancers, and we front our pushgateway using [Ambassador](getambassador.io) which uses service annotations for discovery.

#### Special notes for your reviewer:
@gianrubio is listed as the maintainer. Thanks for reviewing!

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
