### PR TITLE
[stable/envoy] Add general configuration options to make restart-less reload real

### DIFF
--- a/stable/envoy/Chart.yaml
+++ b/stable/envoy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Envoy is an open source edge and service proxy, designed for cloud-native applications.
 name: envoy
-version: 1.5.0
+version: 1.6.0
 appVersion: 1.11.1
 keywords:
 - envoy

--- a/stable/envoy/Chart.yaml
+++ b/stable/envoy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Envoy is an open source edge and service proxy, designed for cloud-native applications.
 name: envoy
 version: 1.5.0
-appVersion: 1.9.0
+appVersion: 1.11.1
 keywords:
 - envoy
 - proxy

--- a/stable/envoy/README.md
+++ b/stable/envoy/README.md
@@ -26,24 +26,21 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the envoy chart and their default values.
 
-| Parameter                         | Description                                                                                                                                                       | Default                                           |
-|-----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------|
-| `args`                            | Command-line args passed to Envoy                                                                                                                                 | `["-l", "$loglevel", "-c", "/config/envoy.yaml"]` |
-| `argsTemplate`                    | Golang template of command-line args passed to Envoy. Must be a string containing a template snippet rather than YAML array. Prefered over `args` if both are set | ``                                                |
-| `files.envoy\.yaml`               | content of a full envoy configuration file as documented in https://www.envoyproxy.io/docs/envoy/latest/configuration/configuration                               | See [values.yaml](values.yaml)                    |
-| `templates.envoy\.yaml`           | golang template of a full configuration file. Use the `{{ .Values.foo.bar }}` syntax to embed chart values                                                        | See [values.yaml](values.yaml)                    |
-| `serviceMonitor.enabled`          | if `true`, creates a Prometheus Operator ServiceMonitor                                                                                                           | `false`                                           |
-| `serviceMonitor.interval`         | Interval that Prometheus scrapes Envoy metrics                                                                                                                    | `15s`                                             |
-| `serviceMonitor.namespace`        | Namespace which the operated Prometheus is running in                                                                                                             | ``                                                |
-| `serviceMonitor.additionalLabels` | Labels used by Prometheus Operator to discover your Service Monitor. Set according to your Prometheus setup                                                       | `{}`                                              |
-| `prometheusRule.enabled`          | If `true`, creates a Prometheus Operator PrometheusRule                                                                                                           | `false``                                          |
-| `prometheusRule.groups`           | Prometheus alerting rules                                                                                                                                         | `{}`                                              |
-| `prometheusRule.additionalLabels` | Labels used by Prometheus Operator to discover your Prometheus Rule                                                                                               | `{}`                                              |
-| `prometheusRule.additionalLabels` | Labels used by Prometheus Operator to discover your Prometheus Rule                                                                                               | `{}`                                              |
-| `prometheusRule.additionalLabels` | Labels used by Prometheus Operator to discover your Prometheus Rule                                                                                               | `{}`                                              |
-| `volumes`                         | Additional volumes to be added to Envoy pods                                                                                                                      | ``                                                |
-| `volumeMounts`                    | Additional volume mounts to be added to Envoy containers(Primary containers of Envoy pods)                                                                        | ``                                                |
-| `initContainerTemplate`           | Golang template of the init container added to Envoy pods                                                                                                         | ``                                                |
-| `sidecarContainersTemplate`       | Golang template of additional containers added after the primary container of Envoy pods                                                                          | ``                                                |
+Parameter | Description | Default
+--- | --- | ---
+`args` | Command-line args passed to Envoy | `["-l", "$loglevel", "-c", "/config/envoy.yaml"]`
+`argsTemplate` | Golang template of command-line args passed to Envoy. Must be a string containing a template snippet rather than YAML array. Prefered over `args` if both are set | ``
+`files.envoy\.yaml` | content of a full envoy configuration file as documented in https://www.envoyproxy.io/docs/envoy/latest/configuration/configuration | See [values.yaml](values.yaml)
+`templates.envoy\.yaml` | golang template of a full configuration file. Use the `{{ .Values.foo.bar }}` syntax to embed chart values | See [values.yaml](values.yaml)
+`serviceMonitor.enabled` | if `true`, creates a Prometheus Operator ServiceMonitor | `false`
+`serviceMonitor.interval` | Interval that Prometheus scrapes Envoy metrics | `15s`
+`serviceMonitor.namespace` | Namespace which the operated Prometheus is running in | ``
+`serviceMonitor.additionalLabels` | Labels used by Prometheus Operator to discover your Service Monitor. Set according to your Prometheus setup | `{}`
+`prometheusRule.enabled` | If `true`, creates a Prometheus Operator PrometheusRule | `false`
+`prometheusRule.groups` | Prometheus alerting rules | `{}`
+`prometheusRule.additionalLabels` | Labels used by Prometheus Operator to discover your Prometheus Rule | `{}`| `volumes` | Additional volumes to be added to Envoy pods
+`volumeMounts` | Additional volume mounts to be added to Envoy containers(Primary containers of Envoy pods) | ``
+`initContainerTemplate` | Golang template of the init container added to Envoy pods| ``
+`sidecarContainersTemplate` | Golang template of additional containers added after the primary container of Envoy pods | ``
 
 All other user-configurable settings, default values and some commentary about them can be found in [values.yaml](values.yaml).

--- a/stable/envoy/README.md
+++ b/stable/envoy/README.md
@@ -26,16 +26,24 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the envoy chart and their default values.
 
-Parameter | Description | Default
---- | --- | ---
-`files.envoy\.yaml` | content of a full envoy configuration file as documented in https://www.envoyproxy.io/docs/envoy/latest/configuration/configuration | See [values.yaml](values.yaml)
-`templates.envoy\.yaml` | golang template of a full configuration file. Use the `{{ .Values.foo.bar }}` syntax to embed chart values | See [values.yaml](values.yaml)
-`serviceMonitor.enabled` | if `true`, creates a Prometheus Operator ServiceMonitor | `false`
-`serviceMonitor.interval` | Interval that Prometheus scrapes Envoy metrics | `15s`
-`serviceMonitor.namespace` | Namespace which the operated Prometheus is running in | ``
-`serviceMonitor.additionalLabels` | Labels used by Prometheus Operator to discover your Service Monitor. Set according to your Prometheus setup | `{}`
-| `prometheusRule.enabled` | If `true`, creates a Prometheus Operator PrometheusRule | `false``
-| `prometheusRule.groups` | Prometheus alerting rules | `{}`
-| `prometheusRule.additionalLabels` | Labels used by Prometheus Operator to discover your Prometheus Rule | `{}`
+| Parameter                         | Description                                                                                                                                                       | Default                                           |
+|-----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------|
+| `args`                            | Command-line args passed to Envoy                                                                                                                                 | `["-l", "$loglevel", "-c", "/config/envoy.yaml"]` |
+| `argsTemplate`                    | Golang template of command-line args passed to Envoy. Must be a string containing a template snippet rather than YAML array. Prefered over `args` if both are set | ``                                                |
+| `files.envoy\.yaml`               | content of a full envoy configuration file as documented in https://www.envoyproxy.io/docs/envoy/latest/configuration/configuration                               | See [values.yaml](values.yaml)                    |
+| `templates.envoy\.yaml`           | golang template of a full configuration file. Use the `{{ .Values.foo.bar }}` syntax to embed chart values                                                        | See [values.yaml](values.yaml)                    |
+| `serviceMonitor.enabled`          | if `true`, creates a Prometheus Operator ServiceMonitor                                                                                                           | `false`                                           |
+| `serviceMonitor.interval`         | Interval that Prometheus scrapes Envoy metrics                                                                                                                    | `15s`                                             |
+| `serviceMonitor.namespace`        | Namespace which the operated Prometheus is running in                                                                                                             | ``                                                |
+| `serviceMonitor.additionalLabels` | Labels used by Prometheus Operator to discover your Service Monitor. Set according to your Prometheus setup                                                       | `{}`                                              |
+| `prometheusRule.enabled`          | If `true`, creates a Prometheus Operator PrometheusRule                                                                                                           | `false``                                          |
+| `prometheusRule.groups`           | Prometheus alerting rules                                                                                                                                         | `{}`                                              |
+| `prometheusRule.additionalLabels` | Labels used by Prometheus Operator to discover your Prometheus Rule                                                                                               | `{}`                                              |
+| `prometheusRule.additionalLabels` | Labels used by Prometheus Operator to discover your Prometheus Rule                                                                                               | `{}`                                              |
+| `prometheusRule.additionalLabels` | Labels used by Prometheus Operator to discover your Prometheus Rule                                                                                               | `{}`                                              |
+| `volumes`                         | Additional volumes to be added to Envoy pods                                                                                                                      | ``                                                |
+| `volumeMounts`                    | Additional volume mounts to be added to Envoy containers(Primary containers of Envoy pods)                                                                        | ``                                                |
+| `initContainerTemplate`           | Golang template of the init container added to Envoy pods                                                                                                         | ``                                                |
+| `sidecarContainersTemplate`       | Golang template of additional containers added after the primary container of Envoy pods                                                                          | ``                                                |
 
 All other user-configurable settings, default values and some commentary about them can be found in [values.yaml](values.yaml).

--- a/stable/envoy/templates/deployment.yaml
+++ b/stable/envoy/templates/deployment.yaml
@@ -80,7 +80,11 @@ spec:
           {{- range $key, $value := .Values.secretMounts }}
             - name: {{ $key }}
               mountPath: {{ $value.mountPath }}
-          {{- end }}
+            {{- end }}
+
+{{ if .Values.sidecarContainersTemplate -}}
+{{ tpl .Values.sidecarContainersTemplate $ | indent 8 }}
+      {{ end -}}
 
     {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/stable/envoy/templates/deployment.yaml
+++ b/stable/envoy/templates/deployment.yaml
@@ -81,7 +81,10 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /config
-          {{- range $key, $value := .Values.secretMounts }}
+          {{- if .Values.volumeMounts }}
+{{ toYaml .Values.volumeMounts | indent 12 }}
+            {{- end }}
+            {{- range $key, $value := .Values.secretMounts }}
             - name: {{ $key }}
               mountPath: {{ $value.mountPath }}
             {{- end }}
@@ -106,6 +109,9 @@ spec:
         - name: config
           configMap:
             name: {{ template "envoy.fullname" . }}
+      {{- if .Values.volumes }}
+{{ toYaml .Values.volumes | indent 8 }}
+      {{- end }}
       {{- range $key, $value := .Values.secretMounts }}
         - name: {{ $key }}
           secret:

--- a/stable/envoy/templates/deployment.yaml
+++ b/stable/envoy/templates/deployment.yaml
@@ -54,7 +54,11 @@ spec:
           command:
 {{ toYaml .Values.command | indent 12 }}
           args:
+          {{- if $.Values.argsTemplate }}
+{{ tpl $.Values.argsTemplate $ | indent 12}}
+          {{- else }}
 {{ toYaml .Values.args | indent 12 }}
+          {{- end }}
           ports:
 {{- with .Values.ports }}
   {{- range $key, $port := . }}

--- a/stable/envoy/templates/deployment.yaml
+++ b/stable/envoy/templates/deployment.yaml
@@ -14,107 +14,107 @@ spec:
       app: {{ template "envoy.name" . }}
       release: {{ .Release.Name }}
   strategy:
-{{ .Values.strategy | indent 4 }}
+    {{ .Values.strategy | nindent 4 }}
   template:
     metadata:
       labels:
         app: {{ template "envoy.name" . }}
         release: {{ .Release.Name }}
         component: controller
-      {{- if .Values.podLabels }}
+        {{- if .Values.podLabels }}
         ## Custom pod labels
         {{- range $key, $value := .Values.podLabels }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
-      {{- end }}
+        {{- end }}
       annotations:
         checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
-      {{- if .Values.podAnnotations }}
+        {{- if .Values.podAnnotations }}
         ## Custom pod annotations
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
-      {{- end }}
+        {{- end }}
     spec:
       securityContext:
-{{ toYaml .Values.securityContext | indent 8 }}
-{{- if .Values.priorityClassName }}
+        {{ toYaml .Values.securityContext | nindent 8 }}
+      {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
-{{- end }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
-      {{ if .Values.initContainersTemplate -}}
+      {{- if .Values.initContainersTemplate }}
       initContainers:
-{{ tpl .Values.initContainersTemplate $ | indent 8 }}
-      {{ end -}}
+        {{ tpl .Values.initContainersTemplate $ | nindent 8 }}
+      {{- end }}
       containers:
 
         - name: envoy
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
-{{ toYaml .Values.command | indent 12 }}
+            {{ toYaml .Values.command | nindent 12 }}
           args:
-          {{- if $.Values.argsTemplate }}
-{{ tpl $.Values.argsTemplate $ | indent 12}}
-          {{- else }}
-{{ toYaml .Values.args | indent 12 }}
-          {{- end }}
+            {{- if $.Values.argsTemplate }}
+            {{ tpl $.Values.argsTemplate $ | nindent 12}}
+            {{- else }}
+            {{ toYaml .Values.args | nindent 12 }}
+            {{- end }}
           ports:
-{{- with .Values.ports }}
-  {{- range $key, $port := . }}
+            {{- with .Values.ports }}
+            {{- range $key, $port := . }}
             - name: {{ $key }}
-{{ toYaml $port | indent 14 }}
-  {{- end }}
-{{- end }}
+              {{ toYaml $port | nindent 14 }}
+            {{- end }}
+            {{- end }}
 
           livenessProbe:
-{{ toYaml .Values.livenessProbe | indent 12 }}
+            {{ toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-{{ toYaml .Values.readinessProbe | indent 12 }}
+            {{ toYaml .Values.readinessProbe | nindent 12 }}
           env:
           {{- range $key, $value := .Values.env }}
             - name: {{ $key | upper | replace "." "_" }}
               value: {{ $value | quote }}
           {{- end }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+            {{ toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: config
               mountPath: /config
-          {{- if .Values.volumeMounts }}
-{{ toYaml .Values.volumeMounts | indent 12 }}
+            {{- if .Values.volumeMounts }}
+            {{ toYaml .Values.volumeMounts | nindent 12 }}
             {{- end }}
             {{- range $key, $value := .Values.secretMounts }}
             - name: {{ $key }}
               mountPath: {{ $value.mountPath }}
             {{- end }}
 
-{{ if .Values.sidecarContainersTemplate -}}
-{{ tpl .Values.sidecarContainersTemplate $ | indent 8 }}
-      {{ end -}}
+        {{- if .Values.sidecarContainersTemplate }}
+        {{ tpl .Values.sidecarContainersTemplate $ | nindent 8 }}
+        {{- end }}
 
-    {{- with .Values.nodeSelector }}
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: config
           configMap:
             name: {{ template "envoy.fullname" . }}
-      {{- if .Values.volumes }}
-{{ toYaml .Values.volumes | indent 8 }}
-      {{- end }}
-      {{- range $key, $value := .Values.secretMounts }}
+        {{- if .Values.volumes }}
+        {{ toYaml .Values.volumes | nindent 8 }}
+        {{- end }}
+        {{- range $key, $value := .Values.secretMounts }}
         - name: {{ $key }}
           secret:
             secretName: {{ $value.secretName }}
             defaultMode: {{ $value.defaultMode }}
-      {{- end }}
+        {{- end }}

--- a/stable/envoy/templates/deployment.yaml
+++ b/stable/envoy/templates/deployment.yaml
@@ -42,6 +42,10 @@ spec:
       priorityClassName: "{{ .Values.priorityClassName }}"
 {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{ if .Values.initContainersTemplate -}}
+      initContainers:
+{{ tpl .Values.initContainersTemplate $ | indent 8 }}
+      {{ end -}}
       containers:
 
         - name: envoy

--- a/stable/envoy/values.yaml
+++ b/stable/envoy/values.yaml
@@ -258,6 +258,25 @@ files:
 #     - name: xds
 #       mountPath: /srv/runtime
 
+## Sidecar containers
+# sidecarContainersTemplate: |-
+#   - name: xds-update
+#     image: mumoshu/envoy-xds-configmap-loader:canary-6090275
+#     command:
+#     - envoy-xds-configmap-loader
+#     args:
+#     - --configmap={{ template "envoy.fullname" . }}-xds
+#     - --sync-interval=5s
+#     - --insecure
+#     env:
+#     - name: POD_NAMESPACE
+#       valueFrom:
+#         fieldRef:
+#           fieldPath: metadata.namespace
+#     volumeMounts:
+#     - name: xds
+#       mountPath: /srv/runtime
+
 ## ServiceMonitor consumed by prometheus-operator
 serviceMonitor:
   ## If the operator is installed in your cluster, set to true to create a Service Monitor Entry

--- a/stable/envoy/values.yaml
+++ b/stable/envoy/values.yaml
@@ -20,7 +20,6 @@ image:
 command:
   - /usr/local/bin/envoy
 args:
-  - --v2-config-only
   - -l
   - $loglevel
   - -c

--- a/stable/envoy/values.yaml
+++ b/stable/envoy/values.yaml
@@ -13,16 +13,13 @@ strategy: |
     maxUnavailable: 1
 
 image:
-  repository: envoyproxy/envoy-alpine
-  tag: d920944aed67425f91fc203774aebce9609e5d9a
-  ## ^ ref: https://github.com/envoyproxy/envoy/commit/d920944aed67425f91fc203774aebce9609e5d9a
+  repository: envoyproxy/envoy
+  tag: v1.11.1
   pullPolicy: IfNotPresent
 
 command:
-  - /usr/bin/dumb-init
-  - --
-args:
   - /usr/local/bin/envoy
+args:
   - --v2-config-only
   - -l
   - $loglevel

--- a/stable/envoy/values.yaml
+++ b/stable/envoy/values.yaml
@@ -29,6 +29,11 @@ args:
   - -c
   - /config/envoy.yaml
 
+## Args template allows you to use Chart template expressions to dynamically generate args
+# argsTemplate: |-
+#   - -c
+#   - /docker-entrypoint.sh envoy --service-node ${POD_NAME} --service-cluster {{ template "envoy.fullname" . }} -l debug -c /config/envoy.yaml
+
 ## Client service.
 service:
   enabled: true

--- a/stable/envoy/values.yaml
+++ b/stable/envoy/values.yaml
@@ -244,6 +244,16 @@ files:
 #         tls_context:
 #           sni: www.google.com
 
+## Additional volumes to be added to Envoy pods
+# volumes:
+# - name: xds
+#   emptyDir: {}
+
+## Additional volume mounts to be added to Envoy containers(Primary containers of Envoy pods)
+# volumeMounts:
+# - name: xds
+#   mountPath: /srv/runtime
+
 ## Init containers
 # initContainersTemplate: |-
 #   - name: xds-init

--- a/stable/envoy/values.yaml
+++ b/stable/envoy/values.yaml
@@ -239,6 +239,25 @@ files:
 #         tls_context:
 #           sni: www.google.com
 
+## Init containers
+# initContainersTemplate: |-
+#   - name: xds-init
+#     image: mumoshu/envoy-xds-configmap-loader:canary-6090275
+#     command:
+#     - envoy-xds-configmap-loader
+#     args:
+#     - --configmap={{ template "envoy.fullname" . }}-xds
+#     - --onetime
+#     - --insecure
+#     env:
+#     - name: POD_NAMESPACE
+#       valueFrom:
+#         fieldRef:
+#           fieldPath: metadata.namespace
+#     volumeMounts:
+#     - name: xds
+#       mountPath: /srv/runtime
+
 ## ServiceMonitor consumed by prometheus-operator
 serviceMonitor:
   ## If the operator is installed in your cluster, set to true to create a Service Monitor Entry


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

Add the `stable/envoy` chart more configuration options for wider use-cases.

#### Special notes for your reviewer:

@josdotso I've added several configuration options that seemed general and useful enough to be included in this chart, while I was making [restart-less config reload available to Envoy](https://github.com/mumoshu/envoy-xds-configmap-loader) deployed from this chart.

The number of changes are relatively large but I think it's reviewable if you see each commit 🙏 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
