### PR TITLE
[stable/fluent-bit] Add ignore_older parameter support for tail input…

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.7.0
+version: 2.7.1
 appVersion: 1.2.2
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -114,6 +114,7 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `input.tail.memBufLimit`           | Specify Mem_Buf_Limit in tail input        | `5MB`                                             |
 | `input.tail.parser`                | Specify Parser in tail input.        | `docker`                                             |
 | `input.tail.path`                  | Specify log file(s) through the use of common wildcards.        | `/var/log/containers/*.log`                                             |
+| `input.tail.ignore_older`          | Ignores files that have been last modified before this time in seconds. Supports m,h,d (minutes, hours,days) syntax.        | `false`                                             |
 | `input.systemd.enabled`            | [Enable systemd input](https://docs.fluentbit.io/manual/input/systemd)                   | `false`                                       |
 | `input.systemd.filters.systemdUnit` | Please see https://docs.fluentbit.io/manual/input/systemd | `[docker.service, kubelet.service`, `node-problem-detector.service]`                                       |
 | `input.systemd.maxEntries`         | Please see https://docs.fluentbit.io/manual/input/systemd | `1000`                             |

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -114,7 +114,7 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `input.tail.memBufLimit`           | Specify Mem_Buf_Limit in tail input        | `5MB`                                             |
 | `input.tail.parser`                | Specify Parser in tail input.        | `docker`                                             |
 | `input.tail.path`                  | Specify log file(s) through the use of common wildcards.        | `/var/log/containers/*.log`                                             |
-| `input.tail.ignore_older`          | Ignores files that have been last modified before this time in seconds. Supports m,h,d (minutes, hours,days) syntax.        | `false`                                             |
+| `input.tail.ignore_older`          | Ignores files that have been last modified before this time in seconds. Supports m,h,d (minutes, hours,days) syntax.        | ``                                             |
 | `input.systemd.enabled`            | [Enable systemd input](https://docs.fluentbit.io/manual/input/systemd)                   | `false`                                       |
 | `input.systemd.filters.systemdUnit` | Please see https://docs.fluentbit.io/manual/input/systemd | `[docker.service, kubelet.service`, `node-problem-detector.service]`                                       |
 | `input.systemd.maxEntries`         | Please see https://docs.fluentbit.io/manual/input/systemd | `1000`                             |

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -33,6 +33,9 @@ data:
         Refresh_Interval 5
         Mem_Buf_Limit    {{ .Values.input.tail.memBufLimit }}
         Skip_Long_Lines  On
+{{- if .Values.input.tail.ignore_older }}
+        Ignore_Older    {{ .Values.input.tail.ignore_older }}
+{{- end }}
 {{- if .Values.trackOffsets }}
         DB               /tail-db/tail-containers-state.db
         DB.Sync          Normal

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -221,7 +221,7 @@ input:
     memBufLimit: 5MB
     parser: docker
     path: /var/log/containers/*.log
-    ignore_older: false
+    ignore_older: ""
   systemd:
     enabled: false
     filters:

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -221,6 +221,7 @@ input:
     memBufLimit: 5MB
     parser: docker
     path: /var/log/containers/*.log
+    ignore_older: false
   systemd:
     enabled: false
     filters:


### PR DESCRIPTION
… plugin

#### Is this a new chart
No

#### What this PR does / why we need it:

This MR add support for `ignore_older` parameter for tail input plugin introduced in fluent-bit 0.14.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
