### PR TITLE
[stable/wordpress] Fixes service.type value for production

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 7.3.7
+version: 7.3.8
 appVersion: 5.2.3
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -180,12 +180,6 @@ $ helm install --name my-release -f ./values-production.yaml stable/wordpress
 + replicaCount: 3
 ```
 
-- Kubernetes Service type:
-```diff
-- service.type: LoadBalancer
-+ service.type: ClusterIP
-```
-
 - Enable client source IP preservation:
 ```diff
 - service.externalTrafficPolicy: Cluster

--- a/stable/wordpress/values-production.yaml
+++ b/stable/wordpress/values-production.yaml
@@ -188,7 +188,7 @@ mariadb:
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer or ClusterIP
 ##
 service:
-  type: ClusterIP
+  type: LoadBalancer
   # HTTP Port
   port: 80
   # HTTPS Port


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes the default value for `service.type` in the production values file.

#### Which issue this PR fixes
  - fixes #17438 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
