### PR TITLE
[incubator/jaeger] Expose zipkinPort on collector when set

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.15.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.17.3
+version: 0.17.4
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -105,7 +105,7 @@ spec:
             value: /etc/conf/strategies.json
           {{- end }}
           - name: COLLECTOR_ZIPKIN_HTTP_PORT
-            value: {{ .Values.collector.service.zipkinPort }}
+            value: {{ .Values.collector.service.zipkinPort | quote }}
         ports:
         - containerPort: {{ .Values.collector.service.grpcPort }}
           name: grpc

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -103,6 +103,9 @@ spec:
           {{- if .Values.collector.samplingConfig}}
           - name: SAMPLING_STRATEGIES_FILE
             value: /etc/conf/strategies.json
+          {{- if hasKey .Values.collector.service "zipkinPort" }}
+          - name: COLLECTOR_ZIPKIN_HTTP_PORT
+            value: {{ .Values.collector.service.zipkinPort }}
           {{- end }}
         ports:
         - containerPort: {{ .Values.collector.service.grpcPort }}
@@ -117,9 +120,11 @@ spec:
         - containerPort: 14269
           name: admin
           protocol: TCP
+        {{- if hasKey .Values.collector.service "zipkinPort" }}
         - containerPort: {{ .Values.collector.service.zipkinPort }}
           name: zipkin
           protocol: TCP
+        {{- end }}}
         readinessProbe:
           httpGet:
             path: /

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -103,10 +103,9 @@ spec:
           {{- if .Values.collector.samplingConfig}}
           - name: SAMPLING_STRATEGIES_FILE
             value: /etc/conf/strategies.json
-          {{- if hasKey .Values.collector.service "zipkinPort" }}
+          {{- end }}
           - name: COLLECTOR_ZIPKIN_HTTP_PORT
             value: {{ .Values.collector.service.zipkinPort }}
-          {{- end }}
         ports:
         - containerPort: {{ .Values.collector.service.grpcPort }}
           name: grpc
@@ -120,11 +119,9 @@ spec:
         - containerPort: 14269
           name: admin
           protocol: TCP
-        {{- if hasKey .Values.collector.service "zipkinPort" }}
         - containerPort: {{ .Values.collector.service.zipkinPort }}
           name: zipkin
           protocol: TCP
-        {{- end }}}
         readinessProbe:
           httpGet:
             path: /

--- a/incubator/jaeger/templates/collector-svc.yaml
+++ b/incubator/jaeger/templates/collector-svc.yaml
@@ -32,7 +32,7 @@ spec:
     port: {{ .Values.collector.service.zipkinPort }}
     protocol: TCP
     targetPort: zipkin
-  {{- end }}}
+  {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "jaeger.name" . }}
     app.kubernetes.io/component: collector

--- a/incubator/jaeger/templates/collector-svc.yaml
+++ b/incubator/jaeger/templates/collector-svc.yaml
@@ -27,10 +27,12 @@ spec:
     port: {{ .Values.collector.service.httpPort }}
     protocol: TCP
     targetPort: http
+  {{- if hasKey .Values.collector.service "zipkinPort" }}
   - name: zipkin
     port: {{ .Values.collector.service.zipkinPort }}
     protocol: TCP
     targetPort: zipkin
+  {{- end }}}
   selector:
     app.kubernetes.io/name: {{ include "jaeger.name" . }}
     app.kubernetes.io/component: collector

--- a/incubator/jaeger/templates/collector-svc.yaml
+++ b/incubator/jaeger/templates/collector-svc.yaml
@@ -27,12 +27,10 @@ spec:
     port: {{ .Values.collector.service.httpPort }}
     protocol: TCP
     targetPort: http
-  {{- if hasKey .Values.collector.service "zipkinPort" }}
   - name: zipkin
     port: {{ .Values.collector.service.zipkinPort }}
     protocol: TCP
     targetPort: zipkin
-  {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "jaeger.name" . }}
     app.kubernetes.io/component: collector


### PR DESCRIPTION
@dvonthenen @pavelnikolov @naseemkullah 

#### What this PR does / why we need it:

The helm chart currently doesn't set the environment variable `COLLECTOR_ZIPKIN_HTTP_PORT` in jaeger-collector, although a `zipkin` port is set in the deployment and service, as well in the values by default. Without the environment variable jaeger-collector does not listen on that port. This PR changes that behavior to set this requirement variable when a value for `zipkinPort` is set and to not expose the container and service port, when `zipkinPort` is unset.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #16072 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
