### PR TITLE
fix service account name reference

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.18.2
+version: 0.18.3
 appVersion: 1.3

--- a/stable/kong/templates/_helpers.tpl
+++ b/stable/kong/templates/_helpers.tpl
@@ -35,7 +35,7 @@ Create the name of the service account to use
 {{- if .Values.ingressController.serviceAccount.create -}}
     {{ default (include "kong.fullname" .) .Values.ingressController.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
+    {{ default "default" .Values.ingressController.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
#### Is this a new chart

no

#### What this PR does / why we need it:

In EKS the created cluster role is missing the following rule, in order to successfully provision an ingress controller for kong.

```
rule {
    api_groups = [
      "networking.k8s.io"
    ]
    resources = [
      "ingresses"
    ]
    verbs = [
      "get",
      "list",
      "watch"
    ]
  }
```

To fix this we would like to use a custom service account and set `.Values.ingressController.serviceAccount.create` to `false` and provide a custom name in `.Values.ingressController.serviceAccount.name`. This fails with the message 

```
render error in "kong/templates/controller-rbac-role-binding.yaml": template: kong/templates/_helpers.tpl:38:32: executing "kong.serviceAccountName" at <.Values.serviceAccount.name>: nil pointer evaluating interface {}.name
```

This is caused by a incorrect reference in `_helpers`. This is fixed by this PR.

