### PR TITLE
[stable/pomerium] Bump version to pomerium 0.3.1

### DIFF
--- a/stable/pomerium/Chart.yaml
+++ b/stable/pomerium/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: pomerium
-version: 2.0.0
-appVersion: 0.3.0
+version: 2.0.1
+appVersion: 0.3.1
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo.svg
 description: Pomerium is an identity-aware access proxy.

--- a/stable/pomerium/values.yaml
+++ b/stable/pomerium/values.yaml
@@ -120,7 +120,7 @@ extraVolumes: {}
 
 image:
   repository: "pomerium/pomerium"
-  tag: "v0.3.0"
+  tag: "v0.3.1"
   pullPolicy: "IfNotPresent"
 
 metrics:


### PR DESCRIPTION
#### What this PR does / why we need it:
Updates Pomerium to 0.3.1 to address CVE-2019-16276

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
