### PR TITLE
[incubator/solr] Added namespace to SOLR_HOST

### DIFF
--- a/incubator/solr/Chart.yaml
+++ b/incubator/solr/Chart.yaml
@@ -2,7 +2,7 @@
 
 apiVersion: "v1"
 name: "solr"
-version: "1.2.0"
+version: "1.2.1"
 appVersion: "7.7.2"
 description: "A helm chart to install Apache Solr: http://lucene.apache.org/solr/"
 keywords:

--- a/incubator/solr/README.md
+++ b/incubator/solr/README.md
@@ -32,7 +32,7 @@ The following table shows the configuration options for the Solr helm chart:
 | `extraEnvVars`                                | Additional environment variables to set on the solr pods (in yaml syntax) | `[]` |
 | `terminationGracePeriodSeconds`               | The termination grace period of the Solr pods | `180`|
 | `image.repository`                            | The repository to pull the docker image from| `solr`                                                                |
-| `image.tag`                                   | The tag on the repository to pull | `7.6.0`                                                               |
+| `image.tag`                                   | The tag on the repository to pull | `7.7.2`                                                               |
 | `image.pullPolicy`                            | Solr pod pullPolicy | `IfNotPresent`                                                              |
 | `livenessProbe.initialDelaySeconds`           | Inital Delay for Solr pod liveness probe | `20`                                                                  |
 | `livenessProbe.periodSeconds`                 | Poll rate for liveness probe | `10`                                                                  |

--- a/incubator/solr/templates/statefulset.yaml
+++ b/incubator/solr/templates/statefulset.yaml
@@ -148,7 +148,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: "SOLR_HOST"
-              value: "$(POD_HOSTNAME).{{ include "solr.headless-service-name" . }}"
+              value: "$(POD_HOSTNAME).{{ include "solr.headless-service-name" . }}.{{ .Release.Namespace }}"
             - name: "ZK_HOST"
               value: "{{ include "solr.zookeeper-name" . }}:2181"
             - name: "SOLR_LOG_LEVEL"


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This PR fixes:
- Unable to connect to solr from another namespace using CloudSolrClient with zkhosts param

Using CloudSolrClient will retrieve a list of solr hosts from zk without the .namespace domain name. This results in non-namespaced solr hosts being passed to the LBHttpSolrClient (solr-0.solr-headless,...), which cant be resolve from another namespace.

To correct this, solr should be configured to use a namespaced host name (solr-0.solr-headless.namespace,...) such that the LBHttpSolrClient can to connect to solr from another namespace.

#### Special notes for your reviewer:
Solr successfully launches with the default params.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
