### PR TITLE
[stable/postgresql] Fix rediness probe for bitnami images

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 6.3.9
+version: 6.3.10
 appVersion: 11.5.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/statefulset-slaves.yaml
+++ b/stable/postgresql/templates/statefulset-slaves.yaml
@@ -158,6 +158,7 @@ spec:
             command:
             - sh
             - -c
+            - -e
             {{- include "postgresql.readinessProbeCommand" . | nindent 12 }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -183,6 +183,7 @@ spec:
             command:
             - sh
             - -c
+            - -e
             {{- include "postgresql.readinessProbeCommand" . | nindent 12 }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}


### PR DESCRIPTION
The readiness probe for the postgresql startup got broken by commit https://github.com/helm/charts/commit/60d89aa1651844d68df0fbed18c910deee25dc64 
because the refactoring misses the `&&`

/cc @desaintmartin 
/cc @tompizmor 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
