### PR TITLE
[stable/external-dns] Kubefed support and compatibility, allow external crd resources

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.6.4
+version: 2.6.5
 appVersion: 0.5.17
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -109,7 +109,7 @@ The following table lists the configurable parameters of the external-dns chart 
 | `annotationFilter`                 | Filter sources managed by external-dns via annotation using label selector (optional)                    | `""`                                                     |
 | `domainFilters`                    | Limit possible target zones by domain suffixes (optional)                                                | `[]`                                                     |
 | `zoneIdFilters`                    | Limit possible target zones by zone id (optional)                                                        | `[]`                                                     |
-| `crd.create`                       | Install the integrated DNSEndpoint CRD                                                                   | `false`                                                  |
+| `crd.create`                       | Install and use the integrated DNSEndpoint CRD                                                           | `false`                                                  |
 | `crd.apiversion`                   | Sets the API version for the CRD to watch                                                                | `""`                                                     |
 | `crd.kind`                         | Sets the kind for the CRD to watch                                                                       | `""`                                                     |
 | `dryRun`                           | When enabled, prints DNS record changes rather than actually performing them (optional)                  | `false`                                                  |

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -109,9 +109,9 @@ The following table lists the configurable parameters of the external-dns chart 
 | `annotationFilter`                 | Filter sources managed by external-dns via annotation using label selector (optional)                    | `""`                                                     |
 | `domainFilters`                    | Limit possible target zones by domain suffixes (optional)                                                | `[]`                                                     |
 | `zoneIdFilters`                    | Limit possible target zones by zone id (optional)                                                        | `[]`                                                     |
-| `crd.create`                       | If true, create CRD ressource                                                                            | `false`                                                  |
-| `crd.apiversion`                   | Sets the API version for the CRD to watch                                                                | `"`                                                      |
-| `crd.kind`                         | Sets the kind for the CRD to watch                                                                       | `"`                                                      |
+| `crd.create`                       | Installs the integrated DNSEndpoint CRD                                                                  | `false`                                                  |
+| `crd.apiversion`                   | Sets the API version for the CRD to watch                                                                | `""`                                                     |
+| `crd.kind`                         | Sets the kind for the CRD to watch                                                                       | `""`                                                     |
 | `dryRun`                           | When enabled, prints DNS record changes rather than actually performing them (optional)                  | `false`                                                  |
 | `logLevel`                         | Verbosity of the logs (options: panic, debug, info, warn, error, fatal)                                  | `info`                                                   |
 | `interval`                         | Interval update period to use                                                                            | `1m`                                                     |

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -109,7 +109,7 @@ The following table lists the configurable parameters of the external-dns chart 
 | `annotationFilter`                 | Filter sources managed by external-dns via annotation using label selector (optional)                    | `""`                                                     |
 | `domainFilters`                    | Limit possible target zones by domain suffixes (optional)                                                | `[]`                                                     |
 | `zoneIdFilters`                    | Limit possible target zones by zone id (optional)                                                        | `[]`                                                     |
-| `crd.create`                       | Installs the integrated DNSEndpoint CRD                                                                  | `false`                                                  |
+| `crd.create`                       | Install the integrated DNSEndpoint CRD                                                                   | `false`                                                  |
 | `crd.apiversion`                   | Sets the API version for the CRD to watch                                                                | `""`                                                     |
 | `crd.kind`                         | Sets the kind for the CRD to watch                                                                       | `""`                                                     |
 | `dryRun`                           | When enabled, prints DNS record changes rather than actually performing them (optional)                  | `false`                                                  |

--- a/stable/external-dns/templates/_helpers.tpl
+++ b/stable/external-dns/templates/_helpers.tpl
@@ -248,3 +248,4 @@ WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.t
 +info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
 {{- end }}
 {{- end -}}
+

--- a/stable/external-dns/templates/_helpers.tpl
+++ b/stable/external-dns/templates/_helpers.tpl
@@ -248,4 +248,3 @@ WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.t
 +info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
 {{- end }}
 {{- end -}}
-

--- a/stable/external-dns/templates/clusterrole.yaml
+++ b/stable/external-dns/templates/clusterrole.yaml
@@ -41,14 +41,27 @@ rules:
   {{- end }}
   resources:
   {{- if .Values.crd.create }}
-  - dnsendpoints/status
+  - dnsendpoints
   {{- else }}
-  - {{ printf "%ss/status" (.Values.crd.kind | lower) }}
+  - {{ printf "%ss" (.Values.crd.kind | lower) }}
   {{- end }}
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  {{- if .Values.crd.create }}
+  - externaldns.k8s.io
+  {{- else }}
+  - {{ $api := splitn "/" 2 .Values.crd.apiversion }}{{ $api._0 }}
+  {{- end }}
+  resources:
+  {{- if .Values.crd.create }}
+  - dnsendpoints/status
+  {{- else }}
+  - {{ printf "%ss/status" (.Values.crd.kind | lower) }}
+  {{- end }}
+  verbs:
   - update
 {{- end }}
 {{- end }}

--- a/stable/external-dns/templates/clusterrole.yaml
+++ b/stable/external-dns/templates/clusterrole.yaml
@@ -32,20 +32,23 @@ rules:
   - get
   - list
   - watch
+{{- if or .Values.crd.create .Values.crd.apiversion }}
 - apiGroups:
+  {{- if .Values.crd.create }}
   - externaldns.k8s.io
+  {{- else }}
+  - {{ $api := splitn "/" 2 .Values.crd.apiversion }}{{ $api._0 }}
+  {{- end }}
   resources:
-  - dnsendpoints
+  {{- if .Values.crd.create }}
+  - dnsendpoints/status
+  {{- else }}
+  - {{ printf "%ss/status" (.Values.crd.kind | lower) }}
+  {{- end }}
   verbs:
   - get
   - list
   - watch
-{{- if .Values.crd.create }}
-- apiGroups:
-  - externaldns.k8s.io
-  resources:
-  - dnsendpoints/status
-  verbs:
   - update
 {{- end }}
 {{- end }}

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -78,13 +78,11 @@ spec:
         {{- if .Values.annotationFilter }}
         - --annotation-filter={{ .Values.annotationFilter }}
         {{- end }}
-        {{- if .Values.crd.create }}
-          {{- if .Values.crd.apiversion }}
+        {{- if .Values.crd.apiversion }}
         - --crd-source-apiversion={{ .Values.crd.apiversion }}
-          {{- end }}
-          {{- if .Values.crd.kind }}
+        {{- end }}
+        {{- if .Values.crd.kind }}
         - --crd-source-kind={{ .Values.crd.kind }}
-          {{- end }}
         {{- end }}
         {{- range .Values.istioIngressGateways }}
         - --istio-ingress-gateway={{ . }}

--- a/stable/external-dns/values-production.yaml
+++ b/stable/external-dns/values-production.yaml
@@ -283,10 +283,12 @@ podLabels: {}
 ##
 priorityClassName: ""
 
-## Installs the DNSEndpoint CRD
+## Options for the source type "crd"
 ##
 crd:
+  ## Installs the integrated DNSEndpoint CRD
   create: false
+  ## Change these to use an external DNSEndpoint CRD (E.g. from kubefed)
   apiversion: ""
   kind: ""
 

--- a/stable/external-dns/values-production.yaml
+++ b/stable/external-dns/values-production.yaml
@@ -286,7 +286,7 @@ priorityClassName: ""
 ## Options for the source type "crd"
 ##
 crd:
-  ## Installs the integrated DNSEndpoint CRD
+  ## Install and use the integrated DNSEndpoint CRD
   create: false
   ## Change these to use an external DNSEndpoint CRD (E.g. from kubefed)
   apiversion: ""

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -283,10 +283,12 @@ podLabels: {}
 ##
 priorityClassName: ""
 
-## Installs the DNSEndpoint CRD
+## Options for the source type "crd"
 ##
 crd:
+  ## Installs the integrated DNSEndpoint CRD
   create: false
+  ## Change these to use an external DNSEndpoint CRD (E.g. from kubefed)
   apiversion: ""
   kind: ""
 

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -286,7 +286,7 @@ priorityClassName: ""
 ## Options for the source type "crd"
 ##
 crd:
-  ## Installs the integrated DNSEndpoint CRD
+  ## Install and use the integrated DNSEndpoint CRD
   create: false
   ## Change these to use an external DNSEndpoint CRD (E.g. from kubefed)
   apiversion: ""


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

Support and compatibility with kubefed.

Currently the way this template is set up doesn't allow / correctly setups parameters and permissions to use external CRDs.

[Kubernetes Federation (kubefed)](https://github.com/kubernetes-sigs/kubefed) installs a [`dnsendpoints.multiclusterdns.kubefed.io` CRD](https://github.com/kubernetes-sigs/kubefed/blob/master/charts/kubefed/charts/controllermanager/templates/crds.yaml#L715) which external-dns should use, but the previous implementation didn't account for a CRD coming from outside external-dns (most things were encapsulated in `{{- if .Values.crd.create }}`).

[kubefed is even dependant on external-dns](https://github.com/kubernetes-sigs/kubefed/blob/master/docs/servicedns-with-externaldns.md) to enable multicluster service and ingress dns.

#### Special notes for your reviewer:
- compatibility with existing api ensured
  - no changes in values, just better clarification and expected outcomes when filling these options
- now only sets clusterrole if a CRD is even in use
- Maybe look into PR https://github.com/helm/charts/pull/17494 for the other part of kubefed compatibility

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)