### PR TITLE
[stable/chart/cluster-overprovisioner] Added labels and annotations to the deployments

### DIFF
--- a/stable/cluster-overprovisioner/Chart.yaml
+++ b/stable/cluster-overprovisioner/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: Installs the a deployment that overprovisions the cluster
 name: cluster-overprovisioner
 home: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler
-version: 0.2.4
+version: 0.2.5
 maintainers:
 - name: max-rocket-internet
   email: max.williams@deliveryhero.com

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -49,10 +49,12 @@ The following table lists the configurable parameters for this chart and their d
 | `deployments`                      | Define optional additional deployments                                                                                          | `[]`              |
 | `deployments[].name`               | Name for additional deployments (will be added as label cluster-over-provisioner-name, so you can match it with affinity rules) | ``                |
 | `deployments[].replicaCount`       | Number of replicas                                                                                                              | `1`               |
+| `deployments[].annotations`       | Annotations to add to the deployment                                                                                                              | `{}`               |
 | `deployments[].resources`          | Resources for the overprovision pods                                                                                            | `{}`              |
 | `deployments[].affinity`           | Map of node/pod affinities                                                                                                      | `{}`              |
 | `deployments[].nodeSelector`       | Node labels for pod assignment                                                                                                  | `{}`              |
 | `deployments[].tolerations`        | Optional deployment tolerations                                                                                                 | `[]`              |
+| `deployments[].labels`        | Optional labels tolerations                                                                                                 | `{}`              |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:

--- a/stable/cluster-overprovisioner/ci/additional-deploys-values.yaml
+++ b/stable/cluster-overprovisioner/ci/additional-deploys-values.yaml
@@ -15,4 +15,3 @@ deployments:
     tolerations: []
     affinity: {}
     labels: {}
-

--- a/stable/cluster-overprovisioner/ci/additional-deploys-values.yaml
+++ b/stable/cluster-overprovisioner/ci/additional-deploys-values.yaml
@@ -1,13 +1,18 @@
 deployments:
   - name: ci-test1
+    annotations: {}
     replicaCount: 1
     nodeSelector: {}
     resources: {}
     tolerations: []
     affinity: {}
+    labels: {}
   - name: ci-test2
+    annotations: {}
     replicaCount: 1
     nodeSelector: {}
     resources: {}
     tolerations: []
     affinity: {}
+    labels: {}
+

--- a/stable/cluster-overprovisioner/templates/deployments.yaml
+++ b/stable/cluster-overprovisioner/templates/deployments.yaml
@@ -29,10 +29,17 @@ spec:
       app.kubernetes.io/instance: {{ $relName }}
   template:
     metadata:
+    {{- with .annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       labels:
         app.kubernetes.io/name: {{ $name }}
         cluster-overprovisioner-name: {{ .name }}
         app.kubernetes.io/instance: {{ $relName }}
+    {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     spec:
       priorityClassName: {{ $priorityClassName }}
       containers:

--- a/stable/cluster-overprovisioner/values.yaml
+++ b/stable/cluster-overprovisioner/values.yaml
@@ -25,4 +25,3 @@ deployments: []
   #   tolerations: []
   #   affinity: {}
   #   labels: {}
-

--- a/stable/cluster-overprovisioner/values.yaml
+++ b/stable/cluster-overprovisioner/values.yaml
@@ -18,8 +18,11 @@ fullnameOverride: ""
 
 deployments: []
   # - name: default
+  #   annotations: {}
   #   replicaCount: 1
   #   nodeSelector: {}
   #   resources: {}
   #   tolerations: []
   #   affinity: {}
+  #   labels: {}
+


### PR DESCRIPTION
/cc @max-rocket-internet
/cc @mmingorance-dh

#### Is this a new chart
no

#### What this PR does / why we need it:
To extend the idea with overprovision ressources we add kube-downscaler annotations to have more or less overprovision depending on the time of the day.
Labels are required for us, because of strict labeling policy.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
