### PR TITLE
[stable/percona]: Resource and image overrides for initcontainer

### DIFF
--- a/stable/percona/Chart.yaml
+++ b/stable/percona/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: percona
-version: 1.1.0
+version: 1.1.1
 appVersion: 5.7.17
 description: free, fully compatible, enhanced, open source drop-in replacement for
   MySQL

--- a/stable/percona/Chart.yaml
+++ b/stable/percona/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: percona
-version: 1.1.1
+version: 1.2.0
 appVersion: 5.7.17
 description: free, fully compatible, enhanced, open source drop-in replacement for
   MySQL

--- a/stable/percona/templates/deployment.yaml
+++ b/stable/percona/templates/deployment.yaml
@@ -18,8 +18,10 @@ spec:
       {{- end }}
       initContainers:
       - name: "remove-lost-found"
-        image: "busybox:1.25.0"
-        imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+        image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
+        imagePullPolicy: {{ .Values.initImage.pullPolicy | quote }}
+        resources:
+{{ toYaml .Values.initResources | indent 10 }}
         command:
         - "rm"
         - "-fr"

--- a/stable/percona/values.yaml
+++ b/stable/percona/values.yaml
@@ -73,3 +73,20 @@ tolerations: []
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ##
 affinity: {}
+
+## Configure resources for the init container
+##
+initResources: {}
+  # limits:
+  #   cpu: 25m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 25m
+  #   memory 128Mi
+
+## Override image used by init container
+##
+initImage:
+  repository: "busybox"
+  tag: "1.25.0"
+  pullPolicy: "IfNotPresent"


### PR DESCRIPTION
Signed-off-by: Asmund Tokheim <tokheim@outlook.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No

#### What this PR does / why we need it:

Sets resources for percona init container so it can be used in namespaces with resource quotas. Also allows overriding init container image as most other charts do.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
