### PR TITLE
[incubator/kafka] Fix some API versions for Kubernetes 1.16 compatibility

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.18.2
+version: 0.19.0
 appVersion: 5.0.1
 keywords:
 - kafka

--- a/incubator/kafka/templates/deployment-kafka-exporter.yaml
+++ b/incubator/kafka/templates/deployment-kafka-exporter.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.prometheus.kafka.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kafka.fullname" . }}-exporter

--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- $advertisedListenersOverride := first (pluck "advertised.listeners" .Values.configurationOverrides) }}
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "kafka.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Kubernetes 1.16 has changed made a few API versions stable and deprecated the non-stable ones.

#### Which issue this PR fixes
./.

#### Special notes for your reviewer: ./.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
