### PR TITLE
[stable/elasticsearch-curator] Added compatibility for K8s 1.16

### DIFF
--- a/stable/elasticsearch-curator/Chart.yaml
+++ b/stable/elasticsearch-curator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "5.5.4"
 description: A Helm chart for Elasticsearch Curator
 name: elasticsearch-curator
-version: 2.0.1
+version: 2.0.2
 home: https://github.com/elastic/curator
 keywords:
 - curator

--- a/stable/elasticsearch-curator/templates/_helpers.tpl
+++ b/stable/elasticsearch-curator/templates/_helpers.tpl
@@ -12,6 +12,17 @@ Return the appropriate apiVersion for cronjob APIs.
 {{- end -}}
 
 {{/*
+Return the appropriate apiVersion for podsecuritypolicy.
+*/}}
+{{- define "podsecuritypolicy.apiVersion" -}}
+{{- if semverCompare "<1.10-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "policy/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "elasticsearch-curator.name" -}}

--- a/stable/elasticsearch-curator/templates/psp.yml
+++ b/stable/elasticsearch-curator/templates/psp.yml
@@ -1,5 +1,5 @@
 {{- if .Values.psp.create }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "podsecuritypolicy.apiVersion" . }}
 kind: PodSecurityPolicy
 metadata:
   labels:


### PR DESCRIPTION
Signed-off-by: Christian Kotzbauer <christian.kotzbauer@gmail.com>

#### What this PR does / why we need it:
Changed apiVersion of PodSecurityPolicy to be compatible with Kubernetes 1.16. (Older versions will use old apiVersion)

#### Special notes for your reviewer:
Nothing special

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
