### PR TITLE
[stable/pomerium] Fully address running Authorize as Headless

### DIFF
--- a/stable/pomerium/Chart.yaml
+++ b/stable/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 2.0.2
+version: 2.0.3
 appVersion: 0.3.1
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo.svg

--- a/stable/pomerium/templates/ingress.yaml
+++ b/stable/pomerium/templates/ingress.yaml
@@ -27,6 +27,7 @@ spec:
             backend:
               serviceName: {{ template "pomerium.proxy.fullname" . }}
               servicePort: https
+{{- if not .Values.service.authorize.headless }}
     - host:  {{ printf "authorize.%s" .Values.config.rootDomain }}
       http:
         paths:
@@ -34,6 +35,7 @@ spec:
             backend:
               serviceName: {{ template "pomerium.authorize.fullname" . }}
               servicePort: https
+{{- end }}
     - host: {{ printf "authenticate.%s" .Values.config.rootDomain }}
       http:
         paths:


### PR DESCRIPTION
#### What this PR does / why we need it:
Ensure headless Authorize runs as expected

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
