### PR TITLE
[stable/openldap] Fix 1.16 compatibility

### DIFF
--- a/stable/openldap/Chart.yaml
+++ b/stable/openldap/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: openldap
 home: https://www.openldap.org
-version: 1.2.1
+version: 1.2.2
 appVersion: 2.4.47
 description: Community developed LDAP software
 icon: http://www.openldap.org/images/headers/LDAPworm.gif

--- a/stable/openldap/README.md
+++ b/stable/openldap/README.md
@@ -27,6 +27,7 @@ The following table lists the configurable parameters of the openldap chart and 
 | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
 | `replicaCount`                     | Number of replicas                                                                                                                        | `1`                 |
 | `strategy`                         | Deployment strategy                                                                                                                       | `{}`                |
+| `apiVersion`                       | The API Version to use for the Deployment. This can be changed for backwards compatibility purposes                                       | `apps/v1`           |
 | `image.repository`                 | Container image repository                                                                                                                | `osixia/openldap`   |
 | `image.tag`                        | Container image tag                                                                                                                       | `1.1.10`            |
 | `image.pullPolicy`                 | Container pull policy                                                                                                                     | `IfNotPresent`      |

--- a/stable/openldap/templates/deployment.yaml
+++ b/stable/openldap/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: {{ .Values.apiVersion }}
 kind: Deployment
 metadata:
   name:  {{ template "openldap.fullname" . }}

--- a/stable/openldap/values.yaml
+++ b/stable/openldap/values.yaml
@@ -16,6 +16,9 @@ strategy: {}
   #
   # type: Recreate
   # rollingUpdate: null
+
+apiVersion: apps/v1
+
 image:
   # From repository https://github.com/osixia/docker-openldap
   repository: osixia/openldap


### PR DESCRIPTION
Due to the deprecation of the extensions/v1beta1 and apps/v1beta2 API groups
being deprecated, the deployment of this chart was no longer working.

This commit solves that by making the flag configurable through a value.

Deprecation announcement: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

Signed-off-by: Alexandru Bogdan Pica <dtk077@gmail.com>

#### What this PR does / why we need it:
This commit fixes compatibilty with k8s 1.16.
Right now, the chart cannot be deployed at all if deployment is attempted on a 1.16 cluster.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
