### PR TITLE
[stable/node-problem-detector] Custom env vars in daemonset

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-problem-detector
-version: "1.6.0"
+version: "1.6.1"
 appVersion: v0.7.0
 home: https://github.com/kubernetes/node-problem-detector
 description: Installs the node-problem-detector daemonset for monitoring extra attributes on nodes

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -51,12 +51,13 @@ The following table lists the configurable parameters for this chart and their d
 | `settings.custom_monitor_definitions` | User-specified custom monitor definitions  | `{}`                                                         |
 | `settings.log_monitors`               | System log monitor config files            | `/config/kernel-monitor.json`, `/config/docker-monitor.json` |
 | `settings.custom_plugin_monitors`     | Custom plugin monitor config files         | `[]`                                                         |
-| `settings.prometheus_address`         | Prometheus exporter address                | `0.0.0.0`                                                         |
-| `settings.prometheus_port`            | Prometheus exporter port                   | `20257`                                                         |
+| `settings.prometheus_address`         | Prometheus exporter address                | `0.0.0.0`                                                    |
+| `settings.prometheus_port`            | Prometheus exporter port                   | `20257`                                                      |
 | `serviceAccount.create`               | Whether a ServiceAccount should be created | `true`                                                       |
 | `serviceAccount.name`                 | Name of the ServiceAccount to create       | Generated value from template                                |
 | `tolerations`                         | Optional daemonset tolerations             | `[]`                                                         |
 | `nodeSelector`                        | Optional daemonset nodeSelector            | `{}`                                                         |
+| `env`                                 | Optional daemonset environment variables   | `[]`                                                         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
 

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -47,6 +47,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+{{- if .Values.env }}
+{{ toYaml .Values.env | indent 12 }}
+{{- end }}
           volumeMounts:
             - name: log
               mountPath: /var/log

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -78,3 +78,11 @@ metrics:
   serviceMonitor:
     enabled: false
     additionalLabels: {}
+
+env:
+#  - name: FOO
+#    value: BAR
+#  - name: POD_NAME
+#    valueFrom:
+#      fieldRef:
+#        fieldPath: metadata.name


### PR DESCRIPTION
Signed-off-by: Salmaan Rizvi <sar228@cornell.edu>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
Allow developers to pass in custom environment variables to pods. This is especially useful for with custom plugin monitors that may need meta information like cluster environment etc.

#### Special notes for your reviewer:
@max-rocket-internet, @Random-Liu, @andyxning, @wangzhen127

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
