### PR TITLE
[stable/aerospike] upgraded statefulset to apps/v1, needed for kubernetes 1.16

### DIFF
--- a/stable/aerospike/Chart.yaml
+++ b/stable/aerospike/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v4.5.0.5
+appVersion: v4.5.0.6
 description: A Helm chart for Aerospike in Kubernetes
 name: aerospike
 keywords:

--- a/stable/aerospike/Chart.yaml
+++ b/stable/aerospike/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
-appVersion: v4.5.0.6
+appVersion: v4.5.0.5
 description: A Helm chart for Aerospike in Kubernetes
 name: aerospike
 keywords:
   - aerospike
   - big-data
 home: http://aerospike.com
-version: 0.2.8
+version: 0.2.9
 icon: https://s3-us-west-1.amazonaws.com/aerospike-fd/wp-content/uploads/2016/06/Aerospike_square_logo.png
 sources:
 - https://github.com/aerospike/aerospike-server

--- a/stable/aerospike/README.md
+++ b/stable/aerospike/README.md
@@ -6,7 +6,7 @@ This is an implementation of Aerospike StatefulSet found here:
 
 ## Pre Requisites
 
-* Kubernetes 1.7+ with beta APIs enabled and support for statefulsets
+* Kubernetes 1.9+
 
 * PV support on underlying infrastructure (only if you are provisioning persistent volume).
 

--- a/stable/aerospike/templates/statefulset.yaml
+++ b/stable/aerospike/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "aerospike.fullname" . }}
@@ -10,6 +10,10 @@ metadata:
 spec:
   serviceName: {{ template "aerospike.fullname" . }}-mesh
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "aerospike.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
Signed-off-by: Radu Crisan <radu.crisan@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

#### What this PR does / why we need it:
Minikube 1.4.0 deploys kubernetes version is 1.16.  The developers that use it (or other ways of using kubernetes 1.16)  will not be able to have the aerospike chart working anymore without this change. Reason: the deprecation of statefulsets versioned apps/v1beta1. Older versions of kubernetes are not affected, since the statefulsets v1 have been introduced in kubernetes 1.9.
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
