### PR TITLE
[incubator/zookeeper] Fixes compatibility with 1.16

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 2.0.1
+version: 2.0.2
 appVersion: 3.5.5
 description: Centralized service for maintaining configuration information, naming,
   providing distributed synchronization, and providing group services.

--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 2.0.2
+version: 2.1.1
 appVersion: 3.5.5
 description: Centralized service for maintaining configuration information, naming,
   providing distributed synchronization, and providing group services.

--- a/incubator/zookeeper/templates/statefulset.yaml
+++ b/incubator/zookeeper/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "zookeeper.fullname" . }}


### PR DESCRIPTION
Make zookeeper compatible with 1.16. A quick overview of deprecated APIs can be found on their blog post: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/.

Signed-off-by: Xiang Dai <764524258@qq.com>