### PR TITLE
[stable/tensorflow-notebook] Fixes compatibility with 1.16

### DIFF
--- a/stable/tensorflow-notebook/Chart.yaml
+++ b/stable/tensorflow-notebook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for tensorflow notebook and tensorboard
 name: tensorflow-notebook
-version: 0.1.2
+version: 0.1.3
 appVersion: 1.6.0
 sources:
   - https://github.com/tensorflow/tensorflow

--- a/stable/tensorflow-notebook/templates/deployment.yaml
+++ b/stable/tensorflow-notebook/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "tensorflow-notebook.fullname" . }}


### PR DESCRIPTION
To support 1.16. A quick overview of deprecated APIs can be found on their blog post: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/.

Signed-off-by: Xiang Dai <764524258@qq.com>