### PR TITLE
[stable/tensorflow-serving] Fixes compatibility with 1.16

### DIFF
--- a/stable/tensorflow-serving/Chart.yaml
+++ b/stable/tensorflow-serving/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: tensorflow-serving
 home: https://github.com/kubernetes/charts
-version: 1.0.0
+version: 1.0.1
 appVersion: 1.14.0
 description: TensorFlow Serving is an open-source software library for serving machine learning models.
 sources:

--- a/stable/tensorflow-serving/templates/deployment.yaml
+++ b/stable/tensorflow-serving/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $gpuCount := .Values.gpuCount -}}
-apiVersion: app/v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "tensorflow-serving.fullname" . }}

--- a/stable/tensorflow-serving/templates/deployment.yaml
+++ b/stable/tensorflow-serving/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $gpuCount := .Values.gpuCount -}}
-apiVersion: extensions/v1beta1
+apiVersion: app/v1
 kind: Deployment
 metadata:
   name: {{ template "tensorflow-serving.fullname" . }}


### PR DESCRIPTION
To support 1.16. A quick overview of deprecated APIs can be found on their blog post: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/.

Signed-off-by: Xiang Dai <764524258@qq.com>