### PR TITLE
[stable/weave-cloud] Fixes compatibility with 1.16

### DIFF
--- a/stable/weave-cloud/Chart.yaml
+++ b/stable/weave-cloud/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 appVersion: "1.3.0"
 name: weave-cloud
-version: 0.3.3
+version: 0.3.4
 description: |
     Weave Cloud is a add-on to Kubernetes which provides Continuous Delivery, along with hosted Prometheus Monitoring and a visual dashboard for exploring & debugging microservices
 home: https://weave.works

--- a/stable/weave-cloud/templates/_helpers.tpl
+++ b/stable/weave-cloud/templates/_helpers.tpl
@@ -41,3 +41,14 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the apiVerion of deployment.
+*/}}
+{{- define "deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "app/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/weave-cloud/templates/_helpers.tpl
+++ b/stable/weave-cloud/templates/_helpers.tpl
@@ -49,6 +49,6 @@ Return the apiVerion of deployment.
 {{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "extensions/v1beta1" -}}
 {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "app/v1" -}}
+{{- print "apps/v1" -}}
 {{- end -}}
 {{- end -}}

--- a/stable/weave-cloud/templates/deployment.yaml
+++ b/stable/weave-cloud/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ .Values.agent.name }}


### PR DESCRIPTION
To support 1.16. A quick overview of deprecated APIs can be found on their blog post: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/.

Signed-off-by: Xiang Dai <764524258@qq.com>