### PR TITLE
[stable/weave-scope] Fixes compatibility with 1.16

### DIFF
--- a/stable/weave-scope/Chart.yaml
+++ b/stable/weave-scope/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: weave-scope
-version: 1.1.6
+version: 1.11.6
 appVersion: 1.11.5
 description: A Helm chart for the Weave Scope cluster visualizer.
 keywords:

--- a/stable/weave-scope/Chart.yaml
+++ b/stable/weave-scope/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: weave-scope
-version: 1.1.5
+version: 1.1.6
 appVersion: 1.11.5
 description: A Helm chart for the Weave Scope cluster visualizer.
 keywords:

--- a/stable/weave-scope/Chart.yaml
+++ b/stable/weave-scope/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: weave-scope
-version: 1.11.6
-appVersion: 1.11.5
+version: 1.1.6
+appVersion: 1.11.6
 description: A Helm chart for the Weave Scope cluster visualizer.
 keywords:
   - containers

--- a/stable/weave-scope/charts/weave-scope-agent/Chart.yaml
+++ b/stable/weave-scope/charts/weave-scope-agent/Chart.yaml
@@ -1,6 +1,6 @@
 description: A Helm chart for the Weave Scope cluster visualizer node agent.
 name: weave-scope-agent
-version: 1.1.6
+version: 1.11.6
 appVersion: 1.11.5
 keywords:
   - containers

--- a/stable/weave-scope/charts/weave-scope-agent/Chart.yaml
+++ b/stable/weave-scope/charts/weave-scope-agent/Chart.yaml
@@ -1,6 +1,6 @@
 description: A Helm chart for the Weave Scope cluster visualizer node agent.
 name: weave-scope-agent
-version: 1.1.5
+version: 1.1.6
 appVersion: 1.11.5
 keywords:
   - containers

--- a/stable/weave-scope/charts/weave-scope-agent/Chart.yaml
+++ b/stable/weave-scope/charts/weave-scope-agent/Chart.yaml
@@ -1,7 +1,7 @@
 description: A Helm chart for the Weave Scope cluster visualizer node agent.
 name: weave-scope-agent
-version: 1.11.6
-appVersion: 1.11.5
+version: 1.1.6
+appVersion: 1.11.6
 keywords:
   - containers
   - dashboard

--- a/stable/weave-scope/charts/weave-scope-agent/templates/_helpers.tpl
+++ b/stable/weave-scope/charts/weave-scope-agent/templates/_helpers.tpl
@@ -59,3 +59,14 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the apiVerion of daemonset.
+*/}}
+{{- define "daemonset.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "app/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/weave-scope/charts/weave-scope-agent/templates/_helpers.tpl
+++ b/stable/weave-scope/charts/weave-scope-agent/templates/_helpers.tpl
@@ -61,12 +61,12 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
-Return the apiVerion of daemonset.
+Return the apiVersion of daemonset.
 */}}
 {{- define "daemonset.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "extensions/v1beta1" -}}
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else -}}
 {{- print "apps/v1" -}}
 {{- end -}}
 {{- end -}}

--- a/stable/weave-scope/charts/weave-scope-agent/templates/_helpers.tpl
+++ b/stable/weave-scope/charts/weave-scope-agent/templates/_helpers.tpl
@@ -67,6 +67,6 @@ Return the apiVerion of daemonset.
 {{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "extensions/v1beta1" -}}
 {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "app/v1" -}}
+{{- print "apps/v1" -}}
 {{- end -}}
 {{- end -}}

--- a/stable/weave-scope/charts/weave-scope-agent/templates/daemonset.yaml
+++ b/stable/weave-scope/charts/weave-scope-agent/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "daemonset.apiVersion" . }}
 kind: DaemonSet
 metadata:
   labels:

--- a/stable/weave-scope/charts/weave-scope-cluster-agent/Chart.yaml
+++ b/stable/weave-scope/charts/weave-scope-cluster-agent/Chart.yaml
@@ -1,6 +1,6 @@
 description: A Helm chart for the Weave Scope cluster visualizer node agent.
 name: weave-scope-cluster-agent
-version: 1.1.5
+version: 1.1.6
 appVersion: 1.11.5
 keywords:
   - containers

--- a/stable/weave-scope/charts/weave-scope-cluster-agent/Chart.yaml
+++ b/stable/weave-scope/charts/weave-scope-cluster-agent/Chart.yaml
@@ -1,7 +1,7 @@
 description: A Helm chart for the Weave Scope cluster visualizer node agent.
 name: weave-scope-cluster-agent
 version: 1.1.6
-appVersion: 1.11.5
+appVersion: 1.11.6
 keywords:
   - containers
   - dashboard

--- a/stable/weave-scope/charts/weave-scope-cluster-agent/templates/_helpers.tpl
+++ b/stable/weave-scope/charts/weave-scope-cluster-agent/templates/_helpers.tpl
@@ -67,6 +67,6 @@ Return the apiVerion of deployment.
 {{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "extensions/v1beta1" -}}
 {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "app/v1" -}}
+{{- print "apps/v1" -}}
 {{- end -}}
 {{- end -}}

--- a/stable/weave-scope/charts/weave-scope-cluster-agent/templates/_helpers.tpl
+++ b/stable/weave-scope/charts/weave-scope-cluster-agent/templates/_helpers.tpl
@@ -59,3 +59,14 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the apiVerion of deployment.
+*/}}
+{{- define "deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "app/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/weave-scope/charts/weave-scope-cluster-agent/templates/deployment.yaml
+++ b/stable/weave-scope/charts/weave-scope-cluster-agent/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
To support 1.16. A quick overview of deprecated APIs can be found on their blog post: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/.

Signed-off-by: Xiang Dai <764524258@qq.com>