### PR TITLE
[stable/minio] feat: fix invalid yaml generation for podAnnotations

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: MinIO is a high performance distributed object storage server, designed for large-scale private cloud infrastructure.
 name: minio
-version: 2.5.15
+version: 2.5.16
 appVersion: RELEASE.2019-08-07T01-59-21Z
 keywords:
 - storage

--- a/stable/minio/templates/deployment.yaml
+++ b/stable/minio/templates/deployment.yaml
@@ -49,7 +49,9 @@ spec:
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-{{- if .Values.podAnnotations }}{{ toYaml .Values.podAnnotations | indent 8 }}{{- end }}
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | trimSuffix "\n" | indent 8 }}
+{{- end }}
     spec:
   {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"


### PR DESCRIPTION
#### What this PR does / why we need it:
fix the podAnnotations from
```
annotations:
  checksum/config: XXX newAnnotationFromPodAnnotations: YYY
```

into

```
annotations:
  checksum/config: XXX 
  newAnnotationFromPodAnnotations: YYY
```

otherwise it's impossible to use the `podAnnotations` at all
#### Which issue this PR fixes
no issue created

#### Special notes for your reviewer:
The trimsuffix is used to remove the newline added by toYaml

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
