### PR TITLE
[stable/gitlab-ce] Fixes compatibility with 1.16

### DIFF
--- a/stable/gitlab-ce/Chart.yaml
+++ b/stable/gitlab-ce/Chart.yaml
@@ -1,6 +1,6 @@
 name: gitlab-ce
 deprecated: true
-version: 0.2.2
+version: 0.2.3
 appVersion: 9.4.1
 description: GitLab Community Edition
 keywords:

--- a/stable/gitlab-ce/templates/_helpers.tpl
+++ b/stable/gitlab-ce/templates/_helpers.tpl
@@ -30,3 +30,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "gitlab-ce.redis.fullname" -}}
 {{- printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Return the apiVerion of deployment.
+*/}}
+{{- define "deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/gitlab-ce/templates/deployment.yaml
+++ b/stable/gitlab-ce/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if default "" .Values.externalUrl }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "gitlab-ce.fullname" . }}


### PR DESCRIPTION
To support 1.16. A quick overview of deprecated APIs can be found on their blog post: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/.

Signed-off-by: Xiang Dai 764524258@qq.com