### PR TITLE
[stable/influxdb] Fixes compatibility with 1.16

### DIFF
--- a/stable/influxdb/Chart.yaml
+++ b/stable/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 1.4.0
+version: 1.4.1
 appVersion: 1.7.6
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/stable/influxdb/templates/_helpers.tpl
+++ b/stable/influxdb/templates/_helpers.tpl
@@ -32,7 +32,7 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
-Return the apiVerion of deployment.
+Return the apiVersion of deployment.
 */}}
 {{- define "deployment.apiVersion" -}}
 {{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}

--- a/stable/influxdb/templates/_helpers.tpl
+++ b/stable/influxdb/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "influxdb.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Return the apiVerion of deployment.
+*/}}
+{{- define "deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/influxdb/templates/deployment.yaml
+++ b/stable/influxdb/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: "{{ template "influxdb.fullname" . }}"


### PR DESCRIPTION
To support 1.16. A quick overview of deprecated APIs can be found on their blog post: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/.

Signed-off-by: Xiang Dai 764524258@qq.com