### PR TITLE
[stable/selenium] Fixes compatibility with 1.16

### DIFF
--- a/stable/selenium/Chart.yaml
+++ b/stable/selenium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: selenium
-version: 1.0.8
+version: 1.0.9
 appVersion: 3.141.59
 description: Chart for selenium grid
 keywords:

--- a/stable/selenium/templates/_helpers.tpl
+++ b/stable/selenium/templates/_helpers.tpl
@@ -56,7 +56,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-Return the apiVerion of deployment.
+Return the apiVersion of deployment.
 */}}
 {{- define "deployment.apiVersion" -}}
 {{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}

--- a/stable/selenium/templates/_helpers.tpl
+++ b/stable/selenium/templates/_helpers.tpl
@@ -55,3 +55,13 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-selenium-firefox-debug" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Return the apiVerion of deployment.
+*/}}
+{{- define "deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/selenium/templates/chrome-deployment.yaml
+++ b/stable/selenium/templates/chrome-deployment.yaml
@@ -88,7 +88,7 @@ spec:
           resources:
 {{ toYaml .Values.chrome.resources | trim | indent 12 }}
 {{- if or .Values.global.imagePullSecrets .Values.chrome.imagePullSecrets }}
-      imagePullSecrets: 
+      imagePullSecrets:
       - name: {{ .Values.chrome.imagePullSecrets | default .Values.global.imagePullSecrets | quote }}
 {{- end }}
       volumes:

--- a/stable/selenium/templates/chrome-deployment.yaml
+++ b/stable/selenium/templates/chrome-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if eq true .Values.chrome.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "selenium.chrome.fullname" . }}

--- a/stable/selenium/templates/chromeDebug-deployment.yaml
+++ b/stable/selenium/templates/chromeDebug-deployment.yaml
@@ -90,7 +90,7 @@ spec:
           resources:
 {{ toYaml .Values.chromeDebug.resources | indent 12 }}
 {{- if or .Values.global.imagePullSecrets .Values.chromeDebug.imagePullSecrets }}
-      imagePullSecrets: 
+      imagePullSecrets:
       - name: {{ .Values.chromeDebug.imagePullSecrets | default .Values.global.imagePullSecrets | quote }}
 {{- end }}
       volumes:

--- a/stable/selenium/templates/chromeDebug-deployment.yaml
+++ b/stable/selenium/templates/chromeDebug-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if eq true .Values.chromeDebug.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "selenium.chromeDebug.fullname" . }}

--- a/stable/selenium/templates/firefox-deployment.yaml
+++ b/stable/selenium/templates/firefox-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if eq true .Values.firefox.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "selenium.firefox.fullname" . }}

--- a/stable/selenium/templates/firefox-deployment.yaml
+++ b/stable/selenium/templates/firefox-deployment.yaml
@@ -84,7 +84,7 @@ spec:
           resources:
 {{ toYaml .Values.firefox.resources | indent 12 }}
 {{- if or .Values.global.imagePullSecrets .Values.firefox.imagePullSecrets }}
-      imagePullSecrets: 
+      imagePullSecrets:
       - name: {{ .Values.firefox.imagePullSecrets | default .Values.global.imagePullSecrets | quote }}
 {{- end }}
       hostAliases:

--- a/stable/selenium/templates/firefoxDebug-deployment.yaml
+++ b/stable/selenium/templates/firefoxDebug-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if eq true .Values.firefoxDebug.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "selenium.firefoxDebug.fullname" . }}

--- a/stable/selenium/templates/firefoxDebug-deployment.yaml
+++ b/stable/selenium/templates/firefoxDebug-deployment.yaml
@@ -86,7 +86,7 @@ spec:
           resources:
 {{ toYaml .Values.firefoxDebug.resources | indent 12 }}
 {{- if or .Values.global.imagePullSecrets .Values.firefoxDebug.imagePullSecrets }}
-      imagePullSecrets: 
+      imagePullSecrets:
       - name: {{ .Values.firefoxDebug.imagePullSecrets | default .Values.global.imagePullSecrets | quote }}
 {{- end }}
       hostAliases:

--- a/stable/selenium/templates/hub-deployment.yaml
+++ b/stable/selenium/templates/hub-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "selenium.hub.fullname" . }}

--- a/stable/selenium/templates/hub-deployment.yaml
+++ b/stable/selenium/templates/hub-deployment.yaml
@@ -94,7 +94,7 @@ spec:
           resources:
 {{ toYaml .Values.hub.resources | trim | indent 12 -}}
 {{- if or .Values.global.imagePullSecrets .Values.hub.imagePullSecrets }}
-      imagePullSecrets: 
+      imagePullSecrets:
       - name: {{ .Values.hub.imagePullSecrets | default .Values.global.imagePullSecrets | quote }}
 {{- end }}
       nodeSelector:


### PR DESCRIPTION
To support 1.16. A quick overview of deprecated APIs can be found on their blog post: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/.

Signed-off-by: Xiang Dai 764524258@qq.com