### PR TITLE
[stable/prometheus-operator] Allow config-reloader containers resources to be unset

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -10,7 +10,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 6.11.2
+version: 6.11.3
 appVersion: 0.32.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
@@ -47,12 +47,8 @@ spec:
             - --localhost=127.0.0.1
             - --prometheus-config-reloader={{ .Values.prometheusOperator.prometheusConfigReloaderImage.repository }}:{{ .Values.prometheusOperator.prometheusConfigReloaderImage.tag }}
             - --config-reloader-image={{ .Values.prometheusOperator.configmapReloadImage.repository }}:{{ .Values.prometheusOperator.configmapReloadImage.tag }}
-          {{- if .Values.prometheusOperator.configReloaderCpu }}
             - --config-reloader-cpu={{ .Values.prometheusOperator.configReloaderCpu }}
-          {{- end }}
-          {{- if .Values.prometheusOperator.configReloaderMemory }}
             - --config-reloader-memory={{ .Values.prometheusOperator.configReloaderMemory }}
-          {{- end }}
           ports:
             - containerPort: 8080
               name: http

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -1123,13 +1123,13 @@ prometheusOperator:
     repository: quay.io/coreos/prometheus-config-reloader
     tag: v0.32.0
 
-  ## Set the prometheus config reloader side-car CPU limit. If unset, uses the prometheus-operator project default
+  ## Set the prometheus config reloader side-car CPU limit
   ##
-  # configReloaderCpu: 100m
+  configReloaderCpu: 100m
 
-  ## Set the prometheus config reloader side-car memory limit. If unset, uses the prometheus-operator project default
+  ## Set the prometheus config reloader side-car memory limit
   ##
-  # configReloaderMemory: 25Mi
+  configReloaderMemory: 25Mi
 
   ## Hyperkube image to use when cleaning up
   ##


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
This PR allows the resources of the config-reloader containers to be unset. The current behavior of the chart is to set default values for both cpu and memory. This makes it's not possible to set those values to `0` to unset the resources as stated in the source of prometheus-operator: https://github.com/coreos/prometheus-operator/blob/master/cmd/operator/main.go#L135
```
Value \"0\" disables it and causes no limit to be configured
```

#### Which issue this PR fixes
  - possibly fixes #17389

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
