### PR TITLE
Fix support for older zookeeper versions

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 2.1.3
+version: 2.1.4
 appVersion: 3.5.5
 kubeVersion: "^1.10.0-0"
 description: Centralized service for maintaining configuration information, naming,

--- a/incubator/zookeeper/README.md
+++ b/incubator/zookeeper/README.md
@@ -91,6 +91,12 @@ The Java Virtual Machine used for this chart is the OpenJDK JVM 8u192 JRE (headl
 ## ZooKeeper Details
 The chart defaults to ZooKeeper 3.5 (latest released version).
 
+### ZooKeeper 3.4.x
+Using ZooKeeper 3.4.x with this chart requires the following modifications:
+
+* Setting the environment-variable `ROOT_DIRECTORY` to `/zookeeper-*`
+* Setting the image.tag value to 3.4.x (eg. 3.4.14)
+
 ## Failover
 You can test failover by killing the leader. Insert a key:
 ```console

--- a/incubator/zookeeper/templates/config-script.yaml
+++ b/incubator/zookeeper/templates/config-script.yaml
@@ -22,7 +22,8 @@ data:
       #!/bin/bash
 
       set -a
-      ROOT=$(echo /apache-zookeeper-*)
+      ROOT_DIRECTORY=${ROOT_DIRECTORY:-"/apache-zookeeper-*"}
+      ROOT=$(echo $ROOT_DIRECTORY)
 
       ZK_USER=${ZK_USER:-"zookeeper"}
       ZK_LOG_LEVEL=${ZK_LOG_LEVEL:-"INFO"}


### PR DESCRIPTION
#### Is this a new chart
no

#### What this PR does / why we need it:
The zookeeper chart does not support older versions, due to a directory-name mismatch. The zookeeper-root directory for 3.5.x is expanded in `/apache-zookeper...` while the 3.4.x verson is located in `/zookeeper...`.

#### Which issue this PR fixes
* There is no ticket for this issue

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped


