### PR TITLE
[stable/sealed-secrets] Have optional command args passed to controller

### DIFF
--- a/stable/sealed-secrets/Chart.yaml
+++ b/stable/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.4.1
+version: 1.4.2
 appVersion: 0.8.2
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/stable/sealed-secrets/Chart.yaml
+++ b/stable/sealed-secrets/Chart.yaml
@@ -1,7 +1,7 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
 version: 1.4.2
-appVersion: 0.8.2
+appVersion: 0.9.1
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets
 apiVersion: v1

--- a/stable/sealed-secrets/README.md
+++ b/stable/sealed-secrets/README.md
@@ -58,6 +58,7 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 | **crd.keep** | `true` if the sealed secret CRD should be kept when the chart is deleted | `true` |
 |**networkPolicy** | Whether to create a network policy that allows access to the service | `false`|
 |**securityContext.runAsUser** | Defines under which user the operator Pod and its containers/processes run | `1001`|
+|**commandArgs** | Set optional command line arguments passed to the controller process | |
 
 - In the case that **serviceAccount.create** is `false` and **rbac.create** is `true` it is expected for a service account with the name **serviceAccount.name** to exist _in the same namespace as this chart_ before installation.
 - If **serviceAccount.create** is `true` there cannot be an existing service account with the name **serviceAccount.name**.

--- a/stable/sealed-secrets/templates/deployment.yaml
+++ b/stable/sealed-secrets/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
           args:
             - "--key-prefix"
             - "{{ .Values.secretName }}"
+            {{- range $value := .Values.commandArgs }}
+            - {{ $value | quote }}
+            {{- end }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/stable/sealed-secrets/values.yaml
+++ b/stable/sealed-secrets/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/bitnami/sealed-secrets-controller
-  tag: v0.8.2
+  tag: v0.9.1
   pullPolicy: IfNotPresent
 
 resources: {}


### PR DESCRIPTION
This enables us to set command line arguments, like
  commandArgs:
    - "--key-renew-period"
    - "0"
or:
  $ helm ... --set commandArgs={--key-renew-period,0}

Signed-off-by: Tino Reinhardt <t@freeshell.org>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
no

#### What this PR does / why we need it:
As the default value for "--key-renew-period" changed in recent Sealed Secrets releases, I need some way to pass this command line option to the controller process (actually to keep automatic key rotation disabled in my current environment).

#### Which issue this PR fixes
  - fixes #17556

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
