### PR TITLE
[stable/airflow] fix typo in environment variable name

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 4.1.0
+version: 4.1.1
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/templates/configmap-env.yaml
+++ b/stable/airflow/templates/configmap-env.yaml
@@ -33,7 +33,7 @@ data:
   AIRFLOW__SCHEDULER__CHILD_PROCESS_LOG_DIRECTORY: "{{ printf "%s/%s" .Values.logs.path "scheduler" }}"
   AIRFLOW__WEBSERVER__BASE_URL: "http://localhost:8080{{ .Values.ingress.web.path }}"
   # Disabling XCom pickling for forward compatibility
-  AIRFLOW__CODE__ENABLE_XCOM_PICKLING: "false"
+  AIRFLOW__CORE__ENABLE_XCOM_PICKLING: "false"
   # For backwards compat with AF < 1.10, CELERY_CONCURRENCY got renamed to WORKER_CONCURRENCY
   AIRFLOW__CELERY__CELERY_CONCURRENCY: "{{ .Values.workers.celery.instances }}"
   # Note: changing `Values.airflow.config` won't change the configmap checksum and so won't make


### PR DESCRIPTION
Signed-off-by: Marcin Szymanski <ms32035@gmail.com>

#### What this PR does / why we need it:

Fix an incorrectly named environment variable

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
