### PR TITLE
[stable/instana-agent] Add agent.host.repository for mounting host repository

### DIFF
--- a/stable/instana-agent/Chart.yaml
+++ b/stable/instana-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: instana-agent
-version: 1.0.14
+version: 1.0.15
 appVersion: 1.0
 description: Instana Agent for Kubernetes
 home: https://www.instana.com/

--- a/stable/instana-agent/README.md
+++ b/stable/instana-agent/README.md
@@ -125,6 +125,14 @@ The following table lists the configurable parameters of the Instana chart and t
 | `podSecurityPolicy.enable`         | Whether a PodSecurityPolicy should be authorized for the Instana Agent pods. Requires `rbac.create` to be `true` as well. | `false` See [PodSecurityPolicy](https://docs.instana.io/quick_start/agent_setup/container/kubernetes/#podsecuritypolicy) for more details. |
 | `podSecurityPolicy.name`           | Name of an _existing_ PodSecurityPolicy to authorize for the Instana Agent pods. If not provided and `podSecurityPolicy.enable` is `true`, a PodSecurityPolicy will be created for you. | `nil` |
 
+#### Development and debugging options
+
+These options will be rarely used outside of development or debugging of the agent.
+
+|             Parameter              |            Description                                                  |                    Default                                                                                  |
+|------------------------------------|-------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
+| `agent.host.repository`            | Host path to mount as the agent maven repository                        | `nil`                                                                                                       |
+
 ### Agent
 
 To configure the agent, you can either:

--- a/stable/instana-agent/README.md
+++ b/stable/instana-agent/README.md
@@ -28,6 +28,8 @@ If you're in the EU, you'll probably also want to set the regional equivalent va
 * agent.endpointHost
 * agent.endpointPort
 
+_Note:_ Check the values for the endpoint entries in the [agent backend configuration](https://docs.instana.io/quick_start/agent_configuration/#backend).
+
 Optionally, if your infrastructure uses a proxy, you should ensure that you set values for:
 
 * agent.pod.proxyHost
@@ -49,25 +51,13 @@ Agent can have APM, INFRASTRUCTURE or AWS mode. Default is APM and if you want t
 
 * agent.mode
 
-_Note:_ Check the values for the endpoint entries in the [agent backend configuration](https://docs.instana.io/quick_start/agent_configuration/#backend).
-
 To install the chart with the release name `instana-agent` and set the values on the command line run:
 
 ```bash
 $ helm install --name instana-agent --namespace instana-agent \
 --set agent.key=INSTANA_AGENT_KEY \
 --set agent.endpointHost=HOST \
---set agent.endpointPort=PORT \
 --set zone.name=ZONE_NAME \
---set cluster.name=CLUSTER_NAME \
---set agent.downloadKey=INSTANA_DOWNLOAD_KEY \
---set agent.proxyHost=INSTANA_AGENT_PROXY_HOST \
---set agent.proxyPort=INSTANA_AGENT_PROXY_PORT \
---set agent.proxyProtocol=INSTANA_AGENT_PROXY_PROTOCOL \
---set agent.proxyUser=INSTANA_AGENT_PROXY_USER \
---set agent.proxyPassword=INSTANA_AGENT_PROXY_PASSWORD \
---set agent.proxyUseDNS=INSTANA_AGENT_PROXY_USE_DNS \
---set agent.listenAddress=INSTANA_AGENT_HTTP_LISTEN \
 stable/instana-agent
 ```
 
@@ -93,37 +83,37 @@ The following table lists the configurable parameters of the Instana chart and t
 
 |             Parameter              |            Description                                                  |                    Default                                                                                  |
 |------------------------------------|-------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
-| `agent.key`                        | Your Instana Agent key                                                  | `nil` You must provide your own key                                                                         |
-| `zone.name`                        | Zone that detected technologies will be assigned to                     | `nil` You must provide either `zone.name` or `cluster.name`, see [above](#installing-the-chart) for details |
-| `cluster.name`                     | Display name of the monitored cluster                                   | Value of `zone.name`                                                                                        |
+| `agent.configuration_yaml`         | Custom content for the agent configuration.yaml file                    | `nil` See [below](#agent) for more details                                                                  |
+| `agent.downloadKey`                | Your Instana Download key                                               | `nil` Usually not required                                                                                  |
+| `agent.endpointHost`               | Instana Agent backend endpoint host                                     | `saas-us-west-2.instana.io`                                                                                 |
+| `agent.endpointPort`               | Instana Agent backend endpoint port                                     | `443`                                                                                                       |
 | `agent.image.name`                 | The image name to pull                                                  | `instana/agent`                                                                                             |
 | `agent.image.tag`                  | The image tag to pull                                                   | `1.0.17`                                                                                                    |
 | `agent.image.pullPolicy`           | Image pull policy                                                       | `IfNotPresent`                                                                                              |
+| `agent.key`                        | Your Instana Agent key                                                  | `nil` You must provide your own key                                                                         |
 | `agent.leaderElectorPort`          | Instana leader elector sidecar port                                     | `42655`                                                                                                     |
-| `agent.endpointHost`               | Instana Agent backend endpoint host                                     | `saas-us-west-2.instana.io`                                                                                 |
-| `agent.endpointPort`               | Instana Agent backend endpoint port                                     | `443`                                                                                                       |
-| `agent.downloadKey`                | Your Instana Download key                                               | `nil` You must provide your own download key                                                                |
+| `agent.listenAddress`              | List of addresses to listen on, or "*" for all interfaces               | `nil`                                                                                                       |
 | `agent.mode`                       | Agent mode (Supported values are APM, INFRASTRUCTURE, AWS)              | `APM`                                                                                                       |
 | `agent.pod.annotations`            | Additional annotations to apply to the pod                              | `{}`                                                                                                        |
-| `agent.pod.tolerations`            | Tolerations for pod assignment                                          | `[]`                                                                                                        |
+| `agent.pod.limits.cpu`             | Container cpu limits in cpu cores                                       | `1.5`                                                                                                       |
+| `agent.pod.limits.memory`          | Container memory limits in MiB                                          | `512`                                                                                                       |
 | `agent.pod.proxyHost`              | Hostname/address of a proxy                                             | `nil`                                                                                                       |
 | `agent.pod.proxyPort`              | Port of a proxy                                                         | `nil`                                                                                                       |
 | `agent.pod.proxyProtocol`          | Proxy protocol (Supported proxy types are "http", "socks4", "socks5")   | `nil`                                                                                                       |
 | `agent.pod.proxyUser`              | Username of the proxy auth                                              | `nil`                                                                                                       |
 | `agent.pod.proxyPassword`          | Password of the proxy auth                                              | `nil`                                                                                                       |
 | `agent.pod.proxyUseDNS`            | Boolean if proxy also does DNS                                          | `nil`                                                                                                       |
-| `agent.listenAddress`              | List of addresses to listen on, or "*" for all interfaces               | `nil`                                                                                                       |
 | `agent.pod.requests.memory`        | Container memory requests in MiB                                        | `512`                                                                                                       |
 | `agent.pod.requests.cpu`           | Container cpu requests in cpu cores                                     | `0.5`                                                                                                       |
-| `agent.pod.limits.memory`          | Container memory limits in MiB                                          | `512`                                                                                                       |
-| `agent.pod.limits.cpu`             | Container cpu limits in cpu cores                                       | `1.5`                                                                                                       |
-| `agent.configuration_yaml`         | Custom content for the agent configuration.yaml file                    | `nil` See [below](#agent) for more details                                                                  |
+| `agent.pod.tolerations`            | Tolerations for pod assignment                                          | `[]`                                                                                                        |
 | `agent.redactKubernetesSecrets`    | Enable additional secrets redaction for selected Kubernetes resources   | `nil` See [Kubernetes secrets](https://docs.instana.io/quick_start/agent_setup/container/kubernetes/#secrets) for more details.   |
+| `cluster.name`                     | Display name of the monitored cluster                                   | Value of `zone.name`                                                                                        |
+| `podSecurityPolicy.enable`         | Whether a PodSecurityPolicy should be authorized for the Instana Agent pods. Requires `rbac.create` to be `true` as well. | `false` See [PodSecurityPolicy](https://docs.instana.io/quick_start/agent_setup/container/kubernetes/#podsecuritypolicy) for more details. |
+| `podSecurityPolicy.name`           | Name of an _existing_ PodSecurityPolicy to authorize for the Instana Agent pods. If not provided and `podSecurityPolicy.enable` is `true`, a PodSecurityPolicy will be created for you. | `nil` |
 | `rbac.create`                      | Whether RBAC resources should be created                                | `true`                                                                                                      |
 | `serviceAccount.create`            | Whether a ServiceAccount should be created                              | `true`                                                                                                      |
 | `serviceAccount.name`              | Name of the ServiceAccount to use                                       | `instana-agent`                                                                                             |
-| `podSecurityPolicy.enable`         | Whether a PodSecurityPolicy should be authorized for the Instana Agent pods. Requires `rbac.create` to be `true` as well. | `false` See [PodSecurityPolicy](https://docs.instana.io/quick_start/agent_setup/container/kubernetes/#podsecuritypolicy) for more details. |
-| `podSecurityPolicy.name`           | Name of an _existing_ PodSecurityPolicy to authorize for the Instana Agent pods. If not provided and `podSecurityPolicy.enable` is `true`, a PodSecurityPolicy will be created for you. | `nil` |
+| `zone.name`                        | Zone that detected technologies will be assigned to                     | `nil` You must provide either `zone.name` or `cluster.name`, see [above](#installing-the-chart) for details |
 
 #### Development and debugging options
 

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -110,6 +110,10 @@ spec:
             - name: configuration
               subPath: configuration.yaml
               mountPath: /root/configuration.yaml
+            {{- if .Values.agent.host.repository }}
+            - name: repo
+              mountPath: /opt/instana/agent/data/repo
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /status
@@ -175,5 +179,10 @@ spec:
         - name: configuration
           configMap:
             name: {{ template "instana-agent.fullname" . }}
+        {{- if .Values.agent.host.repository }}
+        - name: repo
+          hostPath:
+            path: {{ .Values.agent.host.repository }}
+        {{- end }}
 {{- end -}}
 {{- end -}}

--- a/stable/instana-agent/templates/podsecuritypolicy.yaml
+++ b/stable/instana-agent/templates/podsecuritypolicy.yaml
@@ -30,6 +30,10 @@ spec:
       readOnly: false
     - pathPrefix: "/etc/machine-id"
       readOnly: false
+    {{- if .Values.agent.host.repository }}
+    - pathPrefix: {{ .Values.agent.host.repository }}
+      readOnly: false
+    {{- end }}
   hostNetwork: true
   hostPorts:
     - min: 0

--- a/stable/instana-agent/values.yaml
+++ b/stable/instana-agent/values.yaml
@@ -68,6 +68,10 @@ agent:
   # agent.redactKubernetesSecrets sets the INSTANA_KUBERNETES_REDACT_SECRETS environment variable.
   # redactKubernetesSecrets: null
 
+  # agent.host.repository sets a host path to be mounted as the agent maven repository (for debugging or development purposes)
+  host:
+    repository: null
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds ability to mount a maven repository from the host for the agent for debugging and development purposes.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
