### PR TITLE
[stable/velero] Update GitHub URLs to point to vmware-tanzu org

### DIFF
--- a/stable/velero/Chart.yaml
+++ b/stable/velero/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v1
 appVersion: 1.1.0
 description: A Helm chart for velero
 name: velero
-version: 2.1.6
-home: https://github.com/heptio/velero
+version: 2.1.7
+home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:
-- https://github.com/heptio/velero
+- https://github.com/vmware-tanzu/velero
 maintainers:
   - name: domcar
     email: d-caruso@hotmail.it

--- a/stable/velero/README.md
+++ b/stable/velero/README.md
@@ -1,18 +1,18 @@
 # Velero-server
 
 This helm chart installs Velero version v1.1.0
-https://github.com/heptio/velero/tree/v1.1.0
+https://github.com/vmware-tanzu/velero/tree/v1.1.0
 
 
 ## Upgrading to v1.1.0
 
-As of v1.1.0, Heptio Velero is no longer backwards-compatible with Heptio Ark.
+As of v1.1.0, Velero is no longer backwards-compatible with Heptio Ark.
 
 The [instructions found here](https://velero.io/docs/v1.1.0/upgrade-to-1.1/) will assist you in upgrading from version v1.0.0 to v1.1.0
 
 ## Upgrading to v1.0.0
 
-As of v1.0.0, Heptio Velero is no longer backwards-compatible with Heptio Ark.
+As of v1.0.0, Velero is no longer backwards-compatible with Heptio Ark.
 
 The [instructions found here](https://velero.io/docs/v1.0.0/upgrade-to-1.0/) will assist you in upgrading from version v0.11.0 to v1.0.0
 

--- a/stable/velero/templates/NOTES.txt
+++ b/stable/velero/templates/NOTES.txt
@@ -7,7 +7,7 @@ Check that the secret has been created:
     kubectl get secret/{{ include "velero.fullname" . }} -n {{ .Release.Namespace }}
 
 Once velero server is up and running you need the client before you can use it
-1. wget https://github.com/heptio/velero/releases/download/{{ .Values.image.tag }}/velero-{{ .Values.image.tag }}-darwin-amd64.tar.gz
+1. wget https://github.com/vmware-tanzu/velero/releases/download/{{ .Values.image.tag }}/velero-{{ .Values.image.tag }}-darwin-amd64.tar.gz
 2. tar -xvf velero-{{ .Values.image.tag }}-darwin-amd64.tar.gz -C velero-client
 
-More info on the official site: https://github.com/heptio/velero#install-client
+More info on the official site: https://github.com/vmware-tanzu/velero#install-client


### PR DESCRIPTION
## What this PR does / why we need it:

Velero has moved from the github.com/heptio organization to the github.com/vmware-tanzu organization.

#### Special notes for your reviewer:

The container image repo has not changed; gcr.io/heptio-images is still valid.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
