### PR TITLE
[stable/cluster-autoscaler] Bump to 1.14.5 and update RBAC permissions

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 5.0.0
-appVersion: 1.13.7
+version: 5.1.0
+appVersion: 1.14.5
 home: https://github.com/kubernetes/autoscaler
 sources:
 - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler

--- a/stable/cluster-autoscaler/templates/clusterrole.yaml
+++ b/stable/cluster-autoscaler/templates/clusterrole.yaml
@@ -95,6 +95,7 @@ rules:
     - storage.k8s.io
     resources:
     - storageclasses
+    - csinodes
     verbs:
     - watch
     - list

--- a/stable/cluster-autoscaler/values.yaml
+++ b/stable/cluster-autoscaler/values.yaml
@@ -53,7 +53,7 @@ cloudConfigPath: /etc/gce.conf
 
 image:
   repository: k8s.gcr.io/cluster-autoscaler
-  tag: v1.13.7
+  tag: v1.14.5
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Updates to 1.14.5 because 1.13.x is EOL now that Kubernetes 1.13 has EOL'd and matches RBAC changes from https://github.com/kubernetes/autoscaler/pull/2404

#### Special notes for your reviewer: 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
