### PR TITLE
[stable/external-dns] Add support for use Cloudflare API token

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.6.5
+version: 2.7.0
 appVersion: 0.5.17
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.7.0
+version: 2.8.0
 appVersion: 0.5.17
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.7.0
+version: 2.6.5
 appVersion: 0.5.17
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -74,6 +74,7 @@ The following table lists the configurable parameters of the external-dns chart 
 | `azure.aadClientId`                 | When using the Azure provider, set the Azure AAD Client ID                                               | `""`                                                        |
 | `azure.aadClientSecret`             | When using the Azure provider, set the Azure AAD Client Secret                                           | `""`                                                        |
 | `azure.useManagedIdentityExtension` | When using the Azure provider, set if you use Azure MSI                                                  | `""`                                                        |
+| `cloudflare.apiToken`               | When using the Cloudflare provider, `CF_API_TOKEN` to set (optional)                                     | `""`                                                        |
 | `cloudflare.apiKey`                 | When using the Cloudflare provider, `CF_API_KEY` to set (optional)                                       | `""`                                                        |
 | `cloudflare.email`                  | When using the Cloudflare provider, `CF_API_EMAIL` to set (optional)                                     | `""`                                                        |
 | `cloudflare.proxied`                | When using the Cloudflare provider, enable the proxy feature (DDOS protection, CDN...) (optional)        | `true`                                                      |

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
         {{- if or .Values.podAnnotations .Values.metrics.enabled }}
         {{ include "external-dns.podAnnotations" . | nindent 8 }}
         {{- end }}
-        {{- if or (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey) .Values.cloudflare.Token .Values.cloudflare.apiKey .Values.digitalocean.apiToken (and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword) .Values.rfc2136.tsigSecret .Values.extraEnv .Values.google.serviceAccountKey }}
+        {{- if or (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey) (or .Values.cloudflare.apiToken .Values.cloudflare.apiKey) .Values.digitalocean.apiToken (and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword) .Values.rfc2136.tsigSecret .Values.extraEnv .Values.google.serviceAccountKey }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
         {{- if and (eq .Values.provider "designate") .Values.designate.customCA.enabled }}
@@ -198,7 +198,7 @@ spec:
               name: {{ template "external-dns.fullname" . }}
               key: cloudflare_api_key
         - name: CF_API_EMAIL
-          value: {{ .Values.cloudflare.email | quote }}
+          value: {{ required "cloudflare.email is required if cloudflare.apiToken is not provided" .Values.cloudflare.email | quote }}
         {{- end }}
         {{- end }}
         # CoreDNS environment variables

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
         {{- if or .Values.podAnnotations .Values.metrics.enabled }}
         {{ include "external-dns.podAnnotations" . | nindent 8 }}
         {{- end }}
-        {{- if or (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey) .Values.cloudflare.apiKey .Values.digitalocean.apiToken (and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword) .Values.rfc2136.tsigSecret .Values.extraEnv .Values.google.serviceAccountKey }}
+        {{- if or (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey) .Values.cloudflare.Token .Values.cloudflare.apiKey .Values.digitalocean.apiToken (and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword) .Values.rfc2136.tsigSecret .Values.extraEnv .Values.google.serviceAccountKey }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
         {{- if and (eq .Values.provider "designate") .Values.designate.customCA.enabled }}
@@ -185,6 +185,13 @@ spec:
         {{- end }}
         # Cloudflare environment variables
         {{- if eq .Values.provider "cloudflare" }}
+        {{- if .Values.cloudflare.apiToken }}
+        - name: CF_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "external-dns.fullname" . }}
+              key: cloudflare_api_token
+        {{- else }}
         - name: CF_API_KEY
           valueFrom:
             secretKeyRef:
@@ -192,6 +199,7 @@ spec:
               key: cloudflare_api_key
         - name: CF_API_EMAIL
           value: {{ .Values.cloudflare.email | quote }}
+        {{- end }}
         {{- end }}
         # CoreDNS environment variables
         {{- if eq .Values.provider "coredns" }}

--- a/stable/external-dns/templates/secret.yaml
+++ b/stable/external-dns/templates/secret.yaml
@@ -21,7 +21,7 @@ data:
   {{- if .Values.cloudflare.apiToken }}
   cloudflare_api_token: {{ .Values.cloudflare.apiToken | b64enc | quote }}
   {{- else }}
-  cloudflare_api_key: {{ .Values.cloudflare.apiKey | b64enc | quote }}
+  cloudflare_api_key: {{ required "cloudflare.apiKey is required if cloudflare.apiToken is not provided" .Values.cloudflare.apiKey | b64enc | quote }}
   {{- end }}
   {{- end }}
   {{- if .Values.digitalocean.apiToken }}

--- a/stable/external-dns/templates/secret.yaml
+++ b/stable/external-dns/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.aws.assumeRoleArn (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey) .Values.cloudflare.apiKey .Values.digitalocean.apiToken .Values.google.serviceAccountKey (and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword) .Values.rfc2136.tsigSecret .Values.pdns.apiKey (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId .Values.azure.aadClientId .Values.azure.aadClientSecret (not .Values.azure.useManagedIdentityExtension)) (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId .Values.azure.useManagedIdentityExtension) }}
+{{- if or .Values.aws.assumeRoleArn (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey) (or .Values.cloudflare.apiToken .Values.cloudflare.apiKey) .Values.digitalocean.apiToken .Values.google.serviceAccountKey (and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword) .Values.rfc2136.tsigSecret .Values.pdns.apiKey (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId .Values.azure.aadClientId .Values.azure.aadClientSecret (not .Values.azure.useManagedIdentityExtension)) (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId .Values.azure.useManagedIdentityExtension) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -17,8 +17,12 @@ data:
   {{- if and (eq .Values.provider "google") .Values.google.serviceAccountKey }}
   credentials.json: {{ .Values.google.serviceAccountKey | b64enc | quote }}
   {{- end }}
-  {{- if .Values.cloudflare.apiKey }}
+  {{- if eq .Values.provider "cloudflare" }}
+  {{- if .Values.cloudflare.apiToken }}
+  cloudflare_api_token: {{ .Values.cloudflare.apiToken | b64enc | quote }}
+  {{- else }}
   cloudflare_api_key: {{ .Values.cloudflare.apiKey | b64enc | quote }}
+  {{- end }}
   {{- end }}
   {{- if .Values.digitalocean.apiToken }}
   digitalocean_api_token: {{ .Values.digitalocean.apiToken | b64enc | quote }}

--- a/stable/external-dns/values-production.yaml
+++ b/stable/external-dns/values-production.yaml
@@ -106,6 +106,9 @@ azure:
 ## Cloudflare configuration to be set via arguments/env. variables
 ##
 cloudflare:
+  ## `CF_API_TOKEN` to set in the environment
+  ##
+  apiToken: ""
   ## `CF_API_KEY` to set in the environment
   ##
   apiKey: ""

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -106,6 +106,9 @@ azure:
 ## Cloudflare configuration to be set via arguments/env. variables
 ##
 cloudflare:
+  ## `CF_API_TOKEN` to set in the environment
+  ##
+  apiToken: ""
   ## `CF_API_KEY` to set in the environment
   ##
   apiKey: ""


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

No.
#### What this PR does / why we need it:

Add `cloudflare.apiToken` value to set `CF_API_TOKEN`.

#### Which issue this PR fixes
  - fixes #17573 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
