### PR TITLE
[stable/ambassador] Added sidecarContainers parameter

### DIFF
--- a/stable/ambassador/Chart.yaml
+++ b/stable/ambassador/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.81.0
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 4.1.0
+version: 4.2.0
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/stable/ambassador/README.md
+++ b/stable/ambassador/README.md
@@ -76,6 +76,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `resources`                        | CPU/memory resource requests/limits                                             | `{}`                              |
 | `securityContext`                  | Set security context for pod                                                    | `{ "runAsUser": "8888" }`         |
 | `initContainers`                   | Containers used to initialize context for pods                                  | `[]`                              |
+| `sidecarContainers`                | Containers that share the pod context                                           | `[]`                              |
 | `service.annotations`              | Annotations to apply to Ambassador service                                      | `""`                              |
 | `service.externalTrafficPolicy`    | Sets the external traffic policy for the service                                | `""`                              |
 | `service.ports`                    | List of ports Ambassador is listening on                                        |  `[{"name": "http","port": 80,"targetPort": 8080},{"name": "https","port": 443,"targetPort": 8443}]` |

--- a/stable/ambassador/templates/deployment.yaml
+++ b/stable/ambassador/templates/deployment.yaml
@@ -222,6 +222,9 @@ spec:
           resources:
             {{- toYaml .Values.pro.resources | nindent 12 }}
         {{- end }}
+      {{- with .Values.sidecarContainers }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/stable/ambassador/values.yaml
+++ b/stable/ambassador/values.yaml
@@ -149,6 +149,8 @@ serviceAccount:
 
 initContainers: []
 
+sidecarContainers: []
+
 volumes: []
 
 volumeMounts: []


### PR DESCRIPTION
Signed-off-by: Pieter Vogelaar <pieter@pietervogelaar.nl>

#### What this PR does / why we need it:
With this PR a AuthService (https://www.getambassador.io/reference/services/auth-service/) can run as sidecar container in the same pod context as the ambassador pod.

I have a use case where the auth service determines based on the host header `footenant-staging.my-ruby-api.example` if a tenant belongs to the tenant group `early-adopters`, `early-majority` or `late-majority`. It adds a request header. Based on this, the request will reach the app in the correct kubernetes namespace.

Running the auth service as a sidecar container is the fastest way possible, no network latency etc.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [X] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
