### PR TITLE
Fix zookeeper chart to work with k8 >= 1.16

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 2.0.1
+version: 2.0.2
 appVersion: 3.5.5
 description: Centralized service for maintaining configuration information, naming,
   providing distributed synchronization, and providing group services.

--- a/incubator/zookeeper/templates/statefulset.yaml
+++ b/incubator/zookeeper/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "zookeeper.fullname" . }}


### PR DESCRIPTION
- statefuleset.yaml fails because apps/v1beta
  adjusted to apps/v1. 

Signed-off-by: Stephan Ruegamer <sh@sourcecode.de>

