### PR TITLE
[stable/rabbitmq] Added extra secrets support

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.7.4
+version: 6.8.0
 appVersion: 3.7.18
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -275,6 +275,27 @@ Any load definitions specified will be available within in the container at `/ap
 
 > Loading a definition will take precedence over any configuration done through [Helm values](#configuration).
 
+If needed, you can use `extraSecrets` to let the chart create the secret for you. This way, you don't need to manually create it before deploying a release. For example :
+
+```yaml
+extraSecrets:
+  load-definition:
+    load_definition.json: |
+      {
+        "vhosts": [
+          {
+            "name": "/"
+          }
+        ]
+      }
+rabbitmq:
+  loadDefinition:
+    enabled: true
+    secretName: load-definition
+  extraConfiguration: |
+    management.load_definitions = /app/load_definition.json
+```
+
 ## Persistence
 
 The [Bitnami RabbitMQ](https://github.com/bitnami/bitnami-docker-rabbitmq) image stores the RabbitMQ data and configurations at the `/opt/bitnami/rabbitmq/var/lib/rabbitmq/` path of the container.

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -152,6 +152,7 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `volumePermissions.image.pullPolicy`       | Init container volume-permissions image pull policy                                                            | `Always`                                             |
 | `volumePermissions.resources`                  | Init container resource requests/limit                 | `nil`                                                   |
 | `forceBoot.enabled`         | Executes 'rabbitmqctl force_boot' to force boot cluster shut down unexpectedly in an unknown order. Use it only if you prefer availability over integrity.                                                               | `false`                                          |
+| `extraSecrets`                       | Optionally specify extra secrets to be created by the chart. | `{}`                                        |
 
 The above parameters map to the env variables defined in [bitnami/rabbitmq](http://github.com/bitnami/bitnami-docker-rabbitmq). For more information please refer to the [bitnami/rabbitmq](http://github.com/bitnami/bitnami-docker-rabbitmq) image documentation.
 

--- a/stable/rabbitmq/templates/secrets.yaml
+++ b/stable/rabbitmq/templates/secrets.yaml
@@ -1,4 +1,4 @@
-{{ if or (not .Values.rabbitmq.existingErlangSecret) (not .Values.rabbitmq.existingPasswordSecret) }}
+{{- if or (not .Values.rabbitmq.existingErlangSecret) (not .Values.rabbitmq.existingPasswordSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -20,4 +20,19 @@ data:
   {{ else }}
   rabbitmq-erlang-cookie: {{ randAlphaNum 32 | b64enc | quote }}
   {{ end }}{{ end }}
-{{ end }}
+{{- end }}
+{{- range $key, $value := .Values.extraSecrets }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $key }}
+  labels:
+    app: {{ template "rabbitmq.name" $ }}
+    chart: {{ template "rabbitmq.chart" $ }}
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+type: Opaque
+stringData:
+{{ $value | toYaml | nindent 2 }}
+{{- end }}

--- a/stable/rabbitmq/values-production.yaml
+++ b/stable/rabbitmq/values-production.yaml
@@ -388,3 +388,13 @@ volumePermissions:
 ##
 forceBoot:
   enabled: false
+
+## Optionally specify extra secrets to be created by the chart.
+## This can be useful when combined with load_definitions to automatically create the secret containing the definitions to be loaded.
+##
+extraSecrets: {}
+  # load_definition:
+  #   load_definition.json: |
+  #     {
+  #       ...
+  #     }

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -388,3 +388,13 @@ volumePermissions:
 ##
 forceBoot:
   enabled: false
+
+## Optionally specify extra secrets to be created by the chart.
+## This can be useful when combined with load_definitions to automatically create the secret containing the definitions to be loaded.
+##
+extraSecrets: {}
+  # load_definition:
+  #   load_definition.json: |
+  #     {
+  #       ...
+  #     }


### PR DESCRIPTION
Added `extraSecrets` support to the chart.
This can be useful when combined with load_definitions to automatically create the secret containing the definitions to be loaded.
