### PR TITLE
[stable/nginx-ingress] Make prometheus scrape interval configurable

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.23.0
+version: 1.24.0
 appVersion: 0.26.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -137,8 +137,9 @@ Parameter | Description | Default
 `controller.metrics.service.type` | type of Prometheus metrics service to create | `ClusterIP`
 `controller.metrics.serviceMonitor.enabled` | Set this to `true` to create ServiceMonitor for Prometheus operator | `false`
 `controller.metrics.serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`
-`controller.metrics.serviceMonitor.namespace` | namespace where servicemonitor resource should be created | `the same namespace as nginx ingress`
 `controller.metrics.serviceMonitor.honorLabels` | honorLabels chooses the metric's labels on collisions with target labels. | `false`
+`controller.metrics.serviceMonitor.namespace` | namespace where servicemonitor resource should be created | `the same namespace as nginx ingress`
+`controller.metrics.serviceMonitor.scrapeInterval` | interval between Prometheus scraping | `30s`
 `controller.metrics.prometheusRule.enabled` | Set this to `true` to create prometheusRules for Prometheus operator | `false`
 `controller.metrics.prometheusRule.additionalLabels` | Additional labels that can be used so prometheusRules will be discovered by Prometheus | `{}`
 `controller.metrics.prometheusRule.namespace` | namespace where prometheusRules resource should be created | `the same namespace as nginx ingress`

--- a/stable/nginx-ingress/templates/controller-servicemonitor.yaml
+++ b/stable/nginx-ingress/templates/controller-servicemonitor.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   endpoints:
     - port: metrics
-      interval: 30s
+      interval: {{ .Values.controller.metrics.serviceMonitor.scrapeInterval }}
       {{- if .Values.controller.metrics.serviceMonitor.honorLabels }}
       honorLabels: true
       {{- end }}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -365,6 +365,7 @@ controller:
       enabled: false
       additionalLabels: {}
       namespace: ""
+      scrapeInterval: 30s
       # honorLabels: true
 
     prometheusRule:


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Makes Prometheus scrape interval configurable. Since nginx-ingress produces a lot of metric samples, some users might want to configure Prometheus to scrape nginx less frequently to mitigate performance issues with Prometheus.

#### Which issue this PR fixes

#### Special notes for your reviewer:
:star2::notes::star2:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
