### PR TITLE
[stable/spinnaker] Support custom local BOM for Halyard deployment.

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.19.0
+version: 1.20.0
 appVersion: 1.12.5
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/README.md
+++ b/stable/spinnaker/README.md
@@ -212,6 +212,72 @@ halyard:
 
 Any files added through `additionalConfigMaps` will be written to disk at `/opt/halyard/additionalConfigMaps`.
 
+### Use a custom Halyard BOM
+
+Spinnaker uses a Bill of Materials to describe the services that are part of a release. See the [BOM documentation](https://www.spinnaker.io/guides/operator/custom-boms/#the-bill-of-materials-bom) for more details.   
+
+A [custom BOM](https://www.spinnaker.io/guides/operator/custom-boms/#boms-and-configuration-on-your-filesystem) can be provided to the Helm chart and used for the Halyard deployment: 
+
+```yaml
+halyard:
+  spinnakerVersion: '1.16.1'
+  bom: |-
+    artifactSources:
+      debianRepository: https://dl.bintray.com/spinnaker-releases/debians
+      dockerRegistry: gcr.io/spinnaker-marketplace
+      gitPrefix: https://github.com/spinnaker
+      googleImageProject: marketplace-spinnaker-release
+    dependencies:
+      consul:
+        version: 0.7.5
+      redis:
+        version: 2:2.8.4-2
+      vault:
+        version: 0.7.0
+    services:
+      clouddriver:
+        commit: 031bcec52d6c3eb447095df4251b9d7516ed74f5
+        version: 6.3.0-20190904130744
+      deck:
+        commit: b0aac478e13a7f9642d4d39479f649dd2ef52a5a
+        version: 2.12.0-20190916141821
+      defaultArtifact: {}
+      echo:
+        commit: 7aae2141883240bd5747b981b2196adfa5b24225
+        version: 2.8.0-20190914075316
+      fiat:
+        commit: e92cfbcac018d9dcfa03869224f7106bf2a11315
+        version: 1.7.0-20190904130744
+      front50:
+        commit: abc5c168e3619ac084d4130eef7313cbdcfc3f61
+        version: 0.19.0-20190904130744
+      gate:
+        commit: fd0128a6b79ddaca984c3bcdd1259c14f167cd2d
+        version: 1.12.0-20190914075316
+      igor:
+        commit: c9bbca8e5c340d90b812f4fd27c6ebe3088dbc8d
+        version: 1.6.0-20190914075316
+      kayenta:
+        commit: 8aa41e6e723e8d37831f5d4fe0bd5aa24ede5872
+        version: 0.11.0-20190830172818
+      monitoring-daemon:
+        commit: 922385def92058877d61dfc835873539f0377cd7
+        version: 0.15.0-20190820135930
+      monitoring-third-party:
+        commit: 922385def92058877d61dfc835873539f0377cd7
+        version: 0.15.0-20190820135930
+      orca:
+        commit: 7b4e3dd6c4393ba88ebb3ea209a9c95df63e5e87
+        version: 2.10.0-20190914075316
+      rosco:
+        commit: cfb88bb57f7af064876cfe5eef3c330a2621507b
+        version: 0.14.0-20190904130744
+    timestamp: '2019-09-16 18:18:44'
+    version: 1.16.1
+```
+
+This will result in the specified BOM contents being written to a `1.16.1.yml` BOM file, and the Spinnaker version set to `local:1.16.1`.  
+
 ### Set custom annotations for the halyard pod
 
 ```yaml

--- a/stable/spinnaker/templates/configmap/bom.yaml
+++ b/stable/spinnaker/templates/configmap/bom.yaml
@@ -1,0 +1,11 @@
+{{ if .Values.halyard.bom -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "spinnaker.fullname" . }}-halyard-bom
+  labels:
+{{ include "spinnaker.standard-labels" . | indent 4 }}
+data:
+  {{ .Values.halyard.spinnakerVersion }}.yml:
+  {{ .Values.halyard.bom | toYaml | indent 4 }}
+{{- end }}

--- a/stable/spinnaker/templates/configmap/halyard-config.yaml
+++ b/stable/spinnaker/templates/configmap/halyard-config.yaml
@@ -31,7 +31,11 @@ data:
     $HAL_COMMAND deploy clean -q
   config.sh: |
     # Spinnaker version
+    {{ if .Values.halyard.bom }}
+    $HAL_COMMAND config version edit --version local:{{ .Values.halyard.spinnakerVersion }}
+    {{ else }}
     $HAL_COMMAND config version edit --version {{ .Values.halyard.spinnakerVersion }}
+    {{ end }}
 
     # Storage
     {{ if .Values.minio.enabled }}

--- a/stable/spinnaker/templates/configmap/halyard-init-script.yaml
+++ b/stable/spinnaker/templates/configmap/halyard-init-script.yaml
@@ -20,6 +20,12 @@ data:
     mkdir -p /tmp/spinnaker/.hal/default/profiles
     cp /tmp/additionalProfileConfigMaps/* /tmp/spinnaker/.hal/default/profiles/
 
+    {{- if .Values.halyard.bom }}
+    rm -rf /tmp/spinnaker/.hal/.boms/bom
+    mkdir -p /tmp/spinnaker/.hal/.boms/bom
+    cp /tmp/halyard-bom/* /tmp/spinnaker/.hal/.boms/bom
+    {{- end }}
+
     {{- if hasKey .Values.halyard "additionalInitScript" }}
     # additionalInitScript
     {{ tpl .Values.halyard.additionalInitScript $ | indent 4 }}

--- a/stable/spinnaker/templates/hooks/install-using-hal.yaml
+++ b/stable/spinnaker/templates/hooks/install-using-hal.yaml
@@ -56,6 +56,11 @@ spec:
         configMap:
           name: {{ template "spinnaker.fullname" . }}-additional-scripts
       {{- end }}
+      {{- if .Values.halyard.bom }}
+      - name: halyard-bom
+        configMap:
+          name: {{ template "spinnaker.fullname" . }}-halyard-bom
+      {{- end }}
       {{- if .Values.gcs.enabled }}
       - name: gcs-key
         secret:
@@ -91,6 +96,10 @@ spec:
         {{- if .Values.halyard.additionalScripts.create }}
         - name: additional-scripts
           mountPath: /opt/halyard/additionalScripts
+        {{- end }}
+        {{- if .Values.halyard.bom }}
+        - name: halyard-bom
+          mountPath: /opt/halyard/bom
         {{- end }}
         {{- if .Values.gcs.enabled }}
         - name: gcs-key

--- a/stable/spinnaker/templates/statefulsets/halyard.yaml
+++ b/stable/spinnaker/templates/statefulsets/halyard.yaml
@@ -44,6 +44,10 @@ spec:
           mountPath: /tmp/spinnaker
         - name: additional-profile-config-maps
           mountPath: /tmp/additionalProfileConfigMaps
+        {{- if .Values.halyard.bom }}
+        - name: halyard-bom
+          mountPath: /tmp/halyard-bom
+        {{- end }}
         - name: halyard-initscript
           mountPath: /tmp/initscript
         {{- if .Values.halyard.customCerts.enabled }}
@@ -103,6 +107,11 @@ spec:
       - name: additional-profile-config-maps
         configMap:
           name: {{ template "spinnaker.fullname" . }}-additional-profile-config-maps
+      {{- if .Values.halyard.bom }}
+      - name: halyard-bom
+        configMap:
+          name: {{ template "spinnaker.fullname" . }}-halyard-bom
+      {{- end }}
       - name: halyard-config
         emptyDir: {}
       - name: service-settings

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -58,6 +58,25 @@ halyard:
     #     podAnnotations:
     #       iam.amazonaws.com/role: <role_arn>
 
+  ## Populate to provide a custom local BOM for Halyard to use for deployment. Read more for details:
+  ## https://www.spinnaker.io/guides/operator/custom-boms/#boms-and-configuration-on-your-filesystem
+  bom: ~
+  #   artifactSources:
+  #     debianRepository: https://dl.bintray.com/spinnaker-releases/debians
+  #     dockerRegistry: gcr.io/spinnaker-marketplace
+  #     gitPrefix: https://github.com/spinnaker
+  #     googleImageProject: marketplace-spinnaker-release
+  #   services:
+  #     clouddriver:
+  #       commit: 031bcec52d6c3eb447095df4251b9d7516ed74f5
+  #       version: 6.3.0-20190904130744
+  #     deck:
+  #       commit: b0aac478e13a7f9642d4d39479f649dd2ef52a5a
+  #       version: 2.12.0-20190916141821
+  #     ...
+  #   timestamp: '2019-09-16 18:18:44'
+  #   version: 1.16.1
+
   ## Uncomment if you want to add extra commands to the init script
   ## run by the init container before halyard is started.
   ## The content will be passed through `tpl`, so value interpolation is supported.


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

Enhances the Spinnaker chart to allow a custom BOM to be provided in `values.yml`.

#### Which issue this PR fixes

No issue

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
