### PR TITLE
[stable/memcached] Kubernetes 1.16 compatibility

### DIFF
--- a/stable/memcached/Chart.yaml
+++ b/stable/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 2.10.2
+version: 3.0.0
 appVersion: 1.5.12
 description: Free & open source, high-performance, distributed memory object caching
   system.

--- a/stable/memcached/README.md
+++ b/stable/memcached/README.md
@@ -84,3 +84,42 @@ $ helm install --name my-release -f values.yaml stable/memcached
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Upgrading to 3.x from a previous major version
+Version 3.0.0 of this chart makes an incompatible change to the way StatefulSet/Deployment selectors are configured. If you try to upgrade from a previous major version, you will see an error like this:
+
+```
+Error: UPGRADE FAILED: Deployment.apps "mc-test-memcached" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"app":"mc-test-memcached", "chart":"memcached-3.0.0", "custom":"value", "heritage":"Tiller", "release":"mc-test"}: `selector` does not match template `labels`
+```
+
+To upgrade from a previous major version, you'll either need to perform a small manual fix or delete and reinstall the chart.
+
+The manual fix is to remove all selectors from the existing StatefulSet/Deployment except `app` and `release`.  Run `kubectl edit sts|deploy name-goes-here` (as needed), and you should see a part like this in your editor about 20 lines down:
+
+```yaml
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: mc-test-memcached
+      chart: memcached-2.10.2
+      heritage: Tiller
+      release: mc-test
+```
+
+Remove the lines under `matchLabels` except `app: ...` and `release: ...`, and don't change any other lines. The part from above should look like this when you're done:
+
+```yaml
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: mc-test-memcached
+      release: mc-test
+```
+
+Once you've done this, you can upgrade to 3.x with Helm as normal.

--- a/stable/memcached/templates/statefulset.yaml
+++ b/stable/memcached/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: {{ .Values.kind }}
 metadata:
   name: {{ template "memcached.fullname" . }}
@@ -8,6 +8,10 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "memcached.fullname" . }}
+      release: "{{ .Release.Name }}"
   {{- if eq .Values.kind "StatefulSet" }}
   serviceName: {{ template "memcached.fullname" . }}
   {{- end }}


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
This PR updates the Deployment template to use version apps/v1 instead of apps/v1beta1. The apps/v1beta1 version has been deprecated since Kubernetes 1.8, and is off by default in Kubernetes 1.16 (which prevents this chart from being installed). apps/v1 has been available since Kubernetes 1.9.

In apps/v1beta2, the `spec.selector` field on Deployments and StatefulSets became mandatory and immutable. Previously it would default to the value of `spec.template.metadata.labels`. Unfortunately, because this chart includes the chart version in the pod labels, all existing installs have the chart version in their selector. That means any chart upgrade tries to change the selector, which is impossible under apps/v1.

I took the approach of pruning the selector to the minimum labels necessary to uniquely identify the pods. This will prevent upgrades from existing installs, so it is a breaking change. However, it's possible to unblock the upgrade by running `kubectl edit` to remove the extra selectors. I've tested this procedure and added a note to the README with instructions.

#### Which issue this PR fixes
No issue

#### Special notes for your reviewer:
I understand making a breaking change like this is disruptive. I tried to come up with some alternatives, but none of them manage to avoid the issue completely:

- We could release an intermediate version 2.11 that keeps the apiVersion at apps/v1beta1 but adds an explicit selector with only `app` and `release`, and instruct users to upgrade to that before 3.x. Unfortunately, this doesn't work at all: since Helm didn't create the default `selector` value, it doesn't delete the `chart` entry and the upgrade fails due to a label mismatch.
- We could release _two_ intermediate versions 2.11 and 2.12 that keep the apiVersion at apps/v1beta1 which add and then explicitly remove all the extra selector entries. This technically works but is really clumsy; upgrades from <2.11 directly to 2.12 would break in the same way as above, which arguably means it should get its own major version bump as well.
- We could make apiVersion configurable and defaulting to apps/v1beta1. This allows smooth upgrades for everyone but breaks new installs on 1.16+ unless you set a value. It doesn't provide a good path to apps/v1, so users who upgrade to 1.16 will be on their own to navigate changing that value the next time they try to upgrade this chart.
- We could make apiVersion configurable and defaulting to apps/v1. New installs will be smooth, but it's still a breaking change and existing installs will need to either make the same manual fix or change values to stay on apps/v1beta1. If they do the latter, they'll still need to make a manual fix if they later upgrade to 1.16.

With the strategy I propose, there's a one-time annoyance for everyone, but it's highlighted by a major version bump and we can provide tested live-upgrade instructions. The alternatives I came up with are either more troublesome or leave the user on their own to figure out the hard part of the upgrade.

Let me know what you think -- I'd be happy to implement an alternate solution if there's one you'd prefer to the one in this PR!

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
