### PR TITLE
[incubator/zookeeper] Updated deprecated API version for Kubernetes 1.16

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 2.0.1
+version: 2.1.0
 appVersion: 3.5.5
 description: Centralized service for maintaining configuration information, naming,
   providing distributed synchronization, and providing group services.

--- a/incubator/zookeeper/README.md
+++ b/incubator/zookeeper/README.md
@@ -50,7 +50,7 @@ NAME                TYPE       CLUSTER-IP     EXTERNAL-IP  PORT(S)              
 zookeeper-headless  ClusterIP  None           <none>       2181/TCP,3888/TCP,2888/TCP  2m
 zookeeper           ClusterIP  10.98.179.165  <none>       2181/TCP                    2m
 
-==> v1beta1/StatefulSet
+==> v1/StatefulSet
 NAME       DESIRED  CURRENT  AGE
 zookeeper  3        3        2m
 

--- a/incubator/zookeeper/templates/statefulset.yaml
+++ b/incubator/zookeeper/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "zookeeper.fullname" . }}


### PR DESCRIPTION
@lachie83 @kow3ns 

#### What this PR does / why we need it:
Kubernetes 1.16 has deprecated non-stable API's.

#### Which issue this PR fixes
./.

#### Special notes for your reviewer:
./.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)