### PR TITLE
[elasticsearch and filebeat] Update api versions to support k8s 1.16

### DIFF
--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 1.10.1
+version: 1.11.0
 appVersion: 1.1.0
 home: https://github.com/justwatchcom/elasticsearch_exporter
 sources:

--- a/stable/elasticsearch-exporter/README.md
+++ b/stable/elasticsearch-exporter/README.md
@@ -17,7 +17,7 @@ cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 
-- Kubernetes 1.8+ with Beta APIs enabled
+- Kubernetes 1.10+
 
 ## Installing the Chart
 

--- a/stable/elasticsearch-exporter/templates/deployment.yaml
+++ b/stable/elasticsearch-exporter/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "elasticsearch-exporter.fullname" . }}

--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.31.1
+version: 1.32.0
 appVersion: 6.8.2
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/stable/elasticsearch/README.md
+++ b/stable/elasticsearch/README.md
@@ -19,7 +19,7 @@ If you want to avoid doing that upgrade to Elasticsearch 5.6 first before moving
 
 ## Prerequisites Details
 
-* Kubernetes 1.6+
+* Kubernetes 1.10+
 * PV dynamic provisioning support on the underlying infrastructure
 
 ## StatefulSets Details

--- a/stable/elasticsearch/templates/client-deployment.yaml
+++ b/stable/elasticsearch/templates/client-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/stable/elasticsearch/templates/data-statefulset.yaml
+++ b/stable/elasticsearch/templates/data-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:

--- a/stable/elasticsearch/templates/master-statefulset.yaml
+++ b/stable/elasticsearch/templates/master-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:

--- a/stable/elasticsearch/templates/podsecuritypolicy.yaml
+++ b/stable/elasticsearch/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podSecurityPolicy.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "elasticsearch.fullname" . }}

--- a/stable/filebeat/Chart.yaml
+++ b/stable/filebeat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart to collect Kubernetes logs with filebeat
 icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.svg
 name: filebeat
-version: 3.0.1
+version: 3.1.0
 appVersion: 7.0.1
 home: https://www.elastic.co/products/beats/filebeat
 sources:

--- a/stable/filebeat/README.md
+++ b/stable/filebeat/README.md
@@ -4,7 +4,7 @@
 
 ## Prerequisites
 
-- Kubernetes 1.9+
+- Kubernetes 1.10+
 
 ## Note
 

--- a/stable/filebeat/templates/daemonset.yaml
+++ b/stable/filebeat/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "filebeat.fullname" . }}

--- a/stable/filebeat/templates/podsecuritypolicy.yaml
+++ b/stable/filebeat/templates/podsecuritypolicy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create -}}
 {{- if .Values.podSecurityPolicy.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "filebeat.fullname" . }}


### PR DESCRIPTION
Update api versions (deprecated -> actual) to support k8s 1.16

ref: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

Signed-off-by: Anton Gorkovenko <gostom@gmail.com>

#### Is this a new chart
no
#### What this PR does / why we need it:
Update api versions (deprecated -> actual) to support k8s 1.16
#### Which issue this PR fixes
-
#### Special notes for your reviewer:
-
#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
