### PR TITLE
[gitlab] Update api versions to support k8s 1.16

### DIFF
--- a/stable/gitlab-ce/Chart.yaml
+++ b/stable/gitlab-ce/Chart.yaml
@@ -1,7 +1,7 @@
 name: gitlab-ce
 deprecated: true
-version: 0.2.2
-appVersion: 9.4.1
+version: 0.3.0
+appVersion: 12.3.3
 description: GitLab Community Edition
 keywords:
 - git

--- a/stable/gitlab-ce/templates/deployment.yaml
+++ b/stable/gitlab-ce/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if default "" .Values.externalUrl }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "gitlab-ce.fullname" . }}

--- a/stable/gitlab-ee/Chart.yaml
+++ b/stable/gitlab-ee/Chart.yaml
@@ -1,7 +1,7 @@
 name: gitlab-ee
 deprecated: true
-version: 0.2.2
-appVersion: 9.4.1
+version: 0.3.0
+appVersion: 12.3.3
 description: GitLab Enterprise Edition
 keywords:
 - git

--- a/stable/gitlab-ee/templates/deployment.yaml
+++ b/stable/gitlab-ee/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if default "" .Values.externalUrl }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "gitlab-ee.fullname" . }}


### PR DESCRIPTION
Signed-off-by: Anton Gorkovenko <gostom@gmail.com>

#### Is this a new chart
no
#### What this PR does / why we need it:
Update api versions (deprecated -> actual) to support k8s 1.16
ref: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
#### Which issue this PR fixes
-
#### Special notes for your reviewer:
-
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
