### PR TITLE
[stable/prometheus-redis-exporter] Update api versions to support k8s 1.16

### DIFF
--- a/stable/prometheus-redis-exporter/Chart.yaml
+++ b/stable/prometheus-redis-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.4
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 3.0.1
+version: 3.1.0
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/stable/prometheus-redis-exporter/README.md
+++ b/stable/prometheus-redis-exporter/README.md
@@ -14,7 +14,7 @@ This chart bootstraps a [redis_exporter](https://github.com/oliver006/redis_expo
 
 ## Prerequisites
 
-- Kubernetes 1.8+ with Beta APIs enabled
+- Kubernetes 1.10+ with Beta APIs enabled
 
 ## Installing the Chart
 

--- a/stable/prometheus-redis-exporter/templates/deployment.yaml
+++ b/stable/prometheus-redis-exporter/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "prometheus-redis-exporter.fullname" . }}

--- a/stable/prometheus-redis-exporter/templates/podsecuritypolicy.yaml
+++ b/stable/prometheus-redis-exporter/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-redis-exporter.fullname" . }}


### PR DESCRIPTION
Signed-off-by: Anton Gorkovenko <gostom@gmail.com>

#### Is this a new chart
no
#### What this PR does / why we need it:
Update api versions (deprecated -> actual) to support k8s 1.16
ref: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
#### Which issue this PR fixes
-
#### Special notes for your reviewer:
-
#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
