### PR TITLE
[stable/mysql] Update api versions to support k8s 1.16

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mysql
-version: 1.3.3
-appVersion: 5.7.14
+version: 1.4.0
+appVersion: 5.7.27
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.
 keywords:

--- a/stable/mysql/README.md
+++ b/stable/mysql/README.md
@@ -8,7 +8,7 @@ This chart bootstraps a single node MySQL deployment on a [Kubernetes](http://ku
 
 ## Prerequisites
 
-- Kubernetes 1.6+ with Beta APIs enabled
+- Kubernetes 1.10+ with Beta APIs enabled
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
     metadata:
       labels:
         app: {{ template "mysql.fullname" . }}
+        release: {{ .Release.Name }}
 {{- with .Values.podLabels }}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "mysql.fullname" . }}
@@ -14,6 +14,10 @@ metadata:
 {{- end }}
 
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "mysql.fullname" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
Signed-off-by: Anton Gorkovenko <gostom@gmail.com>

#### Is this a new chart
no
#### What this PR does / why we need it:
Update api versions (deprecated -> actual) to support k8s 1.16
ref: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
#### Which issue this PR fixes
#### Special notes for your reviewer:
#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
