### PR TITLE
[stable/elasticsearch] Update api versions to support k8s 1.16

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.31.1
+version: 1.32.0
 appVersion: 6.8.2
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/stable/elasticsearch/README.md
+++ b/stable/elasticsearch/README.md
@@ -19,7 +19,7 @@ If you want to avoid doing that upgrade to Elasticsearch 5.6 first before moving
 
 ## Prerequisites Details
 
-* Kubernetes 1.6+
+* Kubernetes 1.10+
 * PV dynamic provisioning support on the underlying infrastructure
 
 ## StatefulSets Details

--- a/stable/elasticsearch/templates/client-deployment.yaml
+++ b/stable/elasticsearch/templates/client-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/stable/elasticsearch/templates/client-deployment.yaml
+++ b/stable/elasticsearch/templates/client-deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "elasticsearch.client.fullname" . }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "elasticsearch.name" . }}
+      release: {{ .Release.Name }}
   replicas: {{ .Values.client.replicas }}
   template:
     metadata:

--- a/stable/elasticsearch/templates/client-deployment.yaml
+++ b/stable/elasticsearch/templates/client-deployment.yaml
@@ -12,6 +12,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "elasticsearch.name" . }}
+      component: "{{ .Values.client.name }}"
       release: {{ .Release.Name }}
   replicas: {{ .Values.client.replicas }}
   template:

--- a/stable/elasticsearch/templates/data-statefulset.yaml
+++ b/stable/elasticsearch/templates/data-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:

--- a/stable/elasticsearch/templates/data-statefulset.yaml
+++ b/stable/elasticsearch/templates/data-statefulset.yaml
@@ -9,6 +9,10 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "elasticsearch.data.fullname" . }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "elasticsearch.name" . }}
+      release: {{ .Release.Name }}
   serviceName: {{ template "elasticsearch.data.fullname" . }}
   replicas: {{ .Values.data.replicas }}
   template:

--- a/stable/elasticsearch/templates/master-statefulset.yaml
+++ b/stable/elasticsearch/templates/master-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:

--- a/stable/elasticsearch/templates/master-statefulset.yaml
+++ b/stable/elasticsearch/templates/master-statefulset.yaml
@@ -9,6 +9,10 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "elasticsearch.master.fullname" . }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "elasticsearch.name" . }}
+      release: {{ .Release.Name }}
   serviceName: {{ template "elasticsearch.master.fullname" . }}
   replicas: {{ .Values.master.replicas }}
   template:

--- a/stable/elasticsearch/templates/podsecuritypolicy.yaml
+++ b/stable/elasticsearch/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podSecurityPolicy.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "elasticsearch.fullname" . }}


### PR DESCRIPTION
Signed-off-by: Anton Gorkovenko gostom@gmail.com

#### Is this a new chart
no
#### What this PR does / why we need it:
Update api versions (deprecated -> actual) to support k8s 1.16
ref: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
#### Which issue this PR fixes
no
#### Special notes for your reviewer:
no
#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
