### PR TITLE
[stable/filebeat] Update api versions to support k8s 1.16

### DIFF
--- a/stable/filebeat/Chart.yaml
+++ b/stable/filebeat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart to collect Kubernetes logs with filebeat
 icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.svg
 name: filebeat
-version: 3.0.1
+version: 3.1.0
 appVersion: 7.0.1
 home: https://www.elastic.co/products/beats/filebeat
 sources:

--- a/stable/filebeat/README.md
+++ b/stable/filebeat/README.md
@@ -4,7 +4,7 @@
 
 ## Prerequisites
 
-- Kubernetes 1.9+
+- Kubernetes 1.10+
 
 ## Note
 

--- a/stable/filebeat/templates/daemonset.yaml
+++ b/stable/filebeat/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "filebeat.fullname" . }}

--- a/stable/filebeat/templates/podsecuritypolicy.yaml
+++ b/stable/filebeat/templates/podsecuritypolicy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create -}}
 {{- if .Values.podSecurityPolicy.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "filebeat.fullname" . }}


### PR DESCRIPTION
Signed-off-by: Anton Gorkovenko <gostom@gmail.com>

#### Is this a new chart
no
#### What this PR does / why we need it:
Update api versions (deprecated -> actual) to support k8s 1.16
ref: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
#### Which issue this PR fixes
#### Special notes for your reviewer:
#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
