### PR TITLE
[incubator/kafka] fix spine case secret name results in invalid envir…

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.20.0
+version: 0.20.1
 appVersion: 5.0.1
 keywords:
 - kafka

--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -177,7 +177,7 @@ spec:
         {{- range $secret := .Values.secrets }}
           {{- if not $secret.mountPath }}
             {{- range $key := $secret.keys }}
-        - name: {{ (print ($secret.name | replace "-" "_" ) "_" $key) | upper }}
+        - name: {{ (print ($secret.name | replace "-" "_") "_" $key) | upper }}
           valueFrom:
             secretKeyRef:
               name: {{ $secret.name }}
@@ -246,9 +246,11 @@ spec:
 {{ toYaml .Values.securityContext | indent 8 }}
       {{- end }}
       {{- range .Values.secrets }}
+      {{- if .mountPath }}
       - name: {{ include "kafka.fullname" $ }}-{{ .name }}
         secret:
           secretName: {{ .name }}
+      {{- end }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
   {{- if .Values.persistence.enabled }}

--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -177,7 +177,7 @@ spec:
         {{- range $secret := .Values.secrets }}
           {{- if not $secret.mountPath }}
             {{- range $key := $secret.keys }}
-        - name: {{ (print $secret.name "_" $key) | upper }}
+        - name: {{ (print ($secret.name | replace "-" "_" ) "_" $key) | upper }}
           valueFrom:
             secretKeyRef:
               name: {{ $secret.name }}


### PR DESCRIPTION
…onment variable name

A spine-case secret results in a  SPINE-CASE environment variable which isn't allowed since bash 4.1.
This change replaces dashes (-) with underscores (_) resulting in valid environment variables for spine-case secrets.

Also adding the same secret twice, once as a volume mount and once as an environment variable results in the secret being mounted twice.
Changed so that volume mounts are only created if the secret has a mountPath value

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)