### PR TITLE
[stable/joomla] Update broken link to NGINX Ingress Annotations docs

### DIFF
--- a/stable/joomla/Chart.yaml
+++ b/stable/joomla/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: joomla
-version: 6.1.7
+version: 6.1.8
 appVersion: 3.9.12
 description: PHP content management system (CMS) for publishing web content
 keywords:

--- a/stable/joomla/values.yaml
+++ b/stable/joomla/values.yaml
@@ -205,7 +205,7 @@ ingress:
 
     ## Ingress annotations done as key:value pairs
     ## For a full list of possible ingress annotations, please see
-    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
     ##
     ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
     ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

The NGINX Ingress Controller annotations documentation was moved from:

- https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md

to:

- https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md

This PR address this change

**Checklist**

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)