### PR TITLE
[stable/mediawiki] Update broken link to NGINX Ingress Annotations docs

### DIFF
--- a/stable/mediawiki/Chart.yaml
+++ b/stable/mediawiki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mediawiki
-version: 8.2.4
+version: 8.2.5
 appVersion: 1.33.0
 description: Extremely powerful, scalable software and a feature-rich wiki implementation that uses PHP to process and display data stored in a database.
 home: http://www.mediawiki.org/

--- a/stable/mediawiki/values.yaml
+++ b/stable/mediawiki/values.yaml
@@ -190,7 +190,7 @@ ingress:
 
     ## Ingress annotations done as key:value pairs
     ## For a full list of possible ingress annotations, please see
-    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
     ##
     ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
     ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

The NGINX Ingress Controller annotations documentation was moved from:

- https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md

to:

- https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md

This PR address this change

**Checklist**

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)