### PR TITLE
[stable/moodle] Update broken link to NGINX Ingress Annotations docs

### DIFF
--- a/stable/moodle/Chart.yaml
+++ b/stable/moodle/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: moodle
-version: 6.1.8
+version: 6.1.9
 appVersion: 3.7.2
 description: Moodle is a learning platform designed to provide educators, administrators and learners with a single robust, secure and integrated system to create personalised learning environments
 keywords:

--- a/stable/moodle/values.yaml
+++ b/stable/moodle/values.yaml
@@ -201,7 +201,7 @@ ingress:
 
     ## Ingress annotations done as key:value pairs
     ## For a full list of possible ingress annotations, please see
-    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
     ##
     ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
     annotations:


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

The NGINX Ingress Controller annotations documentation was moved from:

- https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md

to:

- https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md

This PR address this change

**Checklist**

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)