### PR TITLE
[stable/nats] Update broken link to NGINX Ingress Annotations docs

### DIFF
--- a/stable/nats/Chart.yaml
+++ b/stable/nats/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nats
-version: 4.2.0
+version: 4.2.1
 appVersion: 2.1.0
 description: An open-source, cloud-native messaging system
 keywords:

--- a/stable/nats/values-production.yaml
+++ b/stable/nats/values-production.yaml
@@ -262,7 +262,7 @@ ingress:
     ## kubernetes.io/tls-acme: true
     ##
     ## For a full list of possible ingress annotations, please see
-    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
     ##
     ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
     annotations:

--- a/stable/nats/values.yaml
+++ b/stable/nats/values.yaml
@@ -262,7 +262,7 @@ ingress:
     ## kubernetes.io/tls-acme: true
     ##
     ## For a full list of possible ingress annotations, please see
-    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
     ##
     ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
     annotations:


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

The NGINX Ingress Controller annotations documentation was moved from:

- https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md

to:

- https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md

This PR address this change

**Checklist**

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)