### PR TITLE
[stable/osclass] Update broken link to NGINX Ingress Annotations docs

### DIFF
--- a/stable/osclass/Chart.yaml
+++ b/stable/osclass/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: osclass
-version: 6.2.3
+version: 6.2.4
 appVersion: 3.7.4
 description: Osclass is a php script that allows you to quickly create and manage
   your own free classifieds site.

--- a/stable/osclass/values.yaml
+++ b/stable/osclass/values.yaml
@@ -182,7 +182,7 @@ ingress:
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

The NGINX Ingress Controller annotations documentation was moved from:

- https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md

to:

- https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md

This PR address this change

**Checklist**

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)