### PR TITLE
[stable/phabricator] Update broken link to NGINX Ingress Annotations docs

### DIFF
--- a/stable/phabricator/Chart.yaml
+++ b/stable/phabricator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: phabricator
-version: 7.0.10
+version: 7.0.11
 appVersion: 2019.39.0
 description: Collection of open source web applications that help software companies build better software.
 keywords:

--- a/stable/phabricator/values.yaml
+++ b/stable/phabricator/values.yaml
@@ -170,7 +170,7 @@ ingress:
 
   ## Ingress annotations done as key:value pairs
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
   annotations:
   #  kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

The NGINX Ingress Controller annotations documentation was moved from:

- https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md

to:

- https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md

This PR address this change

**Checklist**

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)