### PR TITLE
[stable/dex] Fix compatibility with k8s 1.16

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 2.3.1
+version: 2.3.2
 appVersion: 2.19.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/templates/deployment.yaml
+++ b/stable/dex/templates/deployment.yaml
@@ -6,7 +6,7 @@
 {{ $grpcCaBuiltName := printf "%s-ca" $fullname }}
 {{ $grpcCaSecretName := default $grpcCaBuiltName .Values.certs.grpc.secret.caName }}
 
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "dex.fullname" . }}


### PR DESCRIPTION
Signed-off-by: Giacomo Longo <gabibbo97@gmail.com>

#### What this PR does / why we need it:

`apps/v1beta2` is deprecated on k8s 1.16

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
