### PR TITLE
[stable/dex] Fix compatibility with Helm 3

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 2.4.0
+version: 2.4.1
 appVersion: 2.19.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/values.yaml
+++ b/stable/dex/values.yaml
@@ -156,7 +156,7 @@ config:
     tlsCert: /etc/dex/tls/grpc/server/tls.crt
     tlsKey: /etc/dex/tls/grpc/server/tls.key
     tlsClientCA: /etc/dex/tls/grpc/ca/tls.crt
-  connectors: {}
+  connectors: []
 #  - type: github
 #    id: github
 #    name: GitHub


### PR DESCRIPTION
Signed-off-by: Giacomo Longo <gabibbo97@gmail.com>

#### What this PR does / why we need it:

Using Helm `v3.0.0-beta.3` the chart deployment fails with

```sh
coalesce.go:186: warning: cannot overwrite table with non table for connectors (map[])
```

To reproduce

```sh
helm install dex ./stable/dex --set config.connectors[0].type=mockCallback --set config.connectors[0].id=mock --set config.connectors[0].name=Example
```

This fixes it by removing the object interface and replacing it with an array

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
