### PR TITLE
[stable/datadog] enable custom logs in datadog

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.39.6
+version: 1.39.7
 appVersion: "7"
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -106,6 +106,23 @@ datadog:
  logsConfigContainerCollectAll: true
 ```
 
+To collect custom logs, the following configuration could be used:
+
+```
+datadog:
+  (...)
+  logsEnabled: true
+  customLogFiles:
+  - type:     file
+    path:     <host-path/filename>  # Eg. /var/log/audit.log
+    service:  <service-name>        # Eg. audit
+    source:   <source-name>         # Eg. audit-logs
+  confd:
+    customLogFiles.yaml: |-
+      logs:
+        {{- .Values.datadog.customLogFiles | toYaml | nindent 4 }}
+```
+
 then upgrade your Datadog Helm chart:
 
 ```bash
@@ -184,6 +201,9 @@ datadog:
       instances:
         - host: "outside-k8s.example.com"
           port: 6379
+    customLogFiles.yaml: |-
+      logs:
+        {{- .Values.datadog.customLogFiles | toYaml | nindent 4 }}
 ```
 
 then upgrade your Datadog Helm chart:
@@ -261,6 +281,7 @@ helm install --name <RELEASE_NAME> \
 | `datadog.logLevel`                       | Agent log verbosity (possible values: trace, debug, info, warn, error, critical, and off) | `INFO`                                      |
 | `datadog.logsEnabled`                    | Enable log collection                                                                     | `nil`                                       |
 | `datadog.logsConfigContainerCollectAll`  | Collect logs from all containers                                                          | `nil`                                       |
+| `datadog.customLogFiles`                 | Definition of files from the host (see [Custom Log Collection](https://docs.datadoghq.com/agent/logs/?tab=tailexistingfiles#custom-log-collection))                                                                                    | `nil`                                       |
 | `datadog.logsPointerHostPath`            | Host path to store the log tailing state in                                               | `/var/lib/datadog-agent/logs`               |
 | `datadog.apmEnabled`                     | Enable tracing from the host                                                              | `nil`                                       |
 | `datadog.processAgentEnabled`            | Control live process and container monitoring. Possible values: `nil` for container monitoring only, `true` for container and process monitoring, `false` turns off process-agent | `nil`|

--- a/stable/datadog/templates/container-agent.yaml
+++ b/stable/datadog/templates/container-agent.yaml
@@ -144,6 +144,11 @@
       mountPath: {{ .Values.datadog.containerLogsPath | quote }}
       readOnly: true
     {{- end }}
+    {{- range .Values.datadog.customLogFiles }}
+    - name: {{ .service }}
+      mountPath: {{ .path }}
+      readOnly: true
+    {{- end }}
     {{- end }}
 {{- if .Values.datadog.volumeMounts }}
 {{ toYaml .Values.datadog.volumeMounts | indent 4 }}

--- a/stable/datadog/templates/container-agents.yaml
+++ b/stable/datadog/templates/container-agents.yaml
@@ -192,6 +192,11 @@
       mountPath: {{ .Values.datadog.containerLogsPath | quote }}
       readOnly: true
     {{- end }}
+    {{- range .Values.datadog.customLogFiles }}
+    - name: {{ .service }}
+      mountPath: {{ .path }}
+      readOnly: true
+    {{- end }}
     {{- end }}
     {{- if .Values.datadog.processAgentEnabled }}
     - name: passwd

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -137,6 +137,12 @@ spec:
             path: {{ .Values.datadog.containerLogsPath | quote }}
           name: logcontainerpath
         {{- end }}
+        {{- range .Values.datadog.customLogFiles }}
+        - hostPath:
+            path: {{ .path | quote }}
+            type: File
+          name: {{ .service }}
+        {{- end }}
         {{- end }}
         {{- if or (kindIs "invalid" .Values.datadog.processAgentEnabled) .Values.datadog.processAgentEnabled .Values.systemProbe.enabled }}
         - hostPath:

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -201,6 +201,23 @@ datadog:
   #
   containerLogsPath: /var/lib/docker/containers
 
+  ## @param customLogFiles - array - optional
+  ## Format a list of files from the host to mount into the container. Format
+  ## must follow the "Custom log collection" format for files. Wildcard files
+  ## are NOT accepted at this time. For these logs to be read,
+  ## confd must also be updated. See the "customLogFiles" key in the confd
+  ## example.
+  ## ref: https://docs.datadoghq.com/agent/logs/?tab=tailexistingfiles#custom-log-collection
+  #
+  # customLogFiles:
+  # - type:     file
+  #   path:     /var/log/audit.log
+  #   service:  audit
+  #   source:   audit-logs
+  #   log_processing_rules:
+  #     - type: include_at_match
+  #       name: delete-only-logs
+  #       pattern: delete
 
   ## @param apmEnabled - boolean - optional - default: false
   ## Enable this to enable APM and tracing, on port 8126
@@ -257,6 +274,9 @@ datadog:
   #     init_config:
   #     instances:
   #       - kube_state_url: http://%%host%%:8080/metrics
+  #   customLogFiles.yaml: |-
+  #     logs:
+  #       {{- .Values.datadog.customLogFiles | toYaml | nindent 4 }}
 
   ## @param checksd - list of key:value strings - optional
   ## Provide additional custom checks as python code


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Adds the ability to mount host files to DataDog pods for consumption with DataDog's [Agent Log Collection](https://docs.datadoghq.com/agent/logs/?tab=tailexistingfiles)


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
