### PR TITLE
[stable/memcached] Update 3.x upgrade docs for StatefulSet installs

### DIFF
--- a/stable/memcached/Chart.yaml
+++ b/stable/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 3.0.0
+version: 3.0.1
 appVersion: 1.5.12
 description: Free & open source, high-performance, distributed memory object caching
   system.

--- a/stable/memcached/README.md
+++ b/stable/memcached/README.md
@@ -94,7 +94,11 @@ Error: UPGRADE FAILED: Deployment.apps "mc-test-memcached" is invalid: spec.temp
 
 To upgrade from a previous major version, you'll either need to perform a small manual fix or delete and reinstall the chart.
 
-The manual fix is to remove all selectors from the existing StatefulSet/Deployment except `app` and `release`.  Run `kubectl edit sts|deploy name-goes-here` (as needed), and you should see a part like this in your editor about 20 lines down:
+### Upgrading with `kind: StatefulSet`
+If you're using a StatefulSet, you'll have to manually delete it and allow Helm to re-create it. Run `kubectl delete --cascade=false sts name-goes-here` to delete the StatefulSet without deleting the pods. Once you've done this, upgrade the chart as normal, and the newly-created StatefulSet will adopt the old pods.
+
+### Upgrading with `kind: Deployment`
+If you're using a Deployment, the manual fix is to remove all selectors from the spec except `app` and `release`.  Run `kubectl edit deploy name-goes-here`, and you should see a part like this in your editor about 20 lines down:
 
 ```yaml
 spec:


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Updates the 3.x upgrade docs added in #17627 to have working instructions for StatefulSet deployments.

#### Which issue this PR fixes
No issue

#### Special notes for your reviewer:
The instructions I provided in the previous PR only worked for Deployments -- I must have messed something up while testing. The `selector` field on StatefulSetSpec is immutable even in `apps/v1beta1`, so the manual edit step doesn't work. The best alternative appears to be a delete-and-recreate, which can be made zero-downtime by adding `--cascade=false`.

I was surprised by this, but confirmed that this limitation means this chart can't be upgraded without manual fixes if using a StatefulSet on <3.0.0:

```
$ helm install --name mc-test --version 2.10.0 stable/memcached 
NAME:   mc-test
...
$ helm upgrade --version 2.10.2 mc-test stable/memcached
Error: UPGRADE FAILED: StatefulSet.apps "mc-test-memcached" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"app":"mc-test-memcached", "chart":"memcached-2.10.2", "heritage":"Tiller", "release":"mc-test"}: `selector` does not match template `labels`
```

Once on 3.x, however, StatefulSets can be upgraded without any hacks, which seems like a pretty nice side-effect!

```
$ helm install --name mc-test --version 3.0.0 stable/memcached 
NAME:   mc-test
...
$ helm upgrade mc-test . # (on checkout with this PR)
Release "mc-test" has been upgraded. Happy Helming!
```

(CC @olemarkus)

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
