### PR TITLE
Include Release.Namespace within each object

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -10,7 +10,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 6.14.1
+version: 6.14.2
 appVersion: 0.32.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/templates/alertmanager/alertmanager.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/alertmanager.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default 
 kind: Alertmanager
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-alertmanager
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-alertmanager
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/alertmanager/ingress.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/ingress.yaml
@@ -7,6 +7,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $serviceName }}
+  namespace: {{ .Release.Namespace }}
 {{- if .Values.alertmanager.ingress.annotations }}
   annotations:
 {{ toYaml .Values.alertmanager.ingress.annotations | indent 4 }}

--- a/stable/prometheus-operator/templates/alertmanager/podDisruptionBudget.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/podDisruptionBudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-alertmanager
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-alertmanager
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/alertmanager/psp-clusterrole.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/psp-clusterrole.yaml
@@ -3,6 +3,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-alertmanager
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-alertmanager
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/alertmanager/psp-clusterrolebinding.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/psp-clusterrolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-alertmanager
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-alertmanager
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/alertmanager/psp.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/psp.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-alertmanager
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-alertmanager
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/alertmanager/secret.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: alertmanager-{{ template "prometheus-operator.fullname" . }}-alertmanager
+  namespace: {{ .Release.Namespace }}
 {{- if .Values.alertmanager.secret.annotations }}
   annotations:
 {{ toYaml .Values.alertmanager.secret.annotations | indent 4 }}

--- a/stable/prometheus-operator/templates/alertmanager/service.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-alertmanager
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-alertmanager
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/alertmanager/serviceaccount.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "prometheus-operator.alertmanager.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-alertmanager
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/alertmanager/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default 
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-alertmanager
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-alertmanager
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/exporters/core-dns/service.yaml
+++ b/stable/prometheus-operator/templates/exporters/core-dns/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-coredns
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-coredns
     jobLabel: coredns

--- a/stable/prometheus-operator/templates/exporters/core-dns/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/core-dns/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default 
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-coredns
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-coredns
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/exporters/kube-api-server/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-api-server/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default 
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-apiserver
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-apiserver
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/exporters/kube-controller-manager/endpoints.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-controller-manager/endpoints.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-kube-controller-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-kube-controller-manager
     k8s-app: kube-controller-manager

--- a/stable/prometheus-operator/templates/exporters/kube-controller-manager/service.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-controller-manager/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-kube-controller-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-kube-controller-manager
     jobLabel: kube-controller-manager

--- a/stable/prometheus-operator/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default 
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-kube-controller-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-kube-controller-manager
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/exporters/kube-dns/service.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-dns/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-kube-dns
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-kube-dns
     jobLabel: kube-dns

--- a/stable/prometheus-operator/templates/exporters/kube-dns/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-dns/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default 
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-kube-dns
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-kube-dns
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/exporters/kube-etcd/endpoints.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-etcd/endpoints.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-kube-etcd
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-kube-etcd
     k8s-app: etcd-server

--- a/stable/prometheus-operator/templates/exporters/kube-etcd/service.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-etcd/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-kube-etcd
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-kube-etcd
     jobLabel: kube-etcd

--- a/stable/prometheus-operator/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default 
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-kube-etcd
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-kube-etcd
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/exporters/kube-proxy/service.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-proxy/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-kube-proxy
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-kube-proxy
     jobLabel: kube-proxy

--- a/stable/prometheus-operator/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default 
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-kube-proxy
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-kube-proxy
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/exporters/kube-scheduler/endpoints.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-scheduler/endpoints.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-kube-scheduler
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-kube-scheduler
     k8s-app: kube-scheduler

--- a/stable/prometheus-operator/templates/exporters/kube-scheduler/service.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-scheduler/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-kube-scheduler
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-kube-scheduler
     jobLabel: kube-scheduler

--- a/stable/prometheus-operator/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default 
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-kube-scheduler
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-kube-scheduler
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/exporters/kube-state-metrics/serviceMonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-state-metrics/serviceMonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default 
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-kube-state-metrics
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-kube-state-metrics
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default 
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-kubelet
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-kubelet
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/exporters/node-exporter/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/node-exporter/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default 
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-node-exporter
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-node-exporter
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/grafana/configmap-dashboards.yaml
+++ b/stable/prometheus-operator/templates/grafana/configmap-dashboards.yaml
@@ -10,6 +10,7 @@ items:
   kind: ConfigMap
   metadata:
     name: {{ printf "%s-%s" (include "prometheus-operator.fullname" $) $dashboardName | trunc 63 | trimSuffix "-" }}
+    namespace: {{ .Release.Namespace }}
     labels:
       {{- if $.Values.grafana.sidecar.dashboards.label }}
       {{ $.Values.grafana.sidecar.dashboards.label }}: "1"

--- a/stable/prometheus-operator/templates/grafana/configmaps-datasources.yaml
+++ b/stable/prometheus-operator/templates/grafana/configmaps-datasources.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-grafana-datasource
+  namespace: {{ .Release.Namespace }}
   labels:
     {{ $.Values.grafana.sidecar.datasources.label }}: "1"
     app: {{ template "prometheus-operator.name" $ }}-grafana

--- a/stable/prometheus-operator/templates/grafana/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/grafana/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default 
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-grafana
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-grafana
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/clusterrole.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/clusterrole.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name:  {{ template "prometheus-operator.fullname" . }}-admission
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/clusterrolebinding.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/clusterrolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name:  {{ template "prometheus-operator.fullname" . }}-admission
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name:  {{ template "prometheus-operator.fullname" . }}-admission-create
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name:  {{ template "prometheus-operator.fullname" . }}-admission-patch
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/psp.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/psp.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-admission
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/role.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name:  {{ template "prometheus-operator.fullname" . }}-admission
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/rolebinding.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name:  {{ template "prometheus-operator.fullname" . }}-admission
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/serviceaccount.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name:  {{ template "prometheus-operator.fullname" . }}-admission
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/mutatingWebhookConfiguration.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/mutatingWebhookConfiguration.yaml
@@ -3,6 +3,7 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
   name:  {{ template "prometheus-operator.fullname" . }}-admission
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" $ }}-admission
 {{- include "prometheus-operator.labels" $ | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/validatingWebhookConfiguration.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/admission-webhooks/validatingWebhookConfiguration.yaml
@@ -3,6 +3,7 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name:  {{ template "prometheus-operator.fullname" . }}-admission
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" $ }}-admission
 {{- include "prometheus-operator.labels" $ | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/clusterrole.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/clusterrole.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-operator
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-operator
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/clusterrolebinding.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/clusterrolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-operator
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-operator
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/crd-alertmanager.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/crd-alertmanager.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   name: {{ printf "alertmanagers.%s" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-operator
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/crd-podmonitor.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/crd-podmonitor.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   name: {{ printf "podmonitors.%s" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-operator
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/crd-prometheus.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/crd-prometheus.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   name: {{ printf "prometheuses.%s" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-operator
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/crd-prometheusrules.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/crd-prometheusrules.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   name: {{ printf "prometheusrules.%s" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-operator
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/crd-servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/crd-servicemonitor.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   name: {{ printf "servicemonitors.%s" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-operator
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-operator
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-operator
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/psp-clusterrole.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/psp-clusterrole.yaml
@@ -3,6 +3,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-operator-psp
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-operator
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/psp-clusterrolebinding.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/psp-clusterrolebinding.yaml
@@ -3,6 +3,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-operator-psp
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-operator
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/psp.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/psp.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-operator
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-operator
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/service.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-operator
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-operator
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/serviceaccount.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "prometheus-operator.operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-operator
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus-operator/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default 
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-operator
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-operator
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus/additionalAlertRelabelConfigs.yaml
+++ b/stable/prometheus-operator/templates/prometheus/additionalAlertRelabelConfigs.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-prometheus-am-relabel-confg
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-prometheus-am-relabel-confg
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus/additionalAlertmanagerConfigs.yaml
+++ b/stable/prometheus-operator/templates/prometheus/additionalAlertmanagerConfigs.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-prometheus-am-confg
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-prometheus-am-confg
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus/additionalPrometheusRules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/additionalPrometheusRules.yaml
@@ -8,6 +8,7 @@ items:
     kind: PrometheusRule
     metadata:
       name: {{ template "prometheus-operator.name" $ }}-{{ $prometheusRuleName }}
+      namespace: {{ .Release.Namespace }}
       labels:
         app: {{ template "prometheus-operator.name" $ }}
 {{ include "prometheus-operator.labels" $ | indent 8 }}
@@ -24,6 +25,7 @@ items:
     kind: PrometheusRule
     metadata:
       name: {{ template "prometheus-operator.name" $ }}-{{ .name }}
+      namespace: {{ .Release.Namespace }}
       labels:
         app: {{ template "prometheus-operator.name" $ }}
 {{ include "prometheus-operator.labels" $ | indent 8 }}

--- a/stable/prometheus-operator/templates/prometheus/additionalScrapeConfigs.yaml
+++ b/stable/prometheus-operator/templates/prometheus/additionalScrapeConfigs.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-prometheus-scrape-confg
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-prometheus-scrape-confg
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus/clusterrole.yaml
+++ b/stable/prometheus-operator/templates/prometheus/clusterrole.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-prometheus
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-prometheus
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus/clusterrolebinding.yaml
+++ b/stable/prometheus-operator/templates/prometheus/clusterrolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-prometheus
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-prometheus
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus/ingress.yaml
+++ b/stable/prometheus-operator/templates/prometheus/ingress.yaml
@@ -11,6 +11,7 @@ metadata:
 {{ toYaml .Values.prometheus.ingress.annotations | indent 4 }}
 {{- end }}
   name: {{ $serviceName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-prometheus
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus/ingressperreplica.yaml
+++ b/stable/prometheus-operator/templates/prometheus/ingressperreplica.yaml
@@ -6,12 +6,14 @@ apiVersion: extensions/v1beta1
 kind: IngressList
 metadata:
   name: {{ include "prometheus-operator.fullname" $ }}-prometheus-ingressperreplica
+  namespace: {{ .Release.Namespace }}
 items:
 {{ range $i, $e := until $count }}
   - apiVersion: extensions/v1beta1
     kind: Ingress
     metadata:
       name: {{ include "prometheus-operator.fullname" $ }}-prometheus-{{ $i }}
+      namespace: {{ .Release.Namespace }}
       labels:
         app: {{ include "prometheus-operator.name" $ }}-prometheus
 {{ include "prometheus-operator.labels" $ | indent 8 }}

--- a/stable/prometheus-operator/templates/prometheus/podDisruptionBudget.yaml
+++ b/stable/prometheus-operator/templates/prometheus/podDisruptionBudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-prometheus
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-prometheus
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus/podmonitors.yaml
+++ b/stable/prometheus-operator/templates/prometheus/podmonitors.yaml
@@ -7,6 +7,7 @@ items:
     kind: PodMonitor
     metadata:
       name: {{ .name }}
+      namespace: {{ .Release.Namespace }}
       labels:
         app: {{ template "prometheus-operator.name" $ }}-prometheus
 {{ include "prometheus-operator.labels" $ | indent 8 }}

--- a/stable/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/stable/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default 
 kind: Prometheus
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-prometheus
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-prometheus
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus/psp-clusterrole.yaml
+++ b/stable/prometheus-operator/templates/prometheus/psp-clusterrole.yaml
@@ -3,6 +3,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-prometheus-psp
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-prometheus
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus/psp-clusterrolebinding.yaml
+++ b/stable/prometheus-operator/templates/prometheus/psp-clusterrolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-prometheus-psp
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-prometheus
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus/psp.yaml
+++ b/stable/prometheus-operator/templates/prometheus/psp.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-prometheus
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-prometheus
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus/service.yaml
+++ b/stable/prometheus-operator/templates/prometheus/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-prometheus
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-prometheus
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus/serviceaccount.yaml
+++ b/stable/prometheus-operator/templates/prometheus/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "prometheus-operator.prometheus.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-prometheus
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/prometheus/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default 
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-prometheus
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-prometheus
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus/servicemonitors.yaml
+++ b/stable/prometheus-operator/templates/prometheus/servicemonitors.yaml
@@ -7,6 +7,7 @@ items:
     kind: ServiceMonitor
     metadata:
       name: {{ .name }}
+      namespace: {{ .Release.Namespace }}
       labels:
         app: {{ template "prometheus-operator.name" $ }}-prometheus
 {{ include "prometheus-operator.labels" $ | indent 8 }}

--- a/stable/prometheus-operator/templates/prometheus/serviceperreplica.yaml
+++ b/stable/prometheus-operator/templates/prometheus/serviceperreplica.yaml
@@ -5,12 +5,14 @@ apiVersion: v1
 kind: ServiceList
 metadata:
   name: {{ include "prometheus-operator.fullname" $ }}-prometheus-serviceperreplica
+  namespace: {{ .Release.Namespace }}
 items:
 {{ range $i, $e := until $count }}
   - apiVersion: v1
     kind: Service
     metadata:
       name: {{ include "prometheus-operator.fullname" $ }}-prometheus-{{ $i }}
+      namespace: {{ .Release.Namespace }}
       labels:
         app: {{ include "prometheus-operator.name" $ }}-prometheus
 {{ include "prometheus-operator.labels" $ | indent 8 }}


### PR DESCRIPTION
I have been creating a Spinnaker pipeline to install the Prometheus Operator via Helm. However,
the Helm chart requires that Release.Namespace is specified otherwise the Helm chart gets install in the incorrect location.

#### What this PR does / why we need it:

This PR just includes the Release.Namespace which is required by Spinnakers during a Helm install.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
