### PR TITLE
[stable/prometheus-postgres-exporter] Fix compatibility with k8s 1.16

### DIFF
--- a/stable/prometheus-postgres-exporter/Chart.yaml
+++ b/stable/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.1"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 0.7.2
+version: 0.7.3
 home: https://github.com/wrouesnel/postgres_exporter
 sources:
 - https://github.com/wrouesnel/postgres_exporter

--- a/stable/prometheus-postgres-exporter/Chart.yaml
+++ b/stable/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.1"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 0.7.3
+version: 1.0.0
 home: https://github.com/wrouesnel/postgres_exporter
 sources:
 - https://github.com/wrouesnel/postgres_exporter

--- a/stable/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/stable/prometheus-postgres-exporter/templates/deployment.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.config.datasource.passwordSecret .Values.config.datasource.password -}}
 {{ fail (printf "ERROR: only one of .Values.config.datasource.passwordSecret and .Values.config.datasource.password must be defined") }}
 {{- end -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}

--- a/stable/prometheus-postgres-exporter/templates/podsecuritypolicy.yaml
+++ b/stable/prometheus-postgres-exporter/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}


### PR DESCRIPTION
Signed-off-by: Bastian Hofmann <bashofmann@gmail.com>

#### What this PR does / why we need it:
Fix compatibility with k8s 1.16 wich removes old api versions for Deployments and PodSecurityPolicies.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
