### PR TITLE
[stable/node-red] bumping docker image to latest official v1.0.1 version

### DIFF
--- a/stable/node-red/Chart.yaml
+++ b/stable/node-red/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.20.7
+appVersion: 1.0.1
 description: Node-RED is flow-based programming for the Internet of Things
 name: node-red
-version: 1.3.3
+version: 1.3.4
 keywords:
   - nodered
   - node-red

--- a/stable/node-red/README.md
+++ b/stable/node-red/README.md
@@ -38,8 +38,8 @@ The following tables lists the configurable parameters of the Node-RED chart and
 
 | Parameter                          | Description                                                             | Default                   |
 |:---------------------------------- |:----------------------------------------------------------------------- |:------------------------- |
-| `image.repository`                 | node-red image                                                          | `nodered/node-red-docker` |
-| `image.tag`                        | node-red image tag                                                      | `0.20.7-slim-v8`          |
+| `image.repository`                 | node-red image                                                          | `nodered/node-red`        |
+| `image.tag`                        | node-red image tag                                                      | `1.0.1-12-minimal`        |
 | `image.pullPolicy`                 | node-red image pull policy                                              | `IfNotPresent`            |
 | `strategyType`                     | Specifies the strategy used to replace old Pods by new ones             | `Recreate`                |
 | `flows`                            | Default flows configuration                                             | `flows.json`              |

--- a/stable/node-red/values.yaml
+++ b/stable/node-red/values.yaml
@@ -6,8 +6,8 @@
 strategyType: Recreate
 
 image:
-  repository: nodered/node-red-docker
-  tag: 0.20.7-slim-v8
+  repository: nodered/node-red
+  tag: 1.0.1-12-minimal
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
## What this PR does / why we need it:

This chart bumps node-red to the official v1.0 branch (specifically v1.0.1) using the `1.0.1-12-minimal` tag.  See [this repo](https://github.com/node-red/node-red-docker#image-variations) for more details.

Starting with v1.x, the node-red images are multi-arch meaning that the workloads can now be deployed to architectures other than just amd64.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
