### PR TITLE
[stable/unifi] bumping docker image to 5.11.47

### DIFF
--- a/stable/unifi/Chart.yaml
+++ b/stable/unifi/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 5.10.19
+appVersion: 5.11.47
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 0.4.2
+version: 0.4.3
 keywords:
   - ubiquiti
   - unifi

--- a/stable/unifi/README.md
+++ b/stable/unifi/README.md
@@ -37,7 +37,7 @@ The following tables lists the configurable parameters of the Unifi chart and th
 | Parameter                                    | Description                                                                                                            | Default                      |
 | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
 | `image.repository`                           | Image repository                                                                                                       | `jacobalberty/unifi`         |
-| `image.tag`                                  | Image tag. Possible values listed [here][docker].                                                                      | `5.9.29`                     |
+| `image.tag`                                  | Image tag. Possible values listed [here][docker].                                                                      | `5.11.47`                    |
 | `image.pullPolicy`                           | Image pull policy                                                                                                      | `IfNotPresent`               |
 | `strategyType`                               | Specifies the strategy used to replace old Pods by new ones                                                            | `Recreate`                   |
 | `guiService.type`                            | Kubernetes service type for the Unifi GUI                                                                              | `ClusterIP`                  |

--- a/stable/unifi/values.yaml
+++ b/stable/unifi/values.yaml
@@ -7,7 +7,7 @@ strategyType: Recreate
 
 image:
   repository: jacobalberty/unifi
-  tag: 5.10.19
+  tag: 5.11.47
   pullPolicy: IfNotPresent
 
 # If enabled, the controller, discovery, GUI, and STUN services will not be


### PR DESCRIPTION
#### What this PR does / why we need it:

* Bumps the unifi docker image to version 5.11.47

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
