### PR TITLE
Include .Release.Namespace in chart

### DIFF
--- a/stable/prometheus-node-exporter/Chart.yaml
+++ b/stable/prometheus-node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.18.0"
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 1.7.0
+version: 1.7.1
 home: https://github.com/prometheus/node_exporter/
 sources:
 - https://github.com/prometheus/node_exporter/

--- a/stable/prometheus-node-exporter/templates/daemonset.yaml
+++ b/stable/prometheus-node-exporter/templates/daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "prometheus-node-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
 spec:
   selector:

--- a/stable/prometheus-node-exporter/templates/endpoints.yaml
+++ b/stable/prometheus-node-exporter/templates/endpoints.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   name: {{ template "prometheus-node-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "prometheus-node-exporter.labels" . | indent 4 }}
 subsets:

--- a/stable/prometheus-node-exporter/templates/monitor.yaml
+++ b/stable/prometheus-node-exporter/templates/monitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-node-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
   {{- if .Values.prometheus.monitor.additionalLabels }}
 {{ toYaml .Values.prometheus.monitor.additionalLabels | indent 4 }}

--- a/stable/prometheus-node-exporter/templates/psp-clusterrole.yaml
+++ b/stable/prometheus-node-exporter/templates/psp-clusterrole.yaml
@@ -5,6 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
   name: psp-{{ template "prometheus-node-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups: ['extensions']
   resources: ['podsecuritypolicies']

--- a/stable/prometheus-node-exporter/templates/psp-clusterrolebinding.yaml
+++ b/stable/prometheus-node-exporter/templates/psp-clusterrolebinding.yaml
@@ -5,6 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
   name: psp-{{ template "prometheus-node-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/stable/prometheus-node-exporter/templates/psp.yaml
+++ b/stable/prometheus-node-exporter/templates/psp.yaml
@@ -5,6 +5,7 @@ kind: PodSecurityPolicy
 metadata:
   labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
   name: {{ template "prometheus-node-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   privileged: false
   # Required to prevent escalations to root.

--- a/stable/prometheus-node-exporter/templates/service.yaml
+++ b/stable/prometheus-node-exporter/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "prometheus-node-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/stable/prometheus-node-exporter/templates/serviceaccount.yaml
+++ b/stable/prometheus-node-exporter/templates/serviceaccount.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "prometheus-node-exporter.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-node-exporter.name" . }}
     chart: {{ template "prometheus-node-exporter.chart" . }}    


### PR DESCRIPTION
## What this PR does / why we need it:

This PR includes .Release.Namespace that is required when doing Helm deployments from Spinnaker.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
