### PR TITLE
[stable/hackmd] Support kubernetes >= 1.16

### DIFF
--- a/stable/hackmd/Chart.yaml
+++ b/stable/hackmd/Chart.yaml
@@ -1,6 +1,6 @@
 name: hackmd
 apiVersion: v1
-version: "1.2.1"
+version: "1.2.2"
 appVersion: "1.3.0-alpine"
 description: Realtime collaborative markdown notes on all platforms.
 icon: https://hackmd.io/favicon.png

--- a/stable/hackmd/templates/deployment.yaml
+++ b/stable/hackmd/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "hackmd.fullname" . }}

--- a/stable/hackmd/templates/ingress.yaml
+++ b/stable/hackmd/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "hackmd.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -16,6 +16,9 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "hackmd.name" . }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No.

#### What this PR does / why we need it:

stable/hackmd uses `extensions/v1beta2`and `extensions/v1beta1` but kubernetes 1.16 deprecates them.
So this PR migrates charts to use  `apps/v1`.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
