### PR TITLE
[stable/openvpn] Add configurable readiness probes

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 3.14.0
+version: 3.14.1
 appVersion: 1.1.0
 maintainers:
 - name: jasongwartz

--- a/stable/openvpn/README.md
+++ b/stable/openvpn/README.md
@@ -69,47 +69,50 @@ The following table lists the configurable parameters of the `openvpn` chart and
 and can be overwritten via the helm `--set` flag.
 
 Parameter | Description | Default
----                            | ---                                                                  | ---
-`replicaCount`                 | amount of parallel openvpn replicas to be started                    | `1`
-`updateStrategy`               | update strategy for deployment                                       | `{}`
-`image.repository`             | `openvpn` image repository                                           | `jfelten/openvpn-docker`
-`image.tag`                    | `openvpn` image tag                                                  | `1.1.0`
-`image.pullPolicy`             | Image pull policy                                                    | `IfNotPresent`
-`service.type`                 | k8s service type exposing ports, e.g. `NodePort`                     | `LoadBalancer`
-`service.externalPort`         | TCP port reported when creating configuration files                  | `443`
-`service.internalPort`         | TCP port on which the service works                                  | `443`
-`service.hostPort`             | Expose openvpn directly using host port                              | `nil`
-`service.nodePort`             | NodePort value if service.type is `NodePort`                         | `nil` (auto-assigned)
-`service.clusterIP`            | clusterIP value if service.type is `ClusterIP`                       | `nil`
-`service.externalIPs`          | External IPs to listen on                                            | `[]`
-`resources.requests.cpu`       | OpenVPN cpu request                                                  | `300m`
-`resources.requests.memory`    | OpenVPN memory request                                               | `128Mi`
-`resources.limits.cpu`         | OpenVPN cpu limit                                                    | `300m`
-`resources.limits.memory`      | OpenVPN memory limit                                                 | `128Mi`
-`persistence.enabled`          | Use a PVC to persist configuration                                   | `true`
-`persistence.subPath`          | Subdirectory of the volume to mount at                               | `nil`
-`persistence.existingClaim`    | Provide an existing PersistentVolumeClaim                            | `nil`
-`persistence.storageClass`     | Storage class of backing PVC                                         | `nil`
-`persistence.accessMode`       | Use volume as ReadOnly or ReadWrite                                  | `ReadWriteOnce`
-`persistence.size`             | Size of data volume                                                  | `2M`
-`podAnnotations`               | Key-value pairs to add as pod annotations                            | `{}`
-`openvpn.OVPN_NETWORK`         | Network allocated for openvpn clients                                | `10.240.0.0`
-`openvpn.OVPN_SUBNET`          | Network subnet allocated for openvpn                                 | `255.255.0.0`
-`openvpn.OVPN_PROTO`           | Protocol used by openvpn tcp or udp                                  | `tcp`
-`openvpn.OVPN_K8S_POD_NETWORK` | Kubernetes pod network (optional)                                    | `10.0.0.0`
-`openvpn.OVPN_K8S_POD_SUBNET`  | Kubernetes pod network subnet (optional)                             | `255.0.0.0`
-`openvpn.OVPN_K8S_SVC_NETWORK` | Kubernetes service network (optional)                                | `nil`
-`openvpn.OVPN_K8S_SVC_SUBNET`  | Kubernetes service network subnet (optional)                         | `nil`
-`openvpn.dhcpOptionDomain`     | Push a `dhcp-option DOMAIN` config                                   | `true`
-`openvpn.conf`                 | Arbitrary lines appended to the end of the server configuration file | `nil`
-`openvpn.redirectGateway`      | Redirect all client traffic through VPN                              | `true`
-`openvpn.useCrl`               | Use/generate a certificate revocation list (crl.pem)                 | `false`
-`openvpn.taKey`                | Use/generate a ta.key file for hardening security                    | `false`
-`openvpn.cipher`               | Override the default cipher                                          | `nil` (OpenVPN default)
-`openvpn.istio.enabled`        | Enables istio support for openvpn clients                            | `false`
-`openvpn.istio.proxy.port`     | Istio proxy port                                                     | `15001`
-`openvpn.iptablesExtra`        | Custom iptables rules for clients                                    | `[]`
-`nodeSelector`                 | Node labels for pod assignment                                       | `{}`
+---                                  | ---                                                                  | ---
+`replicaCount`                       | amount of parallel openvpn replicas to be started                    | `1`
+`updateStrategy`                     | update strategy for deployment                                       | `{}`
+`image.repository`                   | `openvpn` image repository                                           | `jfelten/openvpn-docker`
+`image.tag`                          | `openvpn` image tag                                                  | `1.1.0`
+`image.pullPolicy`                   | Image pull policy                                                    | `IfNotPresent`
+`service.type`                       | k8s service type exposing ports, e.g. `NodePort`                     | `LoadBalancer`
+`service.externalPort`               | TCP port reported when creating configuration files                  | `443`
+`service.internalPort`               | TCP port on which the service works                                  | `443`
+`service.hostPort`                   | Expose openvpn directly using host port                              | `nil`
+`service.nodePort`                   | NodePort value if service.type is `NodePort`                         | `nil` (auto-assigned)
+`service.clusterIP`                  | clusterIP value if service.type is `ClusterIP`                       | `nil`
+`service.externalIPs`                | External IPs to listen on                                            | `[]`
+`resources.requests.cpu`             | OpenVPN cpu request                                                  | `300m`
+`resources.requests.memory`          | OpenVPN memory request                                               | `128Mi`
+`resources.limits.cpu`               | OpenVPN cpu limit                                                    | `300m`
+`resources.limits.memory`            | OpenVPN memory limit                                                 | `128Mi`
+`readinessProbe.initialDelaySeconds` | Time to wait to start first probe                                    | `5`
+`readinessProbe.periodSeconds`       | Interval of readiness probe                                          | `5`
+`readinessProbe.successThreshold`    | Minimum consecutive successes for probe to be considered healthy     | `2`
+`persistence.enabled`                | Use a PVC to persist configuration                                   | `true`
+`persistence.subPath`                | Subdirectory of the volume to mount at                               | `nil`
+`persistence.existingClaim`          | Provide an existing PersistentVolumeClaim                            | `nil`
+`persistence.storageClass`           | Storage class of backing PVC                                         | `nil`
+`persistence.accessMode`             | Use volume as ReadOnly or ReadWrite                                  | `ReadWriteOnce`
+`persistence.size`                   | Size of data volume                                                  | `2M`
+`podAnnotations`                     | Key-value pairs to add as pod annotations                            | `{}`
+`openvpn.OVPN_NETWORK`               | Network allocated for openvpn clients                                | `10.240.0.0`
+`openvpn.OVPN_SUBNET`                | Network subnet allocated for openvpn                                 | `255.255.0.0`
+`openvpn.OVPN_PROTO`                 | Protocol used by openvpn tcp or udp                                  | `tcp`
+`openvpn.OVPN_K8S_POD_NETWORK`       | Kubernetes pod network (optional)                                    | `10.0.0.0`
+`openvpn.OVPN_K8S_POD_SUBNET`        | Kubernetes pod network subnet (optional)                             | `255.0.0.0`
+`openvpn.OVPN_K8S_SVC_NETWORK`       | Kubernetes service network (optional)                                | `nil`
+`openvpn.OVPN_K8S_SVC_SUBNET`        | Kubernetes service network subnet (optional)                         | `nil`
+`openvpn.dhcpOptionDomain`           | Push a `dhcp-option DOMAIN` config                                   | `true`
+`openvpn.conf`                       | Arbitrary lines appended to the end of the server configuration file | `nil`
+`openvpn.redirectGateway`            | Redirect all client traffic through VPN                              | `true`
+`openvpn.useCrl`                     | Use/generate a certificate revocation list (crl.pem)                 | `false`
+`openvpn.taKey`                      | Use/generate a ta.key file for hardening security                    | `false`
+`openvpn.cipher`                     | Override the default cipher                                          | `nil` (OpenVPN default)
+`openvpn.istio.enabled`              | Enables istio support for openvpn clients                            | `false`
+`openvpn.istio.proxy.port`           | Istio proxy port                                                     | `15001`
+`openvpn.iptablesExtra`              | Custom iptables rules for clients                                    | `[]`
+`nodeSelector`                       | Node labels for pod assignment                                       | `{}`
 
 This chart has been engineered to use kube-dns and route all network traffic to kubernetes pods and services,
 to disable this behaviour set `openvpn.OVPN_K8S_POD_NETWORK` and `openvpn.OVPN_K8S_POD_SUBNET` to `null`.

--- a/stable/openvpn/templates/openvpn-deployment.yaml
+++ b/stable/openvpn/templates/openvpn-deployment.yaml
@@ -44,9 +44,9 @@ spec:
             add:
               - NET_ADMIN
         readinessProbe:
-          initialDelaySeconds: 5
-          periodSeconds: 5
-          successThreshold: 2
+          initialDelaySeconds: "{{ .Values.readinessProbe.initialDelaySeconds }}"
+          periodSeconds: "{{ .Values.readinessProbe.periodSeconds }}"
+          successThreshold: "{{ .Values.readinessProbe.successThreshold }}"
           exec:
             command:
             - nc

--- a/stable/openvpn/templates/openvpn-deployment.yaml
+++ b/stable/openvpn/templates/openvpn-deployment.yaml
@@ -44,9 +44,9 @@ spec:
             add:
               - NET_ADMIN
         readinessProbe:
-          initialDelaySeconds: "{{ .Values.readinessProbe.initialDelaySeconds }}"
-          periodSeconds: "{{ .Values.readinessProbe.periodSeconds }}"
-          successThreshold: "{{ .Values.readinessProbe.successThreshold }}"
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
           exec:
             command:
             - nc

--- a/stable/openvpn/values.yaml
+++ b/stable/openvpn/values.yaml
@@ -32,7 +32,6 @@ service:
 # podAnnotations:
 #   backup.ark.heptio.com/backup-volumes: certs
 podAnnotations: {}
-
 resources:
   limits:
     cpu: 300m
@@ -40,6 +39,12 @@ resources:
   requests:
     cpu: 300m
     memory: 128Mi
+
+readinessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  successThreshold: 2
+
 persistence:
   enabled: true
   # subPath: openvpn


### PR DESCRIPTION
Signed-off-by: Aaron Lucas <aaron@alucas.me>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Adds configurable readiness probes to give flexibility for slow-start containers as well as slimming down logging output.
#### Which issue this PR fixes
  - fixes #17238 


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
