### PR TITLE
[stable/prometheus-cloudwatch-exporter] add extra annotations and fix serviceAccount

### DIFF
--- a/stable/prometheus-cloudwatch-exporter/CHANGELOG.md
+++ b/stable/prometheus-cloudwatch-exporter/CHANGELOG.md
@@ -9,8 +9,8 @@ NOTE: The change log until version 0.4.10 is auto generated based on git commits
 
 ## 0.5.0
 
-Added value: additionalAnnotations to allow passing annotations to pod
-Fix service account name/creation not being honored
+Added value: additionalAnnotations to allow passing annotations to deployment
+Fix custom service account name not being honored
 
 ## 0.4.11
 

--- a/stable/prometheus-cloudwatch-exporter/CHANGELOG.md
+++ b/stable/prometheus-cloudwatch-exporter/CHANGELOG.md
@@ -7,6 +7,11 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 0.4.10 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 0.5.0
+
+Added value: additionalAnnotations to allow passing annotations to pod
+Fix service account name/creation not being honored
+
 ## 0.4.11
 
 Added CHANGELOG.md
@@ -105,4 +110,3 @@ commit: 647b56cc4
 
 Add cloudwatch exporter (#4022)
 commit: 0f730f26e
-

--- a/stable/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/stable/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.4.11
+version: 0.5.0
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -72,6 +72,7 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | `tolerations`                     | Add tolerations                                                         | `[]`                        |
 | `nodeSelector`                    | node labels for pod assignment                                          | `{}`                        |
 | `affinity`                        | node/pod affinities                                                     | `{}`                        |
+| `additionalAnnotations`           | Additional annotations to attach to deployment                          | `{}`                        |
 | `livenessProbe`                   | Liveness probe settings                                                 |                             |
 | `readinessProbe`                  | Readiness probe settings                                                |                             |
 | `serviceMonitor.enabled`          | Use servicemonitor from prometheus operator                             | `false`                     |

--- a/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       annotations:
         {{ if .Values.aws.role}}iam.amazonaws.com/role: {{ .Values.aws.role }}{{ end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.additionalAnnotations }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
     spec:
       containers:
         - name: {{ .Chart.Name }}
@@ -106,6 +109,13 @@ spec:
       securityContext:
 {{ toYaml . | indent 8 }}
     {{- end }}
+      {{ if .Values.serviceAccount.create }}
+      {{ if .Values.serviceAccount.name }}
+      serviceAccount: {{ .Values.serviceAccount.name }}
+      {{- else }}
+      serviceAccount: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
+      {{- end }}
+      {{- end }}
       volumes:
       - configMap:
           defaultMode: 420

--- a/stable/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
@@ -2,10 +2,14 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  {{- if .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name }}
+  {{- else }}
   name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
+  {{- end }}
   labels:
     app: {{ template "prometheus-cloudwatch-exporter.name" . }}
-    chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}    
+    chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{- end }}

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -106,6 +106,9 @@ tolerations: []
 
 affinity: {}
 
+# extra annotations to add to deployment
+additionalAnnotations: {}
+
 # Configurable health checks against the /healthy and /ready endpoints
 livenessProbe:
   initialDelaySeconds: 30


### PR DESCRIPTION
Signed-off-by: ephur <richard.maynard@gmail.com>

#### What this PR does / why we need it:
This PR addresses issues with the service account being improperly configured.

This deployment also offers the ability to add additional annotations to the deployment. These may be needed for a variety of different reasons. For my use case it allows for handling by some mutating webhooks.

#### Which issue this PR fixes
  - fixes #17733

#### Special notes for your reviewer:
@gianrubio
@torstenwalter

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
