### PR TITLE
Handle affinity with templating and add podDisruptionBudget support

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.11.1
+version: 6.12.0
 appVersion: 3.8.1
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -134,6 +134,7 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `livenessProbe.periodSeconds`                | number of seconds                                | 30                                                      |
 | `livenessProbe.failureThreshold`             | number of failures                               | 6                                                       |
 | `livenessProbe.successThreshold`             | number of successes                              | 1                                                       |
+| `podDisruptionBudget`                        | Pod Disruption Budget settings                   | {}                                                      |
 | `readinessProbe.enabled`                     | would you like a readinessProbe to be enabled    | `true`                                                  |
 | `readinessProbe.initialDelaySeconds`         | number of seconds                                | 10                                                      |
 | `readinessProbe.timeoutSeconds`              | number of seconds                                | 20                                                      |

--- a/stable/rabbitmq/templates/pdb.yaml
+++ b/stable/rabbitmq/templates/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "rabbitmq.fullname" . }}
+  labels:
+    app: {{ template "rabbitmq.name" . }}
+    chart: {{ template "rabbitmq.chart" .  }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "rabbitmq.name" . }}
+      release: "{{ .Release.Name }}"
+{{ toYaml .Values.podDisruptionBudget | indent 2 }}
+{{- end -}}

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -41,10 +41,12 @@ spec:
       {{- if .Values.rbacEnabled}}
       serviceAccountName: {{ template "rabbitmq.fullname" . }}
       {{- end }}
-      {{- if .Values.affinity }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
-      {{- end }}
+{{- if .Values.affinity }}
+    {{- with .Values.affinity }}
+{{ tpl . $ | indent 8 }}
+    {{- end }}
+{{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
@@ -261,7 +263,7 @@ spec:
         {{- end }}
         ports:
         - name: metrics
-          containerPort: 9090
+          containerPort: {{ .Values.metrics.port }}
         {{- if .Values.metrics.livenessProbe.enabled }}
         livenessProbe:
           httpGet:

--- a/stable/rabbitmq/values-production.yaml
+++ b/stable/rabbitmq/values-production.yaml
@@ -285,8 +285,30 @@ nodeSelector:
 tolerations: []
 affinity: {}
 
+## affinity: |
+##   podAntiAffinity:
+##     requiredDuringSchedulingIgnoredDuringExecution:
+##       - labelSelector:
+##           matchLabels:
+##             app: {{ template "rabbitmq.name" . }}
+##             release: {{ .Release.Name | quote }}
+##         topologyKey: kubernetes.io/hostname
+##     preferredDuringSchedulingIgnoredDuringExecution:
+##       - weight: 100
+##         podAffinityTerm:
+##           labelSelector:
+##             matchLabels:
+##               app:  {{ template "rabbitmq.name" . }}
+##               release: {{ .Release.Name | quote }}
+##           topologyKey: failure-domain.beta.kubernetes.io/zone
+
 ## annotations for rabbitmq pods
 podAnnotations: {}
+
+## Configure the podDisruptionBudget
+podDisruptionBudget: {}
+# maxUnavailable: 1
+# minAvailable: 1
 
 ## Configure the ingress resource that allows you to access the
 ## Wordpress installation. Set up the URL
@@ -429,7 +451,7 @@ forceBoot:
 ## This can be useful when combined with load_definitions to automatically create the secret containing the definitions to be loaded.
 ##
 extraSecrets: {}
-  # load_definition:
+  # load-definition:
   #   load_definition.json: |
   #     {
   #       ...

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -280,7 +280,9 @@ updateStrategy:
 nodeSelector: {}
 tolerations: []
 affinity: {}
-
+podDisruptionBudget: {}
+  # maxUnavailable: 1
+  # minAvailable: 1
 ## annotations for rabbitmq pods
 podAnnotations: {}
 
@@ -429,7 +431,7 @@ forceBoot:
 ## This can be useful when combined with load_definitions to automatically create the secret containing the definitions to be loaded.
 ##
 extraSecrets: {}
-  # load_definition:
+  # load-definition:
   #   load_definition.json: |
   #     {
   #       ...


### PR DESCRIPTION
Currently, it's complicated to set a complex antiAffinity block dealing with {{ .Release.Name }}.
This PR should be that. Example can be found in values.yaml and values-production.yaml

This PR also create PodDisruptionObject that should be setup for production deployment.