### PR TITLE
[stable/elasticsearch-curator] Make restartPolicy configurable

### DIFF
--- a/stable/elasticsearch-curator/Chart.yaml
+++ b/stable/elasticsearch-curator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "5.7.6"
 description: A Helm chart for Elasticsearch Curator
 name: elasticsearch-curator
-version: 2.0.3
+version: 2.1.0
 home: https://github.com/elastic/curator
 keywords:
 - curator

--- a/stable/elasticsearch-curator/README.md
+++ b/stable/elasticsearch-curator/README.md
@@ -50,6 +50,7 @@ their default values.
 | `cronjob.concurrencyPolicy`          | `Allow|Forbid|Replace` concurrent jobs                      | `nil`                                        |
 | `cronjob.failedJobsHistoryLimit`     | Specify the number of failed Jobs to keep                   | `nil`                                        |
 | `cronjob.successfulJobsHistoryLimit` | Specify the number of completed Jobs to keep                | `nil`                                        |
+| `cronjob.jobRestartPolicy`           | Control the Job restartPolicy                               | `Never`                                        |
 | `pod.annotations`                    | Annotations to add to the pod                               | {}                                           |
 | `dryrun`                             | Run Curator in dry-run mode                                 | `false`                                      |
 | `env`                                | Environment variables to add to the cronjob container       | {}                                           |

--- a/stable/elasticsearch-curator/templates/cronjob.yaml
+++ b/stable/elasticsearch-curator/templates/cronjob.yaml
@@ -45,7 +45,7 @@ spec:
 {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 12 }}
 {{- end }}
-          restartPolicy: Never
+          restartPolicy: {{ .Values.cronjob.jobRestartPolicy }}
 {{- if .Values.priorityClassName }}
           priorityClassName: "{{ .Values.priorityClassName }}"
 {{- end }}

--- a/stable/elasticsearch-curator/values.yaml
+++ b/stable/elasticsearch-curator/values.yaml
@@ -9,6 +9,7 @@ cronjob:
   concurrencyPolicy: ""
   failedJobsHistoryLimit: ""
   successfulJobsHistoryLimit: ""
+  jobRestartPolicy: Never
 
 pod:
   annotations: {}


### PR DESCRIPTION
We're currently in a situation where our ES _sometimes_ fails to clear
up indexes, especially under load, but will eventually succeed when the
job is restarted.

There are two approaches to this kind of issues as far as I understand:

- Let the CronJob recreate a new Job resource, which will create a new
  Pod and succeed
- Set the Job's restartPolicy to Always or OnFailure, and let the Job
  finish

The first option is currently doable through this chart, but hits the
default Prometheus alerting rules that will warn you if a Job resource
has failed and is left in failed state for a while. This is of course a
spurious warning as the CronJob has eventually succeeded... But it's
there :(

By giving the user the possibility to change the restartPolicy, we make
that second option available to go around Prometheus' over-sensitivity.

Note: I relaise it's also possible to delete failed Jobs by setting the
`failedJobsHistoryLimit` to zero, but that would hide _actual_ failures
as well as temporary flakiness.

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
