### PR TITLE
[stable/nginx-ingress] fix HPA to target correct Deployment version

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.24.0
+version: 1.24.1
 appVersion: 0.26.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/controller-hpa.yaml
+++ b/stable/nginx-ingress/templates/controller-hpa.yaml
@@ -12,7 +12,7 @@ metadata:
   name: {{ template "nginx-ingress.controller.fullname" . }}
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1beta1
+    apiVersion: {{ .Values.controller.apiVersion }}
     kind: Deployment
     name: {{ template "nginx-ingress.controller.fullname" . }}
   minReplicas: {{ .Values.controller.autoscaling.minReplicas }}


### PR DESCRIPTION
### What this PR does / why we need it:
https://github.com/helm/charts/pull/17319/files changed the `Deployment` apiVersion without updating the apiVersion referenced in the `HorizontalPodAutoscaler`. This PR updates the `HorizontalPodAutoscaler` to target the correct `Deployment` version

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
