### PR TITLE
[stable/grafana] Add variable to disable creating test resources

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 3.8.19
+version: 3.9.0
 appVersion: 6.3.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -129,6 +129,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `rbac.extraRoleRules`                     | Additional rules to add to the Role                                                                     | [] |
 | `rbac.extraClusterRoleRules`              | Additional rules to add to the ClusterRole                                                              | [] |
 | `command`                     | Define command to be executed by grafana container at startup  | `nil` |
+| `testFramework.enabled`                   | Whether to create test-related resources       | `true`                                                 |
 | `testFramework.image`                     | `test-framework` image repository.             | `dduportal/bats`                                       |
 | `testFramework.tag`                       | `test-framework` image tag.                    | `0.4.0`                                                |
 | `testFramework.securityContext`           | `test-framework` securityContext                | `{}`                                                   |

--- a/stable/grafana/templates/tests/test-configmap.yaml
+++ b/stable/grafana/templates/tests/test-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.testFramework.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -16,3 +17,4 @@ data:
       code=$(curl -s -o /dev/null -I -w "%{http_code}" $url)
       [ "$code" == "200" ]
     }
+{{- end }}

--- a/stable/grafana/templates/tests/test-podsecuritypolicy.yaml
+++ b/stable/grafana/templates/tests/test-podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.pspEnabled }}
+{{- if and .Values.testFramework.enabled .Values.rbac.pspEnabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/stable/grafana/templates/tests/test-role.yaml
+++ b/stable/grafana/templates/tests/test-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.pspEnabled -}}
+{{- if and .Values.testFramework.enabled .Values.rbac.pspEnabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/stable/grafana/templates/tests/test-rolebinding.yaml
+++ b/stable/grafana/templates/tests/test-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.pspEnabled -}}
+{{- if and .Values.testFramework.enabled .Values.rbac.pspEnabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/stable/grafana/templates/tests/test-serviceaccount.yaml
+++ b/stable/grafana/templates/tests/test-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create }}
+{{- if and .Values.testFramework.enabled .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/stable/grafana/templates/tests/test.yaml
+++ b/stable/grafana/templates/tests/test.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.testFramework.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -63,3 +64,4 @@ spec:
   - name: tools
     emptyDir: {}
   restartPolicy: Never
+{{- end }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -54,6 +54,7 @@ image:
   #   - myRegistrKeySecretName
 
 testFramework:
+  enabled: true
   image: "dduportal/bats"
   tag: "0.4.0"
   securityContext: {}


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Adds a value (w/ docs) to allow extra test resources to be disabled. While Helm will skip the test Pod itself unless you do `helm test`, the remaining resources in the `tests` directory are always created, even if you never run the tests.

#### Which issue this PR fixes
No issue

#### Special notes for your reviewer:
Test resources are enabled by default so `helm test` will still work out of the box.

Verified installs/upgrades with and without `testFramework.enabled=false` in a test cluster.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
