### PR TITLE
[stable/redis-ha] Fixes #17752

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.9.2
+version: 3.9.3
 appVersion: 5.0.5
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/_configs.tpl
+++ b/stable/redis-ha/templates/_configs.tpl
@@ -189,7 +189,7 @@
       option tcp-check
       tcp-check connect
       {{- if .Values.auth }}
-      tcp-check send AUTH\ {{ .Values.redisPassword }}\r\n
+      tcp-check send AUTH\ REPLACE_AUTH_SECRET\r\n
       tcp-check expect string +OK
       {{- end }}
       tcp-check send PING\r\n
@@ -208,7 +208,7 @@
       option tcp-check
       tcp-check connect
       {{- if .Values.auth }}
-      tcp-check send AUTH\ {{ .Values.redisPassword }}\r\n
+      tcp-check send AUTH\ REPLACE_AUTH_SECRET\r\n
       tcp-check expect string +OK
       {{- end }}
       tcp-check send PING\r\n
@@ -241,5 +241,11 @@
       exit 1
     fi
     sed -i "s/REPLACE_ANNOUNCE{{ $i }}/$ANNOUNCE_IP{{ $i }}/" "$HAPROXY_CONF"
+
+    if [ "${AUTH:-}" ]; then
+        echo "Setting auth values"
+        ESCAPED_AUTH=$(echo "$AUTH" | sed -e 's/[\/&]/\\&/g');
+        sed -i "s/REPLACE_AUTH_SECRET/${ESCAPED_AUTH}/" "$HAPROXY_CONF"
+    fi
     {{- end }}
 {{- end }}

--- a/stable/redis-ha/templates/redis-haproxy-deployment.yaml
+++ b/stable/redis-ha/templates/redis-haproxy-deployment.yaml
@@ -47,6 +47,18 @@ spec:
         - sh
         args:
         - /readonly/haproxy_init.sh
+{{- if .Values.auth }}
+        env:
+        - name: AUTH
+          valueFrom:
+            secretKeyRef:
+            {{- if .Values.existingSecret }}
+              name: {{ .Values.existingSecret }}
+            {{- else }}
+              name: {{ template "redis-ha.fullname" . }}
+            {{- end }}
+              key: {{ .Values.authKey }}
+{{- end }}
         volumeMounts:
         - name: config-volume
           mountPath: /readonly


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Fixes issue #117752 in stable/redis-ha allowing the activation of haproxy and the use of an external existing secret

#### Which issue this PR fixes
  - fixes #17752

#### Special notes for your reviewer:
N/A

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
