### PR TITLE
[stable/nginx-ingress] respect build numbers usage in nginx-ingress versioning (#17775)

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.24.1
+version: 1.24.2
 appVersion: 0.26.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/_helpers.tpl
+++ b/stable/nginx-ingress/templates/_helpers.tpl
@@ -7,6 +7,13 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nginx-ingress.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/stable/nginx-ingress/templates/addheaders-configmap.yaml
+++ b/stable/nginx-ingress/templates/addheaders-configmap.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/clusterrole.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -8,7 +8,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -26,7 +26,7 @@ spec:
 {{- end }}
       labels:
         app: {{ template "nginx-ingress.name" . }}
-        chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        chart: {{ template "nginx-ingress.chart" . }}
         component: "{{ .Values.controller.name }}"
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -8,7 +8,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -26,7 +26,7 @@ spec:
 {{- end }}
       labels:
         app: {{ template "nginx-ingress.name" . }}
-        chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        chart: {{ template "nginx-ingress.chart" . }}
         component: "{{ .Values.controller.name }}"
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/psp.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/psp.yaml
@@ -8,7 +8,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/role.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/role.yaml
@@ -8,7 +8,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/rolebinding.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/rolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/admission-webhooks/job-patch/serviceaccount.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/job-patch/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/admission-webhooks/validating-webhook.yaml
+++ b/stable/nginx-ingress/templates/admission-webhooks/validating-webhook.yaml
@@ -4,7 +4,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}-admission
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "admission-webhook"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/clusterrole.yaml
+++ b/stable/nginx-ingress/templates/clusterrole.yaml
@@ -4,7 +4,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.fullname" . }}

--- a/stable/nginx-ingress/templates/clusterrolebinding.yaml
+++ b/stable/nginx-ingress/templates/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.fullname" . }}

--- a/stable/nginx-ingress/templates/controller-configmap.yaml
+++ b/stable/nginx-ingress/templates/controller-configmap.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -6,7 +6,7 @@ kind: DaemonSet
 metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/controller-hpa.yaml
+++ b/stable/nginx-ingress/templates/controller-hpa.yaml
@@ -5,7 +5,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/controller-metrics-service.yaml
+++ b/stable/nginx-ingress/templates/controller-metrics-service.yaml
@@ -13,7 +13,7 @@ metadata:
 {{ toYaml .Values.controller.metrics.service.labels | indent 4 }}
 {{- end }}
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/controller-poddisruptionbudget.yaml
+++ b/stable/nginx-ingress/templates/controller-poddisruptionbudget.yaml
@@ -4,7 +4,7 @@ kind: PodDisruptionBudget
 metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/controller-prometheusrules.yaml
+++ b/stable/nginx-ingress/templates/controller-prometheusrules.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- end }}
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/controller-psp.yaml
+++ b/stable/nginx-ingress/templates/controller-psp.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "nginx-ingress.fullname" . }}
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:

--- a/stable/nginx-ingress/templates/controller-role.yaml
+++ b/stable/nginx-ingress/templates/controller-role.yaml
@@ -4,7 +4,7 @@ kind: Role
 metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.fullname" . }}

--- a/stable/nginx-ingress/templates/controller-rolebinding.yaml
+++ b/stable/nginx-ingress/templates/controller-rolebinding.yaml
@@ -4,7 +4,7 @@ kind: RoleBinding
 metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.fullname" . }}

--- a/stable/nginx-ingress/templates/controller-service.yaml
+++ b/stable/nginx-ingress/templates/controller-service.yaml
@@ -13,7 +13,7 @@ metadata:
 {{ toYaml .Values.controller.service.labels | indent 4 }}
 {{- end }}
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/controller-serviceaccount.yaml
+++ b/stable/nginx-ingress/templates/controller-serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.serviceAccountName" . }}

--- a/stable/nginx-ingress/templates/controller-servicemonitor.yaml
+++ b/stable/nginx-ingress/templates/controller-servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- end }}
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/controller-webhook-service.yaml
+++ b/stable/nginx-ingress/templates/controller-webhook-service.yaml
@@ -10,7 +10,7 @@ metadata:
 {{- end }}
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/stable/nginx-ingress/templates/default-backend-deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.defaultBackend.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/default-backend-poddisruptionbudget.yaml
+++ b/stable/nginx-ingress/templates/default-backend-poddisruptionbudget.yaml
@@ -4,7 +4,7 @@ kind: PodDisruptionBudget
 metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.defaultBackend.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/default-backend-psp.yaml
+++ b/stable/nginx-ingress/templates/default-backend-psp.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "nginx-ingress.fullname" . }}-backend
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:

--- a/stable/nginx-ingress/templates/default-backend-role.yaml
+++ b/stable/nginx-ingress/templates/default-backend-role.yaml
@@ -4,7 +4,7 @@ kind: Role
 metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.fullname" . }}-backend

--- a/stable/nginx-ingress/templates/default-backend-rolebinding.yaml
+++ b/stable/nginx-ingress/templates/default-backend-rolebinding.yaml
@@ -4,7 +4,7 @@ kind: RoleBinding
 metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.fullname" . }}-backend

--- a/stable/nginx-ingress/templates/default-backend-service.yaml
+++ b/stable/nginx-ingress/templates/default-backend-service.yaml
@@ -10,7 +10,7 @@ metadata:
 {{- end }}
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.defaultBackend.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/default-backend-serviceaccount.yaml
+++ b/stable/nginx-ingress/templates/default-backend-serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.defaultBackend.serviceAccountName" . }}

--- a/stable/nginx-ingress/templates/proxyheaders-configmap.yaml
+++ b/stable/nginx-ingress/templates/proxyheaders-configmap.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/tcp-configmap.yaml
+++ b/stable/nginx-ingress/templates/tcp-configmap.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/stable/nginx-ingress/templates/udp-configmap.yaml
+++ b/stable/nginx-ingress/templates/udp-configmap.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "nginx-ingress.chart" . }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
[stable/nginx-ingress] respect build numbers usage in nginx-ingress versioning (#17775)

Signed-off-by: Erhan Kesken <erhankesken@gmail.com>

#### What this PR does / why we need it:
We want to use build versions to track our private changes over upstream charts, with a convention like that:

```
<ORIGINAL_VERSION>+<TEAM_NAME>.<TEAM_VERSION>
ex: v0.7.0+cre.01
```

Which is compatible with [semver](https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions) rules, but this kind of versioning ends up with following error for nginx-ingress chart:

```
Error: release nginx-ingress failed: PodDisruptionBudget.policy "nginx-ingress-controller" is invalid: metadata.labels: Invalid value: "nginx-ingress-1.7.0+cre.01": a valid label must be an empty string or consist of
alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```

We should respect semver, and allow usage of build numbers in chart version, for that it's enough to replace `+` with `_` before using in label fields, with a template function.

#### Which issue this PR fixes

  - fixes #17775

#### Special notes for your reviewer:

We considered just using `-` instead of `+`, because semver `+` means build number, `-` means prebuild. And prebuilds are ignored by `helm upgrade/install` commands
if you're using a Helm repo over HTTP and do not pass chart version explicitly.

See [github.com/Masterminds/semver/constraints.go#L212-L217](https://github.com/Masterminds/semver/blob/3c560837130448941620d7694991d3ec440aefc0/constraints.go#L212-L217)

```
Issue #21: Per the SemVer spec (section 9) a pre-release is unstable and might not satisfy the intended compatibility.
The change here ignores pre-releases on constraint checks (e.g., ~ or ^) when a pre-release is not part of the constraint.
For example, ^1.2.3 will ignore pre-releases while ^1.2.3-alpha will include them.
```

So semver library used by Helm is skipping pre releases on purpose. If you use `v0.7.0-cre.01` as, then you'll get an error
like this `Error: chart "cert-manager" not found in http://127.0.0.1:8879 repository`.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
