### PR TITLE
[stable/stolon] support for extra vars #17684

### DIFF
--- a/stable/stolon/Chart.yaml
+++ b/stable/stolon/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stolon
-version: 1.2.0
+version: 1.3.0
 appVersion: 0.13.0
 description: Stolon - PostgreSQL cloud native High Availability.
 home: https://github.com/sorintlab/stolon

--- a/stable/stolon/README.md
+++ b/stable/stolon/README.md
@@ -68,6 +68,7 @@ Kubernetes is the default store backend. `consul`, `etcdv2` or `etcdv3` can also
 | `keeper.volumes`                        | Additional volumes                             | `[]`                                                         |
 | `keeper.volumeMounts`                   | Mount paths for `keeper.volumes`               | `[]`                                                         |
 | `keeper.hooks.failKeeper.enabled`       | Enable failkeeper pre-stop hook                | `false`                                                      |
+| `keeper.extraEnv`                       | Extra [environment variables](https://github.com/sorintlab/stolon/blob/master/doc/commands_invocation.md#commands-invocation) for keeper | `[]` |
 | `keeper.podDisruptionBudget.enabled`    | If true, create a pod disruption budget for keeper pods. | `false`                                            |
 | `keeper.podDisruptionBudget.minAvailable` | Minimum number / percentage of pods that should remain scheduled | `""`                                     |
 | `keeper.podDisruptionBudget.maxUnavailable` | Maximum number / percentage of pods that may be made unavailable | `""`                                   |
@@ -77,6 +78,7 @@ Kubernetes is the default store backend. `consul`, `etcdv2` or `etcdv3` can also
 | `proxy.nodeSelector`                    | Node labels for proxy pod assignment           | `{}`                                                         |
 | `proxy.affinity`                        | Affinity settings for proxy pod assignment     | `{}`                                                         |
 | `proxy.tolerations`                     | Toleration labels for proxy pod assignment     | `[]`                                                         |
+| `proxy.extraEnv`                        | Extra [environment variables](https://github.com/sorintlab/stolon/blob/master/doc/commands_invocation.md#commands-invocation) for proxy | `[]` |
 | `proxy.podDisruptionBudget.enabled`     | If true, create a pod disruption budget for proxy pods. | `false`                                             |
 | `proxy.podDisruptionBudget.minAvailable` | Minimum number / percentage of pods that should remain scheduled | `""`                                      |
 | `proxy.podDisruptionBudget.maxUnavailable` | Maximum number / percentage of pods that may be made unavailable | `""`                                    |
@@ -86,6 +88,7 @@ Kubernetes is the default store backend. `consul`, `etcdv2` or `etcdv3` can also
 | `sentinel.nodeSelector`                 | Node labels for sentinel pod assignment        | `{}`                                                         |
 | `sentinel.affinity`                     | Affinity settings for sentinel pod assignment  | `{}`                                                         |
 | `sentinel.tolerations`                  | Toleration labels for sentinel pod assignment  | `[]`                                                         |
+| `sentinel.extraEnv`                     | Extra [environment variables](https://github.com/sorintlab/stolon/blob/master/doc/commands_invocation.md#commands-invocation) for sentinel | `[]` |
 | `sentinel.podDisruptionBudget.enabled`  | If true, create a pod disruption budget for sentinel pods. | `false`                                          |
 | `sentinel.podDisruptionBudget.minAvailable` | Minimum number / percentage of pods that should remain scheduled | `""`                                   |
 | `sentinel.podDisruptionBudget.maxUnavailable` | Maximum number / percentage of pods that may be made unavailable | `""`                                 |

--- a/stable/stolon/templates/keeper-statefulset.yaml
+++ b/stable/stolon/templates/keeper-statefulset.yaml
@@ -98,6 +98,9 @@ spec:
               value: "0.0.0.0:8080"
             - name: STKEEPER_DEBUG
               value: {{ .Values.debug | quote}}
+            {{- if .Values.keeper.extraEnv }}
+            {{ toYaml .Values.keeper.extraEnv | nindent 12 }}
+            {{- end }}
           ports:
 {{- range $key, $value := .Values.ports }}
             - name: {{ $key }}

--- a/stable/stolon/templates/proxy-deployment.yaml
+++ b/stable/stolon/templates/proxy-deployment.yaml
@@ -61,6 +61,9 @@ spec:
               value: "0.0.0.0:8080"
             - name: STPROXY_DEBUG
               value: {{ .Values.debug | quote}}
+            {{- if .Values.proxy.extraEnv }}
+            {{ toYaml .Values.proxy.extraEnv | nindent 12 }}
+            {{- end }}
           ports:
 {{- range $key, $value := .Values.ports }}
             - name: {{ $key }}

--- a/stable/stolon/templates/sentinel-deployment.yaml
+++ b/stable/stolon/templates/sentinel-deployment.yaml
@@ -60,6 +60,9 @@ spec:
               value: "0.0.0.0:8080"
             - name: STSENTINEL_DEBUG
               value: {{ .Values.debug | quote}}
+            {{- if .Values.sentinel.extraEnv }}
+            {{ toYaml .Values.sentinel.extraEnv | nindent 12 }}
+            {{- end }}
           ports:
 {{- range $key, $value := .Values.ports }}
             - name: {{ $key }}

--- a/stable/stolon/values.yaml
+++ b/stable/stolon/values.yaml
@@ -99,6 +99,10 @@ keeper:
   podDisruptionBudget:
     # minAvailable: 1
     # maxUnavailable: 1
+  ## See https://github.com/sorintlab/stolon/blob/master/doc/commands_invocation.md#commands-invocation
+  extraEnv: []
+  #  - name: STKEEPER_LOG_LEVEL 
+  #    value: "info"
 
 proxy:
   replicaCount: 2
@@ -120,6 +124,15 @@ proxy:
   podDisruptionBudget:
     # minAvailable: 1
     # maxUnavailable: 1
+  extraEnv: []
+  #  - name: STPROXY_LOG_LEVEL 
+  #    value: "info"
+  #  - name: STPROXY_TCP_KEEPALIVE_COUNT
+  #    value: "0"
+  #  - name: STPROXY_TCP_KEEPALIVE_IDLE
+  #    value: "0"
+  #  - name: STPROXY_TCP_KEEPALIVE_INTERVAL
+  #    value: "0"
 
 sentinel:
   replicaCount: 2
@@ -132,6 +145,9 @@ sentinel:
   podDisruptionBudget:
     # minAvailable: 1
     # maxUnavailable: 1
+  extraEnv: []
+  #  - name: STSENTINEL_LOG_LEVEL 
+  #    value: "info"
 
 ## initdb scripts
 ## Specify dictionary of scripts to be run at first boot, the entry point script is create_script.sh

--- a/stable/stolon/values.yaml
+++ b/stable/stolon/values.yaml
@@ -101,7 +101,7 @@ keeper:
     # maxUnavailable: 1
   ## See https://github.com/sorintlab/stolon/blob/master/doc/commands_invocation.md#commands-invocation
   extraEnv: []
-  #  - name: STKEEPER_LOG_LEVEL 
+  #  - name: STKEEPER_LOG_LEVEL
   #    value: "info"
 
 proxy:
@@ -125,7 +125,7 @@ proxy:
     # minAvailable: 1
     # maxUnavailable: 1
   extraEnv: []
-  #  - name: STPROXY_LOG_LEVEL 
+  #  - name: STPROXY_LOG_LEVEL
   #    value: "info"
   #  - name: STPROXY_TCP_KEEPALIVE_COUNT
   #    value: "0"
@@ -146,7 +146,7 @@ sentinel:
     # minAvailable: 1
     # maxUnavailable: 1
   extraEnv: []
-  #  - name: STSENTINEL_LOG_LEVEL 
+  #  - name: STSENTINEL_LOG_LEVEL
   #    value: "info"
 
 ## initdb scripts


### PR DESCRIPTION
@rtluckie  
@lwolf 

#### What this PR does / why we need it:

Add extra environment variables to keeper, proxy and sentinel 

#### Which issue this PR fixes
  - fixes #17684

#### Special notes for your reviewer:

First ever pr. apologies in case I missed something.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
