### PR TITLE
[stable/instana-agent] Update apiVersions for DaemonSet, PodSecurityPolicy

### DIFF
--- a/stable/instana-agent/Chart.yaml
+++ b/stable/instana-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: instana-agent
-version: 1.0.15
+version: 1.0.16
 appVersion: 1.0
 description: Instana Agent for Kubernetes
 home: https://www.instana.com/

--- a/stable/instana-agent/templates/clusterrole.yaml
+++ b/stable/instana-agent/templates/clusterrole.yaml
@@ -42,7 +42,7 @@ rules:
     - "endpoints"
   verbs: ["create", "update", "patch"]
 {{- if .Values.podSecurityPolicy.enable}}
-- apiGroups: ["extensions"]
+- apiGroups: ["policy"]
   resources: ["podsecuritypolicies"]
   verbs:     ["use"]
   resourceNames:

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.agent.key -}}
 {{- if or .Values.zone.name .Values.cluster.name -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "instana-agent.fullname" . }}

--- a/stable/instana-agent/templates/podsecuritypolicy.yaml
+++ b/stable/instana-agent/templates/podsecuritypolicy.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.rbac.create -}}
 {{- if (and .Values.podSecurityPolicy.enable (not .Values.podSecurityPolicy.name)) -}}
 kind: PodSecurityPolicy
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 metadata:
   name: {{ template "instana-agent.podSecurityPolicyName" . }}
   labels:


### PR DESCRIPTION
#### What this PR does / why we need it:

Update the `apiVersions` for `DaemonSet` and `PodSecurityPolicy` for k8s v1.16 capability support.

#### Special notes for your reviewer:

Update the `apiVersion` for `DaemonSet` and `PodSecurityPolicy` resource, and also when authorizing a `PodSecurityPolicy` in the `ClusterRole`.

See deprecated API removal announcement: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
`apps/v1` for `DaemonSet` has been available since k8s 1.9
`policy/v1beta1` for `PodSecurityPolicy` has been available since k8s 1.10. But since k8s 1.9 is no longer supported, this should be ok. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
