### PR TITLE
[stable/kong] use custom server block for health-checking

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.19.1
+version: 0.19.2
 appVersion: 1.3

--- a/stable/kong/templates/config-custom-server-blocks.yaml
+++ b/stable/kong/templates/config-custom-server-blocks.yaml
@@ -9,11 +9,15 @@ metadata:
     heritage: "{{ .Release.Service }}"
 data:
   servers.conf: |
-    # Prometheus metrics server
+    # Prometheus metrics and health-checking server
     server {
         server_name kong_prometheus_exporter;
         listen 0.0.0.0:9542; # can be any other port as well
         access_log off;
+        location /status {
+            default_type text/plain;
+            return 200;
+        }
         location /metrics {
             default_type text/plain;
             content_by_lua_block {

--- a/stable/kong/templates/controller-deployment.yaml
+++ b/stable/kong/templates/controller-deployment.yaml
@@ -41,6 +41,8 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
+        - name: KONG_NGINX_HTTP_INCLUDE
+          value: /kong/servers.conf
         - name: KONG_PROXY_LISTEN
           value: 'off'
         {{- if .Values.enterprise.enabled }}
@@ -83,9 +85,15 @@ spec:
         {{- end }}
         {{- include "kong.env" .  | indent 8 }}
         ports:
+        - name: metrics
+          containerPort: 9542
+          protocol: TCP
         - name: admin
           containerPort: {{ .Values.admin.containerPort }}
           protocol: TCP
+        volumeMounts:
+          - name: custom-nginx-template-volume
+            mountPath: /kong
         readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 10 }}
         livenessProbe:
@@ -93,4 +101,8 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       {{- include "kong.controller-container" . | nindent 6 }}
+      volumes:
+        - name: custom-nginx-template-volume
+          configMap:
+            name: {{ template "kong.fullname" . }}-default-custom-server-blocks
 {{- end -}}

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -292,8 +292,8 @@ resources: {}
 readinessProbe:
   httpGet:
     path: "/status"
-    port: admin
-    scheme: HTTPS
+    port: metrics
+    scheme: HTTP
   initialDelaySeconds: 30
   timeoutSeconds: 1
   periodSeconds: 10
@@ -305,8 +305,8 @@ readinessProbe:
 livenessProbe:
   httpGet:
     path: "/status"
-    port: admin
-    scheme: HTTPS
+    port: metrics
+    scheme: HTTP
   initialDelaySeconds: 30
   timeoutSeconds: 5
   periodSeconds: 30


### PR DESCRIPTION
Signed-off-by: Harry Bagdi <harrybagdi@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practice

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Uses custom server block for health-checking.
Meaning, if RBAC is turned on, then , the health-checks will not fail.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
