### PR TITLE
[stable/grafana] spec is immutable with auto provisioning claims

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 3.8.19
+version: 3.8.20
 appVersion: 6.3.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 3.8.20
+version: 5.0.1
 appVersion: 6.3.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: grafana
 version: 5.0.1
-appVersion: 6.3.5
+appVersion: 6.6.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/stable/grafana/templates/pvc.yaml
+++ b/stable/grafana/templates/pvc.yaml
@@ -22,5 +22,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClassName }}
   storageClassName: {{ .Values.persistence.storageClassName }}
+  {{- end -}}
 {{- end -}}

--- a/stable/grafana/templates/pvc.yaml
+++ b/stable/grafana/templates/pvc.yaml
@@ -25,5 +25,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClassName }}
   storageClassName: {{ .Values.persistence.storageClassName }}
+  {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## Is this a new chart
No.

## What this PR does / why we need it:
Fix an issue with pvc and default providers. The pvc `storageClassName` will be changed by kubernetes on pvc generation (default storageClass). setting the `storageClassName` empty will change the value back on a (second) upgrade / raise an immutable error while upgrading.

error with helm 3.0 beta.3:
```
client.go:357: Cannot patch PersistentVolumeClaim: "t1-grafana" (PersistentVolumeClaim "t1-grafana" is invalid: spec: Forbidden: is immutable after creation except resources.requests for bound claims)
client.go:376: Use --force to force recreation of the resource
client.go:172: [debug] error updating the resource "t1-grafana":
	 PersistentVolumeClaim "t1-grafana" is invalid: spec: Forbidden: is immutable after creation except resources.requests for bound claims
upgrade.go:260: [debug] warning: Upgrade "t1" failed: PersistentVolumeClaim "t1-grafana" is invalid: spec: Forbidden: is immutable after creation except resources.requests for bound claims
Error: UPGRADE FAILED: PersistentVolumeClaim "t1-grafana" is invalid: spec: Forbidden: is immutable after creation except resources.requests for bound claims
helm.go:81: [debug] PersistentVolumeClaim "t1-grafana" is invalid: spec: Forbidden: is immutable after creation except resources.requests for bound claims
```

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
