### PR TITLE
Use better way to check ready

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 2.1.0
+version: 2.1.1
 appVersion: 3.5.5
 kubeVersion: "^1.10.0-0"
 description: Centralized service for maintaining configuration information, naming,

--- a/incubator/zookeeper/templates/config-script.yaml
+++ b/incubator/zookeeper/templates/config-script.yaml
@@ -12,11 +12,11 @@ metadata:
 data:
     ok: |
       #!/bin/sh
-      echo ruok | nc 127.0.0.1 ${1:-2181}
+      zkServer.sh status
 
     ready: |
       #!/bin/sh
-      zkServer.sh status
+      echo ruok | nc 127.0.0.1 ${1:-2181}
 
     run: |
       #!/bin/bash

--- a/incubator/zookeeper/templates/config-script.yaml
+++ b/incubator/zookeeper/templates/config-script.yaml
@@ -16,7 +16,7 @@ data:
 
     ready: |
       #!/bin/sh
-      echo ruok | nc 127.0.0.1 ${1:-2181}
+      zkServer.sh status
 
     run: |
       #!/bin/bash


### PR DESCRIPTION
Even ruok is fine, does not mean zk can provide service as expected.
```
root@zookeeper-1:/apache-zookeeper-3.5.5-bin# echo ruok | nc localhost 2181
imokroot@zookeeper-1:/apache-zookeeper-3.5.5-bin# ./bin/zkServer.sh status
ZooKeeper JMX enabled by default
Using config: /conf/zoo.cfg
Client port found: 2181. Client address: localhost.
Error contacting service. It is probably not running.
```

Signed-off-by: Xiang Dai <764524258@qq.com>