### PR TITLE
[stable/kube-state-metrics] Avoid spec.template.spec.containers.0.res…

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - monitoring
 - prometheus
 - kubernetes
-version: 2.4.0
+version: 2.4.1
 appVersion: 1.8.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/templates/deployment.yaml
+++ b/stable/kube-state-metrics/templates/deployment.yaml
@@ -132,9 +132,10 @@ spec:
             port: 8080
           initialDelaySeconds: 5
           timeoutSeconds: 5
-
+{{- if .Values.resources }}
         resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.resources | indent 10 }}
+{{- end }}
 {{- if .Values.affinity }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}


### PR DESCRIPTION

#### What this PR does / why we need it:

When the value of pec.template.spec.containers.0.resources is null, Kube Api neglects it and removes it but it fails when validating against https://github.com/garethr/kubernetes-json-schema for example that waits for an object (empty object) and not null.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)