### PR TITLE
[stable/grafana] Avoid data key with an empty value in templates/dash…

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 3.9.0
+version: 3.9.1
 appVersion: 6.3.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/dashboards-json-configmap.yaml
+++ b/stable/grafana/templates/dashboards-json-configmap.yaml
@@ -13,6 +13,7 @@ metadata:
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
     dashboard-provider: {{ $provider }}
+{{- if $dashboards }}
 data:
 {{- range $key, $value := $dashboards }}
 {{- if (or (hasKey $value "json") (hasKey $value "file")) }}
@@ -23,6 +24,7 @@ data:
 {{- end }}
 {{- if hasKey $value "file" }}
 {{ toYaml ( $files.Get $value.file ) | indent 4}}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

When the value of `data:` in a configmap is null, Kube Api neglects it and removes it but it fails when validating against https://github.com/garethr/kubernetes-json-schema for example that waits for an object (empty object) and not null.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)