### PR TITLE
[stable/aerospike] add labels/annotations

### DIFF
--- a/stable/aerospike/Chart.yaml
+++ b/stable/aerospike/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - aerospike
   - big-data
 home: http://aerospike.com
-version: 0.2.9
+version: 0.2.10
 icon: https://s3-us-west-1.amazonaws.com/aerospike-fd/wp-content/uploads/2016/06/Aerospike_square_logo.png
 sources:
 - https://github.com/aerospike/aerospike-server

--- a/stable/aerospike/README.md
+++ b/stable/aerospike/README.md
@@ -45,6 +45,8 @@ The chart can be customized using the following configurable parameters:
 | `replicaCount`                  | Aerospike Brokers                                               | `1`                          |
 | `command`                       | Custom command (Docker Entrypoint)                              | `[]`                         |
 | `args`                          | Custom args (Docker Cmd)                                        | `[]`                         |
+| `labels`                        | Map of labels to add to the statefulset                         | `{}`                         |
+| `annotations`                   | Map of annotations to add to the statefulset                    | `{}`                         |
 | `tolerations`                   | List of node taints to tolerate                                 | `[]`                         |
 | `persistentVolume`              | Config of persistent volumes for storage-engine                 | `{}`                         |
 | `confFile`                      | Config filename. This file should be included in the chart path | `aerospike.conf`             |

--- a/stable/aerospike/templates/statefulset.yaml
+++ b/stable/aerospike/templates/statefulset.yaml
@@ -7,6 +7,13 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   serviceName: {{ template "aerospike.fullname" . }}-mesh
   replicas: {{ .Values.replicaCount }}

--- a/stable/aerospike/values.yaml
+++ b/stable/aerospike/values.yaml
@@ -40,6 +40,9 @@ service:
 meshService:
   annotations: {}
 
+labels: {}
+annotations: {}
+
 tolerations: []
 
 resources: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

Add support for custom labels and annotations on the statefulset, so that people can enable third-party kubernetes features that use either labels or annotations.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
