### PR TITLE
[stable/reloader] Adds imagePullSecrets and securityContext

### DIFF
--- a/stable/reloader/Chart.yaml
+++ b/stable/reloader/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: reloader
 description: Reloader chart that runs on kubernetes
-version: 1.1.3
-appVersion: "v0.0.29"
+version: 1.2.0
+appVersion: "v0.0.41"
 keywords:
   - Reloader
   - kubernetes

--- a/stable/reloader/README.md
+++ b/stable/reloader/README.md
@@ -85,13 +85,19 @@ Update the `values.yaml` and set the following properties
 | reloader.deployment.env.open         | Additional key value pair as environment variables                          | ``                                 |
 | reloader.deployment.env.secret       | Additional Key value pair as environment variables. It gets the values based on keys from default reloader secret if any | ``                                 |
 | reloader.deployment.env.field        | Additional environment variables to expose pod information to containers.   | ``                                 |
+| reloader.deployment.affinity         | Optional node affinity for pod assignment                                   | `{}`                               |
+| reloader.deployment.nodeSelector     | Optional node labels for pod assignment                                     | `{}`                               |
 | reloader.deployment.securityContext  | Defines deployment security context                                         | `{}`                               |
+| reloader.deployment.tolerations      | Optional tolerations for pod assignment                                     | `{}`                               |
+| reloader.isOpenshift                 | Optional flag if we are using Openshift for additional permissions          | `false`                            |
+| reloader.ignoreSecrets               | Ignores secrets tracking                                                    | `false`                            |
+| reloader.ignoreConfigMaps            | Ignores configmap tracking                                                  | `false`                            |
 | reloader.rbac.enabled                | Option to create rbac                                                       | `true`                             |
 | reloader.rbac.labels                 | Additional labels for rbac                                                  | `{}`                               |
 | reloader.serviceAccount.create       | Option to create serviceAccount                                             | `true`                             |
 | reloader.serviceAccount.name         | Name of serviceAccount                                                      | `reloader`                         |
 | reloader.custom_annotations          | Optional flags to pass to the Reloader entrypoint                           | `{}`                               |
-| reloader.nodeSelector                | Optional node labels for pod assignment                                     | `{}`                               |
+
 
 ## Deploying to Kubernetes
 

--- a/stable/reloader/README.md
+++ b/stable/reloader/README.md
@@ -72,24 +72,27 @@ The following quickstart let's you set up Reloader quickly:
 
 Update the `values.yaml` and set the following properties
 
-| Key           | Description                                                               | Example                            | Default Value                      |
-|---------------|---------------------------------------------------------------------------|------------------------------------|------------------------------------|
-| reloader.watchGlobally          | Option to watch configmap and secrets in all namespaces                                                | `true`                        | `true`                        |
-| reloader.matchLabels          | Additional match Labels for selector                                                | `{}`                        | `{}`                        |
-| reloader.deployment.annotations          | Annotations for deployment                                                | `{}`                        | `{}`                        |
-| reloader.deployment.labels          | Labels for deployment                                                | `provider`                        | `provider`                        |
-| reloader.deployment.image.name          | Image name for reloader                                                | `stakater/reloader`                        | `stakater/reloader`                        |
-| reloader.deployment.image.tag          | Image tag for reloader                                                | `v0.0.29`                        | `v0.0.29`                        |
-| reloader.deployment.image.pullPolicy          | Image pull policy for reloader                                                | `IfNotPresent`                        | `IfNotPresent`                        |
-| reloader.deployment.env.open          | Additional key value pair as environment variables                                                | `STORAGE: local`                        | ``                        |
-| reloader.deployment.env.secret          | Additional Key value pair as environment variables. It gets the values based on keys from default reloader secret if any                        | `BASIC_AUTH_USER: test`                        | ``                        |
-| reloader.deployment.env.field          | Additional environment variables to expose pod information to containers.                                               | `POD_IP: status.podIP`                        | ``                        |
-| reloader.rbac.enabled          | Option to create rbac                                               | `true`                        | `true`                        |
-| reloader.rbac.labels          | Additional labels for rbac                                               | `{}`                        | `{}`                        |
-| reloader.serviceAccount.create          | Option to create serviceAccount                                               | `true`                        | `true`                        |
-| reloader.serviceAccount.name          | Name of serviceAccount                                               | `reloader`                        | `reloader`                        |
-| reloader.custom_annotations          | Optional flags to pass to the Reloader entrypoint           | `{}`          | `{}`          |
-| reloader.nodeSelector          | Optional node labels for pod assignment           | `{}`          | `{}`          |
+| Key                                  | Description                                                                 | Default Value                      |
+|--------------------------------------|-----------------------------------------------------------------------------|------------------------------------|
+| global.imagePullSecrets              | Reference to one or more secrets to be used when pulling images             | `[]`                               |
+| reloader.watchGlobally               | Option to watch configmap and secrets in all namespaces                     | `true`                             |
+| reloader.matchLabels                 | Additional match Labels for selector                                        | `{}`                               |
+| reloader.deployment.annotations      | Annotations for deployment                                                  | `{}`                               |
+| reloader.deployment.labels           | Labels for deployment                                                       | `provider`                         |
+| reloader.deployment.image.name       | Image name for reloader                                                     | `stakater/reloader`                |
+| reloader.deployment.image.tag        | Image tag for reloader                                                      | `v0.0.29`                          |
+| reloader.deployment.image.pullPolicy | Image pull policy for reloader                                              | `IfNotPresent`                     |
+| reloader.deployment.env.open         | Additional key value pair as environment variables                          | ``                                 |
+| reloader.deployment.env.secret       | Additional Key value pair as environment variables. It gets the values based on keys from default reloader secret if any | ``                                 |
+| reloader.deployment.env.field        | Additional environment variables to expose pod information to containers.   | ``                                 |
+| reloader.deployment.securityContext  | Defines deployment security context                                         | `{}`                               |
+| reloader.rbac.enabled                | Option to create rbac                                                       | `true`                             |
+| reloader.rbac.labels                 | Additional labels for rbac                                                  | `{}`                               |
+| reloader.serviceAccount.create       | Option to create serviceAccount                                             | `true`                             |
+| reloader.serviceAccount.name         | Name of serviceAccount                                                      | `reloader`                         |
+| reloader.custom_annotations          | Optional flags to pass to the Reloader entrypoint                           | `{}`                               |
+| reloader.nodeSelector                | Optional node labels for pod assignment                                     | `{}`                               |
+
 ## Deploying to Kubernetes
 
 You can deploy Reloader by following methods:

--- a/stable/reloader/templates/_helpers.tpl
+++ b/stable/reloader/templates/_helpers.tpl
@@ -2,6 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
+
 {{- define "reloader-name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | lower -}}
 {{- end -}}
@@ -15,20 +16,17 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "reloader-labels.selector" -}}
-app: {{ template "reloader-name" . }}
-release: {{ .Release.Name | quote }}
-{{- end -}}
-
 {{- define "reloader-labels.chart" -}}
+app: {{ template "reloader-fullname" . }}
 chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+release: {{ .Release.Name | quote }}
 heritage: {{ .Release.Service | quote }}
 {{- end -}}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "serviceAccountName" -}}
+{{- define "reloader-serviceAccountName" -}}
 {{- if .Values.reloader.serviceAccount.create -}}
     {{ default (include "reloader-fullname" .) .Values.reloader.serviceAccount.name }}
 {{- else -}}

--- a/stable/reloader/templates/clusterrole.yaml
+++ b/stable/reloader/templates/clusterrole.yaml
@@ -1,11 +1,9 @@
----
 {{- if and .Values.reloader.watchGlobally (.Values.reloader.rbac.enabled) }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   labels:
 {{ include "reloader-labels.chart" . | indent 4 }}
-{{ include "reloader-labels.selector" . | indent 4 }}
 {{- if .Values.reloader.rbac.labels }}
 {{ toYaml .Values.reloader.rbac.labels | indent 4 }}
 {{- end }}
@@ -17,20 +15,45 @@ metadata:
 rules:
   - apiGroups:
       - ""
-    resources:      
+    resources:
+{{- if .Values.reloader.ignoreSecrets }}{{- else }}
       - secrets
+{{- end }}
+{{- if .Values.reloader.ignoreConfigMaps }}{{- else }}
       - configmaps
+{{- end }}
     verbs:
       - list
       - get
       - watch
+{{- if or (.Capabilities.APIVersions.Has "apps.openshift.io/v1") (.Values.isOpenshift) }}
   - apiGroups:
-      - "extensions"
+      - "apps.openshift.io"
+      - ""
+    resources:
+      - deploymentconfigs
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+{{- end }}
+  - apiGroups:
       - "apps"
     resources:
       - deployments
       - daemonsets
       - statefulsets
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - deployments
+      - daemonsets
     verbs:
       - list
       - get

--- a/stable/reloader/templates/clusterrolebinding.yaml
+++ b/stable/reloader/templates/clusterrolebinding.yaml
@@ -1,11 +1,9 @@
 {{- if and .Values.reloader.watchGlobally (.Values.reloader.rbac.enabled) }}
----
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   labels:
 {{ include "reloader-labels.chart" . | indent 4 }}
-{{ include "reloader-labels.selector" . | indent 4 }}
 {{- if .Values.reloader.rbac.labels }}
 {{ toYaml .Values.reloader.rbac.labels | indent 4 }}
 {{- end }}
@@ -20,6 +18,6 @@ roleRef:
   name: {{ template "reloader-fullname" . }}-role
 subjects:
   - kind: ServiceAccount
-    name: {{ template "serviceAccountName" . }}
+    name: {{ template "reloader-serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/stable/reloader/templates/deployment.yaml
+++ b/stable/reloader/templates/deployment.yaml
@@ -87,6 +87,9 @@ spec:
           - "{{ .Values.reloader.custom_annotations.auto }}"
           {{- end }}
         {{- end }}
+{{- if .Values.reloader.deployment.securityContext }}
+      securityContext: {{ toYaml .Values.reloader.deployment.securityContext | nindent 8 }}
+{{- end }}
       serviceAccountName: {{ template "serviceAccountName" . }}
 {{- if .Values.reloader.nodeSelector }}
       nodeSelector:

--- a/stable/reloader/templates/deployment.yaml
+++ b/stable/reloader/templates/deployment.yaml
@@ -7,7 +7,6 @@ metadata:
 {{- end }}
   labels:
 {{ include "reloader-labels.chart" . | indent 4 }}
-{{ include "reloader-labels.selector" . | indent 4 }}
 {{- if .Values.reloader.deployment.labels }}
 {{ toYaml .Values.reloader.deployment.labels | indent 4 }}
 {{- end }}
@@ -15,20 +14,19 @@ metadata:
 {{ toYaml .Values.reloader.matchLabels | indent 4 }}
 {{- end }}
   name: {{ template "reloader-fullname" . }}
-  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   revisionHistoryLimit: 2
   selector:
     matchLabels:
-{{ include "reloader-labels.selector" . | indent 6 }}
+      app: {{ template "reloader-fullname" . }}
+      release: {{ .Release.Name | quote }}
 {{- if .Values.reloader.matchLabels }}
 {{ toYaml .Values.reloader.matchLabels | indent 6 }}
 {{- end }}
   template:
     metadata:
       labels:
-{{ include "reloader-labels.selector" . | indent 8 }}
 {{ include "reloader-labels.chart" . | indent 8 }}
 {{- if .Values.reloader.deployment.labels }}
 {{ toYaml .Values.reloader.deployment.labels | indent 8 }}
@@ -37,6 +35,18 @@ spec:
 {{ toYaml .Values.reloader.matchLabels | indent 8 }}
 {{- end }}
     spec:
+      {{- if .Values.reloader.deployment.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.reloader.deployment.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.reloader.deployment.affinity }}
+      affinity:
+{{ toYaml .Values.reloader.deployment.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.reloader.deployment.tolerations }}
+      tolerations:
+{{ toYaml .Values.reloader.deployment.tolerations | indent 8 }}
+      {{- end }}
       containers:
       - env:
       {{- range $name, $value := .Values.reloader.deployment.env.open }}
@@ -71,27 +81,45 @@ spec:
       {{- end }}
         image: "{{ .Values.reloader.deployment.image.name }}:{{ .Values.reloader.deployment.image.tag }}"
         imagePullPolicy: {{ .Values.reloader.deployment.image.pullPolicy }}
-        name: {{ template "reloader-name" . }}
-      {{- if .Values.reloader.custom_annotations }}
+        name: {{ template "reloader-fullname" . }}
+      {{- if eq .Values.reloader.readOnlyRootFileSystem true }}
+        volumeMounts:
+          - mountPath: /tmp/
+            name: tmp-volume
+      {{- end }}
         args:
-          {{- if .Values.reloader.custom_annotations.configmap }}
-          - "--configmap-annotation"
-          - "{{ .Values.reloader.custom_annotations.configmap }}"
+          {{- if .Values.reloader.ignoreSecrets }}
+          - "--resources-to-ignore=secrets"
           {{- end }}
-          {{- if .Values.reloader.custom_annotations.secret }}
-          - "--secret-annotation"
-          - "{{ .Values.reloader.custom_annotations.secret }}"
+          {{- if eq .Values.reloader.ignoreConfigMaps true }}
+          - "--resources-to-ignore=configMaps"
           {{- end }}
-          {{- if .Values.reloader.custom_annotations.auto }}
-          - "--auto-annotation"
-          - "{{ .Values.reloader.custom_annotations.auto }}"
+
+          {{- if .Values.reloader.custom_annotations }}
+            {{- if .Values.reloader.custom_annotations.configmap }}
+            - "--configmap-annotation"
+            - "{{ .Values.reloader.custom_annotations.configmap }}"
+            {{- end }}
+            {{- if .Values.reloader.custom_annotations.secret }}
+            - "--secret-annotation"
+            - "{{ .Values.reloader.custom_annotations.secret }}"
+            {{- end }}
+            {{- if .Values.reloader.custom_annotations.auto }}
+            - "--auto-annotation"
+            - "{{ .Values.reloader.custom_annotations.auto }}"
+            {{- end }}
           {{- end }}
-        {{- end }}
+
+      {{- if .Values.reloader.deployment.resources }}
+        resources:
+{{ toYaml .Values.reloader.deployment.resources | indent 10 }}
+      {{- end }}
 {{- if .Values.reloader.deployment.securityContext }}
       securityContext: {{ toYaml .Values.reloader.deployment.securityContext | nindent 8 }}
 {{- end }}
-      serviceAccountName: {{ template "serviceAccountName" . }}
-{{- if .Values.reloader.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.reloader.nodeSelector | indent 8 }}
-{{- end }}
+      serviceAccountName: {{ template "reloader-serviceAccountName" . }}
+    {{- if eq .Values.reloader.readOnlyRootFileSystem true }}
+      volumes:
+        - emptyDir: {}
+          name: tmp-volume
+    {{- end }}

--- a/stable/reloader/templates/role.yaml
+++ b/stable/reloader/templates/role.yaml
@@ -4,7 +4,6 @@ kind: Role
 metadata:
   labels:
 {{ include "reloader-labels.chart" . | indent 4 }}
-{{ include "reloader-labels.selector" . | indent 4 }}
 {{- if .Values.reloader.rbac.labels }}
 {{ toYaml .Values.reloader.rbac.labels | indent 4 }}
 {{- end }}
@@ -16,20 +15,45 @@ metadata:
 rules:
   - apiGroups:
       - ""
-    resources:      
+    resources:
+{{- if .Values.reloader.ignoreSecrets }}{{- else }}
       - secrets
+{{- end }}
+{{- if .Values.reloader.ignoreConfigMaps }}{{- else }}
       - configmaps
+{{- end }}
     verbs:
       - list
       - get
       - watch
+{{- if or (.Capabilities.APIVersions.Has "apps.openshift.io/v1") (.Values.isOpenshift) }}
   - apiGroups:
-      - "extensions"
+      - "apps.openshift.io"
+      - ""
+    resources:
+      - deploymentconfigs
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+{{- end }}
+  - apiGroups:
       - "apps"
     resources:
       - deployments
       - daemonsets
       - statefulsets
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - deployments
+      - daemonsets
     verbs:
       - list
       - get

--- a/stable/reloader/templates/rolebinding.yaml
+++ b/stable/reloader/templates/rolebinding.yaml
@@ -1,11 +1,9 @@
 {{- if and (not (.Values.reloader.watchGlobally)) (.Values.reloader.rbac.enabled) }}
----
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  labels: 
+  labels:
 {{ include "reloader-labels.chart" . | indent 4 }}
-{{ include "reloader-labels.selector" . | indent 4 }}
 {{- if .Values.reloader.rbac.labels }}
 {{ toYaml .Values.reloader.rbac.labels | indent 4 }}
 {{- end }}
@@ -20,6 +18,6 @@ roleRef:
   name: {{ template "reloader-fullname" . }}-role
 subjects:
   - kind: ServiceAccount
-    name: {{ template "serviceAccountName" . }}
+    name: {{ template "reloader-serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/stable/reloader/templates/serviceaccount.yaml
+++ b/stable/reloader/templates/serviceaccount.yaml
@@ -1,6 +1,9 @@
 {{- if .Values.reloader.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
+{{- end }}
 metadata:
   labels:
 {{ include "reloader-labels.chart" . | indent 4 }}

--- a/stable/reloader/templates/serviceaccount.yaml
+++ b/stable/reloader/templates/serviceaccount.yaml
@@ -7,13 +7,11 @@ imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
 metadata:
   labels:
 {{ include "reloader-labels.chart" . | indent 4 }}
-{{ include "reloader-labels.selector" . | indent 4 }}
 {{- if .Values.reloader.serviceAccount.labels }}
 {{ toYaml .Values.reloader.serviceAccount.labels | indent 4 }}
 {{- end }}
 {{- if .Values.reloader.matchLabels }}
 {{ toYaml .Values.reloader.matchLabels | indent 4 }}
 {{- end }}
-  name: {{ template "serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ template "reloader-serviceAccountName" . }}
 {{- end }}

--- a/stable/reloader/values.yaml
+++ b/stable/reloader/values.yaml
@@ -1,3 +1,10 @@
+global:
+  ## Reference to one or more secrets to be used when pulling images
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  imagePullSecrets: []
+  # - name: "image-pull-secret"
+
 reloader:
   watchGlobally: true
   matchLabels: {}
@@ -8,16 +15,21 @@ reloader:
       group: com.stakater.platform
     image:
       name: stakater/reloader
-      tag: "v0.0.29"
+      tag: "v0.0.41"
       pullPolicy: IfNotPresent
     # Support for extra environment variables.
     env:
       # Open supports Key value pair as environment variables.
       open:
+      # POD_IP: status.podIP
       # secret supports Key value pair as environment variables. It gets the values based on keys from default reloader secret if any.
       secret:
+      # BASIC_AUTH_USER: test
       # field supports Key value pair as environment variables. It gets the values from other fields of pod.
       field:
+    # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+    securityContext: {}
+    # runAsUser: 1000
   rbac:
     enabled: true
     labels: {}

--- a/stable/reloader/values.yaml
+++ b/stable/reloader/values.yaml
@@ -5,14 +5,45 @@ global:
   imagePullSecrets: []
   # - name: "image-pull-secret"
 
+kubernetes:
+  host: https://kubernetes.default
+
 reloader:
+  isOpenshift: false
+  ignoreSecrets: false
+  ignoreConfigMaps: false
   watchGlobally: true
+  # Set to true if you have a pod security policy that enforces readOnlyRootFilesystem
+  readOnlyRootFileSystem: false
   matchLabels: {}
   deployment:
+    nodeSelector:
+    # cloud.google.com/gke-nodepool: default-pool
+
+    # An affinity stanza to be applied to the Deployment.
+    # Example:
+    #   affinity:
+    #     nodeAffinity:
+    #       requiredDuringSchedulingIgnoredDuringExecution:
+    #         nodeSelectorTerms:
+    #         - matchExpressions:
+    #           - key: "node-role.kubernetes.io/infra-worker"
+    #             operator: "Exists"
+    affinity: {}
+
+    # A list of tolerations to be applied to the Deployment.
+    # Example:
+    #   tolerations:
+    #   - key: "node-role.kubernetes.io/infra-worker"
+    #     operator: "Exists"
+    #     effect: "NoSchedule"
+    tolerations: []
+
     annotations: {}
     labels:
       provider: stakater
       group: com.stakater.platform
+      version: v0.0.41
     image:
       name: stakater/reloader
       tag: "v0.0.41"
@@ -21,15 +52,25 @@ reloader:
     env:
       # Open supports Key value pair as environment variables.
       open:
-      # POD_IP: status.podIP
       # secret supports Key value pair as environment variables. It gets the values based on keys from default reloader secret if any.
       secret:
-      # BASIC_AUTH_USER: test
       # field supports Key value pair as environment variables. It gets the values from other fields of pod.
       field:
+
+    # Specify resource requests/limits for the deployment.
+    # Example:
+    # resources:
+    #   limits:
+    #     cpu: "100m"
+    #     memory: "512Mi"
+    #   requests:
+    #     cpu: "10m"
+    #     memory: "128Mi"
+    resources: {}
     # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
     securityContext: {}
     # runAsUser: 1000
+
   rbac:
     enabled: true
     labels: {}
@@ -47,4 +88,3 @@ reloader:
   #     configmap: "my.company.com/configmap"
   #     secret: "my.company.com/secret"
   custom_annotations: {}
-  nodeSelector: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds imagePullSecrets to ServiceAccount

Adds securityContext to Deployment

Updates stakater/reloader image to v0.0.41

Moves examples from README.md to values.yaml

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
