### PR TITLE
[stable/prometheus-operator] Allow to pass --namespaces to Prometheus Operator

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -10,7 +10,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 6.15.0
+version: 6.16.0
 appVersion: 0.32.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -182,6 +182,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.logFormat` | Operator log output formatting | `"logfmt"` |
 | `prometheusOperator.logLevel` | Operator log level. Possible values: "all", "debug",	"info",	"warn",	"error", "none" | `"info"` |
 | `prometheusOperator.namespaces` | Namespaces to scope the interaction of the Prometheus Operator and the apiserver | `[]` |
+| `prometheusOperator.manageCustomResource` | Manage all CRDs with the Prometheus Operator. | `"true"` |
 | `prometheusOperator.nodeSelector` | Prometheus operator node selector https://kubernetes.io/docs/user-guide/node-selection/ | `{}` |
 | `prometheusOperator.podAnnotations` | Annotations to add to the operator pod | `{}` |
 | `prometheusOperator.podLabels` | Labels to add to the operator pod | `{}` |

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -181,6 +181,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.kubeletService.namespace` | Namespace to deploy kubelet service | `kube-system` |
 | `prometheusOperator.logFormat` | Operator log output formatting | `"logfmt"` |
 | `prometheusOperator.logLevel` | Operator log level. Possible values: "all", "debug",	"info",	"warn",	"error", "none" | `"info"` |
+| `prometheusOperator.namespaces` | Namespaces to scope the interaction of the Prometheus Operator and the apiserver | `[]` |
 | `prometheusOperator.nodeSelector` | Prometheus operator node selector https://kubernetes.io/docs/user-guide/node-selection/ | `{}` |
 | `prometheusOperator.podAnnotations` | Annotations to add to the operator pod | `{}` |
 | `prometheusOperator.podLabels` | Labels to add to the operator pod | `{}` |

--- a/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
@@ -43,6 +43,9 @@ spec:
           {{- if .Values.prometheusOperator.logLevel }}
             - --log-level={{ .Values.prometheusOperator.logLevel }}
           {{- end }}
+          {{- if .Values.prometheusOperator.namespaces }}
+            - --namespaces={{ .Values.prometheusOperator.namespaces | join "," }}
+          {{- end }}
             - --logtostderr=true
             - --crd-apigroup={{ .Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com" }}
             - --localhost=127.0.0.1

--- a/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
@@ -48,6 +48,9 @@ spec:
           {{- end }}
             - --logtostderr=true
             - --crd-apigroup={{ .Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com" }}
+          {{- if not .Values.prometheusOperator.manageCustomResource }}
+            - --manage-crds=false
+          {{- end }}
             - --localhost=127.0.0.1
             - --prometheus-config-reloader={{ .Values.prometheusOperator.prometheusConfigReloaderImage.repository }}:{{ .Values.prometheusOperator.prometheusConfigReloaderImage.tag }}
             - --config-reloader-image={{ .Values.prometheusOperator.configmapReloadImage.repository }}:{{ .Values.prometheusOperator.configmapReloadImage.tag }}

--- a/stable/prometheus-operator/templates/prometheus-operator/role.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/role.yaml
@@ -1,0 +1,79 @@
+{{- if .Values.prometheusOperator.enabled }}
+{{- range .Values.prometheusOperator.namespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "prometheus-operator.fullname" $ }}-operator
+  namespace: {{ . }}
+  labels:
+    app: {{ template "prometheus-operator.name" $ }}-operator
+{{ include "prometheus-operator.labels" $ | indent 4 }}
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - {{ $.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com" }}
+  resources:
+  - alertmanagers
+  - prometheuses
+  - prometheuses/finalizers
+  - alertmanagers/finalizers
+  - servicemonitors
+  - podmonitors
+  - prometheusrules
+  - podmonitors
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - services/finalizers
+  - endpoints
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}
+{{- end }}

--- a/stable/prometheus-operator/templates/prometheus-operator/rolebinding.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/rolebinding.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.prometheusOperator.enabled }}
+{{- range .Values.prometheusOperator.namespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "prometheus-operator.fullname" $ }}-operator
+  namespace: {{ . }}
+  labels:
+    app: {{ template "prometheus-operator.name" $ }}-operator
+{{ include "prometheus-operator.labels" $ | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "prometheus-operator.fullname" $ }}-operator
+subjects:
+- kind: ServiceAccount
+  name: {{ template "prometheus-operator.operator.serviceAccountName" $ }}
+  namespace: {{ $.Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -1011,6 +1011,10 @@ prometheusOperator:
   ##
   createCustomResource: true
 
+  ## Manage all CRDs with the Prometheus Operator.
+  ##
+  manageCustomResource: true
+
   ## Customize CRDs API Group
   crdApiGroup: monitoring.coreos.com
 

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -968,6 +968,10 @@ prometheusOperator:
     create: true
     name: ""
 
+  ## Namespaces to scope the interaction of the Prometheus Operator and the apiserver.
+  ##
+  namespaces: []
+
   ## Configuration for Prometheus operator service
   ##
   service:


### PR DESCRIPTION
## What this PR does / why we need it:
This PR allows to pass the `--namespaces` parameter to the Prometheus Operator. It also creates the proper `Roles` and `RoleBindings` accordingly.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
