### PR TITLE
[stable/cockroachdb] Fix for compatibiliy with Kubernetes 1.16

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 2.1.14
+version: 2.1.15
 appVersion: 19.1.5
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/templates/_helpers.tpl
+++ b/stable/cockroachdb/templates/_helpers.tpl
@@ -19,3 +19,14 @@ Create the name of the service account to use
     {{ default "default" .Values.Secure.ServiceAccount.Name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for StatefulSets
+*/}}
+{{- define "statefulset.apiVersion" -}}
+{{- if semverCompare "<1.12-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apps/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/cockroachdb/templates/statefulset.yaml
+++ b/stable/cockroachdb/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: {{ template "statefulset.apiVersion" . }}
 kind: StatefulSet
 metadata:
   name: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}"


### PR DESCRIPTION
In Kubernetes 1.16, all resources under `apps/v1beta1` are now only available
under `apps/v1`:
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#deprecations-and-removals

This updates our StatefulSet apiVersion, while maintaining compatibility with
old versions of Kubernetes where StatefulSets are not available under the
`apps/v1` APIVersion.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
