### PR TITLE
[stable/fluent-bit] Use apps/v1 api for DaemonSet if k8s > 1.9

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.7.1
+version: 2.7.2
 appVersion: 1.2.2
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/_helpers.tpl
+++ b/stable/fluent-bit/templates/_helpers.tpl
@@ -65,3 +65,14 @@ Return the appropriate apiGroup for PodSecurityPolicy.
 {{- print "policy" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for DaemonSet.
+*/}}
+{{- define "daemonSet.apiVersion" -}}
+{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/fluent-bit/templates/daemonset.yaml
+++ b/stable/fluent-bit/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "daemonSet.apiVersion" . }}
 kind: DaemonSet
 metadata:
   name: {{ template "fluent-bit.fullname" . }}
@@ -8,6 +8,13 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fluent-bit.name" . }}
+      release: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 6 }}
+{{- end }}
   updateStrategy:
     type: RollingUpdate
   template:


### PR DESCRIPTION
Signed-off-by: László Kondás <laszlo.kondas@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Which issue this PR fixes
  - fixes #17834

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
