### PR TITLE
[stable/falco]: Restrict to RO access to /dev on underlying host

### DIFF
--- a/stable/falco/CHANGELOG.md
+++ b/stable/falco/CHANGELOG.md
@@ -3,6 +3,12 @@
 This file documents all notable changes to Sysdig Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.0.9
+
+### Minor Changes
+
+* Restrict the access to `/dev` on underlying host to read only
+
 ## v1.0.8
 
 ### Minor Changes

--- a/stable/falco/Chart.yaml
+++ b/stable/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: falco
-version: 1.0.8
+version: 1.0.9
 appVersion: 0.17.1
 description: Falco
 keywords:

--- a/stable/falco/templates/daemonset.yaml
+++ b/stable/falco/templates/daemonset.yaml
@@ -90,6 +90,7 @@ spec:
             {{- end}}
             - mountPath: /host/dev
               name: dev-fs
+              readOnly: true
             - mountPath: /host/proc
               name: proc-fs
               readOnly: true


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This PR improves the security posture of falco container itself by only allowing readOnly access to `/dev` on underlying host. Following the [least-privilage access principle](https://en.wikipedia.org/wiki/Principle_of_least_privilege) is a nice to have, especially for a security tool itself.

#### Special notes for your reviewer:
I tested this change locally on minikube. Falco container was able to correctly load kernel modules and start cleanly. I also tested the detection by falco when a privileged container is spawned.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
