### PR TITLE
[stable/telegraf] Bump telegraf version from 1.10 to 1.12

### DIFF
--- a/stable/telegraf/Chart.yaml
+++ b/stable/telegraf/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: telegraf
-version: 1.1.5
-appVersion: 1.10
+version: 1.1.6
+appVersion: 1.12
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.
 keywords:

--- a/stable/telegraf/values.yaml
+++ b/stable/telegraf/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repo: "telegraf"
-  tag: "1.10-alpine"
+  tag: "1.12-alpine"
   pullPolicy: IfNotPresent
 
 podAnnotations: {}


### PR DESCRIPTION
## What this PR does / why we need it:
Bumps the version of telegraf which provides multiple fixes. Save future chart users from day(s) debugging.


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)

@naseemkullah 