### PR TITLE
[stable/kong] fix SMTP password variable

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.19.1
+version: 0.19.3
 appVersion: 1.3

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -136,7 +136,7 @@ spec:
         - name: KONG_SMTP_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.enterprise.smtp.auth.smtp_password }}
+              name: {{ .Values.enterprise.smtp.auth.smtp_password_secret }}
               key: smtp_password
         {{- end }}
         {{- else }}


### PR DESCRIPTION
#### What this PR does / why we need it:
I forgot to update a variable name (`.enterprise.smtp.auth.smtp_password_secret`) in the template after changing it in values.yaml. This resolves that inconsistency.

#### Which issue this PR fixes
Fix #17784

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
