### PR TITLE
[stable/kube-state-metrics] Include .Release.Namespace in chart

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - monitoring
 - prometheus
 - kubernetes
-version: 2.4.1
+version: 2.4.2
 appVersion: 1.8.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/templates/clusterrole.yaml
+++ b/stable/kube-state-metrics/templates/clusterrole.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
   name: {{ template "kube-state-metrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 rules:
 {{ if .Values.collectors.certificatesigningrequests }}
 - apiGroups: ["certificates.k8s.io"]

--- a/stable/kube-state-metrics/templates/clusterrolebinding.yaml
+++ b/stable/kube-state-metrics/templates/clusterrolebinding.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
   name: {{ template "kube-state-metrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/stable/kube-state-metrics/templates/deployment.yaml
+++ b/stable/kube-state-metrics/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kube-state-metrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/kube-state-metrics/templates/podsecuritypolicy.yaml
+++ b/stable/kube-state-metrics/templates/podsecuritypolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "kube-state-metrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/stable/kube-state-metrics/templates/psp-clusterrole.yaml
+++ b/stable/kube-state-metrics/templates/psp-clusterrole.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
   name: psp-{{ template "kube-state-metrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups: ['extensions']
   resources: ['podsecuritypolicies']

--- a/stable/kube-state-metrics/templates/psp-clusterrolebinding.yaml
+++ b/stable/kube-state-metrics/templates/psp-clusterrolebinding.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
   name: psp-{{ template "kube-state-metrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/stable/kube-state-metrics/templates/service.yaml
+++ b/stable/kube-state-metrics/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kube-state-metrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/kube-state-metrics/templates/serviceaccount.yaml
+++ b/stable/kube-state-metrics/templates/serviceaccount.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
   name: {{ template "kube-state-metrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}
 {{- end -}}

--- a/stable/kube-state-metrics/templates/servicemonitor.yaml
+++ b/stable/kube-state-metrics/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-state-metrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR includes .Release.Namespace that is required when doing Helm deployments from Spinnaker.


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
