### PR TITLE
[stable/external-dns] adding --aws-prefer-cname to create CNAME records for Kubernetes service or ingress

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.8.0
+version: 2.9.0
 appVersion: 0.5.17
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -67,6 +67,7 @@ The following table lists the configurable parameters of the external-dns chart 
 | `aws.assumeRoleArn`                 | When using the AWS provider, assume role by specifying --aws-assume-role to the external-dns daemon      | `""`                                                        |
 | `aws.batchChangeSize`               | When using the AWS provider, set the maximum number of changes that will be applied in each batch        | `1000`                                                      |
 | `aws.zoneTags`                      | When using the AWS provider, filter for zones with these tags                                            | `[]`                                                        |
+| `aws.preferCNAME`                   | When using the AWS provider, replaces Alias recors with CNAME (options: true, false)                     | `[]`                                                        |
 | `azure.secretName`                  | When using the Azure provider, set the secret containing the `azure.json` file                           | `""`                                                        |
 | `azure.resourceGroup`               | When using the Azure provider, set the Azure Resource Group                                              | `""`                                                        |
 | `azure.tenantId`                    | When using the Azure provider, set the Azure Tenant ID                                                   | `""`                                                        |

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -105,6 +105,9 @@ spec:
         {{- range .Values.aws.zoneTags }}
         - --aws-zone-tags={{ . }}
         {{- end }}
+        {{- if .Values.aws.preferCNAME }}
+        - --aws-prefer-cname
+        {{- end }}
         # Azure Arguments
         {{- if eq .Values.provider "azure" }}
         {{- if .Values.azure.resourceGroup }}

--- a/stable/external-dns/values-production.yaml
+++ b/stable/external-dns/values-production.yaml
@@ -74,6 +74,9 @@ aws:
   ## Zone Tag Filter
   ##
   zoneTags: []
+  ## Enable AWS Prefer CNAME. Available values are: true, false
+  ##
+  preferCNAME: ""
 
 ## Azure configuration to be set via arguments/env. variables
 ##

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -74,7 +74,7 @@ aws:
   ## AWS Zone tags
   ##
   zoneTags: []
-  ## AWS Prefer CNAME. Available values are: true, false
+  ## Enable AWS Prefer CNAME. Available values are: true, false
   ##
   preferCNAME: ""
 ## Azure configuration to be set via arguments/env. variables

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -74,7 +74,9 @@ aws:
   ## AWS Zone tags
   ##
   zoneTags: []
-
+  ## AWS Prefer CNAME. Available values are: true, false
+  ##
+  preferCNAME: ""
 ## Azure configuration to be set via arguments/env. variables
 ##
 azure:


### PR DESCRIPTION
Signed-off-by: Venkata Surya Lolla suryasaicharan@gmail.com

#### Is this a new chart
No

#### What this PR does / why we need it:
In this PR, I added a piece of code in the `stable/external-dns/template/deployments.yaml` the file that will add the `--aws-prefer-cname` argument in the container. The default behavior of the external-dns is to create Alias records for service or ingress by adding this argument, we give the ability to create a CNAME instead of Alias records for a service or an ingress when using external-dns Helm chart. 

#### Which issue this PR fixes
This is a new feature for this Helm Chart

#### Special notes for your reviewer:
I added the helm chart option in the `README.md` and also made changes in the `stable/external-dns/template/deployments.yaml` and `stable/external-dns/values.yaml` files.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x]  Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
