### PR TITLE
[stable/wordpress] Allow to specify a single hostname

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 7.3.11
+version: 7.4.0
 appVersion: 5.2.3
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -104,6 +104,7 @@ The following table lists the configurable parameters of the WordPress chart and
 | `readinessProbeHeaders`          | Headers to use for readinessProbe                                             | `nil`                                                        |
 | `ingress.enabled`                | Enable ingress controller resource                                            | `false`                                                      |
 | `ingress.certManager`            | Add annotations for cert-manager                                              | `false`                                                      |
+| `ingress.hostname`               | Default host for the ingress resource                                         | `wordpress.local`                                            |
 | `ingress.annotations`            | Ingress annotations                                                           | `[]`                                                         |
 | `ingress.hosts[0].name`          | Hostname to your Wordpress installation                                       | `wordpress.local`                                            |
 | `ingress.hosts[0].path`          | Path within the url structure                                                 | `/`                                                          |
@@ -270,8 +271,9 @@ To enable ingress integration, please set `ingress.enabled` to `true`
 ### Hosts
 
 Most likely you will only want to have one hostname that maps to this
-WordPress installation, however, it is possible to have more than one
-host.  To facilitate this, the `ingress.hosts` object is an array.
+WordPress installation. If that's your case, the property `ingress.hostname`
+will set it. However, it is possible to have more than one host. To
+facilitate this, the `ingress.hosts` object is can be specified as an array.
 
 For each item, please indicate a `name`, `tls`, `tlsSecret`, and any
 `annotations` that you may want the ingress controller to know about.

--- a/stable/wordpress/templates/ingress.yaml
+++ b/stable/wordpress/templates/ingress.yaml
@@ -17,6 +17,15 @@ metadata:
     {{- end }}
 spec:
   rules:
+  {{- if .Values.ingress.hostname }}
+  - host: {{ .Values.ingress.hostname }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: "{{ template "wordpress.fullname" $ }}"
+          servicePort: http
+  {{- end }}
   {{- range .Values.ingress.hosts }}
   - host: {{ .name }}
     http:

--- a/stable/wordpress/values-production.yaml
+++ b/stable/wordpress/values-production.yaml
@@ -255,6 +255,9 @@ ingress:
   ## Set this to true in order to add the corresponding annotations for cert-manager
   certManager: false
 
+  ## When the ingress is enabled, a host pointing to this will be created
+  hostname: wordpress.local
+
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
   ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
@@ -264,11 +267,11 @@ ingress:
   annotations:
   #  kubernetes.io/ingress.class: nginx
 
-  ## The list of hostnames to be covered with this ingress record.
-  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
-  hosts:
-  - name: wordpress.local
-    path: /
+  ## The list of additional hostnames to be covered with this ingress record.
+  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+  ## hosts:
+  ## - name: wordpress.local
+  ##   path: /
 
   ## The tls configuration for the ingress
   ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -255,6 +255,9 @@ ingress:
   ## Set this to true in order to add the corresponding annotations for cert-manager
   certManager: false
 
+  ## When the ingress is enabled, a host pointing to this will be created
+  hostname: wordpress.local
+
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
   ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
@@ -264,11 +267,11 @@ ingress:
   annotations:
   #  kubernetes.io/ingress.class: nginx
 
-  ## The list of hostnames to be covered with this ingress record.
-  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
-  hosts:
-  - name: wordpress.local
-    path: /
+  ## The list of additional hostnames to be covered with this ingress record.
+  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+  ## hosts:
+  ## - name: wordpress.local
+  ##   path: /
 
   ## The tls configuration for the ingress
   ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls


### PR DESCRIPTION
Signed-off-by: Andres Martinez Gotor <andres@bitnami.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

As stated in the comments/documentation, the normal use case is to set a single hostname for the application. It's unnecessary complex to setup an object within an array within an object to simply set the default hostname. This PR adds the value `.ingress.hostname` for that purpose.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
