### PR TITLE
[helm/charts] [incubator/wave] Adds pusher/wave to helm incubator charts

### DIFF
--- a/incubator/wave/.helmignore
+++ b/incubator/wave/.helmignore
@@ -1,0 +1,2 @@
+# OWNERS file for Kubernetes
+OWNERS

--- a/incubator/wave/Chart.yaml
+++ b/incubator/wave/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+name: wave
+description: wave chart that runs on kubernetes
+version: 1.0.0
+appVersion: v0.4.0
+keywords:
+  - wave
+  - kubernetes
+home: https://github.com/pusher/wave
+sources:
+- https://github.com/pusher/wave

--- a/incubator/wave/Chart.yaml
+++ b/incubator/wave/Chart.yaml
@@ -9,3 +9,8 @@ keywords:
 home: https://github.com/pusher/wave
 sources:
 - https://github.com/pusher/wave
+maintainers:
+- name: JoelSpeed
+  email: Joel.speed@hotmail.co.uk
+- name: marcostvz
+  email: marcos.stvz@gmail.com

--- a/incubator/wave/OWNERS
+++ b/incubator/wave/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- JoelSpeed
+- marcostvz
+reviewers:
+- JoelSpeed
+- marcostvz

--- a/incubator/wave/README.md
+++ b/incubator/wave/README.md
@@ -1,0 +1,53 @@
+<img src="https://github.com/pusher/wave/blob/master/wave-logo.svg" width=150 height=150 alt="Wave Logo"/>
+
+# Wave
+This charts deploys [Wave](https://github.com/pusher/wave/)
+
+Wave watches Deployments/Statefulset/Daemonsets within a Kubernetes cluster and
+ensures that their Pods always have up to date configuration.
+
+By monitoring ConfigMaps and Secrets mounted, Wave can trigger a Rolling Update
+of the Deployment when the mounted configuration is changed.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
+$ helm dependency update
+$ helm install --name my-release incubator/wave
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the wave chart and their default values.
+
+|       Parameter                   |           Description                       |                         Default                     |
+|-----------------------------------|---------------------------------------------|-----------------------------------------------------|
+| `global.imagePullSecrets`         | Defines image pulling secrets               | `[]`                                                |
+| `global.rbac.create`              | Create required role and rolebindings       | `true`                                              |
+| `annotations`                     | Defines pod annotations                     | ``                                                  |
+| `image.name`                      | The image to pull                           | `quay.io/pusher/wave`                               |
+| `image.tag`                       | The version of the image to pull            | `v0.4.0`                                            |
+| `image.pullPolicy`                | The pull policy                             | `IfNotPresent`                                      |
+| `nameOverride`                    | Override the name of the chart              | ``                                                  |
+| `nodeSelector`                    | Node label to use for scheduling            | `{}`                                                |
+| `replicas`                        | Amount of pods to spawn                     | `1`                                                 |
+| `securityContext`                 | Security context template                   | `{runAsNonRoot: true, runAsUser: 1000}`             |
+| `serviceAccount.create`           | If true, create a new service account	      | `true`                                              |
+| `serviceAccount.name`             | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template | `` |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name my-release -f values.yaml incubator/wave
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Cleanup
+
+To remove the spawned pods you can run a simple `helm delete <release-name>`.

--- a/incubator/wave/templates/_helpers.tpl
+++ b/incubator/wave/templates/_helpers.tpl
@@ -15,7 +15,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "wave-labels.selector" -}}
+{{- define "wave-labels.chart" -}}
 app: {{ template "wave-name" . }}
 release: {{ .Release.Name | quote }}
 chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/incubator/wave/templates/_helpers.tpl
+++ b/incubator/wave/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "wave-name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | lower -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "wave-fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "wave-labels.selector" -}}
+app: {{ template "wave-name" . }}
+release: {{ .Release.Name | quote }}
+chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+heritage: {{ .Release.Service | quote }}
+{{- end -}}

--- a/incubator/wave/templates/clusterrole.yaml
+++ b/incubator/wave/templates/clusterrole.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.global.rbac.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+{{ include "wave-labels.chart" . | indent 4 }}
+  name: {{ template "wave-fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - statefulsets
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+      - watch
+{{- end }}

--- a/incubator/wave/templates/clusterrolebinding.yaml
+++ b/incubator/wave/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.global.rbac.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+{{ include "wave-labels.chart" . | indent 4 }}
+  name: {{ template "wave-fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "wave-fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name | default (include "wave-fullname" .) }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/incubator/wave/templates/configmap.yaml
+++ b/incubator/wave/templates/configmap.yaml
@@ -1,0 +1,9 @@
+{{- if gt .Values.replicas 1.0 }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+{{ include "wave-labels.chart" . | indent 4 }}
+  name: {{ template "wave-fullname" . }}
+data:
+{{- end }}

--- a/incubator/wave/templates/deployment.yaml
+++ b/incubator/wave/templates/deployment.yaml
@@ -9,8 +9,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      app: {{ template "wave-fullname" . }}
-      release: {{ .Release.Name | quote }}
+{{ include "wave-labels.chart" . | indent 6 }}
   template:
     metadata:
       labels:

--- a/incubator/wave/templates/deployment.yaml
+++ b/incubator/wave/templates/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {{ toYaml .Values.annotations | nindent 4 }}
+  labels:
+{{ include "wave-labels.chart" . | indent 4 }}
+  name: {{ template "wave-fullname" . }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "wave-fullname" . }}
+      release: {{ .Release.Name | quote }}
+  template:
+    metadata:
+      labels:
+{{ include "wave-labels.chart" . | indent 8 }}
+    spec:
+      containers:
+        - image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          name: {{ template "wave-fullname" . }}
+          args:
+          {{- if gt .Values.replicas 1.0 }}
+            - --leader-election=true
+            - --leader-election-id={{ template "wave-fullname" . }}
+            - --leader-election-namespace={{ .Release.Namespace }}
+          {{- end }}
+          {{- if .Values.syncPeriod }}
+            - --sync-period={{ .Values.syncPeriod }}
+          {{- end }}
+      securityContext: {{ toYaml .Values.securityContext | nindent 8 }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "wave-fullname" .) }}
+      nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}

--- a/incubator/wave/templates/serviceaccount.yaml
+++ b/incubator/wave/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
+{{- end }}
+metadata:
+  labels:
+{{ include "wave-labels.chart" . | indent 4 }}
+  name: {{ .Values.serviceAccount.name | default (include "wave-fullname" .) }}
+{{- end }}

--- a/incubator/wave/values.yaml
+++ b/incubator/wave/values.yaml
@@ -1,0 +1,37 @@
+global:
+  ## Reference to one or more secrets to be used when pulling images
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  imagePullSecrets: []
+  # - name: "image-pull-secret"
+  rbac:
+    enabled: true
+
+# Annotations for the wave pods
+annotations: {}
+image:
+  name: quay.io/pusher/wave
+  tag: v0.4.0
+  pullPolicy: IfNotPresent
+
+# Node selector for the wave pods
+nodeSelector: {}
+
+# Replicas > 1 will enable leader election
+replicas: 1
+
+# https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+
+# Service account config for the agent pods
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+# Period for reconciliation
+# syncPeriod: 5m


### PR DESCRIPTION
Signed-off-by: Marcos Estevez <marcos.stvz@gmail.com>

This is a new chart under incubator.

#### What this PR does / why we need it:
- [wave](https://github.com/pusher/wave) an opensource tool maintained by [pusher](https://github.com/pusher)
- wave is a Kubernetes controller to watch changes in ConfigMap and Secrets and then restart pods for Deployment, StatefulSet, and DaemonSet
- Added to the incubator repository because it needs proper testing and more contributions before going to stable

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
