### PR TITLE
[stable/prometheus-operator] add missing $ to .Release.Namespace

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -10,7 +10,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 6.16.0
+version: 6.16.1
 appVersion: 0.32.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/templates/prometheus/additionalPrometheusRules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/additionalPrometheusRules.yaml
@@ -8,7 +8,7 @@ items:
     kind: PrometheusRule
     metadata:
       name: {{ template "prometheus-operator.name" $ }}-{{ $prometheusRuleName }}
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ $.Release.Namespace }}
       labels:
         app: {{ template "prometheus-operator.name" $ }}
 {{ include "prometheus-operator.labels" $ | indent 8 }}


### PR DESCRIPTION
The range block changes the value scope, so $ is needed to access to the
top-level .Release.Namespace.

Signed-off-by: Qingkun Li <qingkun.li@bytedance.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

No

#### What this PR does / why we need it:

Add the missing scope specifier $ in prometheus/additionalPrometheusRules.yaml. Without it, following error would be raised when installing the prometheus-operator chart.

```
Error: render error in "prometheus-operator/templates/prometheus/additionalPrometheusRules.yaml": template: prometheus-operator/templates/prometheus/additionalPrometheusRules.yaml:11:28: executing "prometheus-operator/templates/prometheus/additionalPrometheusRules.yaml" at <.Release.Namespace>: nil pointer evaluating interface {}.Namespace
Error: UPGRADE FAILED: render error in "prometheus-operator/templates/prometheus/additionalPrometheusRules.yaml": template: prometheus-operator/templates/prometheus/additionalPrometheusRules.yaml:11:28: executing "prometheus-operator/templates/prometheus/additionalPrometheusRules.yaml" at <.Release.Namespace>: nil pointer evaluating interface {}.Namespace
make: *** [upgrade] Error 1
```

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

#### Special notes for your reviewer:

Have locally tested with helm lint and install.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
