### PR TITLE
[incubator/haproxy-ingress] PR for Cannot deploy chart if using --set controller.service.type="NodePort".

### DIFF
--- a/incubator/haproxy-ingress/Chart.yaml
+++ b/incubator/haproxy-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: haproxy-ingress
-version: 0.0.16
+version: 0.0.17
 appVersion: 0.7.2
 home: https://github.com/jcmoraisjr/haproxy-ingress
 description: Ingress controller implementation for haproxy loadbalancer.

--- a/incubator/haproxy-ingress/templates/NOTES.txt
+++ b/incubator/haproxy-ingress/templates/NOTES.txt
@@ -3,8 +3,8 @@ The haproxy-ingress controller has been installed.
 {{- if contains "NodePort" .Values.controller.service.type }}
 Get the application URL by running these commands:
 
-  export HTTP_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[0].nodePort}" {{ template "haproxy-ingress.fullname" . }}-controller)
-  export HTTPS_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[1].nodePort}" {{ template "haproxy-ingress.fullname" . }}-controller)
+  export HTTP_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[0].nodePort}" {{ template "haproxy-ingress.controller.fullname" . }})
+  export HTTPS_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[1].nodePort}" {{ template "haproxy-ingress.controller.fullname" . }})
   export NODE_IP=$(kubectl --namespace {{ .Release.Namespace }} get nodes -o jsonpath="{.items[0].status.addresses[1].address}")
 
   echo "Visit http://$NODE_IP:$HTTP_NODE_PORT to access your application via HTTP."

--- a/incubator/haproxy-ingress/templates/NOTES.txt
+++ b/incubator/haproxy-ingress/templates/NOTES.txt
@@ -2,17 +2,6 @@ The haproxy-ingress controller has been installed.
 
 {{- if contains "NodePort" .Values.controller.service.type }}
 Get the application URL by running these commands:
-
-{{- if (not (empty .Values.controller.service.nodePorts.http)) }}
-  export HTTP_NODE_PORT={{ .Values.controller.service.nodePorts.http }}
-{{- else }}
-  export HTTP_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[0].nodePort}" {{ template "haproxy-ingress.fullname" . }})
-{{- end }}
-{{- if (not (empty .Values.controller.service.nodePorts.https)) }}
-  export HTTPS_NODE_PORT={{ .Values.controller.service.nodePorts.https }}
-{{- else }}
-  export HTTPS_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[1].nodePort}" {{ template "haproxy-ingress.fullname" . }})
-{{- end }}
   export NODE_IP=$(kubectl --namespace {{ .Release.Namespace }} get nodes -o jsonpath="{.items[0].status.addresses[1].address}")
 
   echo "Visit http://$NODE_IP:$HTTP_NODE_PORT to access your application via HTTP."

--- a/incubator/haproxy-ingress/templates/NOTES.txt
+++ b/incubator/haproxy-ingress/templates/NOTES.txt
@@ -13,6 +13,7 @@ Get the application URL by running these commands:
 {{- else }}
   export HTTPS_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[1].nodePort}" {{ template "haproxy-ingress.controller.fullname" . }})
 {{- end }}
+  export NODE_IP=$(kubectl --namespace {{ .Release.Namespace }} get nodes -o jsonpath="{.items[0].status.addresses[1].address}")
 
   echo "Visit http://$NODE_IP:$HTTP_NODE_PORT to access your application via HTTP."
   echo "Visit https://$NODE_IP:$HTTPS_NODE_PORT to access your application via HTTPS."

--- a/incubator/haproxy-ingress/templates/NOTES.txt
+++ b/incubator/haproxy-ingress/templates/NOTES.txt
@@ -3,9 +3,16 @@ The haproxy-ingress controller has been installed.
 {{- if contains "NodePort" .Values.controller.service.type }}
 Get the application URL by running these commands:
 
+{{- if (not (empty .Values.controller.service.nodePorts)) }}
+  export HTTP_NODE_PORT={{ .Values.controller.service.nodePorts.http }}
+{{- else }}
   export HTTP_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[0].nodePort}" {{ template "haproxy-ingress.controller.fullname" . }})
+{{- end }}
+{{- if (not (empty .Values.controller.service.nodePorts)) }}
+  export HTTPS_NODE_PORT={{ .Values.controller.service.nodePorts.https }}
+{{- else }}
   export HTTPS_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[1].nodePort}" {{ template "haproxy-ingress.controller.fullname" . }})
-  export NODE_IP=$(kubectl --namespace {{ .Release.Namespace }} get nodes -o jsonpath="{.items[0].status.addresses[1].address}")
+{{- end }}
 
   echo "Visit http://$NODE_IP:$HTTP_NODE_PORT to access your application via HTTP."
   echo "Visit https://$NODE_IP:$HTTPS_NODE_PORT to access your application via HTTPS."

--- a/incubator/haproxy-ingress/templates/NOTES.txt
+++ b/incubator/haproxy-ingress/templates/NOTES.txt
@@ -2,6 +2,17 @@ The haproxy-ingress controller has been installed.
 
 {{- if contains "NodePort" .Values.controller.service.type }}
 Get the application URL by running these commands:
+
+{{- if (not (empty .Values.controller.service.nodePorts.http)) }}
+  export HTTP_NODE_PORT={{ .Values.controller.service.nodePorts.http }}
+{{- else }}
+  export HTTP_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[0].nodePort}" {{ template "haproxy-ingress.fullname" . }})
+{{- end }}
+{{- if (not (empty .Values.controller.service.nodePorts.https)) }}
+  export HTTPS_NODE_PORT={{ .Values.controller.service.nodePorts.https }}
+{{- else }}
+  export HTTPS_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[1].nodePort}" {{ template "haproxy-ingress.fullname" . }})
+{{- end }}
   export NODE_IP=$(kubectl --namespace {{ .Release.Namespace }} get nodes -o jsonpath="{.items[0].status.addresses[1].address}")
 
   echo "Visit http://$NODE_IP:$HTTP_NODE_PORT to access your application via HTTP."

--- a/incubator/haproxy-ingress/templates/NOTES.txt
+++ b/incubator/haproxy-ingress/templates/NOTES.txt
@@ -3,16 +3,8 @@ The haproxy-ingress controller has been installed.
 {{- if contains "NodePort" .Values.controller.service.type }}
 Get the application URL by running these commands:
 
-{{- if (not (empty .Values.controller.service.nodePorts.http)) }}
-  export HTTP_NODE_PORT={{ .Values.controller.service.nodePorts.http }}
-{{- else }}
-  export HTTP_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[0].nodePort}" {{ template "haproxy-ingress.fullname" . }})
-{{- end }}
-{{- if (not (empty .Values.controller.service.nodePorts.https)) }}
-  export HTTPS_NODE_PORT={{ .Values.controller.service.nodePorts.https }}
-{{- else }}
-  export HTTPS_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[1].nodePort}" {{ template "haproxy-ingress.fullname" . }})
-{{- end }}
+  export HTTP_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[0].nodePort}" {{ template "haproxy-ingress.fullname" . }}-controller)
+  export HTTPS_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[1].nodePort}" {{ template "haproxy-ingress.fullname" . }}-controller)
   export NODE_IP=$(kubectl --namespace {{ .Release.Namespace }} get nodes -o jsonpath="{.items[0].status.addresses[1].address}")
 
   echo "Visit http://$NODE_IP:$HTTP_NODE_PORT to access your application via HTTP."

--- a/incubator/haproxy-ingress/templates/controller-deployment.yaml
+++ b/incubator/haproxy-ingress/templates/controller-deployment.yaml
@@ -18,6 +18,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "haproxy-ingress.name" . }}
+      component: "{{ .Values.controller.name }}"
       release: {{ .Release.Name }}
   template:
     metadata:

--- a/incubator/haproxy-ingress/templates/default-backend-deployment.yaml
+++ b/incubator/haproxy-ingress/templates/default-backend-deployment.yaml
@@ -13,6 +13,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "haproxy-ingress.name" . }}
+      component: "{{ .Values.defaultBackend.name }}"
       release: {{ .Release.Name }}
   template:
     metadata:


### PR DESCRIPTION
#### Is this a new chart
No. This is not a new Chart. This is a Bug Fix PR for existing chart.

#### What this PR does / why we need it:
This PR help solve minor issues in the Chart.

#### Which issue this PR fixes
This PR Fixes Issue #17880 

#### Special notes for your reviewer:
There is additional bug in Deployment Pod Selector that's also fixed in this PR. The bug shows up in Google Kubernetes Engine. The bug is crossed pod selection due to Pod Selector in Deployment not specific enough in defining which pod is for which Deployment.
I hope this PR help solves minor issue @xianlubird 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
