### PR TITLE
[stable/mongodb-replicaset] Update peer-finder to fix #8576

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.10.1
+version: 3.10.2
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/install/Dockerfile
+++ b/stable/mongodb-replicaset/install/Dockerfile
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+FROM golang
+ADD https://raw.githubusercontent.com/kubernetes-retired/contrib/master/peer-finder/peer-finder.go .
+RUN go get -d -v k8s.io/apimachinery/pkg/util/sets
+RUN CGO_ENABLED=0 go build -a -installsuffix cgo --ldflags '-w' ./peer-finder.go
+
 FROM alpine:3.8
 
 LABEL maintainer="Reinhard Nägele <unguiculus@gmail.com>"
@@ -21,5 +26,6 @@ RUN apk update && apk add bash openssl && wget -qO /peer-finder http://storage.g
 ENTRYPOINT ["/install.sh"]
 
 COPY install.sh /
-
+COPY --from=0 /go/peer-finder /peer-finder
 RUN chmod -c 755 /install.sh /peer-finder
+

--- a/stable/mongodb-replicaset/install/Makefile
+++ b/stable/mongodb-replicaset/install/Makefile
@@ -14,7 +14,7 @@
 
 all: push
 
-TAG = 0.7
+TAG = 0.8
 PREFIX = unguiculus/mongodb-install
 
 build:

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -28,7 +28,7 @@ imagePullSecrets: []
 # Specs for the Docker image for the init container that establishes the replica set
 installImage:
   repository: unguiculus/mongodb-install
-  tag: 0.7
+  tag: 0.8
   pullPolicy: IfNotPresent
 
 # Specs for the Docker image for the copyConfig init container


### PR DESCRIPTION

#### What this PR does / why we need it:
Peer-finder is outdated so the cluster can not start if the domain is not ".cluster.local".
This change fetches the latest version of peer-finder (decom project).

#### Which issue this PR fixes
  - fixes #8576

#### Checklist
- [x] Chart Version bumped
