### PR TITLE
[stable/concourse] Create workers as a deployment instead of statefulset when using ephemeral workers

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 8.2.6
+version: 8.2.7
 appVersion: 5.6.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -316,6 +316,10 @@ kubectl create secret generic my-release-concourse --from-file=.
 Make sure you clean up after yourself.
 
 
+### Ephemeral Workers
+
+If you set `workers.ephemeral: true`, then the workers are created as a `Deployment` instead of a `StatefulSet`. This means that they will have randomised hostnames, and will be treated by ATC as new workers when they start.
+
 ### Persistence
 
 This chart mounts a Persistent Volume for each Concourse Worker.
@@ -351,6 +355,7 @@ persistence:
 
 It is highly recommended to use Persistent Volumes for Concourse Workers; otherwise, the Concourse volumes managed by the Worker are stored in an [`emptyDir`](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) volume on the Kubernetes node's disk. This will interfere with Kubernete's [ImageGC](https://kubernetes.io/docs/concepts/cluster-administration/kubelet-garbage-collection/#image-collection) and the node's disk will fill up as a result.
 
+If you are using `ephemeral` workers then you should consider disabling persistence.
 
 ### Ingress TLS
 

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.worker.enabled -}}
 apiVersion: apps/v1beta1
+{{- if .Values.concourse.worker.ephemeral }}
+kind: Deployment
+{{- else }}
 kind: StatefulSet
+{{- end }}
 metadata:
   name: {{ template "concourse.worker.fullname" . }}
   labels:
@@ -9,7 +13,9 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  {{- if not .Values.concourse.worker.ephemeral }}
   serviceName: {{ template "concourse.worker.fullname" . }}
+  {{- end }}
   replicas: {{ .Values.worker.replicas }}
   template:
     metadata:
@@ -350,11 +356,13 @@ spec:
             {{- end }}
       {{- end }}
   {{- end }}
+  {{- if not .Values.concourse.worker.ephemeral }}
   {{- if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion }}
   updateStrategy:
     type: {{ .Values.worker.updateStrategy }}
   {{- end }}
   {{- if .Values.worker.podManagementPolicy }}
   podManagementPolicy: {{ .Values.worker.podManagementPolicy }}
+  {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adjusts the concourse helm chart so that if workers are set as `ephemeral` they are deployed as a deployment instead of a stateful set.

When using ephemeral workers and non-persistent storage, there is an issue which occurs frequently where worker pods are created by kubernetes with the same name as previously, but the volumes are missing. This leads to a situation where all pipelines have the `volume xxx disappeared from worker xxx` error.

#### Which issue this PR fixes

https://github.com/concourse/concourse/issues/1737
https://github.com/concourse/concourse/issues/2993
https://github.com/helm/charts/issues/17888

#### Special notes for your reviewer:

I have tested the templates with `ephemeral: false`, `ephemeral: true` and `ephemeral` unset. My concourse deployment is now much happier with truly ephemeral workers.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
