### PR TITLE
[stable/minecraft] allow for more complex loadbalancer settings for services

### DIFF
--- a/stable/minecraft/Chart.yaml
+++ b/stable/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 1.1.1
+version: 1.1.2
 appVersion: 1.14.4
 home: https://minecraft.net/
 description: Minecraft server

--- a/stable/minecraft/templates/minecraft-svc.yaml
+++ b/stable/minecraft/templates/minecraft-svc.yaml
@@ -8,7 +8,23 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+{{- if (or (eq .Values.minecraftServer.serviceType "ClusterIP") (empty .Values.minecraftServer.serviceType)) }}
+  type: ClusterIP
+{{- else if eq .Values.minecraftServer.serviceType "LoadBalancer" }}
   type: {{ .Values.minecraftServer.serviceType }}
+  {{- if .Values.minecraftServer.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.minecraftServer.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.minecraftServer.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.minecraftServer.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.minecraftServer.serviceType }}
+{{- end }}
+  {{- if .Values.minecraftServer.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.minecraftServer.externalTrafficPolicy }}
+  {{- end }}
   ports:
   - name: minecraft
     port: 25565

--- a/stable/minecraft/templates/rcon-svc.yaml
+++ b/stable/minecraft/templates/rcon-svc.yaml
@@ -9,7 +9,23 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+{{- if (or (eq .Values.minecraftServer.rcon.serviceType "ClusterIP") (empty .Values.minecraftServer.rcon.serviceType)) }}
+  type: ClusterIP
+{{- else if eq .Values.minecraftServer.rcon.serviceType "LoadBalancer" }}
   type: {{ .Values.minecraftServer.rcon.serviceType }}
+  {{- if .Values.minecraftServer.rcon.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.minecraftServer.rcon.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.minecraftServer.rcon.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.minecraftServer.rcon.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.minecraftServer.rcon.serviceType }}
+{{- end }}
+  {{- if .Values.minecraftServer.rcon.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.minecraftServer.rcon.externalTrafficPolicy }}
+  {{- end }}
   ports:
   - name: rcon
     port: {{ .Values.minecraftServer.rcon.port }}

--- a/stable/minecraft/values.yaml
+++ b/stable/minecraft/values.yaml
@@ -126,12 +126,22 @@ minecraftServer:
   # Options like -X that need to proceed general JVM options
   jvmXXOpts: ""
   serviceType: LoadBalancer
+  loadBalancerIP:
+  # loadBalancerSourceRanges: []
+  ## Set the externalTrafficPolicy in the Service to either Cluster or Local
+  # externalTrafficPolicy: Cluster
+
   rcon:
     # If you enable this, make SURE to change your password below.
     enabled: false
     port: 25575
     password: "CHANGEME!"
     serviceType: LoadBalancer
+    loadBalancerIP:
+    # loadBalancerSourceRanges: []
+    ## Set the externalTrafficPolicy in the Service to either Cluster or Local
+    # externalTrafficPolicy: Cluster
+
 
   query:
     # If you enable this, your server will be "published" to Gamespy


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds the ability to set `loadBalancerIP`, `loadBalancerSourceRanges`, & `externalTrafficPolicy` for the minecraft service and the rcon service.

This is particularly useful when using a service type of LoadBalancer and you want control over what IP is being requested from the loadbalancer.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
