### PR TITLE
[stable/prometheus-pushgateway] Compat k8s >= 1.16

### DIFF
--- a/stable/prometheus-pushgateway/Chart.yaml
+++ b/stable/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.9.1"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.0.1
+version: 1.0.2
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/stable/prometheus-pushgateway/templates/deployment.yaml
+++ b/stable/prometheus-pushgateway/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "prometheus-pushgateway.fullname" . }}


### PR DESCRIPTION
**Is this a new chart**

No.

**What this PR does / why we need it:**

Kubernetes 1.16 deprecates using `apps/v1beta2` for deployment.
So this PR migrates charts to use `apps/v1`.

**Checklist**

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] DCO signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. [stable/chart])