### PR TITLE
[stable/kube-ops-view] Compat k8s 1.16

### DIFF
--- a/stable/kube-ops-view/Chart.yaml
+++ b/stable/kube-ops-view/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kube-ops-view
-version: 1.1.1
+version: 1.1.2
 appVersion: 19.9.0
 description: Kubernetes Operational View - read-only system dashboard for multiple
   K8s clusters

--- a/stable/kube-ops-view/templates/deployment.yaml
+++ b/stable/kube-ops-view/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kube-ops-view.fullname" . }}

--- a/stable/kube-ops-view/templates/deployment.yaml
+++ b/stable/kube-ops-view/templates/deployment.yaml
@@ -3,13 +3,23 @@ kind: Deployment
 metadata:
   name: {{ template "kube-ops-view.fullname" . }}
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "kube-ops-view.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "kube-ops-view.name" . }}
+      chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ template "kube-ops-view.fullname" . }}
+        app: {{ template "kube-ops-view.name" . }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        release: {{ .Release.Name }}
         {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
         {{- end }}

--- a/stable/kube-ops-view/templates/service.yaml
+++ b/stable/kube-ops-view/templates/service.yaml
@@ -18,4 +18,6 @@ spec:
     targetPort: {{ .Values.service.internalPort }}
     protocol: TCP
   selector:
-    app: {{ template "kube-ops-view.fullname" . }}
+    app: {{ template "kube-ops-view.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}


### PR DESCRIPTION
**Is this a new chart**

No.

**What this PR does / why we need it:**

Kubernetes 1.16 deprecates using `extensions/v1beta1` for deployment.
So this PR migrates charts to use `apps/v1`.

**Checklist**

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] DCO signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. [stable/chart])