### PR TITLE
[stable/prometheus-operator]: added missing $

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -10,7 +10,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 6.17.0
+version: 6.17.1
 appVersion: 0.32.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/templates/prometheus/podmonitors.yaml
+++ b/stable/prometheus-operator/templates/prometheus/podmonitors.yaml
@@ -7,7 +7,7 @@ items:
     kind: PodMonitor
     metadata:
       name: {{ .name }}
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ $.Release.Namespace }}
       labels:
         app: {{ template "prometheus-operator.name" $ }}-prometheus
 {{ include "prometheus-operator.labels" $ | indent 8 }}

--- a/stable/prometheus-operator/templates/prometheus/servicemonitors.yaml
+++ b/stable/prometheus-operator/templates/prometheus/servicemonitors.yaml
@@ -7,7 +7,7 @@ items:
     kind: ServiceMonitor
     metadata:
       name: {{ .name }}
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ $.Release.Namespace }}
       labels:
         app: {{ template "prometheus-operator.name" $ }}-prometheus
 {{ include "prometheus-operator.labels" $ | indent 8 }}

--- a/stable/prometheus-operator/templates/prometheus/serviceperreplica.yaml
+++ b/stable/prometheus-operator/templates/prometheus/serviceperreplica.yaml
@@ -12,7 +12,7 @@ items:
     kind: Service
     metadata:
       name: {{ include "prometheus-operator.fullname" $ }}-prometheus-{{ $i }}
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ $.Release.Namespace }}
       labels:
         app: {{ include "prometheus-operator.name" $ }}-prometheus
 {{ include "prometheus-operator.labels" $ | indent 8 }}


### PR DESCRIPTION
#### What this PR does / why we need it:

It failed to apply here when upgrading, seems like this is the issue...

- https://github.com/helm/charts/pull/17889
- https://github.com/helm/charts/pull/17877

#### Which issue this PR fixes


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
