### PR TITLE
[stable/prometheus-operator] Another namespace fix missed in #17889 and #17877

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -10,7 +10,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 6.17.0
+version: 6.17.1
 appVersion: 0.32.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/templates/prometheus/servicemonitors.yaml
+++ b/stable/prometheus-operator/templates/prometheus/servicemonitors.yaml
@@ -7,7 +7,7 @@ items:
     kind: ServiceMonitor
     metadata:
       name: {{ .name }}
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ $.Release.Namespace }}
       labels:
         app: {{ template "prometheus-operator.name" $ }}-prometheus
 {{ include "prometheus-operator.labels" $ | indent 8 }}


### PR DESCRIPTION
Signed-off-by: Joe Hohertz <joe@viafoura.com>

@gianrubio 

#### What this PR does / why we need it:

Fixes remaining issue introduced in #17689 and partially addressed by #17889 and #17877

#### Which issue this PR fixes

Don't see any open and related.

#### Special notes for your reviewer:

Probably need to configure additionalServiceMonitors to be affected, and how this was missed.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
