### PR TITLE
[stable/kong] custom plugins support

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.21.1
+version: 0.22.0
 appVersion: 1.3

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -101,6 +101,7 @@ and their default values.
 | proxy.ingress.annotations          | Ingress annotations. See documentation for your ingress controller for details        | `{}`                |
 | updateStrategy                     | update strategy for deployment                                                        | `{}`                |
 | env                                | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/)      |                     |
+| plugins                            | Install custom plugins into Kong via ConfigMaps and Secrets                           | `{}`                |
 | runMigrations                      | Run Kong migrations job                                                               | `true`              |
 | readinessProbe                     | Kong readiness probe                                                                  |                     |
 | livenessProbe                      | Kong liveness probe                                                                   |                     |

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -101,7 +101,7 @@ and their default values.
 | proxy.ingress.annotations          | Ingress annotations. See documentation for your ingress controller for details        | `{}`                |
 | updateStrategy                     | update strategy for deployment                                                        | `{}`                |
 | env                                | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/)      |                     |
-| plugins                            | Install custom plugins into Kong via ConfigMaps and Secrets                           | `{}`                |
+| plugins                            | Install custom plugins into Kong via ConfigMaps or Secrets                            | `{}`                |
 | runMigrations                      | Run Kong migrations job                                                               | `true`              |
 | readinessProbe                     | Kong readiness probe                                                                  |                     |
 | livenessProbe                      | Kong liveness probe                                                                   |                     |

--- a/stable/kong/templates/_helpers.tpl
+++ b/stable/kong/templates/_helpers.tpl
@@ -187,6 +187,17 @@ Create the ingress servicePort value string
 {{- end }}
 {{- end -}}
 
+{{- define "kong.plugins" -}}
+{{ $myList := list "bundled" }}
+{{- range .Values.plugins.configMaps -}}
+{{- $myList = append $myList .pluginName -}}
+{{- end -}}
+{{- range .Values.plugins.secrets -}}
+  {{ $myList = append $myList .pluginName -}}
+{{- end }}
+{{- $myList | join "," -}}
+{{- end -}}
+
 {{- define "kong.wait-for-db" -}}
 - name: wait-for-db
   image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/kong/templates/_helpers.tpl
+++ b/stable/kong/templates/_helpers.tpl
@@ -136,6 +136,57 @@ Create the ingress servicePort value string
 {{- end -}}
 {{- end -}}
 
+{{- define "kong.volumes" -}}
+{{- range .Values.plugins.configMaps }}
+- name: kong-plugin-{{ .pluginName }}
+  configMap:
+    name: {{ .name }}
+{{- end }}
+{{- range .Values.plugins.secrets }}
+- name: kong-plugin-{{ .pluginName }}
+  secret:
+    secretName: {{ .name }}
+{{- end }}
+- name: custom-nginx-template-volume
+  configMap:
+    name: {{ template "kong.fullname" . }}-default-custom-server-blocks
+{{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
+- name: kong-custom-dbless-config-volume
+  configMap:
+    {{- if .Values.dblessConfig.configMap }}
+    name: {{ .Values.dblessConfig.configMap }}
+    {{- else }}
+    name: {{ template "kong.dblessConfig.fullname" . }}
+    {{- end }}
+{{- end }}
+{{- range $secretVolume := .Values.secretVolumes }}
+- name: {{ . }}
+  secret:
+    secretName: {{ . }}
+{{- end }}
+{{- end -}}
+
+{{- define "kong.volumeMounts" -}}
+- name: custom-nginx-template-volume
+  mountPath: /kong
+{{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
+- name: kong-custom-dbless-config-volume
+  mountPath: /kong_dbless/
+{{- end }}
+{{- range .Values.secretVolumes }}
+- name:  {{ . }}
+  mountPath: /etc/secrets/{{ . }}
+{{- end }}
+{{- range .Values.plugins.configMaps }}
+- name:  kong-plugin-{{ .pluginName }}
+  mountPath: /opt/kong/plugins/{{ .pluginName }}
+{{- end }}
+{{- range .Values.plugins.secrets }}
+- name:  kong-plugin-{{ .pluginName }}
+  mountPath: /opt/kong/plugins/{{ .pluginName }}
+{{- end }}
+{{- end -}}
+
 {{- define "kong.wait-for-db" -}}
 - name: wait-for-db
   image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -149,6 +200,8 @@ Create the ingress servicePort value string
     value: {{ template "kong.postgresql.fullname" . }}
   - name: KONG_PG_PORT
     value: "{{ .Values.postgresql.service.port }}"
+  - name: KONG_LUA_PACKAGE_PATH
+    value: "/opt/?.lua;;"
   - name: KONG_PG_PASSWORD
     valueFrom:
       secretKeyRef:
@@ -161,6 +214,8 @@ Create the ingress servicePort value string
   {{- end }}
   {{- include "kong.env" .  | nindent 2 }}
   command: [ "/bin/sh", "-c", "until kong start; do echo 'waiting for db'; sleep 1; done; kong stop" ]
+  volumeMounts:
+  {{- include "kong.volumeMounts" . | nindent 4 }}
 {{- end -}}
 
 {{- define "kong.controller-container" -}}

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -168,6 +168,8 @@ spec:
         - name: KONG_DECLARATIVE_CONFIG
           value: "/kong_dbless/kong.yml"
         {{- end }}
+        - name: KONG_PLUGINS
+          value: {{ template "kong.plugins" . }}
         {{- include "kong.env" .  | indent 8 }}
         lifecycle:
           preStop:

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -57,6 +57,8 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
+        - name: KONG_LUA_PACKAGE_PATH
+          value: "/opt/?.lua;;"
         {{- if not .Values.env.admin_listen }}
         {{- if .Values.admin.useTLS }}
         - name: KONG_ADMIN_LISTEN
@@ -248,16 +250,7 @@ spec:
         {{- end }}
         {{- end }}
         volumeMounts:
-          - name: custom-nginx-template-volume
-            mountPath: /kong
-          {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
-          - name: kong-custom-dbless-config-volume
-            mountPath: /kong_dbless/
-          {{- end }}
-          {{- range .Values.secretVolumes }}
-          - name:  {{ . }}
-            mountPath: /etc/secrets/{{ . }}
-          {{- end }}
+        {{- include "kong.volumeMounts" . | nindent 10 }}
         readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 10 }}
         livenessProbe:
@@ -275,21 +268,4 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       volumes:
-        - name: custom-nginx-template-volume
-          configMap:
-            name: {{ template "kong.fullname" . }}-default-custom-server-blocks
-{{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
-        - name: kong-custom-dbless-config-volume
-          configMap:
-            {{- if .Values.dblessConfig.configMap }}
-            name: {{ .Values.dblessConfig.configMap }}
-            {{- else }}
-            name: {{ template "kong.dblessConfig.fullname" . }}
-            {{- end }}
-{{- end }}
-
-{{- range $secretVolume := .Values.secretVolumes }}
-        - name: {{ . }}
-          secret:
-            secretName: {{ . }}
-{{- end }}
+      {{- include "kong.volumes" . | nindent 8 -}}

--- a/stable/kong/templates/migrations-post-upgrade.yaml
+++ b/stable/kong/templates/migrations-post-upgrade.yaml
@@ -53,7 +53,7 @@ spec:
         - name: KONG_LUA_PACKAGE_PATH
           value: "/opt/?.lua;;"
         - name: KONG_PLUGINS
-          value: {{ default "bundled" .Values.env.plugins }}
+          value: {{ template "kong.plugins" . }}
         - name: KONG_NGINX_DAEMON
           value: "off"
         {{- if .Values.enterprise.enabled }}

--- a/stable/kong/templates/migrations-post-upgrade.yaml
+++ b/stable/kong/templates/migrations-post-upgrade.yaml
@@ -50,6 +50,10 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
+        - name: KONG_LUA_PACKAGE_PATH
+          value: "/opt/?.lua;;"
+        - name: KONG_PLUGINS
+          value: {{ default "bundled" .Values.env.plugins }}
         - name: KONG_NGINX_DAEMON
           value: "off"
         {{- if .Values.enterprise.enabled }}
@@ -72,5 +76,9 @@ spec:
         {{- end }}
         {{- include "kong.env" .  | indent 8 }}
         command: [ "/bin/sh", "-c", "kong migrations finish" ]
+        volumeMounts:
+        {{- include "kong.volumeMounts" . | nindent 8 }}
       restartPolicy: OnFailure
+      volumes:
+      {{- include "kong.volumes" . | nindent 6 -}}
 {{- end }}

--- a/stable/kong/templates/migrations-pre-upgrade.yaml
+++ b/stable/kong/templates/migrations-pre-upgrade.yaml
@@ -53,7 +53,7 @@ spec:
         - name: KONG_LUA_PACKAGE_PATH
           value: "/opt/?.lua;;"
         - name: KONG_PLUGINS
-          value: {{ default "bundled" .Values.env.plugins }}
+          value: {{ template "kong.plugins" . }}
         - name: KONG_NGINX_DAEMON
           value: "off"
         {{- if .Values.enterprise.enabled }}

--- a/stable/kong/templates/migrations-pre-upgrade.yaml
+++ b/stable/kong/templates/migrations-pre-upgrade.yaml
@@ -50,6 +50,10 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
+        - name: KONG_LUA_PACKAGE_PATH
+          value: "/opt/?.lua;;"
+        - name: KONG_PLUGINS
+          value: {{ default "bundled" .Values.env.plugins }}
         - name: KONG_NGINX_DAEMON
           value: "off"
         {{- if .Values.enterprise.enabled }}
@@ -72,5 +76,9 @@ spec:
         {{- end }}
         {{- include "kong.env" .  | indent 8 }}
         command: [ "/bin/sh", "-c", "kong migrations up" ]
+        volumeMounts:
+        {{- include "kong.volumeMounts" . | nindent 8 }}
       restartPolicy: OnFailure
+      volumes:
+      {{- include "kong.volumes" . | nindent 6 -}}
 {{- end }}

--- a/stable/kong/templates/migrations.yaml
+++ b/stable/kong/templates/migrations.yaml
@@ -45,6 +45,10 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
+        - name: KONG_PLUGINS
+          value: {{ default "bundled" .Values.env.plugins }}
+        - name: KONG_LUA_PACKAGE_PATH
+          value: "/opt/?.lua;;"
         - name: KONG_NGINX_DAEMON
           value: "off"
         {{- if .Values.enterprise.enabled }}
@@ -67,5 +71,9 @@ spec:
         {{- end }}
         {{- include "kong.env" .  | indent 8 }}
         command: [ "/bin/sh", "-c", "kong migrations bootstrap" ]
+        volumeMounts:
+        {{- include "kong.volumeMounts" . | nindent 8 }}
       restartPolicy: OnFailure
+      volumes:
+      {{- include "kong.volumes" . | nindent 6 -}}
 {{- end }}

--- a/stable/kong/templates/migrations.yaml
+++ b/stable/kong/templates/migrations.yaml
@@ -46,7 +46,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: KONG_PLUGINS
-          value: {{ default "bundled" .Values.env.plugins }}
+          value: {{ template "kong.plugins" . }}
         - name: KONG_LUA_PACKAGE_PATH
           value: "/opt/?.lua;;"
         - name: KONG_NGINX_DAEMON

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -358,7 +358,8 @@ postgresql:
   service:
     port: 5432
 
-# Custom Kong plugins can be loaded into Kong by installing them inside
+# Custom Kong plugins can be loaded into Kong by mounting the plugin code
+# into the file-system of Kong container.
 # The plugin code should be present in ConfigMap or Secret inside the same
 # namespace as Kong is being installed.
 # The `name` property refers to the name of the ConfigMap or Secret

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -364,9 +364,6 @@ postgresql:
 # The `name` property refers to the name of the ConfigMap or Secret
 # itself, while the pluginName refers to the name of the plugin as it appears
 # in Kong.
-# These properties mount the plugin code such that Kong can find them but does
-# not enable loading. To load the plugins into Kong, set the env.plugins
-# property, eg: `env.plugins=bundled,rewriter`
 plugins: {}
   # configMaps:
   # - pluginName: rewriter

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -358,6 +358,22 @@ postgresql:
   service:
     port: 5432
 
+# Custom Kong plugins can be loaded into Kong by installing them inside
+# The plugin code should be present in ConfigMap or Secret inside the sam
+# namespace as Kong is being installed.
+# The `name` property refers to the name of the ConfigMap or Secret
+# itself, while the pluginName refers to the name of the plugin as it appears
+# in Kong.
+# These properties mount the plugin code such that Kong can find them but does
+# not enable loading. To load the plugins into Kong, set the env.plugins
+# property, eg: `env.plugins=bundled,rewriter`
+plugins: {}
+  # configMaps:
+  # - pluginName: rewriter
+  #   name: kong-plugin-rewriter
+  # secrets:
+  # - pluginName: rewriter
+  #   name: kong-plugin-rewriter
 # Kong Ingress Controller's primary purpose is to satisfy Ingress resources
 # created in k8s.  It uses CRDs for more fine grained control over routing and
 # for Kong specific configuration.

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -359,7 +359,7 @@ postgresql:
     port: 5432
 
 # Custom Kong plugins can be loaded into Kong by installing them inside
-# The plugin code should be present in ConfigMap or Secret inside the sam
+# The plugin code should be present in ConfigMap or Secret inside the same
 # namespace as Kong is being installed.
 # The `name` property refers to the name of the ConfigMap or Secret
 # itself, while the pluginName refers to the name of the plugin as it appears


### PR DESCRIPTION
- Refactor out volumes and volumeMounts into helpers
- Allow users to easily mount custom plugins via secrets and configmaps
- Custom plugins containing custom DAOs are allowed as well

A guide will be published in near future on how to exactly use this
feature.

In a subsequent PR, we will de-duplicate env and initContainer sections
in the migrations jobs to reduce duplication.

Signed-off-by: Harry Bagdi <harrybagdi@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Allows users to install and use custom plugins easily in Kong.

#### Special notes for your reviewer:

ping @shashiranjan84 @rainest 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
