### PR TITLE
[stable/rabbitmq-ha] Add RabbitMQ Prometeus Plugin

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.19
-version: 1.33.1
+version: 1.34.0
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -142,6 +142,7 @@ and their default values.
 | `rabbitmqWebMQTTPlugin.enabled`                | Enable MQTT over websocket plugin                                                                                                                                                                     | `false`                                                    |
 | `rabbitmqWebSTOMPPlugin.config`                | STOMP over websocket configuration                                                                                                                                                                    | ``                                                         |
 | `rabbitmqWebSTOMPPlugin.enabled`               | Enable STOMP over websocket plugin                                                                                                                                                                    | `false`                                                    |
+| `rabbitmqPrometheusPlugin.enabled`               | Enable native RabbitMQ prometheus plugin. (Available in RabbitMQ 3.8)                                                                                                                                                                    | `false`                                                    |
 | `rbac.create`                                  | If true, create & use RBAC resources                                                                                                                                                                  | `true`                                                     |
 | `replicaCount`                                 | Number of replica                                                                                                                                                                                     | `3`                                                        |
 | `resources`                                    | CPU/Memory resource requests/limits                                                                                                                                                                   | `{}`                                                       |
@@ -256,7 +257,13 @@ the following keys:
 
 ### Prometheus Monitoring & Alerts
 
-Prometheus and its features can be enabled by setting `prometheus.enabled` to `true`.  See values.yaml for more details and configuration options
+As of RabbitMQ 3.8.0, it is possible to enable Prometheus metrics natively, no need to run an external exporter. To enable native Prometheus metrics, set `rabbitmqPrometheusPlugin.enabled` to `true`. This will expose all RabbitMQ node metrics via the `<<rabbitmqhost>>:15692/metrics` URL. Since all metrics are node local, they add the least pressure on RabbitMQ and will be available for as long as RabbitMQ is running, regardless of inter-node pressure or other nodes in the cluster going away.
+
+To learn more about RabbitMQ's native support for Prometheus, please refer to the official [Monitoring with Prometheus & Grafana guide](https://www.rabbitmq.com/prometheus.html).
+
+Team RabbitMQ manages Grafana dashboards that are meant to be used with the native Prometheus support. They are publicly available at [grafana.com/orgs/rabbitmq](https://grafana.com/orgs/rabbitmq).
+
+To enable metrics via the traditional [rabbitmq_exporter](https://github.com/kbudde/rabbitmq_exporter) sidecar container, set `prometheus.enabled` to `true`. See `values.yaml` file for more details and configuration options.
 
 ### Usage of the `tpl` Function
 

--- a/stable/rabbitmq-ha/templates/configmap.yaml
+++ b/stable/rabbitmq-ha/templates/configmap.yaml
@@ -44,9 +44,14 @@ data:
       rabbitmq_auth_backend_http,
       {{- end }}
 
+      {{- if .Values.rabbitmqPrometheusPlugin.enabled }}
+      rabbitmq_prometheus,
+      {{- end }}
+
       rabbitmq_consistent_hash_exchange,
       rabbitmq_management,
       rabbitmq_peer_discovery_k8s
+      
     ].
 
   rabbitmq.conf: |
@@ -105,6 +110,11 @@ data:
     ## Web STOMP Plugin
     {{- if .Values.rabbitmqWebSTOMPPlugin.enabled }}
 {{ .Values.rabbitmqWebSTOMPPlugin.config | indent 4 }}
+    {{- end }}
+
+    ## Prometheus Plugin
+    {{- if .Values.rabbitmqPrometheusPlugin.enabled }}
+{{ .Values.rabbitmqPrometheusPlugin.config | indent 4 }}
     {{- end }}
 
     ## AMQPS support

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -253,6 +253,15 @@ rabbitmqWebSTOMPPlugin:
     # web_stomp.ws_frame = binary
     # web_stomp.cowboy_opts.max_keepalive = 10
 
+## Prometheus Plugin
+## Ref: https://www.rabbitmq.com/prometheus.html
+rabbitmqPrometheusPlugin:
+  enabled: false
+  ## Prometheus configuration:
+  config: |
+   # prometheus.path = /metrics
+   # prometheus.tcp.port =  15692
+
 ## AMQPS support
 ## Ref: http://www.rabbitmq.com/ssl.html
 rabbitmqAmqpsSupport:


### PR DESCRIPTION
-->
#### Is this a new chart
No
#### What this PR does / why we need it:
With rabbitmq 3.8 the rabbitmq prometheus plugin is shipped by default
With this commit is possible to enable/disable it

#### Which issue this PR fixes

#### Special notes for your reviewer:
This plugin is shipped only with RabbitMQ 3.8.
It is useful for people (like me ) that need to use RabbitMQ 3.8.
Thank you

cc @steven-sheehy 
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)

Signed-off-by: Gabriele Santomaggio <g.santomaggio@gmail.com>

