### PR TITLE
[stable/node-red] fixing podAnnotations for node-red chart

### DIFF
--- a/stable/node-red/Chart.yaml
+++ b/stable/node-red/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.1
 description: Node-RED is flow-based programming for the Internet of Things
 name: node-red
-version: 1.3.5
+version: 1.3.6
 keywords:
   - nodered
   - node-red

--- a/stable/node-red/templates/deployment.yaml
+++ b/stable/node-red/templates/deployment.yaml
@@ -7,12 +7,6 @@ metadata:
     helm.sh/chart: {{ include "node-red.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-  {{- if .Values.podAnnotations }}
-  annotations:
-    {{- range $key, $value := .Values.podAnnotations }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
-  {{- end }}
 spec:
   replicas: 1
   strategy:
@@ -26,6 +20,12 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "node-red.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
     spec:
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
#### What this PR does / why we need it:

The previous change to add podAnnotations was applied incorrectly. This PR is to fix that. Sorry!

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
