### PR TITLE
[stable/velero]: support annotations on the created service account

### DIFF
--- a/stable/velero/Chart.yaml
+++ b/stable/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.1.0
 description: A Helm chart for velero
 name: velero
-version: 2.1.7
+version: 2.2.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/stable/velero/README.md
+++ b/stable/velero/README.md
@@ -63,6 +63,7 @@ Parameter | Description | Default
 `rbac.create` | If true, create and use RBAC resources | `true`
 `serviceAccount.server.create` | Whether a new service account name that the server will use should be created | `true`
 `serviceAccount.server.name` | Service account to be used for the server. If not set and `serviceAccount.server.create` is `true` a name is generated using the fullname template | ``
+`serviceAccount.server.annotations` | Annotations to add to the created service account.  Only relevant if `serviceAccount.server.create` is `true` | `{}`
 `resources` | Resource requests and limits | `{}`
 `initContainers` | InitContainers and their specs to start with the deployment pod | `[]`
 `tolerations` | List of node taints to tolerate | `[]`

--- a/stable/velero/README.md
+++ b/stable/velero/README.md
@@ -61,8 +61,8 @@ Parameter | Description | Default
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `podAnnotations` | Annotations for the Velero server pod | `{}`
 `rbac.create` | If true, create and use RBAC resources | `true`
-`rbac.server.serviceAccount.create` | Whether a new service account name that the server will use should be created | `true`
-`rbac.server.serviceAccount.name` | Service account to be used for the server. If not set and `rbac.server.serviceAccount.create` is `true` a name is generated using the fullname template | ``
+`serviceAccount.server.create` | Whether a new service account name that the server will use should be created | `true`
+`serviceAccount.server.name` | Service account to be used for the server. If not set and `serviceAccount.server.create` is `true` a name is generated using the fullname template | ``
 `resources` | Resource requests and limits | `{}`
 `initContainers` | InitContainers and their specs to start with the deployment pod | `[]`
 `tolerations` | List of node taints to tolerate | `[]`

--- a/stable/velero/templates/deployment.yaml
+++ b/stable/velero/templates/deployment.yaml
@@ -105,6 +105,11 @@ spec:
       initContainers:
         {{- toYaml .Values.initContainers | nindent 8 }}
 {{- end }}
+      securityContext:
+        # This fsGroup is needed so that our process can read projected service account tokens, such as when we're
+        # trying to use IAM Roles for Service Accounts on EKS.
+        # Ref: https://github.com/aws/amazon-eks-pod-identity-webhook/issues/8
+        fsGroup: 65534
       volumes:
         {{- if and .Values.credentials.useSecret (or (eq $provider "aws") (eq $provider "gcp")) }}
         - name: cloud-credentials

--- a/stable/velero/templates/serviceaccount-server.yaml
+++ b/stable/velero/templates/serviceaccount-server.yaml
@@ -8,4 +8,5 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "velero.chart" . }}
+  annotations: {{ toYaml .Values.serviceAccount.server.annotations | nindent 4 }}
 {{- end }}

--- a/stable/velero/values.yaml
+++ b/stable/velero/values.yaml
@@ -131,6 +131,8 @@ rbac:
 serviceAccount:
   server:
     create: true
+     # Annotatons to add to the service account.  Only relevant if `create` is true.
+    annotations: {}
     name:
 
 # Info about the secret to be used by the Velero deployment, which


### PR DESCRIPTION
For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

@domcar @hectorj2f @nrb @prydonius 

#### What this PR does / why we need it:

Add supports for service account annotations which is needed for https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
