### PR TITLE
[stable/mariadb] Fix the command generated to retrieve the administra…

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb
-version: 6.11.1
+version: 6.11.2
 appVersion: 10.3.18
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/templates/NOTES.txt
+++ b/stable/mariadb/templates/NOTES.txt
@@ -15,7 +15,7 @@ Services:
 Administrator credentials:
 
   Username: root
-  Password : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "mariadb.fullname" . }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
+  Password : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "mariadb.secretName" . }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
 
 To connect to your database:
 
@@ -38,7 +38,7 @@ To upgrade this helm chart:
 
   1. Obtain the password as described on the 'Administrator credentials' section and set the 'rootUser.password' parameter as shown below:
 
-      ROOT_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "mariadb.fullname" . }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
+      ROOT_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "mariadb.secretName" . }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
       helm upgrade {{ .Release.Name }} stable/mariadb --set rootUser.password=$ROOT_PASSWORD
 
 {{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}

--- a/stable/mariadb/templates/_helpers.tpl
+++ b/stable/mariadb/templates/_helpers.tpl
@@ -242,3 +242,14 @@ but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else 
     {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the name of the Secret used to store the passwords
+*/}}
+{{- define "mariadb.secretName" -}}
+{{- if .Values.existingSecret -}}
+{{ .Values.existingSecret }}
+{{- else -}}
+{{ template "mariadb.fullname" . -}}
+{{- end -}}
+{{- end -}}

--- a/stable/mariadb/templates/master-statefulset.yaml
+++ b/stable/mariadb/templates/master-statefulset.yaml
@@ -117,11 +117,7 @@ spec:
         - name: MARIADB_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-            {{- if .Values.existingSecret }}
-              name: {{ .Values.existingSecret }}
-            {{- else }}
-              name: {{ template "mariadb.fullname" . }}
-            {{- end }}
+              name: {{ template "mariadb.secretName" . }}
               key: mariadb-root-password
         {{- if .Values.db.user }}
         - name: MARIADB_USER
@@ -129,11 +125,7 @@ spec:
         - name: MARIADB_PASSWORD
           valueFrom:
             secretKeyRef:
-            {{- if .Values.existingSecret }}
-              name: {{ .Values.existingSecret }}
-            {{- else }}
-              name: {{ template "mariadb.fullname" . }}
-            {{- end }}
+              name: {{ template "mariadb.secretName" . }}
               key: mariadb-password
         {{- end }}
         - name: MARIADB_DATABASE
@@ -146,11 +138,7 @@ spec:
         - name: MARIADB_REPLICATION_PASSWORD
           valueFrom:
             secretKeyRef:
-            {{- if .Values.existingSecret }}
-              name: {{ .Values.existingSecret }}
-            {{- else }}
-              name: {{ template "mariadb.fullname" . }}
-            {{- end }}
+              name: {{ template "mariadb.secretName" . }}
               key: mariadb-replication-password
         {{- end }}
         ports:
@@ -201,11 +189,7 @@ spec:
         - name: MARIADB_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-            {{- if .Values.existingSecret }}
-              name: {{ .Values.existingSecret }}
-            {{- else }}
-              name: {{ template "mariadb.fullname" . }}
-            {{- end }}
+              name: {{ template "mariadb.secretName" . }}
               key: mariadb-root-password
         command:
           - sh

--- a/stable/mariadb/templates/slave-statefulset.yaml
+++ b/stable/mariadb/templates/slave-statefulset.yaml
@@ -126,22 +126,14 @@ spec:
         - name: MARIADB_MASTER_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-            {{- if .Values.existingSecret }}
-              name: {{ .Values.existingSecret }}
-            {{- else }}
-              name: {{ template "mariadb.fullname" . }}
-            {{- end }}
+              name: {{ template "mariadb.secretName" . }}
               key: mariadb-root-password
         - name: MARIADB_REPLICATION_USER
           value: "{{ .Values.replication.user }}"
         - name: MARIADB_REPLICATION_PASSWORD
           valueFrom:
             secretKeyRef:
-            {{- if .Values.existingSecret }}
-              name: {{ .Values.existingSecret }}
-            {{- else }}
-              name: {{ template "mariadb.fullname" . }}
-            {{- end }}
+              name: {{ template "mariadb.secretName" . }}
               key: mariadb-replication-password
         ports:
         - name: mysql
@@ -184,11 +176,7 @@ spec:
         - name: MARIADB_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-            {{- if .Values.existingSecret }}
-              name: {{ .Values.existingSecret }}
-            {{- else }}
-              name: {{ template "mariadb.fullname" . }}
-            {{- end }}
+              name: {{ template "mariadb.secretName" . }}
               key: mariadb-root-password
         command:
           - sh

--- a/stable/mariadb/templates/test-runner.yaml
+++ b/stable/mariadb/templates/test-runner.yaml
@@ -27,11 +27,7 @@ spec:
         - name: MARIADB_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-            {{- if .Values.existingSecret }}
-              name: {{ .Values.existingSecret }}
-            {{- else }}
-              name: {{ template "mariadb.fullname" . }}
-            {{- end }}
+              name: {{ template "mariadb.secretName" . }}
               key: mariadb-root-password
       volumeMounts:
       - mountPath: /tests


### PR DESCRIPTION
…tor password in NOTES.txt

Signed-off-by: Nicolas Camus <nicolas@octopulse.io>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No

#### What this PR does / why we need it:

When deploying/upgrading a release, the [NOTES.txt](https://github.com/helm/charts/blob/master/stable/mariadb/templates/NOTES.txt) template file generates a command to retrieve the administrator password.

E.g. `kubectl get secret --namespace default mariadb -o jsonpath="{.data.mariadb-root-password}" | base64 --decode`

This command reads by default a Secret named after the fully qualified app name, regardless the `existingSecret` field has been set or not in the Chart release's values.

However this field's value may be different from the app's fullname, and therefore the generated command may try to read a Secret which has not been created by the Chart (as `existingSecret` was already provided).

To fix this, I defined and used a new template called `mariadb.secretName` which returns the correct Secret name, depending on whether the `existingSecret` value has been set or not.

I used this template to replace the faulty values in [NOTES.txt](https://github.com/helm/charts/blob/master/stable/mariadb/templates/NOTES.txt), as well as in the other parts of the Chart referencing the Secret name, to avoid code duplication. 

#### Which issue this PR fixes

No opened issue is related to this PR to my knowledge.

#### Special notes for your reviewer:

Sorry if my English is bad (I'm not a native speaker), I will gladly try to reword my PR if it's not clear enough.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
