### PR TITLE
[stable/grafana] enable LDAP when using admin.existingSecret

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 3.10.1
+version: 3.10.2
 appVersion: 6.4.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -91,6 +91,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dashboards`                              | Dashboards to import                          | `{}`                                                    |
 | `dashboardsConfigMaps`                    | ConfigMaps reference that contains dashboards | `{}`                                                    |
 | `grafana.ini`                             | Grafana's primary configuration               | `{}`                                                    |
+| `ldap_enabled`                            | Enable LDAP authentication                    | `false`                                                 |
 | `ldap.existingSecret`                     | The name of an existing secret containing the `ldap.toml` file, this must have the key `ldap-toml`. | `""` |
 | `ldap.config  `                           | Grafana's LDAP configuration                  | `""`                                                    |
 | `annotations`                             | Deployment annotations                        | `{}`                                                    |

--- a/stable/grafana/templates/_pod.tpl
+++ b/stable/grafana/templates/_pod.tpl
@@ -133,7 +133,7 @@ containers:
       - name: config
         mountPath: "/etc/grafana/grafana.ini"
         subPath: grafana.ini
-      {{- if not .Values.admin.existingSecret }}
+      {{- if .Values.ldap.enabled }}
       - name: ldap
         mountPath: "/etc/grafana/ldap.toml"
         subPath: ldap.toml
@@ -302,7 +302,7 @@ volumes:
       name: {{ tpl $name $root }}
     {{- end }}
   {{- end }}
-  {{- if not .Values.admin.existingSecret }}
+  {{- if .Values.ldap.enabled }}
   - name: ldap
     secret:
       {{- if .Values.ldap.existingSecret }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -384,6 +384,7 @@ grafana.ini:
 ## ref: http://docs.grafana.org/installation/configuration/#auth-ldap
 ## ref: http://docs.grafana.org/installation/ldap/#configuration
 ldap:
+  enabled: false
   # `existingSecret` is a reference to an existing secret containing the ldap configuration
   # for Grafana in a key `ldap-toml`.
   existingSecret: ""


### PR DESCRIPTION
Signed-off-by: Laurent Perrin <laurent2.perrin@orange.com>

#### Is this a new chart
No

#### What this PR does / why we need it:
It should be possible to configure LDAP and using admin.existingSecret variable.

#### Which issue this PR fixes
  - fixes #17551

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
