### PR TITLE
[stable/stolon] #17684 add extraEnv vars

### DIFF
--- a/stable/stolon/Chart.yaml
+++ b/stable/stolon/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stolon
-version: 1.2.0
+version: 1.3.0
 appVersion: 0.13.0
 description: Stolon - PostgreSQL cloud native High Availability.
 home: https://github.com/sorintlab/stolon

--- a/stable/stolon/README.md
+++ b/stable/stolon/README.md
@@ -71,6 +71,7 @@ Kubernetes is the default store backend. `consul`, `etcdv2` or `etcdv3` can also
 | `keeper.podDisruptionBudget.enabled`    | If true, create a pod disruption budget for keeper pods. | `false`                                            |
 | `keeper.podDisruptionBudget.minAvailable` | Minimum number / percentage of pods that should remain scheduled | `""`                                     |
 | `keeper.podDisruptionBudget.maxUnavailable` | Maximum number / percentage of pods that may be made unavailable | `""`                                   |
+| `keeper.extraEnv`                       | Extra [environment variables](https://github.com/sorintlab/stolon/blob/master/doc/commands_invocation.md#commands-invocation) for keeper | `[]` |
 | `proxy.replicaCount`                    | Number of proxy nodes                          | `2`                                                          |
 | `proxy.resources`                       | Proxy resource requests/limit                  | `{}`                                                         |
 | `proxy.priorityClassName`               | Proxy priorityClassName                        | `nil`                                                        |
@@ -80,6 +81,7 @@ Kubernetes is the default store backend. `consul`, `etcdv2` or `etcdv3` can also
 | `proxy.podDisruptionBudget.enabled`     | If true, create a pod disruption budget for proxy pods. | `false`                                             |
 | `proxy.podDisruptionBudget.minAvailable` | Minimum number / percentage of pods that should remain scheduled | `""`                                      |
 | `proxy.podDisruptionBudget.maxUnavailable` | Maximum number / percentage of pods that may be made unavailable | `""`                                    |
+| `proxy.extraEnv`                        | Extra [environment variables](https://github.com/sorintlab/stolon/blob/master/doc/commands_invocation.md#commands-invocation) for proxy | `[]` |
 | `sentinel.replicaCount`                 | Number of sentinel nodes                       | `2`                                                          |
 | `sentinel.resources`                    | Sentinel resource requests/limit               | `{}`                                                         |
 | `sentinel.priorityClassName`            | Sentinel priorityClassName                     | `nil`                                                        |
@@ -89,6 +91,7 @@ Kubernetes is the default store backend. `consul`, `etcdv2` or `etcdv3` can also
 | `sentinel.podDisruptionBudget.enabled`  | If true, create a pod disruption budget for sentinel pods. | `false`                                          |
 | `sentinel.podDisruptionBudget.minAvailable` | Minimum number / percentage of pods that should remain scheduled | `""`                                   |
 | `sentinel.podDisruptionBudget.maxUnavailable` | Maximum number / percentage of pods that may be made unavailable | `""`                                 |
+| `sentinel.extraEnv`                     | Extra [environment variables](https://github.com/sorintlab/stolon/blob/master/doc/commands_invocation.md#commands-invocation) for sentinel | `[]` |
 | `initdbScripts` | Dictionary of scripts. Executed after cluster startup | `nil`                                 |
 | `nodePostStartScript` | Dictionary of scripts. Executed after the node startup | `nil`                                 |
 

--- a/stable/stolon/templates/keeper-statefulset.yaml
+++ b/stable/stolon/templates/keeper-statefulset.yaml
@@ -98,6 +98,9 @@ spec:
               value: "0.0.0.0:8080"
             - name: STKEEPER_DEBUG
               value: {{ .Values.debug | quote}}
+{{- if .Values.keeper.extraEnv }}
+{{ toYaml .Values.keeper.extraEnv | indent 12 }}
+{{- end }}
           ports:
 {{- range $key, $value := .Values.ports }}
             - name: {{ $key }}

--- a/stable/stolon/templates/proxy-deployment.yaml
+++ b/stable/stolon/templates/proxy-deployment.yaml
@@ -61,6 +61,9 @@ spec:
               value: "0.0.0.0:8080"
             - name: STPROXY_DEBUG
               value: {{ .Values.debug | quote}}
+{{- if .Values.proxy.extraEnv }}
+{{ toYaml .Values.proxy.extraEnv | indent 12 }}
+{{- end }}
           ports:
 {{- range $key, $value := .Values.ports }}
             - name: {{ $key }}

--- a/stable/stolon/templates/sentinel-deployment.yaml
+++ b/stable/stolon/templates/sentinel-deployment.yaml
@@ -60,6 +60,9 @@ spec:
               value: "0.0.0.0:8080"
             - name: STSENTINEL_DEBUG
               value: {{ .Values.debug | quote}}
+{{- if .Values.sentinel.extraEnv }}
+{{ toYaml .Values.sentinel.extraEnv | indent 12 }}
+{{- end }}
           ports:
 {{- range $key, $value := .Values.ports }}
             - name: {{ $key }}

--- a/stable/stolon/values.yaml
+++ b/stable/stolon/values.yaml
@@ -99,6 +99,9 @@ keeper:
   podDisruptionBudget:
     # minAvailable: 1
     # maxUnavailable: 1
+  extraEnv: []
+  #  - name: STKEEPER_LOG_LEVEL
+  #    value: "info"
 
 proxy:
   replicaCount: 2
@@ -120,6 +123,15 @@ proxy:
   podDisruptionBudget:
     # minAvailable: 1
     # maxUnavailable: 1
+  extraEnv: []
+  #  - name: STPROXY_LOG_LEVEL
+  #    value: "info"
+  #  - name: STPROXY_TCP_KEEPALIVE_COUNT
+  #    value: "0"
+  #  - name: STPROXY_TCP_KEEPALIVE_IDLE
+  #    value: "0"
+  #  - name: STPROXY_TCP_KEEPALIVE_INTERVAL
+  #    value: "0"
 
 sentinel:
   replicaCount: 2
@@ -132,6 +144,9 @@ sentinel:
   podDisruptionBudget:
     # minAvailable: 1
     # maxUnavailable: 1
+  extraEnv: []
+  #  - name: STSENTINEL_LOG_LEVEL
+  #    value: "info"
 
 ## initdb scripts
 ## Specify dictionary of scripts to be run at first boot, the entry point script is create_script.sh


### PR DESCRIPTION
Signed-off-by: arjan.ligthart <arjan.ligthart@gmail.com>

@rtluckie 
@lwolf 

#### What this PR does / why we need it:
Adds the ability to specify extra arguments in stateful sets and deployments in a similar way as done in other charts. For reasons needed in this chart see #17684

#### Which issue this PR fixes
- fixes #17684

#### Special notes for your reviewer:
First pr ever. Sorry for any mistakes. 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
