### PR TITLE
[stable/node-red] Bumping node-red to v1.0.2 and adding options

### DIFF
--- a/stable/node-red/Chart.yaml
+++ b/stable/node-red/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.0.1
-description: Node-RED is flow-based programming for the Internet of Things
+appVersion: 1.0.2
+description: Node-RED is low-code programming for event-driven applications
 name: node-red
-version: 1.3.6
+version: 1.4.0
 keywords:
   - nodered
   - node-red

--- a/stable/node-red/README.md
+++ b/stable/node-red/README.md
@@ -1,6 +1,6 @@
 # Node-RED
 
-Flow-based programming for the Internet of Things
+Low-code programming for event-driven applications
 
 **This chart is not maintained by the Node-RED project and any issues with the chart should be raised [here](https://github.com/helm/charts/issues/new)**
 
@@ -12,8 +12,7 @@ helm install stable/node-red
 
 ## Introduction
 
-This code is adopted from the [official node-red docker image](https://hub.docker.com/r/nodered/node-red-docker/) which runs the [Node-RED application](https://nodered.org/)
-
+This code is adopted from the [official node-red docker image](https://hub.docker.com/r/nodered/node-red/) which runs the [Node-RED application](https://nodered.org/)
 
 ## Installing the Chart
 
@@ -39,10 +38,12 @@ The following tables lists the configurable parameters of the Node-RED chart and
 | Parameter                          | Description                                                             | Default                   |
 |:---------------------------------- |:----------------------------------------------------------------------- |:------------------------- |
 | `image.repository`                 | node-red image                                                          | `nodered/node-red`        |
-| `image.tag`                        | node-red image tag                                                      | `1.0.1-12-minimal`        |
+| `image.tag`                        | node-red image tag                                                      | `1.0.2-12-minimal`        |
 | `image.pullPolicy`                 | node-red image pull policy                                              | `IfNotPresent`            |
 | `strategyType`                     | Specifies the strategy used to replace old Pods by new ones             | `Recreate`                |
 | `flows`                            | Default flows configuration                                             | `flows.json`              |
+| `safeMode`                         | Setting to true starts Node-RED in safe (not running) mode              | `false`                   |
+| `enableProjects`                   | setting to true starts Node-RED with the projects feature enabled       | `false`                   |
 | `nodeOptions`                      | Node.js runtime arguments                                               | ``                        |
 | `extraEnvs`                        | Extra environment variables which will be appended to the env           | `[]`                      |
 | `timezone`                         | Default timezone                                                        | `UTC`                     |

--- a/stable/node-red/templates/deployment.yaml
+++ b/stable/node-red/templates/deployment.yaml
@@ -46,6 +46,10 @@ spec:
           env:
             - name: FLOWS
               value: "{{ .Values.flows }}"
+            - name: NODE_RED_ENABLE_SAFE_MODE
+              value: "{{ .Values.safeMode }}"
+            - name: NODE_RED_ENABLE_PROJECTS
+              value: "{{ .Values.enableProjects }}"
             - name: NODE_OPTIONS
               value: "{{ .Values.nodeOptions }}"
             - name: TZ

--- a/stable/node-red/values.yaml
+++ b/stable/node-red/values.yaml
@@ -14,6 +14,8 @@ nameOverride: ""
 fullnameOverride: ""
 
 flows: "flows.json"
+safeMode: "false"
+enableProjects: "false"
 # nodeOptions: ""
 extraEnvs: []
 timezone: "UTC"


### PR DESCRIPTION
#### What this PR does / why we need it:

* Bumping node-red docker image to the latest 1.0.2
* adding `safeMode` values option to start Node-RED in safe (not running) mode - defaults to false
* adding `enableProjects` values option to start Node-RED with 'projects' support (see https://nodered.org/docs/user-guide/projects/ ) - defaults to false

#### Special notes for your reviewer:

`enabledProjects` is defaulted to false - I wonder if this should default to true - thoughts?

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
