### PR TITLE
[stable/prometheus] Add customized readiness/liveness probe config

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 9.1.2
+version: 9.1.3
 appVersion: 2.11.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -98,14 +98,14 @@ spec:
             httpGet:
               path: {{ .Values.server.prefixURL }}/-/ready
               port: 9090
-            initialDelaySeconds: 30
-            timeoutSeconds: 30
+            initialDelaySeconds: {{ .Values.server.readinessProbeInitialDelay }}
+            timeoutSeconds: {{ .Values.server.readinessProbeTimeout }}
           livenessProbe:
             httpGet:
               path: {{ .Values.server.prefixURL }}/-/healthy
               port: 9090
-            initialDelaySeconds: 30
-            timeoutSeconds: 30
+            initialDelaySeconds: {{ .Values.server.livenessProbeInitialDelay }}
+            timeoutSeconds: {{ .Values.server.livenessProbeTimeout }}
           resources:
 {{ toYaml .Values.server.resources | indent 12 }}
           volumeMounts:

--- a/stable/prometheus/templates/server-statefulset.yaml
+++ b/stable/prometheus/templates/server-statefulset.yaml
@@ -98,14 +98,14 @@ spec:
             httpGet:
               path: {{ .Values.server.prefixURL }}/-/ready
               port: 9090
-            initialDelaySeconds: 30
-            timeoutSeconds: 30
+            initialDelaySeconds: {{ .Values.server.readinessProbeInitialDelay }}
+            timeoutSeconds: {{ .Values.server.readinessProbeTimeout }}
           livenessProbe:
             httpGet:
               path: {{ .Values.server.prefixURL }}/-/healthy
               port: 9090
-            initialDelaySeconds: 30
-            timeoutSeconds: 30
+            initialDelaySeconds: {{ .Values.server.livenessProbeInitialDelay }}
+            timeoutSeconds: {{ .Values.server.livenessProbeTimeout }}
           resources:
 {{ toYaml .Values.server.resources | indent 12 }}
           volumeMounts:

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -788,6 +788,14 @@ server:
       labels: {}
       servicePort: 80
 
+  ## Prometheus server readiness and liveness probe initial delay and timeout
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  ##
+  readinessProbeInitialDelay: 30
+  readinessProbeTimeout: 30
+  livenessProbeInitialDelay: 30
+  livenessProbeTimeout: 30
+
   ## Prometheus server resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##


### PR DESCRIPTION
- Updated templates/server-deployment.yaml and templates/server-statefulset.yaml to use configurable initialDelaySeconds and timeoutSeconds in readinessProbe/livenessProbe
- Updated chart version 9.1.3
- Updated values.yaml

Signed-off-by: Tuan Anh Nguyen <tuananh.nguyen-ext@commercetools.de>

#### Is this a new chart
No

#### What this PR does / why we need it:
Prometheus server with a large dataset can take some time to start up (in our case up to 3 minutes), it is nice to have a configurable initialDelaySeconds for the readiness probe to increase the value accordingly.

The timeout values are not required to be configurable in our case, but I hope it might be useful for other to not have the 30 seconds hard-coded in the template.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
