### PR TITLE
[stable/mariadb] add time zone support

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb
-version: 6.11.1
+version: 6.12.0
 appVersion: 10.3.18
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -60,6 +60,7 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `image.debug`                             | Specify if debug logs should be enabled             | `false`                                                           |
 | `nameOverride`                            | String to partially override mariadb.fullname template with a string (will prepend the release name) | `nil`            |
 | `fullnameOverride`                        | String to fully override mariadb.fullname template with a string                                     | `nil`            |
+| `timeZone`                                | Time zone of the mariadb instances                  | `nil`                                                             |
 | `volumePermissions.enabled`          | Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work) | `false`                                                      |
 | `volumePermissions.image.registry`   | Init container volume-permissions image registry                                                                                                          | `docker.io`                                                  |
 | `volumePermissions.image.repository` | Init container volume-permissions image name                                                                                                              | `bitnami/minideb`                                            |

--- a/stable/mariadb/templates/master-statefulset.yaml
+++ b/stable/mariadb/templates/master-statefulset.yaml
@@ -106,6 +106,10 @@ spec:
         image: {{ template "mariadb.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
+        {{- if .Values.timeZone }}
+        - name: TZ
+          value: {{ .Values.timeZone | quote }}
+        {{- end }}
         {{- if .Values.image.debug}}
         - name: BITNAMI_DEBUG
           value: "true"

--- a/stable/mariadb/templates/slave-statefulset.yaml
+++ b/stable/mariadb/templates/slave-statefulset.yaml
@@ -107,6 +107,10 @@ spec:
         image: {{ template "mariadb.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
+        {{- if .Values.timeZone }}
+        - name: TZ
+          value: {{ .Values.timeZone | quote }}
+        {{- end }}
         {{- if .Values.image.debug}}
         - name: BITNAMI_DEBUG
           value: "true"

--- a/stable/mariadb/values-production.yaml
+++ b/stable/mariadb/values-production.yaml
@@ -37,6 +37,11 @@ image:
   ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-bash-debugging
   debug: false
 
+## MariaDb instances time zone
+##
+timeZone: null
+# timeZone: Europe/Paris
+
 ## String to partially override mariadb.fullname template (will maintain the release name)
 ##
 # nameOverride:

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -37,6 +37,11 @@ image:
   ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-bash-debugging
   debug: false
 
+## MariaDb instances time zone
+##
+timeZone: null
+# timeZone: Europe/Paris
+
 ## String to partially override mariadb.fullname template (will maintain the release name)
 ##
 # nameOverride:


### PR DESCRIPTION
I added time zone support to the chart.
As the mariadb container is not running as root, the only solution to set the server time zone is to use the TZ environment variable.

This PR adds a helm property timeZone that is used to set the TZ environment variable accordingly.