### PR TITLE
[stable/prometheus-operator] Update prometheus-node-exporter version

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -10,7 +10,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 6.19.1
+version: 6.20.0
 appVersion: 0.32.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/requirements.lock
+++ b/stable/prometheus-operator/requirements.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 2.4.1
 - name: prometheus-node-exporter
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.5.2
+  version: 1.7.0
 - name: grafana
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 3.10.2
-digest: sha256:37e820ebaccbcc6672cf52c5fb7c772193250d6e1959c8ee45314a351720948f
-generated: "2019-10-16T16:21:11.085262+02:00"
+digest: sha256:76bdb624ab8850dce9fc50f299c7f959fe8e318895754b3e8fb86dd322205783
+generated: "2019-10-17T20:33:18.516405134+03:00"

--- a/stable/prometheus-operator/requirements.yaml
+++ b/stable/prometheus-operator/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
     condition: kubeStateMetrics.enabled
 
   - name: prometheus-node-exporter
-    version: 1.5.*
+    version: 1.7.*
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: nodeExporter.enabled
 


### PR DESCRIPTION
###  What this PR does / why we need it:

In order to get support of 1.16 node-exporter we need to use
appropriate version of prometheus-node-exporter

Signed-off-by: Dmitriy Rabotyagov <drabotyagov@vexxhost.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
