### PR TITLE
[stable/prometheus-adapter] Support extra volumes

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 1.3.0
+version: 1.3.1
 appVersion: v0.5.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 1.3.1
+version: 1.4.0
 appVersion: v0.5.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/README.md
+++ b/stable/prometheus-adapter/README.md
@@ -104,37 +104,39 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Prometheus Adapter chart and their default values.
 
-| Parameter                       | Description                                                                     | Default                                     |
-| ------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------|
-| `affinity`                      | Node affinity                                                                   | `{}`                                        |
-| `image.repository`              | Image repository                                                                | `directxman12/k8s-prometheus-adapter-amd64` |
-| `image.tag`                     | Image tag                                                                       | `v0.5.0`                                    |
-| `image.pullPolicy`              | Image pull policy                                                               | `IfNotPresent`                              |
-| `image.pullSecrets`             | Image pull secrets                                                              | `{}`                                        |
-| `logLevel`                      | Log level                                                                       | `4`                                         |
-| `metricsRelistInterval`         | Interval at which to re-list the set of all available metrics from Prometheus   | `1m`                                        |
-| `nodeSelector`                  | Node labels for pod assignment                                                  | `{}`                                        |
-| `podAnnotations`                | Annotations to add to the pod                                                   | `{}`                                        |
-| `priorityClassName`             | Pod priority                                                                    | ``                                          |
-| `prometheus.url`                | Url of where we can find the Prometheus service                                 | `http://prometheus.default.svc`             |
-| `prometheus.port`               | Port of where we can find the Prometheus service, zero to omit this option      | `9090`                                      |
-| `rbac.create`                   | If true, create & use RBAC resources                                            | `true`                                      |
-| `resources`                     | CPU/Memory resource requests/limits                                             | `{}`                                        |
-| `rules.default`                 | If `true`, enable a set of default rules in the configmap                       | `true`                                      |
-| `rules.custom`                  | A list of custom configmap rules                                                | `[]`                                        |
-| `rules.existing`                | The name of an existing configMap with rules. Overrides default, custom and external. | ``                                    |
-| `rules.external`                | A list of custom rules for external metrics API                                 | `[]`                                        |
-| `rules.resource`                | `resourceRules` to set in configmap rules                                       | `{}`                                        |
-| `service.annotations`           | Annotations to add to the service                                               | `{}`                                        |
-| `service.port`                  | Service port to expose                                                          | `443`                                       |
-| `service.type`                  | Type of service to create                                                       | `ClusterIP`                                 |
-| `serviceAccount.create`         | If true, create & use Serviceaccount                                            | `true`                                      |
-| `serviceAccount.name`           | If not set and create is true, a name is generated using the fullname template  | ``                                          |
-| `tls.enable`                    | If true, use the provided certificates. If false, generate self-signed certs    | `false`                                     |
-| `tls.ca`                        | Public CA file that signed the APIService (ignored if tls.enable=false)         | ``                                          |
-| `tls.key`                       | Private key of the APIService (ignored if tls.enable=false)                     | ``                                          |
-| `tls.certificate`               | Public key of the APIService (ignored if tls.enable=false)                      | ``                                          |
-| `tolerations`                   | List of node taints to tolerate                                                 | `[]`                                        |
+| Parameter               | Description                                                                           | Default                                     |
+|-------------------------|---------------------------------------------------------------------------------------|---------------------------------------------|
+| `affinity`              | Node affinity                                                                         | `{}`                                        |
+| `image.repository`      | Image repository                                                                      | `directxman12/k8s-prometheus-adapter-amd64` |
+| `image.tag`             | Image tag                                                                             | `v0.5.0`                                    |
+| `image.pullPolicy`      | Image pull policy                                                                     | `IfNotPresent`                              |
+| `image.pullSecrets`     | Image pull secrets                                                                    | `{}`                                        |
+| `logLevel`              | Log level                                                                             | `4`                                         |
+| `metricsRelistInterval` | Interval at which to re-list the set of all available metrics from Prometheus         | `1m`                                        |
+| `nodeSelector`          | Node labels for pod assignment                                                        | `{}`                                        |
+| `podAnnotations`        | Annotations to add to the pod                                                         | `{}`                                        |
+| `priorityClassName`     | Pod priority                                                                          | ``                                          |
+| `prometheus.url`        | Url of where we can find the Prometheus service                                       | `http://prometheus.default.svc`             |
+| `prometheus.port`       | Port of where we can find the Prometheus service, zero to omit this option            | `9090`                                      |
+| `rbac.create`           | If true, create & use RBAC resources                                                  | `true`                                      |
+| `resources`             | CPU/Memory resource requests/limits                                                   | `{}`                                        |
+| `rules.default`         | If `true`, enable a set of default rules in the configmap                             | `true`                                      |
+| `rules.custom`          | A list of custom configmap rules                                                      | `[]`                                        |
+| `rules.existing`        | The name of an existing configMap with rules. Overrides default, custom and external. | ``                                          |
+| `rules.external`        | A list of custom rules for external metrics API                                       | `[]`                                        |
+| `rules.resource`        | `resourceRules` to set in configmap rules                                             | `{}`                                        |
+| `service.annotations`   | Annotations to add to the service                                                     | `{}`                                        |
+| `service.port`          | Service port to expose                                                                | `443`                                       |
+| `service.type`          | Type of service to create                                                             | `ClusterIP`                                 |
+| `serviceAccount.create` | If true, create & use Serviceaccount                                                  | `true`                                      |
+| `serviceAccount.name`   | If not set and create is true, a name is generated using the fullname template        | ``                                          |
+| `tls.enable`            | If true, use the provided certificates. If false, generate self-signed certs          | `false`                                     |
+| `tls.ca`                | Public CA file that signed the APIService (ignored if tls.enable=false)               | ``                                          |
+| `tls.key`               | Private key of the APIService (ignored if tls.enable=false)                           | ``                                          |
+| `tls.certificate`       | Public key of the APIService (ignored if tls.enable=false)                            | ``                                          |
+| `extraVolumeMounts`     | Any extra volumes mounts                                                              | `[]`                                        |
+| `extraVolumes`          | Any extra volumes                                                                     | `[]`                                        |
+| `tolerations`           | List of node taints to tolerate                                                       | `[]`                                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-adapter/README.md
+++ b/stable/prometheus-adapter/README.md
@@ -107,6 +107,7 @@ The command removes all the Kubernetes components associated with the chart and 
 ## Configuration
 
 The following table lists the configurable parameters of the Prometheus Adapter chart and their default values.
+
 | Parameter                       | Description                                                                     | Default                                     |
 | ------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------|
 | `affinity`                      | Node affinity                                                                   | `{}`                                        |

--- a/stable/prometheus-adapter/README.md
+++ b/stable/prometheus-adapter/README.md
@@ -18,7 +18,11 @@ This command deploys the prometheus adapter with the default configuration. The 
 
 ## Using the Chart
 
-To use the chart, ensure the `prometheus.url` and `prometheus.port` are configured with the correct Prometheus service endpoint. Additionally, the chart comes with a set of default rules out of the box but they may pull in too many metrics or not map them correctly for your needs. Therefore, it is recommended to populate `rules.custom` with a list of rules (see the [config document](https://github.com/DirectXMan12/k8s-prometheus-adapter/blob/master/docs/config.md) for the proper format). Finally, to configure your Horizontal Pod Autoscaler to use the custom metric, see the custom metrics section of the [HPA walkthrough](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics).
+To use the chart, ensure the `prometheus.url` and `prometheus.port` are configured with the correct Prometheus service endpoint. If Prometheus is exposed under HTTPS the host's CA Bundle must be exposed to the container using `extraVolumes` and `extraVolumeMounts`.
+
+Additionally, the chart comes with a set of default rules out of the box but they may pull in too many metrics or not map them correctly for your needs. Therefore, it is recommended to populate `rules.custom` with a list of rules (see the [config document](https://github.com/DirectXMan12/k8s-prometheus-adapter/blob/master/docs/config.md) for the proper format).
+
+Finally, to configure your Horizontal Pod Autoscaler to use the custom metric, see the custom metrics section of the [HPA walkthrough](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics).
 
 The Prometheus Adapter can serve three different [metrics APIs](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-metrics-apis):
 
@@ -103,40 +107,39 @@ The command removes all the Kubernetes components associated with the chart and 
 ## Configuration
 
 The following table lists the configurable parameters of the Prometheus Adapter chart and their default values.
-
-| Parameter               | Description                                                                           | Default                                     |
-|-------------------------|---------------------------------------------------------------------------------------|---------------------------------------------|
-| `affinity`              | Node affinity                                                                         | `{}`                                        |
-| `image.repository`      | Image repository                                                                      | `directxman12/k8s-prometheus-adapter-amd64` |
-| `image.tag`             | Image tag                                                                             | `v0.5.0`                                    |
-| `image.pullPolicy`      | Image pull policy                                                                     | `IfNotPresent`                              |
-| `image.pullSecrets`     | Image pull secrets                                                                    | `{}`                                        |
-| `logLevel`              | Log level                                                                             | `4`                                         |
-| `metricsRelistInterval` | Interval at which to re-list the set of all available metrics from Prometheus         | `1m`                                        |
-| `nodeSelector`          | Node labels for pod assignment                                                        | `{}`                                        |
-| `podAnnotations`        | Annotations to add to the pod                                                         | `{}`                                        |
-| `priorityClassName`     | Pod priority                                                                          | ``                                          |
-| `prometheus.url`        | Url of where we can find the Prometheus service                                       | `http://prometheus.default.svc`             |
-| `prometheus.port`       | Port of where we can find the Prometheus service, zero to omit this option            | `9090`                                      |
-| `rbac.create`           | If true, create & use RBAC resources                                                  | `true`                                      |
-| `resources`             | CPU/Memory resource requests/limits                                                   | `{}`                                        |
-| `rules.default`         | If `true`, enable a set of default rules in the configmap                             | `true`                                      |
-| `rules.custom`          | A list of custom configmap rules                                                      | `[]`                                        |
-| `rules.existing`        | The name of an existing configMap with rules. Overrides default, custom and external. | ``                                          |
-| `rules.external`        | A list of custom rules for external metrics API                                       | `[]`                                        |
-| `rules.resource`        | `resourceRules` to set in configmap rules                                             | `{}`                                        |
-| `service.annotations`   | Annotations to add to the service                                                     | `{}`                                        |
-| `service.port`          | Service port to expose                                                                | `443`                                       |
-| `service.type`          | Type of service to create                                                             | `ClusterIP`                                 |
-| `serviceAccount.create` | If true, create & use Serviceaccount                                                  | `true`                                      |
-| `serviceAccount.name`   | If not set and create is true, a name is generated using the fullname template        | ``                                          |
-| `tls.enable`            | If true, use the provided certificates. If false, generate self-signed certs          | `false`                                     |
-| `tls.ca`                | Public CA file that signed the APIService (ignored if tls.enable=false)               | ``                                          |
-| `tls.key`               | Private key of the APIService (ignored if tls.enable=false)                           | ``                                          |
-| `tls.certificate`       | Public key of the APIService (ignored if tls.enable=false)                            | ``                                          |
-| `extraVolumeMounts`     | Any extra volumes mounts                                                              | `[]`                                        |
-| `extraVolumes`          | Any extra volumes                                                                     | `[]`                                        |
-| `tolerations`           | List of node taints to tolerate                                                       | `[]`                                        |
+| Parameter                       | Description                                                                     | Default                                     |
+| ------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------|
+| `affinity`                      | Node affinity                                                                   | `{}`                                        |
+| `image.repository`              | Image repository                                                                | `directxman12/k8s-prometheus-adapter-amd64` |
+| `image.tag`                     | Image tag                                                                       | `v0.5.0`                                    |
+| `image.pullPolicy`              | Image pull policy                                                               | `IfNotPresent`                              |
+| `image.pullSecrets`             | Image pull secrets                                                              | `{}`                                        |
+| `logLevel`                      | Log level                                                                       | `4`                                         |
+| `metricsRelistInterval`         | Interval at which to re-list the set of all available metrics from Prometheus   | `1m`                                        |
+| `nodeSelector`                  | Node labels for pod assignment                                                  | `{}`                                        |
+| `podAnnotations`                | Annotations to add to the pod                                                   | `{}`                                        |
+| `priorityClassName`             | Pod priority                                                                    | ``                                          |
+| `prometheus.url`                | Url of where we can find the Prometheus service                                 | `http://prometheus.default.svc`             |
+| `prometheus.port`               | Port of where we can find the Prometheus service, zero to omit this option      | `9090`                                      |
+| `rbac.create`                   | If true, create & use RBAC resources                                            | `true`                                      |
+| `resources`                     | CPU/Memory resource requests/limits                                             | `{}`                                        |
+| `rules.default`                 | If `true`, enable a set of default rules in the configmap                       | `true`                                      |
+| `rules.custom`                  | A list of custom configmap rules                                                | `[]`                                        |
+| `rules.existing`                | The name of an existing configMap with rules. Overrides default, custom and external. | ``                                    |
+| `rules.external`                | A list of custom rules for external metrics API                                 | `[]`                                        |
+| `rules.resource`                | `resourceRules` to set in configmap rules                                       | `{}`                                        |
+| `service.annotations`           | Annotations to add to the service                                               | `{}`                                        |
+| `service.port`                  | Service port to expose                                                          | `443`                                       |
+| `service.type`                  | Type of service to create                                                       | `ClusterIP`                                 |
+| `serviceAccount.create`         | If true, create & use Serviceaccount                                            | `true`                                      |
+| `serviceAccount.name`           | If not set and create is true, a name is generated using the fullname template  | ``                                          |
+| `tls.enable`                    | If true, use the provided certificates. If false, generate self-signed certs    | `false`                                     |
+| `tls.ca`                        | Public CA file that signed the APIService (ignored if tls.enable=false)         | ``                                          |
+| `tls.key`                       | Private key of the APIService (ignored if tls.enable=false)                     | ``                                          |
+| `tls.certificate`               | Public key of the APIService (ignored if tls.enable=false)                      | ``                                          |
+| `extraVolumeMounts`             | Any extra volumes mounts                                                        | `[]`                                        |
+| `extraVolumes`                  | Any extra volumes                                                               | `[]`                                        |
+| `tolerations`                   | List of node taints to tolerate                                                 | `[]`                                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
@@ -72,6 +72,7 @@ spec:
           runAsNonRoot: true
           runAsUser: 10001
         volumeMounts:
+        {{- if .Values.extraVolumeMounts }}{{ toYaml .Values.extraVolumeMounts | trim | nindent 8 }}{{ end }}
         - mountPath: /etc/adapter/
           name: config
           readOnly: true
@@ -96,6 +97,7 @@ spec:
         {{- end }}
       {{- end }}
       volumes:
+      {{- if .Values.extraVolumes  }}{{ toYaml .Values.extraVolumes | trim | nindent 6 }}{{ end }}
       - name: config
         configMap:
           name: {{ .Values.rules.existing | default (include "k8s-prometheus-adapter.fullname" . ) }}

--- a/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
@@ -72,7 +72,9 @@ spec:
           runAsNonRoot: true
           runAsUser: 10001
         volumeMounts:
-        {{- if .Values.extraVolumeMounts }}{{ toYaml .Values.extraVolumeMounts | trim | nindent 8 }}{{ end }}
+        {{- if .Values.extraVolumeMounts }}
+        {{ toYaml .Values.extraVolumeMounts | trim | nindent 8 }}
+        {{ end }}
         - mountPath: /etc/adapter/
           name: config
           readOnly: true
@@ -97,7 +99,9 @@ spec:
         {{- end }}
       {{- end }}
       volumes:
-      {{- if .Values.extraVolumes  }}{{ toYaml .Values.extraVolumes | trim | nindent 6 }}{{ end }}
+      {{- if .Values.extraVolumes  }}
+      {{ toYaml .Values.extraVolumes | trim | nindent 6 }}
+      {{ end }}
       - name: config
         configMap:
           name: {{ .Values.rules.existing | default (include "k8s-prometheus-adapter.fullname" . ) }}

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -102,6 +102,25 @@ tls:
   certificate: |-
     # Public key of the APIService
 
+# Any extra volumes
+extraVolumes: []
+  # - name: example-name
+  #   hostPath:
+  #     path: /path/on/host
+  #     type: DirectoryOrCreate
+  # - name: ssl-certs
+  #   hostPath:
+  #     path: /etc/ssl/certs/ca-bundle.crt
+  #     type: File
+
+# Any extra volume mounts
+extraVolumeMounts: []
+  #   - name: example-name
+  #     mountPath: /path/in/container
+  #   - name: ssl-certs
+  #     mountPath: /etc/ssl/certs/ca-certificates.crt
+  #     readOnly: true
+
 tolerations: []
 
 # Annotations added to the pod


### PR DESCRIPTION
#### What this PR does / why we need it:

Due to a lack of SSL certificates in the base image for `prometheus-adapter` attempting to use this with Prometheus exposed on HTTPS will fail with `x509: failed to load system roots and no roots provided`.

As discussed in https://github.com/DirectXMan12/k8s-prometheus-adapter/pull/172 the preffered solution is to mount the hosts' CA bundle in the container. This PR adds that option in a generic way.

#### Which issue this PR fixes

Fixes https://github.com/DirectXMan12/k8s-prometheus-adapter/pull/172 I guess.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
