### PR TITLE
[stable/concourse] fix createTeamNamespaces

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 8.2.7
+version: 8.2.8
 appVersion: 5.6.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/web-rolebinding.yaml
+++ b/stable/concourse/templates/web-rolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.web.enabled -}}
 {{- if .Values.rbac.create -}}
-{{- if .Values.concourse.web.kubernetes.enabled -}}
+{{- if and .Values.concourse.web.kubernetes.enabled .Values.concourse.web.kubernetes.createTeamNamespaces -}}
 {{- range .Values.concourse.web.kubernetes.teams }}
 ---
 apiVersion: rbac.authorization.k8s.io/{{ $.Values.rbac.apiVersion }}


### PR DESCRIPTION
The optional creation of team namespaces was not very optional, as the web rolebindings hardcoded assumed their presence. This PR fixes this.

```
$ helm install --set concourse.web.kubernetes.createTeamNamespaces=false --name concourse stable/concourse
Error: release concourse failed: namespaces "concourse-main" not found
```

Fixes #18008