### PR TITLE
[stable/prometheus-operator] Fix minor inconsistencies in time series naming in CoreDNS dashboard

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -10,7 +10,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 6.19.0
+version: 6.19.1
 appVersion: 0.32.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-coredns.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-coredns.yaml
@@ -458,15 +458,15 @@ data:
                 "renderer": "flot",
                 "seriesOverrides": [
                     {
-                        "alias": "tcp:90",
+                        "alias": "tcp:90%",
                         "yaxis": 2
                     },
                     {
-                        "alias": "tcp:99 ",
+                        "alias": "tcp:99%",
                         "yaxis": 2
                     },
                     {
-                        "alias": "tcp:50",
+                        "alias": "tcp:50%",
                         "yaxis": 2
                     }
                 ],
@@ -477,21 +477,21 @@ data:
                     {
                         "expr": "histogram_quantile(0.99, sum(rate(coredns_dns_request_size_bytes_bucket{instance=~\"$instance\",proto=\"udp\"}[5m])) by (le,proto))",
                         "intervalFactor": 2,
-                        "legendFormat": "{{`{{proto}}`}}:99 ",
+                        "legendFormat": "{{`{{proto}}`}}:99%",
                         "refId": "A",
                         "step": 60
                     },
                     {
                         "expr": "histogram_quantile(0.90, sum(rate(coredns_dns_request_size_bytes_bucket{instance=~\"$instance\",proto=\"udp\"}[5m])) by (le,proto))",
                         "intervalFactor": 2,
-                        "legendFormat": "{{`{{proto}}`}}:90",
+                        "legendFormat": "{{`{{proto}}`}}:90%",
                         "refId": "B",
                         "step": 60
                     },
                     {
                         "expr": "histogram_quantile(0.50, sum(rate(coredns_dns_request_size_bytes_bucket{instance=~\"$instance\",proto=\"udp\"}[5m])) by (le,proto))",
                         "intervalFactor": 2,
-                        "legendFormat": "{{`{{proto}}`}}:50",
+                        "legendFormat": "{{`{{proto}}`}}:50%",
                         "refId": "C",
                         "step": 60
                     }
@@ -570,15 +570,15 @@ data:
                 "renderer": "flot",
                 "seriesOverrides": [
                     {
-                        "alias": "tcp:90",
+                        "alias": "tcp:90%",
                         "yaxis": 1
                     },
                     {
-                        "alias": "tcp:99 ",
+                        "alias": "tcp:99%",
                         "yaxis": 1
                     },
                     {
-                        "alias": "tcp:50",
+                        "alias": "tcp:50%",
                         "yaxis": 1
                     }
                 ],
@@ -589,21 +589,21 @@ data:
                     {
                         "expr": "histogram_quantile(0.99, sum(rate(coredns_dns_request_size_bytes_bucket{instance=~\"$instance\",proto=\"tcp\"}[5m])) by (le,proto))",
                         "intervalFactor": 2,
-                        "legendFormat": "{{`{{proto}}`}}:99 ",
+                        "legendFormat": "{{`{{proto}}`}}:99%",
                         "refId": "A",
                         "step": 60
                     },
                     {
                         "expr": "histogram_quantile(0.90, sum(rate(coredns_dns_request_size_bytes_bucket{instance=~\"$instance\",proto=\"tcp\"}[5m])) by (le,proto))",
                         "intervalFactor": 2,
-                        "legendFormat": "{{`{{proto}}`}}:90",
+                        "legendFormat": "{{`{{proto}}`}}:90%",
                         "refId": "B",
                         "step": 60
                     },
                     {
                         "expr": "histogram_quantile(0.50, sum(rate(coredns_dns_request_size_bytes_bucket{instance=~\"$instance\",proto=\"tcp\"}[5m])) by (le,proto))",
                         "intervalFactor": 2,
-                        "legendFormat": "{{`{{proto}}`}}:50",
+                        "legendFormat": "{{`{{proto}}`}}:50%",
                         "refId": "C",
                         "step": 60
                     }
@@ -611,7 +611,7 @@ data:
                 "thresholds": [],
                 "timeFrom": null,
                 "timeShift": null,
-                "title": "Requests (size,tcp)",
+                "title": "Requests (size, tcp)",
                 "tooltip": {
                     "shared": true,
                     "sort": 0,

--- a/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-coredns.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards-1.14/k8s-coredns.yaml
@@ -897,7 +897,7 @@ data:
                         "step": 40
                     },
                     {
-                        "expr": "histogram_quantile(0.90, sum(rate(coredns_dns_response_size_bytes_bucket{instance=\"$instance\",proto=\"udp\"}[5m])) by (le,proto)) ",
+                        "expr": "histogram_quantile(0.90, sum(rate(coredns_dns_response_size_bytes_bucket{instance=~\"$instance\",proto=\"udp\"}[5m])) by (le,proto)) ",
                         "intervalFactor": 2,
                         "legendFormat": "{{`{{proto}}`}}:90%",
                         "refId": "B",

--- a/stable/prometheus-operator/templates/grafana/dashboards/k8s-coredns.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards/k8s-coredns.yaml
@@ -458,15 +458,15 @@ data:
                 "renderer": "flot",
                 "seriesOverrides": [
                     {
-                        "alias": "tcp:90",
+                        "alias": "tcp:90%",
                         "yaxis": 2
                     },
                     {
-                        "alias": "tcp:99 ",
+                        "alias": "tcp:99%",
                         "yaxis": 2
                     },
                     {
-                        "alias": "tcp:50",
+                        "alias": "tcp:50%",
                         "yaxis": 2
                     }
                 ],
@@ -477,21 +477,21 @@ data:
                     {
                         "expr": "histogram_quantile(0.99, sum(rate(coredns_dns_request_size_bytes_bucket{instance=~\"$instance\",proto=\"udp\"}[5m])) by (le,proto))",
                         "intervalFactor": 2,
-                        "legendFormat": "{{`{{proto}}`}}:99 ",
+                        "legendFormat": "{{`{{proto}}`}}:99%",
                         "refId": "A",
                         "step": 60
                     },
                     {
                         "expr": "histogram_quantile(0.90, sum(rate(coredns_dns_request_size_bytes_bucket{instance=~\"$instance\",proto=\"udp\"}[5m])) by (le,proto))",
                         "intervalFactor": 2,
-                        "legendFormat": "{{`{{proto}}`}}:90",
+                        "legendFormat": "{{`{{proto}}`}}:90%",
                         "refId": "B",
                         "step": 60
                     },
                     {
                         "expr": "histogram_quantile(0.50, sum(rate(coredns_dns_request_size_bytes_bucket{instance=~\"$instance\",proto=\"udp\"}[5m])) by (le,proto))",
                         "intervalFactor": 2,
-                        "legendFormat": "{{`{{proto}}`}}:50",
+                        "legendFormat": "{{`{{proto}}`}}:50%",
                         "refId": "C",
                         "step": 60
                     }
@@ -570,15 +570,15 @@ data:
                 "renderer": "flot",
                 "seriesOverrides": [
                     {
-                        "alias": "tcp:90",
+                        "alias": "tcp:90%",
                         "yaxis": 1
                     },
                     {
-                        "alias": "tcp:99 ",
+                        "alias": "tcp:99%",
                         "yaxis": 1
                     },
                     {
-                        "alias": "tcp:50",
+                        "alias": "tcp:50%",
                         "yaxis": 1
                     }
                 ],
@@ -589,21 +589,21 @@ data:
                     {
                         "expr": "histogram_quantile(0.99, sum(rate(coredns_dns_request_size_bytes_bucket{instance=~\"$instance\",proto=\"tcp\"}[5m])) by (le,proto))",
                         "intervalFactor": 2,
-                        "legendFormat": "{{`{{proto}}`}}:99 ",
+                        "legendFormat": "{{`{{proto}}`}}:99%",
                         "refId": "A",
                         "step": 60
                     },
                     {
                         "expr": "histogram_quantile(0.90, sum(rate(coredns_dns_request_size_bytes_bucket{instance=~\"$instance\",proto=\"tcp\"}[5m])) by (le,proto))",
                         "intervalFactor": 2,
-                        "legendFormat": "{{`{{proto}}`}}:90",
+                        "legendFormat": "{{`{{proto}}`}}:90%",
                         "refId": "B",
                         "step": 60
                     },
                     {
                         "expr": "histogram_quantile(0.50, sum(rate(coredns_dns_request_size_bytes_bucket{instance=~\"$instance\",proto=\"tcp\"}[5m])) by (le,proto))",
                         "intervalFactor": 2,
-                        "legendFormat": "{{`{{proto}}`}}:50",
+                        "legendFormat": "{{`{{proto}}`}}:50%",
                         "refId": "C",
                         "step": 60
                     }
@@ -611,7 +611,7 @@ data:
                 "thresholds": [],
                 "timeFrom": null,
                 "timeShift": null,
-                "title": "Requests (size,tcp)",
+                "title": "Requests (size, tcp)",
                 "tooltip": {
                     "shared": true,
                     "sort": 0,

--- a/stable/prometheus-operator/templates/grafana/dashboards/k8s-coredns.yaml
+++ b/stable/prometheus-operator/templates/grafana/dashboards/k8s-coredns.yaml
@@ -897,7 +897,7 @@ data:
                         "step": 40
                     },
                     {
-                        "expr": "histogram_quantile(0.90, sum(rate(coredns_dns_response_size_bytes_bucket{instance=\"$instance\",proto=\"udp\"}[5m])) by (le,proto)) ",
+                        "expr": "histogram_quantile(0.90, sum(rate(coredns_dns_response_size_bytes_bucket{instance=~\"$instance\",proto=\"udp\"}[5m])) by (le,proto)) ",
                         "intervalFactor": 2,
                         "legendFormat": "{{`{{proto}}`}}:90%",
                         "refId": "B",


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR fixes inconsistencies in the naming of time series labels in the CoreDNS dashboard.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
