### PR TITLE
[stable/prometheus] Ability to scope alertmanager to a specific instance using podAnnotations

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 9.7.0
+version: 9.7.1
 appVersion: 2.13.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/server-configmap.yaml
+++ b/stable/prometheus/templates/server-configmap.yaml
@@ -59,6 +59,9 @@ data:
         - source_labels: [__meta_kubernetes_pod_label_component]
           regex: alertmanager
           action: keep
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_probe]
+          regex: {{ index $root.Values.alertmanager.podAnnotations "prometheus.io/probe" | default ".*" }}
+          action: keep
         - source_labels: [__meta_kubernetes_pod_container_port_number]
           regex:
           action: drop

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -215,6 +215,11 @@ alertmanager:
   ## Annotations to be added to alertmanager pods
   ##
   podAnnotations: {}
+    ## Tell prometheus to use a specific set of alertmanager pods
+    ## instead of all alertmanager pods found in the same namespace
+    ## Useful if you deploy multiple releases within the same namespace
+    ##
+    ## prometheus.io/probe: alertmanager-teamA
 
   ## Specify if a Pod Security Policy for node-exporter must be created
   ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/


### PR DESCRIPTION
#### What this PR does / why we need it:

This pull request introduces a way to pin prometheus to a specific set of alertmanager pods. It allows user to leverage `"prometheus.io/probe"` pod annotation to target alertmanager

Right now if multiple prometheus stacks are deployed within the same namespace the current `relabel_configs` will include all alertmanager pods found in this namespace even though it's not an instance of the helm release.

#### Special notes for your reviewer:

The default behavior should not be impacted as it will default to `.*` if annotations are not set.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
