### PR TITLE
[stable/grafana] Restore old envFromSecret behavior

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 3.10.2
+version: 3.11.0
 appVersion: 6.4.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -79,7 +79,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `initChownData.resources`                 | init-chown-data pod resource requests & limits | `{}`                                                   |
 | `schedulerName`                           | Alternate scheduler name                      | `nil`                                                   |
 | `env`                                     | Extra environment variables passed to pods    | `{}`                                                    |
-| `envFromSecret`                           | Sensible environment variables passed to pods and stored as secret | `{}`                               |
+| `envFromSecret`                           | Name of a Kubernetes secret (must be manually created in the same namespace) containing values to be added to the environment | `""` |
+| `envRenderSecret`                         | Sensible environment variables passed to pods and stored as secret | `{}`                               |
 | `extraSecretMounts`                       | Additional grafana server secret mounts       | `[]`                                                    |
 | `extraVolumeMounts`                       | Additional grafana server volume mounts       | `[]`                                                    |
 | `extraConfigmapMounts`                    | Additional grafana server configMap volume mounts  | `[]`                                               |

--- a/stable/grafana/templates/_pod.tpl
+++ b/stable/grafana/templates/_pod.tpl
@@ -255,6 +255,11 @@ containers:
     {{- if .Values.envFromSecret }}
     envFrom:
       - secretRef:
+          name: {{ .Values.envFromSecret }}
+    {{- end }}
+    {{- if .Values.envRenderSecret }}
+    envFrom:
+      - secretRef:
           name: {{ template "grafana.fullname" . }}-env
     {{- end }}
     livenessProbe:

--- a/stable/grafana/templates/secret-env.yaml
+++ b/stable/grafana/templates/secret-env.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.envFromSecret }}
+{{- if .Values.envRenderSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,7 +11,7 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
-{{- range $key, $val := .Values.envFromSecret }}
+{{- range $key, $val := .Values.envRenderSecret }}
   {{ $key }}: {{ $val | b64enc | quote }}
 {{- end -}}
 {{- end }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -246,9 +246,13 @@ admin:
 ## Extra environment variables that will be pass onto deployment pods
 env: {}
 
-## Sensible environment variables that will be stored as secret
+## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
 ## This can be useful for auth tokens, etc
-envFromSecret: {}
+envFromSecret: ""
+
+## Sensible environment variables that will be rendered as new secret object
+## This can be useful for auth tokens, etc
+envRenderSecret: {}
 
 ## Additional grafana server secret mounts
 # Defines additional mounts with secrets. Secrets must be manually created in the namespace.


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No.

#### What this PR does / why we need it:

Recovers backward compatibility for `envFromSecret` key by restoring it's old behavior. Moves functionality introduced by PR #17788 to `envRenderSecret` key.

#### Which issue this PR fixes

Resolves backward-compatibility issues discussed in #17788 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
