### PR TITLE
[stable/kube-registry-proxy] Update api versions to support k8s 1.16

### DIFF
--- a/incubator/kube-registry-proxy/Chart.yaml
+++ b/incubator/kube-registry-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kube-registry-proxy
 home: https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/registry
-version: 0.3.1
+version: 0.4.0
 appVersion: 0.4
 description: Installs the kubernetes-registry-proxy cluster addon.
 maintainers:

--- a/incubator/kube-registry-proxy/Chart.yaml
+++ b/incubator/kube-registry-proxy/Chart.yaml
@@ -3,6 +3,7 @@ name: kube-registry-proxy
 home: https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/registry
 version: 0.4.0
 appVersion: 0.4
+kubeVersion: "^1.10.0-0"
 description: Installs the kubernetes-registry-proxy cluster addon.
 maintainers:
 - name: maorfr

--- a/incubator/kube-registry-proxy/templates/daemon.yaml
+++ b/incubator/kube-registry-proxy/templates/daemon.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "kube-registry-proxy.fullname" . }}
@@ -7,6 +7,9 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
+  selector:
+    matchLabels:
+      release: {{ .Release.Name | quote }}
   template:
     metadata:
       name: {{ template "kube-registry-proxy.fullname" . }}

--- a/incubator/kube-registry-proxy/templates/daemon.yaml
+++ b/incubator/kube-registry-proxy/templates/daemon.yaml
@@ -3,18 +3,23 @@ kind: DaemonSet
 metadata:
   name: {{ template "kube-registry-proxy.fullname" . }}
   labels:
+    app: {{ template "kube-registry-proxy.fullname" . }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
   selector:
     matchLabels:
+      app: {{ template "kube-registry-proxy.fullname" . }}
       release: {{ .Release.Name | quote }}
   template:
     metadata:
       name: {{ template "kube-registry-proxy.fullname" . }}
       labels:
         app: {{ template "kube-registry-proxy.fullname" . }}
+        heritage: {{ .Release.Service | quote }}
+        release: {{ .Release.Name | quote }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     spec:
       containers:
       - name: kube-registry-proxy


### PR DESCRIPTION
Signed-off-by: Anton Gorkovenko <gostom@gmail.com>

#### Is this a new chart
no
#### What this PR does / why we need it:
Update api versions to support k8s 1.16
#### Which issue this PR fixes
no
#### Special notes for your reviewer:
no
#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
