### PR TITLE
[stable/sonarqube] add support for Oracle DB

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 3.1.0
+version: 3.2.0
 appVersion: 7.9.1
 keywords:
   - coverage

--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -72,7 +72,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `customCerts.secretName`                    | Name of the secret which conatins your `cacerts` | false                                      |
 | `sonarSecretKey`                            | Name of existing secret used for settings encryption | None                            |
 | `sonarProperties`                           | Custom `sonar.properties` file            | `{}`                                       |
-| `database.type`                             | Set to "mysql" to use mysql database       | `postgresql`|
+| `database.type`                             | Set to "mysql" to use mysql database or "oracle" to use oracle database  | `postgresql`|
 | `postgresql.enabled`                        | Set to `false` to use external server / mysql database     | `true`                                     |
 | `postgresql.postgresServer`                 | Hostname of the external Postgresql server| `null`                                     |
 | `postgresql.postgresPasswordSecret`         | Secret containing the password of the external Postgresql server | `null`              |
@@ -88,6 +88,14 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `mysql.mysqlDatabase`                       | Mysql database name                       | `sonarDB`                                  |
 | `mysql.mysqlParams`                         | Mysql parameters for JDBC connection string     | `{}`                                 |
 | `mysql.service.port`                        | Mysql port                                | `3306`                                     |
+| `oracle.oracleHostname`                     | Hostname of the external Oracle server    | `null`                                     |
+| `oracle.oracleHostport`                     | Oracle port                               | `1521`                                     |
+| `oracle.oraclePasswordSecret`               | Secret containing the password of the external Oracle server | `null`              |
+| `oracle.oracleUser`                         | Oracle database user                      | `sonarUser`                                |
+| `oracle.oraclePassword`                     | Oracle database password                  | `sonarPass`                                |
+| `oracle.oracleDatabase`                     | Oracle database name (if not using oraclePasswordSecret) | `sonarDB`                                  |
+| `oracle.oracleInstallDriver`                | Set to `true` to install the Oracle JDBC driver (must provide URL to file in `oracle.oracleDriverPath`)  | `false`                                |
+| `oracle.oracleDriverPath`                   | URL where the Oracle JDBC driver can be found  | `null`                                |
 | `annotations`                               | Sonarqube Pod annotations                 | `{}`                                       |
 | `resources`                                 | Sonarqube Pod resource requests & limits  | `{}`                                       |
 | `affinity`                                  | Node / Pod affinities                     | `{}`                                       |

--- a/stable/sonarqube/templates/copy-plugins.yaml
+++ b/stable/sonarqube/templates/copy-plugins.yaml
@@ -13,7 +13,7 @@ data:
       {{- if .Values.plugins.deleteDefaultPlugins }}
       rm -f /opt/sonarqube/extensions/plugins/*.jar
       {{- end }}
-      for f in /opt/sonarqube/extensions/plugins/tmp/*.jar
+      for f in /opt/sonarqube/extensions/tmp/plugins/*.jar
       do
         file=${f##*/} && file=${file%-[0-9]*} 
         for original in /opt/sonarqube/extensions/plugins/*.jar
@@ -24,7 +24,9 @@ data:
           fi
         done
       done
-      cp /opt/sonarqube/extensions/plugins/tmp/*.jar /opt/sonarqube/extensions/plugins/
+      cp /opt/sonarqube/extensions/tmp/plugins/*.jar /opt/sonarqube/extensions/plugins/
+      {{- if and .Values.oracle.oracleInstallDriver .Values.oracle.oracleDriverPath }}
+      cp /opt/sonarqube/extensions/tmp/jdbc-driver/*.jar /opt/sonarqube/extensions/jdbc-driver/oracle/
+      {{- end }}
       /opt/sonarqube/bin/run.sh
-    
-    
+

--- a/stable/sonarqube/templates/deployment.yaml
+++ b/stable/sonarqube/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
-      {{- if .Values.plugins.install }}
+        {{- if or .Values.plugins.install .Values.oracle.oracleInstallDriver }}
         - name: install-plugins
           image: {{ default "joosthofman/wget:1.0" .Values.plugins.initContainerImage }}
           env:
@@ -54,42 +54,21 @@ spec:
             {{- end }}
           command: ["sh",
             "-c",
-            "mkdir -p /opt/sonarqube/extensions/plugins/tmp &&
-            rm -f /opt/sonarqube/extensions/plugins/tmp/* &&
-            cp /tmp/scripts/install_plugins.sh /opt/sonarqube/extensions/plugins/tmp/install_plugins.sh &&
-            chmod 0775 /opt/sonarqube/extensions/plugins/tmp/install_plugins.sh &&
-            /opt/sonarqube/extensions/plugins/tmp/install_plugins.sh && pwd && ls -lah
-            "
-           ]
+            "mkdir -p /opt/sonarqube/extensions/tmp/plugins &&
+            rm -f /opt/sonarqube/extensions/tmp/plugins/tmp/* &&
+            cp /tmp/scripts/install_plugins.sh /opt/sonarqube/extensions/tmp/plugins/install_plugins.sh &&
+            chmod 0775 /opt/sonarqube/extensions/tmp/plugins/install_plugins.sh &&
+            /opt/sonarqube/extensions/tmp/plugins/install_plugins.sh"
+          ]
           volumeMounts:
-            - mountPath: /opt/sonarqube/extensions/plugins/tmp
+            - mountPath: /opt/sonarqube/extensions/tmp
               name: sonarqube
               subPath: tmp
             - name: install-plugins
               mountPath: /tmp/scripts/
           resources:
 {{ toYaml .Values.plugins.resources | indent 12 }}
-    {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-    {{- end }}
-    {{- if .Values.hostAliases }}
-      hostAliases:
-{{ toYaml .Values.hostAliases | indent 8 }}
-    {{- end }}
-    {{- if .Values.tolerations }}
-      tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
-    {{- end }}
-    {{- if .Values.affinity }}
-      affinity:
-{{ toYaml .Values.affinity | indent 8 }}
-    {{- end }}
-      {{- end }}
-      {{- if .Values.image.pullSecret }}
-      imagePullSecrets:
-      - name: {{ .Values.image.pullSecret }}
-      {{- end }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -98,7 +77,7 @@ spec:
             - name: http
               containerPort: {{ .Values.service.internalPort }}
               protocol: TCP
-          {{- if .Values.plugins.install }}
+          {{- if or .Values.plugins.install .Values.oracle.oracleInstallDriver }}
           command:
             - /tmp/scripts/copy_plugins.sh
           {{- end }}
@@ -112,6 +91,8 @@ spec:
               value: {{ .Values.postgresql.postgresUser | quote }}
               {{- else if eq .Values.database.type "mysql" }}
               value: {{ .Values.mysql.mysqlUser | quote }}
+              {{- else if eq .Values.database.type "oracle" }}
+              value: {{ .Values.oracle.oracleUser | quote }}
               {{- end }}
             - name: SONARQUBE_JDBC_PASSWORD
               valueFrom:
@@ -122,12 +103,17 @@ spec:
                   {{- else if eq .Values.database.type "mysql" }}
                   name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else if .Values.mysql.mysqlPasswordSecret }} {{ .Values.mysql.mysqlPasswordSecret }} {{- else }} {{ template "sonarqube.fullname" . }} {{- end }}
                   key: mysql-password
+                  {{- else if eq .Values.database.type "oracle" }}
+                  name: {{- if .Values.oracle.enabled }} {{ template "oracle.fullname" .}} {{- else if .Values.oracle.oraclePasswordSecret }} {{ .Values.oracle.oraclePasswordSecret }} {{- else }} {{ template "sonarqube.fullname" . }} {{- end }}
+                  key: oracle-password
                   {{- end }}
             - name: SONARQUBE_JDBC_URL
               {{- if eq .Values.database.type "postgresql" }}
               value: "jdbc:postgresql://{{ template "postgresql.hostname" . }}:{{- .Values.postgresql.service.port -}}/{{- .Values.postgresql.postgresDatabase -}}"
               {{- else if eq .Values.database.type "mysql" }}
               value: "jdbc:mysql://{{ template "mysql.hostname" . }}:{{ .Values.mysql.service.port }}/{{ .Values.mysql.mysqlDatabase }}?useUnicode=true&characterEncoding=utf8&rewriteBatchedStatements=true{{- range $key, $value := .Values.mysql.mysqlParams }}&{{ $key }}={{ $value }}{{- end }}"
+              {{- else if eq .Values.database.type "oracle" }}
+              value: "jdbc:oracle:thin:@{{ .Values.oracle.oracleHostname }}:{{- .Values.oracle.oracleHostport -}}/{{- .Values.oracle.oracleDatabase -}}"
               {{- end }}
           livenessProbe:
             httpGet:
@@ -159,7 +145,7 @@ spec:
             - mountPath: /opt/sonarqube/data
               name: sonarqube
               subPath: data
-            - mountPath: /opt/sonarqube/extensions/plugins/tmp
+            - mountPath: /opt/sonarqube/extensions/tmp
               name: sonarqube
               subPath: tmp
             - mountPath: /opt/sonarqube/extensions/downloads
@@ -180,18 +166,26 @@ spec:
               mountPath: /tmp/scripts
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-    {{- if .Values.nodeSelector }}
+      {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
-    {{- end }}
-    {{- if .Values.tolerations }}
+      {{- end }}
+      {{- if .Values.hostAliases }}
+      hostAliases:
+{{ toYaml .Values.hostAliases | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
-    {{- end }}
-    {{- if .Values.affinity }}
+      {{- end }}
+      {{- if .Values.affinity }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
-    {{- end }}
+      {{- end }}
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.image.pullSecret }}
+      {{- end }}
       volumes:
       {{- if .Values.sonarProperties }}
       - name: config

--- a/stable/sonarqube/templates/install-plugins.yaml
+++ b/stable/sonarqube/templates/install-plugins.yaml
@@ -9,9 +9,15 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   install_plugins.sh: |-
-    cd /opt/sonarqube/extensions/plugins/tmp
     {{- if .Values.plugins.install }}
+      mkdir -p /opt/sonarqube/extensions/tmp/plugins
+      cd /opt/sonarqube/extensions/tmp/plugins
       {{- range $index, $val := .Values.plugins.install }}
         wget {{ $val }} --no-check-certificate
       {{- end }}
+    {{- end }}
+    {{- if and .Values.oracle.oracleInstallDriver .Values.oracle.oracleDriverPath }}
+      mkdir -p /opt/sonarqube/extensions/tmp/jdbc-driver
+      cd /opt/sonarqube/extensions/tmp/jdbc-driver
+      wget {{ .Values.oracle.oracleDriverPath }} --no-check-certificate
     {{- end }}

--- a/stable/sonarqube/templates/secret.yaml
+++ b/stable/sonarqube/templates/secret.yaml
@@ -34,3 +34,19 @@ data:
 {{- end -}}
 {{- end -}}
 {{- end -}}
+{{- if eq .Values.database.type "oracle" -}}
+{{- if not .Values.oracle.oraclePasswordSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "sonarqube.fullname" . }}
+  labels:
+    app: {{ template "sonarqube.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  oracle-password: {{ .Values.oracle.oraclePassword | b64enc | quote }}
+{{- end -}}
+{{- end -}}

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -207,3 +207,19 @@ mysql:
 # podLabels:
 #   key: value
 podLabels: {}
+
+## Configuration values for external Oracle DB
+oracle:
+  oracleHostname: ""
+  oracleHostport: 1521
+  # To use an external secret for the password for an external Oracle
+  # instance, provide the name of the secret on the line below:
+  # oraclePasswordSecret: ""
+  oracleUser: "sonarUser"
+  oraclePassword: "sonarPass"
+  oracleDatabase: "sonarDB"
+  # To use Oracle, you will need to install the Oracle JDBC driver.
+  # Set oracleInstallDriver to true and provide a URL where the driver
+  # can be downloaded in oracleDriverPath.
+  oracleInstallDriver: false
+  oracleDriverPath: ""


### PR DESCRIPTION
#### Is this a new chart
Existing chart maintained by @rjkernick @tsiddique 

#### What this PR does / why we need it:
- Adds support for connecting to an external Oracle database
- Also removes some duplicated properties from the `deployment.yaml` template

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
