### PR TITLE
[stable/datadog] remove useConfigMap, use customAgentConfig for datadog-yaml-configmap

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.38.1
+version: 1.38.2
 appVersion: 6.14.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -320,8 +320,7 @@ helm install --name <RELEASE_NAME> \
 | `daemonset.containers.systemProbe.resources.limits.memory`        | Memory resource limits for the system-probe container                                   | `200Mi`                                       |
 | `daemonset.containers.systemProbe.resources.requests.memory`      | Memory resource requests for the system-probe container                                 | `200Mi`                                       |
 | `daemonset.priorityClassName`            | Which Priority Class to associate with the daemonset                                      | `nil`                                       |
-| `daemonset.useConfigMap`                 | Configures a configmap to provide the agent configuration                                 | `false`                                     |
-| `daemonset.customAgentConfig`            | Specify custom contents for the datadog agent config (datadog.yaml).                      | `{}`                                        |
+| `daemonset.customAgentConfig`            | Specify custom contents for the datadog agent config (datadog.yaml) using a config map.   | `{}`                                        |
 | `daemonset.updateStrategy`               | Which update strategy to deploy the daemonset                                             | RollingUpdate with 10% maxUnavailable       |
 | `datadog.leaderElection`                 | Enable the leader Election feature                                                        | `false`                                     |
 | `datadog.leaderLeaseDuration`            | The duration for which a leader stays elected.                                            | 60 sec, 15 if Cluster Checks enabled        |

--- a/stable/datadog/templates/container-agents.yaml
+++ b/stable/datadog/templates/container-agents.yaml
@@ -191,7 +191,7 @@
       mountPath: /etc/passwd
       readOnly: true
     {{- end }}
-    {{- if .Values.daemonset.useConfigMap }}
+    {{- if .Values.daemonset.customAgentConfig }}
     - name: {{ template "datadog.fullname" . }}-datadog-yaml
       mountPath: /etc/datadog-agent/datadog.yaml
       subPath: datadog.yaml

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -157,7 +157,7 @@ spec:
         - name: sysprobe-socket-dir
           emptyDir: {}
         {{- end }}
-        {{- if .Values.daemonset.useConfigMap }}
+        {{- if .Values.daemonset.customAgentConfig }}
         - name: {{ template "datadog.fullname" . }}-datadog-yaml
           configMap:
             name: {{ template "datadog.fullname" . }}-datadog-yaml

--- a/stable/datadog/templates/datadog-yaml-configmap.yaml
+++ b/stable/datadog/templates/datadog-yaml-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.daemonset.useConfigMap .Values.daemonset.customAgentConfig }}
+{{- if .Values.daemonset.customAgentConfig }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,30 +14,8 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
   annotations:
-    {{- if .Values.daemonset.customAgentConfig }}
     checksum/agent-config: {{ tpl (toYaml .Values.daemonset.customAgentConfig) . | sha256sum }}
-    {{- end }}
 data:
   datadog.yaml: |
-  {{- if .Values.daemonset.customAgentConfig }}
 {{ tpl (toYaml .Values.daemonset.customAgentConfig) . | indent 4 }}
-  {{- else }}
-    ## Provides autodetected defaults, for kubernetes environments,
-    ## please see datadog.yaml.example for all supported options
-
-    # Autodiscovery for Kubernetes
-    listeners:
-      - name: kubelet
-    config_providers:
-      - name: kubelet
-        polling: true
-
-    # Enable APM by setting the DD_APM_ENABLED envvar to true, or override this configuration
-    apm_config:
-      enabled: false
-      apm_non_local_traffic: true
-
-    # Use java cgroup memory awareness
-    jmx_use_cgroup_memory_limit: true
-  {{- end }}
 {{- end }}

--- a/stable/datadog/templates/datadog-yaml-configmap.yaml
+++ b/stable/datadog/templates/datadog-yaml-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.daemonset.useConfigMap }}
+{{- if or .Values.daemonset.useConfigMap .Values.daemonset.customAgentConfig }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -659,13 +659,9 @@ daemonset:
   #
   # podLabels: {}
 
-  ## @param useConfigMap - boolean - optional
-  #  Configures a configmap to provide the agent configuration
-  #
-  # useConfigMap: false
-
   ## @param customAgentConfig - object - optional
-  ## Specify custom contents for the datadog agent config (datadog.yaml).
+  ## Specify custom contents for the datadog agent config (datadog.yaml) using a configmap.
+  ## ref: https://github.com/helm/charts/blob/master/stable/datadog/templates/datadog-yaml-configmap.yaml
   ## ref: https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6
   ## ref: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
   #


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:


If you are adding customAgentConfig, it seems counter intuitive to need an additional boolean:
`useConfigMap: true`


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
