### PR TITLE
[stable/kong] simplify Ingress generation

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.23.0
+version: 0.24.0
 appVersion: 1.3

--- a/stable/kong/templates/_helpers.tpl
+++ b/stable/kong/templates/_helpers.tpl
@@ -125,13 +125,16 @@ Create the ingress servicePort value string
 
 {{/*
 Generate an appropriate external URL from a Kong service's ingress configuration
+Strips trailing slashes from the path. Manager at least does not handle these
+intelligently and will append its own slash regardless, and the admin API cannot handle
+the extra slash.
 */}}
 
 {{- define "kong.ingress.serviceUrl" -}}
 {{- if .tls -}}
-    https://{{ .hostname }}
+    https://{{ .hostname }}{{ .path | trimSuffix "/" }}
 {{- else -}}
-    http://{{ .hostname }}
+    http://{{ .hostname }}{{ .path | trimSuffix "/" }}
 {{- end -}}
 {{- end -}}
 

--- a/stable/kong/templates/_helpers.tpl
+++ b/stable/kong/templates/_helpers.tpl
@@ -123,6 +123,18 @@ Create the ingress servicePort value string
 {{- end -}}
 {{- end -}}
 
+{{/*
+Generate an appropriate external URL from a Kong service's ingress configuration
+/*}}
+
+{{- define "kong.ingress.serviceUrl" -}}
+{{- if .tls -}}
+    https://{{ .hostname }}
+{{- else -}}
+    http://{{ .hostname }}
+{{- end -}}
+{{- end -}}
+
 
 {{- define "kong.env" -}}
 {{- range $key, $val := .Values.env }}

--- a/stable/kong/templates/_helpers.tpl
+++ b/stable/kong/templates/_helpers.tpl
@@ -125,7 +125,7 @@ Create the ingress servicePort value string
 
 {{/*
 Generate an appropriate external URL from a Kong service's ingress configuration
-/*}}
+*/}}
 
 {{- define "kong.ingress.serviceUrl" -}}
 {{- if .tls -}}

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -68,6 +68,10 @@ spec:
           value: 0.0.0.0:{{ .Values.admin.containerPort }}
         {{- end }}
         {{- end }}
+        {{- if .Values.admin.ingress.enabled }}
+        - name: KONG_ADMIN_API_URI
+          value: {{ include "kong.ingress.serviceUrl" .Values.admin.ingress }}
+        {{- end }}
         {{- if not .Values.env.proxy_listen }}
         - name: KONG_PROXY_LISTEN
           value: {{ template "kong.kongProxyListenValue" . }}
@@ -76,13 +80,32 @@ spec:
         - name: KONG_ADMIN_GUI_LISTEN
           value: {{ template "kong.kongManagerListenValue" . }}
         {{- end }}
+        {{- if and (.Values.manager.ingress.enabled) (.Values.enterprise.enabled) }}
+        - name: KONG_ADMIN_GUI_URL
+          value: {{ include "kong.ingress.serviceUrl" .Values.manager.ingress }}
+        {{- end }}
         {{- if and (not .Values.env.portal_gui_listen) (.Values.enterprise.enabled) (.Values.enterprise.portal.enabled) }}
         - name: KONG_PORTAL_GUI_LISTEN
           value: {{ template "kong.kongPortalListenValue" . }}
         {{- end }}
+        {{- if and (.Values.portal.ingress.enabled) (.Values.enterprise.enabled) (.Values.enterprise.portal.enabled) }}
+        - name: KONG_PORTAL_GUI_HOST
+          value: {{ .Values.portal.ingress.hostname }}
+        {{- if .Values.portal.ingress.tls }}
+        - name: KONG_PORTAL_GUI_PROTOCOL
+          value: https
+        {{- else }}
+        - name: KONG_PORTAL_GUI_PROTOCOL
+          value: http
+        {{- end }}
+        {{- end }}
         {{- if and (not .Values.env.portal_api_listen) (.Values.enterprise.enabled) (.Values.enterprise.portal.enabled) }}
         - name: KONG_PORTAL_API_LISTEN
           value: {{ template "kong.kongPortalApiListenValue" . }}
+        {{- end }}
+        {{- if and (.Values.portalapi.ingress.enabled) (.Values.enterprise.enabled) (.Values.enterprise.portal.enabled) }}
+        - name: KONG_PORTAL_API_URL
+          value: {{ include "kong.ingress.serviceUrl" .Values.portalapi.ingress }}
         {{- end }}
         - name: KONG_NGINX_DAEMON
           value: "off"

--- a/stable/kong/templates/ingress-admin.yaml
+++ b/stable/kong/templates/ingress-admin.yaml
@@ -2,7 +2,8 @@
 {{- $serviceName := include "kong.fullname" . -}}
 {{- $servicePort := .Values.admin.servicePort -}}
 {{- $path := .Values.admin.ingress.path -}}
-{{- $hosts_count := len .Values.admin.ingress.hosts -}}
+{{- $tls := .Values.admin.ingress.tls -}}
+{{- $hostname := .Values.admin.ingress.hostname -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -18,26 +19,17 @@ metadata:
     {{- end }}
 spec:
   rules:
-    {{- if eq $hosts_count 0 }}
-    - http:
-        paths:
-          - path: {{ $path }}
-            backend:
-              serviceName: {{ $serviceName }}-admin
-              servicePort: {{ $servicePort }}
-    {{ else -}}
-    {{- range $host := .Values.admin.ingress.hosts }}
-    - host: {{ $host }}
-      http:
-        paths:
-          - path: {{ $path }}
-            backend:
-              serviceName: {{ $serviceName }}-admin
-              servicePort: {{ $servicePort }}
-    {{- end -}}
-    {{- end -}}
-  {{- if .Values.admin.ingress.tls }}
+  - host: {{ $hostname }}
+    http:
+      paths:
+        - path: {{ $path }}
+          backend:
+            serviceName: {{ $serviceName }}-admin
+            servicePort: {{ $servicePort }}
+  {{- if $tls }}
   tls:
-{{ toYaml .Values.admin.ingress.tls | indent 4 }}
+  - hosts:
+    - {{ $hostname }}
+    secretName: {{ $tls }}
   {{- end -}}
 {{- end -}}

--- a/stable/kong/templates/ingress-manager.yaml
+++ b/stable/kong/templates/ingress-manager.yaml
@@ -3,7 +3,8 @@
 {{- $serviceName := include "kong.fullname" . -}}
 {{- $servicePort := include "kong.ingress.servicePort" .Values.manager -}}
 {{- $path := .Values.manager.ingress.path -}}
-{{- $hosts_count := len .Values.manager.ingress.hosts -}}
+{{- $tls := .Values.manager.ingress.tls -}}
+{{- $hostname := .Values.manager.ingress.hostname -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -19,27 +20,18 @@ metadata:
     {{- end }}
 spec:
   rules:
-    {{- if eq $hosts_count 0 }}
-    - http:
-        paths:
-          - path: {{ $path }}
-            backend:
-              serviceName: {{ $serviceName }}-manager
-              servicePort: {{ $servicePort }}
-    {{ else -}}
-    {{- range $host := .Values.manager.ingress.hosts }}
-    - host: {{ $host }}
-      http:
-        paths:
-          - path: {{ $path }}
-            backend:
-              serviceName: {{ $serviceName }}-manager
-              servicePort: {{ $servicePort }}
-    {{- end -}}
-    {{- end -}}
-  {{- if .Values.manager.ingress.tls }}
+  - host: {{ $hostname }}
+    http:
+      paths:
+        - path: {{ $path }}
+          backend:
+            serviceName: {{ $serviceName }}-manager
+            servicePort: {{ $servicePort }}
+  {{- if $tls }}
   tls:
-{{ toYaml .Values.manager.ingress.tls | indent 4 }}
+  - hosts:
+    - {{ $hostname }}
+    secretName: {{ $tls }}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stable/kong/templates/ingress-portal-api.yaml
+++ b/stable/kong/templates/ingress-portal-api.yaml
@@ -3,7 +3,8 @@
 {{- $serviceName := include "kong.fullname" . -}}
 {{- $servicePort := include "kong.ingress.servicePort" .Values.portalapi -}}
 {{- $path := .Values.portalapi.ingress.path -}}
-{{- $hosts_count := len .Values.portalapi.ingress.hosts -}}
+{{- $tls := .Values.portalapi.ingress.tls -}}
+{{- $hostname := .Values.portalapi.ingress.hostname -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -19,27 +20,18 @@ metadata:
     {{- end }}
 spec:
   rules:
-    {{- if eq $hosts_count 0 }}
-    - http:
-        paths:
-          - path: {{ $path }}
-            backend:
-              serviceName: {{ $serviceName }}-portalapi
-              servicePort: {{ $servicePort }}
-    {{ else -}}
-    {{- range $host := .Values.portalapi.ingress.hosts }}
-    - host: {{ $host }}
-      http:
-        paths:
-          - path: {{ $path }}
-            backend:
-              serviceName: {{ $serviceName }}-portalapi
-              servicePort: {{ $servicePort }}
-    {{- end -}}
-    {{- end -}}
-  {{- if .Values.portalapi.ingress.tls }}
+  - host: {{ $hostname }}
+    http:
+      paths:
+        - path: {{ $path }}
+          backend:
+            serviceName: {{ $serviceName }}-portalapi
+            servicePort: {{ $servicePort }}
+  {{- if $tls }}
   tls:
-{{ toYaml .Values.portalapi.ingress.tls | indent 4 }}
+  - hosts:
+    - {{ $hostname }}
+    secretName: {{ $tls }}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stable/kong/templates/ingress-portal.yaml
+++ b/stable/kong/templates/ingress-portal.yaml
@@ -3,7 +3,8 @@
 {{- $serviceName := include "kong.fullname" . -}}
 {{- $servicePort := include "kong.ingress.servicePort" .Values.portal -}}
 {{- $path := .Values.portal.ingress.path -}}
-{{- $hosts_count := len .Values.portal.ingress.hosts -}}
+{{- $tls := .Values.portal.ingress.tls -}}
+{{- $hostname := .Values.portal.ingress.hostname -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -19,27 +20,18 @@ metadata:
     {{- end }}
 spec:
   rules:
-    {{- if eq $hosts_count 0 }}
-    - http:
-        paths:
-          - path: {{ $path }}
-            backend:
-              serviceName: {{ $serviceName }}-portal
-              servicePort: {{ $servicePort }}
-    {{ else -}}
-    {{- range $host := .Values.portal.ingress.hosts }}
-    - host: {{ $host }}
-      http:
-        paths:
-          - path: {{ $path }}
-            backend:
-              serviceName: {{ $serviceName }}-portal
-              servicePort: {{ $servicePort }}
-    {{- end -}}
-    {{- end -}}
-  {{- if .Values.portal.ingress.tls }}
+  - host: {{ $hostname }}
+    http:
+      paths:
+        - path: {{ $path }}
+          backend:
+            serviceName: {{ $serviceName }}-portal
+            servicePort: {{ $servicePort }}
+  {{- if $tls }}
   tls:
-{{ toYaml .Values.portal.ingress.tls | indent 4 }}
+  - hosts:
+    - {{ $hostname }}
+    secretName: {{ $tls }}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -40,8 +40,8 @@ admin:
     enabled: false
     # TLS secret name.
     # tls: kong-admin.example.com-tls
-    # Array of ingress hosts.
-    hosts: []
+    # Ingress hostname
+    hostname:
     # Map of ingress annotations.
     annotations: {}
     # Ingress path.
@@ -77,10 +77,14 @@ proxy:
   ingress:
     # Enable/disable exposure using ingress.
     enabled: false
-    # TLS secret name.
-    # tls: kong-proxy.example.com-tls
-    # Array of ingress hosts.
-    hosts: []
+    # TLS section. Unlike other ingresses, this follows the format at
+    # https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+    # tls:
+    #   hosts:
+    #     - example.com
+    #     secretName: example-com-tls-secret
+    #     - example.net
+    #     secretName: example-net-tls-secret
     # Map of ingress annotations.
     annotations: {}
     # Ingress path.
@@ -117,8 +121,8 @@ manager:
     enabled: false
     # TLS secret name.
     # tls: kong-proxy.example.com-tls
-    # Array of ingress hosts.
-    hosts: []
+    # Ingress hostname
+    hostname:
     # Map of ingress annotations.
     annotations: {}
     # Ingress path.
@@ -155,8 +159,8 @@ portal:
     enabled: false
     # TLS secret name.
     # tls: kong-proxy.example.com-tls
-    # Array of ingress hosts.
-    hosts: []
+    # Ingress hostname
+    hostname:
     # Map of ingress annotations.
     annotations: {}
     # Ingress path.
@@ -193,8 +197,8 @@ portalapi:
     enabled: false
     # TLS secret name.
     # tls: kong-proxy.example.com-tls
-    # Array of ingress hosts.
-    hosts: []
+    # Ingress hostname
+    hostname:
     # Map of ingress annotations.
     annotations: {}
     # Ingress path.

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -77,6 +77,7 @@ proxy:
   ingress:
     # Enable/disable exposure using ingress.
     enabled: false
+    hosts: []
     # TLS section. Unlike other ingresses, this follows the format at
     # https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
     # tls:


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR simplifies automatic ingress generation for services other than the proxy. The simplified definitions accept a single hostname and TLS secret name, whereas previously users could specify multiple hostnames and an entire TLS section. Furthermore, if automatic ingresses are enabled, the chart will automatically populate the various `KONG_SERVICE_URL` settings.

This reduces configuration at the cost of no longer automatically handling use cases (having multiple URLs for the admin API/GUI/Portal) that were unlikely in practice. Users that do require multiple URLs for Kong services can still create those Ingress definitions manually.

The proxy ingress remains as-is with documentation updates, as handling multiple hostnames via this automatic Ingress is likely to be more common.

#### Which issue this PR fixes
Fix #16461

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)