### PR TITLE
[stable/prometheus-exporter] Change prometheus-node-exporter port for CI

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -10,7 +10,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 6.18.0
+version: 6.18.1
 appVersion: 0.32.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/ci/test-values.yaml
+++ b/stable/prometheus-operator/ci/test-values.yaml
@@ -922,6 +922,10 @@ nodeExporter:
 ## Configuration for prometheus-node-exporter subchart
 ##
 prometheus-node-exporter:
+  service:
+    port: 9101
+    targetPort: 9101
+
   podLabels:
     ## Add the 'node-exporter' label to be used by serviceMonitor to match standard common usage in rules and grafana dashboards
     ##
@@ -964,6 +968,9 @@ prometheusOperator:
       podAnnotations: {}
       nodeSelector: {}
 
+  ## Namespaces not to scope the interaction of the Prometheus Operator (deny list).
+  ##
+  denyNamespaces: {}
 
   ## Service account for Alertmanager to use.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
@@ -1152,6 +1159,10 @@ prometheusOperator:
 prometheus:
 
   enabled: true
+
+  ## Annotations for Prometheus
+  ##
+  annotations: {}
 
   ## Service account for Prometheuses to use.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/

--- a/stable/prometheus-operator/hack/update-ci.sh
+++ b/stable/prometheus-operator/hack/update-ci.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
-sed -e 's/cleanupCustomResource: false/cleanupCustomResource: true/' \
+sed \
+  -e 's/cleanupCustomResource: false/cleanupCustomResource: true/' \
 	-e 's/cleanupCustomResourceBeforeInstall: false/cleanupCustomResourceBeforeInstall: true/' \
-	values.yaml > ci/test-values.yaml
+	-e 's/port: 9100/port: 9101/' \
+	-e 's/targetPort: 9100/targetPort: 9101/' \
+  values.yaml > ci/test-values.yaml

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -922,6 +922,10 @@ nodeExporter:
 ## Configuration for prometheus-node-exporter subchart
 ##
 prometheus-node-exporter:
+  service:
+    port: 9100
+    targetPort: 9100
+
   podLabels:
     ## Add the 'node-exporter' label to be used by serviceMonitor to match standard common usage in rules and grafana dashboards
     ##


### PR DESCRIPTION
### What this PR does / why we need it:
All stable/prometheus-operator PRs are broken because  the underlying cluster has issues provisioning the stable/prometheus-node-exporter on port 9100. This is not a long-term solution, but should at least unblock the numerous PRs that people are trying to get merged.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
