### PR TITLE
[stable/mariadb] Add 'extraEnvVars' parameter

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb
-version: 6.11.3
+version: 6.12.0
 appVersion: 10.3.18
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -52,7 +52,7 @@ The following table lists the configurable parameters of the MariaDB chart and t
 |-------------------------------------------|-----------------------------------------------------|-------------------------------------------------------------------|
 | `global.imageRegistry`                    | Global Docker image registry                        | `nil`                                                             |
 | `global.imagePullSecrets`                 | Global Docker registry secret names as an array     | `[]` (does not add image pull secrets to deployed pods)           |
-| `global.storageClass`                     | Global storage class for dynamic provisioning                                               | `nil`                                                        |
+| `global.storageClass`                     | Global storage class for dynamic provisioning       | `nil`                                                             |
 | `image.registry`                          | MariaDB image registry                              | `docker.io`                                                       |
 | `image.repository`                        | MariaDB Image name                                  | `bitnami/mariadb`                                                 |
 | `image.tag`                               | MariaDB Image tag                                   | `{TAG_NAME}`                                                      |
@@ -61,12 +61,12 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `image.debug`                             | Specify if debug logs should be enabled             | `false`                                                           |
 | `nameOverride`                            | String to partially override mariadb.fullname template with a string (will prepend the release name) | `nil`            |
 | `fullnameOverride`                        | String to fully override mariadb.fullname template with a string                                     | `nil`            |
-| `volumePermissions.enabled`          | Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work) | `false`                                                      |
-| `volumePermissions.image.registry`   | Init container volume-permissions image registry                                                                                                          | `docker.io`                                                  |
-| `volumePermissions.image.repository` | Init container volume-permissions image name                                                                                                              | `bitnami/minideb`                                            |
-| `volumePermissions.image.tag`        | Init container volume-permissions image tag                                                                                                               | `stretch`                                                     |
-| `volumePermissions.image.pullPolicy` | Init container volume-permissions image pull policy                                                                                                       | `Always`                                                     |
-| `volumePermissions.resources`        | Init container resource requests/limit                                                                                                                    | `nil`                                                        |
+| `volumePermissions.enabled`               | Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work) | `false`             |
+| `volumePermissions.image.registry`        | Init container volume-permissions image registry    | `docker.io`                                                       |
+| `volumePermissions.image.repository`      | Init container volume-permissions image name        | `bitnami/minideb`                                                 |
+| `volumePermissions.image.tag`             | Init container volume-permissions image tag         | `stretch`                                                         |
+| `volumePermissions.image.pullPolicy`      | Init container volume-permissions image pull policy | `Always`                                                          |
+| `volumePermissions.resources`             | Init container resource requests/limit              | `nil`                                                             |
 | `service.type`                            | Kubernetes service type                             | `ClusterIP`                                                       |
 | `service.clusterIp.master`                | Specific cluster IP for master when service type is cluster IP. Use None for headless service | `nil`                   |
 | `service.clusterIp.slave`                 | Specific cluster IP for slave when service type is cluster IP. Use None for headless service | `nil`                    |
@@ -78,7 +78,7 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `securityContext.enabled`                 | Enable security context                             | `true`                                                            |
 | `securityContext.fsGroup`                 | Group ID for the container                          | `1001`                                                            |
 | `securityContext.runAsUser`               | User ID for the container                           | `1001`                                                            |
-| `existingSecret`                          | Use existing secret for password details (`rootUser.password`, `db.password`, `replication.password` will be ignored and picked up from this secret). The secret has to contain the keys `mariadb-root-password`, `mariadb-replication-password` and `mariadb-password`. |                         |
+| `existingSecret`                          | Use existing secret for password details (`rootUser.password`, `db.password`, `replication.password` will be ignored and picked up from this secret). The secret has to contain the keys `mariadb-root-password`, `mariadb-replication-password` and `mariadb-password`. | `nil`                        |
 | `rootUser.password`                       | Password for the `root` user. Ignored if existing secret is provided. | _random 10 character alphanumeric string_       |
 | `rootUser.forcePassword`                  | Force users to specify a password                   | `false`                                                           |
 | `db.user`                                 | Username of new user to create                      | `nil`                                                             |
@@ -108,6 +108,7 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `master.persistence.accessModes`          | Persistent Volume Access Modes                      | `[ReadWriteOnce]`                                                 |
 | `master.persistence.size`                 | Persistent Volume Size                              | `8Gi`                                                             |
 | `master.extraInitContainers`              | Additional init containers as a string to be passed to the `tpl` function (master) |                                    |
+| `master.extraEnvVars`                     | Array containing extra env vars to configure MariaDB master replicas          | `nil`                                   |
 | `master.config`                           | Config file for the MariaDB Master server           | `_default values in the values.yaml file_`                        |
 | `master.resources`                        | CPU/Memory resource requests/limits for master node | `{}`                                                              |
 | `master.livenessProbe.enabled`            | Turn on and off liveness probe (master)             | `true`                                                            |
@@ -140,7 +141,8 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `slave.persistence.storageClass`          | Persistent Volume Storage Class                     | ``                                                                |
 | `slave.persistence.accessModes`           | Persistent Volume Access Modes                      | `[ReadWriteOnce]`                                                 |
 | `slave.persistence.size`                  | Persistent Volume Size                              | `8Gi`                                                             |
-| `slave.extraInitContainers`               | Additional init containers as a string to be passed to the `tpl` function (slave)               |                       |
+| `slave.extraInitContainers`               | Additional init containers as a string to be passed to the `tpl` function (slave)  | `nil`                              |
+| `slave.extraEnvVars`                      | Array containing extra env vars to configure MariaDB slave replicas          | `nil`                                    |
 | `slave.config`                            | Config file for the MariaDB Slave replicas          | `_default values in the values.yaml file_`                        |
 | `slave.resources`                         | CPU/Memory resource requests/limits for slave node  | `{}`                                                              |
 | `slave.livenessProbe.enabled`             | Turn on and off liveness probe (slave)              | `true`                                                            |
@@ -167,22 +169,22 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `metrics.resources`                       | Exporter resource requests/limit                    | `nil`                                                             |
 | `metrics.extraArgs.master`                | Extra args to be passed to mysqld_exporter          | `[]`                                                              |
 | `metrics.extraArgs.slave`                 | Extra args to be passed to mysqld_exporter          | `[]`                                                              |
-| `metrics.livenessProbe.enabled`            | Turn on and off liveness probe (metrics)             | `true`                                                            |
-| `metrics.livenessProbe.initialDelaySeconds`| Delay before liveness probe is initiated (metrics)   | `120`                                                             |
-| `metrics.livenessProbe.periodSeconds`      | How often to perform the probe (metrics)             | `10`                                                              |
-| `metrics.livenessProbe.timeoutSeconds`     | When the probe times out (metrics)                   | `1`                                                               |
-| `metrics.livenessProbe.successThreshold`   | Minimum consecutive successes for the probe (metrics)| `1`                                                               |
-| `metrics.livenessProbe.failureThreshold`   | Minimum consecutive failures for the probe (metrics) | `3`                                                               |
-| `metrics.readinessProbe.enabled`           | Turn on and off readiness probe (metrics)            | `true`                                                            |
-| `metrics.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated (metrics) | `30`                                                              |
-| `metrics.readinessProbe.periodSeconds`     | How often to perform the probe (metrics)             | `10`                                                              |
-| `metrics.readinessProbe.timeoutSeconds`    | When the probe times out (metrics)                   | `1`                                                               |
-| `metrics.readinessProbe.successThreshold`  | Minimum consecutive successes for the probe (metrics)| `1`                                                               |
-| `metrics.readinessProbe.failureThreshold`  | Minimum consecutive failures for the probe (metrics) | `3`                                                               |
-| `metrics.serviceMonitor.enabled`          | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)                    | `false`                                                             |
+| `metrics.livenessProbe.enabled`            | Turn on and off liveness probe (metrics)             | `true`                                                          |
+| `metrics.livenessProbe.initialDelaySeconds`| Delay before liveness probe is initiated (metrics)   | `120`                                                           |
+| `metrics.livenessProbe.periodSeconds`      | How often to perform the probe (metrics)             | `10`                                                            |
+| `metrics.livenessProbe.timeoutSeconds`     | When the probe times out (metrics)                   | `1`                                                             |
+| `metrics.livenessProbe.successThreshold`   | Minimum consecutive successes for the probe (metrics)| `1`                                                             |
+| `metrics.livenessProbe.failureThreshold`   | Minimum consecutive failures for the probe (metrics) | `3`                                                             |
+| `metrics.readinessProbe.enabled`           | Turn on and off readiness probe (metrics)            | `true`                                                          |
+| `metrics.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated (metrics) | `30`                                                            |
+| `metrics.readinessProbe.periodSeconds`     | How often to perform the probe (metrics)             | `10`                                                            |
+| `metrics.readinessProbe.timeoutSeconds`    | When the probe times out (metrics)                   | `1`                                                             |
+| `metrics.readinessProbe.successThreshold`  | Minimum consecutive successes for the probe (metrics)| `1`                                                             |
+| `metrics.readinessProbe.failureThreshold`  | Minimum consecutive failures for the probe (metrics) | `3`                                                             |
+| `metrics.serviceMonitor.enabled`          | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)  | `false`       |
 | `metrics.serviceMonitor.namespace`        | Optional namespace which Prometheus is running in   | `nil`                                                             |
-| `metrics.serviceMonitor.interval`         | How frequently to scrape metrics (use by default, falling back to Prometheus' default)  | `nil`                                                             |
-| `metrics.serviceMonitor.selector`         | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install                    | `{ prometheus: kube-prometheus }`                                                             |
+| `metrics.serviceMonitor.interval`         | How frequently to scrape metrics (use by default, falling back to Prometheus' default)  | `nil`                         |
+| `metrics.serviceMonitor.selector`         | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install   | `{ prometheus: kube-prometheus }` |
 
 The above parameters map to the env variables defined in [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb). For more information please refer to the [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb) image documentation.
 

--- a/stable/mariadb/templates/master-statefulset.yaml
+++ b/stable/mariadb/templates/master-statefulset.yaml
@@ -3,18 +3,18 @@ kind: StatefulSet
 metadata:
   name: {{ template "master.fullname" . }}
   labels:
-    app: "{{ template "mariadb.name" . }}"
-    chart: "{{ template "mariadb.chart" . }}"
-    component: "master"
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+    app: {{ template "mariadb.name" . }}
+    chart: {{ template "mariadb.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: master
 spec:
   selector:
     matchLabels:
-      release: "{{ .Release.Name }}"
-      component: "master"
-      app: "{{ template "mariadb.name" . }}"
-  serviceName: "{{ template "master.fullname" . }}"
+      app: {{ template "mariadb.name" . }}
+      release: {{ .Release.Name }}
+      component: master
+  serviceName: {{ template "master.fullname" . }}
   replicas: 1
   updateStrategy:
     type: {{ .Values.master.updateStrategy.type }}
@@ -26,19 +26,19 @@ spec:
       {{- if .Values.master.annotations }}
       annotations:
         {{- range $key, $value := .Values.master.annotations }}
-        {{ $key }}: '{{ $value }}'
+        {{ $key }}: {{ $value }}
         {{- end }}
       {{- end }}
       labels:
-        app: "{{ template "mariadb.name" . }}"
-        component: "master"
-        release: "{{ .Release.Name }}"
-        chart: "{{ template "mariadb.chart" . }}"
+        app: {{ template "mariadb.name" . }}
+        chart: {{ template "mariadb.chart" . }}
+        release: {{ .Release.Name }}
+        component: master
     spec:
       {{- if .Values.schedulerName }}
-      schedulerName: "{{ .Values.schedulerName }}"
+      schedulerName: {{ .Values.schedulerName | quote }}
       {{- end }}
-      serviceAccountName: "{{ template "mariadb.serviceAccountName" . }}"
+      serviceAccountName: {{ template "mariadb.serviceAccountName" . }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
@@ -54,8 +54,8 @@ spec:
             - topologyKey: "kubernetes.io/hostname"
               labelSelector:
                 matchLabels:
-                  app: "{{ template "mariadb.name" . }}"
-                  release: "{{ .Release.Name }}"
+                  app: {{ template "mariadb.name" . }}
+                  release: {{ .Release.Name }}
       {{- else if eq .Values.master.antiAffinity "soft" }}
       affinity:
       {{- with .Values.master.affinity  }}
@@ -63,171 +63,173 @@ spec:
       {{- end }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            podAffinityTerm:
-              topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchLabels:
-                  app: "{{ template "mariadb.name" . }}"
-                  release: "{{ .Release.Name }}"
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app: {{ template "mariadb.name" . }}
+                    release: {{ .Release.Name }}
       {{- else}}
       {{- with .Values.master.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
+      affinity: {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- end }}
       {{- if .Values.master.nodeSelector }}
-      nodeSelector:
-        {{ toYaml .Values.master.nodeSelector | nindent 8 }}
+      nodeSelector: {{ toYaml .Values.master.nodeSelector | nindent 8 }}
       {{- end -}}
       {{- with .Values.master.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
+      tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
 {{- include "mariadb.imagePullSecrets" . | indent 6 }}
       initContainers:
-      {{- if .Values.master.extraInitContainers }}
-{{ tpl .Values.master.extraInitContainers . | indent 6}}
-      {{- end }}
-      {{- if and .Values.volumePermissions.enabled .Values.master.persistence.enabled }}
-      - name: volume-permissions
-        image: {{ template "mariadb.volumePermissions.image" . }}
-        imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
-        command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}", "{{ .Values.master.persistence.mountPath }}"]
-        securityContext:
-          runAsUser: 0
-        resources: {{ toYaml .Values.volumePermissions.resources | nindent 10 }}
-        volumeMounts:
-        - name: data
-          mountPath: {{ .Values.master.persistence.mountPath }}
-      {{- end }}
+        {{- if .Values.master.extraInitContainers }}
+{{ tpl .Values.master.extraInitContainers . | indent 8 }}
+        {{- end }}
+        {{- if and .Values.volumePermissions.enabled .Values.master.persistence.enabled }}
+        - name: volume-permissions
+          image: {{ template "mariadb.volumePermissions.image" . }}
+          imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+          command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}", "{{ .Values.master.persistence.mountPath }}"]
+          securityContext:
+            runAsUser: 0
+          resources: {{ toYaml .Values.volumePermissions.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.master.persistence.mountPath }}
+        {{- end }}
       containers:
-      - name: "mariadb"
-        image: {{ template "mariadb.image" . }}
-        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-        env:
-        {{- if .Values.image.debug}}
-        - name: BITNAMI_DEBUG
-          value: "true"
-        {{- end }}
-        {{- if .Values.master.extraFlags }}
-        - name: MARIADB_EXTRA_FLAGS
-          value: "{{ .Values.master.extraFlags }}"
-        {{- end }}
-        - name: MARIADB_ROOT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "mariadb.secretName" . }}
-              key: mariadb-root-password
-        {{- if .Values.db.user }}
-        - name: MARIADB_USER
-          value: "{{ .Values.db.user }}"
-        - name: MARIADB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "mariadb.secretName" . }}
-              key: mariadb-password
-        {{- end }}
-        - name: MARIADB_DATABASE
-          value: "{{ .Values.db.name }}"
-        {{- if .Values.replication.enabled }}
-        - name: MARIADB_REPLICATION_MODE
-          value: "master"
-        - name: MARIADB_REPLICATION_USER
-          value: "{{ .Values.replication.user }}"
-        - name: MARIADB_REPLICATION_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "mariadb.secretName" . }}
-              key: mariadb-replication-password
-        {{- end }}
-        ports:
-        - name: mysql
-          containerPort: 3306
-        {{- if .Values.master.livenessProbe.enabled }}
-        livenessProbe:
-          exec:
-            command: ["sh", "-c", "exec mysqladmin status -uroot -p$MARIADB_ROOT_PASSWORD"]
-          initialDelaySeconds: {{ .Values.master.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.master.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.master.livenessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.master.livenessProbe.successThreshold }}
-          failureThreshold: {{ .Values.master.livenessProbe.failureThreshold }}
-        {{- end }}
-        {{- if .Values.master.readinessProbe.enabled }}
-        readinessProbe:
-          exec:
-            command: ["sh", "-c", "exec mysqladmin status -uroot -p$MARIADB_ROOT_PASSWORD"]
-          initialDelaySeconds: {{ .Values.master.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.master.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.master.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.master.readinessProbe.successThreshold }}
-          failureThreshold: {{ .Values.master.readinessProbe.failureThreshold }}
-        {{- end }}
-        resources:
-{{ toYaml .Values.master.resources | indent 10 }}
-        volumeMounts:
-        - name: data
-          mountPath: {{ .Values.master.persistence.mountPath }}
-          {{- if .Values.master.persistence.subPath }}
-          subPath: {{ .Values.master.persistence.subPath }}
-          {{- end }}
-        {{- if or (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql,sql.gz}") .Values.initdbScriptsConfigMap .Values.initdbScripts }}
-        - name: custom-init-scripts
-          mountPath: /docker-entrypoint-initdb.d
-        {{- end }}
-        {{- if .Values.master.config }}
-        - name: config
-          mountPath: /opt/bitnami/mariadb/conf/my.cnf
-          subPath: my.cnf
-       {{- end }}
-{{- if .Values.metrics.enabled }}
-      - name: metrics
-        image: {{ template "mariadb.metrics.image" . }}
-        imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
-        env:
-        - name: MARIADB_ROOT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "mariadb.secretName" . }}
-              key: mariadb-root-password
-        command:
-          - sh
-          - -c
-          - >-
-            DATA_SOURCE_NAME="root:$MARIADB_ROOT_PASSWORD@(localhost:3306)/"
-            /bin/mysqld_exporter
-            {{- range .Values.metrics.extraArgs.master }}
-            {{ . }}
+        - name: "mariadb"
+          image: {{ template "mariadb.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          env:
+            {{- if .Values.image.debug}}
+            - name: BITNAMI_DEBUG
+              value: "true"
             {{- end }}
-        ports:
+            {{- if .Values.master.extraFlags }}
+            - name: MARIADB_EXTRA_FLAGS
+              value: "{{ .Values.master.extraFlags }}"
+            {{- end }}
+            - name: MARIADB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "mariadb.secretName" . }}
+                  key: mariadb-root-password
+            {{- if .Values.db.user }}
+            - name: MARIADB_USER
+              value: "{{ .Values.db.user }}"
+            - name: MARIADB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "mariadb.secretName" . }}
+                  key: mariadb-password
+            {{- end }}
+            - name: MARIADB_DATABASE
+              value: "{{ .Values.db.name }}"
+            {{- if .Values.replication.enabled }}
+            - name: MARIADB_REPLICATION_MODE
+              value: "master"
+            - name: MARIADB_REPLICATION_USER
+              value: "{{ .Values.replication.user }}"
+            - name: MARIADB_REPLICATION_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "mariadb.secretName" . }}
+                  key: mariadb-replication-password
+            {{- end }}
+            {{- if .Values.master.extraEnvVars }}
+            {{- tpl (toYaml .Values.master.extraEnvVars) $ | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: mysql
+              containerPort: 3306
+          {{- if .Values.master.livenessProbe.enabled }}
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "exec mysqladmin status -uroot -p$MARIADB_ROOT_PASSWORD"]
+            initialDelaySeconds: {{ .Values.master.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.master.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.master.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.master.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.master.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.master.readinessProbe.enabled }}
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "exec mysqladmin status -uroot -p$MARIADB_ROOT_PASSWORD"]
+            initialDelaySeconds: {{ .Values.master.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.master.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.master.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.master.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.master.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.master.resources }}
+          resources: {{ toYaml .Values.master.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.master.persistence.mountPath }}
+              {{- if .Values.master.persistence.subPath }}
+              subPath: {{ .Values.master.persistence.subPath }}
+              {{- end }}
+            {{- if or (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql,sql.gz}") .Values.initdbScriptsConfigMap .Values.initdbScripts }}
+            - name: custom-init-scripts
+              mountPath: /docker-entrypoint-initdb.d
+            {{- end }}
+            {{- if .Values.master.config }}
+            - name: config
+              mountPath: /opt/bitnami/mariadb/conf/my.cnf
+              subPath: my.cnf
+            {{- end }}
+        {{- if .Values.metrics.enabled }}
         - name: metrics
-          containerPort: 9104
-        {{- if .Values.metrics.livenessProbe.enabled }}
-        livenessProbe:
-          httpGet:
-            path: /metrics
-            port: metrics
-          initialDelaySeconds: {{ .Values.metrics.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.metrics.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.metrics.livenessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.metrics.livenessProbe.successThreshold }}
-          failureThreshold: {{ .Values.metrics.livenessProbe.failureThreshold }}
+          image: {{ template "mariadb.metrics.image" . }}
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
+          env:
+            - name: MARIADB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "mariadb.secretName" . }}
+                  key: mariadb-root-password
+          command:
+            - sh
+            - -c
+            - >-
+              DATA_SOURCE_NAME="root:$MARIADB_ROOT_PASSWORD@(localhost:3306)/"
+              /bin/mysqld_exporter
+              {{- range .Values.metrics.extraArgs.master }}
+              {{ . }}
+              {{- end }}
+          ports:
+            - name: metrics
+              containerPort: 9104
+          {{- if .Values.metrics.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: {{ .Values.metrics.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.metrics.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.metrics.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.metrics.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.metrics.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.metrics.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: {{ .Values.metrics.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.metrics.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.metrics.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.metrics.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.metrics.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.metrics.resources }}
+          resources: {{ toYaml .Values.metrics.resources | nindent 12 }}
+          {{- end }}
         {{- end }}
-        {{- if .Values.metrics.readinessProbe.enabled }}
-        readinessProbe:
-          httpGet:
-            path: /metrics
-            port: metrics
-          initialDelaySeconds: {{ .Values.metrics.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.metrics.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.metrics.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.metrics.readinessProbe.successThreshold }}
-          failureThreshold: {{ .Values.metrics.readinessProbe.failureThreshold }}
-        {{- end }}
-        resources:
-{{ toYaml .Values.metrics.resources | indent 10 }}
-{{- end }}
       volumes:
         {{- if .Values.master.config }}
         - name: config

--- a/stable/mariadb/templates/slave-statefulset.yaml
+++ b/stable/mariadb/templates/slave-statefulset.yaml
@@ -4,18 +4,18 @@ kind: StatefulSet
 metadata:
   name: {{ template "slave.fullname" . }}
   labels:
-    app: "{{ template "mariadb.name" . }}"
-    chart: "{{ template "mariadb.chart" . }}"
-    component: "slave"
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+    app: {{ template "mariadb.name" . }}
+    chart: {{ template "mariadb.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: slave
 spec:
   selector:
     matchLabels:
-      release: "{{ .Release.Name }}"
-      component: "slave"
-      app: "{{ template "mariadb.name" . }}"
-  serviceName: "{{ template "slave.fullname" . }}"
+      app: {{ template "mariadb.name" . }}
+      release: {{ .Release.Name }}
+      component: slave
+  serviceName: {{ template "slave.fullname" . }}
   replicas: {{ .Values.slave.replicas }}
   updateStrategy:
     type: {{ .Values.slave.updateStrategy.type }}
@@ -27,19 +27,19 @@ spec:
       {{- if .Values.slave.annotations }}
       annotations:
         {{- range $key, $value := .Values.slave.annotations }}
-        {{ $key }}: '{{ $value }}'
+        {{ $key }}: {{ $value }}
         {{- end }}
       {{- end }}
       labels:
-        app: "{{ template "mariadb.name" . }}"
-        component: "slave"
-        release: "{{ .Release.Name }}"
-        chart: "{{ template "mariadb.chart" . }}"
+        app: {{ template "mariadb.name" . }}
+        chart: {{ template "mariadb.chart" . }}
+        release: {{ .Release.Name }}
+        component: slave
     spec:
       {{- if .Values.schedulerName }}
-      schedulerName: "{{ .Values.schedulerName }}"
+      schedulerName: {{ .Values.schedulerName | quote }}
       {{- end }}
-      serviceAccountName: "{{ template "mariadb.serviceAccountName" . }}"
+      serviceAccountName: {{ template "mariadb.serviceAccountName" . }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
@@ -55,8 +55,8 @@ spec:
             - topologyKey: "kubernetes.io/hostname"
               labelSelector:
                 matchLabels:
-                  app: "{{ template "mariadb.name" . }}"
-                  release: "{{ .Release.Name }}"
+                  app: {{ template "mariadb.name" . }}
+                  release: {{ .Release.Name }}
       {{- else if eq .Values.slave.antiAffinity "soft" }}
       affinity:
       {{- with .Values.slave.affinity  }}
@@ -64,164 +64,169 @@ spec:
       {{- end }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            podAffinityTerm:
-              topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchLabels:
-                  app: "{{ template "mariadb.name" . }}"
-                  release: "{{ .Release.Name }}"
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app: {{ template "mariadb.name" . }}
+                    release: {{ .Release.Name }}
       {{- else}}
       {{- with .Values.slave.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
+      affinity: {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- end }}
       {{- if .Values.slave.nodeSelector }}
-      nodeSelector:
-        {{ toYaml .Values.slave.nodeSelector | nindent 8 }}
+      nodeSelector: {{ toYaml .Values.slave.nodeSelector | nindent 8 }}
       {{- end -}}
       {{- with .Values.slave.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
+      tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
 {{- include "mariadb.imagePullSecrets" . | indent 6 }}
       initContainers:
-      {{- if .Values.master.extraInitContainers }}
+        {{- if .Values.master.extraInitContainers }}
 {{ tpl .Values.master.extraInitContainers . | indent 6}}
-      {{- end }}
-      {{- if and .Values.volumePermissions.enabled .Values.slave.persistence.enabled }}
-      - name: volume-permissions
-        image: {{ template "mariadb.volumePermissions.image" . }}
-        imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
-        command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}", "/bitnami/mariadb"]
-        securityContext:
-          runAsUser: 0
-        resources: {{ toYaml .Values.volumePermissions.resources | nindent 10 }}
-        volumeMounts:
-        - name: data
-          mountPath: /bitnami/mariadb
-      {{- end }}
+        {{- end }}
+        {{- if and .Values.volumePermissions.enabled .Values.slave.persistence.enabled }}
+        - name: volume-permissions
+          image: {{ template "mariadb.volumePermissions.image" . }}
+          imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+          command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}", "/bitnami/mariadb"]
+          securityContext:
+            runAsUser: 0
+          resources: {{ toYaml .Values.volumePermissions.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /bitnami/mariadb
+        {{- end }}
       containers:
-      - name: "mariadb"
-        image: {{ template "mariadb.image" . }}
-        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-        env:
-        {{- if .Values.image.debug}}
-        - name: BITNAMI_DEBUG
-          value: "true"
-        {{- end }}
-        {{- if .Values.slave.extraFlags }}
-        - name: MARIADB_EXTRA_FLAGS
-          value: "{{ .Values.slave.extraFlags }}"
-        {{- end }}
-        - name: MARIADB_REPLICATION_MODE
-          value: "slave"
-        - name: MARIADB_MASTER_HOST
-          value: {{ template "mariadb.fullname" . }}
-        - name: MARIADB_MASTER_PORT_NUMBER
-          value: "{{ .Values.service.port }}"
-        - name: MARIADB_MASTER_ROOT_USER
-          value: "root"
-        - name: MARIADB_MASTER_ROOT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "mariadb.secretName" . }}
-              key: mariadb-root-password
-        - name: MARIADB_REPLICATION_USER
-          value: "{{ .Values.replication.user }}"
-        - name: MARIADB_REPLICATION_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "mariadb.secretName" . }}
-              key: mariadb-replication-password
-        ports:
-        - name: mysql
-          containerPort: 3306
-        {{- if .Values.slave.livenessProbe.enabled }}
-        livenessProbe:
-          exec:
-            command: ["sh", "-c", "exec mysqladmin status -uroot -p$MARIADB_MASTER_ROOT_PASSWORD"]
-          initialDelaySeconds: {{ .Values.slave.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.slave.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.slave.livenessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.slave.livenessProbe.successThreshold }}
-          failureThreshold: {{ .Values.slave.livenessProbe.failureThreshold }}
-        {{- end }}
-        {{- if .Values.slave.readinessProbe.enabled }}
-        readinessProbe:
-          exec:
-            command: ["sh", "-c", "exec mysqladmin status -uroot -p$MARIADB_MASTER_ROOT_PASSWORD"]
-          initialDelaySeconds: {{ .Values.slave.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.slave.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.slave.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.slave.readinessProbe.successThreshold }}
-          failureThreshold: {{ .Values.slave.readinessProbe.failureThreshold }}
-        {{- end }}
-        resources:
-{{ toYaml .Values.slave.resources | indent 10 }}
-        volumeMounts:
-        - name: data
-          mountPath: /bitnami/mariadb
-{{- if .Values.slave.config }}
-        - name: config
-          mountPath: /opt/bitnami/mariadb/conf/my.cnf
-          subPath: my.cnf
-{{- end }}
-{{- if .Values.metrics.enabled }}
-      - name: metrics
-        image: {{ template "mariadb.metrics.image" . }}
-        imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
-        env:
-        - name: MARIADB_ROOT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "mariadb.secretName" . }}
-              key: mariadb-root-password
-        command:
-          - sh
-          - -c
-          - >-
-            DATA_SOURCE_NAME="root:$MARIADB_ROOT_PASSWORD@(localhost:3306)/"
-            /bin/mysqld_exporter
-            {{- range .Values.metrics.extraArgs.slave }}
-            {{ . }}
+        - name: "mariadb"
+          image: {{ template "mariadb.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          env:
+            {{- if .Values.image.debug}}
+            - name: BITNAMI_DEBUG
+              value: "true"
             {{- end }}
-        ports:
+            {{- if .Values.slave.extraFlags }}
+            - name: MARIADB_EXTRA_FLAGS
+              value: "{{ .Values.slave.extraFlags }}"
+            {{- end }}
+            - name: MARIADB_REPLICATION_MODE
+              value: "slave"
+            - name: MARIADB_MASTER_HOST
+              value: {{ template "mariadb.fullname" . }}
+            - name: MARIADB_MASTER_PORT_NUMBER
+              value: "{{ .Values.service.port }}"
+            - name: MARIADB_MASTER_ROOT_USER
+              value: "root"
+            - name: MARIADB_MASTER_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "mariadb.secretName" . }}
+                  key: mariadb-root-password
+            - name: MARIADB_REPLICATION_USER
+              value: "{{ .Values.replication.user }}"
+            - name: MARIADB_REPLICATION_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "mariadb.secretName" . }}
+                  key: mariadb-replication-password
+            {{- if .Values.slave.extraEnvVars }}
+            {{- tpl (toYaml .Values.slave.extraEnvVars) $ | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: mysql
+              containerPort: 3306
+          {{- if .Values.slave.livenessProbe.enabled }}
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "exec mysqladmin status -uroot -p$MARIADB_MASTER_ROOT_PASSWORD"]
+            initialDelaySeconds: {{ .Values.slave.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.slave.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.slave.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.slave.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.slave.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.slave.readinessProbe.enabled }}
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "exec mysqladmin status -uroot -p$MARIADB_MASTER_ROOT_PASSWORD"]
+            initialDelaySeconds: {{ .Values.slave.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.slave.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.slave.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.slave.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.slave.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.slave.resources }}
+          resources: {{ toYaml .Values.slave.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /bitnami/mariadb
+            {{- if .Values.slave.config }}
+            - name: config
+              mountPath: /opt/bitnami/mariadb/conf/my.cnf
+              subPath: my.cnf
+            {{- end }}
+        {{- if .Values.metrics.enabled }}
         - name: metrics
-          containerPort: 9104
-        {{- if .Values.metrics.livenessProbe.enabled }}
-        livenessProbe:
-          httpGet:
-            path: /metrics
-            port: metrics
-          initialDelaySeconds: {{ .Values.metrics.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.metrics.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.metrics.livenessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.metrics.livenessProbe.successThreshold }}
-          failureThreshold: {{ .Values.metrics.livenessProbe.failureThreshold }}
+          image: {{ template "mariadb.metrics.image" . }}
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
+          env:
+            - name: MARIADB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "mariadb.secretName" . }}
+                  key: mariadb-root-password
+          command:
+            - sh
+            - -c
+            - >-
+              DATA_SOURCE_NAME="root:$MARIADB_ROOT_PASSWORD@(localhost:3306)/"
+              /bin/mysqld_exporter
+              {{- range .Values.metrics.extraArgs.slave }}
+              {{ . }}
+              {{- end }}
+          ports:
+            - name: metrics
+              containerPort: 9104
+          {{- if .Values.metrics.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: {{ .Values.metrics.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.metrics.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.metrics.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.metrics.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.metrics.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.metrics.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: {{ .Values.metrics.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.metrics.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.metrics.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.metrics.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.metrics.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.metrics.resources }}
+          resources: {{ toYaml .Values.metrics.resources | nindent 12 }}
+          {{- end }}
         {{- end }}
-        {{- if .Values.metrics.readinessProbe.enabled }}
-        readinessProbe:
-          httpGet:
-            path: /metrics
-            port: metrics
-          initialDelaySeconds: {{ .Values.metrics.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.metrics.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.metrics.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.metrics.readinessProbe.successThreshold }}
-          failureThreshold: {{ .Values.metrics.readinessProbe.failureThreshold }}
-        {{- end }}
-        resources:
-{{ toYaml .Values.metrics.resources | indent 10 }}
-{{- end }}
       volumes:
-      {{- if .Values.slave.config }}
+        {{- if .Values.slave.config }}
         - name: config
           configMap:
             name: {{ template "slave.fullname" . }}
-      {{- end }}
-{{- if .Values.slave.persistence.enabled }}
+        {{- end }}
+{{- if not .Values.slave.persistence.enabled }}
+        - name: "data"
+          emptyDir: {}
+{{- else }}
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -239,8 +244,5 @@ spec:
           requests:
             storage: {{ .Values.slave.persistence.size | quote }}
         {{ include "mariadb.slave.storageClass" . }}
-{{- else }}
-        - name: "data"
-          emptyDir: {}
 {{- end }}
 {{- end }}

--- a/stable/mariadb/values-production.yaml
+++ b/stable/mariadb/values-production.yaml
@@ -229,11 +229,19 @@ master:
     ## Persistent Volume size
     ##
     size: 8Gi
-    ##
+
   extraInitContainers: |
   # - name: do-something
   #   image: busybox
   #   command: ['do', 'something']
+
+  ## An array to add extra environment variables
+  ## For example:
+  ## extraEnvVars:
+  ##  - name: TZ
+  ##    value: "Europe/Paris"
+  ##
+  # extraEnvVars:
 
   ## Configure MySQL with a custom my.cnf file
   ## ref: https://mysql.com/kb/en/mysql/configuring-mysql-with-mycnf/#example-of-configuration-file
@@ -307,7 +315,7 @@ slave:
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   # annotations:
   #   key: value
-  #   another-key: another-value  
+  #   another-key: another-value
 
   ## MariaDB additional command line flags
   ## Can be used to specify command line flags, for example:
@@ -350,11 +358,19 @@ slave:
     ## Persistent Volume size
     ##
     size: 8Gi
-    ##
+
   extraInitContainers: |
   # - name: do-something
   #   image: busybox
   #   command: ['do', 'something']
+
+  ## An array to add extra environment variables
+  ## For example:
+  ## extraEnvVars:
+  ##  - name: TZ
+  ##    value: "Europe/Paris"
+  ##
+  # extraEnvVars:
 
   ## Configure MySQL slave with a custom my.cnf file
   ## ref: https://mysql.com/kb/en/mysql/configuring-mysql-with-mycnf/#example-of-configuration-file

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -229,11 +229,19 @@ master:
     ## Persistent Volume size
     ##
     size: 8Gi
-    ##
+
   extraInitContainers: |
   # - name: do-something
   #   image: busybox
   #   command: ['do', 'something']
+
+  ## An array to add extra environment variables
+  ## For example:
+  ## extraEnvVars:
+  ##  - name: TZ
+  ##    value: "Europe/Paris"
+  ##
+  # extraEnvVars:
 
   ## Configure MySQL with a custom my.cnf file
   ## ref: https://mysql.com/kb/en/mysql/configuring-mysql-with-mycnf/#example-of-configuration-file
@@ -351,11 +359,19 @@ slave:
     ## Persistent Volume size
     ##
     size: 8Gi
-    ##
+
   extraInitContainers: |
   # - name: do-something
   #   image: busybox
   #   command: ['do', 'something']
+
+  ## An array to add extra environment variables
+  ## For example:
+  ## extraEnvVars:
+  ##  - name: TZ
+  ##    value: "Europe/Paris"
+  ##
+  # extraEnvVars:
 
   ## Configure MySQL slave with a custom my.cnf file
   ## ref: https://mysql.com/kb/en/mysql/configuring-mysql-with-mycnf/#example-of-configuration-file


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR adds a couple of new parameters:

- `slave.extraEnvVars`
- `master.extraEnvVars`

These two parameters allow users to specify extra environment variables for Master and Slave replicas.

#### Special notes for your reviewer:

This PR also indent the statefulsets YAML manifests.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
