### PR TITLE
[stable/sentry] Added Sentry s3 "endpoint_url" variable

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 3.0.2
+version: 3.0.3
 appVersion: 9.1.2
 keywords:
   - debugging

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -145,6 +145,7 @@ Parameter                                            | Description              
 `filestore.s3.accessKey`                             | S3 access key                                                                                              | `nil`
 `filestore.s3.secretKey`                             | S3 secret key                                                                                              | `nil`
 `filestore.s3.bucketName`                            | The name of the S3 bucket                                                                                  | `nil`
+`filestore.s3.endpointUrl`                           | The endpoint url of the S3 (using for "MinIO S3 Backend")                                                  | `nil`
 `config.configYml`                                   | Sentry config.yml file                                                                                     | ``
 `config.sentryConfPy`                                | Sentry sentry.conf.py file                                                                                 | ``
 `metrics.enabled`                                    | Start an exporter for sentry metrics                                                                       | `false`

--- a/stable/sentry/templates/configmap.yaml
+++ b/stable/sentry/templates/configmap.yaml
@@ -79,6 +79,7 @@ data:
       access_key: '{{ .Values.filestore.s3.accessKey }}'
       secret_key: '{{ .Values.filestore.s3.secretKey }}'
       bucket_name: '{{ .Values.filestore.s3.bucketName }}'
+      endpoint_url: '{{ .Values.filestore.s3.endpointUrl }}'
 
     {{ end }}
 

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -160,6 +160,7 @@ filestore:
   #  accessKey:
   #  secretKey:
   #  bucketName:
+  #  endpointUrl:
 
 ## Configure ingress resource that allow you to access the
 ## Sentry installation. Set up the URL


### PR DESCRIPTION
#### What this PR does / why we need it:
We need to this PR to configure S3 endpoint url when we want use **MinIO S3 Backend** it must be configurable.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
