### PR TITLE
[stable/oauth2-proxy] feature: add PodDisruptionBudget.

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 2.0.0
+version: 2.1.0
 apiVersion: v1
 appVersion: 4.0.0
 home: http://www.videntity.com/

--- a/stable/oauth2-proxy/README.md
+++ b/stable/oauth2-proxy/README.md
@@ -89,6 +89,8 @@ Parameter | Description | Default
 `nodeSelector` | node labels for pod assignment | `{}`
 `podAnnotations` | annotations to add to each pod | `{}`
 `podLabels` | additional labesl to add to each pod | `{}`
+`podDisruptionBudget.enabled`| Enabled creation of PodDisruptionBudget (only if replicaCount > 1) | true
+`podDisruptionBudget.minAvailable`| minAvailable parameter for PodDisruptionBudget | 1
 `priorityClassName` | priorityClassName | `nil`
 `readinessProbe.enabled` | enable Kubernetes readinessProbe. Disable to use oauth2-proxy with Istio mTLS. See [Istio FAQ](https://istio.io/help/faq/security/#k8s-health-checks) | `true`
 `readinessProbe.initialDelaySeconds` | number of seconds | 0

--- a/stable/oauth2-proxy/default-values.yaml
+++ b/stable/oauth2-proxy/default-values.yaml
@@ -1,0 +1,1 @@
+# Leave this file empty to ensure that CI runs builds against the default configuration in values.yaml.

--- a/stable/oauth2-proxy/pdb-values.yaml
+++ b/stable/oauth2-proxy/pdb-values.yaml
@@ -1,0 +1,2 @@
+# Will trigger creation of pdb
+replicaCount: 2

--- a/stable/oauth2-proxy/templates/poddisruptionbudget.yaml
+++ b/stable/oauth2-proxy/templates/poddisruptionbudget.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.podDisruptionBudget.enabled (gt (.Values.replicaCount | int) 1) }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: {{ template "oauth2-proxy.name" . }}
+    chart: {{ template "oauth2-proxy.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.controller.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "oauth2-proxy.name" . }}
+      release: {{ .Release.Name }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+{{- end }}

--- a/stable/oauth2-proxy/values.yaml
+++ b/stable/oauth2-proxy/values.yaml
@@ -141,6 +141,12 @@ podAnnotations: {}
 podLabels: {}
 replicaCount: 1
 
+## PodDisruptionBudget settings
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
 # whether to use http or https
 httpScheme: http
 


### PR DESCRIPTION
#### What this PR does / why we need it:

add PodDisruptionBudget.

#### Special notes for your reviewer:

Enable it by default.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
