### PR TITLE
Update github template to be more specific about naming convention.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,4 +40,4 @@ even continue reviewing your changes.
 - [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
 - [ ] Chart Version bumped
 - [ ] Variables are documented in the README.md
-- [ ] Title of the PR starts with chart name (e.g. `[stable/chart]`)
+- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)


### PR DESCRIPTION
Lot of PRs have literaly "[stable/charts]" in their name.