### PR TITLE
[stable/velero] Add tolerations for restic

### DIFF
--- a/stable/velero/Chart.yaml
+++ b/stable/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.1.0
 description: A Helm chart for velero
 name: velero
-version: 2.1.7
+version: 2.1.8
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/stable/velero/README.md
+++ b/stable/velero/README.md
@@ -101,6 +101,7 @@ Parameter | Description | Default
 `restic.podVolumePath` | Location of pod volumes on the host | `/var/lib/kubelet/pods`
 `restic.privileged` | Whether restic should run as a privileged pod. Only necessary in special cases (SELinux) | `false`
 `restic.resources` | Restic DaemonSet resource requests and limits | `{}`
+`restic.tolerations` | Restic DaemonSet tolerations | `[]`
 `configMaps` | Velero ConfigMaps | `[]`
 
 ## How to

--- a/stable/velero/templates/restic-daemonset.yaml
+++ b/stable/velero/templates/restic-daemonset.yaml
@@ -96,4 +96,8 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- with .Values.restic.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/stable/velero/values.yaml
+++ b/stable/velero/values.yaml
@@ -160,6 +160,8 @@ restic:
   privileged: false
   # Resource requests/limits to specify for the Restic daemonset deployment. Optional.
   resources: {}
+  # Tolerations to use for the Restic daemonset. Optional.
+  tolerations: []
 
 # Backup schedules to create.
 # Eg:


### PR DESCRIPTION
Signed-off-by: Andrey Izotikov <andrsp@gmail.com>

#### Is this a new chart
> No

#### What this PR does / why we need it:
Adds missing tolerations field for restic daemonset.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
