### PR TITLE
[incubator/sparkoperator] Fix a typo in Configuration section

### DIFF
--- a/incubator/sparkoperator/Chart.yaml
+++ b/incubator/sparkoperator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sparkoperator
 description: A Helm chart for Spark on Kubernetes operator
-version: 0.4.2
+version: 0.4.3
 appVersion: v1beta2-1.0.1-2.4.4
 keywords:
   - spark

--- a/incubator/sparkoperator/README.md
+++ b/incubator/sparkoperator/README.md
@@ -29,7 +29,7 @@ The following table lists the configurable parameters of the Spark operator char
 | `replicas`         | The number of replicas of the operator Deployment                                     | 1                         |
 | `sparkJobNamespace`       | K8s namespace where Spark jobs are to be deployed            | ``                                     |
 | `enableWebhook`           | Whether to enable mutating admission webhook                 | false                                  |
-| `enableMetrics`           | Whether to expose metrics to be scraped by Premetheus        | true                                   |
+| `enableMetrics`           | Whether to expose metrics to be scraped by Prometheus        | true                                   |
 | `controllerThreads`       | Number of worker threads used by the SparkApplication controller | 10                                 |
 | `ingressUrlFormat`        | Ingress URL format                                           | ""                                     |
 | `logLevel`                | Logging verbosity level                                      | 2                                      |

--- a/stable/spark/Chart.yaml
+++ b/stable/spark/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: spark
-version: 1.0.0
+version: 1.0.1
 appVersion: 1.5.1
 description: Fast and general-purpose cluster computing system.
 home: http://spark.apache.org

--- a/stable/spark/Chart.yaml
+++ b/stable/spark/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: spark
-version: 1.0.1
+version: 1.0.0
 appVersion: 1.5.1
 description: Fast and general-purpose cluster computing system.
 home: http://spark.apache.org


### PR DESCRIPTION
Fix the typo in spark operation configuration section.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
