### PR TITLE
[stable/mediawiki] disable https port by default

### DIFF
--- a/stable/mediawiki/Chart.yaml
+++ b/stable/mediawiki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mediawiki
-version: 8.2.7
+version: 8.2.8
 appVersion: 1.33.1
 description: Extremely powerful, scalable software and a feature-rich wiki implementation that uses PHP to process and display data stored in a database.
 home: http://www.mediawiki.org/

--- a/stable/mediawiki/README.md
+++ b/stable/mediawiki/README.md
@@ -83,7 +83,7 @@ The following table lists the configurable parameters of the MediaWiki chart and
 | `service.type`                       | Kubernetes Service type                                     | `LoadBalancer`                                          |
 | `service.loadBalancer`               | Kubernetes LoadBalancerIP to request                        | `nil`                                                   |
 | `service.port`                       | Service HTTP port                                           | `80`                                                    |
-| `service.httpsPort`                  | Service HTTPS port                                          | `443`                                                   |
+| `service.httpsPort`                  | Service HTTPS port                                          | `""`                                                    |
 | `service.externalTrafficPolicy`      | Enable client source IP preservation                        | `Cluster`                                               |
 | `service.nodePorts.http`             | Kubernetes http node port                                   | `""`                                                    |
 | `service.nodePorts.https`            | Kubernetes https node port                                  | `""`                                                    |

--- a/stable/mediawiki/templates/deployment.yaml
+++ b/stable/mediawiki/templates/deployment.yaml
@@ -113,8 +113,10 @@ spec:
         ports:
         - name: http
           containerPort: 80
+        {{- if .Values.service.httpsPort }}
         - name: https
           containerPort: 443
+        {{ end }}
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:

--- a/stable/mediawiki/templates/svc.yaml
+++ b/stable/mediawiki/templates/svc.yaml
@@ -22,11 +22,13 @@ spec:
     {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePorts.http)))}}
     nodePort: {{ .Values.service.nodePorts.http }}
     {{- end }}
+  {{- if .Values.service.httpsPort }}
   - name: https
     port: {{ .Values.service.httpsPort }}
     targetPort: https
     {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePorts.https)))}}
     nodePort: {{ .Values.service.nodePorts.https }}
     {{- end }}
+  {{- end }}
   selector:
     app: {{ template "mediawiki.name" . }}

--- a/stable/mediawiki/values.yaml
+++ b/stable/mediawiki/values.yaml
@@ -151,7 +151,8 @@ service:
   # HTTP Port
   port: 80
   # HTTPS Port
-  httpsPort: 443
+  ## Set this to any value (recommended: 443) to enable the https service port
+  # httpsPort: 443
   ## Use nodePorts to requets some specific ports when usin NodePort
   ## nodePorts:
   ##   http: <to set explicitly, choose port between 30000-32767>


### PR DESCRIPTION
#### What this PR does / why we need it:
Unless you are terminating SSL inside the pod, this is not needed. Most people will terminate SSL at the ingress, be it a LoadBalancer, Istio, or some other Ingress.

#### Which issue this PR fixes
- fixes #18087

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
