### PR TITLE
[stable/kong] Allow custom secret name for postgresql

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.23.0
+version: 0.24.0
 appVersion: 1.3

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -150,6 +150,7 @@ Postgres is enabled by default.
 | ------------------------------| ------------------------------------------------------------------------| ----------------------|
 | cassandra.enabled             | Spin up a new cassandra cluster for Kong                                | `false`               |
 | postgresql.enabled            | Spin up a new postgres instance for Kong                                | `true`                |
+| postgresql.existingSecret     | Existing secret with postgres credentials                               | ``                    |
 | waitImage.repository          | Image used to wait for database to become ready                         | `busybox`             |
 | waitImage.tag                 | Tag for image used to wait for database to become ready                 | `latest`              |
 | env.database                  | Choose either `postgres`, `cassandra` or `"off"` (for dbless mode)      | `postgres`            |

--- a/stable/kong/templates/_helpers.tpl
+++ b/stable/kong/templates/_helpers.tpl
@@ -18,6 +18,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "kong.postgresql.secret" -}}
+{{- default (include "kong.postgresql.fullname" .) .Values.postgresql.existingSecret }}
+{{- end -}}
+
 {{- define "kong.cassandra.fullname" -}}
 {{- $name := default "cassandra" .Values.cassandra.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
@@ -216,7 +220,7 @@ Create the ingress servicePort value string
   - name: KONG_PG_PASSWORD
     valueFrom:
       secretKeyRef:
-        name: {{ template "kong.postgresql.fullname" . }}
+        name: {{ template "kong.postgresql.secret" . }}
         key: postgresql-password
   {{- end }}
   {{- if .Values.cassandra.enabled }}

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -157,7 +157,7 @@ spec:
         - name: KONG_PG_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "kong.postgresql.fullname" . }}
+              name: {{ template "kong.postgresql.secret" . }}
               key: postgresql-password
         {{- end }}
         {{- if .Values.cassandra.enabled }}

--- a/stable/kong/templates/migrations-post-upgrade.yaml
+++ b/stable/kong/templates/migrations-post-upgrade.yaml
@@ -41,7 +41,7 @@ spec:
         - name: KONG_PG_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "kong.postgresql.fullname" . }}
+              name: {{ template "kong.postgresql.secret" . }}
               key: postgresql-password
         command: [ "/bin/sh", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
       {{- end }}
@@ -67,7 +67,7 @@ spec:
         - name: KONG_PG_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "kong.postgresql.fullname" . }}
+              name: {{ template "kong.postgresql.secret" . }}
               key: postgresql-password
         {{- end }}
         {{- if .Values.cassandra.enabled }}

--- a/stable/kong/templates/migrations-pre-upgrade.yaml
+++ b/stable/kong/templates/migrations-pre-upgrade.yaml
@@ -41,7 +41,7 @@ spec:
         - name: KONG_PG_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "kong.postgresql.fullname" . }}
+              name: {{ template "kong.postgresql.secret" . }}
               key: postgresql-password
         command: [ "/bin/sh", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
       {{- end }}
@@ -67,7 +67,7 @@ spec:
         - name: KONG_PG_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "kong.postgresql.fullname" . }}
+              name: {{ template "kong.postgresql.secret" . }}
               key: postgresql-password
         {{- end }}
         {{- if .Values.cassandra.enabled }}

--- a/stable/kong/templates/migrations.yaml
+++ b/stable/kong/templates/migrations.yaml
@@ -36,7 +36,7 @@ spec:
         - name: KONG_PG_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "kong.postgresql.fullname" . }}
+              name: {{ template "kong.postgresql.secret" . }}
               key: postgresql-password
         command: [ "/bin/sh", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
       {{- end }}
@@ -62,7 +62,7 @@ spec:
         - name: KONG_PG_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "kong.postgresql.fullname" . }}
+              name: {{ template "kong.postgresql.secret" . }}
               key: postgresql-password
         {{- end }}
         {{- if .Values.cassandra.enabled }}

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -268,6 +268,7 @@ updateStrategy: {}
 # is set below. In general, you should not set values here if they are set elsewhere.
 env:
   database: postgres
+  nginx_worker_processes: "1"
   proxy_access_log: /dev/stdout
   admin_access_log: /dev/stdout
   admin_gui_access_log: /dev/stdout

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -268,7 +268,6 @@ updateStrategy: {}
 # is set below. In general, you should not set values here if they are set elsewhere.
 env:
   database: postgres
-  nginx_worker_processes: "1"
   proxy_access_log: /dev/stdout
   admin_access_log: /dev/stdout
   admin_gui_access_log: /dev/stdout
@@ -358,6 +357,8 @@ postgresql:
   postgresqlDatabase: kong
   service:
     port: 5432
+  # Existing secret name with postgresql credentials
+  # existingSecret: somesecret
 
 # Custom Kong plugins can be loaded into Kong by mounting the plugin code
 # into the file-system of Kong container.


### PR DESCRIPTION
This will allow to use the same secret name for kong and the postgresql
subchart.

Signed-off-by: Nicolas Salvo <nicolas.salvo@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ x] Chart Version bumped
- [ x] Variables are documented in the README.md
- [ x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
