### PR TITLE
[incubator/rundeck] New-template-annotations

### DIFF
--- a/incubator/rundeck/Chart.yaml
+++ b/incubator/rundeck/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 description: A Rundeck chart for Kubernetes
 name: rundeck
 home: https://github.com/rundeck/rundeck
-version: 0.1.1
-appVersion: 3.0.16
+version: 0.1.2
+appVersion: 3.1.12
 keywords:
 - rundeck
 - jobs
@@ -14,3 +14,7 @@ sources:
 maintainers:
 - name: dwardu89
   email: hello@dwardu.com
+- name: fabioviana
+  email: fabioviana.bh@gmail.com
+- name: dfduarte
+  email: diego.fl.duarte@gmail.com

--- a/incubator/rundeck/README.md
+++ b/incubator/rundeck/README.md
@@ -15,6 +15,7 @@ The following configurations may be set. It is recommended to use values.yaml fo
 Parameter | Description | Default
 --------- | ----------- | -------
 replicaCount | How many replicas to run. Riemann can really only work with one. | 1
+annotations | You can pass annotations inside .spec.template.metadata.annotations. Every value under this is iterated as a key/value and used as a parameter. Useful for KIAM/Kube2IAM and others for example. | ""
 image.repository | Name of the image to run, without the tag. | [rundeck/rundeck](https://github.com/rundeck/rundeck)
 image.tag | The image tag to use. | 3.0.16
 image.pullPolicy | The kubernetes image pull policy. | IfNotPresent

--- a/incubator/rundeck/templates/deployment.yaml
+++ b/incubator/rundeck/templates/deployment.yaml
@@ -15,6 +15,13 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
+      {{- if .Values.annotations }}
+      # Annotations iteration - Useful for KIAM and others
+      annotations:
+        {{- range $key, $value := .Values.annotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "rundeck.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
#### Is this a new chart
> No
#### What this PR does / why we need it:

This PR adds the ability to insert annotations inside spec.templates into this chart using the reffered value.yaml file in this repo.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x ] Chart Version bumped
- [x ] Variables are documented in the README.md
- [x ] Title of the PR starts with chart name (e.g. `[stable/chart]`)
