### PR TITLE
[incubator/janitor] Add hjacobs/kube-janitor

### DIFF
--- a/incubator/janitor/.helmignore
+++ b/incubator/janitor/.helmignore
@@ -1,0 +1,30 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+*.go
+Dockerfile
+*.md
+*.txt
+.travis.yml
+glide.yaml
+glide.lock
+LICENSE
+docs

--- a/incubator/janitor/Chart.yaml
+++ b/incubator/janitor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "v19.9.0"
-description: A Helm chart for running hjacobs/kube-janitor
+description: Clean up (delete) Kubernetes resources after a configured TTL (time to live)
 name: janitor
 version: 0.1.0
 home: https://github.com/hjacobs/kube-janitor

--- a/incubator/janitor/Chart.yaml
+++ b/incubator/janitor/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+appVersion: "v19.9.0"
+description: A Helm chart for running hjacobs/kube-janitor
+name: janitor
+version: 0.1.0
+home: https://github.com/hjacobs/kube-janitor
+maintainers:
+  - name: hjacobs
+    email: henning@jacobs1.de
+  - name: mayppong
+    email: me@mayppong.com
+sources:
+  - https://github.com/hjacobs/kube-janitor

--- a/incubator/janitor/README.md
+++ b/incubator/janitor/README.md
@@ -1,8 +1,12 @@
+# Kube-Janitor
+Kubernetes Janitor cleans up (deletes) Kubernetes resources on (1) a configured TTL (time to live) or (2) a configured expiry date (absolute timestamp).
+
+This chart helps you deploy kube-janitor as CronJob on your Kubernetes cluster. You can find the original repo here: https://github.com/hjacobs/kube-janitor
+
 ## Configuration
 
-https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#cronjob-v1beta1-batch
-
-https://github.com/hjacobs/kube-janitor#configuration
+The deployment option for this chart currently only support CronJob type. Please checkout Kubernete's docs for more info on CronJob's [config options](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#cronjob-v1beta1-batch).
+You can check out more configuration examples on kube-janitor's own [README](https://github.com/hjacobs/kube-janitor#configuration) for more of the package's options.
 
 Some of the default values are not specified in the `values.yaml` and are instead inherited the default from upstream.
 
@@ -14,17 +18,17 @@ Some of the default values are not specified in the `values.yaml` and are instea
 | `cron.schedule`          | `CronJobSpec` for set the schedule of the CronJob resource   | string  | `*/5 * * * *`               |
 | `cron.successfulJobsHistoryLimit` | `CronJobSpec` for number of successful jobs to keep | integer | `3` (k8s default)           |
 | `cron.failedJobsHistoryLimit`     | `CronJobSpec` for number of failed jobs to keep     | integer | `3`                         |
-| `cron.suspend`           | `CronJobSpec` for telling the controller whether to suspend subsequent jobs | boolean | false (k8s default) |
-| `kubejanitor.dryRun`     | Deployed in dry-run mode only. The job will print out what would be done, but does not make changes | boolean | false |
-| `kubejanitor.debug`      | Run in debug-mode                                             | boolean | false |
-| `kubejanitor.once`       | Run once and exit. This MUST BE true for running as a CronJob | boolnea | true  |
-| `kubejanitor.interval`   | Interval for rerunning the execution ONLY USE WHEN not running in CronJob ie. once is set to false | string  | 30s (kube-janitor default)   |
-| `kubejanitor.includeResources`  | List of k8s resource types to include, ex. `deployment,svc,ingress` | all resources (kube-janitor default) |
-| `kubejanitor.excludeResources`  | List of k8s resource types to exclude | events,controllerrevisions (kube-janitor default) |
-| `kubejanitor.includeNamespaces` | List of nameespaces to include | all namespaces (kube-janitor default) |
-| `kubejanitor.excludeNamespaces` | List of nameespaces to exclude | kube-system (kube-janitor default) |
-| `resources`              | `PodSpec` for resource request and limit for CPU and memory | map     | `{}`                        |
-| `restartPolicy`          | `PodSpec` for pod restarting policy on failure              | string  | `OnFailure`                 |
-| `nodeSelector`           | `PodSpec` for defining nodeSelector to deploy the pod on    | map     | |
-| `affinity`               | `PodSpec` for defining affinity to deploy the pod on        | map     | |
-| `tolerations`            | `PodSpec` for defining tolerations to deploy the pod on     | map     | |
+| `cron.suspend`           | `CronJobSpec` for telling the controller whether to suspend subsequent jobs                         | boolean | false (k8s default)          |
+| `kubejanitor.dryRun`     | Deployed in dry-run mode only. The job will print out what would be done, but does not make changes | boolean | false                        |
+| `kubejanitor.debug`      | Run in debug-mode                                             | boolean | false                      |
+| `kubejanitor.once`       | Run once and exit. This MUST BE true for running as a CronJob | boolnea | true                       |
+| `kubejanitor.interval`   | Interval for rerunning the execution ONLY USE WHEN not running in CronJob ie. once is set to false  | string  | 30s (kube-janitor default)   |
+| `kubejanitor.includeResources`  | List of k8s resource types to include, ex. `deployment,svc,ingress` | all resources (kube-janitor default)               | |
+| `kubejanitor.excludeResources`  | List of k8s resource types to exclude                               | events,controllerrevisions (kube-janitor default)  | |
+| `kubejanitor.includeNamespaces` | List of nameespaces to include                                      | all namespaces (kube-janitor default)              | |
+| `kubejanitor.excludeNamespaces` | List of nameespaces to exclude                                      | kube-system (kube-janitor default)                 | |
+| `resources`              | `PodSpec` for resource request and limit for CPU and memory  | map     | `{}`                        |
+| `restartPolicy`          | `PodSpec` for pod restarting policy on failure               | string  | `OnFailure`                 |
+| `nodeSelector`           | `PodSpec` for defining nodeSelector to deploy the pod on     | map     | `{}`                        |
+| `affinity`               | `PodSpec` for defining affinity to deploy the pod on         | map     | `{}`                        |
+| `tolerations`            | `PodSpec` for defining tolerations to deploy the pod on      | map     | `{}`                        |

--- a/incubator/janitor/README.md
+++ b/incubator/janitor/README.md
@@ -1,0 +1,30 @@
+## Configuration
+
+https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#cronjob-v1beta1-batch
+
+https://github.com/hjacobs/kube-janitor#configuration
+
+Some of the default values are not specified in the `values.yaml` and are instead inherited the default from upstream.
+
+| Parameter                | Description                                                  | Type    | Default                     |
+| ------------------------ | ------------------------------------------------------------ | ------- | --------------------------- |
+| `image.repository`       | Image repository                                             | string  | `hjacobs/kube-janitor`      |
+| `image.tag`              | Image tag                                                    | string  | `19.9.0`                    |
+| `image.pullPolicy`       | Image pull policy                                            | string  | `IfNotPresent`              |
+| `cron.schedule`          | `CronJobSpec` for set the schedule of the CronJob resource   | string  | `*/5 * * * *`               |
+| `cron.successfulJobsHistoryLimit` | `CronJobSpec` for number of successful jobs to keep | integer | `3` (k8s default)           |
+| `cron.failedJobsHistoryLimit`     | `CronJobSpec` for number of failed jobs to keep     | integer | `3`                         |
+| `cron.suspend`           | `CronJobSpec` for telling the controller whether to suspend subsequent jobs | boolean | false (k8s default) |
+| `kubejanitor.dryRun`     | Deployed in dry-run mode only. The job will print out what would be done, but does not make changes | boolean | false |
+| `kubejanitor.debug`      | Run in debug-mode                                             | boolean | false |
+| `kubejanitor.once`       | Run once and exit. This MUST BE true for running as a CronJob | boolnea | true  |
+| `kubejanitor.interval`   | Interval for rerunning the execution ONLY USE WHEN not running in CronJob ie. once is set to false | string  | 30s (kube-janitor default)   |
+| `kubejanitor.includeResources`  | List of k8s resource types to include, ex. `deployment,svc,ingress` | all resources (kube-janitor default) |
+| `kubejanitor.excludeResources`  | List of k8s resource types to exclude | events,controllerrevisions (kube-janitor default) |
+| `kubejanitor.includeNamespaces` | List of nameespaces to include | all namespaces (kube-janitor default) |
+| `kubejanitor.excludeNamespaces` | List of nameespaces to exclude | kube-system (kube-janitor default) |
+| `resources`              | `PodSpec` for resource request and limit for CPU and memory | map     | `{}`                        |
+| `restartPolicy`          | `PodSpec` for pod restarting policy on failure              | string  | `OnFailure`                 |
+| `nodeSelector`           | `PodSpec` for defining nodeSelector to deploy the pod on    | map     | |
+| `affinity`               | `PodSpec` for defining affinity to deploy the pod on        | map     | |
+| `tolerations`            | `PodSpec` for defining tolerations to deploy the pod on     | map     | |

--- a/incubator/janitor/templates/_helpers.tpl
+++ b/incubator/janitor/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chart.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/janitor/templates/cluster-role-binding.yaml
+++ b/incubator/janitor/templates/cluster-role-binding.yaml
@@ -1,0 +1,17 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ template "chart.fullname" . }}
+  labels:
+    app: {{ template "chart.name" . }}
+    chart: {{ template "chart.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "chart.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "chart.fullname" . }}
+  namespace: {{ .Release.Namespace }}

--- a/incubator/janitor/templates/cluster-role.yaml
+++ b/incubator/janitor/templates/cluster-role.yaml
@@ -1,0 +1,16 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "chart.fullname" . }}
+  labels:
+    app: {{ template "chart.name" . }}
+    chart: {{ template "chart.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["get", "watch", "list", "delete"]

--- a/incubator/janitor/templates/configmap.yaml
+++ b/incubator/janitor/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "chart.fullname" . }}
+data:
+  rules.yaml: |-
+    # example rules configuration to set TTL for arbitrary objects
+    # see https://github.com/hjacobs/kube-janitor for details
+    rules:
+{{ toYaml .Values.kubejanitor.rules | indent 6 }}

--- a/incubator/janitor/templates/cron-job.yaml
+++ b/incubator/janitor/templates/cron-job.yaml
@@ -1,0 +1,88 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ template "chart.fullname" . }}
+  labels:
+    app: {{ template "chart.name" . }}
+    chart: {{ template "chart.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  schedule: "{{ .Values.cron.schedule }}"
+  {{- if .Values.cron.successfulJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ .Values.cron.successfulJobsHistoryLimit }}
+  {{- end }}
+  {{- if .Values.cron.failedJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.cron.failedJobsHistoryLimit }}
+  {{- end }}
+  {{- if .Values.cron.suspend }}
+  suspend: {{ .Values.cron.suspend }}
+  {{- end }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: {{ template "chart.fullname" . }}
+          restartPolicy: {{ .Values.restartPolicy }}
+          {{- if .Values.nodeSelector }}
+          nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 12 }}
+          {{- end }}
+          {{- if .Values.affinity }}
+          affinity:
+{{ toYaml .Values.affinity | indent 12 }}
+          {{- end }}
+          {{- if .Values.tolerations }}
+          tolerations:
+{{ toYaml .Values.tolerations | indent 12 }}
+          {{- end }}
+          containers:
+          - name: {{ .Chart.Name }}
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            args:
+              {{- if .Values.kubejanitor.dryRun }}
+              - "--dry-run"
+              {{- end }}
+              {{- if .Values.kubejanitor.debug }}
+              - "--debug"
+              {{- end }}
+              {{- if .Values.kubejanitor.once }}
+              - "--once"
+              {{- end }}
+              {{- if .Values.kubejanitor.interval }}
+              - "--interval"
+              - "{{ .Values.kubejanitor.interval }}"
+              {{- end }}
+              {{- if .Values.kubejanitor.includeResources }}
+              - "--include-resources"
+              - "{{ .Values.kubejanitor.includeResources }}"
+              {{- end }}
+              {{- if .Values.kubejanitor.excludeResources }}
+              - "--exclude-resources"
+              - "{{ .Values.kubejanitor.excludeResources }}"
+              {{- end }}
+              {{- if .Values.kubejanitor.includeNamespaces }}
+              - "--include-namespaces"
+              - "{{ .Values.kubejanitor.includeNamespaces }}"
+              {{- end }}
+              {{- if .Values.kubejanitor.excludeNamespaces }}
+              - "--exclude-namespaces"
+              - "{{ .Values.kubejanitor.excludeNamespaces }}"
+              {{- end }}
+              - --rules-file=/config/rules.yaml
+            {{- if .Values.resources }}
+            resources:
+{{ toYaml .Values.resources | indent 14 }}
+            {{- end }}
+            securityContext:
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              runAsUser: 1000
+            volumeMounts:
+              - name: {{ template "chart.fullname" . }}-volume
+                mountPath: /config
+          volumes:
+            - name: {{ template "chart.fullname" . }}-volume
+              configMap:
+                name: {{ template "chart.fullname" . }}

--- a/incubator/janitor/templates/service-account.yaml
+++ b/incubator/janitor/templates/service-account.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "chart.fullname" . }}
+  labels:
+    app: {{ template "chart.name" . }}
+    chart: {{ template "chart.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}

--- a/incubator/janitor/values.yaml
+++ b/incubator/janitor/values.yaml
@@ -1,0 +1,44 @@
+image:
+  repository: hjacobs/kube-janitor
+  tag: 19.9.0
+  pullPolicy: IfNotPresent
+
+kubejanitor:
+  dryRun: false
+  debug: false
+  once: true
+  # example rules configuration to set TTL for arbitrary objects
+  # see https://github.com/hjacobs/kube-janitor for details
+  rules: []
+    # - id: require-application-label
+    #   # remove deployments and statefulsets without a label "application"
+    #   resources:
+    #     # resources are prefixed with "XXX" to make sure they are not active by accident
+    #     # modify the rule as needed and remove the "XXX" prefix to activate
+    #     - XXXdeployments
+    #     - XXXstatefulsets
+    #   # see http://jmespath.org/specification.html
+    #   jmespath: "!(spec.template.metadata.labels.application)"
+    #   ttl: 4d
+    # - id: temporary-pr-namespaces
+    #   # delete all namespaces with a name starting with "pr-*"
+    #   resources:
+    #     # resources are prefixed with "XXX" to make sure they are not active by accident
+    #     # modify the rule as needed and remove the "XXX" prefix to activate
+    #     - XXXnamespaces
+    #   # this uses JMESPath's built-in "starts_with" function
+    #   # see http://jmespath.org/specification.html#starts-with
+    #   jmespath: "starts_with(metadata.name, 'pr-')"
+    #   ttl: 4h
+
+cron:
+  schedule: "*/5 * * * *"
+  failedJobsHistoryLimit: 3
+
+restartPolicy: OnFailure
+resources:
+  limits:
+    memory: 100Mi
+  requests:
+    cpu: 5m
+    memory: 100Mi


### PR DESCRIPTION
There is already another chart named kube-janitor by another person so
the name for this chart has been changed to just janitor as OK'ed by the
developer. See (https://github.com/hjacobs/kube-janitor/issues/44)

#### Is this a new chart
Yes.

#### What this PR does / why we need it:
Adds another new chart to the repo

#### Which issue this PR fixes
n/a

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
