### PR TITLE
[stable/velero] Optional extra volumes and volumeMounts

### DIFF
--- a/stable/velero/Chart.yaml
+++ b/stable/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.1.0
 description: A Helm chart for velero
 name: velero
-version: 2.1.8
+version: 2.2.8
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/stable/velero/Chart.yaml
+++ b/stable/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.1.0
 description: A Helm chart for velero
 name: velero
-version: 2.2.8
+version: 2.2.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/stable/velero/README.md
+++ b/stable/velero/README.md
@@ -67,6 +67,8 @@ Parameter | Description | Default
 `initContainers` | InitContainers and their specs to start with the deployment pod | `[]`
 `tolerations` | List of node taints to tolerate | `[]`
 `nodeSelector` | Node labels for pod assignment | `{}`
+`extraVolumes` | Extra volumes for the Velero deployment | `[]`
+`extraVolumeMounts` | Extra volumeMounts for the Velero deployment | `[]`
 `configuration.backupStorageLocation.name` | The name of the cloud provider that will be used to actually store the backups (`aws`, `azure`, `gcp`) | ``
 `configuration.backupStorageLocation.bucket` | The storage bucket where backups are to be uploaded | ``
 `configuration.backupStorageLocation.config.region` | The cloud provider region (AWS only) | ``

--- a/stable/velero/templates/deployment.yaml
+++ b/stable/velero/templates/deployment.yaml
@@ -79,6 +79,9 @@ spec:
             - name: scratch
               mountPath: /scratch
         {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
           env:
             - name: VELERO_SCRATCH_DIR
               value: /scratch
@@ -115,6 +118,9 @@ spec:
           emptyDir: {}
         - name: scratch
           emptyDir: {}
+        {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/stable/velero/values.yaml
+++ b/stable/velero/values.yaml
@@ -33,6 +33,12 @@ tolerations: []
 # Node selector to use for the Velero deployment. Optional.
 nodeSelector: {}
 
+# Extra volumes for the Velero deployment. Optional.
+extraVolumes: []
+
+# Extra volume mounts for the Velero deployment. Optional.
+extraVolumeMounts: []
+
 # Settings for Velero's prometheus metrics. Disabled by default.
 metrics:
   enabled: false

--- a/stable/velero/values.yaml
+++ b/stable/velero/values.yaml
@@ -36,7 +36,7 @@ nodeSelector: {}
 # Extra volumes for the Velero deployment. Optional.
 extraVolumes: []
 
-# Extra volume mounts for the Velero deployment. Optional.
+# Extra volumeMounts for the Velero deployment. Optional.
 extraVolumeMounts: []
 
 # Settings for Velero's prometheus metrics. Disabled by default.


### PR DESCRIPTION
Signed-off-by: Rick Haan <rickhaan94@gmail.com>

#### What this PR does / why we need it:
I would like to add the option to configure extra `volumes` and `volumeMounts`. This could be used for example to add CA certificates to the Velero deployment.

#### Which issue this PR fixes
N.a.

#### Special notes for your reviewer:
N.a.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)