### PR TITLE
[stable/prometheus-operator] fix specifying resources for tlsProxy sidecar of prometheus-operator

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -10,7 +10,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 6.20.2
+version: 6.20.3
 appVersion: 0.32.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -206,10 +206,10 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.serviceMonitor.relabelings` | The `relabel_configs` for scraping the operator instance. | `` |
 | `prometheusOperator.serviceMonitor.selfMonitor` | Enable monitoring of prometheus operator | `true` |
 | `prometheusOperator.tlsProxy.enabled` | Enable a TLS proxy container. Only the `squareup/ghostunnel` command line arguments are currently supported and the secret where the cert is loaded from is expected to be provided by the admission webhook | `true` |
-| `prometheusOperator.tlsProxy.image.repository` | Image pull policy for the TLS proxy container | `IfNotPresent` |
 | `prometheusOperator.tlsProxy.image.repository` | Repository for the TLS proxy container | `squareup/ghostunnel` |
-| `prometheusOperator.tlsProxy.image.resources` | Resource requests and limits for the TLS proxy container | `{}` |
 | `prometheusOperator.tlsProxy.image.tag` | Repository for the TLS proxy container | `v1.4.1` |
+| `prometheusOperator.tlsProxy.image.pullPolicy` | Image pull policy for the TLS proxy container | `IfNotPresent` |
+| `prometheusOperator.tlsProxy.resources` | Resource requests and limits for the TLS proxy container | `{}` |
 | `prometheusOperator.tolerations` | Tolerations for use with node taints https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ | `[]` |
 
 

--- a/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
@@ -72,10 +72,8 @@ spec:
             - --key=cert/key
             - --cert=cert/cert
             - --disable-authentication
-{{- if .Values.prometheusOperator.tlsProxy.resources }}
           resources:
-{{ toYaml .Values.prometheusOperator.tlsProxy.resources | indent 10 }}
-{{- end }}
+{{ toYaml .Values.prometheusOperator.tlsProxy.resources | indent 12 }}
           volumeMounts:
           - name: tls-proxy-secret
             mountPath: /cert


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently the tlsProxy sidecar of prometheus-operator does not allow for configurable resource requests and limits, as the indent is wrong. This PR fixes it, and also updated the README for the tlsProxy values.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
