### PR TITLE
[stable/heapster] upgrade deployment to apps/v1 (mandatory for k8s 1.16+)

### DIFF
--- a/stable/heapster/Chart.yaml
+++ b/stable/heapster/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Heapster enables Container Cluster Monitoring and Performance Analysis.
 name: heapster
-version: 1.0.1
+version: 1.0.2
 appVersion: 1.5.4
 home: https://github.com/kubernetes/heapster
 sources:

--- a/stable/heapster/README.md
+++ b/stable/heapster/README.md
@@ -1,3 +1,9 @@
+# Retired
+
+Heapster work has been stopped. All efforts have been moved to metrics-server.
+Metrics server helm chart is located at: https://github.com/helm/charts/tree/master/stable/metrics-server
+More info on: https://github.com/kubernetes-retired/heapster
+
 # Heapster
 
 [Heapster](https://github.com/kubernetes/heapster) enables Container Cluster Monitoring and Performance Analysis. It collects and interprets various signals like compute resource usage, lifecycle events, etc, and exports cluster metrics via REST endpoints.

--- a/stable/heapster/templates/deployment.yaml
+++ b/stable/heapster/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "heapster.fullname" . }}
@@ -11,6 +11,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "heapster.fullname" . }}
   template:
     metadata:
       annotations:


### PR DESCRIPTION
upgrade deployment to apps/v1 (mandatory for k8s 1.16)

This PR:
- makes heapster compatible with newer versions of k8s.
- chart version bumped
- heapster project was retired -> notes added
 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
