### PR TITLE
[stable/fluent-bit] Added support of Decode_Field_As to Regexp parser

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.7.3
+version: 2.7.4
 appVersion: 1.2.2
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -192,6 +192,12 @@ data:
 {{- if .timeFormat }}
         Time_Format {{ .timeFormat }}
 {{- end }}
+{{- if .decodeFieldAs  }}
+        Decode_Field_As {{ .decodeFieldAs }} {{ .decodeField | default "log" }}
+{{- end}}
+{{- if .extraEntries }}
+{{ .extraEntries | indent 8 }}
+{{- end }}
 {{ end }}
 {{- end }}
 {{- if .Values.parsers.json }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Regexp parser acceps decoders as well as JSON parser, so I added same support to regexp parser section.
My usecase is RoR application with json logging gem:
```
    - name: rubyonrails
      regex: '^\w, \[(?<time>[^ ]*) #\d+\] +(?<severity>\w+) -- : \[(?<req_id>[^ ]*)\] ((?<rails>{[^$]*})|(?<rails_msg>[^{].+))'
      timeKey: 'time'
      timeFormat: '%Y-%m-%dT%H:%M:%S.%L'
      decodeField: rails
      decodeFieldAs: json
```

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
