### PR TITLE
[incubator/zookeeper] Add Prometheus Operator PrometheusRule support

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 2.0.2
+version: 2.1.0
 appVersion: 3.5.5
 description: Centralized service for maintaining configuration information, naming,
   providing distributed synchronization, and providing group services.

--- a/incubator/zookeeper/README.md
+++ b/incubator/zookeeper/README.md
@@ -18,7 +18,8 @@ This chart will do the following:
 * Optionally apply a [Pod Anti-Affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature) to spread the ZooKeeper ensemble across nodes.
 * Optionally start JMX Exporter and Zookeeper Exporter containers inside Zookeeper pods.
 * Optionally create a job which creates Zookeeper chroots (e.g. `/kafka1`).
-* Optionally create a Prometheus ServiceMonitor for each enabled exporter container
+* Optionally create a Prometheus Operator ServiceMonitor resource for each enabled exporter container.
+* Optionally create a Prometheus Operator PrometheusRules resource.
 
 ## Installing the Chart
 You can install the chart with the release name `zookeeper` as below.

--- a/incubator/zookeeper/README.md
+++ b/incubator/zookeeper/README.md
@@ -19,7 +19,7 @@ This chart will do the following:
 * Optionally start JMX Exporter and Zookeeper Exporter containers inside Zookeeper pods.
 * Optionally create a job which creates Zookeeper chroots (e.g. `/kafka1`).
 * Optionally create a Prometheus Operator ServiceMonitor resource for each enabled exporter container.
-* Optionally create a Prometheus Operator PrometheusRules resource.
+* Optionally create a Prometheus Operator PrometheusRule resource.
 
 ## Installing the Chart
 You can install the chart with the release name `zookeeper` as below.

--- a/incubator/zookeeper/templates/prometheusrules.yaml
+++ b/incubator/zookeeper/templates/prometheusrules.yaml
@@ -1,0 +1,20 @@
+{{ if .Values.prometheus.operator.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "zookeeper.fullname" . }}
+  {{- if .Values.prometheus.operator.prometheusRule.namespace }}
+  namespace: {{ .Values.prometheus.operator.prometheusRule.namespace }}
+  {{- end }}
+  labels:
+{{ toYaml .Values.prometheus.operator.prometheusRule.selector | indent 4 }}
+spec:
+  groups:
+  - name: {{ include "zookeeper.fullname" . }}
+    rules:
+{{- $zookeeperFullname := include "zookeeper.fullname" . }}
+{{- range $key, $value := .Values.prometheus.operator.prometheusRule.rules }}
+    - alert: {{ $zookeeperFullname }}-{{ $key }}
+{{ toYaml $value | indent 6 }}
+{{- end }}
+{{- end }}

--- a/incubator/zookeeper/templates/prometheusrules.yaml
+++ b/incubator/zookeeper/templates/prometheusrules.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.prometheus.operator.prometheusRule.enabled }}
+{{ if and (.Values.prometheus.operator.prometheusRule.enabled) (.Values.prometheus.operator.prometheusRule.rules) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/incubator/zookeeper/templates/prometheusrules.yaml
+++ b/incubator/zookeeper/templates/prometheusrules.yaml
@@ -7,10 +7,10 @@ metadata:
   namespace: {{ .Values.prometheus.prometheusRule.namespace }}
   {{- end }}
   labels:
-    {{ toYaml .Values.prometheus.prometheusRule.selector | nindent 4 }}
+    {{- toYaml .Values.prometheus.prometheusRule.selector | nindent 4 }}
 spec:
   groups:
   - name: {{ include "zookeeper.fullname" . }}
     rules:
-      {{ toYaml .Values.prometheus.prometheusRule.rules | nindent 6 }}
+      {{- toYaml .Values.prometheus.prometheusRule.rules | nindent 6 }}
 {{- end }}

--- a/incubator/zookeeper/templates/prometheusrules.yaml
+++ b/incubator/zookeeper/templates/prometheusrules.yaml
@@ -1,20 +1,16 @@
-{{ if and (.Values.prometheus.operator.prometheusRule.enabled) (.Values.prometheus.operator.prometheusRule.rules) }}
+{{ if and (.Values.prometheus.prometheusRule.enabled) (.Values.prometheus.prometheusRule.rules) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ include "zookeeper.fullname" . }}
-  {{- if .Values.prometheus.operator.prometheusRule.namespace }}
-  namespace: {{ .Values.prometheus.operator.prometheusRule.namespace }}
+  {{- if .Values.prometheus.prometheusRule.namespace }}
+  namespace: {{ .Values.prometheus.prometheusRule.namespace }}
   {{- end }}
   labels:
-{{ toYaml .Values.prometheus.operator.prometheusRule.selector | indent 4 }}
+    {{ toYaml .Values.prometheus.prometheusRule.selector | nindent 4 }}
 spec:
   groups:
   - name: {{ include "zookeeper.fullname" . }}
     rules:
-{{- $zookeeperFullname := include "zookeeper.fullname" . }}
-{{- range $key, $value := .Values.prometheus.operator.prometheusRule.rules }}
-    - alert: {{ $zookeeperFullname }}-{{ $key }}
-{{ toYaml $value | indent 6 }}
-{{- end }}
+      {{ toYaml .Values.prometheus.prometheusRule.rules | nindent 6 }}
 {{- end }}

--- a/incubator/zookeeper/templates/service.yaml
+++ b/incubator/zookeeper/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
     chart: {{ template "zookeeper.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- if .Values.service.annotations }}}
+{{- if .Values.service.annotations }}
   annotations:
 {{- with .Values.service.annotations }}
 {{ toYaml . | indent 4 }}

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -239,7 +239,7 @@ prometheus:
     selector: {}
 
   prometheusRule:
-    ## If true a PrometheusRules resource will be installed
+    ## If true a PrometheusRule resource will be installed
     enabled: false
     # namespace: monitoring
 

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -239,34 +239,30 @@ prometheus:
     selector: {}
 
   prometheusRule:
-    ## Add Prometheus Rules?
+    ## If true a PrometheusRules resource will be installed
     enabled: false
-
-    ## Namespace in which to install the PrometheusRule. Defaults to the same as everything else.
     # namespace: monitoring
 
-    ## Labels to add to the PrometheusRule so it is picked up by the operator.
-    ## If using the [Helm Chart](https://github.com/helm/charts/tree/master/stable/prometheus-operator) this is the name of the Helm release and 'app: prometheus-operator'
-    selector:
-      app: prometheus-operator
-      release: prometheus
+    ## The selector the Prometheus instance is searching for
+    ## [Default Prometheus Operator selector] (https://github.com/helm/charts/blob/f5a751f174263971fafd21eee4e35416d6612a3d/stable/prometheus-operator/templates/prometheus/prometheus.yaml#L102)
+    selector: {}
 
     ## Some example rules. It might be an idea to limit these down to the current release e.g. max(zk_synced_followers{service="my-zookeeper-release"}) < 2
-    rules:
-      ZookeeperSyncedFollowers:
-        annotations:
-          message: The number of synced followers for the leader node in Zookeeper deployment {{ "{{" }} $labels.service {{ "}}" }} is less than 2. This usually means that some of the Zookeeper nodes aren't communicating properly. If it doesn't resolve itself you can try killing the pods (one by one).
-        expr: max(zk_synced_followers) by (service) < 2
-        for: 5m
-        labels:
-          severity: critical
-      ZookeeperOutstandingRequests:
-        annotations:
-          message: The number of outstanding requests for Zookeeper pod {{ "{{" }} $labels.pod {{ "}}" }} is greater than 10. This can indicate a performance issue with the Pod or cluster a whole.
-        expr: zk_outstanding_requests > 10
-        for: 5m
-        labels:
-          severity: critical
+    rules: {}
+    #  ZookeeperSyncedFollowers:
+    #    annotations:
+    #      message: The number of synced followers for the leader node in Zookeeper deployment {{ "{{" }} $labels.service {{ "}}" }} is less than 2. This usually means that some of the Zookeeper nodes aren't communicating properly. If it doesn't resolve itself you can try killing the pods (one by one).
+    #    expr: max(zk_synced_followers) by (service) < 2
+    #    for: 5m
+    #    labels:
+    #      severity: critical
+    #  ZookeeperOutstandingRequests:
+    #    annotations:
+    #      message: The number of outstanding requests for Zookeeper pod {{ "{{" }} $labels.pod {{ "}}" }} is greater than 10. This can indicate a performance issue with the Pod or cluster a whole.
+    #    expr: zk_outstanding_requests > 10
+    #    for: 5m
+    #    labels:
+    #      severity: critical
 
 ## Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -247,16 +247,16 @@ prometheus:
     ## [Default Prometheus Operator selector] (https://github.com/helm/charts/blob/f5a751f174263971fafd21eee4e35416d6612a3d/stable/prometheus-operator/templates/prometheus/prometheus.yaml#L102)
     selector: {}
 
-    ## Some example rules. It might be an idea to limit these down to the current release e.g. max(zk_synced_followers{service="my-zookeeper-release"}) < 2
-    rules: {}
-    #  ZookeeperSyncedFollowers:
+    ## Some example rules. If you use these it would be a good idea to limit them down to the current release e.g. max(zk_synced_followers{service="my-zookeeper-release"}) < 2
+    rules: []
+    #  - alert: ZookeeperSyncedFollowers
     #    annotations:
     #      message: The number of synced followers for the leader node in Zookeeper deployment {{ "{{" }} $labels.service {{ "}}" }} is less than 2. This usually means that some of the Zookeeper nodes aren't communicating properly. If it doesn't resolve itself you can try killing the pods (one by one).
     #    expr: max(zk_synced_followers) by (service) < 2
     #    for: 5m
     #    labels:
     #      severity: critical
-    #  ZookeeperOutstandingRequests:
+    #  - alert: ZookeeperOutstandingRequests
     #    annotations:
     #      message: The number of outstanding requests for Zookeeper pod {{ "{{" }} $labels.pod {{ "}}" }} is greater than 10. This can indicate a performance issue with the Pod or cluster a whole.
     #    expr: zk_outstanding_requests > 10

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -233,6 +233,7 @@ prometheus:
   serviceMonitor:
     ## If true a ServiceMonitor for each enabled exporter will be installed
     enabled: false
+    ## The namespace where the ServiceMonitor(s) will be installed
     # namespace: monitoring
     ## The selector the Prometheus instance is searching for
     ## [Default Prometheus Operator selector] (https://github.com/helm/charts/blob/f5a751f174263971fafd21eee4e35416d6612a3d/stable/prometheus-operator/templates/prometheus/prometheus.yaml#L74)
@@ -241,6 +242,7 @@ prometheus:
   prometheusRule:
     ## If true a PrometheusRule resource will be installed
     enabled: false
+    ## The namespace where the PrometheusRule will be installed
     # namespace: monitoring
 
     ## The selector the Prometheus instance is searching for

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -233,11 +233,40 @@ prometheus:
   serviceMonitor:
     ## If true a ServiceMonitor for each enabled exporter will be installed
     enabled: false
-    ## The namespace where the ServiceMonitor(s) will be installed
     # namespace: monitoring
     ## The selector the Prometheus instance is searching for
     ## [Default Prometheus Operator selector] (https://github.com/helm/charts/blob/f5a751f174263971fafd21eee4e35416d6612a3d/stable/prometheus-operator/templates/prometheus/prometheus.yaml#L74)
     selector: {}
+
+  prometheusRule:
+    ## Add Prometheus Rules?
+    enabled: false
+
+    ## Namespace in which to install the PrometheusRule. Defaults to the same as everything else.
+    # namespace: monitoring
+
+    ## Labels to add to the PrometheusRule so it is picked up by the operator.
+    ## If using the [Helm Chart](https://github.com/helm/charts/tree/master/stable/prometheus-operator) this is the name of the Helm release and 'app: prometheus-operator'
+    selector:
+      app: prometheus-operator
+      release: prometheus
+
+    ## Some example rules. It might be an idea to limit these down to the current release e.g. max(zk_synced_followers{service="my-zookeeper-release"}) < 2
+    rules:
+      ZookeeperSyncedFollowers:
+        annotations:
+          message: The number of synced followers for the leader node in Zookeeper deployment {{ "{{" }} $labels.service {{ "}}" }} is less than 2. This usually means that some of the Zookeeper nodes aren't communicating properly. If it doesn't resolve itself you can try killing the pods (one by one).
+        expr: max(zk_synced_followers) by (service) < 2
+        for: 5m
+        labels:
+          severity: critical
+      ZookeeperOutstandingRequests:
+        annotations:
+          message: The number of outstanding requests for Zookeeper pod {{ "{{" }} $labels.pod {{ "}}" }} is greater than 10. This can indicate a performance issue with the Pod or cluster a whole.
+        expr: zk_outstanding_requests > 10
+        for: 5m
+        labels:
+          severity: critical
 
 ## Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/


### PR DESCRIPTION
#### What this PR does / why we need it:
Add Prometheus Operator PrometheusRule resource support for easily deploying your alerts alongside Zookeeper.  This compliments the existing ServiceMonitor resource support.

See: https://github.com/coreos/prometheus-operator

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md - Not a convention for this chart
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
