### PR TITLE
[incubator/vault] Bump chart and vault versions

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.21.4
-appVersion: 1.1.2
+version: 0.22.0
+appVersion: 1.2.3
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:


### PR DESCRIPTION
Signed-off-by: Janusz Bialy <janusz.bialy@qlik.com>

#### What this PR does / why we need it:

The purpose of this PR is to bump the minor version of the chart to 0.22.0 and also bump Vault version to 1.2.3. Bumping the chart minor is for the purpose of indicating compatibility with Kubernetes 1.16. 

The actual API group fixes have been addressed in https://github.com/helm/charts/pull/17324!

Vault 1.2.3 Changelog:
https://github.com/hashicorp/vault/blob/master/CHANGELOG.md#123-september-12-2019

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
