### PR TITLE
Stable/Airflow Making the probes configurable.

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 4.1.2
+version: 4.1.3
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -357,6 +357,14 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `flower.service.externalPort`            | (optional) external port for Flower UI                  | `5555`                    |
 | `web.resources`                          | custom resource configuration for web pod               | `{}`                      |
 | `web.initialStartupDelay`                | amount of time webserver pod should sleep before initializing webserver             | `60`  |
+| `web.livenessProbe.periodSeconds`        | interval between probes                         | `60`  |
+| `web.livenessProbe.timeoutSeconds`       | time allowed for a result to return             | `1`  |
+| `web.livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful             | `1`  |
+| `web.livenessProbe.failureThreshold`     | Minimum consecutive successes for the probe to be considered failed                 | `5`  |
+| `web.readinessProbe.periodSeconds`       | interval between probes                         | `60`  |
+| `web.readinessProbe.timeoutSeconds`      | time allowed for a result to return             | `1`  |
+| `web.readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful             | `1`  |
+| `web.readinessProbe.failureThreshold`    | Minimum consecutive successes for the probe to be considered failed                 | `5`  |
 | `web.initialDelaySeconds`                | initial delay on livenessprobe before checking if webserver is available    | `360` |
 | `web.secretsDir`                         | directory in which to mount secrets on webserver nodes  | /var/airflow/secrets      |
 | `web.secrets`                            | secrets to mount as volumes on webserver nodes          | []                        |

--- a/stable/airflow/templates/deployments-web.yaml
+++ b/stable/airflow/templates/deployments-web.yaml
@@ -154,19 +154,20 @@ spec:
               port: web
             ## Keep 6 minutes the delay to allow clean wait of postgres and redis containers
             initialDelaySeconds: {{ .Values.web.initialDelaySeconds }}
-            periodSeconds: 60
-            timeoutSeconds: 1
-            successThreshold: 1
-            failureThreshold: 5
+            periodSeconds: {{ .Values.web.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.web.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.web.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.web.livenessProbe.failureThreshold }}
+
           readinessProbe:
             httpGet:
               path: "{{ .Values.ingress.web.path }}/health"
               port: web
             initialDelaySeconds: {{ .Values.web.initialDelaySeconds }}
-            periodSeconds: 60
-            timeoutSeconds: 1
-            successThreshold: 1
-            failureThreshold: 5
+            periodSeconds: {{ .Values.web.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.web.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.web.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
 {{- if .Values.airflow.extraContainers }}
 {{ toYaml .Values.airflow.extraContainers | indent 8 }}
 {{- end }}

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -220,6 +220,17 @@ web:
     #   memory: "512Mi"
   initialStartupDelay: "60"
   initialDelaySeconds: "360"
+  readinessProbe:
+    periodSeconds: 60
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 5
+  livenessProbe:
+    periodSeconds: 60
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 5
+
 
   ## Support Node, affinity and tolerations for web pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector


### PR DESCRIPTION

#### What this PR does / why we need it:
The airflow web probe values are hardcoded. This allows great configurations and flexibility 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
