### PR TITLE
[incubator/buzzfeed-sso] Add wildcard host support in ingress

### DIFF
--- a/incubator/buzzfeed-sso/Chart.yaml
+++ b/incubator/buzzfeed-sso/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Single sign-on for your Kubernetes services using Google OAuth
 name: buzzfeed-sso
-version: 0.1.0
+version: 0.1.1
 appVersion: 2.0.0
 home: https://github.com/buzzfeed/sso
 sources:

--- a/incubator/buzzfeed-sso/templates/ingress.yaml
+++ b/incubator/buzzfeed-sso/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
   {{- range .Values.ingress.tls }}
     - hosts:
       {{- range .hosts }}
-        - {{ . }}
+        - {{ printf "%s" . | quote }}
       {{- end }}
       secretName: {{ .secretName }}
   {{- end }}


### PR DESCRIPTION
Allow to create k8s ingress with wildcard in tls hosts field

Signed-off-by: Tuan Anh Nguyen <tuananh.nguyen-ext@commercetools.de>

#### Is this a new chart
No

#### What this PR does / why we need it:
Allow to create k8s ingress with wildcard in tls hosts field, example:
```
  ingress:
    annotations:
      kubernetes.io/ingress.class: gce
    tls:
      - secretName: sso-tls-secret
        hosts:
          - "*.sso.example.com"
```
#### Special notes for your reviewer:
Replacement for https://github.com/helm/charts/pull/17612

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
