### PR TITLE
[stable/parse] Add support to Cloud Code scripts & lint chart

### DIFF
--- a/stable/parse/Chart.yaml
+++ b/stable/parse/Chart.yaml
@@ -1,21 +1,21 @@
 apiVersion: v1
 name: parse
-version: 10.0.3
+version: 10.1.0
 appVersion: 3.9.0
 description: Parse is a platform that enables users to add a scalable and powerful backend to launch a full-featured app for iOS, Android, JavaScript, Windows, Unity, and more.
 keywords:
-- parse
-- backend
-- serverless
-- platform
-- mbaas
-- mobile
+  - parse
+  - backend
+  - serverless
+  - platform
+  - mbaas
+  - mobile
 home: https://parse.com/
 icon: https://bitnami.com/assets/stacks/parse/img/parse-stack-220x234.png
 sources:
-- https://github.com/bitnami/bitnami-docker-parse
-- https://github.com/bitnami/bitnami-docker-parse-dashboard
+  - https://github.com/bitnami/bitnami-docker-parse
+  - https://github.com/bitnami/bitnami-docker-parse-dashboard
 maintainers:
-- name: Bitnami
-  email: containers@bitnami.com
+  - name: Bitnami
+    email: containers@bitnami.com
 engine: gotpl

--- a/stable/parse/README.md
+++ b/stable/parse/README.md
@@ -78,6 +78,9 @@ The following table lists the configurable parameters of the Parse chart and the
 | `server.mountPath`                     | Parse server API mount path                                                                                                                               | `/parse`                                                |
 | `server.appId`                         | Parse server App Id                                                                                                                                       | `myappID`                                               |
 | `server.masterKey`                     | Parse server Master Key                                                                                                                                   | `random 10 character alphanumeric string`               |
+| `server.enableCloudCode`               | Enable Parse Cloud Clode                                                                                                                                  | `false`                                                 |
+| `server.cloudCodeScripts`              | Dictionary of Cloud Code scripts                                                                                                                          | `nil`                                                   |
+| `server.existingCloudCodeScriptsCM`    | ConfigMap with Cloud Code scripts (Note: Overrides `cloudCodeScripts`).                                                                                   | `nil`                                                   |
 | `server.resources`                     | The [resources] to allocate for container                                                                                                                 | `{}`                                                    |
 | `server.livenessProbe`                 | Liveness probe configuration for Server                                                                                                                   | `Check values.yaml file`                                |
 | `server.readinessProbe`                | Readiness probe configuration for Server                                                                                                                  | `Check values.yaml file`                                |
@@ -184,6 +187,14 @@ By default, the chart is configured to use Kubernetes Security Context to automa
 As an alternative, this chart supports using an initContainer to change the ownership of the volume before mounting it in the final destination.
 
 You can enable this initContainer by setting `volumePermissions.enabled` to `true`.
+
+### Deploy your Cloud functions with Parse Cloud Code
+
+The [Bitnami Parse](https://github.com/bitnami/bitnami-docker-parse) image allows you to deploy your Cloud functions with Parse Cloud Code (a feature which allows running a piece of code in your Parse Server instead of the user's mobile devices). In order to add your custom scripts, they must be located inside the chart folder `files/cloud` so they can be consumed as a ConfigMap.
+
+Alternatively, you can specify custom scripts using the `cloudCodeScripts` parameter as dict.
+
+In addition to these options, you can also set an external ConfigMap with all the Cloud Code scripts. This is done by setting the `existingCloudCodeScriptsCM` parameter. Note that this will override the two previous options.
 
 ## Upgrading
 

--- a/stable/parse/files/cloud/README.md
+++ b/stable/parse/files/cloud/README.md
@@ -1,0 +1,5 @@
+Place your Cloud Code scripts here. This will not be used in case the value *server.existingCloudCodeScriptsCM* is used.
+
+More information can be found in the link below:
+
+- [How to deploy your Cloud functions with Parse Cloud Code?](https://github.com/bitnami/bitnami-docker-parse#how-to-deploy-your-cloud-functions-with-parse-cloud-code)

--- a/stable/parse/requirements.lock
+++ b/stable/parse/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
-- name: mongodb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 7.2.9
+  - name: mongodb
+    repository: https://kubernetes-charts.storage.googleapis.com/
+    version: 7.2.9
 digest: sha256:380fe3c8514cc2d19b28e5b1a79d83961fa9f9d7f438eba85425dbf8c0b89bbd
 generated: "2019-09-23T09:17:59.529409+02:00"

--- a/stable/parse/requirements.yaml
+++ b/stable/parse/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
-- name: mongodb
-  version: 7.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  - name: mongodb
+    version: 7.x.x
+    repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/parse/templates/_helpers.tpl
+++ b/stable/parse/templates/_helpers.tpl
@@ -255,3 +255,27 @@ but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else 
     {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the Parse Cloud Clode scripts configmap.
+*/}}
+{{- define "parse.cloudCodeScriptsCMName" -}}
+{{- if .Values.server.existingCloudCodeScriptsCM -}}
+    {{- printf "%s" (tpl .Values.server.existingCloudCodeScriptsCM $) -}}
+{{- else -}}
+    {{- printf "%s-cloud-code-scripts" (include "parse.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "parse.tplValue" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "parse.tplValue" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/stable/parse/templates/cloud-code-configmap.yaml
+++ b/stable/parse/templates/cloud-code-configmap.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.server.enableCloudCode (or .Values.server.cloudCodeScripts (.Files.Glob "files/cloud/*.js")) (not .Values.server.existingCloudCodeCM) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "parse.fullname" . }}-cloud-code-scripts
+  labels: {{ include "parse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+data:
+{{- with .Files.Glob "files/cloud/*.js" }}
+{{ .AsConfig | indent 2 }}
+{{- end }}
+{{- if .Values.server.cloudCodeScripts }}
+{{- include "parse.tplValue" (dict "value" .Values.server.cloudCodeScripts "context" $) | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/stable/parse/templates/dashboard-deployment.yaml
+++ b/stable/parse/templates/dashboard-deployment.yaml
@@ -15,14 +15,14 @@ spec:
       labels: {{ include "parse.labels" . | nindent 8 }}
         app.kubernetes.io/component: dashboard
     spec:
-      {{- with .Values.dashboard.affinity }}
-      affinity: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- if .Values.dashboard.affinity }}
+      affinity: {{- include "parse.tplValue" (dict "value" .Values.dashboard.affinity "context" $) | nindent 8 }}
       {{- end }}
-      {{- with .Values.dashboard.nodeSelector }}
-      nodeSelector: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- if .Values.dashboard.nodeSelector }}
+      nodeSelector: {{- include "parse.tplValue" (dict "value" .Values.dashboard.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
-      {{- with .Values.dashboard.tolerations }}
-      tolerations: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- if .Values.dashboard.tolerations }}
+      tolerations: {{- include "parse.tplValue" (dict "value" .Values.dashboard.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.dashboard.securityContext.enabled }}
       securityContext:
@@ -31,64 +31,64 @@ spec:
       {{- end }}
 {{- include "parse.imagePullSecrets" . | indent 6 }}
       containers:
-      - name: parse-dashboard
-        image: {{ include "parse.dashboard.image" . }}
-        imagePullPolicy: {{ .Values.dashboard.image.pullPolicy | quote }}
-        env:
-        - name: PARSE_DASHBOARD_USER
-          value: {{ .Values.dashboard.username }}
-        - name: PARSE_DASHBOARD_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "parse.fullname" . }}
-              key: parse-dashboard-password
-        - name: PARSE_HOST
-          value: {{ include "parse.host" . | quote }}
-        - name: PARSE_USE_HOSTNAME
-          value: {{ ternary "yes" "no" .Values.ingress.enabled | quote }}
-        - name: PARSE_PORT_NUMBER
-          value: {{ include "parse.external-port" . | quote }}
-        - name: PARSE_APP_ID
-          value: {{ .Values.server.appId | quote }}
-        - name: PARSE_MASTER_KEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "parse.fullname" . }}
-              key: master-key
-        - name: PARSE_DASHBOARD_APP_NAME
-          value: {{ .Values.dashboard.appName | quote }}
-        ports:
-        - name: dashboard-http
-          containerPort: 4040
-        {{- if and .Values.dashboard.livenessProbe.enabled }}
-        livenessProbe:
-          httpGet:
-            path: /
-            port: dashboard-http
-          initialDelaySeconds: {{ .Values.dashboard.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.dashboard.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.dashboard.livenessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.dashboard.livenessProbe.successThreshold }}
-          failureThreshold: {{ .Values.dashboard.livenessProbe.failureThreshold }}
-        {{- end }}
-        {{- if and .Values.dashboard.readinessProbe.enabled }}
-        readinessProbe:
-          httpGet:
-            path: /
-            port: dashboard-http
-          initialDelaySeconds: {{ .Values.dashboard.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.dashboard.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.dashboard.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.dashboard.readinessProbe.successThreshold }}
-          failureThreshold: {{ .Values.dashboard.readinessProbe.failureThreshold }}
-        {{- end }}
-        {{- if .Values.dashboard.resources }}
-        resources: {{- toYaml .Values.dashboard.resources | nindent 10 }}
-        {{- end }}
-        volumeMounts:
-        - name: parse-dashboard-data
-          mountPath: /bitnami/parse-dashboard
+        - name: parse-dashboard
+          image: {{ include "parse.dashboard.image" . }}
+          imagePullPolicy: {{ .Values.dashboard.image.pullPolicy | quote }}
+          env:
+            - name: PARSE_DASHBOARD_USER
+              value: {{ .Values.dashboard.username }}
+            - name: PARSE_DASHBOARD_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "parse.fullname" . }}
+                  key: parse-dashboard-password
+            - name: PARSE_HOST
+              value: {{ include "parse.host" . | quote }}
+            - name: PARSE_USE_HOSTNAME
+              value: {{ ternary "yes" "no" .Values.ingress.enabled | quote }}
+            - name: PARSE_PORT_NUMBER
+              value: {{ include "parse.external-port" . | quote }}
+            - name: PARSE_APP_ID
+              value: {{ .Values.server.appId | quote }}
+            - name: PARSE_MASTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "parse.fullname" . }}
+                  key: master-key
+            - name: PARSE_DASHBOARD_APP_NAME
+              value: {{ .Values.dashboard.appName | quote }}
+          ports:
+            - name: dashboard-http
+              containerPort: 4040
+          {{- if and .Values.dashboard.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: dashboard-http
+            initialDelaySeconds: {{ .Values.dashboard.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.dashboard.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.dashboard.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.dashboard.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.dashboard.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if and .Values.dashboard.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: dashboard-http
+            initialDelaySeconds: {{ .Values.dashboard.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.dashboard.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.dashboard.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.dashboard.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.dashboard.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.dashboard.resources }}
+          resources: {{- toYaml .Values.dashboard.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: parse-dashboard-data
+              mountPath: /bitnami/parse-dashboard
       volumes:
-      - name: parse-dashboard-data
-        emptyDir: {}
+        - name: parse-dashboard-data
+          emptyDir: {}
 {{- end -}}

--- a/stable/parse/templates/ingress.yaml
+++ b/stable/parse/templates/ingress.yaml
@@ -13,53 +13,53 @@ metadata:
     {{- end }}
 spec:
   rules:
-  {{- if .Values.dashboard.enabled }}
-  {{- range .Values.ingress.dashboard.hosts }}
-  - host: {{ .name }}
-    http:
-      paths:
-      - path: {{ default "/" .path }}
-        backend:
-          serviceName: {{ include "parse.fullname" $ }}
-          servicePort: dashboard-http
-  {{- end }}
-  {{- end }}
-  {{- range .Values.ingress.server.hosts }}
-  - host: {{ .name }}
-    http:
-      paths:
-      - path: {{ default "/" .path }}
-        backend:
-          serviceName: {{ include "parse.fullname" $ }}
-          servicePort: server-http
-  {{- end }}
+    {{- if .Values.dashboard.enabled }}
+    {{- range .Values.ingress.dashboard.hosts }}
+    - host: {{ .name }}
+      http:
+        paths:
+          - path: {{ default "/" .path }}
+            backend:
+              serviceName: {{ include "parse.fullname" $ }}
+              servicePort: dashboard-http
+    {{- end }}
+    {{- end }}
+    {{- range .Values.ingress.server.hosts }}
+    - host: {{ .name }}
+      http:
+        paths:
+          - path: {{ default "/" .path }}
+            backend:
+              serviceName: {{ include "parse.fullname" $ }}
+              servicePort: server-http
+    {{- end }}
   tls:
-  {{- if .Values.dashboard.enabled }}
-  {{- range .Values.ingress.dashboard.hosts }}
-  {{- if .tls }}
-  - hosts:
-  {{- if .tlsHosts }}
-  {{- range $host := .tlsHosts }}
-    - {{ $host }}
-  {{- end }}
-  {{- else }}
-    - {{ .name }}
-  {{- end }}
-    secretName: {{ .tlsSecret }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- range .Values.ingress.server.hosts }}
-  {{- if .tls }}
-  - hosts:
-  {{- if .tlsHosts }}
-  {{- range $host := .tlsHosts }}
-    - {{ $host }}
-  {{- end }}
-  {{- else }}
-    - {{ .name }}
-  {{- end }}
-    secretName: {{ .tlsSecret }}
-  {{- end }}
-  {{- end }}
+    {{- if .Values.dashboard.enabled }}
+    {{- range .Values.ingress.dashboard.hosts }}
+    {{- if .tls }}
+    - hosts:
+    {{- if .tlsHosts }}
+    {{- range $host := .tlsHosts }}
+      - {{ $host }}
+    {{- end }}
+    {{- else }}
+      - {{ .name }}
+    {{- end }}
+      secretName: {{ .tlsSecret }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- range .Values.ingress.server.hosts }}
+    {{- if .tls }}
+    - hosts:
+    {{- if .tlsHosts }}
+    {{- range $host := .tlsHosts }}
+      - {{ $host }}
+    {{- end }}
+    {{- else }}
+      - {{ .name }}
+    {{- end }}
+      secretName: {{ .tlsSecret }}
+    {{- end }}
+    {{- end }}
 {{- end }}

--- a/stable/parse/templates/server-deployment.yaml
+++ b/stable/parse/templates/server-deployment.yaml
@@ -15,14 +15,14 @@ spec:
       labels: {{ include "parse.labels" . | nindent 8 }}
         app.kubernetes.io/component: server
     spec:
-      {{- with .Values.server.affinity }}
-      affinity: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- if .Values.server.affinity }}
+      affinity: {{- include "parse.tplValue" (dict "value" .Values.server.affinity "context" $) | nindent 8 }}
       {{- end }}
-      {{- with .Values.server.nodeSelector }}
-      nodeSelector: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- if .Values.server.nodeSelector }}
+      nodeSelector: {{- include "parse.tplValue" (dict "value" .Values.server.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
-      {{- with .Values.server.tolerations }}
-      tolerations: {{ tpl (toYaml .) $ | nindent 8 }}
+      {{- if .Values.server.tolerations }}
+      tolerations: {{- include "parse.tplValue" (dict "value" .Values.server.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.server.securityContext.enabled }}
       securityContext:
@@ -32,88 +32,99 @@ spec:
 {{- include "parse.imagePullSecrets" . | indent 6 }}
       {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
       initContainers:
-      - name: volume-permissions
-        image: {{ include "parse.volumePermissions.image" . }}
-        imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
-        command: ["chown", "-R", "{{ .Values.server.securityContext.runAsUser }}:{{ .Values.server.securityContext.fsGroup }}", "/bitnami/parse"]
-        securityContext:
-          runAsUser: 0
-        resources: {{ toYaml .Values.volumePermissions.resources | nindent 10 }}
-        volumeMounts:
-        - name: parse-data
-          mountPath: /bitnami/parse
+        - name: volume-permissions
+          image: {{ include "parse.volumePermissions.image" . }}
+          imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+          command: ["chown", "-R", "{{ .Values.server.securityContext.runAsUser }}:{{ .Values.server.securityContext.fsGroup }}", "/bitnami/parse"]
+          securityContext:
+            runAsUser: 0
+          resources: {{ toYaml .Values.volumePermissions.resources | nindent 10 }}
+          volumeMounts:
+            - name: parse-data
+              mountPath: /bitnami/parse
       {{- end }}
       containers:
-      - name: parse
-        image: {{ include "parse.server.image" . }}
-        imagePullPolicy: {{ .Values.server.image.pullPolicy | quote }}
-        env:
-        - name: PARSE_HOST
-          value: "0.0.0.0"
-        - name: PARSE_PORT_NUMBER
-          value: {{ .Values.server.port | quote }}
-        - name: PARSE_MOUNT_PATH
-          value: {{ .Values.server.mountPath | quote }}
-        - name: PARSE_APP_ID
-          value: {{ .Values.server.appId | quote }}
-        - name: PARSE_MASTER_KEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "parse.fullname" . }}
-              key: master-key
-        - name: MONGODB_HOST
-          value: {{ include "parse.mongodb.fullname" . }}
-        - name: MONGODB_PORT
-          value: "27017"
-        {{- if .Values.mongodb.usePassword }}
-        - name: MONGODB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "parse.mongodb.fullname" . }}
-              key: mongodb-root-password
-        {{- end }}
-        ports:
-        - name: server-http
-          containerPort: {{ .Values.server.port }}
-        {{- if and .Values.server.livenessProbe.enabled }}
-        livenessProbe:
-          httpGet:
-            path: {{ .Values.server.mountPath }}/users
-            port: server-http
-            httpHeaders:
-            - name: X-Parse-Application-Id
-              value: {{ .Values.server.appId }}
-          initialDelaySeconds: {{ .Values.server.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.server.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.server.livenessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.server.livenessProbe.successThreshold }}
-          failureThreshold: {{ .Values.server.livenessProbe.failureThreshold }}
-        {{- end }}
-        {{- if and .Values.server.readinessProbe.enabled }}
-        readinessProbe:
-          httpGet:
-            path: {{ .Values.server.mountPath }}/users
-            port: server-http
-            httpHeaders:
-            - name: X-Parse-Application-Id
-              value: {{ .Values.server.appId }}
-          initialDelaySeconds: {{ .Values.server.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.server.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.server.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.server.readinessProbe.successThreshold }}
-          failureThreshold: {{ .Values.server.readinessProbe.failureThreshold }}
-        {{- end }}
-        {{- if .Values.server.resources }}
-        resources: {{- toYaml .Values.server.resources | nindent 10 }}
-        {{- end }}
-        volumeMounts:
-        - name: parse-data
-          mountPath: /bitnami/parse
+        - name: parse
+          image: {{ include "parse.server.image" . }}
+          imagePullPolicy: {{ .Values.server.image.pullPolicy | quote }}
+          env:
+            - name: PARSE_HOST
+              value: "0.0.0.0"
+            - name: PARSE_PORT_NUMBER
+              value: {{ .Values.server.port | quote }}
+            - name: PARSE_MOUNT_PATH
+              value: {{ .Values.server.mountPath | quote }}
+            - name: PARSE_APP_ID
+              value: {{ .Values.server.appId | quote }}
+            - name: PARSE_MASTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "parse.fullname" . }}
+                  key: master-key
+            - name: PARSE_ENABLE_CLOUD_CODE
+              value: {{ ternary "yes" "no" .Values.server.enableCloudCode | quote }}
+            - name: MONGODB_HOST
+              value: {{ include "parse.mongodb.fullname" . }}
+            - name: MONGODB_PORT
+              value: "27017"
+            {{- if .Values.mongodb.usePassword }}
+            - name: MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "parse.mongodb.fullname" . }}
+                  key: mongodb-root-password
+            {{- end }}
+          ports:
+            - name: server-http
+              containerPort: {{ .Values.server.port }}
+          {{- if and .Values.server.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.server.mountPath }}/users
+              port: server-http
+              httpHeaders:
+                - name: X-Parse-Application-Id
+                  value: {{ .Values.server.appId }}
+            initialDelaySeconds: {{ .Values.server.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.server.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.server.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.server.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.server.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if and .Values.server.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.server.mountPath }}/users
+              port: server-http
+              httpHeaders:
+                - name: X-Parse-Application-Id
+                  value: {{ .Values.server.appId }}
+            initialDelaySeconds: {{ .Values.server.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.server.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.server.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.server.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.server.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.server.resources }}
+          resources: {{- toYaml .Values.server.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: parse-data
+              mountPath: /bitnami/parse
+            {{- if and .Values.server.enableCloudCode (or (.Files.Glob "files/cloud/*.js") .Values.server.cloudCodeScripts .Values.server.existingCloudCodeCM) }}
+            - name: cloud-code-config
+              mountPath: /opt/bitnami/parse/cloud
+            {{- end }}
       volumes:
-      - name: parse-data
-      {{- if .Values.persistence.enabled }}
-        persistentVolumeClaim:
-          claimName: {{ include "parse.fullname" . }}
-      {{- else }}
-        emptyDir: {}
-      {{- end }}
+        {{- if and .Values.server.enableCloudCode (or (.Files.Glob "files/cloud/*.js") .Values.server.cloudCodeScripts .Values.server.existingCloudCodeCM) }}
+        - name: cloud-code-config
+          configMap:
+            name: {{ include "parse.cloudCodeScriptsCMName" . }}
+        {{- end }}
+        - name: parse-data
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "parse.fullname" . }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}

--- a/stable/parse/templates/server-deployment.yaml
+++ b/stable/parse/templates/server-deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   labels: {{ include "parse.labels" . | nindent 4 }}
     app.kubernetes.io/component: server
 spec:
-spec:
   selector:
     matchLabels: {{ include "parse.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: server

--- a/stable/parse/templates/svc.yaml
+++ b/stable/parse/templates/svc.yaml
@@ -12,13 +12,13 @@ spec:
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
   {{- end }}
   ports:
-  - name: server-http
-    port: {{ .Values.server.port }}
-    targetPort: server-http
-  - name: dashboard-http
-    port: {{ .Values.service.port }}
-    targetPort: dashboard-http
-    {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePorts.http)))}}
-    nodePort: {{ .Values.service.nodePorts.http }}
-    {{- end }}
+    - name: server-http
+      port: {{ .Values.server.port }}
+      targetPort: server-http
+    - name: dashboard-http
+      port: {{ .Values.service.port }}
+      targetPort: dashboard-http
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePorts.http)))}}
+      nodePort: {{ .Values.service.nodePorts.http }}
+      {{- end }}
   selector: {{ include "parse.matchLabels" . | nindent 4 }}

--- a/stable/parse/values.yaml
+++ b/stable/parse/values.yaml
@@ -104,6 +104,26 @@ server:
   ##
   # masterKey:
 
+  ## Enable Cloud Clode
+  ## ref: https://github.com/bitnami/bitnami-docker-parse#how-to-deploy-your-cloud-functions-with-parse-cloud-code
+  ##
+  enableCloudCode: false
+
+  ## Cloud Code scripts
+  ## Specify dictionary of Cloud Code scripts and content
+  ## Alternatively, you can put your scripts under the files/cloud directory
+  ##
+  # cloudCodeScripts:
+  #   main.js: |
+  #      Parse.Cloud.define("sayHelloWorld", function(request, response) {
+  #        return "Hello world!";
+  #      });
+
+  ## ConfigMap with Cloud Code scripts
+  ## NOTE: This will override cloudCodeScripts
+  ##
+  # existingCloudCodeScriptsCM
+
   ## Parse Server pods' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
@@ -251,46 +271,46 @@ ingress:
     ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
     ##
     hosts:
-    - name: parse.local
-      path: /
+      - name: parse.local
+        path: /
 
-      ## Set this to true in order to enable TLS on the ingress record
-      ##
-      tls: false
+        ## Set this to true in order to enable TLS on the ingress record
+        ##
+        tls: false
 
-      ## Optionally specify the TLS hosts for the ingress record
-      ## Useful when the Ingress controller supports www-redirection
-      ## If not specified, the above host name will be used
-      # tlsHosts:
-      # - www.parse.local
-      # - parse.local
+        ## Optionally specify the TLS hosts for the ingress record
+        ## Useful when the Ingress controller supports www-redirection
+        ## If not specified, the above host name will be used
+        # tlsHosts:
+        # - www.parse.local
+        # - parse.local
 
-      ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
-      ##
-      tlsSecret: parse.local-tls
+        ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+        ##
+        tlsSecret: parse.local-tls
 
   server:
     ## The list of hostnames to be covered with this ingress record.
     ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
     ##
     hosts:
-    - name: parse-server.local
-      path: /
+      - name: parse-server.local
+        path: /
 
-      ## Set this to true in order to enable TLS on the ingress record
-      ##
-      tls: false
+        ## Set this to true in order to enable TLS on the ingress record
+        ##
+        tls: false
 
-      ## Optionally specify the TLS hosts for the ingress record
-      ## Useful when the Ingress controller supports www-redirection
-      ## If not specified, the above host name will be used
-      # tlsHosts:
-      # - www.parse.local
-      # - parse.local
+        ## Optionally specify the TLS hosts for the ingress record
+        ## Useful when the Ingress controller supports www-redirection
+        ## If not specified, the above host name will be used
+        # tlsHosts:
+        # - www.parse.local
+        # - parse.local
 
-      ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
-      ##
-      tlsSecret: parse.local-tls
+        ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+        ##
+        tlsSecret: parse.local-tls
 
   secrets:
   ## If you're providing your own certificates, please use this to add the certificates as secrets


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### Is this a new chart

No

#### What this PR does / why we need it:

This PR adds support to pass custom Cloud Code scripts to Parse Server. It also lints the chart.

#### Which issue this PR fixes

  - fixes https://github.com/bitnami/charts/issues/1500

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
