### PR TITLE
[stable/k8s-spot-termination-handler] This allows users to set docker registry pull secret.

### DIFF
--- a/stable/k8s-spot-termination-handler/Chart.yaml
+++ b/stable/k8s-spot-termination-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.13.7-1"
 description: The K8s Spot Termination handler handles draining AWS Spot Instances in response to termination requests.
 name: k8s-spot-termination-handler
-version: 1.4.5
+version: 1.4.6
 keywords:
   - spot
   - termination

--- a/stable/k8s-spot-termination-handler/README.md
+++ b/stable/k8s-spot-termination-handler/README.md
@@ -29,6 +29,7 @@ Parameter | Description | Default
 `image.repository` | container image repository | `kubeaws/kube-spot-termination-notice-handler`
 `image.tag` | container image tag | `1.13.7-1`
 `image.pullPolicy` | container image pull policy | `IfNotPresent`
+`imagePullSecrets` | array of imagePullSecrets containing private registry credentials | `[]`
 `noticeUrl` | the URL of EC2 spot instance termination notice endpoint | `http://169.254.169.254/latest/meta-data/spot/termination-time`
 `pollInterval` | the interval in seconds between attempts to poll EC2 metadata API for termination events | `"5"`
 `verbose` | Enable verbose | _not defined_

--- a/stable/k8s-spot-termination-handler/templates/daemonset.yaml
+++ b/stable/k8s-spot-termination-handler/templates/daemonset.yaml
@@ -32,6 +32,10 @@ spec:
     spec:
       hostNetwork: {{ .Values.hostNetwork }}
       serviceAccountName: {{ template "k8s-spot-termination-handler.serviceAccountName" . }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/k8s-spot-termination-handler/values.yaml
+++ b/stable/k8s-spot-termination-handler/values.yaml
@@ -17,6 +17,11 @@ image:
   tag: 1.13.7-1
   pullPolicy: IfNotPresent
 
+## Optional array of imagePullSecrets containing private registry credentials
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# - name: secretName
+
 # URL of EC2 spot instance termination notice endpoint
 noticeUrl: http://169.254.169.254/latest/meta-data/spot/termination-time
 


### PR DESCRIPTION
Signed-off-by: Andri Mar Björgvinsson <andri@andes.is>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
Allows users to set dockerPullSecret in values.yaml
#### Which issue this PR fixes
  - fixes #18156 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
