### PR TITLE
[stable/moodle] Add value to enable probes

### DIFF
--- a/stable/moodle/Chart.yaml
+++ b/stable/moodle/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: moodle
-version: 6.1.11
+version: 6.1.12
 appVersion: 3.7.2
 description: Moodle is a learning platform designed to provide educators, administrators and learners with a single robust, secure and integrated system to create personalised learning environments
 keywords:

--- a/stable/moodle/README.md
+++ b/stable/moodle/README.md
@@ -110,11 +110,13 @@ The following table lists the configurable parameters of the Moodle chart and th
 | `mariadb.persistence.existingClaim`   | If PVC exists&bounded for MariaDB                                                            | `nil` (when nil, new one is requested)         |
 | `mariadb.affinity`                    | Set affinity for the MariaDB pods                                                            | `nil`                                          |
 | `mariadb.resources`                   | CPU/Memory resource requests/limits                                                          | Memory: `256Mi`, CPU: `250m`                   |
+| `livenessProbe.enabled`               | Turn on and off liveness probe                                                               | `true`                                         |
 | `livenessProbe.initialDelaySeconds`   | Delay before liveness probe is initiated                                                     | 600                                            |
 | `livenessProbe.periodSeconds`         | How often to perform the probe                                                               | 3                                              |
 | `livenessProbe.timeoutSeconds`        | When the probe times out                                                                     | 5                                              |
 | `livenessProbe.failureThreshold`      | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 6                                              |
 | `livenessProbe.successThreshold`      | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                                              |
+| `readinessProbe.enabled`              | Turn on and off readiness probe                                                              | `true`                                         |
 | `readinessProbe.initialDelaySeconds`  | Delay before readiness probe is initiated                                                    | 30                                             |
 | `readinessProbe.periodSeconds`        | How often to perform the probe                                                               | 3                                              |
 | `readinessProbe.timeoutSeconds`       | When the probe times out                                                                     | 5                                              |

--- a/stable/moodle/values.yaml
+++ b/stable/moodle/values.yaml
@@ -270,12 +270,14 @@ resources:
 ## Configure extra options for liveness and readiness probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
 livenessProbe:
+  enabled: true
   initialDelaySeconds: 600
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 6
   successThreshold: 1
 readinessProbe:
+  enabled: true
   initialDelaySeconds: 30
   periodSeconds: 5
   timeoutSeconds: 3


### PR DESCRIPTION
Signed-off-by: Andrés Bono <andresbonojimenez@gmail.com>

#### What this PR does / why we need it:

The pods are never setting liveness/readiness probes because `livenessProbe.enabled` and `readinessProbe.enabled` are undefined. See:

https://github.com/helm/charts/blob/9740173f7064f45138cbd7a5a1ace7931b8e2a10/stable/moodle/templates/deployment.yaml#L103
https://github.com/helm/charts/blob/9740173f7064f45138cbd7a5a1ace7931b8e2a10/stable/moodle/templates/deployment.yaml#L114

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
