### PR TITLE
[incubator/sparkoperator] introduce imagePullSecret at sparkoperator deployments

### DIFF
--- a/incubator/sparkoperator/Chart.yaml
+++ b/incubator/sparkoperator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sparkoperator
 description: A Helm chart for Spark on Kubernetes operator
-version: 0.4.3
+version: 0.4.4
 appVersion: v1beta2-1.0.1-2.4.4
 keywords:
   - spark

--- a/incubator/sparkoperator/README.md
+++ b/incubator/sparkoperator/README.md
@@ -26,6 +26,7 @@ The following table lists the configurable parameters of the Spark operator char
 | `operatorImageName`       | The name of the operator image                               | `gcr.io/spark-operator/spark-operator` |
 | `operatorVersion`         | The version of the operator to install                       | `v1beta2-1.0.1-2.4.4`                |
 | `imagePullPolicy`         | Docker image pull policy                                     | `IfNotPresent`                         |
+| `imagePullSecrets`        | Docker image pull secrets                                    |                                        |
 | `replicas`         | The number of replicas of the operator Deployment                                     | 1                         |
 | `sparkJobNamespace`       | K8s namespace where Spark jobs are to be deployed            | ``                                     |
 | `enableWebhook`           | Whether to enable mutating admission webhook                 | false                                  |

--- a/incubator/sparkoperator/templates/crd-cleanup-job.yaml
+++ b/incubator/sparkoperator/templates/crd-cleanup-job.yaml
@@ -17,6 +17,8 @@ spec:
     spec:
       serviceAccountName: {{ include "sparkoperator.serviceAccountName" . }}
       restartPolicy: OnFailure
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | trim | indent 8 }}
       containers:
         - name: delete-sparkapp-crd
           image: {{ .Values.operatorImageName }}:{{ .Values.operatorVersion }}

--- a/incubator/sparkoperator/templates/spark-operator-deployment.yaml
+++ b/incubator/sparkoperator/templates/spark-operator-deployment.yaml
@@ -42,6 +42,8 @@ spec:
         pending: []
     spec:
       serviceAccountName: {{ include "sparkoperator.serviceAccountName" . }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | trim | indent 8 }}
       {{- if .Values.enableWebhook }}
       volumes:
         - name: webhook-certs

--- a/incubator/sparkoperator/templates/webhook-cleanup-job.yaml
+++ b/incubator/sparkoperator/templates/webhook-cleanup-job.yaml
@@ -17,6 +17,8 @@ spec:
     spec:
       serviceAccountName: {{ include "sparkoperator.serviceAccountName" . }}
       restartPolicy: OnFailure
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | trim | indent 8 }}
       containers:
       - name: main
         image: {{ .Values.operatorImageName }}:{{ .Values.operatorVersion }}

--- a/incubator/sparkoperator/templates/webhook-init-job.yaml
+++ b/incubator/sparkoperator/templates/webhook-init-job.yaml
@@ -14,6 +14,8 @@ spec:
     spec:
       serviceAccountName: {{ include "sparkoperator.serviceAccountName" . }}
       restartPolicy: OnFailure
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | trim | indent 8 }}
       containers:
       - name: main
         image: {{ .Values.operatorImageName }}:{{ .Values.operatorVersion }}

--- a/incubator/sparkoperator/values.yaml
+++ b/incubator/sparkoperator/values.yaml
@@ -1,6 +1,7 @@
 operatorImageName: gcr.io/spark-operator/spark-operator
 operatorVersion: v1beta2-1.0.1-2.4.4
 imagePullPolicy: IfNotPresent
+imagePullSecrets: []
 replicas: 1
 
 rbac:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Which issue this PR fixes
* missing `imagePullSecrets` at deployments so we can use `sparkoperator` images from private docker repos

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
