### PR TITLE
[stable/distributed-tensorflow] Add Dysproz to OWNERS, update owner in Chart.yml

### DIFF
--- a/stable/distributed-tensorflow/Chart.yaml
+++ b/stable/distributed-tensorflow/Chart.yaml
@@ -8,5 +8,5 @@ sources:
 - https://www.tensorflow.org/deploy/distributed
 home: https://www.tensorflow.org
 maintainers:
-- name: cheyang
-  email: cheyang@163.com
+- name: Dysproz
+  email: krasuski.szymon.piotr@gmail.com

--- a/stable/distributed-tensorflow/Chart.yaml
+++ b/stable/distributed-tensorflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for running distributed TensorFlow on Kubernetes
 name: distributed-tensorflow
-version: 0.1.2
+version: 0.1.3
 appVersion: 1.6.0
 sources:
 - https://github.com/tensorflow/tensorflow

--- a/stable/distributed-tensorflow/OWNERS
+++ b/stable/distributed-tensorflow/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- Dysproz
+reviewers:
+- Dysproz
+emeritus:
+- cheyang


### PR DESCRIPTION
As discussed with @zanhsieh in PR #16436, I add myself to OWNERS of this chart and update Chart.yml. I've mentioned previous owner in OWNERS file in emeritus section.

This PR is based on issue #13869 

Signed-off-by: Szymon <krasuski.szymon.piotr@gmail.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped (Should it be bumped in this situation?)
- [x] Variables are documented in the README.md (Owner is not mentioned in README)
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
