### PR TITLE
[stable/nextcloud] Bump to Nextcloud 17

### DIFF
--- a/stable/nextcloud/Chart.yaml
+++ b/stable/nextcloud/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: nextcloud
-version: 1.7.2
-appVersion: 16.0.3
+version: 1.8.0
+appVersion: 17.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
 - nextcloud

--- a/stable/nextcloud/templates/ingress.yaml
+++ b/stable/nextcloud/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "nextcloud.fullname" . }}

--- a/stable/nextcloud/values.yaml
+++ b/stable/nextcloud/values.yaml
@@ -3,7 +3,7 @@
 ##
 image:
   repository: nextcloud
-  tag: 16.0.3-apache
+  tag: 17.0.0-apache
   pullPolicy: IfNotPresent
   # pullSecrets:
   #   - myRegistrKeySecretName


### PR DESCRIPTION
#### Special notes for your reviewer:
- Also fixed compatibility with Kubernetes 1.16 ([kubernetes.io](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/))

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
