### PR TITLE
[stable/postgresql] Fix warning with 'extraEnv' parameter and lint chart

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,22 +1,22 @@
 apiVersion: v1
 name: postgresql
-version: 6.5.0
+version: 6.5.1
 appVersion: 11.5.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:
-- postgresql
-- postgres
-- database
-- sql
-- replication
-- cluster
+  - postgresql
+  - postgres
+  - database
+  - sql
+  - replication
+  - cluster
 home: https://www.postgresql.org/
 icon: https://bitnami.com/assets/stacks/postgresql/img/postgresql-stack-110x117.png
 sources:
-- https://github.com/bitnami/bitnami-docker-postgresql
+  - https://github.com/bitnami/bitnami-docker-postgresql
 maintainers:
-- name: Bitnami
-  email: containers@bitnami.com
-- name: desaintmartin
-  email: cedric@desaintmartin.fr
+  - name: Bitnami
+    email: containers@bitnami.com
+  - name: desaintmartin
+    email: cedric@desaintmartin.fr
 engine: gotpl

--- a/stable/postgresql/templates/_helpers.tpl
+++ b/stable/postgresql/templates/_helpers.tpl
@@ -348,3 +348,16 @@ but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else 
     {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "postgresql.tplValue" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "logstash.tplValue" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/stable/postgresql/templates/metrics-svc.yaml
+++ b/stable/postgresql/templates/metrics-svc.yaml
@@ -16,9 +16,9 @@ spec:
   loadBalancerIP: {{ .Values.metrics.service.loadBalancerIP }}
   {{- end }}
   ports:
-  - name: metrics
-    port: 9187
-    targetPort: metrics
+    - name: metrics
+      port: 9187
+      targetPort: metrics
   selector:
     app: {{ template "postgresql.name" . }}
     release: {{ .Release.Name }}

--- a/stable/postgresql/templates/networkpolicy.yaml
+++ b/stable/postgresql/templates/networkpolicy.yaml
@@ -16,19 +16,19 @@ spec:
   ingress:
     # Allow inbound connections
     - ports:
-      - port: {{ template "postgresql.port" . }}
-    {{- if not .Values.networkPolicy.allowExternal }}
+        - port: {{ template "postgresql.port" . }}
+      {{- if not .Values.networkPolicy.allowExternal }}
       from:
-      - podSelector:
-          matchLabels:
-            {{ template "postgresql.fullname" . }}-client: "true"
-      - podSelector:
-          matchLabels:
-            app: {{ template "postgresql.name" . }}
-            release: {{ .Release.Name | quote }}
-            role: slave
-    {{- end }}
+        - podSelector:
+            matchLabels:
+              {{ template "postgresql.fullname" . }}-client: "true"
+        - podSelector:
+            matchLabels:
+              app: {{ template "postgresql.name" . }}
+              release: {{ .Release.Name | quote }}
+              role: slave
+      {{- end }}
     # Allow prometheus scrapes
     - ports:
-      - port: 9187
+        - port: 9187
 {{- end }}

--- a/stable/postgresql/templates/statefulset-slaves.yaml
+++ b/stable/postgresql/templates/statefulset-slaves.yaml
@@ -68,155 +68,157 @@ spec:
       {{- end }}
       {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
       initContainers:
-      - name: init-chmod-data
-        image: {{ template "postgresql.volumePermissions.image" . }}
-        imagePullPolicy: "{{ .Values.volumePermissions.image.pullPolicy }}"
-        resources:
-{{ toYaml .Values.resources | indent 10 }}
-        command:
-          - sh
-          - -c
-          - |
-            mkdir -p {{ .Values.persistence.mountPath }}/data
-            chmod 700 {{ .Values.persistence.mountPath }}/data
-            find {{ .Values.persistence.mountPath }} -mindepth 0 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | \
-              xargs chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}
-        securityContext:
-          runAsUser: {{ .Values.volumePermissions.securityContext.runAsUser }}
-        volumeMounts:
-        - name: data
-          mountPath: {{ .Values.persistence.mountPath }}
-          subPath: {{ .Values.persistence.subPath }}
+        - name: init-chmod-data
+          image: {{ template "postgresql.volumePermissions.image" . }}
+          imagePullPolicy: "{{ .Values.volumePermissions.image.pullPolicy }}"
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p {{ .Values.persistence.mountPath }}/data
+              chmod 700 {{ .Values.persistence.mountPath }}/data
+              find {{ .Values.persistence.mountPath }} -mindepth 0 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | \
+                xargs chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}
+          securityContext:
+            runAsUser: {{ .Values.volumePermissions.securityContext.runAsUser }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+              subPath: {{ .Values.persistence.subPath }}
       {{- end }}
       containers:
-      - name: {{ template "postgresql.fullname" . }}
-        image: {{ template "postgresql.image" . }}
-        imagePullPolicy: "{{ .Values.image.pullPolicy }}"
-        resources:
-{{ toYaml .Values.resources | indent 10 }}
-        {{- if .Values.securityContext.enabled }}
-        securityContext:
-          runAsUser: {{ .Values.securityContext.runAsUser }}
-        {{- end }}
-        env:
-        - name: BITNAMI_DEBUG
-          value: {{ ternary "true" "false" .Values.image.debug | quote }}
-        - name: POSTGRESQL_VOLUME_DIR
-          value: "{{ .Values.persistence.mountPath }}"
-        - name: POSTGRESQL_PORT_NUMBER
-          value: "{{ template "postgresql.port" . }}"
-        {{- if .Values.persistence.mountPath }}
-        - name: PGDATA
-          value: {{ .Values.postgresqlDataDir | quote }}
-        {{- end }}
-        - name: POSTGRES_REPLICATION_MODE
-          value: "slave"
-        - name: POSTGRES_REPLICATION_USER
-          value: {{ include "postgresql.replication.username" . | quote }}
-        {{- if .Values.usePasswordFile }}
-        - name: POSTGRES_REPLICATION_PASSWORD_FILE
-          value: "/opt/bitnami/postgresql/secrets/postgresql-replication-password"
-        {{- else }}
-        - name: POSTGRES_REPLICATION_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "postgresql.secretName" . }}
-              key: postgresql-replication-password
-        {{- end }}
-        - name: POSTGRES_CLUSTER_APP_NAME
-          value: {{ .Values.replication.applicationName }}
-        - name: POSTGRES_MASTER_HOST
-          value: {{ template "postgresql.fullname" . }}
-        - name: POSTGRES_MASTER_PORT_NUMBER
-          value: {{ include "postgresql.port" . | quote }}
-        {{- if .Values.usePasswordFile }}
-        - name: POSTGRES_PASSWORD_FILE
-          value: "/opt/bitnami/postgresql/secrets/postgresql-password"
-        {{- else }}
-        - name: POSTGRES_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "postgresql.secretName" . }}
-              key: postgresql-password
-        {{- end }}
-        ports:
-        - name: postgresql
-          containerPort: {{ template "postgresql.port" . }}
-        {{- if .Values.livenessProbe.enabled }}
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-           {{- if (include "postgresql.database" .) }}
-            - exec pg_isready -U {{ include "postgresql.username" . | quote }} -d {{ (include "postgresql.database" .) | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
-           {{- else }}
-            - exec pg_isready -U {{ include "postgresql.username" . | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
-           {{- end }}
-          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.livenessProbe.successThreshold }}
-          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
-        {{- end }}
-        {{- if .Values.readinessProbe.enabled }}
-        readinessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - -e
-            {{- include "postgresql.readinessProbeCommand" . | nindent 12 }}
-          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.readinessProbe.successThreshold }}
-          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
-        {{- end }}
-        volumeMounts:
+        - name: {{ template "postgresql.fullname" . }}
+          image: {{ template "postgresql.image" . }}
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          {{- if .Values.securityContext.enabled }}
+          securityContext:
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+          {{- end }}
+          env:
+            - name: BITNAMI_DEBUG
+              value: {{ ternary "true" "false" .Values.image.debug | quote }}
+            - name: POSTGRESQL_VOLUME_DIR
+              value: "{{ .Values.persistence.mountPath }}"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "{{ template "postgresql.port" . }}"
+            {{- if .Values.persistence.mountPath }}
+            - name: PGDATA
+              value: {{ .Values.postgresqlDataDir | quote }}
+            {{- end }}
+            - name: POSTGRES_REPLICATION_MODE
+              value: "slave"
+            - name: POSTGRES_REPLICATION_USER
+              value: {{ include "postgresql.replication.username" . | quote }}
+            {{- if .Values.usePasswordFile }}
+            - name: POSTGRES_REPLICATION_PASSWORD_FILE
+              value: "/opt/bitnami/postgresql/secrets/postgresql-replication-password"
+            {{- else }}
+            - name: POSTGRES_REPLICATION_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "postgresql.secretName" . }}
+                  key: postgresql-replication-password
+            {{- end }}
+            - name: POSTGRES_CLUSTER_APP_NAME
+              value: {{ .Values.replication.applicationName }}
+            - name: POSTGRES_MASTER_HOST
+              value: {{ template "postgresql.fullname" . }}
+            - name: POSTGRES_MASTER_PORT_NUMBER
+              value: {{ include "postgresql.port" . | quote }}
+            {{- if .Values.usePasswordFile }}
+            - name: POSTGRES_PASSWORD_FILE
+              value: "/opt/bitnami/postgresql/secrets/postgresql-password"
+            {{- else }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "postgresql.secretName" . }}
+                  key: postgresql-password
+            {{- end }}
+          ports:
+            - name: postgresql
+              containerPort: {{ template "postgresql.port" . }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                {{- if (include "postgresql.database" .) }}
+                - exec pg_isready -U {{ include "postgresql.username" . | quote }} -d {{ (include "postgresql.database" .) | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
+                {{- else }}
+                - exec pg_isready -U {{ include "postgresql.username" . | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
+                {{- end }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - -e
+                {{- include "postgresql.readinessProbeCommand" . | nindent 16 }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.usePasswordFile }}
+            - name: postgresql-password
+              mountPath: /opt/bitnami/postgresql/secrets/
+            {{- end }}
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+              subPath: {{ .Values.persistence.subPath }}
+            {{ end }}
+            {{- if or (.Files.Glob "files/conf.d/*.conf") .Values.postgresqlExtendedConf .Values.extendedConfConfigMap }}
+            - name: postgresql-extended-config
+              mountPath: /bitnami/postgresql/conf/conf.d/
+            {{- end }}
+            {{- if or (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") .Values.postgresqlConfiguration .Values.pgHbaConfiguration .Values.configurationConfigMap }}
+            - name: postgresql-config
+              mountPath: /bitnami/postgresql/conf
+            {{- end }}
+            {{- if .Values.slave.extraVolumeMounts }}
+            {{- toYaml .Values.slave.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+      volumes:
         {{- if .Values.usePasswordFile }}
         - name: postgresql-password
-          mountPath: /opt/bitnami/postgresql/secrets/
+          secret:
+            secretName: {{ template "postgresql.secretName" . }}
         {{- end }}
-        {{- if .Values.persistence.enabled }}
-        - name: data
-          mountPath: {{ .Values.persistence.mountPath }}
-          subPath: {{ .Values.persistence.subPath }}
-        {{ end }}
+        {{- if or (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") .Values.postgresqlConfiguration .Values.pgHbaConfiguration .Values.configurationConfigMap}}
+        - name: postgresql-config
+          configMap:
+            name: {{ template "postgresql.configurationCM" . }}
+        {{- end }}
         {{- if or (.Files.Glob "files/conf.d/*.conf") .Values.postgresqlExtendedConf .Values.extendedConfConfigMap }}
         - name: postgresql-extended-config
-          mountPath: /bitnami/postgresql/conf/conf.d/
+          configMap:
+            name: {{ template "postgresql.extendedConfigurationCM" . }}
         {{- end }}
-        {{- if or (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") .Values.postgresqlConfiguration .Values.pgHbaConfiguration .Values.configurationConfigMap }}
-        - name: postgresql-config
-          mountPath: /bitnami/postgresql/conf
+        {{- if not .Values.persistence.enabled }}
+        - name: data
+          emptyDir: {}
         {{- end }}
-        {{- if .Values.slave.extraVolumeMounts }}
-        {{- toYaml .Values.slave.extraVolumeMounts | nindent 8 }}
+        {{- if .Values.slave.extraVolumes }}
+        {{- toYaml .Values.slave.extraVolumes | nindent 8 }}
         {{- end }}
-      volumes:
-      {{- if .Values.usePasswordFile }}
-      - name: postgresql-password
-        secret:
-          secretName: {{ template "postgresql.secretName" . }}
-      {{- end }}
-      {{- if or (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") .Values.postgresqlConfiguration .Values.pgHbaConfiguration .Values.configurationConfigMap}}
-      - name: postgresql-config
-        configMap:
-          name: {{ template "postgresql.configurationCM" . }}
-      {{- end }}
-      {{- if or (.Files.Glob "files/conf.d/*.conf") .Values.postgresqlExtendedConf .Values.extendedConfConfigMap }}
-      - name: postgresql-extended-config
-        configMap:
-          name: {{ template "postgresql.extendedConfigurationCM" . }}
-      {{- end }}
-      {{- if not .Values.persistence.enabled }}
-      - name: data
-        emptyDir: {}
-      {{- end }}
-      {{- if .Values.slave.extraVolumes }}
-      {{- toYaml .Values.slave.extraVolumes | nindent 6}}
-      {{- end }}
   updateStrategy:
     type: {{ .Values.updateStrategy.type }}
     {{- if (eq "Recreate" .Values.updateStrategy.type) }}

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -72,256 +72,259 @@ spec:
       {{- end }}
       {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
       initContainers:
-      - name: init-chmod-data
-        image: {{ template "postgresql.volumePermissions.image" . }}
-        imagePullPolicy: "{{ .Values.volumePermissions.image.pullPolicy }}"
-        resources:
-{{ toYaml .Values.resources | indent 10 }}
-        command:
-          - sh
-          - -c
-          - |
-            mkdir -p {{ .Values.persistence.mountPath }}/data
-            chmod 700 {{ .Values.persistence.mountPath }}/data
-            find {{ .Values.persistence.mountPath }} -mindepth 0 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | \
-              xargs chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}
-        securityContext:
-          runAsUser: {{ .Values.volumePermissions.securityContext.runAsUser }}
-        volumeMounts:
-        - name: data
-          mountPath: {{ .Values.persistence.mountPath }}
-          subPath: {{ .Values.persistence.subPath }}
+        - name: init-chmod-data
+          image: {{ template "postgresql.volumePermissions.image" . }}
+          imagePullPolicy: "{{ .Values.volumePermissions.image.pullPolicy }}"
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p {{ .Values.persistence.mountPath }}/data
+              chmod 700 {{ .Values.persistence.mountPath }}/data
+              find {{ .Values.persistence.mountPath }} -mindepth 0 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | \
+                xargs chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}
+          securityContext:
+            runAsUser: {{ .Values.volumePermissions.securityContext.runAsUser }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+              subPath: {{ .Values.persistence.subPath }}
       {{- end }}
       containers:
-      - name: {{ template "postgresql.fullname" . }}
-        image: {{ template "postgresql.image" . }}
-        imagePullPolicy: "{{ .Values.image.pullPolicy }}"
-        resources:
-{{ toYaml .Values.resources | indent 10 }}
-        {{- if .Values.securityContext.enabled }}
-        securityContext:
-          runAsUser: {{ .Values.securityContext.runAsUser }}
+        - name: {{ template "postgresql.fullname" . }}
+          image: {{ template "postgresql.image" . }}
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          {{- if .Values.securityContext.enabled }}
+          securityContext:
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+          {{- end }}
+          env:
+            - name: BITNAMI_DEBUG
+              value: {{ ternary "true" "false" .Values.image.debug | quote }}
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "{{ template "postgresql.port" . }}"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: "{{ .Values.persistence.mountPath }}"
+            {{- if .Values.postgresqlInitdbArgs }}
+            - name: POSTGRES_INITDB_ARGS
+              value: {{ .Values.postgresqlInitdbArgs | quote }}
+            {{- end }}
+            {{- if .Values.postgresqlInitdbWalDir }}
+            - name: POSTGRES_INITDB_WALDIR
+              value: {{ .Values.postgresqlInitdbWalDir | quote }}
+            {{- end }}
+            {{- if .Values.persistence.mountPath }}
+            - name: PGDATA
+              value: {{ .Values.postgresqlDataDir | quote }}
+            {{- end }}
+            {{- if .Values.replication.enabled }}
+            - name: POSTGRES_REPLICATION_MODE
+              value: "master"
+            - name: POSTGRES_REPLICATION_USER
+              value: {{ include "postgresql.replication.username" . | quote }}
+            {{- if .Values.usePasswordFile }}
+            - name: POSTGRES_REPLICATION_PASSWORD_FILE
+              value: "/opt/bitnami/postgresql/secrets/postgresql-replication-password"
+            {{- else }}
+            - name: POSTGRES_REPLICATION_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "postgresql.secretName" . }}
+                  key: postgresql-replication-password
+            {{- end }}
+            {{- if not (eq .Values.replication.synchronousCommit "off")}}
+            - name: POSTGRES_SYNCHRONOUS_COMMIT_MODE
+              value: {{ .Values.replication.synchronousCommit | quote }}
+            - name: POSTGRES_NUM_SYNCHRONOUS_REPLICAS
+              value: {{ .Values.replication.numSynchronousReplicas | quote }}
+            {{- end }}
+            - name: POSTGRES_CLUSTER_APP_NAME
+              value: {{ .Values.replication.applicationName }}
+            {{- end }}
+            - name: POSTGRES_USER
+              value: {{ include "postgresql.username" . | quote }}
+            {{- if .Values.usePasswordFile }}
+            - name: POSTGRES_PASSWORD_FILE
+              value: "/opt/bitnami/postgresql/secrets/postgresql-password"
+            {{- else }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "postgresql.secretName" . }}
+                  key: postgresql-password
+            {{- end }}
+            {{- if (include "postgresql.database" .) }}
+            - name: POSTGRES_DB
+              value: {{ (include "postgresql.database" .) | quote }}
+            {{- end }}
+            {{- if .Values.extraEnv }}
+            {{- include "postgresql.tplValue" (dict "value" .Values.extraEnv "context" $) | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: postgresql
+              containerPort: {{ template "postgresql.port" . }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                {{- if (include "postgresql.database" .) }}
+                - exec pg_isready -U {{ include "postgresql.username" . | quote }} -d {{ (include "postgresql.database" .) | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
+                {{- else }}
+                - exec pg_isready -U {{ include "postgresql.username" . | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
+                {{- end }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - -e
+                {{- include "postgresql.readinessProbeCommand" . | nindent 16 }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          volumeMounts:
+            {{- if or (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql,sql.gz}") .Values.initdbScriptsConfigMap .Values.initdbScripts }}
+            - name: custom-init-scripts
+              mountPath: /docker-entrypoint-initdb.d/
+            {{- end }}
+            {{- if .Values.initdbScriptsSecret }}
+            - name: custom-init-scripts-secret
+              mountPath: /docker-entrypoint-initdb.d/secret
+            {{- end }}
+            {{- if or (.Files.Glob "files/conf.d/*.conf") .Values.postgresqlExtendedConf .Values.extendedConfConfigMap }}
+            - name: postgresql-extended-config
+              mountPath: /bitnami/postgresql/conf/conf.d/
+            {{- end }}
+            {{- if .Values.usePasswordFile }}
+            - name: postgresql-password
+              mountPath: /opt/bitnami/postgresql/secrets/
+            {{- end }}
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+              subPath: {{ .Values.persistence.subPath }}
+            {{- end }}
+            {{- if or (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") .Values.postgresqlConfiguration .Values.pgHbaConfiguration .Values.configurationConfigMap }}
+            - name: postgresql-config
+              mountPath: /bitnami/postgresql/conf
+            {{- end }}
+            {{- if .Values.master.extraVolumeMounts }}
+            {{- toYaml .Values.master.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+{{- if .Values.metrics.enabled }}
+        - name: metrics
+          image: {{ template "postgresql.metrics.image" . }}
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
+         {{- if .Values.metrics.securityContext.enabled }}
+          securityContext:
+            runAsUser: {{ .Values.metrics.securityContext.runAsUser }}
         {{- end }}
-        env:
-        - name: BITNAMI_DEBUG
-          value: {{ ternary "true" "false" .Values.image.debug | quote }}
-        - name: POSTGRESQL_PORT_NUMBER
-          value: "{{ template "postgresql.port" . }}"
-        - name: POSTGRESQL_VOLUME_DIR
-          value: "{{ .Values.persistence.mountPath }}"
-        {{- if .Values.postgresqlInitdbArgs }}
-        - name: POSTGRES_INITDB_ARGS
-          value: {{ .Values.postgresqlInitdbArgs | quote }}
-        {{- end }}
-        {{- if .Values.postgresqlInitdbWalDir }}
-        - name: POSTGRES_INITDB_WALDIR
-          value: {{ .Values.postgresqlInitdbWalDir | quote }}
-        {{- end }}
-        {{- if .Values.persistence.mountPath }}
-        - name: PGDATA
-          value: {{ .Values.postgresqlDataDir | quote }}
-        {{- end }}
-        {{- if .Values.replication.enabled }}
-        - name: POSTGRES_REPLICATION_MODE
-          value: "master"
-        - name: POSTGRES_REPLICATION_USER
-          value: {{ include "postgresql.replication.username" . | quote }}
-        {{- if .Values.usePasswordFile }}
-        - name: POSTGRES_REPLICATION_PASSWORD_FILE
-          value: "/opt/bitnami/postgresql/secrets/postgresql-replication-password"
-        {{- else }}
-        - name: POSTGRES_REPLICATION_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "postgresql.secretName" . }}
-              key: postgresql-replication-password
-        {{- end }}
-        {{- if not (eq .Values.replication.synchronousCommit "off")}}
-        - name: POSTGRES_SYNCHRONOUS_COMMIT_MODE
-          value: {{ .Values.replication.synchronousCommit | quote }}
-        - name: POSTGRES_NUM_SYNCHRONOUS_REPLICAS
-          value: {{ .Values.replication.numSynchronousReplicas | quote }}
-        {{- end }}
-        - name: POSTGRES_CLUSTER_APP_NAME
-          value: {{ .Values.replication.applicationName }}
-        {{- end }}
-        - name: POSTGRES_USER
-          value: {{ include "postgresql.username" . | quote }}
-        {{- if .Values.usePasswordFile }}
-        - name: POSTGRES_PASSWORD_FILE
-          value: "/opt/bitnami/postgresql/secrets/postgresql-password"
-        {{- else }}
-        - name: POSTGRES_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "postgresql.secretName" . }}
-              key: postgresql-password
-        {{- end }}
-        {{- if (include "postgresql.database" .) }}
-        - name: POSTGRES_DB
-          value: {{ (include "postgresql.database" .) | quote }}
-        {{- end }}
-{{- if .Values.extraEnv }}
-{{ tpl (toYaml .Values.extraEnv) $ | indent 8 }}
+          env:
+            {{- $database := required "In order to enable metrics you need to specify a database (.Values.postgresqlDatabase or .Values.global.postgresql.postgresqlDatabase)" (include "postgresql.database" .) }}
+            - name: DATA_SOURCE_URI
+              value: {{ printf "127.0.0.1:%d/%s?sslmode=disable" (int (include "postgresql.port" .)) $database | quote }}
+            {{- if .Values.usePasswordFile }}
+            - name: DATA_SOURCE_PASS_FILE
+              value: "/opt/bitnami/postgresql/secrets/postgresql-password"
+            {{- else }}
+            - name: DATA_SOURCE_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "postgresql.secretName" . }}
+                  key: postgresql-password
+            {{- end }}
+            - name: DATA_SOURCE_USER
+              value: {{ template "postgresql.username" . }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: metrics
+            initialDelaySeconds: {{ .Values.metrics.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.metrics.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.metrics.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.metrics.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.metrics.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: metrics
+            initialDelaySeconds: {{ .Values.metrics.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.metrics.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.metrics.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.metrics.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.metrics.readinessProbe.failureThreshold }}
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.usePasswordFile }}
+            - name: postgresql-password
+              mountPath: /opt/bitnami/postgresql/secrets/
+            {{- end }}
+          ports:
+            - name: metrics
+              containerPort: 9187
+          {{- if .Values.metrics.resources }}
+          resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
+          {{- end }}
 {{- end }}
-        ports:
-        - name: postgresql
-          containerPort: {{ template "postgresql.port" . }}
-        {{- if .Values.livenessProbe.enabled }}
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-           {{- if (include "postgresql.database" .) }}
-            - exec pg_isready -U {{ include "postgresql.username" . | quote }} -d {{ (include "postgresql.database" .) | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
-           {{- else }}
-            - exec pg_isready -U {{ include "postgresql.username" . | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
-           {{- end }}
-          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.livenessProbe.successThreshold }}
-          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
-        {{- end }}
-        {{- if .Values.readinessProbe.enabled }}
-        readinessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - -e
-            {{- include "postgresql.readinessProbeCommand" . | nindent 12 }}
-          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.readinessProbe.successThreshold }}
-          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
-        {{- end }}
-        volumeMounts:
-        {{- if or (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql,sql.gz}") .Values.initdbScriptsConfigMap .Values.initdbScripts }}
-        - name: custom-init-scripts
-          mountPath: /docker-entrypoint-initdb.d/
-        {{- end }}
-        {{- if .Values.initdbScriptsSecret }}
-        - name: custom-init-scripts-secret
-          mountPath: /docker-entrypoint-initdb.d/secret
+      volumes:
+        {{- if or (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") .Values.postgresqlConfiguration .Values.pgHbaConfiguration .Values.configurationConfigMap}}
+        - name: postgresql-config
+          configMap:
+            name: {{ template "postgresql.configurationCM" . }}
         {{- end }}
         {{- if or (.Files.Glob "files/conf.d/*.conf") .Values.postgresqlExtendedConf .Values.extendedConfConfigMap }}
         - name: postgresql-extended-config
-          mountPath: /bitnami/postgresql/conf/conf.d/
+          configMap:
+            name: {{ template "postgresql.extendedConfigurationCM" . }}
         {{- end }}
         {{- if .Values.usePasswordFile }}
         - name: postgresql-password
-          mountPath: /opt/bitnami/postgresql/secrets/
+          secret:
+            secretName: {{ template "postgresql.secretName" . }}
         {{- end }}
-        {{- if .Values.persistence.enabled }}
-        - name: data
-          mountPath: {{ .Values.persistence.mountPath }}
-          subPath: {{ .Values.persistence.subPath }}
+        {{- if  or (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql,sql.gz}") .Values.initdbScriptsConfigMap .Values.initdbScripts }}
+        - name: custom-init-scripts
+          configMap:
+            name: {{ template "postgresql.initdbScriptsCM" . }}
         {{- end }}
-        {{- if or (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") .Values.postgresqlConfiguration .Values.pgHbaConfiguration .Values.configurationConfigMap }}
-        - name: postgresql-config
-          mountPath: /bitnami/postgresql/conf
+        {{- if .Values.initdbScriptsSecret }}
+        - name: custom-init-scripts-secret
+          secret:
+            secretName: {{ template "postgresql.initdbScriptsSecret" . }}
         {{- end }}
-        {{- if .Values.master.extraVolumeMounts }}
-        {{- toYaml .Values.master.extraVolumeMounts | nindent 8 }}
+        {{- if .Values.master.extraVolumes }}
+        {{- toYaml .Values.master.extraVolumes | nindent 8 }}
         {{- end }}
-{{- if .Values.metrics.enabled }}
-      - name: metrics
-        image: {{ template "postgresql.metrics.image" . }}
-        imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
-       {{- if .Values.metrics.securityContext.enabled }}
-        securityContext:
-          runAsUser: {{ .Values.metrics.securityContext.runAsUser }}
-      {{- end }}
-        env:
-        {{- $database := required "In order to enable metrics you need to specify a database (.Values.postgresqlDatabase or .Values.global.postgresql.postgresqlDatabase)" (include "postgresql.database" .) }}
-        - name: DATA_SOURCE_URI
-          value: {{ printf "127.0.0.1:%d/%s?sslmode=disable" (int (include "postgresql.port" .)) $database | quote }}
-        {{- if .Values.usePasswordFile }}
-        - name: DATA_SOURCE_PASS_FILE
-          value: "/opt/bitnami/postgresql/secrets/postgresql-password"
-        {{- else }}
-        - name: DATA_SOURCE_PASS
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "postgresql.secretName" . }}
-              key: postgresql-password
-        {{- end }}
-        - name: DATA_SOURCE_USER
-          value: {{ template "postgresql.username" . }}
-        {{- if .Values.livenessProbe.enabled }}
-        livenessProbe:
-          httpGet:
-            path: /
-            port: metrics
-          initialDelaySeconds: {{ .Values.metrics.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.metrics.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.metrics.livenessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.metrics.livenessProbe.successThreshold }}
-          failureThreshold: {{ .Values.metrics.livenessProbe.failureThreshold }}
-        {{- end }}
-        {{- if .Values.readinessProbe.enabled }}
-        readinessProbe:
-          httpGet:
-            path: /
-            port: metrics
-          initialDelaySeconds: {{ .Values.metrics.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.metrics.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.metrics.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.metrics.readinessProbe.successThreshold }}
-          failureThreshold: {{ .Values.metrics.readinessProbe.failureThreshold }}
-        {{- end }}
-        volumeMounts:
-        {{- if .Values.usePasswordFile }}
-        - name: postgresql-password
-          mountPath: /opt/bitnami/postgresql/secrets/
-        {{- end }}
-        ports:
-        - name: metrics
-          containerPort: 9187
-        resources:
-{{ toYaml .Values.metrics.resources | indent 10 }}
-{{- end }}
-      volumes:
-      {{- if or (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") .Values.postgresqlConfiguration .Values.pgHbaConfiguration .Values.configurationConfigMap}}
-      - name: postgresql-config
-        configMap:
-          name: {{ template "postgresql.configurationCM" . }}
-      {{- end }}
-      {{- if or (.Files.Glob "files/conf.d/*.conf") .Values.postgresqlExtendedConf .Values.extendedConfConfigMap }}
-      - name: postgresql-extended-config
-        configMap:
-          name: {{ template "postgresql.extendedConfigurationCM" . }}
-      {{- end }}
-      {{- if .Values.usePasswordFile }}
-      - name: postgresql-password
-        secret:
-          secretName: {{ template "postgresql.secretName" . }}
-      {{- end }}
-      {{- if  or (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql,sql.gz}") .Values.initdbScriptsConfigMap .Values.initdbScripts }}
-      - name: custom-init-scripts
-        configMap:
-          name: {{ template "postgresql.initdbScriptsCM" . }}
-      {{- end }}
-      {{- if .Values.initdbScriptsSecret }}
-      - name: custom-init-scripts-secret
-        secret:
-          secretName: {{ template "postgresql.initdbScriptsSecret" . }}
-      {{- end }}
-      {{- if .Values.master.extraVolumes }}
-      {{- toYaml .Values.master.extraVolumes | nindent 6}}
-      {{- end }}
 {{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}
-      - name: data
-        persistentVolumeClaim:
+        - name: data
+          persistentVolumeClaim:
 {{- with .Values.persistence.existingClaim }}
-          claimName: {{ tpl . $ }}
+            claimName: {{ tpl . $ }}
 {{- end }}
 {{- else if not .Values.persistence.enabled }}
-      - name: data
-        emptyDir: {}
+        - name: data
+          emptyDir: {}
 {{- else if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
   volumeClaimTemplates:
     - metadata:

--- a/stable/postgresql/templates/svc-headless.yaml
+++ b/stable/postgresql/templates/svc-headless.yaml
@@ -11,9 +11,9 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-  - name: postgresql
-    port: {{ template "postgresql.port" . }}
-    targetPort: postgresql
+    - name: postgresql
+      port: {{ template "postgresql.port" . }}
+      targetPort: postgresql
   selector:
     app: {{ template "postgresql.name" . }}
     release: {{ .Release.Name | quote }}

--- a/stable/postgresql/templates/svc-read.yaml
+++ b/stable/postgresql/templates/svc-read.yaml
@@ -18,12 +18,12 @@ spec:
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
   ports:
-  - name: postgresql
-    port:  {{ template "postgresql.port" . }}
-    targetPort: postgresql
-    {{- if .Values.service.nodePort }}
-    nodePort: {{ .Values.service.nodePort }}
-    {{- end }}
+    - name: postgresql
+      port:  {{ template "postgresql.port" . }}
+      targetPort: postgresql
+      {{- if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
   selector:
     app: {{ template "postgresql.name" . }}
     release: {{ .Release.Name | quote }}

--- a/stable/postgresql/templates/svc.yaml
+++ b/stable/postgresql/templates/svc.yaml
@@ -26,12 +26,12 @@ spec:
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
   ports:
-  - name: postgresql
-    port: {{ template "postgresql.port" . }}
-    targetPort: postgresql
-    {{- if .Values.service.nodePort }}
-    nodePort: {{ .Values.service.nodePort }}
-    {{- end }}
+    - name: postgresql
+      port: {{ template "postgresql.port" . }}
+      targetPort: postgresql
+      {{- if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
   selector:
     app: {{ template "postgresql.name" . }}
     release: {{ .Release.Name | quote }}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### Is this a new chart

No

#### What this PR does / why we need it:

This PR fixes a warning with `extraEnv` parameter when using Helm 1.15 and it lints the Helm chart.

#### Which issue this PR fixes

  - fixes #18145 

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
