### PR TITLE
[stable/grafana] Advertise that this Chart requires 2.12.0.

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 3.12.1
+version: 4.0.0
 appVersion: 6.4.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
@@ -16,3 +16,4 @@ maintainers:
   - name: maorfr
     email: maor.friedman@redhat.com
 engine: gotpl
+tillerVersion: ">=2.12.0"

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -26,6 +26,14 @@ $ helm delete my-release
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+## Upgrading an existing Release to a new major version
+
+A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an
+incompatible breaking change needing manual actions.
+
+### To 4.0.0 (And 3.12.1)
+
+This version requires Helm >= 2.12.0.
 
 ## Configuration
 


### PR DESCRIPTION
The requirement has actually been introduced in 3.12.1 (https://github.com/helm/charts/pull/18115).

See discussion at https://github.com/helm/charts/commit/39723f2574290702c0fae03f4573ce31d3707e6c#r35595953

Note: Does it require a breaking change?
Note2: is tillerVersion the right approach as we actually need a specific version of the client-side Helm?

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
