### PR TITLE
[stable/oauth2-proxy] Add securityContext for container

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 1.1.0
+version: 1.1.1
 apiVersion: v1
 appVersion: 4.0.0
 home: http://www.videntity.com/

--- a/stable/oauth2-proxy/README.md
+++ b/stable/oauth2-proxy/README.md
@@ -97,6 +97,9 @@ Parameter | Description | Default
 `service.loadBalancerIP` | ip of load balancer | `nil`
 `service.loadBalancerSourceRanges` | allowed source ranges in load balancer | `nil`
 `tolerations` | list of node taints to tolerate | `[]`
+`securityContext.enabled` | enable Kubernetes security context | `false`
+`securityContext.runAsNonRoot` | make sure that the container runs as a non-root user | `true`
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/oauth2-proxy/templates/deployment.yaml
+++ b/stable/oauth2-proxy/templates/deployment.yaml
@@ -135,6 +135,10 @@ spec:
 {{- if ne (len .Values.extraVolumeMounts) 0 }}
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.securityContext.enabled }}
+        securityContext:
+          runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+{{- end}}
       volumes:
 {{- with .Values.config.google }}
 {{- if and .adminEmail (or .serviceAccountJson .existingSecret) }}

--- a/stable/oauth2-proxy/values.yaml
+++ b/stable/oauth2-proxy/values.yaml
@@ -131,6 +131,12 @@ readinessProbe:
   periodSeconds: 10
   successThreshold: 1
 
+# Configure Kubernetes security context for container
+# Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+securityContext:
+  enabled: false
+  runAsNonRoot: true
+
 podAnnotations: {}
 podLabels: {}
 replicaCount: 1


### PR DESCRIPTION
Add securityContext for the oauth2-proxy container, allowing the user for setting the `securityContext.runAsNonRoot: true`, which forces the containers to run as a non-root user.

By default this feature is disabled, so that it does not result in a breaking change for any users of the chart.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
