### PR TITLE
[pomerium/stable] Bump for Pomerium 0.4.2

### DIFF
--- a/stable/pomerium/Chart.yaml
+++ b/stable/pomerium/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: pomerium
-version: 4.0.0
-appVersion: 0.4.0
+version: 4.0.1
+appVersion: 0.4.2
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo.svg
 description: Pomerium is an identity-aware access proxy.

--- a/stable/pomerium/values.yaml
+++ b/stable/pomerium/values.yaml
@@ -126,7 +126,7 @@ extraVolumes: {}
 
 image:
   repository: "pomerium/pomerium"
-  tag: "v0.4.0"
+  tag: "v0.4.2"
   pullPolicy: "IfNotPresent"
 
 metrics:


### PR DESCRIPTION
## What this PR does / why we need it:

Updates default image version to 0.4.2

#### Which issue this PR fixes
  - fixes https://github.com/pomerium/pomerium/pull/370

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
