### PR TITLE
[stable/goldpinger] Bump bloomberg/goldpinger image tag from 1.5.0 to 2.0.0

### DIFF
--- a/stable/goldpinger/Chart.yaml
+++ b/stable/goldpinger/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: goldpinger
-version: 1.2.1
-appVersion: 1.5.0
+version: 2.0.0
+appVersion: 2.0.0
 description: Goldpinger makes calls between its instances for visibility and alerting.
 home: https://github.com/bloomberg/goldpinger
 sources:

--- a/stable/goldpinger/README.md
+++ b/stable/goldpinger/README.md
@@ -45,7 +45,7 @@ The following table lists the configurable parameters of the Goldpinger chart an
 | Parameter                      | Description                                  | Default                |
 | ------------------------------ | -------------------------------------------- | ---------------------- |
 | `image.repository`             | Goldpinger image                             | `bloomberg/goldpinger` |
-| `image.tag`                    | Goldpinger image tag                         | `1.5.0`                |
+| `image.tag`                    | Goldpinger image tag                         | `2.0.0`                |
 | `pullPolicy`                   | Image pull policy                            | `IfNotPresent`         |
 | `rbac.create`                  | Install required rbac clusterrole            | `true`                 |
 | `serviceAccount.create`        | Enable ServiceAccount creation               | `true`                 |
@@ -67,7 +67,7 @@ The following table lists the configurable parameters of the Goldpinger chart an
 | `resources`                    | CPU/Memory resource requests/limits          | `{}`                   |
 | `podSecurityPolicy.enabled`    | Enable podSecuritypolicy                     | `false`                |
 | `podSecurityPolicy.policyName` | PodSecurityPolicy Name                       | `unrestricted-psp`     |
-| `serviceMonitor.enabled`       | Set this to `true` to create ServiceMonitor for Prometheus operator | `false` | 
+| `serviceMonitor.enabled`       | Set this to `true` to create ServiceMonitor for Prometheus operator | `false` |
 | `serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}` |
 | `serviceMonitor.honorLabels` | honorLabels chooses the metric's labels on collisions with target labels. | `false`|
 | `serviceMonitor.namespace` | namespace where servicemonitor resource should be created | `the same namespace as goldpinger` |

--- a/stable/goldpinger/values.yaml
+++ b/stable/goldpinger/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: bloomberg/goldpinger
-  tag: 1.5.0
+  tag: 2.0.0
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
#### What this PR does / why we need it:
Bump the image tag from 1.5.0 to the newest 2.0.0.

#### Special notes for your reviewer:
Thanks for the good work @okgolove @s-vkropotko. Tested the new image version on our production cluster and it is all good. So let's update the image tag.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
