### PR TITLE
[stable/cluster-overprovisioner] Set deployment strategy to Recreate

### DIFF
--- a/stable/cluster-overprovisioner/Chart.yaml
+++ b/stable/cluster-overprovisioner/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: Installs the a deployment that overprovisions the cluster
 name: cluster-overprovisioner
 home: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler
-version: 0.2.5
+version: 0.2.6
 maintainers:
 - name: max-rocket-internet
   email: max.williams@deliveryhero.com

--- a/stable/cluster-overprovisioner/templates/deployments.yaml
+++ b/stable/cluster-overprovisioner/templates/deployments.yaml
@@ -21,6 +21,8 @@ metadata:
     app.kubernetes.io/instance: {{ $relName }}
     app.kubernetes.io/managed-by: {{ $relService }}
 spec:
+  strategy:
+    type: Recreate
   replicas: {{ .replicaCount }}
   selector:
     matchLabels:


### PR DESCRIPTION
#### What this PR does / why we need it:
The default strategy was RollingUpdate with a maxSurge of 25% and a maxUnavailble of 25%. This could cause the cluster autoscaler to add more nodes to the cluster any time we update the overprovisioner deployment.

Changing the strategy to Recreate seems sensible as this would keep the same number of nodes on the cluster during updates.

#### Special notes for your reviewer:
cc @max-rocket-internet @mmingorance-dh 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
