### PR TITLE
[stable/elastalert] adding env support

### DIFF
--- a/stable/elastalert/Chart.yaml
+++ b/stable/elastalert/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: ElastAlert is a simple framework for alerting on anomalies, spikes, or other patterns of interest from data in Elasticsearch.
 name: elastalert
-version: 1.2.0
+version: 1.2.1
 appVersion: 0.2.1
 home: https://github.com/Yelp/elastalert
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg

--- a/stable/elastalert/README.md
+++ b/stable/elastalert/README.md
@@ -69,6 +69,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `elasticsearch.certsVolumes` | certs volumes, required to mount ssl certificates when elasticsearch has tls enabled | `NULL` |
 | `elasticsearch.certsVolumeMounts` | mount certs volumes, required to mount ssl certificates when elasticsearch has tls enabled | `NULL` |
 | `extraConfigOptions` | Additional options to propagate to all rules, cannot be `alert`, `type`, `name` or `index` | `{}` |
+| `optEnv`           | Additional pod environment variable definitions                     | []                  |
 | `extraVolumes`           | Additional volume definitions                     | []                              |
 | `extraVolumeMounts`      | Additional volumeMount definitions                | []                              |
 | `resources`              | Container resource requests and limits            | {}                              |

--- a/stable/elastalert/templates/deployment.yaml
+++ b/stable/elastalert/templates/deployment.yaml
@@ -46,6 +46,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 12 }}
+{{- if .Values.optEnv }}
+        env:
+{{ .Values.optEnv | toYaml | indent 10}}
+{{- end }}
       restartPolicy: Always
 {{- if .Values.tolerations }}
       tolerations:

--- a/stable/elastalert/values.yaml
+++ b/stable/elastalert/values.yaml
@@ -64,6 +64,9 @@ elasticsearch:
   #     mountPath: /certs
   #     readOnly: true
 
+# Optional env variables for the pod
+optEnv: []
+
 extraConfigOptions: {}
   # # Options to propagate to all rules, e.g. a common slack_webhook_url or kibana_url
   # # Please note at the time of implementing this value, it will not work for required_locals


### PR DESCRIPTION
adding support for pod environment variables
Signed-off-by: Newman Hui <newman.hui@klarrio.com>

#### What this PR does / why we need it:
This PR adds support for environment variables to be declared in the pod

#### Which issue this PR fixes
  - fixes, no issues currently open for this that I could find.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
