### PR TITLE
[stable/opa] Add ServiceMonitor

### DIFF
--- a/stable/opa/Chart.yaml
+++ b/stable/opa/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - opa
 - admission control
 - policy
-version: 1.11.0
+version: 1.12.0
 home: https://www.openpolicyagent.org
 icon: https://raw.githubusercontent.com/open-policy-agent/opa/master/logo/logo.png
 sources:

--- a/stable/opa/README.md
+++ b/stable/opa/README.md
@@ -84,7 +84,10 @@ Reference](https://www.openpolicyagent.org/docs/configuration.html).
 | `mgmt.resources` | CPU and memory limits for the kube-mgmt container. | `{}` |
 | `sar.resources` | CPU and memory limits for the sar container. | `{}` |
 | `priorityClassName` | The name of the priorityClass for the pods. | Unset |
-| `prometheus.enabled` | Flag to expose the `/metrics` endpoint to be scraped. | `false` | 
+| `prometheus.enabled` | Flag to expose the `/metrics` endpoint to be scraped. | `false` |
+| `serviceMonitor.enabled` | if `true`, creates a Prometheus Operator ServiceMonitor | `false` |
+| `serviceMonitor.interval` | Interval that Prometheus scrapes Envoy metrics | `15s` |
+| `serviceMonitor.namespace` | Namespace which the operated Prometheus is running in | `` |
 | `annotations` | Annotations to be added to the deployment template. | `{}` |
 | `bootstrapPolicies` | Bootstrap policies to be loaded during OPA startup. | `{}` |
 | `timeoutSeconds` | Timeout for a webhook call in seconds. | `` |

--- a/stable/opa/templates/servicemonitor.yaml
+++ b/stable/opa/templates/servicemonitor.yaml
@@ -1,0 +1,30 @@
+{{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") .Values.prometheus.enabled .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: {{ template "opa.name" . }}
+    chart: {{ template "opa.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    {{- if .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4}}
+    {{- end }}
+  name: {{ template "opa.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+spec:
+  endpoints:
+  - targetPort: 8181
+    interval: {{ .Values.serviceMonitor.interval }}
+    path: "/metrics"
+  jobLabel: {{ template "opa.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "opa.name" . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/stable/opa/values.yaml
+++ b/stable/opa/values.yaml
@@ -23,6 +23,17 @@ certManager:
 prometheus:
   enabled: false
 
+## ServiceMonitor consumed by prometheus-operator
+serviceMonitor:
+  ## If the operator is installed in your cluster, set to true to create a Service Monitor Entry
+  enabled: false
+  interval: "15s"
+  ## Namespace in which the service monitor is created
+  # namespace: monitoring
+  # Added to the ServiceMonitor object so that prometheus-operator is able to discover it
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+  additionalLabels: {}
+
 # Annotations in the deployment template
 annotations:
   {}


### PR DESCRIPTION
#### What this PR does / why we need it:
Add a ServiceMonitor template.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
