### PR TITLE
[incubator/vault] Allow disabling of setting `VAULT_API_ADDR` 

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.22.1
+version: 0.22.2
 appVersion: 1.2.3
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.22.0
+version: 0.22.1
 appVersion: 1.2.3
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -61,6 +61,7 @@ The following table lists the configurable parameters of the Vault chart and the
 | `vault.extraVolumes`              | Additional volumes to the controller pod | `{}`                                |
 | `vault.extraVolumeMounts`         | Extra volumes to mount to the controller pod | `{}`                                |
 | `vault.existingConfigName`        | Location of existing Vault configuration | nil                                 |
+| `vault.podApiAddress`             | Set the `VAULT_API_ADDR` environment variable to the Pod IP Address. This is the address (full URL) to advertise to other Vault servers in the cluster for client redirection.| `true`           |
 | `vault.config`                    | Vault configuration                      | No default backend                  |
 | `replicaCount`                    | k8s replicas                             | `3`                                 |
 | `resources.limits.cpu`            | Container requested CPU                  | `nil`                               |

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -139,8 +139,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+        {{- if .Values.vault.podApiAddress }}
           - name: VAULT_API_ADDR
             value: "http://$(POD_IP):8200"
+        {{- end }}
         {{- if not .Values.vault.dev }}
           - name: VAULT_CLUSTER_ADDR
             value: "https://$(POD_IP):8201"

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -141,7 +141,7 @@ spec:
                 fieldPath: status.podIP
         {{- if .Values.vault.podApiAddress }}
           - name: VAULT_API_ADDR
-            value: "http://$(POD_IP):8200"
+            value: "{{ if .Values.vault.config.listener.tcp.tls_disable }}http{{ else }}https{{ end }}://$(POD_IP):8200"
         {{- end }}
         {{- if not .Values.vault.dev }}
           - name: VAULT_CLUSTER_ADDR

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -241,6 +241,10 @@ vault:
     readyIfUninitialized: true
     initialDelaySeconds: 10
     periodSeconds: 10
+  # Set the `VAULT_API_ADDR` environment variable to the Pod IP Address
+  # This is the address (full URL) to advertise to other Vault servers in the cluster for client redirection.
+  # See https://www.vaultproject.io/docs/configuration/#api_addr
+  podApiAddress: true
   ## Use an existing config in a named ConfigMap
   # existingConfigName: vault-cm
   config:


### PR DESCRIPTION
If the chart sets this, this breaks configuration where the API address is set in the configuration file. Use cases include making the Vault server accessible from outside the Kubernetes cluster by clients.

- Also fixes the scheme on the API address depending on whether TLS is disabled.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
