### PR TITLE
[stable/redis-ha] Fix missing redis ha announce services

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.9.0
+version: 3.9.1
 appVersion: 5.0.5
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.9.1
+version: 3.9.2
 appVersion: 5.0.5
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/_configs.tpl
+++ b/stable/redis-ha/templates/_configs.tpl
@@ -150,7 +150,7 @@
 
     {{- $root := . }}
     {{- $fullName := include "redis-ha.fullname" . }}
-    {{- $replicas := .Values.replicas }}
+    {{- $replicas := int (toString .Values.replicas) }}
     {{- range $i := until $replicas }}
     # Check Sentinel and whether they are nominated master
     backend check_if_redis_is_master_{{ $i }}

--- a/stable/redis-ha/templates/_configs.tpl
+++ b/stable/redis-ha/templates/_configs.tpl
@@ -229,7 +229,7 @@
     HAPROXY_CONF=/data/haproxy.cfg
     cp /readonly/haproxy.cfg "$HAPROXY_CONF"
     {{- $fullName := include "redis-ha.fullname" . }}
-    {{- $replicas := .Values.replicas }}
+    {{- $replicas := int (toString .Values.replicas) }}
     {{- range $i := until $replicas }}
     for loop in $(seq 1 10); do
       getent hosts {{ $fullName }}-announce-{{ $i }} && break

--- a/stable/redis-ha/templates/_configs.tpl
+++ b/stable/redis-ha/templates/_configs.tpl
@@ -150,7 +150,7 @@
 
     {{- $root := . }}
     {{- $fullName := include "redis-ha.fullname" . }}
-    {{- $replicas := int .Values.replicas }}
+    {{- $replicas := .Values.replicas }}
     {{- range $i := until $replicas }}
     # Check Sentinel and whether they are nominated master
     backend check_if_redis_is_master_{{ $i }}
@@ -229,7 +229,7 @@
     HAPROXY_CONF=/data/haproxy.cfg
     cp /readonly/haproxy.cfg "$HAPROXY_CONF"
     {{- $fullName := include "redis-ha.fullname" . }}
-    {{- $replicas := int .Values.replicas }}
+    {{- $replicas := .Values.replicas }}
     {{- range $i := until $replicas }}
     for loop in $(seq 1 10); do
       getent hosts {{ $fullName }}-announce-{{ $i }} && break

--- a/stable/redis-ha/templates/redis-ha-announce-service.yaml
+++ b/stable/redis-ha/templates/redis-ha-announce-service.yaml
@@ -1,5 +1,5 @@
 {{- $fullName := include "redis-ha.fullname" . }}
-{{- $replicas := .Values.replicas }}
+{{- $replicas := int (toString .Values.replicas) }}
 {{- $root := . }}
 {{- range $i := until $replicas }}
 ---

--- a/stable/redis-ha/templates/redis-ha-announce-service.yaml
+++ b/stable/redis-ha/templates/redis-ha-announce-service.yaml
@@ -1,5 +1,5 @@
 {{- $fullName := include "redis-ha.fullname" . }}
-{{- $replicas := int .Values.replicas }}
+{{- $replicas : .Values.replicas }}
 {{- $root := . }}
 {{- range $i := until $replicas }}
 ---

--- a/stable/redis-ha/templates/redis-ha-announce-service.yaml
+++ b/stable/redis-ha/templates/redis-ha-announce-service.yaml
@@ -1,5 +1,5 @@
 {{- $fullName := include "redis-ha.fullname" . }}
-{{- $replicas : .Values.replicas }}
+{{- $replicas := .Values.replicas }}
 {{- $root := . }}
 {{- range $i := until $replicas }}
 ---

--- a/stable/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/stable/redis-ha/templates/redis-ha-statefulset.yaml
@@ -121,7 +121,7 @@ spec:
         args:
         - /readonly-config/init.sh
         env:
-{{- $replicas := int .Values.replicas -}}
+{{- $replicas := .Values.replicas -}}
 {{- range $i := until $replicas }}
         - name: SENTINEL_ID_{{ $i }}
           value: {{ printf "%s\n%s\nindex: %d" (include "redis-ha.name" $) ($.Release.Name) $i | sha1sum }}

--- a/stable/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/stable/redis-ha/templates/redis-ha-statefulset.yaml
@@ -121,7 +121,7 @@ spec:
         args:
         - /readonly-config/init.sh
         env:
-{{- $replicas := .Values.replicas -}}
+{{- $replicas := int (toString .Values.replicas) -}}
 {{- range $i := until $replicas }}
         - name: SENTINEL_ID_{{ $i }}
           value: {{ printf "%s\n%s\nindex: %d" (include "redis-ha.name" $) ($.Release.Name) $i | sha1sum }}


### PR DESCRIPTION
#### What this PR does / why we need it:
This fixes an issue, where announce services and SENTINEL_ID's were not properly created, when .Values.replicas was a number, as the values.yaml suggests
This happened because the int function returned 0 when used on a value that was of the json.Number type

#### Which issue this PR fixes
  - fixes #18190 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
