### PR TITLE
[stable/prometheus-blackbox-exporter] Add option to enable/disable PodDisruptionBudget

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 1.3.1
+version: 1.4.0
 appVersion: 0.15.1
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/templates/poddisruptionbudget.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/poddisruptionbudget.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -15,3 +16,4 @@ spec:
       app.kubernetes.io/managed-by: {{ .Release.Service }}
       helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" . }}
 {{ toYaml .Values.podDisruptionBudget | indent 2 }}
+{{- end }}

--- a/stable/prometheus-blackbox-exporter/values.yaml
+++ b/stable/prometheus-blackbox-exporter/values.yaml
@@ -1,6 +1,7 @@
 restartPolicy: Always
 
 podDisruptionBudget:
+  enabled: true
   maxUnavailable: 0
 
 strategy:


### PR DESCRIPTION
Related to https://github.com/helm/charts/pull/16815

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
