### PR TITLE
[stable/minecraft] update to support k8s v1.16

### DIFF
--- a/stable/minecraft/Chart.yaml
+++ b/stable/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 1.1.4
+version: 1.1.5
 appVersion: 1.14.4
 home: https://minecraft.net/
 description: Minecraft server

--- a/stable/minecraft/templates/deployment.yaml
+++ b/stable/minecraft/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if ne (printf "%s" .Values.minecraftServer.eula) "FALSE" }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "minecraft.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Handle [API deprecations](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) in kubernetes v1.16

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
