### PR TITLE
[stable/chronograf] update to support k8s v1.16

### DIFF
--- a/stable/chronograf/Chart.yaml
+++ b/stable/chronograf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: chronograf
-version: 1.1.0
+version: 1.1.1
 appVersion: 1.7.12
 description: Open-source web application written in Go and React.js that provides
   the tools to visualize your monitoring data and easily create alerting and automation

--- a/stable/chronograf/templates/deployment.yaml
+++ b/stable/chronograf/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "chronograf.fullname" . }}

--- a/stable/chronograf/templates/deployment.yaml
+++ b/stable/chronograf/templates/deployment.yaml
@@ -9,6 +9,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: {{ .Values.service.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "chronograf.fullname" . }}
   template:
     metadata:
       labels:

--- a/stable/chronograf/templates/ingress.yaml
+++ b/stable/chronograf/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "chronograf.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Handle [API deprecations](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) in kubernetes v1.16

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
