### PR TITLE
[stable/jenkins] Prevented Jenkins Setup Wizard on new installations (helm/#18250)

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.7.8
+version: 1.7.9
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -236,6 +236,12 @@ data:
   {{- end }}
   {{- end }}
 {{- end }}
+{{- else }}
+{{- if .Values.master.JCasC.enabled }}
+    # Prevent Setup Wizard when JCasC is enabled
+    echo $JENKINS_VERSION > /var/jenkins_home/jenkins.install.UpgradeWizard.state
+    echo $JENKINS_VERSION > /var/jenkins_home/jenkins.install.InstallUtil.lastExecVersion
+{{- end }}
 {{- end }}
 {{- if .Values.master.overwritePlugins }}
     # remove all plugins from shared volume


### PR DESCRIPTION
Signed-off-by: Alex Pogrebnyak <alex.pogrebnyak@sophos.com>

@lachie83 
@viglesiasce
@maorfr
@torstenwalter 
@mogaal

#### Is this a new chart
No

#### What this PR does / why we need it:
 - Proposed fix for #18250.  Creates 2 files in Jenkins home directory in accordance from JCasC guidance -> https://github.com/jenkinsci/configuration-as-code-plugin/issues/38#issuecomment-494509452

#### Which issue this PR fixes
  - fixes #18250

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
