### PR TITLE
[stable/selenium] fix for #18217 deployment spec selector does not match template labels

### DIFF
--- a/stable/selenium/Chart.yaml
+++ b/stable/selenium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: selenium
-version: 1.0.9
+version: 1.0.10
 appVersion: 3.141.59
 description: Chart for selenium grid
 keywords:

--- a/stable/selenium/templates/chrome-deployment.yaml
+++ b/stable/selenium/templates/chrome-deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
   replicas: {{ .Values.chrome.replicas }}
+  selector:
+    matchLabels:
+      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   template:
     metadata:
       labels:

--- a/stable/selenium/templates/chrome-deployment.yaml
+++ b/stable/selenium/templates/chrome-deployment.yaml
@@ -9,7 +9,8 @@ spec:
   replicas: {{ .Values.chrome.replicas }}
   selector:
     matchLabels:
-      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      app: {{ template "selenium.chrome.fullname" . }}
+      release: "{{ .Release.Name }}"
   template:
     metadata:
       labels:

--- a/stable/selenium/templates/chromeDebug-deployment.yaml
+++ b/stable/selenium/templates/chromeDebug-deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
   replicas: {{ .Values.chromeDebug.replicas }}
+  selector:
+    matchLabels:
+      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   template:
     metadata:
       labels:

--- a/stable/selenium/templates/chromeDebug-deployment.yaml
+++ b/stable/selenium/templates/chromeDebug-deployment.yaml
@@ -9,7 +9,8 @@ spec:
   replicas: {{ .Values.chromeDebug.replicas }}
   selector:
     matchLabels:
-      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      app: {{ template "selenium.chromeDebug.fullname" . }}
+      release: "{{ .Release.Name }}"
   template:
     metadata:
       labels:

--- a/stable/selenium/templates/firefox-deployment.yaml
+++ b/stable/selenium/templates/firefox-deployment.yaml
@@ -9,7 +9,8 @@ spec:
   replicas: {{ .Values.firefox.replicas }}
   selector:
     matchLabels:
-      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      app: {{ template "selenium.firefox.fullname" . }}
+      release: "{{ .Release.Name }}"
   template:
     metadata:
       labels:

--- a/stable/selenium/templates/firefox-deployment.yaml
+++ b/stable/selenium/templates/firefox-deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
   replicas: {{ .Values.firefox.replicas }}
+  selector:
+    matchLabels:
+      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   template:
     metadata:
       labels:

--- a/stable/selenium/templates/firefoxDebug-deployment.yaml
+++ b/stable/selenium/templates/firefoxDebug-deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
   replicas: {{ .Values.firefoxDebug.replicas }}
+  selector:
+    matchLabels:
+      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   template:
     metadata:
       labels:

--- a/stable/selenium/templates/firefoxDebug-deployment.yaml
+++ b/stable/selenium/templates/firefoxDebug-deployment.yaml
@@ -9,7 +9,8 @@ spec:
   replicas: {{ .Values.firefoxDebug.replicas }}
   selector:
     matchLabels:
-      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+       app: {{ template "selenium.firefoxDebug.fullname" . }}
+       release: "{{ .Release.Name }}"
   template:
     metadata:
       labels:

--- a/stable/selenium/templates/hub-deployment.yaml
+++ b/stable/selenium/templates/hub-deployment.yaml
@@ -8,7 +8,8 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      app: {{ template "selenium.hub.fullname" . }}
+      release: "{{ .Release.Name }}"
   template:
     metadata:
       labels:

--- a/stable/selenium/templates/hub-deployment.yaml
+++ b/stable/selenium/templates/hub-deployment.yaml
@@ -6,6 +6,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   template:
     metadata:
       labels:


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Not able to deploy this chart due to not matching selector and label in deployments.

#### Which issue this PR fixes
  - fixes #18217

#### Special notes for your reviewer:
None.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
