### PR TITLE
[incubator/kafka] fixes #18254

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.20.2
+version: 0.20.3
 appVersion: 5.0.1
 keywords:
 - kafka

--- a/incubator/kafka/requirements.lock
+++ b/incubator/kafka/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: zookeeper
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  version: 2.0.2
-digest: sha256:31fcefa3c492b4200bf5bb3b99bac67194a70942a5dce0a6f671a7f1af8455ee
-generated: "2019-10-23T16:32:06.44599-07:00"
+  version: 2.1.0
+digest: sha256:f50b0b5f50f4938a5369c5ea479030a4f87e99aecb7752ab434f75a6c39f304a
+generated: "2019-11-05T16:37:25.868424523-06:00"

--- a/incubator/kafka/requirements.yaml
+++ b/incubator/kafka/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: zookeeper
-  version: 2.0.2
+  version: 2.1.0
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
   condition: kafka.zookeeper.enabled,zookeeper.enabled


### PR DESCRIPTION

#### Is this a new chart
No

#### What this PR does / why we need it:
To allow incubator/kafka chart to be installed in k8s 1.16

#### Which issue this PR fixes
  - fixes #18254

#### Special notes for your reviewer:
  n/a

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
