### PR TITLE
[stable/minecraft] Add spec.selector.matchLabels.app for app/v1 compat

### DIFF
--- a/stable/minecraft/Chart.yaml
+++ b/stable/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 1.1.5
+version: 1.1.6
 appVersion: 1.14.4
 home: https://minecraft.net/
 description: Minecraft server

--- a/stable/minecraft/templates/deployment.yaml
+++ b/stable/minecraft/templates/deployment.yaml
@@ -9,6 +9,9 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "minecraft.fullname" . }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
#### What this PR does / why we need it:
@billimek Commit 8c4f4e0161 introduced the change that utilizes app/v1 API for the Deployment (yay!). For me this required spec.selector.matchLabels.app to be set and match what is defined in template.metadata.labels.app. I'm running latest k3s 0.10.0, K8s 1.16 with Helm v3.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
