### PR TITLE
[stable/graylog] New graylog prestop hook

### DIFF
--- a/stable/graylog/Chart.yaml
+++ b/stable/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: graylog
 home: https://www.graylog.org
-version: 1.3.8
+version: 1.3.9
 appVersion: 3.1.2-1
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:

--- a/stable/graylog/templates/statefulset.yaml
+++ b/stable/graylog/templates/statefulset.yaml
@@ -171,7 +171,7 @@ spec:
                   - -ec
                   - |
                       ROOT_PASSWORD=`/k8s/kubectl get secret {{ template "graylog.fullname" . }} -o "jsonpath={.data['graylog-password-secret']}" | base64 -d`
-                      curl -XPOST -sS -u "{{ .Values.graylog.rootUsername }}:${ROOT_PASSWORD}" "localhost:9000/api/system/shutdown/shutdown"
+                      curl -XPOST -sS -u "{{ .Values.graylog.rootUsername }}:${ROOT_PASSWORD}" -H "X-Requested-By: {{ template "graylog.fullname" . }}" "localhost:9000/api/system/shutdown/shutdown"
       terminationGracePeriodSeconds: {{ default 30 .Values.graylog.terminationGracePeriodSeconds }}
       volumes:
         - name: config

--- a/stable/graylog/values.yaml
+++ b/stable/graylog/values.yaml
@@ -90,12 +90,10 @@ graylog:
   ## Additional plugins you need to install on Graylog.
   ##
   plugins: []
-    # - name: graylog-plugin-slack-2.7.1.jar
-    #   url: https://github.com/omise/graylog-plugin-slack/releases/download/2.7.1/graylog-plugin-slack-2.7.1.jar
+    # - name: graylog-plugin-slack-notification-3.1.0.jar
+    #   url: https://github.com/omise/graylog-plugin-slack-notification/releases/download/v3.1.0/graylog-plugin-slack-notification-3.1.0.jar
     # - name: graylog-plugin-function-check-diff-1.0.0.jar
     #   url: https://github.com/omise/graylog-plugin-function-check-diff/releases/download/1.0.0/graylog-plugin-function-check-diff-1.0.0.jar
-    # - name: graylog-plugin-custom-alert-condition-1.0.0.jar
-    #   url: https://github.com/omise/graylog-plugin-custom-alert-condition/releases/download/v1.0.0/graylog-plugin-custom-alert-condition-1.0.0.jar
     # - name: graylog-plugin-auth-sso-3.0.0.jar
     #   url: https://github.com/Graylog2/graylog-plugin-auth-sso/releases/download/3.0.0/graylog-plugin-auth-sso-3.0.0.jar
 


### PR DESCRIPTION
### Is this a new chart

No

#### What this PR does / why we need it:

Since Graylog 3.0 requires `X-Requested-By` when calling SHUTDOWN API. Add the header to SHUTDOWN request.


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
