### PR TITLE
[stable/sematext-agent] Remove customUrl prefix for custom URLs

### DIFF
--- a/stable/sematext-agent/Chart.yaml
+++ b/stable/sematext-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.0"
-version: 1.0.19
+version: 1.0.20
 description: Helm chart for deploying Sematext Agent to Kubernetes
 keywords:
   - sematext

--- a/stable/sematext-agent/Chart.yaml
+++ b/stable/sematext-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.0"
-version: 1.0.18
+version: 1.0.19
 description: Helm chart for deploying Sematext Agent to Kubernetes
 keywords:
   - sematext

--- a/stable/sematext-agent/README.md
+++ b/stable/sematext-agent/README.md
@@ -63,7 +63,7 @@ The following table lists the configuration parameters of the `sematext-agent` c
 | `nodeSelector`                   | Node selector                     | `{}`                                      |
 | `serverBaseUrl`                  | Custom Base URL                   | `Nil`                                     |
 | `logsReceiverUrl`                | Custom Logs receiver URL          | `Nil`                                     |
-| `eventsRecieverUrl`              | Custom Event receiver URL         | `Nil`                                     |
+| `eventsReceiverUrl`              | Custom Event receiver URL         | `Nil`                                     |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/stable/sematext-agent/README.md
+++ b/stable/sematext-agent/README.md
@@ -56,14 +56,14 @@ The following table lists the configuration parameters of the `sematext-agent` c
 | `logagent.resources`             | Logagent resources                | `{}`                                      |
 | `logagent.customConfigs`         | Logagent custom configs           | `[]` Check `values.yaml`                  |
 | `logagent.extraHostVolumeMounts` | Extra mounts                      | `{}`                                      |
-| `customUrl.serverBaseUrl`        | Custom Base URL                   | `Nil`                                     |
-| `customUrl.logsReceiverUrl`      | Custom Logs receiver URL          | `Nil`                                     |
-| `customUrl.eventsRecieverUrl`    | Custom Event receiver URL         | `Nil`                                     |
 | `serviceAccount.create`          | Create a service account          | `true`                                    |
 | `serviceAccount.name`            | Service account name              | `Nil` Defaults to chart name              |
 | `rbac.create`                    | RBAC enabled                      | `true`                                    |
 | `tolerations`                    | Tolerations                       | `[]`                                      |
 | `nodeSelector`                   | Node selector                     | `{}`                                      |
+| `serverBaseUrl`                  | Custom Base URL                   | `Nil`                                     |
+| `logsReceiverUrl`                | Custom Logs receiver URL          | `Nil`                                     |
+| `eventsRecieverUrl`              | Custom Event receiver URL         | `Nil`                                     |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/stable/sematext-agent/templates/configmap-agent.yaml
+++ b/stable/sematext-agent/templates/configmap-agent.yaml
@@ -15,8 +15,8 @@ data:
   {{- if .Values.serverBaseUrl }}
   SERVER_BASE_URL: {{ default "" .Values.serverBaseUrl | quote }}
   {{- end }}
-  {{- if .Values.eventsRecieverUrl }}
-  EVENTS_RECEIVER_URL: {{ default "" .Values.eventsRecieverUrl | quote }}
+  {{- if .Values.eventsReceiverUrl }}
+  EVENTS_RECEIVER_URL: {{ default "" .Values.eventsReceiverUrl | quote }}
   {{- end }}
   {{- if .Values.logsReceiverUrl }}
   LOGS_RECEIVER_URL: {{ default "" .Values.logsReceiverUrl | quote }}

--- a/stable/sematext-agent/templates/configmap-agent.yaml
+++ b/stable/sematext-agent/templates/configmap-agent.yaml
@@ -12,9 +12,13 @@ data:
   {{- range $key, $val := .Values.agent.config }}
   {{ $key }}: {{ $val | quote }}
   {{- end }}
-  {{- if .Values.customUrl }}
-  SERVER_BASE_URL: {{ default "" .Values.customUrl.serverBaseUrl | quote }}
-  EVENTS_RECEIVER_URL: {{ default "" .Values.customUrl.eventsRecieverUrl | quote }}
-  LOGS_RECEIVER_URL: {{ default "" .Values.customUrl.logsReceiverUrl | quote }}
+  {{- if .Values.serverBaseUrl }}
+  SERVER_BASE_URL: {{ default "" .Values.serverBaseUrl | quote }}
+  {{- end }}
+  {{- if .Values.eventsRecieverUrl }}
+  EVENTS_RECEIVER_URL: {{ default "" .Values.eventsRecieverUrl | quote }}
+  {{- end }}
+  {{- if .Values.logsReceiverUrl }}
+  LOGS_RECEIVER_URL: {{ default "" .Values.logsReceiverUrl | quote }}
   {{- end }}
   API_SERVER_PORT: "{{ .Values.agent.service.port }}"

--- a/stable/sematext-agent/templates/configmap-logagent.yaml
+++ b/stable/sematext-agent/templates/configmap-logagent.yaml
@@ -12,6 +12,6 @@ data:
   {{- range $key, $val := .Values.logagent.config }}
   {{ $key }}: {{ $val | quote }}
   {{- end }}
-  {{- if .Values.customUrl }}
-  LOGS_RECEIVER_URL: {{ default "" .Values.customUrl.logsReceiverUrl | quote }}
+  {{- if .Values.logsReceiverUrl }}
+  LOGS_RECEIVER_URL: {{ default "" .Values.logsReceiverUrl | quote }}
   {{- end }}

--- a/stable/sematext-agent/templates/daemonset.yaml
+++ b/stable/sematext-agent/templates/daemonset.yaml
@@ -50,10 +50,6 @@ spec:
               secretKeyRef:
                 name: {{ template "sematext-agent.fullname" . }}
                 key: logs-token
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
           - name: STA_NAMESPACE
             valueFrom:
             fieldRef:

--- a/stable/sematext-agent/values.yaml
+++ b/stable/sematext-agent/values.yaml
@@ -71,10 +71,9 @@ logsToken: null
 region: US
 
 # support for custom URLs
-customUrl: {}
-  # serverBaseUrl: https://metrics-receiver.apps.test.sematext.com
-  # eventsRecieverUrl: https://event-receiver.apps.test.sematext.com
-  # logsReceiverUrl: https://logs-token-receiver.apps.test.sematext.com
+serverBaseUrl: null
+eventsRecieverUrl: null
+logsReceiverUrl: null
 
 tolerations: []
 

--- a/stable/sematext-agent/values.yaml
+++ b/stable/sematext-agent/values.yaml
@@ -72,7 +72,7 @@ region: US
 
 # support for custom URLs
 serverBaseUrl: null
-eventsRecieverUrl: null
+eventsReceiverUrl: null
 logsReceiverUrl: null
 
 tolerations: []


### PR DESCRIPTION
#### What this PR does / why we need it:
  - Removes customUrl prefix for custom URLs
  - Removes NODE_NAME env var

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
