### PR TITLE
[stable/prometheus-operator] Remove CRD hooks from CI entirely

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -10,7 +10,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 6.21.0
+version: 6.21.1
 appVersion: 0.32.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -162,7 +162,6 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.admissionWebhooks.patch.podAnnotations` | Annotations for the webhook job pods | `nil` |
 | `prometheusOperator.admissionWebhooks.patch.priorityClassName` | Priority class for the webhook integration jobs | `nil` |
 | `prometheusOperator.affinity` | Assign custom affinity rules to the prometheus operator https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ | `{}` |
-| `prometheusOperator.cleanupCustomResourceBeforeInstall` | Remove CRDs before running the crd-install hook on changes. | `false` |
 | `prometheusOperator.cleanupCustomResource` | Attempt to delete CRDs when the release is removed. This option may be useful while testing but is not recommended, as deleting the CRD definition will delete resources and prevent the operator from being able to clean up resources that it manages | `false` |
 | `prometheusOperator.configReloaderCpu` | Set the prometheus config reloader side-car CPU limit. If unset, uses the prometheus-operator project default | `nil` |
 | `prometheusOperator.configReloaderMemory` | Set the prometheus config reloader side-car memory limit. If unset, uses the prometheus-operator project default | `nil` |

--- a/stable/prometheus-operator/ci/01-provision-crds-values.yaml
+++ b/stable/prometheus-operator/ci/01-provision-crds-values.yaml
@@ -1,0 +1,36 @@
+alertmanager:
+  enabled: false
+coreDns:
+  enabled: false
+kubeApiServer:
+  enabled: false
+kubeControllerManager:
+  enabled: false
+kubeDns:
+  enabled: false
+kubeEtcd:
+  enabled: false
+kubeProxy:
+  enabled: false
+kubeScheduler:
+  enabled: false
+kubeStateMetrics:
+  enabled: false
+kubelet:
+  enabled: false
+nodeExporter:
+  enabled: false
+grafana:
+  enabled: false
+prometheus:
+  enabled: false
+defaultRules:
+  create: false
+# Default configuration of prometheus operator will create CRDs in the cluster idempotently
+prometheusOperator:
+  enabled: true
+  createCustomResource: false
+  tlsProxy:
+    enabled: false
+  admissionWebhooks:
+    enabled: false

--- a/stable/prometheus-operator/ci/02-test-without-crds-values.yaml
+++ b/stable/prometheus-operator/ci/02-test-without-crds-values.yaml
@@ -817,6 +817,13 @@ kubeScheduler:
 kubeProxy:
   enabled: true
 
+  ## If your kube proxy is not deployed as a pod, specify IPs it can be found on
+  ##
+  endpoints: []
+  # - 10.141.4.22
+  # - 10.141.4.23
+  # - 10.141.4.24
+
   service:
     port: 10249
     targetPort: 10249
@@ -1016,17 +1023,17 @@ prometheusOperator:
 
   ## Deploy CRDs used by Prometheus Operator.
   ##
-  createCustomResource: true
+  createCustomResource: false
 
   ## Customize CRDs API Group
   crdApiGroup: monitoring.coreos.com
 
   # Remove CRDs before instaling, created for use on CI environment.
-  cleanupCustomResourceBeforeInstall: true
+  cleanupCustomResourceBeforeInstall: false
 
   ## Attempt to clean up CRDs created by Prometheus Operator.
   ##
-  cleanupCustomResource: true
+  cleanupCustomResource: false
 
   ## Labels to add to the operator pod
   ##

--- a/stable/prometheus-operator/hack/update-ci.sh
+++ b/stable/prometheus-operator/hack/update-ci.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 sed \
-  -e 's/cleanupCustomResource: false/cleanupCustomResource: true/' \
-	-e 's/cleanupCustomResourceBeforeInstall: false/cleanupCustomResourceBeforeInstall: true/' \
+	-e 's/createCustomResource: true/createCustomResource: false/' \
 	-e 's/port: 9100/port: 9101/' \
 	-e 's/targetPort: 9100/targetPort: 9101/' \
-  values.yaml > ci/test-values.yaml
+  values.yaml > ci/02-test-without-crds-values.yaml

--- a/stable/prometheus-operator/templates/prometheus-operator/crd-alertmanager.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/crd-alertmanager.yaml
@@ -10,9 +10,6 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-operator
 {{ include "prometheus-operator.labels" . | indent 4 }}
   annotations:
-{{- if .Values.prometheusOperator.cleanupCustomResourceBeforeInstall }}
-    "helm.sh/hook-delete-policy": "before-hook-creation"
-{{- end }}
     "helm.sh/hook": crd-install
 spec:
   group: {{ .Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com" }}

--- a/stable/prometheus-operator/templates/prometheus-operator/crd-podmonitor.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/crd-podmonitor.yaml
@@ -10,9 +10,6 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-operator
 {{ include "prometheus-operator.labels" . | indent 4 }}
   annotations:
-{{- if .Values.prometheusOperator.cleanupCustomResourceBeforeInstall }}
-    "helm.sh/hook-delete-policy": "before-hook-creation"
-{{- end }}
     "helm.sh/hook": crd-install
 spec:
   group: {{ .Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com" }}

--- a/stable/prometheus-operator/templates/prometheus-operator/crd-prometheus.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/crd-prometheus.yaml
@@ -10,9 +10,6 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-operator
 {{ include "prometheus-operator.labels" . | indent 4 }}
   annotations:
-{{- if .Values.prometheusOperator.cleanupCustomResourceBeforeInstall }}
-    "helm.sh/hook-delete-policy": "before-hook-creation"
-{{- end }}
     "helm.sh/hook": crd-install
 spec:
   group: {{ .Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com" }}

--- a/stable/prometheus-operator/templates/prometheus-operator/crd-prometheusrules.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/crd-prometheusrules.yaml
@@ -10,9 +10,6 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-operator
 {{ include "prometheus-operator.labels" . | indent 4 }}
   annotations:
-{{- if .Values.prometheusOperator.cleanupCustomResourceBeforeInstall }}
-    "helm.sh/hook-delete-policy": "before-hook-creation"
-{{- end }}
     "helm.sh/hook": crd-install
 spec:
   group: {{ .Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com" }}

--- a/stable/prometheus-operator/templates/prometheus-operator/crd-servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/crd-servicemonitor.yaml
@@ -10,9 +10,6 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-operator
 {{ include "prometheus-operator.labels" . | indent 4 }}
   annotations:
-{{- if .Values.prometheusOperator.cleanupCustomResourceBeforeInstall }}
-    "helm.sh/hook-delete-policy": "before-hook-creation"
-{{- end }}
     "helm.sh/hook": crd-install
 spec:
   group: {{ .Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com" }}

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -1028,9 +1028,6 @@ prometheusOperator:
   ## Customize CRDs API Group
   crdApiGroup: monitoring.coreos.com
 
-  # Remove CRDs before instaling, created for use on CI environment.
-  cleanupCustomResourceBeforeInstall: false
-
   ## Attempt to clean up CRDs created by Prometheus Operator.
   ##
   cleanupCustomResource: false


### PR DESCRIPTION
#### What this PR does / why we need it:
The helm bug around provisioning CRDs has now started to affect the CI process for the prometheus-operator chart: https://github.com/helm/charts/issues/9241

In order to work around this I am proposing to perform the tests in two steps, by using the `ci/*-values.yaml` files
1. Deploy prometheus-operator main component only. This when the pod comes up its default configuration idempotently creates CRDs in the cluster. This will mean that the test cluster will always contain the necessary CRDs and if it ever gets reset they will be re-created.
2. Deploy the regular values file but disable CRD creation, avoiding the helm bug altogether.

Affected PRs:
- https://github.com/helm/charts/pull/18188
- https://github.com/helm/charts/pull/18161
- https://github.com/helm/charts/pull/17844
- https://github.com/helm/charts/pull/17997
- https://github.com/helm/charts/pull/17354

#### Permanent solution:
This issue should be solved if we the test image is updated to at least helm version 2.14.x and then we update it in this repository.
- https://github.com/helm/charts/issues/18310
- https://github.com/helm/chart-testing/issues/179

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
