### PR TITLE
[stable/clamav] Add support for providing clamd config

### DIFF
--- a/stable/clamav/Chart.yaml
+++ b/stable/clamav/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.6"
 description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats.
 name: clamav
-version: 1.0.3
+version: 1.0.4
 home: https://www.clamav.net
 icon: https://www.clamav.net/assets/clamav-trademark.png
 maintainers:

--- a/stable/clamav/templates/clamd-configmap.yaml
+++ b/stable/clamav/templates/clamd-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.clamdConfig -}}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "clamav.fullname" . }}-clamd
+  labels:
+    app: {{ template "clamav.name" . }}
+    chart: {{ template "clamav.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  clamd.conf:
+    {{ toYaml .Values.clamdConfig | indent 4 }}
+{{- end }}

--- a/stable/clamav/templates/deployment.yaml
+++ b/stable/clamav/templates/deployment.yaml
@@ -32,6 +32,12 @@ spec:
             mountPath: /etc/clamav/freshclam.conf
             subPath: freshclam.conf
 {{- end }}
+{{- if .Values.clamdConfig }}
+          volumeMounts:
+          - name: clamd-config-volume
+            mountPath: /etc/clamav/clamd.conf
+            subPath: clamd.conf
+{{- end }}
           ports:
             - name: clamavport
               containerPort: 3310
@@ -51,6 +57,12 @@ spec:
         - name: freshclam-config-volume
           configMap:
             name: {{ include "clamav.fullname" . }}-freshclam
+{{- end }}
+{{- if .Values.clamdConfig }}
+      volumes:
+        - name: clamd-config-volume
+          configMap:
+            name: {{ include "clamav.fullname" . }}-clamd
 {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds the ability to specify the customize config for ClamAV (clamd.conf). For example: By default, ClamAV will not scan files larger than 20Mb, which can be overwritten using this configuration.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/clamav]`)