### PR TITLE
[incubator/haproxy-ingress] use defaultBackend.replicaCount variable

### DIFF
--- a/incubator/haproxy-ingress/Chart.yaml
+++ b/incubator/haproxy-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: haproxy-ingress
-version: 0.0.18
+version: 0.0.19
 appVersion: 0.7.2
 home: https://github.com/jcmoraisjr/haproxy-ingress
 description: Ingress controller implementation for haproxy loadbalancer.

--- a/incubator/haproxy-ingress/templates/default-backend-deployment.yaml
+++ b/incubator/haproxy-ingress/templates/default-backend-deployment.yaml
@@ -11,6 +11,7 @@ metadata:
   name: {{ template "haproxy-ingress.defaultBackend.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
+  replicas: {{ .Values.defaultBackend.replicaCount }}
   selector:
     matchLabels:
       app: {{ template "haproxy-ingress.name" . }}


### PR DESCRIPTION
Use defaultBackend.replicaCount, which exists in values.yaml but was not used in deployment