### PR TITLE
[stable/mysqld-exporter] Improve Secrets

### DIFF
--- a/stable/prometheus-mysql-exporter/Chart.yaml
+++ b/stable/prometheus-mysql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 0.5.1
+version: 0.5.2
 home: https://github.com/prometheus/mysqld_exporter
 appVersion: v0.11.0
 sources:

--- a/stable/prometheus-mysql-exporter/README.md
+++ b/stable/prometheus-mysql-exporter/README.md
@@ -57,6 +57,7 @@ The following table lists the configurable parameters of the mysql exporter char
 | `mysql.port`                           | MySQL connection port                               | `3306`                             |
 | `mysql.protocol`                       | MySQL connection protocol (optional)                | `""`                               |
 | `mysql.user`                           | MySQL connection username                           | `exporter`                         |
+| `mysql.existingSecret`                 | Use existing kubernetes secret for DATA_SOURCE_NAME | `false`                            |
 | `cloudsqlproxy.enabled`                | Flag to enable the connection using Cloud SQL Proxy | `false`                            |
 | `cloudsqlproxy.image.repo`             | Cloud SQL Proxy image repository                    | `gcr.io/cloudsql-docker/gce-proxy` |
 | `cloudsqlproxy.image.tag`              | Cloud SQL Proxy image tag                           | `1.14`                             |

--- a/stable/prometheus-mysql-exporter/templates/_helpers.tpl
+++ b/stable/prometheus-mysql-exporter/templates/_helpers.tpl
@@ -37,3 +37,14 @@ Secret name for cloudsql credentials
 {{- define "prometheus-mysql-exporter.cloudsqlsecret" -}}
 {{ template "prometheus-mysql-exporter.fullname" . }}-cloudsqlsecret
 {{- end -}}
+
+{{/*
+Secret name for DATA_SOURCE_NAME
+*/}}
+{{- define "prometheus-mysql-exporter.secret" -}}
+    {{- if .Values.mysql.existingSecret -}}
+        {{- printf "%s" .Values.mysql.existingSecret -}}
+    {{- else -}}
+        {{ template "prometheus-mysql-exporter.fullname" . }}
+    {{- end -}}
+{{- end -}}

--- a/stable/prometheus-mysql-exporter/templates/deployment.yaml
+++ b/stable/prometheus-mysql-exporter/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
 {{- end }}
           envFrom:
             - secretRef:
-                name: {{ template "prometheus-mysql-exporter.fullname" . }}
+                name: {{ template "prometheus-mysql-exporter.secret" . }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/stable/prometheus-mysql-exporter/templates/secret-env.yaml
+++ b/stable/prometheus-mysql-exporter/templates/secret-env.yaml
@@ -1,3 +1,4 @@
+{{- if or (not .Values.mysql.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,3 +6,4 @@ metadata:
 type: Opaque
 stringData:
   DATA_SOURCE_NAME: "{{ .Values.mysql.user }}:{{ .Values.mysql.pass }}@{{ if .Values.mysql.protocol }}{{ .Values.mysql.protocol }}{{ end }}({{ .Values.mysql.host }}:{{ .Values.mysql.port }})/{{ if .Values.mysql.db }}{{ .Values.mysql.db }}{{ end }}{{ if .Values.mysql.param }}?{{ .Values.mysql.param }}{{ end }}"
+{{- end }}

--- a/stable/prometheus-mysql-exporter/values.yaml
+++ b/stable/prometheus-mysql-exporter/values.yaml
@@ -99,6 +99,7 @@ mysql:
   port: 3306
   protocol: ""
   user: "exporter"
+  existingSecret: false
 
 # cloudsqlproxy https://cloud.google.com/sql/docs/mysql/sql-proxy
 cloudsqlproxy:


### PR DESCRIPTION
#### What this PR does / why we need it:
Feature flap secret used for the DATA_SOURCE_NAME to use a custom kubernetes secret to avoid having credentials in the values.yaml.

I bumped to 0.5.2, do we need to bump to 0.6.0?