### PR TITLE
[stable/jaeger-operator] Align resources with the latest jaeger-operator 1.14.0

### DIFF
--- a/stable/jaeger-operator/Chart.yaml
+++ b/stable/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.10.1
+version: 2.10.2
 appVersion: 1.14.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/stable/jaeger-operator/templates/crd.yaml
+++ b/stable/jaeger-operator/templates/crd.yaml
@@ -18,3 +18,7 @@ spec:
     singular: jaeger
   scope: Namespaced
   version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true

--- a/stable/jaeger-operator/templates/deployment.yaml
+++ b/stable/jaeger-operator/templates/deployment.yaml
@@ -44,6 +44,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: OPERATOR_NAME
               value: {{ include "jaeger-operator.fullname" . | quote }}
           resources:

--- a/stable/jaeger-operator/templates/role.yaml
+++ b/stable/jaeger-operator/templates/role.yaml
@@ -45,6 +45,10 @@ rules:
 - apiGroups:
   - extensions
   resources:
+  - replicasets
+  - deployments
+  - daemonsets
+  - statefulsets
   - ingresses
   verbs:
   - "*"
@@ -73,6 +77,21 @@ rules:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  - extensions
+  resourceNames:
+  - jaeger-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
 {{- if .Values.rbac.pspEnabled }}
 - apiGroups: ['policy']
   resources: ['podsecuritypolicies']


### PR DESCRIPTION
This is a follow-up PR for the previous version bump. 

- Align resources with the latest jaeger-operator 1.14.0
- Fix a known issue described here: https://github.com/jaegertracing/jaeger-operator/issues/721

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
