### PR TITLE
[stable/prometheus-operator] Add --namespaces argument to Prometheus operator

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -10,7 +10,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 6.21.0
+version: 6.22.0
 appVersion: 0.32.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -170,7 +170,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.configmapReloadImage.tag` | Tag for configmapReload image | `v0.0.1` |
 | `prometheusOperator.crdApiGroup` | Specify the API Group for the CustomResourceDefinitions | `monitoring.coreos.com` |
 | `prometheusOperator.createCustomResource` | Create CRDs. Required if deploying anything besides the operator itself as part of the release. The operator will create / update these on startup. If your Helm version < 2.10 you will have to either create the CRDs first or deploy the operator first, then the rest of the resources | `true` |
-| `prometheusOperator.denyNamespaces` | Namespaces not to scope the interaction of the Prometheus Operator (deny list). | `{}` |
+| `prometheusOperator.denyNamespaces` | Namespaces not to scope the interaction of the Prometheus Operator (deny list). | `[]` |
 | `prometheusOperator.enabled` | Deploy Prometheus Operator. Only one of these should be deployed into the cluster | `true` |
 | `prometheusOperator.hyperkubeImage.repository` | Image pull policy for hyperkube image used to perform maintenance tasks | `IfNotPresent` |
 | `prometheusOperator.hyperkubeImage.repository` | Repository for hyperkube image used to perform maintenance tasks | `k8s.gcr.io/hyperkube` |
@@ -182,12 +182,14 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.kubeletService.namespace` | Namespace to deploy kubelet service | `kube-system` |
 | `prometheusOperator.logFormat` | Operator log output formatting | `"logfmt"` |
 | `prometheusOperator.logLevel` | Operator log level. Possible values: "all", "debug",	"info",	"warn",	"error", "none" | `"info"` |
+| `prometheusOperator.namespaces` | Namespaces to scope the interaction of the Prometheus Operator (allow list). Not compatible with prometheusOperator.releaseNamespaceOnly. | `[]` |
 | `prometheusOperator.nodeSelector` | Prometheus operator node selector https://kubernetes.io/docs/user-guide/node-selection/ | `{}` |
 | `prometheusOperator.podAnnotations` | Annotations to add to the operator pod | `{}` |
 | `prometheusOperator.podLabels` | Labels to add to the operator pod | `{}` |
 | `prometheusOperator.priorityClassName` | Name of Priority Class to assign pods | `nil` |
 | `prometheusOperator.prometheusConfigReloaderImage.repository` | Repository for config-reloader image | `quay.io/coreos/prometheus-config-reloader` |
 | `prometheusOperator.prometheusConfigReloaderImage.tag` | Tag for config-reloader image | `v0.32.0` |
+| `prometheusOperator.releaseNamespaceOnly` | Restricts the Prometheus scope to the release namespace only. Not compatible with prometheusOperator.namespaces. | `false` |
 | `prometheusOperator.resources` | Resource limits for prometheus operator | `{}` |
 | `prometheusOperator.securityContext` | SecurityContext for prometheus operator | `{"runAsNonRoot": true, "runAsUser": 65534}` |
 | `prometheusOperator.service.annotations` | Annotations to be added to the prometheus operator service | `{}` |

--- a/stable/prometheus-operator/ci/test-values.yaml
+++ b/stable/prometheus-operator/ci/test-values.yaml
@@ -968,9 +968,17 @@ prometheusOperator:
       podAnnotations: {}
       nodeSelector: {}
 
+  ## Restricts the Prometheus scope to the release namespace only. Not compatible with prometheusOperator.namespaces.
+  ##
+  releaseNamespaceOnly: false
+
+  ## Namespaces to scope the interaction of the Prometheus Operator (allow list). Not compatible with prometheusOperator.releaseNamespaceOnly.
+  ##
+  namespaces: []
+
   ## Namespaces not to scope the interaction of the Prometheus Operator (deny list).
   ##
-  denyNamespaces: {}
+  denyNamespaces: []
 
   ## Service account for Alertmanager to use.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/

--- a/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
@@ -43,6 +43,11 @@ spec:
           {{- if .Values.prometheusOperator.logLevel }}
             - --log-level={{ .Values.prometheusOperator.logLevel }}
           {{- end }}
+          {{- if .Values.prometheusOperator.releaseNamespaceOnly }}
+            - --namespaces={{ .Release.Namespace }}
+          {{- else if .Values.prometheusOperator.namespaces }}
+            - --namespaces={{ .Values.prometheusOperator.namespaces | join "," }}
+          {{- end }}
           {{- if .Values.prometheusOperator.denyNamespaces }}
             - --deny-namespaces={{ .Values.prometheusOperator.denyNamespaces | join "," }}
           {{- end }}

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -975,11 +975,11 @@ prometheusOperator:
       podAnnotations: {}
       nodeSelector: {}
 
-  ## Restricts the Prometheus scope to the release namespace only. Not compatible with prometheusOperator.namespaces
+  ## Restricts the Prometheus scope to the release namespace only. Not compatible with prometheusOperator.namespaces.
   ##
   releaseNamespaceOnly: false
 
-  ## Namespaces to scope the interaction of the Prometheus Operator (allow list). Not compatible with prometheusOperator.releaseNamespaceOnly
+  ## Namespaces to scope the interaction of the Prometheus Operator (allow list). Not compatible with prometheusOperator.releaseNamespaceOnly.
   ##
   namespaces: []
 

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -985,7 +985,7 @@ prometheusOperator:
 
   ## Namespaces not to scope the interaction of the Prometheus Operator (deny list).
   ##
-  denyNamespaces: {}
+  denyNamespaces: []
 
   ## Service account for Alertmanager to use.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -975,6 +975,14 @@ prometheusOperator:
       podAnnotations: {}
       nodeSelector: {}
 
+  ## Restricts the Prometheus scope to the release namespace only. Not compatible with prometheusOperator.namespaces
+  ##
+  releaseNamespaceOnly: false
+
+  ## Namespaces to scope the interaction of the Prometheus Operator (allow list). Not compatible with prometheusOperator.releaseNamespaceOnly
+  ##
+  namespaces: []
+
   ## Namespaces not to scope the interaction of the Prometheus Operator (deny list).
   ##
   denyNamespaces: {}


### PR DESCRIPTION
#### What this PR does / why we need it: 

Gives access to the `--namespaces` argument of Prometheus operator in chart values.

#### Special notes for your reviewer:

I added a `releaseNamespaceOnly` option which restricts namespaces to the release one only since it is probably the main use case for this argument.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
