### PR TITLE
[stable/kube2iam] Use newer daemonset API version if available

### DIFF
--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kube2iam
-version: 2.0.2
+version: 2.0.3
 appVersion: 0.10.7
 description: Provide IAM credentials to pods based on annotations.
 keywords:

--- a/stable/kube2iam/templates/daemonset.yaml
+++ b/stable/kube2iam/templates/daemonset.yaml
@@ -1,4 +1,8 @@
+{{- if .Capabilities.APIVersions.Has "apps/v1" }}
+apiVersion: apps/v1
+{{- else }}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: DaemonSet
 metadata:
   labels:

--- a/stable/kube2iam/templates/daemonset.yaml
+++ b/stable/kube2iam/templates/daemonset.yaml
@@ -12,6 +12,13 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   name: {{ template "kube2iam.fullname" . }}
 spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "kube2iam.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 6 }}
+{{- end }}
   template:
     metadata:
     {{- if .Values.podAnnotations }}


### PR DESCRIPTION
Signed-off-by: Joe Hohertz <joe@viafoura.com>

@jmcarp 
@icereval 
@mgoodness 

#### Is this a new chart

No

#### What this PR does / why we need it:

Use `apps/v1` daemonset API if available. (Needed for k8s 1.16+)

#### Which issue this PR fixes

None known.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
