### PR TITLE
[stable/aerospike] evaluate the service's annotations as a template

### DIFF
--- a/stable/aerospike/Chart.yaml
+++ b/stable/aerospike/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - aerospike
   - big-data
 home: http://aerospike.com
-version: 0.2.10
+version: 0.2.11
 icon: https://s3-us-west-1.amazonaws.com/aerospike-fd/wp-content/uploads/2016/06/Aerospike_square_logo.png
 sources:
 - https://github.com/aerospike/aerospike-server

--- a/stable/aerospike/README.md
+++ b/stable/aerospike/README.md
@@ -53,6 +53,11 @@ The chart can be customized using the following configurable parameters:
 | `resources`                     | Resource requests and limits                                    | `{}`                         |
 | `nodeSelector`                  | Labels for pod assignment                                       | `{}`                         |
 | `terminationGracePeriodSeconds` | Wait time before forcefully terminating container               | `30`                         |
+| `service.type`                  | Kubernetes Service type                                         | `ClusterIP`                  |
+| `service.annotations`           | Kubernetes service annotations, evaluated as a template         | `{}`                         |
+| `service.loadBalancerIP`        | Static IP Address to use for LoadBalancer service type          | `nil`                        |
+| `service.clusterIP`             | Static clusterIP or None for headless services                  | `None`                       |
+| `meshService.annotations`       | Kubernetes service annotations, evaluated as a template         | `{}`                         |
 
 Specify parameters using `--set key=value[,key=value]` argument to `helm install`
 

--- a/stable/aerospike/templates/mesh-service.yaml
+++ b/stable/aerospike/templates/mesh-service.yaml
@@ -10,8 +10,8 @@ metadata:
   annotations:
     # deprecation in 1.10, supported until at least 1.13,  breaks peer-finder/kube-dns if not used
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
-    {{- range $key, $value := .Values.meshService.annotations }}
-    {{ $key }}: {{ $value | quote }}
+    {{- with .Values.meshService.annotations }}
+{{ tpl (toYaml .) $ | indent 4 }}
     {{- end }}
 spec:
   # deprecates service.alpha.kubernetes.io/tolerate-unready-endpoints as of 1.10? see: kubernetes/kubernetes#49239 Fixed in 1.11 as of #63742

--- a/stable/aerospike/templates/service.yaml
+++ b/stable/aerospike/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
   annotations:
     # deprecation in 1.10, supported until at least 1.13,  breaks peer-finder/kube-dns if not used
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
-    {{- range $key, $value := .Values.service.annotations }}
-    {{ $key }}: {{ $value | quote }}
+    {{- with .Values.service.annotations }}
+{{ tpl (toYaml .) $ | indent 4 }}
     {{- end }}
 spec:
   # deprecates service.alpha.kubernetes.io/tolerate-unready-endpoints as of 1.10? see: kubernetes/kubernetes#49239 Fixed in 1.11 as of #63742

--- a/stable/aerospike/values.yaml
+++ b/stable/aerospike/values.yaml
@@ -30,6 +30,8 @@ persistentVolume: {}
 
 service:
   type: ClusterIP
+  # Provide any additional annotations which may be required.
+  # The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart
   annotations: {}
   loadBalancerIP:
   clusterIP: None
@@ -38,6 +40,8 @@ service:
   # - 10.0.0.0/8
 
 meshService:
+  # Provide any additional annotations which may be required.
+  # The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart
   annotations: {}
 
 labels: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

update the service templates to evaluate the annotations as a template, to allow people to use dynamic values in annotations key or values.

#### Special notes for your reviewer:

I replaced the custom loop over the annotations by the more common pattern of using the `toYaml` function. And I also added the missing documentation on the README.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
