### PR TITLE
[stable/postgresql] Use array as default extraEnvs

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 6.5.5
+version: 6.5.6
 appVersion: 11.5.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/values-production.yaml
+++ b/stable/postgresql/values-production.yaml
@@ -385,4 +385,4 @@ metrics:
     successThreshold: 1
 
 # Define custom environment variables to pass to the image here
-extraEnv: {}
+extraEnv: []

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -385,4 +385,4 @@ metrics:
     successThreshold: 1
 
 # Define custom environment variables to pass to the image here
-extraEnv: {}
+extraEnv: []


### PR DESCRIPTION
Signed-off-by: Daniel Reigada <daniel@codacy.com>

#### What this PR does / why we need it:
Extra environment variables should be passed as an array to this chart. But the default value in `values.yaml` is an empty object. This is confusing for the users of the chart.

```yaml
#Correct:
  extraEnv:
   - name: POSTGRESQL_MAX_CONNECTIONS
     value: "300"

#Incorrect:
  extraEnv:
    POSTGRESQL_MAX_CONNECTIONS: "300"
```

This PR changes the default value to match the expected value.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
