### PR TITLE
[stable/ipfs] Fix: can't evaluate field Values in type string

### DIFF
--- a/stable/ipfs/Chart.yaml
+++ b/stable/ipfs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the Interplanetary File System
 name: ipfs
-version: 0.3.2
+version: 0.3.3
 icon: https://raw.githubusercontent.com/ipfs/logo/master/raster-generated/ipfs-logo-128-ice-text.png
 home: https://ipfs.io/
 appVersion: v0.4.21

--- a/stable/ipfs/templates/ingress-api.yaml
+++ b/stable/ipfs/templates/ingress-api.yaml
@@ -22,7 +22,7 @@ spec:
         paths:
           - path: /{{ rest $url | join "/" }}
             backend:
-              serviceName: {{ template "ipfs.servicename" . }}
+              serviceName: {{ $serviceName }}
               servicePort: 5001
         {{- end -}}
         {{- if .Values.ingressApi.tls }}

--- a/stable/ipfs/templates/ingress-api.yaml
+++ b/stable/ipfs/templates/ingress-api.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.ingressApi.enabled -}}
-{{- $serviceName := include "ipfs.fullname" . -}}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -22,7 +21,7 @@ spec:
         paths:
           - path: /{{ rest $url | join "/" }}
             backend:
-              serviceName: {{ $serviceName }}
+              serviceName: {{ include "ipfs.fullname" . }}
               servicePort: 5001
         {{- end -}}
         {{- if .Values.ingressApi.tls }}

--- a/stable/ipfs/templates/ingress-gateway.yaml
+++ b/stable/ipfs/templates/ingress-gateway.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.ingressGateway.enabled -}}
-{{- $serviceName := include "ipfs.fullname" . -}}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -22,7 +21,7 @@ spec:
         paths:
           - path: /{{ rest $url | join "/" }}
             backend:
-              serviceName: {{ $serviceName }}
+              serviceName: {{ include "ipfs.fullname" . }}
               servicePort: 8080
         {{- end -}}
         {{- if .Values.ingressGateway.tls }}

--- a/stable/ipfs/templates/ingress-gateway.yaml
+++ b/stable/ipfs/templates/ingress-gateway.yaml
@@ -22,7 +22,7 @@ spec:
         paths:
           - path: /{{ rest $url | join "/" }}
             backend:
-              serviceName: {{ template "ipfs.servicename" . }}
+              serviceName: {{ $serviceName }}
               servicePort: 8080
         {{- end -}}
         {{- if .Values.ingressGateway.tls }}

--- a/stable/ipfs/templates/statefulset.yaml
+++ b/stable/ipfs/templates/statefulset.yaml
@@ -10,6 +10,10 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   serviceName: {{ template "ipfs.servicename" . }}
+  selector:
+    matchLabels:
+      app: {{ template "ipfs.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
#### What this PR does / why we need it:
It fixes an issue where ipfs.servicename would error.
Example:
```
serviceName: {{ template "ipfs.servicename" . }}
```
Would error in: *can't evaluate field Values in type string*

Both the ingress files already have this defined, specifically for this issue: 
```
{{- $serviceName := include "ipfs.fullname" . -}}
```
And by switching to the serviceName variable, the issue is fixed.
So I stripped out the serviceName variable and switched the template to the include if ipfs.serviceName.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
