### PR TITLE
[stable/docker-registry] Adds flag to start with an empty Environment

### DIFF
--- a/stable/docker-registry/Chart.yaml
+++ b/stable/docker-registry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Docker Registry
 name: docker-registry
-version: 1.8.3
+version: 1.8.4
 appVersion: 2.7.1
 home: https://hub.docker.com/_/registry/
 icon: https://hub.docker.com/public/images/logos/mini-logo.svg

--- a/stable/docker-registry/README.md
+++ b/stable/docker-registry/README.md
@@ -73,6 +73,7 @@ their default values.
 | `ingress.path`              | Ingress service path                                                                       | `/`             |
 | `ingress.hosts`             | Ingress hostnames                                                                          | `[]`            |
 | `ingress.tls`               | Ingress TLS configuration (YAML)                                                           | `[]`            |
+| `startWithEmptyEnvironment` | Start with an empty Environment                                                            | `nil`           |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.

--- a/stable/docker-registry/templates/deployment.yaml
+++ b/stable/docker-registry/templates/deployment.yaml
@@ -49,6 +49,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
+{{- if .Values.startWithEmptyEnvironment }}
+          - env
+          - -i
+{{ end }}
           - /bin/registry
           - serve
           - /etc/docker/registry/config.yml


### PR DESCRIPTION
#### What this PR does / why we need it:
Because the docker-registry picks up the default Kubernetes environment variables, we need a way to start without this default variables. 
We have a Service with a port called `registry-auth`. In the container we then have an environment variable `REGISTRY_AUTH_PORT="tcp://1...` which results in an error while starting.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
