### PR TITLE
[incubator/schema-registry] add external service annotations

### DIFF
--- a/incubator/schema-registry/Chart.yaml
+++ b/incubator/schema-registry/Chart.yaml
@@ -1,6 +1,6 @@
 name: schema-registry
 home: https://docs.confluent.io/current/schema-registry/docs/index.html
-version: 1.1.6
+version: 1.1.7
 appVersion: 5.0.1
 keywords:
   - confluent

--- a/incubator/schema-registry/README.md
+++ b/incubator/schema-registry/README.md
@@ -98,6 +98,7 @@ The following table lists the configurable parameters of the SchemaRegistry char
 | `external.servicePort` | set service port | `443` |
 | `external.loadBalancerIP` | set Static IP for LoadBalancer | `""` |
 | `external.nodePort` | set Nodeport (valid range depends on CLoud Provider) | `""` |
+| `external.annotations` | Additional annotations for the external service | `{}` |
 | `jmx.enabled` | Enable JMX? | `true` |
 | `jmx.port` | set JMX port | `5555` |
 | `prometheus.jmx.enabled` | Enable Prometheus JMX Exporter | `false` |

--- a/incubator/schema-registry/templates/schema-registry-external.yaml
+++ b/incubator/schema-registry/templates/schema-registry-external.yaml
@@ -2,6 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
+{{- if .Values.external.annotations }}
+  annotations:
+{{ toYaml .Values.external.annotations | indent 4 }}
+{{- end }}
   name: {{ template "schema-registry.fullname" . }}-external
   labels:
     app: {{ template "schema-registry.name" . }}

--- a/incubator/schema-registry/values.yaml
+++ b/incubator/schema-registry/values.yaml
@@ -134,6 +134,7 @@ external:
   servicePort: 443
   loadBalancerIP: ""
   nodePort: ""
+  annotations: {}
 
 ## Provide JMX Port
 jmx:


### PR DESCRIPTION
Signed-off-by: Diego Nogues <diego.sure@gmail.com>

#### Is this a new chart
No

#### What this PR does / why we need it:
Adds an option to put annotations on the external service.
This is useful, for example, to create an internal Load Balancer if your cloud provider supports it and also to use annotations for custom configurations on the Load Balancer.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
