### PR TITLE
[stable/spinnaker] Support serviceConfigs for local offline installation

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.21.0
+version: 1.22.0
 appVersion: 1.16.2
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/configmap/halyard-init-script.yaml
+++ b/stable/spinnaker/templates/configmap/halyard-init-script.yaml
@@ -11,6 +11,7 @@ data:
     # Override Halyard daemon's listen address
     cp /opt/halyard/config/* /tmp/config
     printf 'server.address: 0.0.0.0\n' > /tmp/config/halyard-local.yml
+
     # Use Redis deployed via the dependent Helm chart
     rm -rf /tmp/spinnaker/.hal/default/service-settings
     mkdir -p /tmp/spinnaker/.hal/default/service-settings
@@ -20,11 +21,21 @@ data:
     mkdir -p /tmp/spinnaker/.hal/default/profiles
     cp /tmp/additionalProfileConfigMaps/* /tmp/spinnaker/.hal/default/profiles/
 
+    rm -rf /tmp/spinnaker/.hal/.boms
+
     {{- if .Values.halyard.bom }}
-    rm -rf /tmp/spinnaker/.hal/.boms/bom
     mkdir -p /tmp/spinnaker/.hal/.boms/bom
     cp /tmp/halyard-bom/* /tmp/spinnaker/.hal/.boms/bom
     {{- end }}
+
+    for filename in /tmp/service-configs/*.yml; do
+      basename=$(basename -- "$filename")
+      rootname="${basename%.yml}"
+      servicename="${rootname%-*}"
+
+      mkdir -p "/tmp/spinnaker/.hal/.boms/$servicename"
+      cp "$filename" "/tmp/spinnaker/.hal/.boms/$servicename"
+    done
 
     {{- if hasKey .Values.halyard "additionalInitScript" }}
     # additionalInitScript

--- a/stable/spinnaker/templates/configmap/halyard-init-script.yaml
+++ b/stable/spinnaker/templates/configmap/halyard-init-script.yaml
@@ -28,6 +28,7 @@ data:
     cp /tmp/halyard-bom/* /tmp/spinnaker/.hal/.boms/bom
     {{- end }}
 
+    {{- if .Values.halyard.serviceConfigs }}
     for filename in /tmp/service-configs/*.yml; do
       basename=$(basename -- "$filename")
       rootname="${basename%.yml}"
@@ -36,6 +37,7 @@ data:
       mkdir -p "/tmp/spinnaker/.hal/.boms/$servicename"
       cp "$filename" "/tmp/spinnaker/.hal/.boms/$servicename"
     done
+    {{- end }}
 
     {{- if hasKey .Values.halyard "additionalInitScript" }}
     # additionalInitScript

--- a/stable/spinnaker/templates/configmap/service-configs.yaml
+++ b/stable/spinnaker/templates/configmap/service-configs.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "spinnaker.fullname" . }}-service-configs
+  labels:
+{{ include "spinnaker.standard-labels" . | indent 4 }}
+
+{{/*
+Render local configuration for each service with values passed by
+.Values.halyard.serviceConfigs
+*/}}
+{{- $settings := dict -}}
+
+{{- if .Values.halyard.serviceConfigs -}}
+{{- $_ := mergeOverwrite $settings .Values.halyard.serviceConfigs -}}
+{{- end -}}
+
+{{- /* Convert the content of settings key to YAML string */}}
+{{- range $filename, $content := $settings -}}
+{{- if not (typeIs "string" $content) -}}
+{{- $_ := set $settings $filename ($content | toYaml) -}}
+{{- end -}}
+{{- end -}}
+
+data:
+{{ $settings | toYaml | indent 2 }}

--- a/stable/spinnaker/templates/statefulsets/halyard.yaml
+++ b/stable/spinnaker/templates/statefulsets/halyard.yaml
@@ -40,6 +40,8 @@ spec:
           mountPath: /tmp/config
         - name: service-settings
           mountPath: /tmp/service-settings
+        - name: service-configs
+          mountPath: /tmp/service-configs
         - name: halyard-home
           mountPath: /tmp/spinnaker
         - name: additional-profile-config-maps
@@ -121,6 +123,9 @@ spec:
       - name: service-settings
         configMap:
           name: {{ template "spinnaker.fullname" . }}-service-settings
+      - name: service-configs
+        configMap:
+          name: {{ template "spinnaker.fullname" . }}-service-configs
       - name: halyard-initscript
         configMap:
           name: {{ template "spinnaker.fullname" . }}-halyard-init-script

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -78,6 +78,27 @@ halyard:
   #   timestamp: '2019-09-16 18:18:44'
   #   version: 1.16.1
 
+  ## Define local configuration for Spinnaker services.
+  ## The contents of these files would be copies of the configuration normally retrieved from
+  ## `gs://halconfig/<service-name>`, but instead need to be available locally on the halyard pod to facilitate
+  ## offline installation. This would typically be used along with a custom `bom:` with the `local:` prefix on a
+  ## service version.
+  ## Read more for details:
+  ## https://www.spinnaker.io/guides/operator/custom-boms/#boms-and-configuration-on-your-filesystem
+  serviceConfigs: {}
+  # clouddriver-boostrap.yml: |-
+  #   ...
+  # clouddriver-caching.yml: |-
+  #   ...
+  # clouddriver-ro-deck.yml: |-
+  #   ...
+  # clouddriver-ro.yml: |-
+  #   ...
+  # clouddriver-rw.yml: |-
+  #   ...
+  # clouddriver.yml: |-
+  #   ...
+
   ## Uncomment if you want to add extra commands to the init script
   ## run by the init container before halyard is started.
   ## The content will be passed through `tpl`, so value interpolation is supported.

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -85,7 +85,7 @@ halyard:
   ## service version.
   ## Read more for details:
   ## https://www.spinnaker.io/guides/operator/custom-boms/#boms-and-configuration-on-your-filesystem
-  serviceConfigs: {}
+  serviceConfigs: ~
   # clouddriver-boostrap.yml: |-
   #   ...
   # clouddriver-caching.yml: |-


### PR DESCRIPTION
Signed-off-by: Scott Frederick <sfrederick@pivotal.io>

#### Is this a new chart

No

#### What this PR does / why we need it:

In order to support a fully offline/airgapped installation of Spinnaker, it is necessary to make service configuration files available locally on the Halyard pod instead of allowing Halyard to read them from a GCS bucket. See https://www.spinnaker.io/guides/operator/custom-boms/#boms-and-configuration-on-your-filesystem for more details. 

This change allows service configuration files to be specified in a `serviceConfigs` section in `values.yml`, in which case the chart will mount them to the appropriate location on the Halyard pod's filesystem. 

This is similar to what is already provided with `additionalServiceSettings`, but with a different target destination on the Halyard pod.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yml
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
