### PR TITLE
[stable/spinnaker] Support imagePullSecrets in halyard pod.

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.20.3
+version: 1.21.0
 appVersion: 1.16.2
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/hooks/cleanup.yaml
+++ b/stable/spinnaker/templates/hooks/cleanup.yaml
@@ -20,6 +20,12 @@ spec:
       - name: halyard-config
         configMap:
           name: {{ template "spinnaker.fullname" . }}-halyard-config
+      {{- if .Values.halyard.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.halyard.image.pullSecrets }}
+        - name: {{ . }}
+        {{- end}}
+      {{- end}}
       containers:
       - name: halyard-install
         image: {{ .Values.halyard.image.repository }}:{{ .Values.halyard.image.tag }}

--- a/stable/spinnaker/templates/hooks/install-using-hal.yaml
+++ b/stable/spinnaker/templates/hooks/install-using-hal.yaml
@@ -75,6 +75,12 @@ spec:
         secret:
           secretName: {{ template "spinnaker.fullname" .}}-s3
       {{- end }}
+      {{- if .Values.halyard.pullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.halyard.image.pullSecrets }}
+        - name: {{ . }}
+        {{- end}}
+      {{- end}}
       containers:
       - name: halyard-install
         image: {{ .Values.halyard.image.repository }}:{{ .Values.halyard.image.tag }}

--- a/stable/spinnaker/templates/statefulsets/halyard.yaml
+++ b/stable/spinnaker/templates/statefulsets/halyard.yaml
@@ -132,6 +132,12 @@ spec:
           - key: cacerts
             path: cacerts
       {{- end }}
+      {{- if .Values.halyard.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.halyard.image.pullSecrets }}
+        - name: {{ . }}
+        {{- end}}
+      {{- end}}
       containers:
       - name: halyard
         image: {{ .Values.halyard.image.repository }}:{{ .Values.halyard.image.tag }}

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -3,6 +3,7 @@ halyard:
   image:
     repository: gcr.io/spinnaker-marketplace/halyard
     tag: 1.23.2
+    pullSecrets: []
   # Set to false to disable persistence data volume for halyard
   persistence:
     enabled: true


### PR DESCRIPTION
Signed-off-by: Scott Frederick <sfrederick@pivotal.io>

#### Is this a new chart

No
#### What this PR does / why we need it:

This change adds support for a `halyard.image.pullSecrets` that can be used to add [`imagePullSecrets`](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret) to the Halyard pod. This makes it possible for the Halyard image to be pulled from a private image repository. 

It's already possible to provide `imagePullSecrets` for service pods using `additionalServiceSettings`. An example `values.yml` to support pulling all images from a private image repo might look like this: 

```
halyard:
  image:
    tag: 1.24.0
    repository: repository.example.com/my-spinnaker/halyard
    pullSecrets:
      - regcred
  additionalServiceSettings:
    deck.yml:
      kubernetes:
        imagePullSecrets:
          - regcred
    gate.yml:
      kubernetes:
        imagePullSecrets:
          - regcred
    [ ... repeat for other services ...]
```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the values.yml
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
