### PR TITLE
[stable/unifi] Allow wildcard ingress certificates

### DIFF
--- a/stable/unifi/Chart.yaml
+++ b/stable/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 5.11.50
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 0.5.0
+version: 0.5.1
 keywords:
   - ubiquiti
   - unifi

--- a/stable/unifi/templates/ingress.yaml
+++ b/stable/unifi/templates/ingress.yaml
@@ -21,7 +21,7 @@ spec:
   {{- range .Values.ingress.tls }}
     - hosts:
       {{- range .hosts }}
-        - {{ . }}
+        - {{ . | quote }}
       {{- end }}
       secretName: {{ .secretName }}
   {{- end }}


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
This resolves an issue when specifying wildcard ingress certificates. The * is interpreted by yaml as a pointer, and fails to deploy the ingress. 

#### Which issue this PR fixes
None (easier to fix than to raise an issue..?)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
