### PR TITLE
[stable/prometheus-operator] Adding the rule from the mixin to allow for node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -10,7 +10,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 6.21.0
+version: 6.21.1
 appVersion: 0.32.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/k8s.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/k8s.rules.yaml
@@ -23,6 +23,11 @@ spec:
     rules:
     - expr: sum(rate(container_cpu_usage_seconds_total{job="kubelet", image!="", container!="POD"}[5m])) by (namespace)
       record: namespace:container_cpu_usage_seconds_total:sum_rate
+    - expr: |
+        sum by (namespace, pod, container) (
+          rate(container_cpu_usage_seconds_total{job="kubelet", image!="", container!="POD"}[5m])
+        ) * on (namespace, pod) group_left(node) max by(namespace, pod, node) (kube_pod_info)
+      record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
     - expr: |-
         sum by (namespace, pod, container) (
           rate(container_cpu_usage_seconds_total{job="kubelet", image!="", container!="POD"}[5m])


### PR DESCRIPTION

#### What this PR does / why we need it:

This is to fix the CPU usage over time metrics in the current helm chart for the prometheus-operator.  Without this fix, none of the CPU % metrics are working in the default grafana dashboards.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #18311

#### Special notes for your reviewer:

This is probably not the way this works?  I presume the rules are autogenerated from the mixin libsonnet stuff?

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
