### PR TITLE
add secrets access to the role

### DIFF
--- a/stable/jenkins/templates/rbac.yaml
+++ b/stable/jenkins/templates/rbac.yaml
@@ -15,7 +15,7 @@ metadata:
     "app.kubernetes.io/component": "{{ .Values.master.componentName }}"
 rules:
 - apiGroups: [""]
-  resources: ["pods", "pods/exec", "pods/log", "persistentvolumeclaims"]
+  resources: ["secrets", "pods", "pods/exec", "pods/log", "persistentvolumeclaims"]
   verbs: ["*"]
 
 ---


### PR DESCRIPTION
Allow jenkins to access kubernetes secrets so that plugins like kubernetes-credentials-provider can work
