### PR TITLE
[stable/prometheus-rabbitmq-exporter] fix serviceMonitor scrapper by wrong svc port

### DIFF
--- a/stable/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/stable/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 0.5.3
+version: 0.5.4
 appVersion: v0.29.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/stable/prometheus-rabbitmq-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-rabbitmq-exporter/templates/servicemonitor.yaml
@@ -16,7 +16,7 @@ spec:
       app: {{ template "prometheus-rabbitmq-exporter.name" . }}
       release: {{ .Release.Name }}
   endpoints:
-    - port: rabbitmq-exporter
+    - port: publish
   {{- if .Values.prometheus.monitor.interval }}
       interval: {{ .Values.prometheus.monitor.interval }}
   {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

When **prometheus.monitor** is enabled, the port referenced must be the same in the **service** object that will be scrapped. Before this PR they are wrong and prometheus couldn't get any metrics from the exporter.

Signed-off-by: Victor Lantier <victor@vermillion.net.br>


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
