### PR TITLE
[stable/kured] Change psp apiVersion for K8s 1.16

### DIFF
--- a/stable/kured/Chart.yaml
+++ b/stable/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.2.0"
 description: A Helm chart for kured
 name: kured
-version: 1.4.0
+version: 1.4.1
 home: https://github.com/weaveworks/kured
 maintainers:
   - name: plumdog

--- a/stable/kured/templates/_helpers.tpl
+++ b/stable/kured/templates/_helpers.tpl
@@ -41,3 +41,14 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for podsecuritypolicy.
+*/}}
+{{- define "kured.psp.apiVersion" -}}
+{{- if semverCompare "<1.10-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "policy/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/kured/templates/podsecuritypolicy.yaml
+++ b/stable/kured/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podSecurityPolicy.create}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "kured.psp.apiVersion" . }}
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "kured.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Ensure compatibility with K8s 1.16 and therefore use new apiVersion for PodSecurityPolicy.

#### Which issue this PR fixes
No issue

#### Special notes for your reviewer:
Nothing special

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)