### PR TITLE
[incubator/vault] Api version backwards compatibility

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.22.2
+version: 0.23.0
 appVersion: 1.2.3
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/templates/_helpers.tpl
+++ b/incubator/vault/templates/_helpers.tpl
@@ -52,3 +52,14 @@ Return the apiVersion of deployment.
     {{- print "extensions/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the apiVersion of ingress.
+*/}}
+{{- define "ingress.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+    {{- print "extensions/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/incubator/vault/templates/_helpers.tpl
+++ b/incubator/vault/templates/_helpers.tpl
@@ -41,3 +41,14 @@ Create chart name and version as used by the chart label.
 {{- define "vault.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Return the apiVersion of deployment.
+*/}}
+{{- define "deployment.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+    {{- print "apps/v1" -}}
+{{- else -}}
+    {{- print "extensions/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/incubator/vault/templates/_helpers.tpl
+++ b/incubator/vault/templates/_helpers.tpl
@@ -63,3 +63,14 @@ Return the apiVersion of ingress.
     {{- print "extensions/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the apiVersion of networkPolicy.
+*/}}
+{{- define "networkPolicy.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+    {{- print "networking.k8s.io/v1" -}}
+{{- else -}}
+    {{- print "extensions/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "vault.fullname" . }}

--- a/incubator/vault/templates/ingress.yaml
+++ b/incubator/vault/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "vault.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "vault.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

1. This PR ensures that the API versions assigned to the `deployment` and `ingress` resources are supported by the Kubernetes version.

2. The PR also adds a helper function which outputs the networkPolicy API version. (which can be used when defining a network policy resource)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
