### PR TITLE
[stable/kube-slack] Support pulling env vars from secrets

### DIFF
--- a/stable/kube-slack/Chart.yaml
+++ b/stable/kube-slack/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube-slack
-version: 1.2.0
+version: 1.3.0
 appVersion: v4.2.0
 apiVersion: v1
 description: Chart for kube-slack, a monitoring service for Kubernetes

--- a/stable/kube-slack/README.md
+++ b/stable/kube-slack/README.md
@@ -11,7 +11,7 @@ This chart adds a deployment, listening for cluster-wide pod failures and postin
 To install the chart with the release name `my-release`, configure an [Incoming Webhook](https://my.slack.com/apps/A0F7XDUAZ-incoming-webhooks) in Slack, note its url(`webhook-url` here) and run:
 
 ```console
-$ helm install stable/kube-slack --set slackUrl=webhook-url --name my-release
+$ helm install stable/kube-slack --set envVars.SLACK_URL=webhook-url --name my-release
 ```
 
 ## Uninstalling the Chart
@@ -26,7 +26,7 @@ $ helm delete my-release
 
 All configuration parameters are listed in [`values.yaml`](values.yaml).
 
-The environment values passed to kube-slack can be described in `envVars` parameter. At a minimum, the `envVars.SLACK_URL` value must be set.
+The environment values passed to kube-slack can be described in `envVars` parameter. At a minimum, the `envVars.SLACK_URL` value must be set. This can be done via either `envVars.SLACK_URL` or `envVarsFromSecret.SLACK_URL`. See [`values.yaml`](values.yaml) for more information about `envVarsFromSecret` usage.
 
 ## RBAC
 By default the chart will install the recommended RBAC roles and rolebindings.

--- a/stable/kube-slack/templates/deployment.yaml
+++ b/stable/kube-slack/templates/deployment.yaml
@@ -23,12 +23,20 @@ spec:
       {{- if .Values.annotations }}
       annotations:
 {{ toYaml .Values.annotations | indent 4 }}
-      {{- end }} 
+      {{- end }}
     spec:
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          {{- range $key, $value := .Values.envVarsFromSecret }}
+          - name: {{ $key }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ $value.secretKeyRef | quote }}
+                key: {{ $value.key | quote }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ template "kube-slack.fullname" . }}

--- a/stable/kube-slack/values.yaml
+++ b/stable/kube-slack/values.yaml
@@ -26,6 +26,13 @@ envVars:
   ##  If no metrics limit defined, alert if the pod utilization is more than the resource request amount
   METRICS_REQUESTS: "false"
 
+## Alternative to specify environment values for the deployment via secrets.
+## See envVars above for some examples
+# envVarsFromSecret:
+#  SLACK_URL:
+#    secretKeyRef: kube-slack
+#    key: SLACK_URL
+
 ## Configuration for the deployment:
 image:
   repository: willwill/kube-slack


### PR DESCRIPTION
Signed-off-by: Tim Costa <tim@timcosta.io>


#### Is this a new chart
No

#### What this PR does / why we need it:
Allow sourcing the SLACK_URL required environment variable from a secret instead of requiring it be set in the helm template. This increases security.

#### Special notes for your reviewer:
This pattern matches the pattern used by `external-secrets` https://github.com/godaddy/kubernetes-external-secrets/blob/master/charts/kubernetes-external-secrets/templates/deployment.yaml#L41

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
