### PR TITLE
[stable/hubot] bump redis dependency version

### DIFF
--- a/stable/hubot/Chart.yaml
+++ b/stable/hubot/Chart.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 description: Hubot chatbot for Slack
 name: hubot
-version: 1.0.0
+version: 1.0.1
 appVersion: 3.3.2
 home: https://hubot.github.com
 sources:

--- a/stable/hubot/requirements.lock
+++ b/stable/hubot/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 8.0.19
-digest: sha256:63c74f491d913133c58a096b312c0f99dfd1b1f3ca40af0f398c8b29466c872c
-generated: "2019-07-30T13:01:44.865771+02:00"
+  version: 9.4.3
+digest: sha256:c924e87888576908953f2f6f7a1835cc03df951d8e2cc9e571606a45d1295423
+generated: 2019-10-27T11:47:27.189073Z

--- a/stable/hubot/requirements.yaml
+++ b/stable/hubot/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: redis
-  version: ~8.0.0
+  version: ~9.4.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: redis.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:

This bumps the version of dependency chart, redis.

Part of the reason we need this is that the existing version of the locked redis dependency version (8.0.19) is not compatible with kubernetes v1.16

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
