### PR TITLE
[incubator/cloudwatch-agent] Add the helm chart for installing AWS CloudWatch Agent to Kubernetes cluster

### DIFF
--- a/incubator/cloudwatch-agent/.helmignore
+++ b/incubator/cloudwatch-agent/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/incubator/cloudwatch-agent/.helmignore
+++ b/incubator/cloudwatch-agent/.helmignore
@@ -20,3 +20,4 @@
 .idea/
 *.tmproj
 .vscode/
+OWNERS

--- a/incubator/cloudwatch-agent/Chart.yaml
+++ b/incubator/cloudwatch-agent/Chart.yaml
@@ -12,8 +12,4 @@ keywords:
 maintainers:
 - name: s2504s
   email: s2504s@gmail.com
-- name: viglesiasce
-  email: viglesiasce@gmail.com
-- name: unguiculus
-  email: unguiculus@gmail.com
 engine: gotpl

--- a/incubator/cloudwatch-agent/Chart.yaml
+++ b/incubator/cloudwatch-agent/Chart.yaml
@@ -9,9 +9,6 @@ keywords:
 - kubernetes
 - cloudwatch
 - monitoring
-#sources:
-#- https://github.com/kubernetes/charts
-#- https://github.com/fluent/fluentd-kubernetes-daemonset
 maintainers:
 - name: Sergey Vasilyev
   email: s2504s@gmail.com

--- a/incubator/cloudwatch-agent/Chart.yaml
+++ b/incubator/cloudwatch-agent/Chart.yaml
@@ -12,4 +12,8 @@ keywords:
 maintainers:
 - name: s2504s
   email: s2504s@gmail.com
+- name: viglesiasce
+  email: viglesiasce@gmail.com
+- name: unguiculus
+  email: unguiculus@gmail.com
 engine: gotpl

--- a/incubator/cloudwatch-agent/Chart.yaml
+++ b/incubator/cloudwatch-agent/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+name: cloudwatch-agent
+version: 0.0.1
+appVersion: 1.230621.0
+description: A CloudWatch Helm chart to collect Kubernetes Cluster Metrics
+home: https://github.com/aws-samples/amazon-cloudwatch-agent
+icon: ""
+keywords:
+- kubernetes
+- cloudwatch
+- monitoring
+#sources:
+#- https://github.com/kubernetes/charts
+#- https://github.com/fluent/fluentd-kubernetes-daemonset
+maintainers:
+- name: Sergey Vasilyev
+  email: s2504s@gmail.com
+engine: gotpl

--- a/incubator/cloudwatch-agent/Chart.yaml
+++ b/incubator/cloudwatch-agent/Chart.yaml
@@ -10,6 +10,6 @@ keywords:
 - cloudwatch
 - monitoring
 maintainers:
-- name: Sergey Vasilyev
+- name: s2504s
   email: s2504s@gmail.com
 engine: gotpl

--- a/incubator/cloudwatch-agent/OWNERS
+++ b/incubator/cloudwatch-agent/OWNERS
@@ -1,10 +1,6 @@
 approvers:
 - viglesiasce
 - unguiculus
-- s2504s
-- comeanother
 reviewers:
 - viglesiasce
 - unguiculus
-- s2504s
-- comeanother

--- a/incubator/cloudwatch-agent/OWNERS
+++ b/incubator/cloudwatch-agent/OWNERS
@@ -1,0 +1,10 @@
+approvers:
+- viglesiasce
+- unguiculus
+- s2504s
+- comeanother
+reviewers:
+- viglesiasce
+- unguiculus
+- s2504s
+- comeanother

--- a/incubator/cloudwatch-agent/README.md
+++ b/incubator/cloudwatch-agent/README.md
@@ -1,0 +1,90 @@
+# CloudWatch Agent
+
+* Installs  [Cloudwatch](https://aws.amazon.com/cloudwatch/) Agent to Collect Kubernetes Cluster Metrics.
+
+## TL;DR;
+
+```console
+$ helm install incubator/cloudwatch-agent
+```
+
+## Introduction
+
+This chart bootstraps a [Cloudwatch](https://aws.amazon.com/cloudwatch/) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.4+ with Beta APIs enabled
+- [kube2iam](../../stable/kube2iam) installed to used the **awsRole** config option
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ # use ec2 instance role credential
+$ helm install --name my-release incubator/cloudwatch-agent
+$ # or add aws_access_key_id and aws_access_key_id with the key/password of a AWS user with a policy to access  Cloudwatch
+$ helm install --name my-release incubator/cloudwatch-agent --set awsAccessKeyId=aws_access_key_id_here --set awsSecretAccessKey=aws_secret_access_key_here
+$ # or add a role to aws with the correct policy to add to cloud watch
+$ helm install --name my-release incubator/cloudwatch-agent --set awsRole=roll_name_here
+```
+
+The command deploys Cloudwatch on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Cloudwatch chart and their default values.
+
+| Parameter                    | Description                                                                     | Default                               |
+| ---------------------------- | ------------------------------------------------------------------------------- | --------------------------------------|
+| `image.repository`           | Image repository                                                                | `fluent/fluentd-kubernetes-daemonset` |
+| `image.tag`                  | Image tag                                                                       | `v1.3.3-debian-cloudwatch-1.0`        |
+| `image.pullPolicy`           | Image pull policy                                                               | `IfNotPresent`                        |
+| `resources.limits.cpu`       | CPU limit                                                                       | `100m`                                |
+| `resources.limits.memory`    | Memory limit                                                                    | `200Mi`                               |
+| `resources.requests.cpu`     | CPU request                                                                     | `100m`                                |
+| `resources.requests.memory`  | Memory request                                                                  | `200Mi`                               |
+| `hostNetwork`                | Host network                                                                    | `false`                               |
+| `podAnnotations`             | Annotations                                                                     | `{}`                                  |
+| `podSecurityContext`         | Security Context                                                                | `{}`                                  |
+| `awsRegion`                  | AWS Cloudwatch region                                                           | `us-east-1`                           |
+| `awsRole`                    | AWS IAM Role To Use                                                             | `nil`                                 |
+| `awsAccessKeyId`             | AWS Access Key Id of a AWS user with a policy to access Cloudwatch              | `nil`                                 |
+| `awsSecretAccessKey`         | AWS Secret Access Key of a AWS user with a policy to access Cloudwatch          | `nil`                                 |
+| `data`                       | Fluentd ConfigMap values. The main configuration is defined under `fluent.conf` | `example configuration`               |
+| `rbac.create`                | If true, create & use RBAC resources                                            | `false`                               |
+| `rbac.serviceAccountName`    | existing ServiceAccount to use (ignored if rbac.create=true)                    | `default`                             |
+| `rbac.pspEnabled`            | PodSecuritypolicy                                                               | `false`                               |
+| `tolerations`                | Add tolerations                                                                 | `[]`                                  |
+| `extraVars`                  | Add pod environment variables (must be specified as a single line object)       | `[]`                                  |
+| `updateStrategy`             | Define daemonset update strategy                                                | `OnDelete`                            |
+| `nodeSelector`               | Node labels for pod assignment                                                  | `{}`                                  |
+| `affinity`                   | Node affinity for pod assignment                                                | `{}`                                  |
+| `priorityClassName`          | Set priority class for daemon set                                               | `nil`                                 |
+
+
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install --name my-release \
+  --set awsRegion=us-east-1 \
+    incubator/cloudwatch-agent
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name my-release -f values.yaml incubator/cloudwatch-agent
+```

--- a/incubator/cloudwatch-agent/templates/_helpers.tpl
+++ b/incubator/cloudwatch-agent/templates/_helpers.tpl
@@ -1,0 +1,33 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cloudwatch-agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cloudwatch-agent.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cloudwatch-agent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/cloudwatch-agent/templates/clusterrole.yaml
+++ b/incubator/cloudwatch-agent/templates/clusterrole.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "cloudwatch-agent.fullname" . }}
+  labels:
+    app: {{ template "cloudwatch-agent.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "nodes", "endpoints"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes/proxy"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["nodes/stats", "configmaps", "events"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["cwagent-clusterleader"]
+    verbs: ["get","update"]
+{{- end }}

--- a/incubator/cloudwatch-agent/templates/clusterrolebinding.yaml
+++ b/incubator/cloudwatch-agent/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{ if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "cloudwatch-agent.fullname" . }}
+  labels:
+    app: {{ template "cloudwatch-agent.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+subjects:
+- kind: ServiceAccount
+  name: {{ template "cloudwatch-agent.name" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "cloudwatch-agent.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/incubator/cloudwatch-agent/templates/cwagent-configmap.yaml
+++ b/incubator/cloudwatch-agent/templates/cwagent-configmap.yaml
@@ -1,0 +1,20 @@
+# create configmap for cwagent config
+apiVersion: v1
+data:
+  # Configuration is in Json format. No matter what configure change you make,
+  # please keep the Json blob valid.
+  cwagentconfig.json: |
+    {
+      "logs": {
+        "metrics_collected": {
+          "kubernetes": {
+            "cluster_name": "{{ .Values.clusterName }}",
+            "metrics_collection_interval": 60
+          }
+        },
+        "force_flush_interval": 5
+      }
+    }
+kind: ConfigMap
+metadata:
+  name: cwagentconfig

--- a/incubator/cloudwatch-agent/templates/cwagent-daemonset.yaml
+++ b/incubator/cloudwatch-agent/templates/cwagent-daemonset.yaml
@@ -84,15 +84,15 @@ spec:
           hostPath:
             path: /dev/disk/
 {{- if .Values.tolerations }}
-    tolerations:
+      tolerations:
 {{ toYaml .Values.tolerations | indent 6 }}
 {{- end }}
       {{- if .Values.affinity }}
-    affinity:
+      affinity:
 {{ toYaml .Values.affinity | indent 8 }}
       {{- end }}
     {{- if .Values.nodeSelector }}
-    nodeSelector:
+      nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
   updateStrategy:

--- a/incubator/cloudwatch-agent/templates/cwagent-daemonset.yaml
+++ b/incubator/cloudwatch-agent/templates/cwagent-daemonset.yaml
@@ -28,7 +28,8 @@ spec:
         #  - containerPort: 8125
         #    hostPort: 8125
         #    protocol: UDP
-
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
         # Please don't change below envs
         env:
           - name: HOST_IP

--- a/incubator/cloudwatch-agent/templates/cwagent-daemonset.yaml
+++ b/incubator/cloudwatch-agent/templates/cwagent-daemonset.yaml
@@ -1,61 +1,69 @@
-# deploy cwagent as daemonset
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "cloudwatch-agent.name" . }}
+  labels:
+    app: {{ template "cloudwatch-agent.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
 spec:
   selector:
     matchLabels:
-      name: {{ template "cloudwatch-agent.name" . }}
+      app: {{ template "cloudwatch-agent.name" . }}
   template:
     metadata:
       labels:
-        name: {{ template "cloudwatch-agent.name" . }}
+        app: {{ template "cloudwatch-agent.name" . }}
+        release: "{{ .Release.Name }}"
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/cwagent-configmap.yaml") . | sha256sum }}
     spec:
+      terminationGracePeriodSeconds: 60
+      serviceAccountName: {{ template "cloudwatch-agent.name" . }}
       containers:
-        - name: {{ template "cloudwatch-agent.name" . }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          #ports:
-          #  - containerPort: 8125
-          #    hostPort: 8125
-          #    protocol: UDP
-          resources:
-  {{ toYaml .Values.resources | indent 10 }}
-          # Please don't change below envs
-          env:
-            - name: HOST_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
-            - name: HOST_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: K8S_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: CI_VERSION
-              value: "k8s/1.0.0"
-          # Please don't change the mountPath
-          volumeMounts:
-            - name: cwagentconfig
-              mountPath: /etc/cwagentconfig
-            - name: rootfs
-              mountPath: /rootfs
-              readOnly: true
-            - name: dockersock
-              mountPath: /var/run/docker.sock
-              readOnly: true
-            - name: varlibdocker
-              mountPath: /var/lib/docker
-              readOnly: true
-            - name: sys
-              mountPath: /sys
-              readOnly: true
-            - name: devdisk
-              mountPath: /dev/disk
-              readOnly: true
+      - name: {{ template "cloudwatch-agent.name" . }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        #ports:
+        #  - containerPort: 8125
+        #    hostPort: 8125
+        #    protocol: UDP
+
+        # Please don't change below envs
+        env:
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: HOST_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: CI_VERSION
+            value: "k8s/1.0.0"
+        # Please don't change the mountPath
+        volumeMounts:
+          - name: cwagentconfig
+            mountPath: /etc/cwagentconfig
+          - name: rootfs
+            mountPath: /rootfs
+            readOnly: true
+          - name: dockersock
+            mountPath: /var/run/docker.sock
+            readOnly: true
+          - name: varlibdocker
+            mountPath: /var/lib/docker
+            readOnly: true
+          - name: sys
+            mountPath: /sys
+            readOnly: true
+          - name: devdisk
+            mountPath: /dev/disk
+            readOnly: true
       volumes:
         - name: cwagentconfig
           configMap:
@@ -75,5 +83,17 @@ spec:
         - name: devdisk
           hostPath:
             path: /dev/disk/
-      terminationGracePeriodSeconds: 60
-      serviceAccountName: {{ template "cloudwatch-agent.name" . }}
+{{- if .Values.tolerations }}
+    tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+{{- end }}
+      {{- if .Values.affinity }}
+    affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end }}
+    {{- if .Values.nodeSelector }}
+    nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+  updateStrategy:
+{{ toYaml .Values.updateStrategy | indent 4 }}

--- a/incubator/cloudwatch-agent/templates/cwagent-daemonset.yaml
+++ b/incubator/cloudwatch-agent/templates/cwagent-daemonset.yaml
@@ -1,0 +1,79 @@
+# deploy cwagent as daemonset
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "cloudwatch-agent.name" . }}
+spec:
+  selector:
+    matchLabels:
+      name: {{ template "cloudwatch-agent.name" . }}
+  template:
+    metadata:
+      labels:
+        name: {{ template "cloudwatch-agent.name" . }}
+    spec:
+      containers:
+        - name: {{ template "cloudwatch-agent.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          #ports:
+          #  - containerPort: 8125
+          #    hostPort: 8125
+          #    protocol: UDP
+          resources:
+  {{ toYaml .Values.resources | indent 10 }}
+          # Please don't change below envs
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: HOST_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CI_VERSION
+              value: "k8s/1.0.0"
+          # Please don't change the mountPath
+          volumeMounts:
+            - name: cwagentconfig
+              mountPath: /etc/cwagentconfig
+            - name: rootfs
+              mountPath: /rootfs
+              readOnly: true
+            - name: dockersock
+              mountPath: /var/run/docker.sock
+              readOnly: true
+            - name: varlibdocker
+              mountPath: /var/lib/docker
+              readOnly: true
+            - name: sys
+              mountPath: /sys
+              readOnly: true
+            - name: devdisk
+              mountPath: /dev/disk
+              readOnly: true
+      volumes:
+        - name: cwagentconfig
+          configMap:
+            name: cwagentconfig
+        - name: rootfs
+          hostPath:
+            path: /
+        - name: dockersock
+          hostPath:
+            path: /var/run/docker.sock
+        - name: varlibdocker
+          hostPath:
+            path: /var/lib/docker
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: devdisk
+          hostPath:
+            path: /dev/disk/
+      terminationGracePeriodSeconds: 60
+      serviceAccountName: {{ template "cloudwatch-agent.name" . }}

--- a/incubator/cloudwatch-agent/templates/psp-clusterrole.yaml
+++ b/incubator/cloudwatch-agent/templates/psp-clusterrole.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.pspEnabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "cloudwatch-agent.fullname" . }}-psp
+  labels:
+    app: {{ template "cloudwatch-agent.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "cloudwatch-agent.name" . }}
+{{- end }}

--- a/incubator/cloudwatch-agent/templates/psp-clusterrolebinding.yaml
+++ b/incubator/cloudwatch-agent/templates/psp-clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "cloudwatch-agent.fullname" . }}-psp
+  labels:
+    app: {{ template "cloudwatch-agent.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "cloudwatch-agent.fullname" . }}-psp
+subjects:
+  - kind: ServiceAccount
+    name: {{ if .Values.rbac.create }}{{ template "cloudwatch-agent.name" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/incubator/cloudwatch-agent/templates/psp.yaml
+++ b/incubator/cloudwatch-agent/templates/psp.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "cloudwatch-agent.fullname" . }}
+  labels:
+    app: {{ template "cloudwatch-agent.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+spec:
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+  hostPID: true
+  hostIPC: true
+  hostNetwork: true
+  hostPorts:
+  - min: 1
+    max: 65536
+{{- end }}

--- a/incubator/cloudwatch-agent/templates/serviceaccount.yaml
+++ b/incubator/cloudwatch-agent/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "cloudwatch-agent.name" . }}
+  labels:
+    app: {{ template "cloudwatch-agent.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- end }}

--- a/incubator/cloudwatch-agent/values.yaml
+++ b/incubator/cloudwatch-agent/values.yaml
@@ -1,0 +1,78 @@
+image:
+  repository: amazon/cloudwatch-agent
+  tag: 1.230621.0
+## Specify an imagePullPolicy (Required)
+## It's recommended to change this to 'Always' if the image tag is 'latest'
+## ref: http://kubernetes.io/docs/user-guide/images/#updating-images
+  pullPolicy: IfNotPresent
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources: {}
+# We usually recommend not to specify default resources and to leave this as a conscious
+# choice for the user. This also increases chances charts run on environments with little
+# resources, such as Minikube. If you do want to specify resources, uncomment the following
+# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+#  limits:
+#    cpu: 100m
+#    memory: 200Mi
+#  requests:
+#    cpu: 100m
+#    memory: 200Mi
+
+# hostNetwork: false
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+  # kubernetes.io/role: node
+# Ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core
+# Expects input structure as per specification for example:
+#   affinity:
+#     nodeAffinity:
+#      requiredDuringSchedulingIgnoredDuringExecution:
+#        nodeSelectorTerms:
+#        - matchExpressions:
+#          - key: foo.bar.com/role
+#            operator: In
+#            values:
+#            - master
+affinity: {}
+## Add tolerations if specified
+tolerations: []
+#   - key: node-role.kubernetes.io/master
+#     operator: Exists
+#     effect: NoSchedule
+
+podSecurityContext: {}
+
+podAnnotations: {}
+
+# Pod priority
+# Sets PriorityClassName if defined.
+#
+# priorityClassName: "my-priority-class"
+
+## Kubernetes cluster name
+clusterName:
+
+awsRegion:
+awsRole:
+awsAccessKeyId:
+awsSecretAccessKey:
+
+rbac:
+  ## If true, create and use RBAC resources
+  create: false
+  pspEnabled: false
+
+  ## Ignored if rbac.create is true
+  serviceAccountName: default
+# Add extra environment variables if specified (must be specified as a single line object and be quoted)
+extraVars: []
+# - "{ name: NODE_NAME, valueFrom: { fieldRef: { fieldPath: spec.nodeName } } }"
+
+updateStrategy:
+  type: RollingUpdate


### PR DESCRIPTION
Signed-off-by: Sergey Vasilyev <s2504s@gmail.com>

#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

#### What this PR does / why we need it:
Setting Up Container Insights on Amazon EKS and Kubernetes
[Description](https://docs.aws.amazon.com/en_us/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-EKS-quickstart.html)
#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
