### PR TITLE
[stable/memcached] - Add servicemonitor for Prometheus-operator

### DIFF
--- a/stable/memcached/Chart.yaml
+++ b/stable/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 3.0.2
+version: 3.1.0
 appVersion: 1.5.19
 description: Free & open source, high-performance, distributed memory object caching
   system.

--- a/stable/memcached/README.md
+++ b/stable/memcached/README.md
@@ -48,6 +48,8 @@ The following table lists the configurable parameters of the Memcached chart and
 | `memcached.maxItemMemory`  | Max memory for items (in MB)    | `64`                                                    |
 | `memcached.extraArgs`      | Additional memcached arguments  | `[]`                                                    |
 | `metrics.enabled`          | Expose metrics in prometheus format | false                                               |
+| `metrics.serviceMonitor.enabled`          | Expose serviceMonitor to be scraped in prometheus-operator target | false                                               |
+| `metrics.serviceMonitor.interval`          | Default frequency to scrap metrics | 15s                                               |
 | `metrics.image`            | The image to pull and run for the metrics exporter | A recent official memcached tag      |
 | `metrics.imagePullPolicy`  | Image pull policy               | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
 | `metrics.resources`        | CPU/Memory resource requests/limits for the metrics exporter | `{}`                       |
@@ -127,3 +129,19 @@ spec:
 ```
 
 Once you've done this, you can upgrade to 3.x with Helm as normal.
+
+If you want prometheus-operator scrap all serviceMonitors in your cluster you need to set:
+```yaml
+prometheus:
+  prometheusSpec:
+    serviceMonitorSelectorNilUsesHelmValues: false
+```
+If you want to be specific:
+```yaml
+prometheus:
+  prometheusSpec:
+    serviceMonitorSelector:
+      matchLabels:
+        app: memcached
+```
+You can have more intel in prometheus-operator values and here [github](https://github.com/helm/charts/issues/11310#issuecomment-463486706)

--- a/stable/memcached/templates/servicemonitor.yaml
+++ b/stable/memcached/templates/servicemonitor.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "memcached.fullname" . }}
+  labels:
+    app: {{ template "memcached.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "memcached.fullname" . }}
+  endpoints:
+  - port: metrics
+    interval: {{ .Values.metrics.serviceMonitor.interval }}
+{{- end }}

--- a/stable/memcached/values.yaml
+++ b/stable/memcached/values.yaml
@@ -77,6 +77,9 @@ securityContext:
 metrics:
   ## Expose memcached metrics in Prometheus format
   enabled: false
+  serviceMonitor:
+    enabled: false
+    interval: 15s
 
   ## Memcached exporter image and tag
   image: quay.io/prometheus/memcached-exporter:v0.4.1


### PR DESCRIPTION
Signed-off-by: Lord-Y <Lord-Y@users.noreply.github.com>

#### What this PR does / why we need it:

Add serviceMonitor to be used by Prometheus-Operator. Some extra config still need to be done on prometheus-operator part.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
