### PR TITLE
[stable/ambassador] Support for LB status being propagated to ingress

### DIFF
--- a/stable/ambassador/Chart.yaml
+++ b/stable/ambassador/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.85.0
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 4.4.3
+version: 4.4.4
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/stable/ambassador/templates/deployment.yaml
+++ b/stable/ambassador/templates/deployment.yaml
@@ -48,6 +48,12 @@ spec:
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
       volumes:
+        - name: ambassador-pod-info
+          downwardAPI:
+            items:
+              - fieldRef:
+                  fieldPath: metadata.labels
+                path: labels
         {{- if .Values.prometheusExporter.enabled }}
         - name: stats-exporter-mapping-config
           configMap:
@@ -162,6 +168,9 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 3
           volumeMounts:
+            - name: ambassador-pod-info
+              mountPath: /tmp/ambassador-pod-info
+              readOnly: true
           {{- if .Values.ambassadorConfig }}
             - name: ambassador-config
               mountPath: /ambassador/ambassador-config/ambassador-config.yaml

--- a/stable/ambassador/templates/service.yaml
+++ b/stable/ambassador/templates/service.yaml
@@ -8,6 +8,7 @@ metadata:
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: ambassador-service
   {{- with .Values.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
* No
#### What this PR does / why we need it:
* Following this PR on ambassador: https://github.com/datawire/ambassador/pull/1868 , the LB status can be propagated to the ingress. To allow that two things are currently missing from the ambassador chart:
* a label "app.kubernetes.io/component: ambassador-service" must be added (as written in the ambassador doc: https://www.getambassador.io/reference/core/ingress-controller/#what-is-required-to-use-the-ingress-resource )
* the downwardAPI must be enabled (see https://github.com/datawire/ambassador/pull/1868/files#diff-42a97a8bbfa211f2bd32e08b0d12c73aR536 )
#### Which issue this PR fixes
- none

#### Special notes for your reviewer: 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
