### PR TITLE
[stable/velero] Restic optional extra volumes and volumeMounts

### DIFF
--- a/stable/velero/Chart.yaml
+++ b/stable/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.1.0
 description: A Helm chart for velero
 name: velero
-version: 2.2.1
+version: 2.3.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/stable/velero/README.md
+++ b/stable/velero/README.md
@@ -104,6 +104,8 @@ Parameter | Description | Default
 `restic.privileged` | Whether restic should run as a privileged pod. Only necessary in special cases (SELinux) | `false`
 `restic.resources` | Restic DaemonSet resource requests and limits | `{}`
 `restic.tolerations` | Restic DaemonSet tolerations | `[]`
+`restic.extraVolumes` | Extra volumes for the Restic daemonsett | `[]`
+`restic.extraVolumeMounts` | Extra volumeMounts for the Restic daemonset | `[]`
 `configMaps` | Velero ConfigMaps | `[]`
 
 ## How to

--- a/stable/velero/README.md
+++ b/stable/velero/README.md
@@ -104,7 +104,7 @@ Parameter | Description | Default
 `restic.privileged` | Whether restic should run as a privileged pod. Only necessary in special cases (SELinux) | `false`
 `restic.resources` | Restic DaemonSet resource requests and limits | `{}`
 `restic.tolerations` | Restic DaemonSet tolerations | `[]`
-`restic.extraVolumes` | Extra volumes for the Restic daemonsett | `[]`
+`restic.extraVolumes` | Extra volumes for the Restic daemonset | `[]`
 `restic.extraVolumeMounts` | Extra volumeMounts for the Restic daemonset | `[]`
 `configMaps` | Velero ConfigMaps | `[]`
 

--- a/stable/velero/templates/restic-daemonset.yaml
+++ b/stable/velero/templates/restic-daemonset.yaml
@@ -42,6 +42,9 @@ spec:
             path: {{ .Values.restic.podVolumePath }}
         - name: scratch
           emptyDir: {}
+        {{- if .Values.restic.extraVolumes }}
+        {{- toYaml .Values.restic.extraVolumes | nindent 8 }}
+        {{- end }}
       containers:
         - name: velero
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -61,6 +64,9 @@ spec:
               mountPropagation: HostToContainer
             - name: scratch
               mountPath: /scratch
+            {{- if .Values.restic.extraVolumeMounts }}
+            {{- toYaml .Values.restic.extraVolumeMounts | nindent 12 }}
+            {{- end }}
           {{- if and .Values.credentials.useSecret (eq $provider "azure") }}
           envFrom:
             - secretRef:

--- a/stable/velero/values.yaml
+++ b/stable/velero/values.yaml
@@ -169,6 +169,12 @@ restic:
   # Tolerations to use for the Restic daemonset. Optional.
   tolerations: []
 
+  # Extra volumes for the Restic daemonset. Optional.
+  extraVolumes: []
+
+  # Extra volumeMounts for the Restic daemonset. Optional.
+  extraVolumeMounts: []
+
 # Backup schedules to create.
 # Eg:
 # schedules:


### PR DESCRIPTION
Signed-off-by: Rick Haan <rickhaan94@gmail.com>

#### What this PR does / why we need it:
I would like to add the option to configure extra `volumes` and `volumeMounts` to the Restic daemonset. This could be used for example to add CA certificates.

Equal functionality as my last PR helm#18120. But this time it's for the Restic daemonset.

#### Which issue this PR fixes
N.a.

#### Special notes for your reviewer:
N.a.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)