### PR TITLE
[stable/jenkins] JCasC auto reload works without ssh keys

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -6,10 +6,25 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.8.0 JCasC auto reload works without ssh keys
+
+We make use of the fact that the Jenkins Configuration as Code Plugin can be triggered via http `POST` to `JENKINS_URL/configuration-as-code/reload`and a pre-shared key.
+The sidecar container responsible for reloading config changes is now `kiwigrid/k8s-sidecar:0.1.20` instead of it's fork `shadwell/k8s-sidecar`.
+
+References:
+- [Triggering Configuration Reload](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/configurationReload.md)
+- [kiwigrid/k8s-sidecar](https://hub.docker.com/r/kiwigrid/k8s-sidecar)
+
+`master.sidecars.configAutoReload.enabled` now works using `casc.reload.token`
+
 ## 1.7.10
 
 Disable direct connection in default configuration (when kubernetes plugin version >= 1.20.2).
 Note: In case direct connection is going to be used `jenkins/jnlp-slave` needs to be version `3.35-5` or newer.
+
+## 1.7.9
+
+Prevented Jenkins Setup Wizard on new installations
 
 ## 1.7.8
 

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.7.10
+version: 1.8.0
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -136,7 +136,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.enableXmlConfig`          | enables configuration done via XML files | `false`                               |
 | `master.sidecars.configAutoReload` | Jenkins Config as Code auto-reload settings |                                   |
 | `master.sidecars.configAutoReload.enabled` | Jenkins Config as Code auto-reload settings (Attention: rbac needs to be enabled otherwise the sidecar can't read the config map) | `false`                                                      |
-| `master.sidecars.configAutoReload.image` | Image which triggers the reload | `shadwell/k8s-sidecar:0.0.2`            |
+| `master.sidecars.configAutoReload.image` | Image which triggers the reload | `kiwigrid/k8s-sidecar:0.1.20`           |
 | `master.sidecars.other`           | Configures additional sidecar container(s) for Jenkins master | `[]`             |
 | `master.initScripts`              | List of Jenkins init scripts         | `[]`                                      |
 | `master.credentialsXmlSecret`     | Kubernetes secret that contains a 'credentials.xml' file | Not set               |

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -261,12 +261,6 @@ data:
 {{- if .Values.master.scriptApproval }}
     yes n | cp -i /var/jenkins_config/scriptapproval.xml /var/jenkins_home/scriptApproval.xml;
 {{- end }}
-{{- if and (.Values.master.JCasC.enabled) (.Values.master.sidecars.configAutoReload.enabled) }}
-  {{- if not .Values.master.initScripts }}
-    mkdir -p /var/jenkins_home/init.groovy.d/;
-    yes n | cp -i /var/jenkins_config/*.groovy /var/jenkins_home/init.groovy.d/;
-  {{- end }}
-{{- end }}
 {{- if .Values.master.initScripts }}
     mkdir -p /var/jenkins_home/init.groovy.d/;
     {{- if .Values.master.overwriteConfig }}
@@ -274,10 +268,8 @@ data:
     {{- end }}
     yes n | cp -i /var/jenkins_config/*.groovy /var/jenkins_home/init.groovy.d/;
 {{- end }}
-{{- if .Values.master.JCasC.enabled }}
-  {{- if .Values.master.sidecars.configAutoReload.enabled }}
-    bash -c 'ssh-keygen -y -f <(echo "${ADMIN_PRIVATE_KEY}") > /var/jenkins_home/key.pub'
-  {{- else }}
+{{- if .Values.master.JCasC.enabled}}
+  {{- if not .Values.master.sidecars.configAutoReload.enabled }}
     mkdir -p /var/jenkins_home/casc_configs;
     rm -rf /var/jenkins_home/casc_configs/*
     cp -v /var/jenkins_config/*.yaml /var/jenkins_home/casc_configs
@@ -302,25 +294,7 @@ data:
 {{ $val | indent 4 }}
 {{- end }}
 {{- if .Values.master.JCasC.enabled }}
-  {{- if .Values.master.sidecars.configAutoReload.enabled }}
-  init-add-ssh-key-to-admin.groovy: |-
-    import jenkins.security.*
-    import hudson.model.User
-    import jenkins.model.Jenkins
-    User user = User.getOrCreateByIdOrFullName("{{ .Values.master.adminUser | default "admin" }}")
-    if (user == null) {
-      System.err.println("ERROR: user '{{ .Values.master.adminUser | default "admin" }}' not found! Can't configure SSH key which is needed to reload JCasC config!")
-    } else {
-      String sshKeyString = new File('/var/jenkins_home/key.pub').text
-      keys_param = new org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl(sshKeyString)
-      user.addProperty(keys_param)
-      def inst = Jenkins.getInstance()
-      def sshDesc = inst.getDescriptor("org.jenkinsci.main.modules.sshd.SSHD")
-      sshDesc.setPort({{ .Values.master.sidecars.configAutoReload.sshTcpPort | default 1044 }})
-      sshDesc.getActualPort()
-      sshDesc.save()
-    }
-  {{- else }}
+  {{- if not .Values.master.sidecars.configAutoReload.enabled }}
 # Only add config to this script if we aren't auto-reloading otherwise the pod will restart upon each config change:
 {{- if .Values.master.JCasC.defaultConfig }}
   jcasc-default-config.yaml: |-

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -101,15 +101,6 @@ spec:
                 secretKeyRef:
                   name: {{ template "jenkins.fullname" . }}
                   key: jenkins-admin-user
-            {{- if or (.Values.master.adminSshKey) (.Values.master.sidecars.configAutoReload.enabled) }}
-            {{- if .Values.master.JCasC.enabled }}
-            - name: ADMIN_PRIVATE_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "jenkins.fullname" . }}
-                  key: {{ "jenkins-admin-private-key" | quote }}
-            {{- end }}
-            {{- end }}
             {{- end }}
             {{- if .Values.master.initContainerEnv }}
 {{ toYaml .Values.master.initContainerEnv | indent 12 }}
@@ -167,8 +158,14 @@ spec:
 {{ toYaml .Values.master.lifecycle | indent 12 }}
           {{- end }}
           env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: JAVA_OPTS
-              value: {{ default "" .Values.master.javaOpts | quote }}
+              value: >
+                {{ default "" .Values.master.javaOpts }}
+                {{- if .Values.master.sidecars.configAutoReload.enabled }} -Dcasc.reload.token=$(POD_NAME) {{end}}
             - name: JENKINS_OPTS
               value: "{{ if .Values.master.jenkinsUriPrefix }}--prefix={{ .Values.master.jenkinsUriPrefix }} {{ end }}{{ default "" .Values.master.jenkinsOpts}}"
             - name: JENKINS_SLAVE_AGENT_PORT
@@ -184,15 +181,6 @@ spec:
                 secretKeyRef:
                   name: {{ template "jenkins.fullname" . }}
                   key: jenkins-admin-user
-            {{- if or (.Values.master.adminSshKey) (.Values.master.sidecars.configAutoReload.enabled) }}
-            {{- if .Values.master.JCasC.enabled }}
-            - name: ADMIN_PRIVATE_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "jenkins.fullname" . }}
-                  key: {{ "jenkins-admin-private-key" | quote }}
-            {{- end }}
-            {{- end }}
             {{- end }}
             {{- if .Values.master.containerEnv }}
 {{ toYaml .Values.master.containerEnv | indent 12 }}
@@ -284,38 +272,24 @@ spec:
             {{- end }}
 
 {{- if and (.Values.master.JCasC.enabled) (.Values.master.sidecars.configAutoReload.enabled) }}
-        - name: {{ template "jenkins.name" . }}-sc-config
+        - name: jenkins-sc-config
           image: "{{ .Values.master.sidecars.configAutoReload.image }}"
           imagePullPolicy: {{ .Values.master.sidecars.configAutoReload.imagePullPolicy }}
           env:
-            - name: JENKINSRELOADCONFIG
-              value: "true"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: LABEL
               value: "{{ template "jenkins.fullname" . }}-jenkins-config"
             - name: FOLDER
               value: "{{ .Values.master.sidecars.configAutoReload.folder }}"
             - name: NAMESPACE
-              value: "{{ .Values.master.sidecars.configAutoReload.searchNamespace }}"
-            - name: SSH_PORT
-              value: "{{ .Values.master.sidecars.configAutoReload.sshTcpPort }}"
-            - name: JENKINS_PORT
-              value: "{{ .Values.master.targetPort }}"
-            {{- if .Values.master.useSecurity }}
-            - name: ADMIN_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "jenkins.fullname" . }}
-                  key: jenkins-admin-user
-            {{- if or (.Values.master.adminSshKey) (.Values.master.sidecars.configAutoReload.enabled) }}
-            {{- if .Values.master.JCasC.enabled }}
-            - name: ADMIN_PRIVATE_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "jenkins.fullname" . }}
-                  key: {{ "jenkins-admin-private-key" | quote }}
-            {{- end }}
-            {{- end }}
-            {{- end }}
+              value: "{{ .Values.master.sidecars.configAutoReload.searchNamespace | default .Release.Namespace }}"
+            - name: REQ_URL
+              value: "http://localhost:8080/reload-configuration-as-code/?casc-reload-token=$(POD_NAME)"
+            - name: REQ_METHOD
+              value: "POST"
           resources:
 {{ toYaml .Values.master.sidecars.configAutoReload.resources | indent 12 }}
           volumeMounts:

--- a/stable/jenkins/templates/secret.yaml
+++ b/stable/jenkins/templates/secret.yaml
@@ -17,12 +17,5 @@ data:
   {{ else -}}
   jenkins-admin-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{ end -}}
-  {{ if and (.Values.master.JCasC.enabled) (.Values.master.sidecars.configAutoReload.enabled) -}}
-  {{ if not .Values.master.adminSshKey -}}
-  {{ ( include "jenkins.gen-key" . ) }}
-  {{ else -}}
-  jenkins-admin-private-key: {{ .Values.master.adminSshKey | b64enc | quote }}
-  {{ end -}}
-  {{ end -}}
   jenkins-admin-user: {{ .Values.master.adminUser | b64enc | quote }}
 {{- end }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -224,7 +224,7 @@ master:
       # over SSH to reapply config when changes to the configScripts are detected.  The admin user (or account you specify in
       # master.adminUser) will have a random SSH private key (RSA 4096) assigned unless you specify adminSshKey.  This will be saved to a k8s secret.
       enabled: false
-      image: shadwell/k8s-sidecar:0.0.2
+      image: kiwigrid/k8s-sidecar:0.1.20
       imagePullPolicy: IfNotPresent
       resources: {}
         #   limits:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
We make use of the fact that the Jenkins Configuration as Code Plugin can be triggered via http `POST` to `JENKINS_URL/configuration-as-code/reload`and a pre-shared key.

This way we do not rely on any users which need to exist in Jenkins and there is no need to configure ssh keys which by the way have more permissions than just reloading the configuration.

It also allows us to us `kiwigrid/k8s-sidecar:0.1.20` as sidecar for configuration reloads instead of it's fork `shadwell/k8s-sidecar`. That's 1M+ vs 10k pulls on dockerhub.

References:
- [Triggering Configuration Reload](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/configurationReload.md)
- [kiwigrid/k8s-sidecar](https://hub.docker.com/r/kiwigrid/k8s-sidecar)

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
