### PR TITLE
[stable/traefik] add labels for Traefik rbac template

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.78.5
+version: 1.78.6
 appVersion: 1.7.14
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/templates/rbac.yaml
+++ b/stable/traefik/templates/rbac.yaml
@@ -3,6 +3,11 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: {{ template "traefik.fullname" . }}
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: {{ template "traefik.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 ---
 kind: {{ include "traefik.rbac.scope" . | printf "%sRole" }}
 {{- if semverCompare "^1.8-0" .Capabilities.KubeVersion.GitVersion }}
@@ -12,6 +17,11 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- end }}
 metadata:
   name: {{ template "traefik.fullname" . }}
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: {{ template "traefik.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 rules:
   - apiGroups:
       - ""
@@ -47,6 +57,11 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- end }}
 metadata:
   name: {{ template "traefik.fullname" . }}
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: {{ template "traefik.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: {{ include "traefik.rbac.scope" . | printf "%sRole" }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds standard labels for ServiceAccount, ClusterRole and ClusterRoleBinding in the rbac template, to ensure consistency with other templates.

#### Which issue this PR fixes
None that I am aware of.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
