### PR TITLE
[stable/wordpress] Add extra configuration parameters

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 7.5.4
+version: 7.6.0
 appVersion: 5.2.4
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -80,6 +80,9 @@ The following table lists the configurable parameters of the WordPress chart and
 | `smtpUsername`                            | User name for SMTP emails                                                     | `nil`                                                        |
 | `smtpProtocol`                            | SMTP protocol [`tls`, `ssl`, `none`]                                          | `nil`                                                        |
 | `replicaCount`                            | Number of WordPress Pods to run                                               | `1`                                                          |
+| `extraEnv`                                | Additional container environment variables                                    | `[]`                                                         |
+| `extraVolumeMounts`                       | Additional volume mounts                                                      | `[]`                                                         |
+| `extraVolumes`                            | Additional volumes                                                            | `[]`                                                         |
 | `mariadb.enabled`                         | Deploy MariaDB container(s)                                                   | `true`                                                       |
 | `mariadb.rootUser.password`               | MariaDB admin password                                                        | `nil`                                                        |
 | `mariadb.db.name`                         | Database name to create                                                       | `bitnami_wordpress`                                          |

--- a/stable/wordpress/templates/deployment.yaml
+++ b/stable/wordpress/templates/deployment.yaml
@@ -131,6 +131,9 @@ spec:
         - name: SMTP_PROTOCOL
           value: {{ .Values.smtpProtocol | quote }}
         {{- end }}
+        {{- with .Values.extraEnv }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
         ports:
         - name: http
           containerPort: 80
@@ -168,6 +171,9 @@ spec:
         - mountPath: /opt/bitnami/wordpress/wordpress-htaccess.conf
           name: custom-htaccess
           subPath: wordpress-htaccess.conf
+        {{- end }}
+        {{- with .Values.extraVolumeMounts }}
+{{ toYaml . | indent 8 }}
         {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
@@ -210,6 +216,9 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
+      {{- with .Values.extraVolumes }}
+{{ toYaml . | indent 6 }}
+      {{- end }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/stable/wordpress/values-production.yaml
+++ b/stable/wordpress/values-production.yaml
@@ -122,6 +122,29 @@ customHTAccessCM:
 
 replicaCount: 3
 
+# Additional container environment variables
+extraEnv: []
+  ## Example: Configure SSL for database
+  # - name: WORDPRESS_DATABASE_SSL_CA_FILE
+  #   value: /path/to/ca_cert
+
+# Additional volume mounts
+extraVolumeMounts: []
+  ## Example: Mount CA file
+  # - name: ca-cert
+  #   subPath: ca_cert
+  #   mountPath: /path/to/ca_cert
+
+# Additional volumes
+extraVolumes: []
+  ## Example: Add secret volume
+  # - name: ca-cert
+  #   secret:
+  #     secretName: ca-cert
+  #     items:
+  #     - key: ca-cert
+  #       path: ca_cert
+
 externalDatabase:
 ## All of these values are only used when mariadb.enabled is set to false
   ## Database host

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -122,6 +122,29 @@ customHTAccessCM:
 
 replicaCount: 1
 
+# Additional container environment variables
+extraEnv: []
+  ## Example: Configure SSL for database
+  # - name: WORDPRESS_DATABASE_SSL_CA_FILE
+  #   value: /path/to/ca_cert
+
+# Additional volume mounts
+extraVolumeMounts: []
+  ## Example: Mount CA file
+  # - name: ca-cert
+  #   subPath: ca_cert
+  #   mountPath: /path/to/ca_cert
+
+# Additional volumes
+extraVolumes: []
+  ## Example: Add secret volume
+  # - name: ca-cert
+  #   secret:
+  #     secretName: ca-cert
+  #     items:
+  #     - key: ca-cert
+  #       path: ca_cert
+
 externalDatabase:
 ## All of these values are only used when mariadb.enabled is set to false
   ## Database host


### PR DESCRIPTION
#### Is this a new chart

No.

#### What this PR does / why we need it:

It adds new configuration parameters (`extraEnv`, `extraVolumeMounts`, and `extraVolumes`) to the Wordpress deployment.

One use-case is the configuration of SSL for the database connection:

```yaml
# in values.yaml

# Additional container environment variables
extraEnv:
  - name: WORDPRESS_DATABASE_SSL_CA_FILE
    value: /path/to/ca_cert

# Additional volume mounts
extraVolumeMounts:
  - name: ca-cert
    subPath: ca_cert
    mountPath: /path/to/ca_cert

# Additional volumes
extraVolumes:
  - name: ca-cert
    secret:
      secretName: ca-cert
      items:
      - key: ca-cert
        path: ca_cert
```

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
