### PR TITLE
[stable/nginx-ingress] Fix HPA deployment apiVersion

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.24.4
+version: 1.24.5
 appVersion: 0.26.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/controller-hpa.yaml
+++ b/stable/nginx-ingress/templates/controller-hpa.yaml
@@ -12,7 +12,7 @@ metadata:
   name: {{ template "nginx-ingress.controller.fullname" . }}
 spec:
   scaleTargetRef:
-    apiVersion: {{ .Values.controller.apiVersion }}
+    apiVersion: {{ template "deployment.apiVersion" . }}
     kind: Deployment
     name: {{ template "nginx-ingress.controller.fullname" . }}
   minReplicas: {{ .Values.controller.autoscaling.minReplicas }}


### PR DESCRIPTION
Signed-off-by: Tyler Gregory <tdgregory@protonmail.com>

#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

No

#### What this PR does / why we need it:

This PR fixes a bug in the recent API version PR that causes the `apiVersion` on the deployment controller's HPA to be blank, which breaks the targeting on the HPA. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
