### PR TITLE
[stable/prometheus-operator] Cleanup, Fix more CI problems

### DIFF
--- a/stable/prometheus-operator/CONTRIBUTING.md
+++ b/stable/prometheus-operator/CONTRIBUTING.md
@@ -3,7 +3,6 @@
 1. Fork this repository, develop and test your Chart.
 1. Bump the chart version for every change.
 1. Ensure PR title has the prefix `[stable/prometheus-operator]`
-1. When making changes to values.yaml, update the files in `ci/` by running `hack/update-ci.sh`
 1. When making changes to rules or dashboards, see the README.md section on how to sync data from upstream repositories
 1. Check the `hack/minikube` folder has scripts to set up minikube and components of this chart that will allow all components to be scraped. You can use this configuration when validating your changes.
 1. Check for changes of RBAC rules.

--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -11,7 +11,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 7.3.0
+version: 7.4.0
 appVersion: 0.34.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -171,14 +171,17 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.configmapReloadImage.repository` | Repository for configmapReload image | `quay.io/coreos/configmap-reload` |
 | `prometheusOperator.configmapReloadImage.tag` | Tag for configmapReload image | `v0.0.1` |
 | `prometheusOperator.createCustomResource` | Create CRDs. Required if deploying anything besides the operator itself as part of the release. The operator will create / update these on startup. If your Helm version < 2.10 you will have to either create the CRDs first or deploy the operator first, then the rest of the resources | `true` |
-| `prometheusOperator.denyNamespaces` | Namespaces not to scope the interaction of the Prometheus Operator (deny list). | `{}` |
+| `prometheusOperator.namespaces` |  Namespaces to scope the interaction of the Prometheus Operator and the apiserver (allow list). This is mutually exclusive with `denyNamespaces`. Setting this to an empty object will disable the configuration | `{}` |
+| `prometheusOperator.namespaces.releaseNamespace` | Include the release namespace | `false` |
+| `prometheusOperator.namespaces.additional` | Include additional namespaces besides the release namespace | `[]` |
+| `prometheusOperator.denyNamespaces` | Namespaces not to scope the interaction of the Prometheus Operator (deny list). This is mutually exclusive with `namespaces` | `[]` |
 | `prometheusOperator.enabled` | Deploy Prometheus Operator. Only one of these should be deployed into the cluster | `true` |
 | `prometheusOperator.hyperkubeImage.repository` | Image pull policy for hyperkube image used to perform maintenance tasks | `IfNotPresent` |
 | `prometheusOperator.hyperkubeImage.repository` | Repository for hyperkube image used to perform maintenance tasks | `k8s.gcr.io/hyperkube` |
 | `prometheusOperator.hyperkubeImage.tag` | Tag for hyperkube image used to perform maintenance tasks | `v1.12.1` |
 | `prometheusOperator.image.pullPolicy` | Pull policy for prometheus operator image | `IfNotPresent` |
 | `prometheusOperator.image.repository` | Repository for prometheus operator image | `quay.io/coreos/prometheus-operator` |
-| `prometheusOperator.image.tag` | Tag for prometheus operator image | `v0.32.0` |
+| `prometheusOperator.image.tag` | Tag for prometheus operator image | `v0.33.0` |
 | `prometheusOperator.kubeletService.enabled` | If true, the operator will create and maintain a service for scraping kubelets | `true` |
 | `prometheusOperator.kubeletService.namespace` | Namespace to deploy kubelet service | `kube-system` |
 | `prometheusOperator.logFormat` | Operator log output formatting | `"logfmt"` |
@@ -188,7 +191,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.podLabels` | Labels to add to the operator pod | `{}` |
 | `prometheusOperator.priorityClassName` | Name of Priority Class to assign pods | `nil` |
 | `prometheusOperator.prometheusConfigReloaderImage.repository` | Repository for config-reloader image | `quay.io/coreos/prometheus-config-reloader` |
-| `prometheusOperator.prometheusConfigReloaderImage.tag` | Tag for config-reloader image | `v0.32.0` |
+| `prometheusOperator.prometheusConfigReloaderImage.tag` | Tag for config-reloader image | `v0.33.0` |
 | `prometheusOperator.resources` | Resource limits for prometheus operator | `{}` |
 | `prometheusOperator.securityContext` | SecurityContext for prometheus operator | `{"runAsNonRoot": true, "runAsUser": 65534}` |
 | `prometheusOperator.service.annotations` | Annotations to be added to the prometheus operator service | `{}` |

--- a/stable/prometheus-operator/ci/01-provision-crds-values.yaml
+++ b/stable/prometheus-operator/ci/01-provision-crds-values.yaml
@@ -29,8 +29,14 @@ defaultRules:
 # Default configuration of prometheus operator will create CRDs in the cluster idempotently
 prometheusOperator:
   enabled: true
+  serviceMonitor:
+    selfMonitor: false
   createCustomResource: false
   tlsProxy:
     enabled: false
   admissionWebhooks:
     enabled: false
+  namespaces:
+    releaseNamespace: true
+    additional:
+      - kube-system

--- a/stable/prometheus-operator/ci/02-test-without-crds-values.yaml
+++ b/stable/prometheus-operator/ci/02-test-without-crds-values.yaml
@@ -1,2 +1,6 @@
 prometheusOperator:
   createCustomResource: false
+  namespaces:
+    releaseNamespace: true
+    additional:
+      - kube-system

--- a/stable/prometheus-operator/hack/update-ci.sh
+++ b/stable/prometheus-operator/hack/update-ci.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-sed \
-	-e 's/createCustomResource: true/createCustomResource: false/' \
-	-e 's/port: 9100/port: 9101/' \
-	-e 's/targetPort: 9100/targetPort: 9101/' \
-  values.yaml > ci/02-test-without-crds-values.yaml

--- a/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
@@ -46,6 +46,13 @@ spec:
           {{- if .Values.prometheusOperator.denyNamespaces }}
             - --deny-namespaces={{ .Values.prometheusOperator.denyNamespaces | join "," }}
           {{- end }}
+          {{- with $.Values.prometheusOperator.namespaces }}
+          {{ $ns := .additional }}
+          {{- if .releaseNamespace }}
+          {{- $ns = append $ns $.Release.Namespace }}
+          {{- end }}
+            - --namespaces={{ $ns | join "," }}
+          {{- end }}
             - --logtostderr=true
             - --localhost=127.0.0.1
             - --prometheus-config-reloader={{ .Values.prometheusOperator.prometheusConfigReloaderImage.repository }}:{{ .Values.prometheusOperator.prometheusConfigReloaderImage.tag }}

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -932,10 +932,6 @@ nodeExporter:
 ## Configuration for prometheus-node-exporter subchart
 ##
 prometheus-node-exporter:
-  service:
-    port: 9100
-    targetPort: 9100
-
   podLabels:
     ## Add the 'node-exporter' label to be used by serviceMonitor to match standard common usage in rules and grafana dashboards
     ##
@@ -978,9 +974,17 @@ prometheusOperator:
       podAnnotations: {}
       nodeSelector: {}
 
+  ## Namespaces to scope the interaction of the Prometheus Operator and the apiserver (allow list).
+  ## This is mutually exclusive with denyNamespaces. Setting this to an empty object will disable the configuration
+  ##
+  namespaces: {}
+    # releaseNamespace: true
+    # additional:
+    # - kube-system
+
   ## Namespaces not to scope the interaction of the Prometheus Operator (deny list).
   ##
-  denyNamespaces: {}
+  denyNamespaces: []
 
   ## Service account for Alertmanager to use.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/


### PR DESCRIPTION
#### What this PR does / why we need it:
- CI is broken again

#### Changes
- Added more `$` to `{{ $.Release.Namespace }}` to fix resources not being rendered
- Dropped `prometheus-node-exporter` custom port because it is not needed
- Since custom ci values files are applied over the values.yaml in the root:
  - Replaced `02....-values.yaml` with just the necessary changes
  - Removed `hack/update-ci` and instructions to use it
- Fixed `denyNamespaces` should be a slice instead of a map
- Introduced `namespaces` to fix CI. Looks like the operator pod is taking a long time to come up, so on a hunch I tested what happens if you deny its ability to scan the cluster. This PR will replace the approach proposed in #18322, but it is necessary to maintain CI and allow a future possibility to add proper tests that all components are working.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
