### PR TITLE
[stable/karma] Add certSecretNames parameter

### DIFF
--- a/stable/karma/Chart.yaml
+++ b/stable/karma/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/prymitive/karma
 sources:
   - https://hub.docker.com/r/lmierzwa/karma/
   - https://github.com/prymitive/karma
-version: 1.1.20
+version: 1.1.21
 maintainers:
 - name: davidkarlsen
   email: david@davidkarlsen.com

--- a/stable/karma/Chart.yaml
+++ b/stable/karma/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/prymitive/karma
 sources:
   - https://hub.docker.com/r/lmierzwa/karma/
   - https://github.com/prymitive/karma
-version: 1.1.21
+version: 1.2.0
 maintainers:
 - name: davidkarlsen
   email: david@davidkarlsen.com

--- a/stable/karma/README.md
+++ b/stable/karma/README.md
@@ -37,33 +37,34 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the karma chart and their default values.
 
-|             Parameter               |            Description                 |                    Default                |
-|-------------------------------------|----------------------------------------|-------------------------------------------|
-| `replicaCount`                      | Number of replicas                     | `1`                                       |
-| `image.repository`                  | The image to run                       | `lmierzwa/karma`                          |
-| `image.tag`                         | The image tag to pull                  | `v0.48`                                   |
-| `image.pullPolicy`                  | Image pull policy                      | `IfNotPresent`                            |
-| `nameOverride`                      | Override name of app                   | ``                                        |
-| `fullnameOverride`                  | Override full name of app              | ``                                        |
-| `service.type`                      | Type of Service                        | `ClusterIP`                               |
-| `service.port`                      | Port for kubernetes service            | `80`                                      |
-| `service.annotations`               | Annotations to add to the service      | `{}`                                      |
-| `resources.requests.cpu`            | CPU resource requests                  |                                           |
-| `resources.limits.cpu`              | CPU resource limits                    |                                           |
-| `resources.requests.memory`         | Memory resource requests               |                                           |
-| `resources.limits.memory`           | Memory resource limits                 |                                           |
-| `ingress`                           | Settings for ingress                   | `{}`                                      |
-| `nodeSelector`                      | Settings for nodeselector              | `{}`                                      |
-| `tolerations`                       | Settings for toleration                | `{}`                                      |
-| `affinity`                          | Settings for affinity                  | `{}`                                      |
-| `securityContext`                   | Settings for security context          | `{}`                                      |
-| `serviceAccount.create`             | Create service-account                 | `true`                                    |
-| `serviceAccount.name`               | Override service-account name          | ``                                        |
-| `livenessProbe.delay`               | Specify delay in executing probe       | `5`                                       |
-| `livenessProbe.period`              | Speicy period of liveness probe        | `5`                                       |
-| `livenessProbe.path`                | Specify path liveness probe should hit | `/`                                       |
-| `configMap.enabled`                 | Provide a custom karma configuration   | `false`                                   |
-| `configMap.rawConfig`               | A karma compatible YAML configuration  | ``                                        |
+|             Parameter               |            Description                                 |                    Default                |
+|-------------------------------------|--------------------------------------------------------|-------------------------------------------|
+| `replicaCount`                      | Number of replicas                                     | `1`                                       |
+| `image.repository`                  | The image to run                                       | `lmierzwa/karma`                          |
+| `image.tag`                         | The image tag to pull                                  | `v0.48`                                   |
+| `image.pullPolicy`                  | Image pull policy                                      | `IfNotPresent`                            |
+| `nameOverride`                      | Override name of app                                   | ``                                        |
+| `fullnameOverride`                  | Override full name of app                              | ``                                        |
+| `service.type`                      | Type of Service                                        | `ClusterIP`                               |
+| `service.port`                      | Port for kubernetes service                            | `80`                                      |
+| `service.annotations`               | Annotations to add to the service                      | `{}`                                      |
+| `resources.requests.cpu`            | CPU resource requests                                  |                                           |
+| `resources.limits.cpu`              | CPU resource limits                                    |                                           |
+| `resources.requests.memory`         | Memory resource requests                               |                                           |
+| `resources.limits.memory`           | Memory resource limits                                 |                                           |
+| `ingress`                           | Settings for ingress                                   | `{}`                                      |
+| `nodeSelector`                      | Settings for nodeselector                              | `{}`                                      |
+| `tolerations`                       | Settings for toleration                                | `{}`                                      |
+| `affinity`                          | Settings for affinity                                  | `{}`                                      |
+| `securityContext`                   | Settings for security context                          | `{}`                                      |
+| `serviceAccount.create`             | Create service-account                                 | `true`                                    |
+| `serviceAccount.name`               | Override service-account name                          | ``                                        |
+| `livenessProbe.delay`               | Specify delay in executing probe                       | `5`                                       |
+| `livenessProbe.period`              | Speicy period of liveness probe                        | `5`                                       |
+| `livenessProbe.path`                | Specify path liveness probe should hit                 | `/`                                       |
+| `configMap.enabled`                 | Provide a custom karma configuration                   | `false`                                   |
+| `configMap.rawConfig`               | A karma compatible YAML configuration                  | ``                                        |
+| `certSecretNames`                   | Mount Alertmanager certificates to `/etc/certs/<name>` | `[]`                                      |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/karma/templates/deployment.yaml
+++ b/stable/karma/templates/deployment.yaml
@@ -58,10 +58,15 @@ spec:
             periodSeconds: {{ .Values.livenessProbe.period }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-          {{- if .Values.configMap.enabled }}
           volumeMounts:
+          {{- if .Values.configMap.enabled }}
             - name: karma-config
               mountPath: /etc/karma
+          {{- end }}
+          {{- range .Values.certSecretNames }}
+            - name: {{ . }}
+              mountPath: /etc/certs/{{ . }}
+              readOnly: true
           {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -75,9 +80,15 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-      {{- if .Values.configMap.enabled }}
       volumes:
+      {{- if .Values.configMap.enabled }}
       - name: karma-config
         configMap:
           name: {{ .Release.Name }}-config
+      {{- end }}
+      {{- range .Values.certSecretNames }}
+      - name: {{ . }}
+        secret:
+          defaultMode: 420
+          secretName: {{ . }}
       {{- end }}

--- a/stable/karma/values.yaml
+++ b/stable/karma/values.yaml
@@ -126,3 +126,11 @@ configMap:
   #   sentry:
   #     private: secret
   #   public: 123456789
+
+# Names of secrets that will be mounted to `/etc/certs/<secret_name>` in the karma container.
+# These secrets can be used to configure TLS for Karma's Alertmanagers by passing their paths to
+# the appropriate Karma configuration parameters. For example, secret `foo` containing a `ca.crt`
+# will yield a file at `/etc/certs/foo/ca.crt`. That path can then be provided as the value to
+# `configMap.rawConfig.alertmanager.servers[].tls.ca`.
+# See <https://github.com/prymitive/karma/blob/master/docs/CONFIGURATION.md#alertmanagers>.
+certSecretNames: []


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No.

#### What this PR does / why we need it:

This PR adds a `certSecretNames` parameter to stable/karma. Setting this parameter in the chart's values causes any listed secrets to be mounted into the karma container at `/etc/certs/<name>`. If a provided secret does not exist in the chart release's namespace, the pod will fail to start.

These secrets can be used to configure TLS for Karma's Alertmanagers by passing their paths to the appropriate Karma configuration parameters. For example, secret `foo` containing a `ca.crt` will yield a file at `/etc/certs/foo/ca.crt`. That path can then be provided as the value to `configMap.rawConfig.alertmanager.servers[].tls.ca`.

This parameter is necessary because certificates must be present on the container's filesystem in order to configure TLS for Alertmanagers. See https://github.com/prymitive/karma/blob/master/docs/CONFIGURATION.md#alertmanagers.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

N/A

#### Special notes for your reviewer:

N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
