### PR TITLE
[stable/atlantis] fix the mount collision between repos.yaml and atlantis.yaml

### DIFF
--- a/stable/atlantis/Chart.yaml
+++ b/stable/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.8.2"
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 3.8.3
+version: 3.8.4
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/stable/atlantis/templates/statefulset.yaml
+++ b/stable/atlantis/templates/statefulset.yaml
@@ -265,12 +265,14 @@ spec:
           {{- end }}
           {{- if .Values.repoConfig }}
           - name: repo-config
-            mountPath: /etc/atlantis
+            mountPath: /etc/atlantis/repos.yaml
+            subPath: repos.yaml
             readOnly: true
           {{- end }}
           {{- if .Values.config }}
           - name: config
-            mountPath: /etc/atlantis
+            mountPath: /etc/atlantis/atlantis.yaml
+            subPath: atlantis.yaml
             readOnly: true
           {{- end }}
           {{- if .Values.extraVolumeMounts }}


### PR DESCRIPTION

#### What this PR does / why we need it:

Fixes a mount collision if both `repoConfig` and `config` are set in the values.yaml

Kubernetes mounts `config` which contains atlantis.yaml first then in the same dir (/etc/atlantis) mounts repos.yaml over it. So the server will not start since it's looking for `/etc/atlantis/atlantis.yaml`


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
