### PR TITLE
[stable/airflow] add workers gracefull termination

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 4.2.0
+version: 4.3.0
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -377,10 +377,12 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `scheduler.annotations`                  | annotations for the scheduler deployment                | `{}`                      |
 | `workers.enabled`                        | enable workers                                          | `true`                    |
 | `workers.replicas`                       | number of workers pods to launch                        | `1`                       |
+| `workers.terminationPeriod`              | gracefull termination period for workers to stop        | `30`                      |
 | `workers.resources`                      | custom resource configuration for worker pod            | `{}`                      |
 | `workers.celery.instances`               | number of parallel celery tasks per worker              | `1`                       |
 | `workers.labels`                         | labels for the worker statefulSet                       | `{}`                      |
 | `workers.annotations`                    | annotations for the worker statefulSet                  | `{}`                      |
+| `workers.celery.gracefullTermination`    | cancel the consumer and wait for the current task to finish before stopping the worker      | `false`     |
 | `workers.podAnnotations`                 | annotations for the worker pods                         | `{}`                      |
 | `workers.secretsDir`                     | directory in which to mount secrets on worker nodes     | /var/airflow/secrets      |
 | `workers.secrets`                        | secrets to mount as volumes on worker nodes             | []                        |

--- a/stable/airflow/templates/configmap-scripts.yaml
+++ b/stable/airflow/templates/configmap-scripts.yaml
@@ -20,3 +20,13 @@ data:
     else
       exit 0
     fi
+  stop-worker.sh: |
+    #!/bin/sh -e
+    celery -b $AIRFLOW__CELERY__BROKER_URL -d celery@$HOSTNAME control cancel_consumer default
+
+    # wait 10 second before checking the status of the worker
+    sleep 10
+
+    while (( $(celery -b $AIRFLOW__CELERY__BROKER_URL inspect active --json | python -c "import sys, json; print(len(json.load(sys.stdin)['celery@$HOSTNAME']))") > 0 )); do
+    sleep 60
+    done

--- a/stable/airflow/templates/statefulsets-workers.yaml
+++ b/stable/airflow/templates/statefulsets-workers.yaml
@@ -55,7 +55,7 @@ spec:
         - name: {{ .Values.airflow.image.pullSecret }}
       {{- end }}
       restartPolicy: Always
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: {{ .Values.workers.terminationPeriod }}
       serviceAccountName: {{ template "airflow.serviceAccountName" . }}
       {{- if .Values.workers.nodeSelector }}
       nodeSelector:
@@ -95,6 +95,12 @@ spec:
         - name: {{ .Chart.Name }}-worker
           imagePullPolicy: {{ .Values.airflow.image.pullPolicy }}
           image: "{{ .Values.airflow.image.repository }}:{{ .Values.airflow.image.tag }}"
+          {{- if and (eq .Values.airflow.executor "Celery") (.Values.workers.celery.gracefullTermination)}}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/entrypoint.sh","/usr/local/scripts/stop-worker.sh"]
+          {{- end}}
           envFrom:
             - configMapRef:
                 name: "{{ template "airflow.fullname" . }}-env"

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -272,6 +272,9 @@ workers:
   ## Number of workers pod to launch
   replicas: 1
   ##
+  ## Gracefull termination period
+  terminationPeriod: 30
+  ##
   ## Custom resource configuration
   resources: {}
     # limits:
@@ -297,6 +300,11 @@ workers:
     ##
     ## number of parallel celery tasks per worker
     instances: 1
+    ##
+    ## Gracefull termination of workers
+    ## Wait for the worker to finish the current task within the gracefull period
+    gracefullTermination: false
+
   ##
   ## Directory in which to mount secrets on worker nodes.
   secretsDir: /var/airflow/secrets


### PR DESCRIPTION
#### What this PR does / why we need it:
Add gracefull termination that allow the worker to wait until the current task to complete before shutting down the worker when using the celery executor.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
