### PR TITLE
[stable/nfs-client-provisioner] fix imagePullSecrets

### DIFF
--- a/stable/nfs-client-provisioner/Chart.yaml
+++ b/stable/nfs-client-provisioner/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 3.1.0
 description: nfs-client is an automatic provisioner that used your *already configured* NFS server, automatically creating Persistent Volumes.
 name: nfs-client-provisioner
 home: https://github.com/kubernetes-incubator/external-storage/tree/master/nfs-client
-version: 1.2.7
+version: 1.2.8
 sources:
 - https://github.com/kubernetes-incubator/external-storage/tree/master/nfs-client
 maintainers:

--- a/stable/nfs-client-provisioner/templates/deployment.yaml
+++ b/stable/nfs-client-provisioner/templates/deployment.yaml
@@ -37,6 +37,10 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
#### Is this a new chart
no

#### What this PR does / why we need it:

* Fixes `imagePullSecrets` which are not working for `stable/nfs-client-provisioner`

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
