### PR TITLE
[bitnami/postgresql] Fix error when running init-container

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 6.5.4
+version: 6.5.5
 appVersion: 11.5.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/statefulset-slaves.yaml
+++ b/stable/postgresql/templates/statefulset-slaves.yaml
@@ -75,7 +75,7 @@ spec:
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
           command:
-            - sh
+            - /bin/sh
             - -c
             - |
               mkdir -p {{ .Values.persistence.mountPath }}/data
@@ -148,7 +148,7 @@ spec:
           livenessProbe:
             exec:
               command:
-                - sh
+                - /bin/sh
                 - -c
                 {{- if (include "postgresql.database" .) }}
                 - exec pg_isready -U {{ include "postgresql.username" . | quote }} -d {{ (include "postgresql.database" .) | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
@@ -165,7 +165,7 @@ spec:
           readinessProbe:
             exec:
               command:
-                - sh
+                - /bin/sh
                 - -c
                 - -e
                 {{- include "postgresql.readinessProbeCommand" . | nindent 16 }}

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -79,7 +79,7 @@ spec:
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
           command:
-            - sh
+            - /bin/sh
             - -c
             - |
               mkdir -p {{ .Values.persistence.mountPath }}/data
@@ -173,7 +173,7 @@ spec:
           livenessProbe:
             exec:
               command:
-                - sh
+                - /bin/sh
                 - -c
                 {{- if (include "postgresql.database" .) }}
                 - exec pg_isready -U {{ include "postgresql.username" . | quote }} -d {{ (include "postgresql.database" .) | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
@@ -190,7 +190,7 @@ spec:
           readinessProbe:
             exec:
               command:
-                - sh
+                - /bin/sh
                 - -c
                 - -e
                 {{- include "postgresql.readinessProbeCommand" . | nindent 16 }}


### PR DESCRIPTION
#### What this PR does / why we need it:

When I use another image like `postgres:11.5` I always get the following error:
```
Error: failed to create containerd task: OCI runtime create failed: container_linux.go:337: starting container process caused "exec: \"sh\": executable file not found in $PATH": unknown
```

Using the full path to `sh` (`/bin/sh`) fixes that problem.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
