### PR TITLE
[stable/atlantis] add extra manifest capability

### DIFF
--- a/stable/atlantis/Chart.yaml
+++ b/stable/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.8.2"
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 3.8.4
+version: 3.9.0
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/stable/atlantis/README.md
+++ b/stable/atlantis/README.md
@@ -20,6 +20,21 @@ In order for Atlantis to start and run successfully:
 
 1. Supply a value for `orgWhitelist`, e.g. `github.org/myorg/*`.
 
+## Additional manifests 
+
+It is possible to add additional manifests into a deployment, to extend the chart. One of the reason is to deploy a manifest specific to a cloud provider ( BackendConfig on GKE for example ).
+
+```yaml
+extraManifests:
+  - apiVersion: cloud.google.com/v1beta1
+    kind: BackendConfig
+    metadata:
+      name: "{{ .Release.Name }}-test"
+    spec:
+      securityPolicy:
+        name: "gcp-cloud-armor-policy-test"
+```
+
 ## Customization
 The following options are supported.  See [values.yaml](values.yaml) for more detailed documentation and examples:
 
@@ -77,6 +92,7 @@ The following options are supported.  See [values.yaml](values.yaml) for more de
 | `ingress.host`                              | Domain name Kubernetes Ingress rule looks for. Set it to the domain Atlantis will be hosted on.                                                                                                                                                                                                           | `chart-example.local`     |
 | `ingress.tls`                               | Kubernetes tls block. See [Kubernetes docs](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) for details.                                                                                                                                                                            | `[]`     |
 | `test.enabled`                              | Whether to enable the test. | `true` |
+| `extraManifests`                         | add additional manifests to deploy                      | `[]`                      |
 
 **NOTE**: All the [Server Configurations](https://www.runatlantis.io/docs/server-configuration.html) are passed as [Environment Variables](https://www.runatlantis.io/docs/server-configuration.html#environment-variables).
 

--- a/stable/atlantis/templates/extra-manifests.yaml
+++ b/stable/atlantis/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/stable/atlantis/values.yaml
+++ b/stable/atlantis/values.yaml
@@ -221,3 +221,13 @@ extraVolumeMounts: []
 # extraVolumeMounts:
 #   - name: some-volume-name
 #     mountPath: /path/in/container
+
+extraManifests: []
+# extraManifests:
+#  - apiVersion: cloud.google.com/v1beta1
+#    kind: BackendConfig
+#    metadata:
+#      name: "{{ .Release.Name }}-test"
+#    spec:
+#      securityPolicy:
+#        name: "gcp-cloud-armor-policy-test"


### PR DESCRIPTION
#### What this PR does / why we need it:
Add the capability to provide additional manifest specific for cloud provider, for example BackendConfig in GKE.
#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
