### PR TITLE
Fix indentation on authorize deployment

### DIFF
--- a/stable/pomerium/Chart.yaml
+++ b/stable/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 4.0.2
+version: 4.0.3
 appVersion: 0.4.2
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo.svg

--- a/stable/pomerium/templates/authorize-deployment.yaml
+++ b/stable/pomerium/templates/authorize-deployment.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           tcpSocket:
             port: https
-            initialDelaySeconds: 15
+          initialDelaySeconds: 15
         readinessProbe:
           tcpSocket:
             port: https


### PR DESCRIPTION
* [stable/pomerium] fix indentation on livenessProbe

The indentation for `initialDelaySeconds` placed it under the `tcpSocket`
where it's a parameter of the `livenessProbe` itself.

Signed-off-by: Daniel van den Berg <dvandenberg@optoro.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
