### PR TITLE
Add parameter for controller service targetPort so they can be overwr…

### DIFF
--- a/incubator/haproxy-ingress/Chart.yaml
+++ b/incubator/haproxy-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: haproxy-ingress
-version: 0.0.19
+version: 0.0.20
 appVersion: 0.7.2
 home: https://github.com/jcmoraisjr/haproxy-ingress
 description: Ingress controller implementation for haproxy loadbalancer.

--- a/incubator/haproxy-ingress/README.md
+++ b/incubator/haproxy-ingress/README.md
@@ -103,8 +103,8 @@ Parameter | Description | Default
 `controller.service.externalIPs` | list of IP addresses at which the controller services are available | `[]`
 `controller.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `controller.service.loadBalancerSourceRanges` |  | `[]`
-`controller.service.httpPorts` | The http ports to open, that map to the Ingress' port 80. Each entry specifies a `port` and an optional `nodePort`. | `[ port: 80 ]`
-`controller.service.httpsPorts` | The https ports to open, that map to the Ingress' port 443. Each entry specifies a `port` and an optional `nodePort`. | `[ port: 443 ]`
+`controller.service.httpPorts` | The http ports to open, that map to the Ingress' port 80. Each entry specifies a `port`, `targetPort` and an optional `nodePort`. | `[ port: 80, targetPort: http ]`
+`controller.service.httpsPorts` | The https ports to open, that map to the Ingress' port 443. Each entry specifies a `port`, `targetPort` and an optional `nodePort`. | `[ port: 443 , targetPort: https]`
 `controller.service.type` | type of controller service to create | `LoadBalancer`
 `controller.stats.enabled` | whether to enable exporting stats |  `false`
 `controller.stats.port` | The port number used haproxy-ingress-controller for haproxy statistics | `1936`

--- a/incubator/haproxy-ingress/templates/controller-service.yaml
+++ b/incubator/haproxy-ingress/templates/controller-service.yaml
@@ -43,7 +43,7 @@ spec:
     - name: "{{ .port }}-http"
       port: {{ .port }}
       protocol: TCP
-      targetPort: http
+      targetPort: {{ .targetPort }}
       {{- if (not (empty .nodePort)) }}
       nodePort: {{ .nodePort }}
       {{- end }}
@@ -52,7 +52,7 @@ spec:
     - name: "{{ .port }}-https"
       port: {{ .port }}
       protocol: TCP
-      targetPort: https
+      targetPort: {{ .targetPort }}
       {{- if (not (empty .nodePort)) }}
       nodePort: {{ .nodePort }}
       {{- end }}

--- a/incubator/haproxy-ingress/values.yaml
+++ b/incubator/haproxy-ingress/values.yaml
@@ -198,9 +198,11 @@ controller:
 
     httpPorts:
       - port: 80
+        targetPort: http
       # nodePort:
     httpsPorts:
       - port: 443
+        targetPort: https
       # nodePort:
 
     ## Set external traffic policy to: "Local" to preserve source IP on


### PR DESCRIPTION
With the current chart, we could not set the https port to use the http targetPort in the controller.service template. 

With this change, by default, it still behave the same with the default value and we can also change the service behaviour. In our use case using AWS ELB we need to use the http targetPort in the https port. 