### PR TITLE
[stable/prometheus-operator] Remove workaround on service selectors

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -11,7 +11,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 7.4.0
+version: 7.5.0
 appVersion: 0.34.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -431,15 +431,15 @@ For a full list of configurable values please refer to the [Grafana chart](https
 | `kubeApiServer.tlsConfig.serverName` | Name of the server to use when validating TLS certificate | `kubernetes` |
 | `kubeControllerManager.enabled` | Deploy a `service` and `serviceMonitor` to scrape the Kubernetes controller-manager | `true` |
 | `kubeControllerManager.endpoints` | Endpoints where Controller-manager runs. Provide this if running Controller-manager outside the cluster | `[]` |
-| `kubeControllermanager.service.port` | Controller-manager port for the service runs on | `10252` |
-| `kubeControllermanager.service.selector` | Controller-manager service selector | `{"component" : "kube-controller-manager" }` |
-| `kubeControllermanager.service.targetPort` | Controller-manager targetPort for the service runs on | `10252` |
-| `kubeControllermanager.serviceMonitor.https` | Controller-manager service scrape over https | `false` |
-| `kubeControllermanager.serviceMonitor.insecureSkipVerify` | Skip TLS certificate validation when scraping | `null` |
-| `kubeControllermanager.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
-| `kubeControllermanager.serviceMonitor.metricRelabelings` | The `metric_relabel_configs` for scraping the scheduler. | `` |
-| `kubeControllermanager.serviceMonitor.relabelings` | The `relabel_configs` for scraping the scheduler. | `` |
-| `kubeControllermanager.serviceMonitor.serverName` | Name of the server to use when validating TLS certificate | `null` |
+| `kubeControllerManager.service.port` | Controller-manager port for the service runs on | `10252` |
+| `kubeControllerManager.service.selector` | Controller-manager service selector | `{"component" : "kube-controller-manager" }` |
+| `kubeControllerManager.service.targetPort` | Controller-manager targetPort for the service runs on | `10252` |
+| `kubeControllerManager.serviceMonitor.https` | Controller-manager service scrape over https | `false` |
+| `kubeControllerManager.serviceMonitor.insecureSkipVerify` | Skip TLS certificate validation when scraping | `null` |
+| `kubeControllerManager.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
+| `kubeControllerManager.serviceMonitor.metricRelabelings` | The `metric_relabel_configs` for scraping the scheduler. | `` |
+| `kubeControllerManager.serviceMonitor.relabelings` | The `relabel_configs` for scraping the scheduler. | `` |
+| `kubeControllerManager.serviceMonitor.serverName` | Name of the server to use when validating TLS certificate | `null` |
 | `kubeDns.enabled` | Deploy kubeDns scraping components. Use either this or coreDns| `false` |
 | `kubeDns.service.selector` | kubeDns service selector | `{"k8s-app" : "kube-dns" }` |
 | `kubeDns.serviceMonitor.dnsmasqMetricRelabelings` | The `metric_relabel_configs` for scraping dnsmasq kubeDns. | `` |

--- a/stable/prometheus-operator/templates/_helpers.tpl
+++ b/stable/prometheus-operator/templates/_helpers.tpl
@@ -80,12 +80,3 @@ heritage: {{ $.Release.Service | quote }}
     {{ default "default" .Values.alertmanager.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
-
-{{/* Workaround for https://github.com/helm/helm/issues/3117 */}}
-{{- define "prometheus-operator.rangeskipempty" -}}
-{{- range $key, $value := . }}
-{{- if $value }}
-{{ $key }}: {{ $value }}
-{{- end }}
-{{- end }}
-{{- end }}

--- a/stable/prometheus-operator/templates/exporters/core-dns/service.yaml
+++ b/stable/prometheus-operator/templates/exporters/core-dns/service.yaml
@@ -17,5 +17,9 @@ spec:
       protocol: TCP
       targetPort: {{ .Values.coreDns.service.targetPort }}
   selector:
-{{ include "prometheus-operator.rangeskipempty" .Values.coreDns.service.selector | indent 4 }}
+    {{- if .Values.coreDns.service.selector }}
+{{ toYaml .Values.coreDns.service.selector | indent 4 }}
+    {{- else}}
+    k8s-app: kube-dns
+    {{- end}}
 {{- end }}

--- a/stable/prometheus-operator/templates/exporters/kube-controller-manager/service.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-controller-manager/service.yaml
@@ -18,7 +18,11 @@ spec:
       targetPort: {{ .Values.kubeControllerManager.service.targetPort }}
 {{- if .Values.kubeControllerManager.endpoints }}{{- else }}
   selector:
-{{ include "prometheus-operator.rangeskipempty" .Values.kubeControllerManager.service.selector | indent 4 }}
+    {{- if .Values.kubeControllerManager.service.selector }}
+{{ toYaml .Values.kubeControllerManager.service.selector | indent 4 }}
+    {{- else}}
+    component: kube-controller-manager
+    {{- end}}
 {{- end }}
   type: ClusterIP
 {{- end }}

--- a/stable/prometheus-operator/templates/exporters/kube-dns/service.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-dns/service.yaml
@@ -21,5 +21,9 @@ spec:
       protocol: TCP
       targetPort: 10055
   selector:
-{{ include "prometheus-operator.rangeskipempty" .Values.kubeDns.service.selector | indent 4 }}
+    {{- if .Values.kubeDns.service.selector }}
+{{ toYaml .Values.kubeDns.service.selector | indent 4 }}
+    {{- else}}
+    k8s-app: kube-dns
+    {{- end}}
 {{- end }}

--- a/stable/prometheus-operator/templates/exporters/kube-etcd/service.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-etcd/service.yaml
@@ -18,7 +18,11 @@ spec:
       targetPort: {{ .Values.kubeEtcd.service.targetPort }}
 {{- if .Values.kubeEtcd.endpoints }}{{- else }}
   selector:
-  {{ include "prometheus-operator.rangeskipempty" .Values.kubeEtcd.service.selector | indent 4 }}
+    {{- if .Values.kubeEtcd.service.selector }}
+{{ toYaml .Values.kubeEtcd.service.selector | indent 4 }}
+    {{- else}}
+    component: etcd
+    {{- end}}
 {{- end }}
   type: ClusterIP
 {{- end -}}

--- a/stable/prometheus-operator/templates/exporters/kube-proxy/service.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-proxy/service.yaml
@@ -18,7 +18,11 @@ spec:
       targetPort: {{ .Values.kubeProxy.service.targetPort }}
 {{- if .Values.kubeProxy.endpoints }}{{- else }}
   selector:
-  {{ include "prometheus-operator.rangeskipempty" .Values.kubeProxy.service.selector | indent 4 }}
+    {{- if .Values.kubeProxy.service.selector }}
+{{ toYaml .Values.kubeProxy.service.selector | indent 4 }}
+    {{- else}}
+    k8s-app: kube-proxy
+    {{- end}}
 {{- end }}
   type: ClusterIP
 {{- end -}}

--- a/stable/prometheus-operator/templates/exporters/kube-scheduler/service.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-scheduler/service.yaml
@@ -18,7 +18,11 @@ spec:
       targetPort: {{ .Values.kubeScheduler.service.targetPort}}
 {{- if .Values.kubeScheduler.endpoints }}{{- else }}
   selector:
-  {{ include "prometheus-operator.rangeskipempty" .Values.kubeScheduler.service.selector | indent 4 }}
+    {{- if .Values.kubeScheduler.service.selector }}
+{{ toYaml .Values.kubeScheduler.service.selector | indent 4 }}
+    {{- else}}
+    component: kube-scheduler
+    {{- end}}
 {{- end }}
   type: ClusterIP
 {{- end -}}

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -592,8 +592,8 @@ kubeControllerManager:
   service:
     port: 10252
     targetPort: 10252
-    selector:
-      component: kube-controller-manager
+    # selector:
+    #   component: kube-controller-manager
 
   serviceMonitor:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
@@ -635,8 +635,8 @@ coreDns:
   service:
     port: 9153
     targetPort: 9153
-    selector:
-      k8s-app: kube-dns
+    # selector:
+    #   k8s-app: kube-dns
   serviceMonitor:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
@@ -663,9 +663,9 @@ coreDns:
 ##
 kubeDns:
   enabled: false
-  service:
-    selector:
-      k8s-app: kube-dns
+  # service:
+  #   selector:
+  #     k8s-app: kube-dns
   serviceMonitor:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
@@ -719,8 +719,8 @@ kubeEtcd:
   service:
     port: 2379
     targetPort: 2379
-    selector:
-      component: etcd
+    # selector:
+    #   component: etcd
 
   ## Configure secure access to the etcd cluster by loading a secret into prometheus and
   ## specifying security configuration below. For example, with a secret named etcd-client-cert
@@ -779,8 +779,8 @@ kubeScheduler:
   service:
     port: 10251
     targetPort: 10251
-    selector:
-      component: kube-scheduler
+    # selector:
+    #   component: kube-scheduler
 
   serviceMonitor:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
@@ -830,8 +830,8 @@ kubeProxy:
   service:
     port: 10249
     targetPort: 10249
-    selector:
-      k8s-app: kube-proxy
+    # selector:
+    #   k8s-app: kube-proxy
 
   serviceMonitor:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.


### PR DESCRIPTION
#### What this PR does / why we need it:

Remove old workaround as now the minimum supported helm version already has a fix for it.

#### Special notes for your reviewer:

This also removes default selector values from values.yaml as trying to modify those later will only append instead of replace. For example:

This values.yaml
```yaml
kubeControllerManager:
  service:
    selector:
      k8s-app: kube-controller-manager
```

Produces this before this changes:
```yaml
  selector:

    component: kube-scheduler
    k8s-app: kube-scheduler
```

And produces this after this changes:
```yaml
selector:
    k8s-app: kube-scheduler
```

In the specific case of selectors it makes sense to replace the whole block and not append.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
