### PR TITLE
[stable/jaeger-operator] Add namespace to deployment and service

### DIFF
--- a/stable/jaeger-operator/Chart.yaml
+++ b/stable/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.10.2
+version: 2.10.3
 appVersion: 1.14.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/stable/jaeger-operator/templates/deployment.yaml
+++ b/stable/jaeger-operator/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "jaeger-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "jaeger-operator.labels" . | indent 4 }}
 spec:

--- a/stable/jaeger-operator/templates/service.yaml
+++ b/stable/jaeger-operator/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "jaeger-operator.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "jaeger-operator.labels" . | indent 4 }}
 spec:


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds the namespace (set to .Release.Namespace) to the deployment and service.

This fixes the following issues: 

- When the chart is rendered via `helm template` and the manifests are applied via Weave Flux (which requires the namespace to be specified via the manifests), the operator is installed in the default namespace.

- If a namespace is specified with helm template, the service account will be in that namespace but the deployment will be in the default namespace which will prevent the pod to be created

#### Which issue this PR fixes
Fixes #18480

@cpanato @batazor
