### PR TITLE
[stable/minio] Fix pod annotations format in statefulset

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: MinIO is a high performance distributed object storage server, designed for large-scale private cloud infrastructure.
 name: minio
-version: 2.5.17
+version: 2.5.18
 appVersion: RELEASE.2019-08-07T01-59-21Z
 keywords:
 - storage

--- a/stable/minio/templates/statefulset.yaml
+++ b/stable/minio/templates/statefulset.yaml
@@ -49,7 +49,9 @@ spec:
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-{{- if .Values.podAnnotations }}{{ toYaml .Values.podAnnotations | indent 8 }}{{- end }}
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | trimSuffix "\n" | indent 8 }}
+{{- end }}
     spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"


### PR DESCRIPTION

#### What this PR does / why we need it:
When value `podAnnotations` in `values.yaml` file is not empty then `statefulset.yaml` will not render template properly which leads to invalid yaml

#### Which issue this PR fixes

#### Special notes for your reviewer:
See how you use podAnnotations in `deployment.yaml`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
