### PR TITLE
[stable/drone] Bump drone version to latest available image v1.6.1

### DIFF
--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 2.2.0
-appVersion: 1.3.1
+version: 2.3.0
+appVersion: 1.6.1
 description: Drone is a Continuous Delivery system built on container technology
 keywords:
 - continuous-delivery

--- a/stable/drone/README.md
+++ b/stable/drone/README.md
@@ -55,10 +55,10 @@ The following table lists the configurable parameters of the drone charts and th
 | Parameter                   | Description                                                                                   | Default                     |
 |-----------------------------|-----------------------------------------------------------------------------------------------|-----------------------------|
 | `images.server.repository`  | Drone **server** image                                                                        | `docker.io/drone/drone`     |
-| `images.server.tag`         | Drone **server** image tag                                                                    | `1.3.1`                       |
+| `images.server.tag`         | Drone **server** image tag                                                                    | `1.6.1`                       |
 | `images.server.pullPolicy`  | Drone **server** image pull policy                                                            | `IfNotPresent`              |
 | `images.agent.repository`   | Drone **agent** image                                                                         | `docker.io/drone/agent`     |
-| `images.agent.tag`          | Drone **agent** image tag                                                                     | `1.3.1`                       |
+| `images.agent.tag`          | Drone **agent** image tag                                                                     | `1.6.1`                       |
 | `images.agent.pullPolicy`   | Drone **agent** image pull policy                                                             | `IfNotPresent`              |
 | `images.dind.repository`    | Docker **dind** image                                                                         | `docker.io/library/docker`  |
 | `images.dind.tag`           | Docker **dind** image tag                                                                     | `18.06.1-ce-dind`           |

--- a/stable/drone/values.yaml
+++ b/stable/drone/values.yaml
@@ -4,7 +4,7 @@ images:
   ##
   server:
     repository: "docker.io/drone/drone"
-    tag: 1.3.1
+    tag: 1.6.1
     pullPolicy: IfNotPresent
 
   ## The official drone (agent) image, change tag to use a different version.
@@ -12,7 +12,7 @@ images:
   ##
   agent:
     repository: "docker.io/drone/agent"
-    tag: 1.3.1
+    tag: 1.6.1
     pullPolicy: IfNotPresent
 
   ## The official docker (dind) image, change tag to use a different version.


### PR DESCRIPTION
#### What this PR does / why we need it:
Use the latest stable drone release from the official repo: https://github.com/drone/drone/releases  

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
