### PR TITLE
[stable/jenkins] Revert direct connection fix in previous version

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -6,6 +6,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.8.2
+
+Revert fix in `1.7.10` since direct connection is now disabled by default.
+
 ## 1.8.1
 
 Add `master.schedulerName` to allow setting a Kubernetes custom scheduler

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.8.1
+version: 1.8.2
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -136,9 +136,6 @@ data:
           <serverUrl>https://kubernetes.default</serverUrl>
           <skipTlsVerify>false</skipTlsVerify>
           <namespace>{{ template "jenkins.master.slaveKubernetesNamespace" . }}</namespace>
-{{- if semverCompare ">=1.20.2" (include "jenkins.kubernetes-version" . ) }}
-          <directConnection>false</directConnection>
-{{- end }}
 {{- if .Values.master.slaveKubernetesNamespace }}
           <jenkinsUrl>http://{{ template "jenkins.fullname" . }}.{{ template "jenkins.namespace" . }}:{{.Values.master.servicePort}}{{ default "" .Values.master.jenkinsUriPrefix }}</jenkinsUrl>
           <jenkinsTunnel>{{ template "jenkins.fullname" . }}-agent.{{ template "jenkins.namespace" . }}:{{ .Values.master.slaveListenerPort }}</jenkinsTunnel>


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix created for direct connection enabled by default in kubernetes plugin version 1.20.2 is no longer needed (#18410). It was changed upstream to default to disabled in version 1.21.1 https://github.com/jenkinsci/kubernetes-plugin/pull/633

#### Which issue this PR fixes
Skips setting direct connect to false.

#### Special notes for your reviewer:
Reverting still causes issues if you happen to install 1.20.2 and using this helm chart. Also, not specifying the option at all makes 
```
<directConnection>false</directConnection>
``` 
being injected to config.xml with each pod start without being handled by helm chart.

I don't think it's possible to configure this option via JCasC atm either.

Alternative would be to keep it but also adding the option if `latest` version of kubernetes plugin is specified, since it caused issues with semver comparison.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
