### PR TITLE
[stable/sonarqube] Upgrade plugins.initContainerImage

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 3.2.1
+version: 3.2.2
 appVersion: 7.9.1
 keywords:
   - coverage

--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -98,7 +98,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `tolerations`                               | List of node taints to tolerate           | `[]`                                       |
 | `plugins.install`                           | List of plugins to install                | `[]`                                       |
 | `plugins.resources`                         | Plugin Pod resource requests & limits     | `{}`                                       |
-| `plugins.initContainerImage`                | Change init container image               | `joosthofman/wget:1.0`                     |
+| `plugins.initContainerImage`                | Change init container image               | `alpine:3.10.3`                            |
 | `plugins.initSysctlContainerImage`          | Change init sysctl container image        | `busybox:1.31`                             |
 | `plugins.deleteDefaultPlugins`              | Remove default plugins and use plugins.install list | `[]`                             |
 | `podLabels`                                 | Map of labels to add to the pods          | `{}`                                       |

--- a/stable/sonarqube/templates/deployment.yaml
+++ b/stable/sonarqube/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
       {{- end }}
       {{- if .Values.plugins.install }}
         - name: install-plugins
-          image: {{ default "joosthofman/wget:1.0" .Values.plugins.initContainerImage }}
+          image: {{ default "alpine:3.10.3" .Values.plugins.initContainerImage }}
           env:
             {{- range $key, $value := .Values.extraEnv }}
             - name: {{ $key }}

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -139,7 +139,7 @@ persistence:
 plugins:
   install: []
 
-  # initContainerImage: alpine:3.9
+  # initContainerImage: alpine:3.10.3
   # deleteDefaultPlugins: true
   resources: {}
   # We allow the plugins init container to have a separate resources declaration because


### PR DESCRIPTION
#### What this PR does / why we need it:
Upgraded init container `joosthofman/wget:1.0` to the newest Alpine release `3.10.3`. The Alpine container has all necessary functionality build-in to download the plugins.

Tested the chart with the `sonar-go` and `sonar-yaml` plugins:
```
plugins:
  install:
    - https://github.com/sbaudoin/sonar-yaml/releases/download/v1.4.3/sonar-yaml-plugin-1.4.3.jar
    - https://binaries.sonarsource.com/Distribution/sonar-go-plugin/sonar-go-plugin-1.6.0.719.jar
```

#### Which issue this PR fixes:
Results when scanning container `joosthofman/wget:1.0` with [anchore-engine](https://github.com/anchore/anchore-engine):
```
CVE-2017-13090 wget-1.19.1-r2         High   1.19.2-r0
CVE-2018-20483 wget-1.19.1-r2         Low    1.20.1-r0
CVE-2018-5407  libcrypto1.0-1.0.2m-r0 Low    1.0.2q-r0
CVE-2018-5407  libssl1.0-1.0.2m-r0    Low    1.0.2q-r0
CVE-2018-5407  openssl-1.0.2m-r0      Low    1.0.2q-r0
CVE-2017-15873 busybox-1.26.2-r7      Medium 1.26.2-r9
CVE-2017-16544 busybox-1.26.2-r7      Medium 1.26.2-r9
CVE-2017-3737  libcrypto1.0-1.0.2m-r0 Medium 1.0.2n-r0
CVE-2017-3737  libssl1.0-1.0.2m-r0    Medium 1.0.2n-r0
CVE-2017-3737  openssl-1.0.2m-r0      Medium 1.0.2n-r0
CVE-2017-3738  libcrypto1.0-1.0.2m-r0 Medium 1.0.2n-r0
CVE-2017-3738  libssl1.0-1.0.2m-r0    Medium 1.0.2n-r0
CVE-2017-3738  openssl-1.0.2m-r0      Medium 1.0.2n-r0
CVE-2018-0494  wget-1.19.1-r2         Medium 1.19.5-r0
CVE-2018-0732  libcrypto1.0-1.0.2m-r0 Medium 1.0.2o-r1
CVE-2018-0732  libssl1.0-1.0.2m-r0    Medium 1.0.2o-r1
CVE-2018-0732  openssl-1.0.2m-r0      Medium 1.0.2o-r1
CVE-2018-0733  libcrypto1.0-1.0.2m-r0 Medium 1.0.2o-r0
CVE-2018-0733  libssl1.0-1.0.2m-r0    Medium 1.0.2o-r0
CVE-2018-0733  openssl-1.0.2m-r0      Medium 1.0.2o-r0
CVE-2018-0734  libcrypto1.0-1.0.2m-r0 Medium 1.0.2q-r0
CVE-2018-0734  libssl1.0-1.0.2m-r0    Medium 1.0.2q-r0
CVE-2018-0734  openssl-1.0.2m-r0      Medium 1.0.2q-r0
CVE-2018-0737  libcrypto1.0-1.0.2m-r0 Medium 1.0.2o-r1
CVE-2018-0737  libssl1.0-1.0.2m-r0    Medium 1.0.2o-r1
CVE-2018-0737  openssl-1.0.2m-r0      Medium 1.0.2o-r1
CVE-2018-0739  libcrypto1.0-1.0.2m-r0 Medium 1.0.2o-r0
CVE-2018-0739  libssl1.0-1.0.2m-r0    Medium 1.0.2o-r0
CVE-2018-0739  openssl-1.0.2m-r0      Medium 1.0.2o-r0
CVE-2019-1559  libcrypto1.0-1.0.2m-r0 Medium 1.0.2r-r0
CVE-2019-1559  libssl1.0-1.0.2m-r0    Medium 1.0.2r-r0
CVE-2019-1559  openssl-1.0.2m-r0      Medium 1.0.2r-r0
```

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
