### PR TITLE
[stable/lamp] Add ability to change sftp service type

### DIFF
--- a/stable/lamp/Chart.yaml
+++ b/stable/lamp/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Modular and transparent LAMP stack chart supporting PHP-FPM, Release Cloning, LoadBalancer, Ingress, SSL and lots more!
 name: lamp
-version: 1.1.1
+version: 1.1.2
 appVersion: 7
 home: https://github.com/lead4good/helm-lamp-stack
 maintainers:

--- a/stable/lamp/README.md
+++ b/stable/lamp/README.md
@@ -199,6 +199,7 @@ SFTP is an instance of the atmoz/sftp container, through which you can access th
 | `sftp.repository` | default sftp image | atmoz/sftp |
 | `sftp.tag` | default sftp image tag | alpine |
 | `sftp.enabled` | Enables sftp service | false |
+| `sftp.serviceType` | Type of sftp service in Ingress mode | NodePort |
 | `sftp.port` | Port to advertise service in LoadBalancer mode | 22 |
 | `sftp.nodePort` |  Port to advertise service in Ingress mode| _empty_ |
 | `sftp.user` | SFTP User | _empty_ |

--- a/stable/lamp/templates/service-sftp.yaml
+++ b/stable/lamp/templates/service-sftp.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
-  type: NodePort
+  type: {{ .Values.sftp.serviceType }}
   ports:
   - targetPort: 22
     port: {{ .Values.sftp.port }}

--- a/stable/lamp/values.yaml
+++ b/stable/lamp/values.yaml
@@ -130,10 +130,14 @@ sftp:
   ## sftp.enabled Enables sftp service
   enabled: false
 
+  ## sftp.serviceType Type of sftp service in Ingress mode
+  serviceType: NodePort
+
   ## sftp.port Port to advertise service in LoadBalancer mode
   port: 22
 
   ## sftp.nodePort  Port to advertise service in Ingress mode
+  ## `sftp.serviceType` must be set to `NodePort`
   # nodePort: 30111
 
   ## sftp.user SFTP User


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds the ability to change the type of the sftp service.
This is needed to expose the service through a LoadBalancer IP while still using the Ingress resource for http access.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
