### PR TITLE
[stable/fluentd] Support custom load balancer IP

### DIFF
--- a/stable/fluentd/Chart.yaml
+++ b/stable/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Fluentd Elasticsearch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd
-version: 2.1.3
+version: 2.2.0
 appVersion: v2.4.0
 home: https://www.fluentd.org/
 sources:

--- a/stable/fluentd/README.md
+++ b/stable/fluentd/README.md
@@ -71,6 +71,7 @@ Parameter | Description | Default
 `serviceAccount.create` | Specifies whether a service account should be created. | `true`
 `serviceAccount.name` | Name of the service account.
 `priorityClassName` | priorityClassName | `nil`
+`service.loadBalancerIP` | If `service.type` is `LoadBalancer` set custom IP load balancer IP address | `nil`
 `service.ports` | port definition for the service | See [values.yaml](values.yaml)
 `service.type` | type of service | `ClusterIP`
 `service.annotations` | list of annotations for the service | `{}`

--- a/stable/fluentd/templates/service.yaml
+++ b/stable/fluentd/templates/service.yaml
@@ -11,6 +11,9 @@ metadata:
 {{ toYaml .Values.service.annotations | indent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  {{ if (and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP))) }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{ end }}
   ports:
   {{- range $port := .Values.service.ports }}
     - name: {{ $port.name }}

--- a/stable/fluentd/values.yaml
+++ b/stable/fluentd/values.yaml
@@ -34,6 +34,7 @@ plugins:
 service:
   annotations: {}
   type: ClusterIP
+  # loadBalancerIP:
   # type: NodePort
   # nodePort:
   # Used to create Service records


### PR DESCRIPTION
Signed-off-by: Austin Orth <aorth@niche.com>
### Motivation
We want to be able to set a custom load balancer IP address when the service type is `LoadBalancer`.

### What I Did
- Added handling to service template for setting a custom load balancer IP address when service type is LoadBalancer.
- Added documentation to readme and default values file.

#### What this PR does / why we need it:

#### Which issue this PR fixes
  - fixes #18495
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

**CC:** @rendhalver @Miouge1 @hectorj2f 