### PR TITLE
[stable/external-dns] Skip mounting when using managed identity extension

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: external-dns
 version: 2.10.0
-appVersion: 0.5.17
+appVersion: 0.5.18
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:
 - external-dns

--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.11.0
+version: 2.10.1
 appVersion: 0.5.17
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: external-dns
-version: 2.10.0
-appVersion: 0.5.18
+version: 2.11.0
+appVersion: 0.5.17
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:
 - external-dns

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -302,6 +302,7 @@ spec:
         - name: azure-config-file
           {{- if or .Values.azure.secretName (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId) }}
           mountPath: /etc/kubernetes/
+          {{- else if .Values.azure.useManagedIdentityExtension }}
           {{- else }}
           mountPath: /etc/kubernetes/azure.json
           {{- end }}
@@ -342,6 +343,7 @@ spec:
         {{- else if (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId) }}
         secret:
           secretName: {{ template "external-dns.fullname" . }}
+        {{- else if .Values.azure.useManagedIdentityExtension }}
         {{- else }}
         hostPath:
           path: /etc/kubernetes/azure.json

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -302,8 +302,7 @@ spec:
         - name: azure-config-file
           {{- if or .Values.azure.secretName (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId) }}
           mountPath: /etc/kubernetes/
-          {{- else if .Values.azure.useManagedIdentityExtension }}
-          {{- else }}
+          {{- else if not .Values.azure.useManagedIdentityExtension }}
           mountPath: /etc/kubernetes/azure.json
           {{- end }}
           readOnly: true
@@ -343,8 +342,7 @@ spec:
         {{- else if (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId) }}
         secret:
           secretName: {{ template "external-dns.fullname" . }}
-        {{- else if .Values.azure.useManagedIdentityExtension }}
-        {{- else }}
+        {{- else if not .Values.azure.useManagedIdentityExtension }}
         hostPath:
           path: /etc/kubernetes/azure.json
           type: File


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds a conditional which skips mounting `/etc/kubernetes` resources if `azure.useManagedIdentityExtension=true` and bumped chart version. From #18494:
>When running ExternalDNS in Azure together with aad-pod-identity and the deployment option useManagedIdentityExtension=true it's not necessary to mount a hostPath to the pod to get credentials to manage the Azure DNS zone.

Signed-off-by: Austin Orth <aorth@niche.com>


#### Which issue this PR fixes
  - fixes #18494

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

CC: @bitnami-bot 