### PR TITLE
[stable/wordpress] Fix custom htaccess

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 7.6.0
+version: 7.6.1
 appVersion: 5.2.4
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -343,7 +343,7 @@ For performance and security reasons, it is a good practice to configure Apache 
 However, some plugins may include `.htaccess` directives that will not be loaded when `AllowOverride` is set to `None`. A way to make them work would be to create your own `wordpress-htaccess.conf` file with all the required dircectives to make the plugin work. After creating it, then create a ConfigMap with it and install the chart with the correct parameters:
 
 ```console
-allowOverrideNone=yes
+allowOverrideNone=true
 customHTAccessCM=custom-htaccess
 ```
 

--- a/stable/wordpress/templates/deployment.yaml
+++ b/stable/wordpress/templates/deployment.yaml
@@ -167,10 +167,9 @@ spec:
         - mountPath: /bitnami/wordpress
           name: wordpress-data
           subPath: wordpress
-        {{- if and .Values.allowOverrideNone .Values.customHTAccessCM}}
-        - mountPath: /opt/bitnami/wordpress/wordpress-htaccess.conf
+        {{- if and .Values.allowOverrideNone .Values.customHTAccessCM }}
+        - mountPath: /htaccess
           name: custom-htaccess
-          subPath: wordpress-htaccess.conf
         {{- end }}
         {{- with .Values.extraVolumeMounts }}
 {{ toYaml . | indent 8 }}
@@ -204,11 +203,14 @@ spec:
 {{ toYaml .Values.sidecars | indent 6 }}
 {{- end }}
       volumes:
-      {{- if and .Values.allowOverrideNone .Values.customHTAccessCM}}
+      {{- if and .Values.allowOverrideNone .Values.customHTAccessCM }}
       - name: custom-htaccess
         configMap:
           name: {{ template "wordpress.customHTAccessCM" . }}
       {{- end }}
+          items:
+            - key: wordpress-htaccess.conf
+              path: wordpress-htaccess.conf
       - name: wordpress-data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:

--- a/stable/wordpress/templates/deployment.yaml
+++ b/stable/wordpress/templates/deployment.yaml
@@ -207,10 +207,10 @@ spec:
       - name: custom-htaccess
         configMap:
           name: {{ template "wordpress.customHTAccessCM" . }}
-      {{- end }}
           items:
             - key: wordpress-htaccess.conf
               path: wordpress-htaccess.conf
+      {{- end }}
       - name: wordpress-data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:

--- a/stable/wordpress/values-production.yaml
+++ b/stable/wordpress/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/wordpress
-  tag: 5.2.4-debian-9-r0
+  tag: 5.2.4-debian-9-r12
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/wordpress
-  tag: 5.2.4-debian-9-r0
+  tag: 5.2.4-debian-9-r12
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>
#### Is this a new chart

No

#### What this PR does / why we need it:

This PR fixes custom htaccess files by moving them to a 3rd directory to avoid conflict when mounting the configmap.

#### Which issue this PR fixes

  - fixes https://github.com/helm/charts/issues/11941


#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
