### PR TITLE
[stable/pomerium] Remove redundant hosts for TLS

### DIFF
--- a/stable/pomerium/Chart.yaml
+++ b/stable/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 4.0.3
+version: 4.0.4
 appVersion: 0.4.2
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo.svg

--- a/stable/pomerium/templates/ingress.yaml
+++ b/stable/pomerium/templates/ingress.yaml
@@ -17,8 +17,6 @@ spec:
     - secretName: {{ default .Values.ingress.secretName .Values.ingress.secret.name}}
       hosts:
         - {{ printf "*.%s" .Values.config.rootDomain | quote }}
-        - {{ printf "authorize.%s" .Values.config.rootDomain | quote }}
-        - {{ printf "authenticate.%s" .Values.config.rootDomain | quote }}
   rules:
     - host: {{ printf "*.%s" .Values.config.rootDomain| quote }}
       http:


### PR DESCRIPTION
* [stable/pomerium] Remove redundant hosts for TLS

A wildcard certificate already covers all hosts specified in this
Ingress, making the requirement for `authorize.<domain>` and
`authenticate.<domain>` as SANs redundant.

Signed-off-by: Daniel van den Berg <dvandenberg@optoro.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
