### PR TITLE
stable/oauth2-proxy  -  Change deployment to V1 for K8s 1.16 compatibility

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 1.1.0
+version: 1.1.1
 apiVersion: v1
 appVersion: 4.0.0
 home: http://www.videntity.com/

--- a/stable/oauth2-proxy/templates/deployment.yaml
+++ b/stable/oauth2-proxy/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
## Description
Currently, this chart is not able to be deployed out of the box to Kubernetes 1.16 as compatibility for deployment `apiVersion: apps/v1beta2` was removed. This change addresses that issue by changing the deployment API version to `v1` instead of `v1beta2`.

Updated the patch version since no functionality was changed, just a fix for deploying to K8s 1.16.

#### Reviewers
Tagging @desaintmartin and @miouge1 for review as they are the owners of this chart.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
