### PR TITLE
[stable/kubernetes-dashboard] Update to stable "rbac.authorization.k8s.io/v1"

### DIFF
--- a/stable/kubernetes-dashboard/Chart.yaml
+++ b/stable/kubernetes-dashboard/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubernetes-dashboard
-version: 1.10.0
+version: 1.10.1
 appVersion: 1.10.1
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/stable/kubernetes-dashboard/templates/clusterrole-readonly.yaml
+++ b/stable/kubernetes-dashboard/templates/clusterrole-readonly.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.rbac.create .Values.rbac.clusterReadOnlyRole (not .Values.rbac.clusterAdminRole) }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:

--- a/stable/kubernetes-dashboard/templates/role.yaml
+++ b/stable/kubernetes-dashboard/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.rbac.create (not .Values.rbac.clusterAdminRole) }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:

--- a/stable/kubernetes-dashboard/templates/rolebinding.yaml
+++ b/stable/kubernetes-dashboard/templates/rolebinding.yaml
@@ -2,7 +2,7 @@
 
 {{- if or .Values.rbac.clusterAdminRole .Values.rbac.clusterReadOnlyRole }}
 # Cluster role binding for clusterAdminRole == true or clusterReadOnlyRole=true
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -25,7 +25,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 {{- else -}}
 # Role binding for clusterAdminRole == false and clusterReadOnlyRole=false
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:


### PR DESCRIPTION
#### What this PR does / why we need it:
`rbac.authorization.k8s.io/v1beta1` API is promoted to `rbac.authorization.k8s.io/v1` in v1.8.
Ref https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.8.md

#### Which issue this PR fixes
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
