### PR TITLE
[stable/redis-ha] fix affinity conflict with the helm test pod

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.9.3
+version: 3.9.4
 appVersion: 5.0.5
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/stable/redis-ha/templates/redis-ha-statefulset.yaml
@@ -3,6 +3,7 @@ kind: StatefulSet
 metadata:
   name: {{ template "redis-ha.fullname" . }}-server
   labels:
+    {{ template "redis-ha.fullname" . }}: replica
 {{ include "labels.standard" . | indent 4 }}
 spec:
   selector:
@@ -29,6 +30,7 @@ spec:
       labels:
         release: {{ .Release.Name }}
         app: {{ template "redis-ha.name" . }}
+        {{ template "redis-ha.fullname" . }}: replica
         {{- range $key, $value := .Values.labels }}
         {{ $key }}: {{ $value }}
         {{- end }}
@@ -60,6 +62,7 @@ spec:
                 matchLabels:
                   app: {{ template "redis-ha.name" . }}
                   release: {{ .Release.Name }}
+                  {{ template "redis-ha.fullname" . }}: replica
               topologyKey: kubernetes.io/hostname
     {{- else }}
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -67,6 +70,7 @@ spec:
                 matchLabels:
                   app: {{ template "redis-ha.name" . }}
                   release: {{ .Release.Name }}
+                  {{ template "redis-ha.fullname" . }}: replica
               topologyKey: kubernetes.io/hostname
     {{- end }}
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -76,6 +80,7 @@ spec:
                   matchLabels:
                     app:  {{ template "redis-ha.name" . }}
                     release: {{ .Release.Name }}
+                    {{ template "redis-ha.fullname" . }}: replica
                 topologyKey: failure-domain.beta.kubernetes.io/zone
     {{- end }}
       securityContext:


### PR DESCRIPTION
#### What this PR does / why we need it:
This commit fixes an issue when redis-ha is installed on clusters that have a node
count equal to the replica count which prevents scheduling of the helm test pod
due to the matching labels.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
