### PR TITLE
[stable/external-dns] Avoid configuring 'role_arn' in AWS default profile

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.10.1
+version: 2.10.2
 appVersion: 0.5.17
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/templates/_helpers.tpl
+++ b/stable/external-dns/templates/_helpers.tpl
@@ -118,7 +118,6 @@ aws_secret_access_key = {{ .Values.aws.credentials.secretKey }}
 
 {{- define "external-dns.aws-config" }}
 [profile default]
-role_arn = {{ .Values.aws.assumeRoleArn }}
 region = {{ .Values.aws.region }}
 source_profile = default
 {{ end }}

--- a/stable/external-dns/templates/secret.yaml
+++ b/stable/external-dns/templates/secret.yaml
@@ -10,7 +10,7 @@ data:
   {{- if and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey }}
   credentials: {{ include "external-dns.aws-credentials" . | b64enc | quote }}
   {{- end }}
-  {{- if .Values.aws.assumeRoleArn }}
+  {{- if .Values.aws.region }}
   config: {{ include "external-dns.aws-config" . | b64enc | quote }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### Is this a new chart

No

#### What this PR does / why we need it:

This PR avoids applying the "AWS assume role" twice since it's already setup using the `--aws-assume-role` flag (see https://github.com/helm/charts/blob/master/stable/external-dns/templates/deployment.yaml#L99)

#### Which issue this PR fixes

  - fixes https://github.com/helm/charts/issues/18474

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
