### PR TITLE
[stable/spinnaker] update spinnaker dependencies for kubernetes 1.16 and higher

### DIFF
--- a/stable/spinnaker/requirements.lock
+++ b/stable/spinnaker/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 3.8.0
+  version: 9.4.3
 - name: minio
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.6.3
-digest: sha256:bccb7348a48817b0c0c654dfecd2f399a64a50b0f677b483a27a76f4ff7ddd89
-generated: 2019-01-21T21:59:54.069291+05:30
+  version: 2.5.17
+digest: sha256:45d10a49a332ff277746697802c66aa03904784e90535e55e6752464c5a21183
+generated: "2019-10-31T13:16:06.41563674+01:00"

--- a/stable/spinnaker/requirements.yaml
+++ b/stable/spinnaker/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
-  version: 3.8.0
+  version: 9.4.3
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: redis.enabled
 - name: minio
-  version: 1.6.3
+  version: 2.5.17
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: minio.enabled

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -2,7 +2,7 @@ halyard:
   spinnakerVersion: 1.16.1
   image:
     repository: gcr.io/spinnaker-marketplace/halyard
-    tag: 1.23.2
+    tag: 1.26.0
     pullSecrets: []
   # Set to false to disable persistence data volume for halyard
   persistence:
@@ -228,6 +228,7 @@ ingressGate:
 #   - pipeline-templates
 spinnakerFeatureFlags:
   - artifacts
+  # - jobs
 
 # Node labels for pod assignment
 # Ref: https://kubernetes.io/docs/user-guide/node-selection/


### PR DESCRIPTION
resolves issue #18460

bumped redis and minio depenencies as they set the correct api endpoints for k8
also needed to remove the `job` feature flag as it is removed in halyard.