### PR TITLE
[stable/prometheus-operator] Add a rule used by grafana dashboards

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -11,7 +11,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 7.4.0
+version: 7.4.1
 appVersion: 0.34.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/node.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/node.rules.yaml
@@ -34,4 +34,9 @@ spec:
       record: node:node_num_cpu:sum
     - expr: sum(node_memory_MemFree_bytes{job="node-exporter"} + node_memory_Cached_bytes{job="node-exporter"} + node_memory_Buffers_bytes{job="node-exporter"})
       record: :node_memory_MemFreeCachedBuffers_bytes:sum
+    - expr: |
+        sum by (namespace, pod, container) (
+          rate(container_cpu_usage_seconds_total{job="kubelet", image!="", container!="POD"}[5m])
+        ) * on (namespace, pod) group_left(node) max by(namespace, pod, node) (kube_pod_info)
+      record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
 {{- end }}


### PR DESCRIPTION
## What this PR does / why we need it:

Several grafana dashboards installed with `stable/prometheus-operator` make use of the
following prometheus rule:
```
node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
```
This rule is not anymore present so added it back.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
