### PR TITLE
[stable/wordpress] Fix warning with ingress annotations

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 7.6.2
+version: 7.6.3
 appVersion: 5.2.4
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/values-production.yaml
+++ b/stable/wordpress/values-production.yaml
@@ -287,7 +287,7 @@ ingress:
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
-  annotations:
+  annotations: {}
   #  kubernetes.io/ingress.class: nginx
 
   ## The list of additional hostnames to be covered with this ingress record.

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -287,7 +287,7 @@ ingress:
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
-  annotations:
+  annotations: {}
   #  kubernetes.io/ingress.class: nginx
 
   ## The list of additional hostnames to be covered with this ingress record.


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### Is this a new chart

No

#### What this PR does / why we need it:

This PR addresses a warning that occurs when overwriting the `ingress.annotations` parameter.

#### Which issue this PR fixes

  - fixes https://github.com/helm/charts/issues/18532

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
