### PR TITLE
concourse - support kubernetes 1.16 and up

### DIFF
--- a/stable/concourse/requirements.lock
+++ b/stable/concourse/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.3.8
-digest: sha256:8beae180ba7a5ca551f75da9552e59cadbbfcce2d0e2edf6c8a93dcfacd0df10
-generated: "2019-06-20T13:43:23.321244-04:00"
+  version: 6.5.5
+digest: sha256:25655b1d890ab9555c02d53f7e32af63e577a8e3d0100215bec99c3a20b2a581
+generated: "2019-11-04T11:55:35.898617288+01:00"

--- a/stable/concourse/requirements.yaml
+++ b/stable/concourse/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: postgresql
-  version: 5.3.8
+  version: 6.5.5
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: postgresql.enabled

--- a/stable/concourse/templates/_helpers.tpl
+++ b/stable/concourse/templates/_helpers.tpl
@@ -61,3 +61,36 @@ Creates the address of the TSA service.
 {{- $port := .Values.concourse.web.tsa.bindPort -}}
 {{ template "concourse.web.fullname" . }}:{{- print $port -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "concourse.deployment.apiVersion" -}}
+{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for statefulset.
+*/}}
+{{- define "concourse.statefulset.apiVersion" -}}
+{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apps/v1beta2" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "concourse.ingress.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.web.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "concourse.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "concourse.web.fullname" . }}
@@ -13,6 +13,10 @@ spec:
 {{- if .Values.web.strategy }}
 {{ toYaml .Values.web.strategy | indent 2 }}
 {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "concourse.web.fullname" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:

--- a/stable/concourse/templates/web-ingress.yaml
+++ b/stable/concourse/templates/web-ingress.yaml
@@ -3,7 +3,7 @@
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := default "web" .Values.web.nameOverride -}}
 {{- $servicePort := .Values.concourse.web.bindPort -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "concourse.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "concourse.web.fullname" . }}

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.worker.enabled -}}
-apiVersion: apps/v1beta1
+apiVersion: {{ template "concourse.statefulset.apiVersion" . }}
 kind: StatefulSet
 metadata:
   name: {{ template "concourse.worker.fullname" . }}
@@ -11,6 +11,10 @@ metadata:
 spec:
   serviceName: {{ template "concourse.worker.fullname" . }}
   replicas: {{ .Values.worker.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "concourse.worker.fullname" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
support kubernetes 1.16 and higher

i needed to add the selector see 
https://github.com/helm/charts/issues/7726

