### PR TITLE
[stable/kong] drop cassandra sub-chart

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.25.0
+version: 0.26.0
 appVersion: 1.3

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -139,17 +139,19 @@ for the service definition to work properly.
 
 Kong has a choice of either Postgres or Cassandra as a backend datatstore.
 This chart allows you to choose either of them with the `env.database`
-parameter.  Postgres is chosen by default.
+parameter. Postgres is chosen by default.
 
-Additionally, this chart allows you to use your own database or spin up a new
-instance by using the `postgres.enabled` or `cassandra.enabled` parameters.
-Enabling both will create both databases in your cluster, but only one
-will be used by Kong based on the `env.database` parameter.
-Postgres is enabled by default.
+This chart allows you to bring your own database that you manage or spin up
+separately (recommended) or spin up a new Postgres instance using 
+the `postgres.enabled` parameter.
+
+Note: Cassandra deployment via a sub-chart was previously supported but
+the support has now been dropped due to stability issues.
+You can still deploy Cassandra on your own and configure Kong to use
+that via the `env.database` parameter.
 
 | Parameter                     | Description                                                             | Default               |
 | ------------------------------| ------------------------------------------------------------------------| ----------------------|
-| cassandra.enabled             | Spin up a new cassandra cluster for Kong                                | `false`               |
 | postgresql.enabled            | Spin up a new postgres instance for Kong                                | `true`                |
 | waitImage.repository          | Image used to wait for database to become ready                         | `busybox`             |
 | waitImage.tag                 | Tag for image used to wait for database to become ready                 | `latest`              |
@@ -159,10 +161,6 @@ Postgres is enabled by default.
 | env.pg_password               | Postgres database password (required if you are using your own database)| `kong`                |
 | env.pg_host                   | Postgres database host (required if you are using your own database)    | ``                    |
 | env.pg_port                   | Postgres database port                                                  | `5432`                |
-| env.cassandra_contact_points  | Cassandra contact points (required if you are using your own database)  | ``                    |
-| env.cassandra_port            | Cassandra query port                                                    | `9042`                |
-| env.cassandra_keyspace        | Cassandra keyspace                                                      | `kong`                |
-| env.cassandra_repl_factor     | Replication factor for the Kong keyspace                                | `2`                   |
 | dblessConfig.configMap        | Name of an existing ConfigMap containing the `kong.yml` file. This must have the key `kong.yml`.| `` |
 | dblessConfig.config           | Yaml configuration file for the dbless (declarative) configuration of Kong | see in `values.yaml`    |
 
@@ -182,13 +180,13 @@ kong:
 ```
 
 
-For complete list of Kong configurations please check https://getkong.org/docs/latest/configuration/.
+For complete list of Kong configurations please check https://docs.konghq.com/latest/configuration/.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
 $ helm install stable/kong --name my-release \
-  --set=image.tag=1.3,env.database=cassandra,cassandra.enabled=true
+  --set=image.tag=1.3,env.database=postgres,postgres.enabled=true
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters

--- a/stable/kong/ci/cassandra.yaml
+++ b/stable/kong/ci/cassandra.yaml
@@ -1,7 +1,0 @@
-env:
-  database: cassandra
-
-cassandra:
-  enabled: true
-postgresql:
-  enabled: false

--- a/stable/kong/requirements.lock
+++ b/stable/kong/requirements.lock
@@ -1,9 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.3.12
-- name: cassandra
-  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  version: 0.13.3
-digest: sha256:6c1d6473c869ee26836bec19f3638ae148d11398a4f16dce25f62beeaf67fb67
-generated: "2019-10-10T11:19:21.654989947-07:00"
+  version: 6.3.15
+digest: sha256:1110c0b8497a990af34f196753420ab9b1b00fed77c540bce43542bdedd74b9b
+generated: "2019-10-31T09:56:30.102440266-07:00"

--- a/stable/kong/requirements.yaml
+++ b/stable/kong/requirements.yaml
@@ -3,7 +3,3 @@ dependencies:
   version: ~6.3.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: postgresql.enabled
-- name: cassandra
-  version: ~0.13.0
-  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  condition: cassandra.enabled

--- a/stable/kong/templates/_helpers.tpl
+++ b/stable/kong/templates/_helpers.tpl
@@ -18,11 +18,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "kong.cassandra.fullname" -}}
-{{- $name := default "cassandra" .Values.cassandra.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
 {{- define "kong.dblessConfig.fullname" -}}
 {{- $name := default "kong-custom-dbless-config" .Values.dblessConfig.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
@@ -233,10 +228,6 @@ the extra slash.
       secretKeyRef:
         name: {{ template "kong.postgresql.fullname" . }}
         key: postgresql-password
-  {{- end }}
-  {{- if .Values.cassandra.enabled }}
-  - name: KONG_CASSANDRA_CONTACT_POINTS
-    value: {{ template "kong.cassandra.fullname" . }}
   {{- end }}
   {{- include "kong.env" .  | nindent 2 }}
   command: [ "/bin/sh", "-c", "until kong start; do echo 'waiting for db'; sleep 1; done; kong stop" ]

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -181,10 +181,6 @@ spec:
               name: {{ template "kong.postgresql.fullname" . }}
               key: postgresql-password
         {{- end }}
-        {{- if .Values.cassandra.enabled }}
-        - name: KONG_CASSANDRA_CONTACT_POINTS
-          value: {{ template "kong.cassandra.fullname" . }}
-        {{- end }}
         {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
         - name: KONG_DECLARATIVE_CONFIG
           value: "/kong_dbless/kong.yml"

--- a/stable/kong/templates/migrations-post-upgrade.yaml
+++ b/stable/kong/templates/migrations-post-upgrade.yaml
@@ -71,10 +71,6 @@ spec:
               name: {{ template "kong.postgresql.fullname" . }}
               key: postgresql-password
         {{- end }}
-        {{- if .Values.cassandra.enabled }}
-        - name: KONG_CASSANDRA_CONTACT_POINTS
-          value: {{ template "kong.cassandra.fullname" . }}
-        {{- end }}
         {{- include "kong.env" .  | indent 8 }}
         command: [ "/bin/sh", "-c", "kong migrations finish" ]
         volumeMounts:

--- a/stable/kong/templates/migrations-pre-upgrade.yaml
+++ b/stable/kong/templates/migrations-pre-upgrade.yaml
@@ -71,10 +71,6 @@ spec:
               name: {{ template "kong.postgresql.fullname" . }}
               key: postgresql-password
         {{- end }}
-        {{- if .Values.cassandra.enabled }}
-        - name: KONG_CASSANDRA_CONTACT_POINTS
-          value: {{ template "kong.cassandra.fullname" . }}
-        {{- end }}
         {{- include "kong.env" .  | indent 8 }}
         command: [ "/bin/sh", "-c", "kong migrations up" ]
         volumeMounts:

--- a/stable/kong/templates/migrations.yaml
+++ b/stable/kong/templates/migrations.yaml
@@ -66,10 +66,6 @@ spec:
               name: {{ template "kong.postgresql.fullname" . }}
               key: postgresql-password
         {{- end }}
-        {{- if .Values.cassandra.enabled }}
-        - name: KONG_CASSANDRA_CONTACT_POINTS
-          value: {{ template "kong.cassandra.fullname" . }}
-        {{- end }}
         {{- include "kong.env" .  | indent 8 }}
         command: [ "/bin/sh", "-c", "kong migrations bootstrap" ]
         volumeMounts:

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -355,9 +355,6 @@ podSecurityPolicy:
 # will be used by Kong based on the `env.database` parameter.
 # Postgres is enabled by default.
 
-# Cassandra chart configs
-cassandra:
-  enabled: false
 
 # PostgreSQL chart configs
 postgresql:


### PR DESCRIPTION
Reasons:
- Cassandra chart has been incubating for a very long time and we have
  stability issues when Cassandra is running on k8s.
- Any serious user who is backing Kong with Cassandra, should be running
  and maintaining cassandra on their own any ways (outside k8s as well).
- Running Kong on k8s with Cassandra buys little. We would like to push
  users to use DB-less mode or use Postgres.
- We still support running Kong with Cassandra on k8s, only the
  sub-chart is being removed, (intentionally) increasing the friction when
  trying to use Kong with Cassandra on k8s.

Signed-off-by: Harry Bagdi <harrybagdi@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
