### PR TITLE
[stable/elastalert] Add podAnnotations field

### DIFF
--- a/stable/elastalert/Chart.yaml
+++ b/stable/elastalert/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: ElastAlert is a simple framework for alerting on anomalies, spikes, or other patterns of interest from data in Elasticsearch.
 name: elastalert
-version: 1.2.2
+version: 1.2.3
 appVersion: 0.2.1
 home: https://github.com/Yelp/elastalert
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg

--- a/stable/elastalert/README.md
+++ b/stable/elastalert/README.md
@@ -49,35 +49,35 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-|       Parameter          |                    Description                    |             Default             |
-| ------------------------ | ------------------------------------------------- | ------------------------------- |
-| `image.repository`       | docker image                                      | jertel/elastalert-docker        |
-| `image.tag`              | docker image tag                                  | 0.2.1                           |
-| `image.pullPolicy`       | image pull policy                                 | IfNotPresent                    |
-| `command`                | command override for container                    | `NULL`                          |
-| `args`                   | args override for container                       | `NULL`                          |
-| `replicaCount`           | number of replicas to run                         | 1                               |
-| `elasticsearch.host`     | elasticsearch endpoint to use                     | elasticsearch                   |
-| `elasticsearch.port`     | elasticsearch port to use                         | 80                              |
-| `elasticsearch.useSsl`   | whether or not to connect to es_host using SSL    | False                           |
-| `elasticsearch.username` | Username for ES with basic auth                   | `NULL`                          |
-| `elasticsearch.password` | Password for ES with basic auth                   | `NULL`                          |
-| `elasticsearch.verifyCerts` | whether or not to verify TLS certificates    | True                            |
-| `elasticsearch.clientCert` | path to a PEM certificate to use as the client certificate | /certs/client.pem  |
-| `elasticsearch.clientKey` | path to a private key file to use as the client key | /certs/client-key.pem      |
-| `elasticsearch.caCerts` | path to a CA cert bundle to use to verify SSL connections | /certs/ca.pem          |
-| `elasticsearch.certsVolumes` | certs volumes, required to mount ssl certificates when elasticsearch has tls enabled | `NULL` |
-| `elasticsearch.certsVolumeMounts` | mount certs volumes, required to mount ssl certificates when elasticsearch has tls enabled | `NULL` |
-| `extraConfigOptions` | Additional options to propagate to all rules, cannot be `alert`, `type`, `name` or `index` | `{}` |
-| `optEnv`           | Additional pod environment variable definitions                     | []                  |
-| `extraVolumes`           | Additional volume definitions                     | []                              |
-| `extraVolumeMounts`      | Additional volumeMount definitions                | []                              |
-| `resources`              | Container resource requests and limits            | {}                              |
-| `rules`                  | Rule and alert configuration for Elastalert       | {} example shown in values.yaml |
-| `runIntervalMins`        | Default interval between alert checks, in minutes | 1                               |
-| `realertIntervalMins`    | Time between alarms for same rule, in minutes     | `NULL`                          |
-| `alertRetryLimitMins`    | Time to retry failed alert deliveries, in minutes | 2880 (2 days)                   |
-| `bufferTimeMins`         | Default rule buffer time, in minutes              | 15                              |
-| `writebackIndex`         | Name or prefix of elastalert index(es)            | elastalert_status               |
-| `nodeSelector`           | Node selector for deployment                      | {}                              |
-| `tolerations`            | Tolerations for deployment                        | []                              |
+| Parameter                         | Description                                                                                | Default                         |
+|-----------------------------------|--------------------------------------------------------------------------------------------|---------------------------------|
+| `image.repository`                | docker image                                                                               | jertel/elastalert-docker        |
+| `image.tag`                       | docker image tag                                                                           | 0.2.1                           |
+| `image.pullPolicy`                | image pull policy                                                                          | IfNotPresent                    |
+| `command`                         | command override for container                                                             | `NULL`                          |
+| `args`                            | args override for container                                                                | `NULL`                          |
+| `replicaCount`                    | number of replicas to run                                                                  | 1                               |
+| `elasticsearch.host`              | elasticsearch endpoint to use                                                              | elasticsearch                   |
+| `elasticsearch.port`              | elasticsearch port to use                                                                  | 80                              |
+| `elasticsearch.useSsl`            | whether or not to connect to es_host using SSL                                             | False                           |
+| `elasticsearch.username`          | Username for ES with basic auth                                                            | `NULL`                          |
+| `elasticsearch.password`          | Password for ES with basic auth                                                            | `NULL`                          |
+| `elasticsearch.verifyCerts`       | whether or not to verify TLS certificates                                                  | True                            |
+| `elasticsearch.clientCert`        | path to a PEM certificate to use as the client certificate                                 | /certs/client.pem               |
+| `elasticsearch.clientKey`         | path to a private key file to use as the client key                                        | /certs/client-key.pem           |
+| `elasticsearch.caCerts`           | path to a CA cert bundle to use to verify SSL connections                                  | /certs/ca.pem                   |
+| `elasticsearch.certsVolumes`      | certs volumes, required to mount ssl certificates when elasticsearch has tls enabled       | `NULL`                          |
+| `elasticsearch.certsVolumeMounts` | mount certs volumes, required to mount ssl certificates when elasticsearch has tls enabled | `NULL`                          |
+| `extraConfigOptions`              | Additional options to propagate to all rules, cannot be `alert`, `type`, `name` or `index` | `{}`                            |
+| `optEnv`                          | Additional pod environment variable definitions                                            | []                              |
+| `extraVolumes`                    | Additional volume definitions                                                              | []                              |
+| `extraVolumeMounts`               | Additional volumeMount definitions                                                         | []                              |
+| `resources`                       | Container resource requests and limits                                                     | {}                              |
+| `rules`                           | Rule and alert configuration for Elastalert                                                | {} example shown in values.yaml |
+| `runIntervalMins`                 | Default interval between alert checks, in minutes                                          | 1                               |
+| `realertIntervalMins`             | Time between alarms for same rule, in minutes                                              | `NULL`                          |
+| `alertRetryLimitMins`             | Time to retry failed alert deliveries, in minutes                                          | 2880 (2 days)                   |
+| `bufferTimeMins`                  | Default rule buffer time, in minutes                                                       | 15                              |
+| `writebackIndex`                  | Name or prefix of elastalert index(es)                                                     | elastalert_status               |
+| `nodeSelector`                    | Node selector for deployment                                                               | {}                              |
+| `tolerations`                     | Tolerations for deployment                                                                 | []                              |

--- a/stable/elastalert/README.md
+++ b/stable/elastalert/README.md
@@ -54,6 +54,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.repository`                | docker image                                                                               | jertel/elastalert-docker        |
 | `image.tag`                       | docker image tag                                                                           | 0.2.1                           |
 | `image.pullPolicy`                | image pull policy                                                                          | IfNotPresent                    |
+| `podAnnotations`                  | Annotations to be added to pods                                                            | {}                              |
 | `command`                         | command override for container                                                             | `NULL`                          |
 | `args`                            | args override for container                                                                | `NULL`                          |
 | `replicaCount`                    | number of replicas to run                                                                  | 1                               |

--- a/stable/elastalert/templates/deployment.yaml
+++ b/stable/elastalert/templates/deployment.yaml
@@ -20,6 +20,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
         checksum/rules: {{ include (print $.Template.BasePath "/rules.yaml") . | sha256sum }}
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
       labels:
         name: {{ template "elastalert.fullname" . }}-elastalert
         app: {{ template "elastalert.name" . }}

--- a/stable/elastalert/values.yaml
+++ b/stable/elastalert/values.yaml
@@ -30,7 +30,11 @@ image:
   # docker image tag
   tag: 0.2.1
   pullPolicy: IfNotPresent
+
 resources: {}
+
+# Annotations to be added to pods
+podAnnotations: {}
 
 elasticsearch:
   # elasticsearch endpoint e.g. (svc.namespace||svc)


### PR DESCRIPTION
#### What this PR does / why we need it:
Add podAnnotations variable to set annotations on pods. Required by kube2iam and kiam for example to grant IAM privileges. https://github.com/jtblin/kube2iam#kubernetes-annotation

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
