### PR TITLE
[stable/prometheus-pushgateway] Compat k8s 1.16

### DIFF
--- a/stable/prometheus-pushgateway/Chart.yaml
+++ b/stable/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.2.1
+version: 1.2.2
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/stable/prometheus-pushgateway/README.md
+++ b/stable/prometheus-pushgateway/README.md
@@ -69,7 +69,6 @@ The following table lists the configurable parameters of the pushgateway chart a
 | `serviceMonitor.selector`   | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install                    | `{ prometheus: kube-prometheus }` |
 | `serviceMonitor.honorLabels`| if `true`, label conflicts are resolved by keeping label values from the scraped data                                         | `true`                            |
 | `podDisruptionBudget`       | If set, create a PodDisruptionBudget with the items in this map set in the spec                                               | ``                                |
-| `kubeTargetVersionOverride` | Provide a target gitVersion of K8S, in case .Capabilites.KubeVersion is not available (e.g. `helm template`)                  | `""`                              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-pushgateway/README.md
+++ b/stable/prometheus-pushgateway/README.md
@@ -69,6 +69,7 @@ The following table lists the configurable parameters of the pushgateway chart a
 | `serviceMonitor.selector`   | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install                    | `{ prometheus: kube-prometheus }` |
 | `serviceMonitor.honorLabels`| if `true`, label conflicts are resolved by keeping label values from the scraped data                                         | `true`                            |
 | `podDisruptionBudget`       | If set, create a PodDisruptionBudget with the items in this map set in the spec                                               | ``                                |
+| `kubeTargetVersionOverride` | Provide a target gitVersion of K8S, in case .Capabilites.KubeVersion is not available (e.g. `helm template`)                  | `""`                              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-pushgateway/templates/ingress.yaml
+++ b/stable/prometheus-pushgateway/templates/ingress.yaml
@@ -1,7 +1,12 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "prometheus-pushgateway.fullname" . }}
 {{- $servicePort := .Values.service.port -}}
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+{{- if semverCompare ">=1.14.0-0" $kubeTargetVersion }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
 {{- if .Values.ingress.annotations }}

--- a/stable/prometheus-pushgateway/templates/ingress.yaml
+++ b/stable/prometheus-pushgateway/templates/ingress.yaml
@@ -1,8 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "prometheus-pushgateway.fullname" . }}
 {{- $servicePort := .Values.service.port -}}
-{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
-{{- if semverCompare ">=1.14.0-0" $kubeTargetVersion }}
+{{- if semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
#### What this PR does / why we need it

Starting from 1.16, some api have been deprecated / moved
- ingress has been moved from `extensions/v1beta1` to `networking.k8s.io/v1beta1` (according to api documentation, available into networking api tree from k8s `v1.14` included)
- deployment has been moved from `apps/v1beta2` to `apps/v1`

See for more info : https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
