### PR TITLE
[stable/redis] Fix metrics.extraArgs

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 9.5.0
+version: 9.5.1
 appVersion: 5.0.5
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/redis-master-statefulset.yaml
+++ b/stable/redis/templates/redis-master-statefulset.yaml
@@ -279,11 +279,7 @@ spec:
           if [[ -f '/secrets/redis-password' ]]; then
            export REDIS_PASSWORD=$(cat /secrets/redis-password)
           fi
-          redis_exporter
-        args:
-        {{- range $key, $value := .Values.metrics.extraArgs }}
-          - --{{ $key }}={{ $value }}
-        {{- end }}
+          redis_exporter{{- range $key, $value := .Values.metrics.extraArgs }} --{{ $key }}={{ $value }}{{- end }}
         env:
         - name: REDIS_ALIAS
           value: {{ template "redis.fullname" . }}

--- a/stable/redis/templates/redis-slave-statefulset.yaml
+++ b/stable/redis/templates/redis-slave-statefulset.yaml
@@ -305,11 +305,7 @@ spec:
           if [[ -f '/secrets/redis-password' ]]; then
            export REDIS_PASSWORD=$(cat /secrets/redis-password)
           fi
-          redis_exporter
-        args:
-        {{- range $key, $value := .Values.metrics.extraArgs }}
-          - --{{ $key }}={{ $value }}
-        {{- end }}
+          redis_exporter{{- range $key, $value := .Values.metrics.extraArgs }} --{{ $key }}={{ $value }}{{- end }}
         env:
         - name: REDIS_ALIAS
           value: {{ template "redis.fullname" . }}


### PR DESCRIPTION
Signed-off-by: Alejandro Moreno <amoreno@bitnami.com>

#### What this PR does / why we need it:
Fixes a bug where `metrics.args` was being ignored as the arguments where being passed to `/bin/bash` instead of `redis_exporter`

#### Which issue this PR fixes
  - fixes #18582 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
