### PR TITLE
[stable/kube-slack] add jstriebel to OWNERS

### DIFF
--- a/stable/kube-slack/.helmignore
+++ b/stable/kube-slack/.helmignore
@@ -1,6 +1,7 @@
 # Patterns to ignore when building packages.
 # This supports shell glob matching, relative path matching, and
 # negation (prefixed with !). Only one pattern per line.
+OWNERS
 .DS_Store
 # Common VCS dirs
 .git/

--- a/stable/kube-slack/Chart.yaml
+++ b/stable/kube-slack/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube-slack
-version: 1.1.0
+version: 1.2.0
 appVersion: v4.2.0
 apiVersion: v1
 description: Chart for kube-slack, a monitoring service for Kubernetes

--- a/stable/kube-slack/OWNERS
+++ b/stable/kube-slack/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- jstriebel
+reviewers:
+- jstriebel


### PR DESCRIPTION
Adding myself as an owner of the `stable/kube-slack` chart, as proposed by @maorfr in https://github.com/helm/charts/pull/18379#issuecomment-549684135.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
