### PR TITLE
[stable/spring-cloud-data-flow] Add support for disabling Skipper Server

### DIFF
--- a/stable/spring-cloud-data-flow/Chart.yaml
+++ b/stable/spring-cloud-data-flow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Toolkit for building data processing pipelines.
 name: spring-cloud-data-flow
-version: 2.4.3
+version: 2.4.4
 appVersion: 2.2.1.RELEASE
 home: http://cloud.spring.io/spring-cloud-dataflow/
 sources:

--- a/stable/spring-cloud-data-flow/README.md
+++ b/stable/spring-cloud-data-flow/README.md
@@ -57,6 +57,12 @@ Only one messaging layer can be used at a given time. If RabbitMQ and Kafka are 
 
 Note that this chart pulls in many different Docker images so can take a while to fully install.
 
+### Disabling Skipper Server
+
+If you only need to deploy tasks, the Skipper Server and Messaging layer can be disabled, for example:
+
+`--set skipper.enabled=false --set rabbitmq.enabled=false`
+
 ## Configuration
 
 The following tables list the configurable parameters and their default values.
@@ -92,6 +98,7 @@ The following tables list the configurable parameters and their default values.
 
 | Parameter                         | Description                                                      | Default          |
 | --------------------------------- | ---------------------------------------------------------------- | ---------------- |
+| skipper.enabled                   | Enable Skipper server                                            | true
 | skipper.version                   | The version/tag of the Skipper server                            | 2.1.2.RELEASE
 | skipper.imagePullPolicy           | The imagePullPolicy of the Skipper server                        | IfNotPresent
 | skipper.platformName              | The name of the configured platform account                      | default

--- a/stable/spring-cloud-data-flow/README.md
+++ b/stable/spring-cloud-data-flow/README.md
@@ -57,11 +57,17 @@ Only one messaging layer can be used at a given time. If RabbitMQ and Kafka are 
 
 Note that this chart pulls in many different Docker images so can take a while to fully install.
 
-### Disabling Skipper Server
+### Feature Toggles
 
-If you only need to deploy tasks, the Skipper Server and Messaging layer can be disabled, for example:
+If you only need to deploy tasks and schedules, streams can be disabled:
 
-`--set skipper.enabled=false --set rabbitmq.enabled=false`
+`--set features.streaming.enabled=false --set rabbitmq.enabled=false`
+
+If you only need to deploy streams, tasks and schedules can be disabled:
+
+`--set features.batch.enabled=false`
+
+NOTE: Both `features.streaming.enabled` and `features.batch.enabled` should not be set to `false` at the same time.
 
 ## Configuration
 
@@ -98,7 +104,6 @@ The following tables list the configurable parameters and their default values.
 
 | Parameter                         | Description                                                      | Default          |
 | --------------------------------- | ---------------------------------------------------------------- | ---------------- |
-| skipper.enabled                   | Enable Skipper server                                            | true
 | skipper.version                   | The version/tag of the Skipper server                            | 2.1.2.RELEASE
 | skipper.imagePullPolicy           | The imagePullPolicy of the Skipper server                        | IfNotPresent
 | skipper.platformName              | The name of the configured platform account                      | default
@@ -159,3 +164,11 @@ The following tables list the configurable parameters and their default values.
 | database.password   | Database password              | nil
 | database.dataflow   | Database name for SCDF server  | dataflow
 | database.skipper    | Database name for SCDF skipper | skipper
+
+### Feature Toggles
+
+| Parameter                    | Description                             | Default                   |
+| ---------------------------- | --------------------------------------- | ------------------------- |
+| features.streaming.enabled   | Enables or disables streams             | true
+| features.batch.enabled       | Enables or disables tasks and schedules | true
+

--- a/stable/spring-cloud-data-flow/templates/server-config.yaml
+++ b/stable/spring-cloud-data-flow/templates/server-config.yaml
@@ -12,6 +12,7 @@ metadata:
 data:
   application.yaml: |-
     spring:
+      {{- if .Values.features.batch.enabled }}
       cloud:
         dataflow:
           task:
@@ -22,6 +23,7 @@ data:
                     limits:
                       memory: {{ .Values.deployer.resourceLimits.memory }}
                       cpu: {{ .Values.deployer.resourceLimits.cpu }}
+      {{- end }}
       datasource:
         url: 'jdbc:{{ template "scdf.database.scheme" . }}://{{ template "scdf.database.host" . }}:{{ template "scdf.database.port" . }}/{{ template "scdf.database.dataflow" . }}'
         driverClassName: {{ template "scdf.database.driver" . }}

--- a/stable/spring-cloud-data-flow/templates/server-deployment.yaml
+++ b/stable/spring-cloud-data-flow/templates/server-deployment.yaml
@@ -60,8 +60,6 @@ spec:
           value: 'false'
         - name: SPRING_CLOUD_KUBERNETES_SECRETS_ENABLE_API
           value: 'true'
-        - name: SPRING_CLOUD_DATAFLOW_FEATURES_SCHEDULES_ENABLED
-          value: 'true'
         - name: SPRING_CLOUD_KUBERNETES_SECRETS_PATHS
           value: /etc/secrets
         - name: SPRING_CLOUD_KUBERNETES_CONFIG_NAME
@@ -70,7 +68,7 @@ spec:
           {{- else }}
           value: {{ template "scdf.fullname" . }}-server
           {{- end }}
-          {{- if .Values.skipper.enabled }}
+          {{- if .Values.features.streaming.enabled }}
         - name: SPRING_CLOUD_SKIPPER_CLIENT_SERVER_URI
           value: 'http://${{ printf "{" }}{{ template "scdf.envname" . }}_SKIPPER_SERVICE_HOST}/api'
           {{- end }}
@@ -81,7 +79,11 @@ spec:
         - name: KUBERNETES_TRUST_CERTIFICATES
           value: {{ .Values.server.trustCerts | quote }}
         - name: SPRING_CLOUD_DATAFLOW_FEATURES_STREAMS_ENABLED
-          value: {{ .Values.skipper.enabled | quote }}
+          value: {{ .Values.features.streaming.enabled | quote }}
+        - name: SPRING_CLOUD_DATAFLOW_FEATURES_TASKS_ENABLED
+          value: {{ .Values.features.batch.enabled | quote }}
+        - name: SPRING_CLOUD_DATAFLOW_FEATURES_SCHEDULES_ENABLED
+          value: {{ .Values.features.batch.enabled | quote }}
       volumes:
         - name: database
           secret:

--- a/stable/spring-cloud-data-flow/templates/server-deployment.yaml
+++ b/stable/spring-cloud-data-flow/templates/server-deployment.yaml
@@ -70,14 +70,18 @@ spec:
           {{- else }}
           value: {{ template "scdf.fullname" . }}-server
           {{- end }}
+          {{- if .Values.skipper.enabled }}
         - name: SPRING_CLOUD_SKIPPER_CLIENT_SERVER_URI
           value: 'http://${{ printf "{" }}{{ template "scdf.envname" . }}_SKIPPER_SERVICE_HOST}/api'
+          {{- end }}
         - name: SPRING_CLOUD_DATAFLOW_SERVER_URI
           value: 'http://${{ printf "{" }}{{ template "scdf.envname" . }}_SERVER_SERVICE_HOST}:${{ printf "{" }}{{ template "scdf.envname" . }}_SERVER_SERVICE_PORT}'
         - name: SPRING_APPLICATION_JSON
           value: "{ \"maven\": { \"local-repository\": null, \"remote-repositories\": { \"repo1\": { \"url\": \"https://repo.spring.io/libs-snapshot\"} } } }"
         - name: KUBERNETES_TRUST_CERTIFICATES
           value: {{ .Values.server.trustCerts | quote }}
+        - name: SPRING_CLOUD_DATAFLOW_FEATURES_STREAMS_ENABLED
+          value: {{ .Values.skipper.enabled | quote }}
       volumes:
         - name: database
           secret:

--- a/stable/spring-cloud-data-flow/templates/skipper-config.yaml
+++ b/stable/spring-cloud-data-flow/templates/skipper-config.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.skipper.enabled }}
 {{- if not .Values.skipper.configMap }}
 apiVersion: v1
 kind: ConfigMap
@@ -36,4 +37,5 @@ data:
         password: {{ template "scdf.database.password" . }}
         testOnBorrow: true
         validationQuery: "SELECT 1"
+{{- end }}
 {{- end }}

--- a/stable/spring-cloud-data-flow/templates/skipper-config.yaml
+++ b/stable/spring-cloud-data-flow/templates/skipper-config.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.skipper.enabled }}
+{{- if .Values.features.streaming.enabled }}
 {{- if not .Values.skipper.configMap }}
 apiVersion: v1
 kind: ConfigMap

--- a/stable/spring-cloud-data-flow/templates/skipper-deployment.yaml
+++ b/stable/spring-cloud-data-flow/templates/skipper-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.skipper.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -122,3 +123,4 @@ spec:
         - 'mysql -h {{ template "scdf.database.host" . }} -P {{ template "scdf.database.port" . }} -u root -e "CREATE DATABASE IF NOT EXISTS {{ template "scdf.database.skipper" . }};"'
       {{- end }}
       serviceAccountName: {{ template "scdf.serviceAccountName" . }}
+{{- end }}

--- a/stable/spring-cloud-data-flow/templates/skipper-deployment.yaml
+++ b/stable/spring-cloud-data-flow/templates/skipper-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.skipper.enabled }}
+{{- if .Values.features.streaming.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/stable/spring-cloud-data-flow/templates/skipper-service.yaml
+++ b/stable/spring-cloud-data-flow/templates/skipper-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.skipper.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -25,3 +26,4 @@ spec:
     app: {{ template "scdf.name" . }}
     component: skipper
     release: {{ .Release.Name }}
+{{- end }}

--- a/stable/spring-cloud-data-flow/templates/skipper-service.yaml
+++ b/stable/spring-cloud-data-flow/templates/skipper-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.skipper.enabled }}
+{{- if .Values.features.streaming.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/stable/spring-cloud-data-flow/values.yaml
+++ b/stable/spring-cloud-data-flow/values.yaml
@@ -97,3 +97,9 @@ database:
   password:
   dataflow: dataflow
   skipper: skipper
+
+features:
+  streaming:
+    enabled: true
+  batch:
+    enabled: true

--- a/stable/spring-cloud-data-flow/values.yaml
+++ b/stable/spring-cloud-data-flow/values.yaml
@@ -37,10 +37,12 @@ server:
   #    memory: 640Mi
 
 skipper:
+  enabled: true
   image: springcloud/spring-cloud-skipper-server
   version: 2.1.2.RELEASE
   imagePullPolicy: IfNotPresent
   platformName: default
+  trustCerts: false
   service:
     type: ClusterIP
     annotations: {}


### PR DESCRIPTION
Add support for disabling Skipper Server

Signed-off-by: Chris Schaefer <cschaefer@pivotal.io>

#### What this PR does / why we need it:
Add support for disabling Skipper Server

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
