### PR TITLE
[stable/prometheus-operator] Add default value to kubedns.service (#1…

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.0.1
+version: 8.0.2
 appVersion: 0.34.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -663,9 +663,9 @@ coreDns:
 ##
 kubeDns:
   enabled: false
-  # service:
-  #   selector:
-  #     k8s-app: kube-dns
+  service: {}
+    # selector:
+    #   k8s-app: kube-dns
   serviceMonitor:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##


### PR DESCRIPTION
…8617)

* Adds a default map value to the kubedns service so the conditional in
the KubeDNS exporter service will not fail

Signed-off-by: Sean Johnson <seanson@users.noreply.github.com>

#### What this PR does / why we need it:

Sets a default value map for kubeDns.service that still allows easy setting of `kubeDns.service.selector`.

#### Which issue this PR fixes
  - fixes #18617 

#### Special notes for your reviewer:

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
