### PR TITLE
[stable/elastic-stack] update requirements for 1.16

### DIFF
--- a/stable/elastic-stack/Chart.yaml
+++ b/stable/elastic-stack/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart for ELK
 home: https://www.elastic.co/products
 icon: https://www.elastic.co/assets/bltb35193323e8f1770/logo-elastic-stack-lt.svg
 name: elastic-stack
-version: 1.8.0
+version: 1.9.0
 appVersion: 6.0
 maintainers:
 - name: rendhalver

--- a/stable/elastic-stack/requirements.lock
+++ b/stable/elastic-stack/requirements.lock
@@ -1,33 +1,33 @@
 dependencies:
 - name: elasticsearch
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.29.0
+  version: 1.32.0
 - name: kibana
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 3.2.1
+  version: 3.2.4
 - name: filebeat
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 1.7.0
 - name: logstash
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.13.0
+  version: 2.3.0
 - name: fluentd
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.10.0
+  version: 2.2.0
 - name: fluent-bit
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.10.3
+  version: 2.8.0
 - name: fluentd-elasticsearch
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 2.0.7
 - name: nginx-ldapauth-proxy
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.1.2
+  version: 0.1.3
 - name: elasticsearch-curator
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.5.0
+  version: 2.1.0
 - name: elasticsearch-exporter
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.4.1
-digest: sha256:21398a637cab285405e7a72c1f0ce3bc7c98ac41a9ccd125a27f7389503f4f7d
-generated: "2019-06-25T12:04:09.841215-07:00"
+  version: 2.1.0
+digest: sha256:e3d77fb315df2d0b952cd0b310cef17db552108f081c2951c832538bbf7b77db
+generated: "2019-11-06T00:25:12.383848379-06:00"

--- a/stable/elastic-stack/requirements.yaml
+++ b/stable/elastic-stack/requirements.yaml
@@ -1,10 +1,10 @@
 dependencies:
 - name: elasticsearch
-  version: ^1.22.0
+  version: ^1.32.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: elasticsearch.enabled
 - name: kibana
-  version: ^3.0.0
+  version: ^3.2.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: kibana.enabled
 - name: filebeat
@@ -12,15 +12,15 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: filebeat.enabled
 - name: logstash
-  version: ^1.6.0
+  version: ^2.3.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: logstash.enabled
 - name: fluentd
-  version: ^1.5.0
+  version: ^2.2.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: fluentd.enabled
 - name: fluent-bit
-  version: ^1.9.0
+  version: ^2.8.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: fluent-bit.enabled
 - name: fluentd-elasticsearch
@@ -32,10 +32,10 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: nginx-ldapauth-proxy.enabled
 - name: elasticsearch-curator
-  version: ^1.2.0
+  version: ^2.1.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: elasticsearch-curator.enabled
 - name: elasticsearch-exporter
-  version: ^1.1.0
+  version: ^2.1.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: elasticsearch-exporter.enabled


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
Updates the requirements versions of subcharts to the minimal versions required for k8s 1.16. Without the updates, `helm install` fails on k8s 1.16+ due to beta apis still being referenced in the current subcharts.

#### Which issue this PR fixes
Allows `helm install` to succeed on k8s 1.16+.

#### Special notes for your reviewer:

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
