### PR TITLE
[stable/sonarqube] add support of secret injection for sonar.properties

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 3.2.2
+version: 3.2.3
 appVersion: 7.9.1
 keywords:
   - coverage

--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -70,6 +70,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `persistence.accessMode`                    | Volumes access mode to be set             | `ReadWriteOnce`                            |
 | `persistence.size`                          | Size of the volume                        | None                                     |
 | `sonarProperties`                           | Custom `sonar.properties` file            | None                                       |
+| `sonarSecretProperties`                     | Additional `sonar.properties` file to load from a secret | None                                       |
 | `customCerts.enabled`                       | Use `customCerts.secretName`              | false                                      |
 | `customCerts.secretName`                    | Name of the secret which conatins your `cacerts` | false                                      |
 | `sonarSecretKey`                            | Name of existing secret used for settings encryption | None                            |

--- a/stable/sonarqube/templates/deployment.yaml
+++ b/stable/sonarqube/templates/deployment.yaml
@@ -88,6 +88,29 @@ spec:
 {{ toYaml .Values.affinity | indent 8 }}
     {{- end }}
       {{- end }}
+      {{- if and .Values.sonarProperties .Values.sonarSecretProperties }}
+        - name: concat-properties
+          image: {{ default "alpine:3.10.3" .Values.plugins.initContainerImage }}
+          env:
+            {{- range $key, $value := .Values.extraEnv }}
+            - name: {{ $key }}
+              value: {{ $value }}
+            {{- end }}
+          command: ["sh",
+            "-c",
+            "awk 1 /tmp/props/sonar.properties /tmp/props/secret.properties > /tmp/result/sonar.properties
+            "
+           ]
+          volumeMounts:
+            - mountPath: /tmp/props/sonar.properties 
+              name: config
+              subPath: sonar.properties
+            - mountPath: /tmp/props/secret.properties
+              name: secret-config
+              subPath: secret.properties
+            - mountPath: /tmp/result
+              name: concat-dir
+      {{- end }}
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:
       - name: {{ .Values.image.pullSecret }}
@@ -145,7 +168,10 @@ spec:
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           volumeMounts:
-            {{- if or .Values.sonarProperties (not .Values.elasticsearch.bootstrapChecks) }}
+            {{- if and .Values.sonarProperties .Values.sonarSecretProperties }}
+            - mountPath: /opt/sonarqube/conf/
+              name: concat-dir
+            {{- else if or .Values.sonarProperties (not .Values.elasticsearch.bootstrapChecks) }}
             - mountPath: /opt/sonarqube/conf/
               name: config
             {{- end }}
@@ -203,6 +229,14 @@ spec:
           - key: sonar.properties
             path: sonar.properties
       {{- end }}
+      {{- if .Values.sonarSecretProperties }}
+      - name: secret-config
+        secret:
+          secretName: {{ .Values.sonarSecretProperties }}
+          items:
+          - key: secret.properties
+            path: secret.properties
+      {{- end }}
       {{- if .Values.sonarSecretKey }}
       - name: secret
         secret:
@@ -241,3 +275,7 @@ spec:
         {{- end  }}
       - name : tmp-dir
         emptyDir: {}
+        {{- if .Values.sonarSecretProperties }}
+      - name : concat-dir
+        emptyDir: {}
+        {{- end }}

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -152,6 +152,9 @@ plugins:
 #   sonar.security.realm: LDAP
 #   ldap.url: ldaps://organization.com
 
+# Additional sonar properties to load from a secret with a key "secret.properties" (must be a string)
+# sonarSecretProperties:
+
 # Kubernetes secret that contains the encryption key for the sonarqube instance.
 # The secret must contain the key 'sonar-secret.txt'.
 # The 'sonar.secretKeyPath' property will be set automatically.


### PR DESCRIPTION
#### What this PR does / why we need it:
This adds ability for a user to provide sonar.properties from external secret (e.g. for configuring OIDC provider with credentials).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
