### PR TITLE
[stable/concourse] Remove quotas on 'rm -rf /concourse-work-dir/*'

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 8.2.7
+version: 8.2.8
 appVersion: 5.6.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -61,7 +61,7 @@ spec:
               for v in $((btrfs subvolume list --sort=-ogen "{{ .Values.concourse.worker.workDir }}" || true) | awk '{print $9}'); do
                 (btrfs subvolume show "{{ .Values.concourse.worker.workDir }}/$v" && btrfs subvolume delete "{{ .Values.concourse.worker.workDir }}/$v") || true
               done
-              rm -rf "{{ .Values.concourse.worker.workDir }}"/*
+              rm -rf {{ .Values.concourse.worker.workDir }}/*
           volumeMounts:
             - name: concourse-work-dir
               mountPath: {{ .Values.concourse.worker.workDir | quote }}


### PR DESCRIPTION
Signed-off-by: Plamen Kovachev <plamen.kovachev@primeholding.com>

#### What this PR does / why we need it:

We need to delete concourse worker data leftovers on worker node initialization properly when storage is type: BTRFS

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
