### PR TITLE
[stable/eventrouter] Make eventrouter compatible with k8s >= 1.16

### DIFF
--- a/stable/eventrouter/Chart.yaml
+++ b/stable/eventrouter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for eventruter (https://github.com/heptiolabs/eventrouter)
 name: eventrouter
-version: 0.2.2
+version: 0.2.3
 appVersion: 0.2
 home: https://github.com/heptiolabs/eventrouter
 sources:

--- a/stable/eventrouter/templates/deployment.yaml
+++ b/stable/eventrouter/templates/deployment.yaml
@@ -1,4 +1,8 @@
+{{- if semverCompare "^1.9-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: apps/v1
+{{- else }}
 apiVersion: apps/v1beta1
+{{- end }}
 kind: Deployment
 metadata:
   labels: {{ include "eventrouter.labels" . | indent 4 }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
no

#### What this PR does / why we need it:
In kubernetes 1.16 `apiVersion: apps/v1beta1` is retired now.

Snip from k8s CHANGELOG:
> Continued deprecation of extensions/v1beta1, apps/v1beta1,
> and apps/v1beta2 APIs; these extensions will be retired in 1.16!

Full changelog:
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md

Signed-off-by: Marco Kilchhofer <marco@kilchhofer.info>

#### Which issue this PR fixes
`-`

#### Special notes for your reviewer:
`-`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
