### PR TITLE
[stable/prometheus-blackbox-exporter] Update the Ingress apiversion to networking.k8s.io/v1beta1

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 1.5.0
+version: 1.5.1
 appVersion: 0.15.1
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/templates/ingress.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "prometheus-blackbox-exporter.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}

--- a/stable/prometheus-blackbox-exporter/templates/ingress.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/ingress.yaml
@@ -1,7 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "prometheus-blackbox-exporter.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
+{{- if semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}


### PR DESCRIPTION
Signed-off-by: Mike Tougeron <tougeron@adobe.com>

#### What this PR does / why we need it:
This PR updates the `Ingress` for `stable/prometheus-blackbox-exporter` to use the `apiVersion` `networking.k8s.io/v1beta1` for Kubernetes 1.16 compatibility.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [n/a] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
