### PR TITLE
[stable/cluster-autoscaler] Allow overriding the Capabilities.KubeVersion.GitVersion

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 6.1.0
+version: 6.1.1
 appVersion: 1.14.6
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 6.1.1
+version: 6.2.0
 appVersion: 1.14.6
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/README.md
+++ b/stable/cluster-autoscaler/README.md
@@ -200,6 +200,7 @@ Parameter | Description | Default
 `azureVMType: "AKS"` | Azure VM type | `AKS`
 `azureNodeResourceGroup` | azure resource group where the clusters Nodes are located, typically set as `MC_<cluster-resource-group-name>_<cluster-name>_<location>` | none
 `azureUseManagedIdentityExtension` | Whether to use Azure's managed identity extension for credentials | false
+`kubeTargetVersionOverride` | Override the .Capabilities.KubeVersion.GitVersion | `""`
 
 Specify each parameter you'd like to override using a YAML file as described above in the [installation](#installing-the-chart) section or by using the `--set key=value[,key=value]` argument to `helm install`. For example, to change the region and [expander](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders):
 

--- a/stable/cluster-autoscaler/templates/_helpers.tpl
+++ b/stable/cluster-autoscaler/templates/_helpers.tpl
@@ -52,7 +52,8 @@ helm.sh/chart: {{ include "cluster-autoscaler.chart" . | quote }}
 Return the appropriate apiVersion for deployment.
 */}}
 {{- define "deployment.apiVersion" -}}
-{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+{{- if semverCompare "<1.9-0" $kubeTargetVersion -}}
 {{- print "apps/v1beta2" -}}
 {{- else -}}
 {{- print "apps/v1" -}}
@@ -63,7 +64,8 @@ Return the appropriate apiVersion for deployment.
 Return the appropriate apiVersion for podsecuritypolicy.
 */}}
 {{- define "podsecuritypolicy.apiVersion" -}}
-{{- if semverCompare "<1.10-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+{{- if semverCompare "<1.10-0" $kubeTargetVersion -}}
 {{- print "extensions/v1beta1" -}}
 {{- else -}}
 {{- print "policy/v1beta1" -}}

--- a/stable/cluster-autoscaler/values.yaml
+++ b/stable/cluster-autoscaler/values.yaml
@@ -172,3 +172,6 @@ nameOverride: ""
 
 ## String to fully override cluster-autoscaler.fullname template
 fullnameOverride: ""
+
+# Allow overridding the .Capabilities.KubeVersion.GitVersion (useful for "helm template" command)
+kubeTargetVersionOverride: ""


### PR DESCRIPTION

Signed-off-by: Mike Tougeron <tougeron@adobe.com>

#### What this PR does / why we need it:
This PR allows you to specify a Kubernetes version to target instead of using `.Capabilities.KubeVersion.GitVersion`. This is needed when Tiller is not in use (e.g., when using `helm template`)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
