### PR TITLE
[stable/kong] Add imagePullPolicy to wait images

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.26.0
+version: 0.26.1
 appVersion: 1.3

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -155,6 +155,7 @@ that via the `env.database` parameter.
 | postgresql.enabled            | Spin up a new postgres instance for Kong                                | `true`                |
 | waitImage.repository          | Image used to wait for database to become ready                         | `busybox`             |
 | waitImage.tag                 | Tag for image used to wait for database to become ready                 | `latest`              |
+| waitImage.pullPolicy          | Wait image pull policy                                                  | `IfNotPresent`        |
 | env.database                  | Choose either `postgres`, `cassandra` or `"off"` (for dbless mode)      | `postgres`            |
 | env.pg_user                   | Postgres username                                                       | `kong`                |
 | env.pg_database               | Postgres database name                                                  | `kong`                |

--- a/stable/kong/templates/migrations-post-upgrade.yaml
+++ b/stable/kong/templates/migrations-post-upgrade.yaml
@@ -34,6 +34,7 @@ spec:
       initContainers:
       - name: wait-for-postgres
         image: "{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
+        imagePullPolicy: {{ .Values.waitImage.pullPolicy }}
         env:
         - name: KONG_PG_HOST
           value: {{ template "kong.postgresql.fullname" . }}

--- a/stable/kong/templates/migrations-pre-upgrade.yaml
+++ b/stable/kong/templates/migrations-pre-upgrade.yaml
@@ -34,6 +34,7 @@ spec:
       initContainers:
       - name: wait-for-postgres
         image: "{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
+        imagePullPolicy: {{ .Values.waitImage.pullPolicy }}
         env:
         - name: KONG_PG_HOST
           value: {{ template "kong.postgresql.fullname" . }}

--- a/stable/kong/templates/migrations.yaml
+++ b/stable/kong/templates/migrations.yaml
@@ -29,6 +29,7 @@ spec:
       initContainers:
       - name: wait-for-postgres
         image: "{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
+        imagePullPolicy: {{ .Values.waitImage.pullPolicy }}
         env:
         - name: KONG_PG_HOST
           value: {{ template "kong.postgresql.fullname" . }}

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -17,6 +17,7 @@ image:
 waitImage:
   repository: busybox
   tag: latest
+  pullPolicy: IfNotPresent
 
 # Specify Kong admin and proxy services configurations
 admin:


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds an option to set image pull policy of the wait images. Default pull policy is `IfNotPresent`.

This feature is needed in order to easily change the image pull policy of the wait images as well. The same functionality already exists for every other kong component.

Signed-off-by: Samu Toimela <toimelas@gmail.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
