### PR TITLE
[stable/wordpress] Fixes template reference in tls-secrets.yaml

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 7.6.6
+version: 7.6.7
 appVersion: 5.2.4
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 7.6.5
+version: 7.6.6
 appVersion: 5.2.4
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/templates/tls-secrets.yaml
+++ b/stable/wordpress/templates/tls-secrets.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   name: {{ .name }}
   labels:
-    app: "{{ template "fullname" $ }}"
+    app: "{{ template "wordpress.fullname" $ }}"
     chart: "{{ template "wordpress.chart" $ }}"
     release: {{ $.Release.Name | quote }}
     heritage: {{ $.Release.Service | quote }}


### PR DESCRIPTION
#### Is this a new chart

No

> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

#### What this PR does / why we need it:

Fixes template reference in tls-secrets.yaml. Template reference was missing `wordpress.` prefix, which was causing chart to fail when TLS secrets were specified.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
