### PR TITLE
[stable/eventrouter] Update the apiVersion for the eventrouter Deployment

### DIFF
--- a/stable/eventrouter/Chart.yaml
+++ b/stable/eventrouter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for eventruter (https://github.com/heptiolabs/eventrouter)
 name: eventrouter
-version: 0.2.2
+version: 0.2.3
 appVersion: 0.2
 home: https://github.com/heptiolabs/eventrouter
 sources:

--- a/stable/eventrouter/README.md
+++ b/stable/eventrouter/README.md
@@ -26,3 +26,4 @@ The following table lists the configurable parameters of the eventrouter chart a
 | `podAnnotations`        | Annotations for pod metadata                                                                                                | `{}`                               |
 | `containerPorts`        | List of ports for the container                                                                                             | `[]`                               |
 | `securityContext`       | Security context for the pod                                                                                                | `{}`                               |
+| `kubeTargetVersionOverride` | Override the .Capabilities.KubeVersion.GitVersion | `""` |

--- a/stable/eventrouter/templates/deployment.yaml
+++ b/stable/eventrouter/templates/deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1beta1
 {{- else -}}
 apiVersion: apps/v1
-{{- end -}}
+{{- end }}
 kind: Deployment
 metadata:
   labels: {{ include "eventrouter.labels" . | indent 4 }}

--- a/stable/eventrouter/templates/deployment.yaml
+++ b/stable/eventrouter/templates/deployment.yaml
@@ -1,4 +1,9 @@
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+{{- if semverCompare "<1.9-0" $kubeTargetVersion -}}
 apiVersion: apps/v1beta1
+{{- else -}}
+apiVersion: apps/v1
+{{- end -}}
 kind: Deployment
 metadata:
   labels: {{ include "eventrouter.labels" . | indent 4 }}

--- a/stable/eventrouter/values.yaml
+++ b/stable/eventrouter/values.yaml
@@ -35,3 +35,5 @@ containerPorts: []
 
 securityContext: {}
   # runAsUser: 1000
+
+kubeTargetVersionOverride: ""


### PR DESCRIPTION
Signed-off-by: Mike Tougeron <tougeron@adobe.com>

#### What this PR does / why we need it:
This PR updates the `apiVersion` of the `eventrouter` `Deployment` for Kubernetes 1.16 compatibility.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
