### PR TITLE
[stable/redis-ha] Change sysctl initContainer base image to busybox

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.10.1
+version: 3.11.0
 appVersion: 5.0.5
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/README.md
+++ b/stable/redis-ha/README.md
@@ -188,9 +188,8 @@ sysctlImage:
   mountHostSys: true
   command:
     - /bin/sh
-    - -c
+    - -xc
     - |-
-      install_packages systemd procps
       sysctl -w net.core.somaxconn=10000
       echo never > /host-sys/kernel/mm/transparent_hugepage/enabled
 ```

--- a/stable/redis-ha/values.yaml
+++ b/stable/redis-ha/values.yaml
@@ -80,8 +80,8 @@ sysctlImage:
   enabled: false
   command: []
   registry: docker.io
-  repository: bitnami/minideb
-  tag: latest
+  repository: busybox
+  tag: 1.31.1
   pullPolicy: Always
   mountHostSys: false
 


### PR DESCRIPTION
Signed-off-by: Philippe Dagenais <pgdagenais@gmail.com>


#### What this PR does / why we need it:
Based on this comment: https://github.com/helm/charts/pull/10723#issuecomment-482712268
Changing the sysctl initContainer to `busybox` make sure that the redis container start faster and doesn't need to install some external packages.

I am also removing the `install_packages` command from the readme since it is not needed anymore with `busybox`.

The `busybox` image is a lot smaller than the `bitnami/minideb` one:
```
$ docker images bitnami/minideb
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
bitnami/minideb     latest              a4132dcdea75        4 weeks ago         67.5MB
$ docker images busybox:1.31.1 
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
busybox             1.31.1              020584afccce        7 days ago          1.22MB
```

#### Special notes for your reviewer:
I added the shell argument `-x` just to get a little bit more logs from the container. I wanted to add the `-e` argument also but that would cause a breaking change on people that use the old documentation from the readme and the new `busybox` image. The error is:
```
kubectl logs -redis-ha-server-2 -c init-sysctl 
+ install_packages systemd procps
/bin/sh: install_packages: not found
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
