### PR TITLE
[stable/unbound] Use gcr.io for exechealthz image

### DIFF
--- a/stable/unbound/Chart.yaml
+++ b/stable/unbound/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Unbound is a fast caching DNS resolver
 home: https://www.unbound.net/
 name: unbound
-version: 1.0.0
+version: 1.0.1
 appVersion: 1.6.7
 sources:
 - http://unbound.nlnetlabs.nl/svn/

--- a/stable/unbound/values.yaml
+++ b/stable/unbound/values.yaml
@@ -17,7 +17,7 @@ unbound:
 # https://github.com/kubernetes/contrib/tree/master/exec-healthz
 healthz:
   image:
-    repository: googlecontainer/exechealthz
+    repository: gcr.io/google_containers/exechealthz
     tag: "1.2"
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
The exechealthz has been deprecated and removed from Docker Hub, as
such this in it's current state won't pass any health checks. However
the image is still available on gcr.io, and while this shouldn't be
considered a long term solution, it's a first step in getting this
chart back in an up to date shape.

#### What this PR does / why we need it:
It updates the the health check images to one that is available.

#### Which issue this PR fixes
  - fixes #18664

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
