### PR TITLE
[stable/grafana] Fix typo minAvailble to minAvailable

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 4.0.1
+version: 4.0.2
 appVersion: 6.4.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/poddisruptionbudget.yaml
+++ b/stable/grafana/templates/poddisruptionbudget.yaml
@@ -12,8 +12,8 @@ metadata:
 {{ toYaml .Values.labels | indent 4 }}
 {{- end }}
 spec:
-{{- if .Values.podDisruptionBudget.minAvailble }}
-  minAvailable: {{ .Values.podDisruptionBudget.minAvailble }}
+{{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
 {{- end }}
 {{- if .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -22,7 +22,7 @@ replicas: 1
 ## See `kubectl explain poddisruptionbudget.spec` for more
 ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
 podDisruptionBudget: {}
-#  minAvailble: 1
+#  minAvailable: 1
 #  maxUnavailable: 1
 
 ## See `kubectl explain deployment.spec.strategy` for more


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR fixes a typo in values.yaml and templates/poddisruptionbudget.yaml where `minAvailble` was used instead of `minAvailable` which is in the k8s spec.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)