### PR TITLE
[stable/drupal] major version bump

### DIFF
--- a/stable/drupal/Chart.yaml
+++ b/stable/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 5.2.9
+version: 6.0.0
 appVersion: 8.7.8
 description: One of the most versatile open source content management systems.
 keywords:

--- a/stable/drupal/README.md
+++ b/stable/drupal/README.md
@@ -195,6 +195,14 @@ $ helm install --name my-release --set persistence.drupal.existingClaim=PVC_NAME
 
 ## Upgrading
 
+### To 6.0.0
+
+Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.
+
+In https://github.com/helm/charts/pull/17295 the `apiVersion` of the deployment resources was updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.
+
+This major version signifies this change.
+
 ### To 2.0.0
 
 Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.

--- a/stable/drupal/requirements.lock
+++ b/stable/drupal/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.12.2
-digest: sha256:a363428d6463718a9523a88c70e485218373e315f2979cb1bb17b034ec2be96a
-generated: 2019-10-29T07:26:54.90698574Z
+  version: 7.0.0
+digest: sha256:cd64413a4a697ccf85c0091e9c55cdc5876938ddced84c05d37c57ff9abc5864
+generated: "2019-11-09T09:50:12.572245686+05:30"

--- a/stable/drupal/requirements.yaml
+++ b/stable/drupal/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
-  version: 6.x.x
+  version: 7.x.x
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: mariadb.enabled

--- a/stable/drupal/templates/_helpers.tpl
+++ b/stable/drupal/templates/_helpers.tpl
@@ -153,3 +153,14 @@ but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else 
     {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "drupal.deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/drupal/templates/deployment.yaml
+++ b/stable/drupal/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: {{ template "drupal.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "drupal.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

In https://github.com/helm/charts/pull/17295 the `apiVersion` of the deployment resource was
updated to `apps/v1` in tune with the api's deprecated in k8s 1.16. This change however breaks
upgradability of existing drupal deployments with helm v3 (rc) as described in
https://github.com/helm/helm/issues/6646.

To fix this, we have defined a `drupal.deployment.apiVersion` helper that returns the new
`apiVersion` only when k8s 1.16 or higher is in use.

#### Which issue this PR fixes
  - fixes chart upgrades

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)