### PR TITLE
stable/wavefront - update to use 1.0.x based wavefront collector

### DIFF
--- a/stable/wavefront/Chart.yaml
+++ b/stable/wavefront/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: wavefront
 description: Wavefront Kubernetes collector
-appVersion: 0.9.7
-version: 1.0.0
+appVersion: 1.0.3
+version: 1.1.0
 keywords:
 - metric
 - monitoring
@@ -10,12 +10,10 @@ keywords:
 - alerting
 home: https://www.wavefront.com
 sources:
-- https://github.com/wavefrontHQ/wavefront-kubernetes-collector
+- https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes
 - https://github.com/wavefrontHQ/java/tree/master/proxy
 maintainers:
 - name: vikramraman
   email: rvikram@vmware.com
 - name: puckpuck
   email: pierre@wavefront.com
-- name: krisclarkdev
-  email: clarkk@vmware.com

--- a/stable/wavefront/OWNERS
+++ b/stable/wavefront/OWNERS
@@ -1,8 +1,6 @@
 approvers:
 - vikramraman 
 - puckpuck
-- krisclarkdev
 reviewers:
 - vikramraman 
 - puckpuck
-- krisclarkdev

--- a/stable/wavefront/README.md
+++ b/stable/wavefront/README.md
@@ -1,13 +1,13 @@
-# Wavefront Kubenetes collector
+# Wavefront Collector for Kubernetes
 
 [Wavefront](https://wavefront.com) is a cloud-native monitoring and analytics platform that provides 
 three dimensional microservices observability with metrics, histograms and OpenTracing-compatible distributed tracing.
 
 ## Introduction
 
-This chart will deploy the Wavefront Kubernetes collector and Wavefront Proxy to your
+This chart will deploy the Wavefront Collector for Kubernetes and Wavefront Proxy to your
 Kubernetes cluster.  You can use this chart to install multiple Wavefront Proxy releases,
-though only one Wavefront Kubernetes collector per cluster should be used.
+though only one Wavefront Collector for Kubernetes per cluster should be used.
 
 You can learn more about the Wavefront and Kubernetes integration [here](https://docs.wavefront.com/wavefront_kubernetes.html)
 
@@ -18,3 +18,10 @@ options for this chart.
 
 The **requried** options are `clusterName`, `wavefront.url` and `wavefront.token`.
 You will need to provide values for those options for a successful installation of the chart.
+
+
+## Upgrading
+### Upgrading from 1.0
+Openshift support has been removed from the helm chart.  Use the Wavefront Openshift operator available [here](https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes/tree/master/deploy/openshift) instead.
+
+The `collector.kubernetesSource` parameter has been replaced with the `collector.useReadOnlyPort` option.

--- a/stable/wavefront/examples/discovery-config-values.yaml
+++ b/stable/wavefront/examples/discovery-config-values.yaml
@@ -1,0 +1,194 @@
+## Discovery configuration examples
+## Use the sections below in your values file to enable auto-discovery
+## Some of these will require you to sepcify some details specific to your environment such as user/passwords
+
+## Ensure you include the following object structure (collector.discovery.config), 
+## then copy / paste the appropriate snippets you need below 
+collector:
+  discovery:
+    config:
+
+
+    # activemq
+    - name: activemq
+      type: telegraf/activemq
+      selectors:
+        images:
+        - "*activemq*"
+      conf: |
+        server = "${host}"
+        port = 8161
+        username = "admin"
+        password = "admin"
+        webadmin = "admin"
+
+    # apache httpd
+    - name: apache
+      type: telegraf/apache
+      selectors:
+        images:
+        - 'httpd*'
+        - '*httpd*'
+      port: 80
+      conf: |
+        urls = ["http://${host}:${port}/server-status?auto"]
+
+    # consul
+    - name: consul
+      type: telegraf/consul
+      selectors:
+        images:
+        - 'consul*'
+      port: 8500
+      conf: |
+        address = "${host}:${port}"
+        scheme = "http"
+
+    # couchbase
+    - name: couchbase
+      type: telegraf/couchbase
+      selectors:
+        images:
+        - 'couchbase/server:enterprise-6.0.1'
+      port: 8091
+      conf: |
+        servers = ["http://Administrator:password@${host}:${port}"]
+
+    # couchdb
+    - name: couchdb
+      type: telegraf/couchdb
+      selectors:
+        images:
+        - '*couchdb*'
+      port: 5984
+      conf: |
+        hosts = ["http://admin:password@${host}:${port}/_node/_local/_stats"]
+
+    # elasticsearch
+    - name: elasticsearch
+      type: telegraf/elasticsearch
+      selectors:
+        images:
+        - '*elastic*'
+      port: 9200
+      conf: |
+        servers = ["http://${host}:${port}"]
+        local = false
+        cluster_health = true
+        cluster_stats = true
+
+    # haProxy
+    - name: haproxy
+      type: telegraf/haproxy
+      selectors:
+        images:
+        - "*haproxy*"
+      port: 8181
+      conf: |
+        servers = ["http://username:password@${host}:${port}/haproxy?stats"]
+
+    # memcached
+    - name: memcached
+      type: telegraf/memcached
+      selectors:
+        images:
+        - 'memcached:*'
+      port: 11211
+      conf: |
+        servers = ["${host}:${port}"]
+
+    # mongodb
+    - name: mongodb
+      type: telegraf/mongodb
+      selectors:
+        images:
+        - 'mongo*'
+      port: 27017
+      conf: |
+        servers = ["mongodb://main_admin:abc123@${host}:${port}"]
+
+    # mysql
+    - name: mysql
+      type: telegraf/mysql
+      selectors:
+        images:
+        - "*sql*"
+      collection:
+        interval: "180s"
+      port: 3306
+      conf: |
+        servers = ["root:password@tcp(${host}:${port})/?tls=false"]
+        perf_events_statements_digest_text_limit  = 120
+        perf_events_statements_limit              = 250
+        perf_events_statements_time_limit         = 86400
+        table_schema_databases                    = []
+        gather_process_list                       = true
+        gather_table_io_waits                     = true
+        gather_table_lock_waits                   = true
+        gather_index_io_waits                     = true
+        gather_event_waits                        = true
+        gather_file_events_stats                  = true
+        interval_slow                             = "30m"
+
+    # nginx
+    - name: nginx
+      type: telegraf/nginx
+      selectors:
+        images:
+        - 'nginx*'
+      port: 80
+      conf: |
+        urls = ["http://${host}:${port}/metrics"]
+
+    # nginx_plus
+    - name: nginx_plus
+      type: telegraf/nginx_plus
+      selectors:
+        images:
+        - 'nginxplus*'
+      conf: |
+        urls = ["http://${host}/api"]
+
+    # rabbitmq
+    - name: rabbitmq
+      type: telegraf/rabbitmq
+      selectors:
+        images:
+        - 'rabbitmq*'
+      conf: |
+        url = "http://${host}:15672"
+        username = "guest"
+        password = "guest"
+
+    # redis master and slaves
+    - name: redis
+      type: telegraf/redis
+      selectors:
+        images:
+        - 'redis:*'
+        - '*redis*'
+      port: 6379
+      scheme: "tcp"
+      conf: |
+        servers = ["${server}"]
+
+    # riak
+    - name: riak
+      type: telegraf/riak
+      selectors:
+        images:
+        - 'riak-kv:*'
+        - '*riak-kv:*'
+      port: 8098
+      conf: |
+        servers = ["http://${host}:${port}"]
+
+    # zookeeper
+    - name: zookeeper
+      type: telegraf/zookeeper
+      selectors:
+        images:
+        - '*zookeeper'
+      port: 2181
+      conf: |
+        servers = ["${host}:${port}"]

--- a/stable/wavefront/requirements.lock
+++ b/stable/wavefront/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.13.0
-digest: sha256:a009e6781117de69f26b9ac1e72267407f5f598642fd20043b88ad815915391c
-generated: 2019-01-17T23:00:41.957053-05:00
+  version: 2.3.1
+digest: sha256:6a42b6ed0c45affe9a5f5c88db2fa3223ea2cf1648bf59861308aac709471169
+generated: 2019-08-25T19:41:26.435664-04:00

--- a/stable/wavefront/requirements.yaml
+++ b/stable/wavefront/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: kube-state-metrics
-    version: ^0.8.0
+    version: ^2.2.1
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: kubeStateMetrics.enabled

--- a/stable/wavefront/templates/_helpers.tpl
+++ b/stable/wavefront/templates/_helpers.tpl
@@ -58,10 +58,4 @@ Create the name of the service account to use
 {{- end -}}
 {{- end -}}
 
-{{/*
-Create template used as options for Wavefront sink in collector
-*/}}
-{{- define "wavefront.collector.sinkOptions" -}}
-{{- printf "&clusterName=%s&includeLabels=%t&includeContainers=%t&prefix=%s" .Values.clusterName (default .Values.collector.includeLabels true) (default .Values.collector.includeContainers true) (default .Values.collector.prefix "kubernetes.") -}}
-{{- end -}}
 

--- a/stable/wavefront/templates/collector-cluster-role.yaml
+++ b/stable/wavefront/templates/collector-cluster-role.yaml
@@ -27,6 +27,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - update
+  - create
+- apiGroups:
   - extensions
   resources:
   - deployments
@@ -34,4 +42,7 @@ rules:
   - get
   - list
   - watch
+- nonResourceURLs: ["/metrics"]
+  verbs:
+  - get
 {{- end }}

--- a/stable/wavefront/templates/collector-config.yaml
+++ b/stable/wavefront/templates/collector-config.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.collector.discovery.enabled .Values.collector.discovery.config }}
+{{- if .Values.collector.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,5 +10,141 @@ metadata:
     app.kubernetes.io/component: collector    
   name: {{ template "wavefront.collector.fullname" . }}-config
 data:
-{{ tpl (toYaml .Values.collector.discovery.config) . | indent 2 }}
+  config.yaml: |
+    clusterName: {{ .Values.clusterName }}    
+    enableDiscovery: {{ .Values.collector.discovery.enabled }}
+    defaultCollectionInterval: {{ .Values.collector.interval | default "60s" }}
+    flushInterval: {{ .Values.collector.flushInterval | default "10s" }}
+    sinkExportDataTimeout: {{ .Values.collector.sinkDelay | default "20s" }}
+
+    sinks:
+    {{- if .Values.collector.useProxy }}
+    {{- if .Values.collector.proxyAddress }}
+    - proxyAddress: {{ .Values.collector.proxyAddress }}
+    {{- else }}
+    - proxyAddress: {{ template "wavefront.proxy.fullname" . }}:{{ .Values.proxy.port }}
+    {{- end }}
+    {{- else }}
+    - server: {{ .Values.wavefront.url }}
+      token: {{ .Values.wavefront.token }}
+    {{- end }}
+    {{- if .Values.collector.tags }}
+      tags:
+{{ tpl (toYaml .Values.collector.tags) . | indent 8 }}
+    {{- end }}     
+      filters:
+        # Filter out infrequently used kube-state-metrics.
+        metricBlacklist:
+        - 'kube.configmap.annotations.gauge'
+        - 'kube.configmap.metadata.resource.version.gauge'
+        - 'kube.endpoint.*'
+        - 'kube.job.owner.gauge'
+        - 'kube.job.labels.gauge'
+        - 'kube.job.spec.completions.gauge'
+        - 'kube.job.spec.parallelism.gauge'
+        - 'kube.job.status.start.time.gauge'
+        - 'kube.limitrange.*'
+        - 'kube.namespace.annotations.gauge'
+        - 'kube.persistentvolume.*'
+        - 'kube.persistentvolumeclaim.*'
+        - 'kube.pod.container.resource.limits.*'
+        - 'kube.pod.container.*.reason.gauge'
+        - 'kube.pod.owner.gauge'
+        - 'kube.pod.start.time.gauge'
+        - 'kube.pod.status.scheduled.gauge'
+        - 'kube.pod.status.scheduled.time.gauge'
+        - 'kube.replicationcontroller.created.gauge'
+        - 'kube.replicationcontroller.metadata.generation.gauge'
+        - 'kube.replicationcontroller.spec.replicas.gauge'
+        - 'kube.resourcequota.*'
+        - 'kube.secret.*'
+        - 'kube.statefulset.*'
+        - 'kube.storageclass.*'
+        # Filter out generated labels
+        tagExclude:
+        - 'label?controller?revision*'
+        - 'label?pod?template*'
+
+    sources:
+      kubernetes_source:
+        {{- if .Values.collector.useReadOnlyPort }} 
+        url: 
+        kubeletPort: 10255
+        kubeletHttps: false
+        {{- else }}
+        url: https://kubernetes.default.svc
+        kubeletPort: 10250
+        kubeletHttps: true
+        {{- end }}
+        {{- if .Values.serviceAccount.create }}
+        useServiceAccount: true
+        {{- else }}
+        useServiceAccount: false
+        {{- end }}
+        insecure: true
+        prefix: kubernetes.
+        filters:
+          metricBlacklist:
+          - 'kubernetes.sys_container.*'
+          - 'kubernetes.node.ephemeral_storage.*'    
+
+      internal_stats_source:
+        prefix: kubernetes.
+
+      telegraf_sources:
+      - plugins: []        
+
+      {{- if .Values.collector.apiServerMetrics }}
+      # Kubernetes API Server
+      prometheus_sources:
+      - url: https://kubernetes.default.svc.cluster.local:443/metrics
+        httpConfig:
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          tls_config:
+            ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            insecure_skip_verify: true
+        prefix: kube.apiserver.
+        filters:
+          metricWhitelist:
+          - 'kube.apiserver.apiserver.*'
+          - 'kube.apiserver.etcd.*'
+          - 'kube.apiserver.process.*'        
+      {{- end }}
+
+    {{- if .Values.collector.discovery.enabled }}
+
+    discovery:
+      {{- if .Values.collector.discovery.annotationPrefix }}
+      annotation_prefix: {{ .Values.collector.discovery.annotationPrefix | quote }}
+      {{- end }}
+      plugins:
+
+
+      # auto-discover kube DNS
+      - name: kube-dns-discovery
+        type: prometheus
+        selectors:
+          labels:
+            k8s-app:
+            - kube-dns
+        port: 10054
+        path: /metrics
+        scheme: http
+        prefix: kube.dns.
+        filters:
+          metricWhitelist:
+          - 'kube.dns.http.request.duration.microseconds'
+          - 'kube.dns.http.request.size.bytes'
+          - 'kube.dns.http.requests.total.counter'
+          - 'kube.dns.http.response.size.bytes'
+          - 'kube.dns.kubedns.dnsmasq.*'
+          - 'kube.dns.process.*'    
+
+    {{- if .Values.collector.discovery.config }}
+
+    # user supplied discovery config
+{{ tpl (toYaml .Values.collector.discovery.config) . | indent 6 }}
+    {{- end }}
+    {{- end }}
+
 {{- end }}

--- a/stable/wavefront/templates/collector-daemonset.yaml
+++ b/stable/wavefront/templates/collector-daemonset.yaml
@@ -1,7 +1,6 @@
-{{- if .Values.collector.enabled }}
-{{- if not .Values.collector.useDaemonset }}
+{{- if and .Values.collector.enabled .Values.collector.useDaemonset }}
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   labels:
     app.kubernetes.io/name : {{ template "wavefront.fullname" . }}
@@ -11,7 +10,6 @@ metadata:
     app.kubernetes.io/component: collector
   name: {{ template "wavefront.collector.fullname" . }}
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name : {{ template "wavefront.fullname" .}}
@@ -22,6 +20,13 @@ spec:
         app.kubernetes.io/name : {{ template "wavefront.fullname" .}}
         app.kubernetes.io/component: collector
     spec:
+      tolerations:
+      - effect: NoSchedule
+        key: node.alpha.kubernetes.io/role
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists      
       serviceAccountName: {{ template "wavefront.collector.serviceAccountName" . }}
       containers:
       - name: wavefront-collector
@@ -29,7 +34,7 @@ spec:
         imagePullPolicy: {{ .Values.collector.image.pullPolicy }}
         command:
         - /wavefront-collector
-        - --daemon=false
+        - --daemon=true
         - --config-file=/etc/collector/config.yaml
         {{- if .Values.collector.maxProcs }}
         - --max-procs={{ .Values.collector.maxProcs }}
@@ -37,21 +42,36 @@ spec:
         {{- if .Values.collector.logLevel }}
         - --log-level={{ .Values.collector.logLevel }}
         {{- end }}
+        env:
+        - name: HOST_PROC
+          value: /host/proc
+        - name: POD_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: POD_NAMESPACE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace        
+        ports:
+        - containerPort: 8088
+          protocol: TCP
         resources:
 {{ toYaml .Values.collector.resources | indent 10 }}
         volumeMounts:
+        - name: procfs
+          mountPath: /host/proc
+          readOnly: true          
         - name: config
           mountPath: /etc/collector/
           readOnly: true        
-        - name: ssl-certs
-          mountPath: /etc/ssl/certs
-          readOnly: true
       volumes:
+      - name: procfs
+        hostPath:
+          path: /proc
       - name: config
         configMap:
           name: {{ template "wavefront.collector.fullname" . }}-config
-      - name: ssl-certs
-        hostPath:
-          path: /etc/ssl/certs
-{{- end }}
 {{- end }}

--- a/stable/wavefront/templates/proxy-deployment.yaml
+++ b/stable/wavefront/templates/proxy-deployment.yaml
@@ -67,19 +67,10 @@ spec:
         - name: preprocessor
           mountPath: /etc/wavefront/wavefront-proxy/preprocessor
         {{- end }}
-        {{- if .Values.openshift.enabled }}
-        - name: spool
-          mountPath: /var/spool/wavefront-proxy
-        {{- end }}
       volumes:
       {{- if .Values.proxy.preprocessor }}
       - name: preprocessor
         configMap:
           name: {{ template "wavefront.proxy.fullname" . }}-preprocessor
-      {{- end }}
-      {{- if .Values.openshift.enabled }}
-      - name: spool
-        persistentVolumeClaim:
-          claimName: {{ .Values.openshift.pvcName | quote }}
       {{- end }}
 {{- end }}

--- a/stable/wavefront/values.yaml
+++ b/stable/wavefront/values.yaml
@@ -45,7 +45,7 @@ collector:
 
   ## If set to true, will use the unauthenticated real only port for the kubelet
   ## If set to false, will use the encrypted full access port for the kubelet (default false)
-  # useReadOnlyPort: false  
+  # useReadOnlyPort: false
 
   ## If set to true, metrics will be sent to Wavefront via a Wavefront Proxy.
   ## When true you must either specify a value for `collector.proxyAddress` or set `proxy.enabled` to true
@@ -71,7 +71,7 @@ collector:
   discovery:
     enabled: true
 
-  ## When specified, this replaces `prometheus.io` as the prefix for annotations used to 
+  ## When specified, this replaces `prometheus.io` as the prefix for annotations used to
   ## auto-discover Prometheus endpoints
   #   annotationPrefix: "wavefront.com"
 
@@ -84,7 +84,7 @@ collector:
   #       labels:
   #         k8s-app:
   #         - prom-example
-  #.    port: 8080
+  #     port: 8080
   #     path: /metrics
   #     prefix: kube.prom-example.
   #     tags:
@@ -114,7 +114,7 @@ collector:
   #     conf: |
   #       url = "http://${host}:${port}"
   #       username = "USER"
-  #       password = "PASSWORD"  
+  #       password = "PASSWORD"
 
   ## Wavefront Collector resource requests and limits
   ## Make sure to keep requests and limits equal to keep the pods in the Guaranteed QoS class
@@ -216,4 +216,3 @@ serviceAccount:
 ## will be configured to capture metrics.
 kubeStateMetrics:
   enabled: true
-

--- a/stable/wavefront/values.yaml
+++ b/stable/wavefront/values.yaml
@@ -20,8 +20,32 @@ collector:
   enabled: true
   image:
     repository: wavefronthq/wavefront-kubernetes-collector
-    tag: 0.9.7
+    tag: 1.0.3
     pullPolicy: IfNotPresent
+
+  ## If set to true, DaemonSet will be used for the collector.
+  ## If set to false, Deployment will be used for the collector.
+  ## Setting this to true is strongly recommended
+  useDaemonset: true
+
+  ## max number of CPUs that can be used simultaneously. Less than 1 for default (number of cores)
+  # maxProcs: 0
+
+  ## log level one of: info, debug, or trace. (default info)
+  # logLevel: info
+
+  ## The resolution at which the collector will retain metrics. (default 60s)
+  # interval: 60s
+
+  ## How often collected data is flushed (default 10s)
+  # flushInterval: 10s
+
+  ## Timeout for exporting data (default 20s)
+  # sinkDelay: 20s
+
+  ## If set to true, will use the unauthenticated real only port for the kubelet
+  ## If set to false, will use the encrypted full access port for the kubelet (default false)
+  # useReadOnlyPort: false  
 
   ## If set to true, metrics will be sent to Wavefront via a Wavefront Proxy.
   ## When true you must either specify a value for `collector.proxyAddress` or set `proxy.enabled` to true
@@ -33,57 +57,64 @@ collector:
   ## Required if `collector.useProxy` is true and `proxy.enabled` is false
   # proxyAddress: wavefront-proxy:2878
 
-  ## This is the Kubelet summary api endpoint and options.
-  ## Ref: https://github.com/wavefrontHQ/wavefront-kubernetes-collector/blob/master/docs/configuration.md#kubernetes-source
-  # kubernetesSource: kubernetes.summary_api:''
-  ## If using Openshift (see below to enable) use the following for kubernetesSource
-  # kubernetesSource: kubernetes.summary_api:${MASTER_URL}?useServiceAccount=true&kubeletHttps=true&kubeletPort=10250
+  ## If set to true Kubernetes API Server will also be scraped for metrics (default false)
+  # apiServerMetrics: false
 
-  ## If set to true, any Kubernetes labels will be applied to metrics as tags. Defaults to false.
-  includeLabels: true
+  ## Map of tags to apply to all metrics collected by the collector (default empty)
+  # tags:
+  ## sample tags to include (env, region)
+  #   env: production
+  #   region: us-west-2
 
-  ## If set to true, all container metrics will be sent to Wavefront.
-  ## When set to false, container level metrics are skipped (pod level and above are still sent to Wavefront). Defaults to true.
-  # includeContainers: true
-
-  ## The global prefix to be added for Kubernetes metrics. Defaults to `kubernetes.`.
-  ## This does not apply to other sources. Use source level prefixes for sources other than the Kubernetes source.
-  # prefix: kubernetes.
-
-  ## max number of CPUs that can be used simultaneously. Less than 1 for default (number of cores)
-  # maxProcs: 0
-
-  ## The resolution at which the collector will retain metrics. (default 1m)
-  # interval: 1m
-
-  ## Timeout for exporting data (default 20s)
-  # sinkDelay: 20s
-
-  ## log level. Uses V logs (glog)
-  # logVerbosity: 0
-
-  ## Discovery capabilities of Wavefront Collector
+  ## Rules based discovery configuration
+  ## Ref: https://github.com/wavefrontHQ/wavefront-kubernetes-collector/blob/master/docs/discovery.md
   discovery:
     enabled: true
 
-  ## Rules based discovery collection configuration
-  ## Ref: https://github.com/wavefrontHQ/wavefront-kubernetes-collector/blob/master/docs/discovery.md#rules-based-discovery
+  ## When specified, this replaces `prometheus.io` as the prefix for annotations used to 
+  ## auto-discover Prometheus endpoints
+  #   annotationPrefix: "wavefront.com"
+
+  ## Can be used to add additional discovery rules
   #   config:
-  #     config.yaml: |
-  #       global:
-  #         discovery_interval: 10m
-  #       prom_configs:
-  #       - name: kube-dns-discovery
-  #         labels:
-  #           k8s-app: kube-dns
-  #         port: 10055
-  #         path: /metrics
-  #         scheme: http
-  #         source: kube-dns
-  #         prefix: kube.dns.
-  #         tags:
-  #           env: prod
-  #           collector: wavefront-collector
+  ## auto-discover a sample prometheus application
+  #   - name: prom-example
+  #     type: prometheus
+  #     selectors:
+  #       labels:
+  #         k8s-app:
+  #         - prom-example
+  #.    port: 8080
+  #     path: /metrics
+  #     prefix: kube.prom-example.
+  #     tags:
+  #       alt_name: sample-app
+  ## auto-discover mongodb pods (replace USER:PASSWORD)
+  #   - name: mongodb
+  #     type: telegraf/mongodb
+  #     selectors:
+  #       images:
+  #       - '*mongodb:*'
+  #     port: 27017
+  #     conf: |
+  #       servers = ["mongodb://USER:PASSWORD${host}:${port}"]
+  #       gather_perdb_stats = true
+  #     filters:
+  #       metricBlacklist:
+  #       - 'mongodb.member.status'
+  #       - 'mongodb.state'
+  #       - 'mongodb.db.stats.type'
+  ## auto-discover rabbitmq pods (replace USER and PASSWORD)
+  #   - name: rabbitmq
+  #     type: telegraf/rabbitmq
+  #     selectors:
+  #       images:
+  #       - '*rabbitmq:*'
+  #     port: 15672
+  #     conf: |
+  #       url = "http://${host}:${port}"
+  #       username = "USER"
+  #       password = "PASSWORD"  
 
   ## Wavefront Collector resource requests and limits
   ## Make sure to keep requests and limits equal to keep the pods in the Guaranteed QoS class
@@ -107,7 +138,7 @@ proxy:
   enabled: true
   image:
     repository: wavefronthq/proxy
-    tag: 4.35
+    tag: 4.38
     pullPolicy: IfNotPresent
 
   ## The port number the proxy will listen on for metrics in Wavefront data format.
@@ -149,16 +180,21 @@ proxy:
   ## through the proxy. You can configure the rules here. By default a rule to drop Kubernetes
   ## generated labels is applied to remove unecessary and often noisy tags.
   ## Ref: https://docs.wavefront.com/proxies_preprocessor_rules.html
-  preprocessor:
-    rules.yaml: |
-      '2878':
-        - rule    : drop-generated-label-tags
-          action  : dropTag
-          tag     : label\.(controller-revision-hash|pod-template-.*|.*kubernetes\.io.*)
-  #       - rule    : add-cluster-tag
-  #         action  : addTag
-  #         tag     : cluster
-  #         value   : {{ .Values.clusterName | quote }}
+  # preprocessor:
+  #   rules.yaml: |
+  #     '2878':
+  #     # fix %2F to be a / instead.  May be required on EKS.
+  #     - rule    : fix-forward-slash
+  #       action  : replaceRegex
+  #       scope   : pointLine
+  #       search  : "%2F"
+  #       replace : "/"
+  #     # replace bad characters ("&", "$", "!", "@") with underscores in the entire point line string
+  #     - rule    : replace-badchars
+  #       action  : replaceRegex
+  #       scope   : pointLine
+  #       search  : "[&\\$!@]"
+  #       replace : "_"
 
 
 ## Specifies whether RBAC resources should be created
@@ -181,14 +217,3 @@ serviceAccount:
 kubeStateMetrics:
   enabled: true
 
-
-## Openshift integration can be enabled here
-## If enabled is true, you must specify `collector.kubernetesSource` to be a valid
-## summary api endpoint within your Openshift environment.
-openshift:
-  enabled: false
-
-  ## Wavefront proxy requires a persistent volume claim for its metrics buffers in Openshift
-  ## If `proxy.enabled` is true, this must be set to the name of a persistent volume claim
-  ## that the proxy can use for its buffers.
-  # pvcName: wavefront-storage


### PR DESCRIPTION
#### What this PR does / why we need it:
This is an update to the Wavefront collector to use the new Daemonset based collector with auto-discovery for workloads

#### Which issue this PR fixes
None

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
