### PR TITLE
[stable/redmine] bump major version

### DIFF
--- a/stable/redmine/Chart.yaml
+++ b/stable/redmine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redmine
-version: 12.2.12
+version: 13.0.0
 appVersion: 4.0.5
 description: A flexible project management web application.
 keywords:

--- a/stable/redmine/README.md
+++ b/stable/redmine/README.md
@@ -178,6 +178,14 @@ $ helm install --name test --set persistence.existingClaim=PVC_REDMINE,mariadb.p
 
 ## Upgrading
 
+### 13.0.0
+
+Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.
+
+In https://github.com/helm/charts/pull/17309 the `apiVersion` of the deployment resources was updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.
+
+This major version signifies this change.
+
 ### To 5.0.0
 
 Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.

--- a/stable/redmine/requirements.lock
+++ b/stable/redmine/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.12.2
+  version: 7.0.0
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.5.4
-digest: sha256:ee162ec03d9c5f09b7cab23f9fc3d98481694ff8295405c6089ea9dd7470d7fa
-generated: 2019-10-29T16:20:12.290649596Z
+  version: 7.0.0
+digest: sha256:c5ed9aba5b8df7c81b029047541d0b75e26b4d7eaf34ea03e09f4d76ac4cc6d4
+generated: "2019-11-09T11:28:29.844388656+05:30"

--- a/stable/redmine/requirements.yaml
+++ b/stable/redmine/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
-  version: 6.x.x
+  version: 7.x.x
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: mariadb.enabled
 - name: postgresql
-  version: 6.x.x
+  version: 7.x.x
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: postgresql.enabled

--- a/stable/redmine/templates/_helpers.tpl
+++ b/stable/redmine/templates/_helpers.tpl
@@ -132,3 +132,14 @@ but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else 
     {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "redmine.deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/redmine/templates/deployment.yaml
+++ b/stable/redmine/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if or .Values.databaseType.mariadb .Values.databaseType.postgresql }}
-apiVersion: apps/v1
+apiVersion: {{ template "redmine.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "redmine.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.

In https://github.com/helm/charts/pull/17309 the `apiVersion` of the deployment resources was updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.

This major version signifies this change.

Signed-off-by: Sameer Naik <sameersbn@vmware.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)