### PR TITLE
[stable/owncloud] bump major version

### DIFF
--- a/stable/owncloud/Chart.yaml
+++ b/stable/owncloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: owncloud
-version: 6.2.9
+version: 7.0.0
 appVersion: 10.3.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/owncloud/README.md
+++ b/stable/owncloud/README.md
@@ -159,6 +159,14 @@ See the [Parameters](#parameters) section to configure the PVC or to disable per
 
 ## Upgrading
 
+### 7.0.0
+
+Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.
+
+In https://github.com/helm/charts/pull/17304 the `apiVersion` of the deployment resources was updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.
+
+This major version signifies this change.
+
 ### To 3.0.0
 
 Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.

--- a/stable/owncloud/requirements.lock
+++ b/stable/owncloud/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.12.2
-digest: sha256:a363428d6463718a9523a88c70e485218373e315f2979cb1bb17b034ec2be96a
-generated: 2019-10-29T14:10:06.538415037Z
+  version: 7.0.0
+digest: sha256:cd64413a4a697ccf85c0091e9c55cdc5876938ddced84c05d37c57ff9abc5864
+generated: "2019-11-09T11:14:44.633832382+05:30"

--- a/stable/owncloud/requirements.yaml
+++ b/stable/owncloud/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
-  version: 6.x.x
+  version: 7.x.x
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: mariadb.enabled

--- a/stable/owncloud/templates/_helpers.tpl
+++ b/stable/owncloud/templates/_helpers.tpl
@@ -175,3 +175,14 @@ but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else 
     {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "owncloud.deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/owncloud/templates/deployment.yaml
+++ b/stable/owncloud/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if include "owncloud.host" . -}}
-apiVersion: apps/v1
+apiVersion: {{ template "owncloud.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "owncloud.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.

In https://github.com/helm/charts/pull/17304 the `apiVersion` of the deployment resources was updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.

This major version signifies this change.

Signed-off-by: Sameer Naik <sameersbn@vmware.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)