### PR TITLE
[stable/magento] bump major version     

### DIFF
--- a/stable/magento/Chart.yaml
+++ b/stable/magento/Chart.yaml
@@ -3,7 +3,7 @@ name: magento
 # The Magento chart is deprecated and no longer maintained. For details on deprecation,
 # including how to un-deprecate a chart, see the PROCESSES.md file.
 deprecated: true
-version: 5.1.4
+version: 6.0.0
 appVersion: 2.3.1
 description: DEPRECATED A feature-rich flexible e-commerce solution. It includes transaction options, multi-store functionality, loyalty programs, product categorization and shopper filtering, promotion rules, and more.
 keywords:

--- a/stable/magento/README.md
+++ b/stable/magento/README.md
@@ -188,6 +188,14 @@ The [Bitnami Magento](https://github.com/bitnami/bitnami-docker-magento) image s
 
 ## Upgrading
 
+### To 6.0.0
+
+Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.
+
+This version updates the `apiVersion` of the deployment resources was updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.
+
+This major version signifies this change.
+
 ### To 5.0.0
 
 Manual intervention is needed if configuring Elasticsearch 6 as Magento search engine is desired.

--- a/stable/magento/requirements.lock
+++ b/stable/magento/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.11.3
+  version: 7.0.0
 - name: elasticsearch
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.28.2
-digest: sha256:b8276d2d458462fb87b222b5a45fa01461f11140acce57ccd1878b80c9eb7991
-generated: 2019-06-10T02:56:23.906858402Z
+  version: 1.32.0
+digest: sha256:8463cdb928ac8f1714775c8f3d7d5239754c960a9c4e6419494a370ac6c7fae4
+generated: "2019-11-09T10:14:06.599699784+05:30"

--- a/stable/magento/requirements.yaml
+++ b/stable/magento/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  version: 5.x.x
+  version: 7.x.x
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: mariadb.enabled
 - name: elasticsearch

--- a/stable/magento/templates/_helpers.tpl
+++ b/stable/magento/templates/_helpers.tpl
@@ -148,3 +148,14 @@ imagePullSecrets:
 {{- end }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "magento.deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/magento/templates/deployment.yaml
+++ b/stable/magento/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if and (include "magento.host" .) (or .Values.mariadb.enabled .Values.externalDatabase.host) -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "magento.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "magento.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need 

Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.
    
In https://github.com/helm/charts/pull/17285 the `apiVersion` of the deployment resources was updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.
    
This major version signifies this change.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)