### PR TITLE
[incubator/zookeeper]: Use declared variable in chroots script

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 2.1.1
+version: 2.1.2
 appVersion: 3.5.5
 kubeVersion: "^1.10.0-0"
 description: Centralized service for maintaining configuration information, naming,

--- a/incubator/zookeeper/templates/job-chroots.yaml
+++ b/incubator/zookeeper/templates/job-chroots.yaml
@@ -49,10 +49,10 @@ spec:
   {{- range $job.config.create }}
               echo '==> {{ . }}';
               echo '====> Create chroot if does not exist.';
-              zkCli.sh -server {{ template "zookeeper.fullname" $root }}:{{ $port }} get {{ . }} 2>&1 >/dev/null | grep 'cZxid'
-              || zkCli.sh -server {{ template "zookeeper.fullname" $root }}:{{ $port }} create {{ . }} "";
+              zkCli.sh -server $SERVER get {{ . }} 2>&1 >/dev/null | grep 'cZxid'
+              || zkCli.sh -server $SERVER create {{ . }} "";
               echo '====> Confirm chroot exists.';
-              zkCli.sh -server {{ template "zookeeper.fullname" $root }}:{{ $port }} get {{ . }} 2>&1 >/dev/null | grep 'cZxid';
+              zkCli.sh -server $SERVER get {{ . }} 2>&1 >/dev/null | grep 'cZxid';
               echo '====> Chroot exists.';
   {{- end }}
           env:


### PR DESCRIPTION
There already was an `export SERVER=...` line at the top of the chroots
command script, but the variable was never used.

This has no functional impact, but makes the script easier to read with
many less in-line `template` calls.

I assume this was always intended to be done, but was just overlooked
previously.

Signed-off-by: Sven Grosen <svengrosen@gmail.com>

#### What this PR does / why we need it:
Cleans up script

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
