### PR TITLE
[stable/nginx-ldapauth-proxy] Update deployment apiVersion to 'apps/v1'

### DIFF
--- a/stable/nginx-ldapauth-proxy/Chart.yaml
+++ b/stable/nginx-ldapauth-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: nginx proxy with ldapauth
 name: nginx-ldapauth-proxy
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
-version: 0.1.3
+version: 0.1.4
 appVersion: 1.13.5
 sources:
 - https://github.com/dweomer/dockerfiles-nginx-auth-ldap

--- a/stable/nginx-ldapauth-proxy/templates/deployment.yaml
+++ b/stable/nginx-ldapauth-proxy/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "nginx-ldapauth-proxy.fullname" . }}


### PR DESCRIPTION
This change is mandatory for kubernetes 1.16.

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
The old apiversions are deprectated with kubernetes version 1.16. See the Changelog of kubernetes: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#deprecations-and-removals . 

The deployment under `apps/v1beta2` cannot be used anymore and we have to update to `apps/v1`. This Pull Request updates the deployment of this chart respecively.

#### Special notes for your reviewer:
First time contribution to the helm chart repository. I hope I did not forget anything important. If not I am happy if you get back to me. 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
