### PR TITLE
[stable/prometheus-operator] - Fix err msg "found duplicate series for the match group"

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.1.3
+version: 8.1.4
 appVersion: 0.34.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/templates/prometheus/rules-1.14/kubernetes-apps.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules-1.14/kubernetes-apps.yaml
@@ -33,7 +33,7 @@ spec:
       annotations:
         message: Pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} has been in a non-ready state for longer than 15 minutes.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
-      expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Failed|Pending|Unknown"} * on(namespace, pod) group_left(owner_kind) kube_pod_owner{owner_kind!="Job"}) > 0
+      expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Failed|Pending|Unknown"} * on(namespace, pod) group_left(owner_kind) kube_pod_owner{owner_kind!="Job",job="kube-state-metrics"}) > 0
       for: 15m
       labels:
         severity: critical


### PR DESCRIPTION

Signed-off-by: Lord-Y <Lord-Y@users.noreply.github.com>

#### What this PR does / why we need it:

Fix err msg found duplicate series for the match group for KubePodNotReady alert. Here is my stack trace:
`
Error executing query: found duplicate series for the match group {namespace="default", pod="nginx-dbddb74b8-vks5q"} on the right hand-side of the operation: [{__name__="kube_pod_owner", endpoint="http", instance="X.X.X.X:8080", job="kube-state-metrics", namespace="default", owner_is_controller="true", owner_kind="ReplicaSet", owner_name="nginx-dbddb74b8", pod="nginx-dbddb74b8-vks5q", service="prometheus-operator-kube-state-metrics"}, {__name__="kube_pod_owner", app_kubernetes_io_instance="prometheus-operator", app_kubernetes_io_managed_by="Tiller", app_kubernetes_io_name="kube-state-metrics", helm_sh_chart="kube-state-metrics-2.4.1", instance="X.X.X.X:8080", job="kubernetes-service-endpoints", kubernetes_name="prometheus-operator-kube-state-metrics", kubernetes_namespace="prometheus-operator", kubernetes_node="XXXXXX-b6b5a477-zq60", namespace="default", owner_is_controller="true", owner_kind="ReplicaSet", owner_name="nginx-dbddb74b8", pod="nginx-dbddb74b8-vks5q"}];many-to-many matching not allowed: matching labels must be unique on one side
`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
