### PR TITLE
[stable/prometheus-operator] fix annotations typo

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.1.4
+version: 8.1.5
 appVersion: 0.34.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/templates/grafana/configmaps-datasources.yaml
+++ b/stable/prometheus-operator/templates/grafana/configmaps-datasources.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 {{- if .Values.grafana.sidecar.datasources.annotations }}
   annotations:
-{{ toYaml .Values.alertmanager.secret.annotations | indent 4 }}
+{{ toYaml .Values.grafana.sidecar.datasources.annotations | indent 4 }}
 {{- end }}
   labels:
     {{ $.Values.grafana.sidecar.datasources.label }}: "1"


### PR DESCRIPTION
#### What this PR does / why we need it:

Sorry, @vsliouniaev I had a typo in the annotations line. The reason I put this PR together is because we need to exclude Spinnaker from versioning this configmap and this is done through annotations.


#### Which issue this PR fixes

This fixes a typo

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
