### PR TITLE
[stable/orangehrm] bump major version

### DIFF
--- a/stable/orangehrm/Chart.yaml
+++ b/stable/orangehrm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: orangehrm
-version: 6.2.8
+version: 7.0.0
 appVersion: 4.3.3-0
 description: OrangeHRM is a free HR management system that offers a wealth of modules
   to suit the needs of your business.

--- a/stable/orangehrm/README.md
+++ b/stable/orangehrm/README.md
@@ -154,6 +154,14 @@ See the [Parameters](#parameters) section to configure the PVC or to disable per
 
 ## Upgrading
 
+### To 7.0.0
+
+Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.
+
+In this version the `apiVersion` of the deployment resources is updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.
+
+This major version signifies this change.
+
 ### To 3.0.0
 
 Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.

--- a/stable/orangehrm/requirements.lock
+++ b/stable/orangehrm/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.12.2
-digest: sha256:a363428d6463718a9523a88c70e485218373e315f2979cb1bb17b034ec2be96a
-generated: 2019-10-29T22:35:21.86486001Z
+  version: 7.0.0
+digest: sha256:cd64413a4a697ccf85c0091e9c55cdc5876938ddced84c05d37c57ff9abc5864
+generated: "2019-11-09T11:38:02.512650528+05:30"

--- a/stable/orangehrm/requirements.yaml
+++ b/stable/orangehrm/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
-  version: 6.x.x
+  version: 7.x.x
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: mariadb.enabled

--- a/stable/orangehrm/templates/_helpers.tpl
+++ b/stable/orangehrm/templates/_helpers.tpl
@@ -153,3 +153,14 @@ but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else 
     {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "orangehrm.deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/orangehrm/templates/deployment.yaml
+++ b/stable/orangehrm/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "orangehrm.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "orangehrm.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.

In this version the `apiVersion` of the deployment resources is updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.

This major version signifies this change.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)