### PR TITLE
[incubator/gogs] Add support for defined loadBalancerIP 

### DIFF
--- a/incubator/gogs/Chart.yaml
+++ b/incubator/gogs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: 'Gogs: Go Git Service'
 name: gogs
-version: 0.7.10
+version: 0.7.11
 appVersion: 0.11.86
 home: https://gogs.io/
 icon: https://gogs.io/img/favicon.ico

--- a/incubator/gogs/README.md
+++ b/incubator/gogs/README.md
@@ -53,6 +53,8 @@ chart and their default values.
 | `postgresql.postgresDatabase`    | PostgreSQL Database to create                                | `gogs`                                                     |
 | `postgresql.postgresSSLMode`     | PostgreSQL SSL Mode                                          | `disable`                                                  |
 | `postgresql.persistence.enabled` | Enable PostgreSQL persistence using Persistent Volume Claims | `true`                                                     |
+| `serviceType`                    | The type of service to create (`ClusterIP`, `NodePort`, `LoadBalancer`) | `NodePort`                                      |
+| `service.loadBalancerIP`         | The IP address to use when using serviceType `LoadBalancer`  | `nil`                                                      |
 | `service.httpNodePort`           | Enable a static port where the Gogs http service is exposed on each Node’s IP | `nil`                                     |
 | `service.sshNodePort`            | Enable a static port where the Gogs ssh service is exposed on each Node’s IP | `nil`                                      |
 

--- a/incubator/gogs/templates/service.yaml
+++ b/incubator/gogs/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.serviceType }}
+  {{- if and (eq .Values.serviceType "LoadBalancer") .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   ports:
   - port: {{ .Values.service.httpPort | int }}
     targetPort: 3000


### PR DESCRIPTION
Signed-off-by: Stephan Fudeus <sfudeus@users.noreply.github.com>

@obeyler 
@poblin-orange 

#### What this PR does / why we need it:

In some environments, IP addresses for services of type LoadBalancer must not be dynamically generated but need a manually defined ip address. This is handled via `spec.loadBalancerIP` in the service manifest. This PR adds support for defining this. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
