### PR TITLE
stable/sealed-secrets: allow disable of controller installation

### DIFF
--- a/stable/sealed-secrets/Chart.yaml
+++ b/stable/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.4.3
+version: 1.5.0
 appVersion: 0.9.1
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/stable/sealed-secrets/README.md
+++ b/stable/sealed-secrets/README.md
@@ -45,6 +45,7 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 
 | Parameter | Description | Default |
 |----------:|:------------|:--------|
+| **controller.create** | `true` if Sealed Secrets controller resources should be created | `true` |
 | **rbac.create** | `true` if rbac resources should be created | `true` |
 | **rbac.pspEnabled** | `true` if psp resources should be created | `false` |
 | **serviceAccount.create** | Whether to create a service account or not | `true` |

--- a/stable/sealed-secrets/templates/NOTES.txt
+++ b/stable/sealed-secrets/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{ if .Values.controller.create -}}
 You should now be able to create sealed secrets.
 
 1. Install client-side tool into /usr/local/bin/
@@ -40,4 +41,7 @@ kubectl create -f mysealedsecret.[json|yaml]
 Running 'kubectl get secret secret-name -o [json|yaml]' will show the decrypted secret that was generated from the sealed secret.
 
 Both the SealedSecret and generated Secret must have the same name and namespace.
-
+{{- else }}
+Sealed Secrets controller not installed, You need to install controller before
+sealed secrets can be created.
+{{- end }}

--- a/stable/sealed-secrets/templates/deployment.yaml
+++ b/stable/sealed-secrets/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.create -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -67,3 +68,4 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+{{- end }}

--- a/stable/sealed-secrets/templates/service.yaml
+++ b/stable/sealed-secrets/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.create -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
     - port: 8080
   selector:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+{{- end }}

--- a/stable/sealed-secrets/values.yaml
+++ b/stable/sealed-secrets/values.yaml
@@ -8,6 +8,10 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
+controller:
+  # controller.create: `true` if Sealed Secrets controller should be created
+  create: true
+
 serviceAccount:
   # serviceAccount.create: Whether to create a service account or not
   create: true


### PR DESCRIPTION
The main goal is to allow installation of CRD using separate Helm deployment.
This is an alternative to using separate Helm Chart for CRD deployment.

#### What this PR does / why we need it:

This is helpfull for example during distaster recovery. When Sealed Secrets installation is broken and need to be reinstalled, the helm tries also to install CRD (if enabled), but when CRD already exists installation fails. This is especially usefull with deployment automation and declarative deployments definitions.

@stefanprodan @olib963 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
