### PR TITLE
[stable/gocd] - GoCD server should be able to have sidecar containers

### DIFF
--- a/stable/gocd/CHANGELOG.md
+++ b/stable/gocd/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.19.3
+* [afd78ccd8](https://github.com/kubernetes/charts/commit/afd78ccd8): GoCD server sidecar containers
+
 ### 1.19.2
 * [cacab5e62](https://github.com/kubernetes/charts/commit/cacab5e62): GoCD agents postStart lifecycle hooks
 

--- a/stable/gocd/Chart.yaml
+++ b/stable/gocd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 1.19.2
+version: 1.19.3
 appVersion: 19.10.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/stable/gocd/README.md
+++ b/stable/gocd/README.md
@@ -106,6 +106,7 @@ The following tables list the configurable parameters of the GoCD chart and thei
 | `server.securityContext.runAsUser`         | The container user for all the GoCD server pods.                                                              | `1000`              |
 | `server.securityContext.runAsGroup`        | The container group for all the GoCD server pods.                                                             | `0`                 |
 | `server.securityContext.fsGroup`           | The container supplementary group for all the GoCD server pods.                                               | `0`                 |
+| `server.sidecarContainers`                 | Sidecar containers to run alongside GoCD server.                                                              | `[]`                |
 
 #### Preconfiguring the GoCD Server
 

--- a/stable/gocd/templates/gocd-server-deployment.yaml
+++ b/stable/gocd/templates/gocd-server-deployment.yaml
@@ -64,6 +64,9 @@ spec:
 {{ toYaml .Values.server.initContainers | indent 8 }}
       {{- end }}
       containers:
+      {{- if .Values.server.sidecarContainers }}
+{{ toYaml .Values.server.sidecarContainers | indent 8 }}
+      {{- end }}
         - name: {{ template "gocd.name" . }}-server
           {{- if .Values.server.image.tag }}
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"

--- a/stable/gocd/values.yaml
+++ b/stable/gocd/values.yaml
@@ -71,7 +71,13 @@ server:
   #     memory: 1024Mi
 
   # Sidecar containers that runs alongside GoCD server.
+  # https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/
   sidecarContainers: []
+  # - name: sidecar-container
+  #   image: sidecar-image:latest
+  #   volumeMounts:
+  #     - name: goserver-vol
+  #     mountPath: /godata
 
   # specify init containers, e.g. to prepopulate home directories etc
   initContainers: []

--- a/stable/gocd/values.yaml
+++ b/stable/gocd/values.yaml
@@ -70,6 +70,9 @@ server:
   #     cpu: 100m
   #     memory: 1024Mi
 
+  # Sidecar containers that runs alongside GoCD server.
+  sidecarContainers: []
+
   # specify init containers, e.g. to prepopulate home directories etc
   initContainers: []
   #  - name: download-kubectl


### PR DESCRIPTION
Signed-off-by: Erik Jutemar <erik.jutemar@pagero.com>
#### Is this a new chart
No.

#### What this PR does / why we need it:
Allow running sidecar containers alongside GoCD server. Our particular use case for this is to run another container that periodically cleans up old artifacts from our PV that has all the artifacts.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
