### PR TITLE
[stable/redis-ha] Increase haproxy replicas

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.0.0
+version: 4.0.1
 appVersion: 5.0.5
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/values.yaml
+++ b/stable/redis-ha/values.yaml
@@ -33,7 +33,7 @@ haproxy:
   readOnly:
     enabled: false
     port: 6380
-  replicas: 1
+  replicas: 3
   image:
     repository: haproxy
     tag: 2.0.4


### PR DESCRIPTION
Signed-off-by: Alex Lundberg alex.lundberg@gmail.com

@salimsalaues@gmail.com
@aaron.layfield@gmail.com

#### Is this a new chart
No

#### What this PR does / why we need it:
The default replicas for 1 for the haproxy service defeats the purpose of a highly available redis. If the proxy server goes down then redis has an outage until a new proxy is spun up.

#### Which issue this PR fixes
fixes #18773 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
