### PR TITLE
[stable/vsphere-cpi] New Helm Chart  for vSphere Cloud Provider Interface (CPI)

### DIFF
--- a/stable/vsphere-cpi/.helmignore
+++ b/stable/vsphere-cpi/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/vsphere-cpi/Chart.yaml
+++ b/stable/vsphere-cpi/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+appVersion: 1.0.0
+description: A Helm chart for vSphere Cloud Provider Interface Manager (CPI)
+name: vsphere-cpi
+version: 0.1.0
+keywords:
+  - vsphere
+  - vmware
+  - cloud
+  - provider
+home: https://github.com/kubernetes/cloud-provider-vsphere
+icon: https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/master/docs/vmware_logo.png
+sources:
+  - https://github.com/kubernetes/cloud-provider-vsphere
+maintainers:
+  - name: dvonthenen
+    email: vonthenend@vmware.com

--- a/stable/vsphere-cpi/OWNERS
+++ b/stable/vsphere-cpi/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- dvonthenen
+- frapposelli
+- andrewsykim
+reviewers:
+- dvonthenen
+- frapposelli
+- andrewsykim

--- a/stable/vsphere-cpi/README.md
+++ b/stable/vsphere-cpi/README.md
@@ -1,0 +1,91 @@
+# vSphere Cloud Provider Interface (CPI)
+
+[vSphere Cloud Provider Interface](https://github.com/kubernetes/cloud-provider-vsphere) handles cloud specific functionality for VMware vSphere infrastructure running on Kubernetes.
+
+## Introduction
+
+This chart deploys all components required to run the external vSphere CPI as described on it's [GitHub page](https://github.com/kubernetes/cloud-provider-vsphere).
+
+## Prerequisites
+
+- Has been tested on Kubernetes 1.13.X+
+- Assumes your Kubernetes cluster has been configured to use the external cloud provider. Please take a look at configuration guidelines located in the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager).
+
+## Installing the Chart
+
+To install this chart with the release name `myrel` and by providing a vCenter information/credentials, run the following command:
+
+```bash
+$ helm install stable/vsphere-cpi --name myrel --set config.enabled=true --set config.vcenter=<vCenter IP> --set config.username=<vCenter Username> --set config.password=<vCenter Password> --set config.datacenter=<vCenter Datacenter>
+```
+
+> **Tip**: List all releases using `helm list --all`
+
+If you want to provide your own `vsphere.conf` and Kubernetes secret `vsphere-cpi` in the `kube-system` namespace (to handle multple datacenters or multiple vCenters), you can learn more about the `vsphere.conf` and `vsphere-cpi` secret by reading the following [doucmentation](https://github.com/kubernetes/cloud-provider-vsphere/blob/master/docs/deploying_cloud_provider_vsphere_with_rbac.md) and then running the following command:
+
+```bash
+$ helm install stable/vsphere-cpi --name myrel
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `myrel` deployment:
+
+```bash
+$ helm delete myrel
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+> **Tip**: To permanently remove the release, run `helm delete --purge myrel`
+
+## Configuration
+
+The following table lists the configurable parameters of the vSphere CPI chart and their default values.
+
+|             Parameter                    |            Description              |                  Default               |
+|------------------------------------------|-------------------------------------|----------------------------------------|
+| `config.enabled`                         | Create a simple single VC config    |  false                                 |
+| `config.vcenter`                         | FQDN or IP of vCenter               |  vcenter.local                         |
+| `config.username`                        | vCenter username                    |  user                                  |
+| `config.password`                        | vCenter password                    |  pass                                  |
+| `config.datacenter`                      | Datacenters within the vCenter      |  dc                                    |
+| `rbac.create`                            | Create roles and role bindings      |  true                                  |
+| `serviceAccount.create`                  | Create the service account          |  true                                  |
+| `serviceAccount.name`                    | Name of the created service account |  cloud-controller-manager              |
+
+| `daemonset.annotations`                  | Annotations for CPI pod             |  nil                                   |
+| `daemonset.image`                        | Image for vSphere CPI               |  gcr.io/cloud-provider-vsphere/        |
+|                                          |                                     |       vsphere-cloud-controller-manager |
+| `daemonset.tag`                          | Tag for vSphere CPI                 |  latest                                |
+| `daemonset.pullPolicy`                   | CPI image pullPolicy                |  IfNotPresent                          |
+| `daemonset.dnsPolicy`                    | CPI dnsPolicy                       |  ClusterFirst                          |
+| `daemonset.cmdline.logging`              | Logging level                       |  2                                     |
+| `daemonset.cmdline.cloudConfig.dir`      | vSphere conf directory              |  /etc/cloud                            |
+| `daemonset.cmdline.cloudConfig.file`     | vSphere conf filename               |  vsphere.conf                          |
+| `daemonset.replicaCount`                 | Node resources                      | `[]`                                   |
+| `daemonset.resources`                    | Node resources                      | `[]`                                   |
+| `daemonset.podAnnotations`               | Annotations for CPI pod             |  nil                                   |
+| `daemonset.podLabels`                    | Labels for CPI pod                  |  nil                                   |
+| `service.enabled`                        | Enabled the CPI API endpoint        |  false                                 |
+| `service.annotations`                    | Annotations for API service         |  nil                                   |
+| `service.type`                           | Service type                        |  ClusterIP                             |
+| `service.loadBalancerSourceRanges`       | list of IP CIDRs allowed access     | `[]`                                   |
+| `service.endpointPort`                   | External accessible port            |  43001                                 |
+| `service.targetPort`                     | Internal API port                   |  43001                                 |
+| `ingress.enabled`                        | Allow external traffic access       |  false                                 |
+| `ingress.annotations`                    | Annotations for Ingress             |  nil                                   |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name myrel \
+    --set daemonset.pullPolicy=Always \
+    stable/vsphere-cpi
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart.
+
+### Image tags
+
+vSphere CPI offers a multitude of [tags](https://github.com/kubernetes/cloud-provider-vsphere/releases) for the various components used in this chart.

--- a/stable/vsphere-cpi/templates/NOTES.txt
+++ b/stable/vsphere-cpi/templates/NOTES.txt
@@ -1,0 +1,27 @@
+The vSphere Cloud Controller Manager API over gRPC exists at the following location:
+
+{{- if not .Values.service.enabled }}
+
+  vSphere CPI API is disabled
+
+{{- else if contains "NodePort" .Values.service.type }}
+
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "cpi.fullname" . }}-query)
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo h$NODE_IP:$NODE_PORT
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "sphere-cpi.fullname" . }}-query'
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "sphere-cpi.fullname" . }}-query -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo $SERVICE_IP:50051
+
+{{- else if contains "ClusterIP"  .Values.service.type }}
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "release={{ .Release.Name }},component=cloud-controller-manager" -o jsonpath="{.items[0].metadata.name}")
+  echo http://127.0.0.1:8080/
+  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 43001:43001
+
+{{- end }}

--- a/stable/vsphere-cpi/templates/_helpers.tpl
+++ b/stable/vsphere-cpi/templates/_helpers.tpl
@@ -1,0 +1,55 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cpi.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec)
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cpi.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified daemonset name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "cpi.daemonset.name" -}}
+{{- $nameGlobalOverride := printf "%s-daemonset" (include "cpi.fullname" .) -}}
+{{- if .Values.daemonset.fullnameOverride -}}
+{{- printf "%s" .Values.daemonset.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" $nameGlobalOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "api.binding" -}}
+{{- printf ":%.0f" .Values.service.endpointPort | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Configure list of IP CIDRs allowed access to load balancer (if supported)
+*/}}
+{{- define "loadBalancerSourceRanges" -}}
+{{- if .service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range $cidr := .service.loadBalancerSourceRanges }}
+    - {{ $cidr }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/stable/vsphere-cpi/templates/common.yaml
+++ b/stable/vsphere-cpi/templates/common.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "cpi.fullname" . }}
+  labels:
+    app: {{ template "cpi.name" . }}
+    vsphere-cpi-infra: common-configmap
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: cloud-controller
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  namespace: kube-system
+data:
+  api.binding: "{{ template "api.binding" . }}"

--- a/stable/vsphere-cpi/templates/configmap.yaml
+++ b/stable/vsphere-cpi/templates/configmap.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.config.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloud-config
+  labels:
+    app: {{ template "cpi.name" . }}
+    vsphere-cpi-infra: cloud-config
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: cloud-controller
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  namespace: kube-system
+data:
+  vsphere.conf: |
+    [Global]
+    # properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.
+    port = "443" #Optional
+    insecure-flag = "1" #set to 1 if the vCenter uses a self-signed cert
+    # settings for using k8s secret
+    secret-name = "vsphere-cpi"
+    secret-namespace = "kube-system"
+
+    [VirtualCenter "{{ .Values.config.vcenter }}"]
+    datacenters = "{{ .Values.config.datacenter }}"
+    # port, insecure-flag will be used from Global section.
+{{- end -}}

--- a/stable/vsphere-cpi/templates/daemonset.yaml
+++ b/stable/vsphere-cpi/templates/daemonset.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "cpi.name" . }}
+  labels:
+    app: {{ template "cpi.name" . }}
+    vsphere-cpi-infra: daemonset
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: cloud-controller
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  namespace: kube-system
+{{- if .Values.daemonset.annotations }}
+  annotations:
+{{ toYaml .Values.daemonset.annotations | indent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "cpi.name" . }}
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+{{- if .Values.daemonset.podAnnotations }}
+      annotations:
+{{ toYaml .Values.daemonset.podAnnotations | indent 8 }}
+{{- end }}
+      labels:
+        app: {{ template "cpi.name" . }}
+        component: cloud-controller
+        release: {{ .Release.Name }}
+        vsphere-cpi-infra: daemonset
+{{- if .Values.daemonset.podLabels }}
+{{ toYaml .Values.daemonset.podLabels | indent 8 }}
+{{- end }}
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      securityContext:
+        runAsUser: 0
+      tolerations:
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- if .Values.daemonset.useHostNetwork }}
+      hostNetwork: true
+      {{- end }}
+      dnsPolicy: {{ .Values.daemonset.dnsPolicy }}
+      containers:
+      - name: {{ template "cpi.name" . }}
+        image: {{ .Values.daemonset.image }}:{{ .Values.daemonset.tag }}
+        imagePullPolicy: {{ .Values.daemonset.pullPolicy }}
+        args:
+          - --cloud-provider=vsphere
+          - --v={{ .Values.daemonset.cmdline.logging }}
+          - --cloud-config={{ .Values.daemonset.cmdline.cloudConfig.dir }}/{{ .Values.daemonset.cmdline.cloudConfig.file }}
+          {{- range $key, $value := .Values.daemonset.cmdline.additionalParams }}
+          - --{{ $key }}{{ if $value }}={{ $value }}{{ end }}
+          {{- end }}
+        {{- if .Values.service.enabled }}
+        env:
+          - name: VSPHERE_API_DISABLE
+            value: "true"
+          - name: VSPHERE_API_BINDING
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "cpi.fullname" . }}
+                key: api.binding
+        ports:
+        - containerPort: {{ .Values.service.endpointPort }}
+          protocol: TCP
+        {{- end }}
+        volumeMounts:
+          - mountPath: {{ .Values.daemonset.cmdline.cloudConfig.dir }}
+            name: vsphere-config-volume
+            readOnly: true
+        resources:
+{{ toYaml .Values.daemonset.resources | indent 10 }}
+      volumes:
+        - name: vsphere-config-volume
+          configMap:
+            name: cloud-config

--- a/stable/vsphere-cpi/templates/ingress.yaml
+++ b/stable/vsphere-cpi/templates/ingress.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.ingress.enabled -}}
+{{- $servicePort := .Values.service.endpointPort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "cpi.name" . }}
+  labels:
+    app: {{ template "cpi.name" . }}
+    vsphere-cpi-infra: ingress
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: cloud-controller
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  namespace: kube-system
+  {{- if .Values.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+  {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ template "cpi.name" $ }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/stable/vsphere-cpi/templates/role-binding.yaml
+++ b/stable/vsphere-cpi/templates/role-binding.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.rbac.create -}}
+apiVersion: v1
+kind: List
+metadata: {}
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: servicecatalog.k8s.io:apiserver-authentication-reader
+    labels:
+      app: {{ template "cpi.name" . }}
+      vsphere-cpi-infra: role-binding
+      chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      component: cloud-controller
+      heritage: {{ .Release.Service }}
+      release: {{ .Release.Name }}
+    namespace: kube-system
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: extension-apiserver-authentication-reader
+  subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name }}
+    namespace: kube-system
+  - apiGroup: ""
+    kind: User
+    name: {{ .Values.serviceAccount.name }}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:{{ .Values.serviceAccount.name }}
+    labels:
+      app: {{ template "cpi.name" . }}
+      vsphere-cpi-infra: cluster-role-binding
+      chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      component: cloud-controller
+      heritage: {{ .Release.Service }}
+      release: {{ .Release.Name }}
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:{{ .Values.serviceAccount.name }}
+  subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name }}
+    namespace: kube-system
+  - kind: User
+    name: {{ .Values.serviceAccount.name }}
+{{- end -}}

--- a/stable/vsphere-cpi/templates/role.yaml
+++ b/stable/vsphere-cpi/templates/role.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:{{ .Values.serviceAccount.name }}
+  labels:
+    app: {{ template "cpi.name" . }}
+    vsphere-cpi-infra: role
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: cloud-controller
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+{{- end -}}

--- a/stable/vsphere-cpi/templates/secret.yaml
+++ b/stable/vsphere-cpi/templates/secret.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.config.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-cpi
+  labels:
+    app: {{ template "cpi.name" . }}
+    vsphere-cpi-infra: secret
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: cloud-controller
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  namespace: kube-system
+data:
+  {{ .Values.config.vcenter }}.username: {{ .Values.config.username | b64enc }}
+  {{ .Values.config.vcenter }}.password: {{ .Values.config.password | b64enc }}
+{{- end -}}

--- a/stable/vsphere-cpi/templates/service-account.yaml
+++ b/stable/vsphere-cpi/templates/service-account.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  labels:
+    app: {{ template "cpi.name" . }}
+    vsphere-cpi-infra: service-account
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: cloud-controller
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  namespace: kube-system
+{{- end -}}

--- a/stable/vsphere-cpi/templates/service.yaml
+++ b/stable/vsphere-cpi/templates/service.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "cpi.name" . }}
+  labels:
+    app: {{ template "cpi.name" . }}
+    vsphere-cpi-infra: service
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: cloud-controller
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  namespace: kube-system
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  ports:
+  - name: cpi-api
+    port: {{ .Values.service.endpointPort }}
+    protocol: TCP
+    targetPort: {{ .Values.service.targetPort }}
+  selector:
+    app: {{ template "cpi.name" . }}
+    component: cloud-controller
+    release: {{ .Release.Name }}
+    vsphere-cpi-infra: vsphere-cpi-daemonset
+  type: {{ .Values.service.type }}
+{{- template "loadBalancerSourceRanges" .Values }}
+{{- end -}}

--- a/stable/vsphere-cpi/values.yaml
+++ b/stable/vsphere-cpi/values.yaml
@@ -1,0 +1,72 @@
+# Default values for vSphere CPI.
+# This is a YAML-formatted file.
+# vSohere CPI values are grouped by component
+
+config:
+  enabled: false
+  vcenter: "vcenter.local"
+  username: "user"
+  password: "pass"
+  datacenter: "dc"
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  name: cloud-controller-manager
+
+daemonset:
+  annotations: {}
+  image: gcr.io/cloud-provider-vsphere/cpi/release/manager
+  tag: v1.0.0
+  pullPolicy: IfNotPresent
+  dnsPolicy: ClusterFirst
+  cmdline:
+    logging: 2
+    # Location of the cloud configmap to be mounted on the filesystem
+    cloudConfig:
+      dir: "/etc/cloud"
+      file: "vsphere.conf"
+    additionalParams: {}
+  replicaCount: 1
+  resources: {}
+    # limits:
+    #   cpu: 500m
+    #   memory: 512Mi
+    # requests:
+    #    cpu: 256m
+    #    memory: 128Mi
+  podAnnotations: {}
+  ## Additional pod labels
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
+
+service:
+  enabled: false
+  annotations: {}
+  type: ClusterIP
+  # List of IP ranges that are allowed to access the load balancer (if supported)
+  loadBalancerSourceRanges: []
+  # endpointPort: externally accessible port for UI and API
+  endpointPort: 43001
+  # targetPort: the internal port the UI and API are exposed on
+  targetPort: 43001
+
+ingress:
+  enabled: false
+  annotations: {}
+  # Used to create an Ingress record.
+  # hosts:
+  #   - chart-example.local
+  # annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  # tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local


### PR DESCRIPTION
#### What this PR does / why we need it:
This introduces the initial release for the vSphere Cloud Provider Interface (CPI) located at https://github.com/kubernetes/cloud-provider-vsphere. There is a move to take all the cloud providers from in-tree to out-of-tree (link: https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/0019-cloud-provider-documentation.md). This Helm Chart will enable users to consume the out-of-tree CPI easier by providing a simple deployment mechanism via Helm.

#### Special notes for your reviewer:
Tested using:
- Helm v3.0.0-rc.3
- vSphere CPI image v1.0.0 (GA release)
- Kubernetes cluster 1.15.4 and 1.16.2 configured for an external cloud provider
- vSphere 6.7u3

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
