### PR TITLE
[stable/concourse] update apiVersion for k8s 1.16 compatibility

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: concourse
-version: 8.2.7
+version: 8.2.8
 appVersion: 5.6.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/_helpers.tpl
+++ b/stable/concourse/templates/_helpers.tpl
@@ -61,3 +61,14 @@ Creates the address of the TSA service.
 {{- $port := .Values.concourse.web.tsa.bindPort -}}
 {{ template "concourse.web.fullname" . }}:{{- print $port -}}
 {{- end -}}
+
+{{/*
+Return the apiVersion of deployment.
+*/}}
+{{- define "deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.web.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "concourse.web.fullname" . }}
@@ -10,6 +10,13 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: {{ .Values.web.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "concourse.web.fullname" . }}
+      release: "{{ .Release.Name }}"
+      {{- with .Values.web.labels }}
+{{ toYaml . | trim | indent 6 }}
+      {{- end }}
 {{- if .Values.web.strategy }}
 {{ toYaml .Values.web.strategy | indent 2 }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: makocchi-git <makocchi@gmail.com>

#### What this PR does / why we need it:

This PR updates the apiVersion for concourse web deployment so that it is Kubernetes 1.16 compatible.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
