### PR TITLE
[stable/datadog] Fix `passwd` volume error when `processAgentEnabled` is unset

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.38.6
+version: 1.38.7
 appVersion: 6.14.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -136,7 +136,7 @@ spec:
           name: logcontainerpath
         {{- end }}
         {{- end }}
-        {{- if or .Values.datadog.processAgentEnabled .Values.systemProbe.enabled }}
+        {{- if or (kindIs "invalid" .Values.datadog.processAgentEnabled) .Values.datadog.processAgentEnabled .Values.systemProbe.enabled }}
         - hostPath:
             path: /etc/passwd
           name: passwd


### PR DESCRIPTION
When `processAgentEnabled` is not set, trying to instantiate the datadog chart caused the following error:

```
Error: release datadog failed: DaemonSet.apps "datadog" is invalid: spec.template.spec.containers[1].volumeMounts[2].name: Not found: "passwd"
```