### PR TITLE
[stable/prometheus] allow non-yaml objects for configmap values

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 9.3.1
+version: 9.3.2
 appVersion: 2.13.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/server-configmap.yaml
+++ b/stable/prometheus/templates/server-configmap.yaml
@@ -14,15 +14,19 @@ data:
     global:
 {{ $root.Values.server.global | toYaml | trimSuffix "\n" | indent 6 }}
 {{- end }}
-{{- if and (eq $key "alerts") (empty $value.groups) }}
+{{- if eq $key "alerts" }}
+{{- if and (not (empty $value)) (empty $value.groups) }}
     groups:
 {{- range $ruleKey, $ruleValue := $value }}
     - name: {{ $ruleKey -}}.rules
       rules:
 {{ $ruleValue | toYaml | trimSuffix "\n" | indent 6 }}
 {{- end }}
-{{ else }}
+{{- else }}
 {{ toYaml $value | indent 4 }}
+{{- end }}
+{{- else }}
+{{ toYaml $value | default "{}" | indent 4 }}
 {{- end }}
 {{- if eq $key "prometheus.yml" -}}
 {{- if $root.Values.extraScrapeConfigs }}


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Fixes the bug quoted here: [https://github.com/helm/charts/pull/18112#issuecomment-550349123](https://github.com/helm/charts/pull/18112#issuecomment-550349123)

#### Special notes for your reviewer:
- Introduce feature allowing multiple alerts files
- Fix the bug introduced in #18112 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
