### PR TITLE
[stable/wordpress] bump major version

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 7.6.8
+version: 8.0.0
 appVersion: 5.2.4
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -356,6 +356,14 @@ See the [Parameters](#parameters) section to configure the PVC or to disable per
 
 ## Upgrading
 
+### To 8.0.0
+
+Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.
+
+In https://github.com/helm/charts/pulls/12642 the `apiVersion` of the deployment resources was updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.
+
+This major version signifies this change.
+
 ### To 3.0.0
 
 Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.

--- a/stable/wordpress/requirements.lock
+++ b/stable/wordpress/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.13.0
-digest: sha256:2ee24c91cd38aab43cd1985a7aaf24cbd0994ab5fd48e5f76eba17c3cffbaea1
-generated: 2019-11-05T10:47:15.794215538Z
+  version: 7.0.1
+digest: sha256:0a5be71f27bb4258b63df284f5006ab452666b4c3125a1c15b8753e71ec8c118
+generated: "2019-11-13T22:19:01.807877447+05:30"

--- a/stable/wordpress/requirements.yaml
+++ b/stable/wordpress/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  version: 6.x.x
+  version: 7.x.x
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: mariadb.enabled
   tags:

--- a/stable/wordpress/templates/_helpers.tpl
+++ b/stable/wordpress/templates/_helpers.tpl
@@ -170,3 +170,14 @@ Return the appropriate apiVersion for ingress.
 {{- print "networking.k8s.io/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "wordpress.deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/wordpress/templates/deployment.yaml
+++ b/stable/wordpress/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: {{ template "wordpress.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "wordpress.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.

In https://github.com/helm/charts/pulls/12642 the `apiVersion` of the deployment resources was updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.

This major version signifies this change.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)