### PR TITLE
[stable/airflow] feature needed to add paths to ingress before default not only after.

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 4.3.1
+version: 4.4.0
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -31,6 +31,17 @@ the `values.yaml` depending on your setup.
 Please read the comments in the `values.yaml` file for more details on how to configure your reverse
 proxy or load balancer.
 
+#### Customizable Ingress Rules
+
+This chart enables you to add various paths in the ingress. It includes two values for you to customize these paths, `precedingPaths` and `succeedingPaths`. The reason there are two possible paths values is because order of paths in an ingress rule matters and because we always add a default path in this chart that routes to the web interface we need loops that allow us to possibly add routes after or before this default one. An example of this happening is if an instance of traffic is routed to a path that covers multiple paths in the http ingress rule, the instance of traffic will be routed to the first one and then the second one. A common case of this will appear when enabling https for this chart using the ingress controller. For example the aws alb ingress controller's ssl-redirect [here](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/tasks/ssl_redirect/) needs the redirect route path to be hit before the airflow-web one. So you will set the values of `precedingPaths` as the following:
+
+```yaml
+precedingPaths:
+  - path: "/*"
+    serviceName: "ssl-redirect"
+    servicePort: "use-annotation"
+```
+
 ### Chart Prefix
 
 This Helm automatically prefixes all names using the release name to avoid collisions.

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -397,6 +397,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `ingress.web.tls.enabled`                | enables TLS termination at the ingress                  | `false`                   |
 | `ingress.web.tls.secretName`             | name of the secret containing the TLS certificate & key | ``                        |
 | `ingress.web.paths`                      | additional paths for the ingress                        | `{}`                      |
+| `ingress.web.precedingPaths`                      | additional paths for the ingress that come before default path to airflow-web                      | `{}`                      |
 | `ingress.flower.host`                    | hostname for the flower ui                              | ""                        |
 | `ingress.flower.path`                    | path of the flower ui (read `values.yaml`)              | ``                        |
 | `ingress.flower.livenessPath`            | path to the liveness probe (read `values.yaml`)         | `/`                       |

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -407,7 +407,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `ingress.web.livenessPath`               | path to the web liveness probe                          | `{{ ingress.web.path }}/health` |
 | `ingress.web.tls.enabled`                | enables TLS termination at the ingress                  | `false`                   |
 | `ingress.web.tls.secretName`             | name of the secret containing the TLS certificate & key | ``                        |
-| `ingress.web.paths`                      | additional paths for the ingress                        | `{}`                      |
+| `ingress.web.succeedingPaths`                      | additional paths for the ingress coming after the airflow-web path                        | `{}`                      |
 | `ingress.web.precedingPaths`                      | additional paths for the ingress that come before default path to airflow-web                      | `{}`                      |
 | `ingress.flower.host`                    | hostname for the flower ui                              | ""                        |
 | `ingress.flower.path`                    | path of the flower ui (read `values.yaml`)              | ``                        |

--- a/stable/airflow/templates/ingress-web.yaml
+++ b/stable/airflow/templates/ingress-web.yaml
@@ -23,6 +23,12 @@ spec:
   rules:
     - http:
         paths:
+          {{- range .Values.ingress.web.precedingPaths }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ .serviceName }}
+              servicePort: {{ .servicePort }}
+          {{- end }}
           - path: {{ .Values.ingress.web.path }}
             backend:
               serviceName: {{ template "airflow.fullname" . }}-web

--- a/stable/airflow/templates/ingress-web.yaml
+++ b/stable/airflow/templates/ingress-web.yaml
@@ -33,7 +33,7 @@ spec:
             backend:
               serviceName: {{ template "airflow.fullname" . }}-web
               servicePort: web
-          {{- range .Values.ingress.web.paths }}
+          {{- range .Values.ingress.web.succeedingPaths }}
           - path: {{ .path }}
             backend:
               serviceName: {{ .serviceName }}

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -365,12 +365,19 @@ ingress:
       ## If enabled, set "secretName" to the secret containing the TLS private key and certificate
       ## Example:
       ## secretName: example-com-crt
+    precedingPaths:
+      ## Different http paths to add to the ingress before the default path 
+      ## Example:
+      ## - path: "/*"
+      ##   serviceName: "ssl-redirect"
+      ##   servicePort: "use-annotation"
     paths:
       ## Different http paths to add to the ingress
       ## Example:
       ## - path: "/*"
       ##   serviceName: "ssl-redirect"
       ##   servicePort: "use-annotation"
+    
   ##
   ## Configure the flower endpoind
   flower:

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -371,8 +371,8 @@ ingress:
       ## - path: "/*"
       ##   serviceName: "ssl-redirect"
       ##   servicePort: "use-annotation"
-    paths:
-      ## Different http paths to add to the ingress
+    succeedingPaths:
+      ## Different http paths to add to the ingress after the default path
       ## Example:
       ## - path: "/*"
       ##   serviceName: "ssl-redirect"

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -366,7 +366,7 @@ ingress:
       ## Example:
       ## secretName: example-com-crt
     precedingPaths:
-      ## Different http paths to add to the ingress before the default path 
+      ## Different http paths to add to the ingress before the default path
       ## Example:
       ## - path: "/*"
       ##   serviceName: "ssl-redirect"
@@ -377,7 +377,7 @@ ingress:
       ## - path: "/*"
       ##   serviceName: "ssl-redirect"
       ##   servicePort: "use-annotation"
-    
+
   ##
   ## Configure the flower endpoind
   flower:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No but it adds a feature so I bumped it up to 4.4.0
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

#### What this PR does / why we need it:
Recently I submitted a pull request to enable additional ingress paths to be added to the chart(https://github.com/helm/charts/pull/18466). To do this I added a for loop of in which you can added multiple paths. I did not realize then though that paths have order so we need to be able to put paths before the default airflow-web ingress paths not just after. If you need clarification here is a page documented for the aws alb ingress controller than specifically says order of paths matter and the ssl-redirect must be the first path(look at notes in bottom of code https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/tasks/ssl_redirect/). If you want to rename the original paths array I added I suggest doing so I did not want to break anything if it uses paths in there values already though.  
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
Feel free to change the names of things but this feature is definitely needed and I am sorry I did not add in original pull request. Thank you for your time.
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
