### PR TITLE
[stable/prometheus-pushgateway] Adjust servicemonitor labels

### DIFF
--- a/stable/prometheus-pushgateway/Chart.yaml
+++ b/stable/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.2.2
+version: 1.2.3
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/stable/prometheus-pushgateway/Chart.yaml
+++ b/stable/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.2.3
+version: 1.2.4
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/stable/prometheus-pushgateway/README.md
+++ b/stable/prometheus-pushgateway/README.md
@@ -38,37 +38,37 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the pushgateway chart and their default values.
 
-|        Parameter            |                                                          Description                                                          |      Default                      |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
-| `affinity`                  | Affinity settings for pod assignment                                                                                          | `{}`                              |
-| `extraArgs`                 | Optional flags for pushgateway                                                                                                | `[]`                              |
-| `extraVars`                 | Optional environment variables for pushgateway                                                                                | `[]`                              |
-| `image.repository`          | Image repository                                                                                                              | `prom/pushgateway`                |
-| `image.tag`                 | Image tag                                                                                                                     | `v1.0.0`                          |
-| `image.pullPolicy`          | Image pull policy                                                                                                             | `IfNotPresent`                    |
-| `ingress.enabled`           | Enables Ingress for pushgateway                                                                                               | `false`                           |
-| `ingress.annotations`       | Ingress annotations                                                                                                           | `{}`                              |
-| `ingress.hosts`             | Ingress accepted hostnames                                                                                                    | `nil`                             |
-| `ingress.tls`               | Ingress TLS configuration                                                                                                     | `[]`                              |
-| `resources`                 | CPU/Memory resource requests/limits                                                                                           | `{}`                              |
-| `replicaCount`              | Number of replicas                                                                                                            | `1`                               |
-| `service.type`              | Service type                                                                                                                  | `ClusterIP`                       |
-| `service.port`              | The service port                                                                                                              | `9091`                            |
-| `service.targetPort`        | The target port of the container                                                                                              | `9091`                            |
-| `serviceLabels`             | Labels for service                                                                                                            | `{}`                              |
-| `serviceAccount.create`     | Specifies whether a service account should be created.                                                                        | `true`                            |
-| `serviceAccount.name`       | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |                                   |
-| `tolerations`               | List of node taints to tolerate                                                                                               | `{}`                              |
-| `nodeSelector`              | Node labels for pod assignment                                                                                                | `{}`                              |
-| `podAnnotations`            | Annotations for pod                                                                                                           | `{}`                              |
-| `podLabels`                 | Labels for pod                                                                                                                | `{}`                              |
-| `serviceAccountLabels`      | Labels for service account                                                                                                    | `{}`                              |
-| `serviceMonitor.enabled`    | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)                        | `false`                           |
-| `serviceMonitor.namespace`  | Namespace which Prometheus is running in                                                                                      | `monitoring`                      |
-| `serviceMonitor.interval`   | How frequently to scrape metrics (use by default, falling back to Prometheus' default)                                        |  `nil`                            |
-| `serviceMonitor.selector`   | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install                    | `{ prometheus: kube-prometheus }` |
-| `serviceMonitor.honorLabels`| if `true`, label conflicts are resolved by keeping label values from the scraped data                                         | `true`                            |
-| `podDisruptionBudget`       | If set, create a PodDisruptionBudget with the items in this map set in the spec                                               | ``                                |
+|        Parameter                  |                                                          Description                                                          |      Default                      |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `affinity`                        | Affinity settings for pod assignment                                                                                          | `{}`                              |
+| `extraArgs`                       | Optional flags for pushgateway                                                                                                | `[]`                              |
+| `extraVars`                       | Optional environment variables for pushgateway                                                                                | `[]`                              |
+| `image.repository`                | Image repository                                                                                                              | `prom/pushgateway`                |
+| `image.tag`                       | Image tag                                                                                                                     | `v1.0.0`                          |
+| `image.pullPolicy`                | Image pull policy                                                                                                             | `IfNotPresent`                    |
+| `ingress.enabled`                 | Enables Ingress for pushgateway                                                                                               | `false`                           |
+| `ingress.annotations`             | Ingress annotations                                                                                                           | `{}`                              |
+| `ingress.hosts`                   | Ingress accepted hostnames                                                                                                    | `nil`                             |
+| `ingress.tls`                     | Ingress TLS configuration                                                                                                     | `[]`                              |
+| `resources`                       | CPU/Memory resource requests/limits                                                                                           | `{}`                              |
+| `replicaCount`                    | Number of replicas                                                                                                            | `1`                               |
+| `service.type`                    | Service type                                                                                                                  | `ClusterIP`                       |
+| `service.port`                    | The service port                                                                                                              | `9091`                            |
+| `service.targetPort`              | The target port of the container                                                                                              | `9091`                            |
+| `serviceLabels`                   | Labels for service                                                                                                            | `{}`                              |
+| `serviceAccount.create`           | Specifies whether a service account should be created.                                                                        | `true`                            |
+| `serviceAccount.name`             | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |                                   |
+| `tolerations`                     | List of node taints to tolerate                                                                                               | `{}`                              |
+| `nodeSelector`                    | Node labels for pod assignment                                                                                                | `{}`                              |
+| `podAnnotations`                  | Annotations for pod                                                                                                           | `{}`                              |
+| `podLabels`                       | Labels for pod                                                                                                                | `{}`                              |
+| `serviceAccountLabels`            | Labels for service account                                                                                                    | `{}`                              |
+| `serviceMonitor.enabled`          | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)                        | `false`                           |
+| `serviceMonitor.namespace`        | Namespace which Prometheus is running in                                                                                      | `monitoring`                      |
+| `serviceMonitor.interval`         | How frequently to scrape metrics (use by default, falling back to Prometheus' default)                                        |  `nil`                            |
+| `serviceMonitor.additionalLables` | Used to pass Labels that are required by the Installed Prometheus Operator                                                    | `{}`                              |
+| `serviceMonitor.honorLabels`      | if `true`, label conflicts are resolved by keeping label values from the scraped data                                         | `true`                            |
+| `podDisruptionBudget`             | If set, create a PodDisruptionBudget with the items in this map set in the spec                                               | ``                                |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-pushgateway/templates/servicemonitor.yaml
+++ b/stable/prometheus-pushgateway/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "prometheus-pushgateway.name" .  }}
+  name: {{ template "prometheus-pushgateway.fullname" .  }}
   {{- if .Values.serviceMonitor.namespace }}
   namespace: {{ .Values.serviceMonitor.namespace }}
   {{- end }}

--- a/stable/prometheus-pushgateway/templates/servicemonitor.yaml
+++ b/stable/prometheus-pushgateway/templates/servicemonitor.yaml
@@ -7,8 +7,12 @@ metadata:
   namespace: {{ .Values.serviceMonitor.namespace }}
   {{- end }}
   labels:
-    {{- range $key, $value := .Values.serviceMonitor.selector }}
-    {{ $key }}: {{ $value | quote }}
+    app: {{ template "prometheus-pushgateway.name" . }}
+    chart: {{ template "prometheus-pushgateway.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    {{- if .Values.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
     {{- end }}
 spec:
   endpoints:
@@ -17,7 +21,13 @@ spec:
     interval: {{ .Values.serviceMonitor.interval }}
     {{- end }}
     honorLabels: {{ .Values.serviceMonitor.honorLabels }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
   selector:
     matchLabels:
       app: {{ template "prometheus-pushgateway.name" . }}
+      chart: {{ template "prometheus-pushgateway.chart" . }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
 {{- end -}}

--- a/stable/prometheus-pushgateway/templates/servicemonitor.yaml
+++ b/stable/prometheus-pushgateway/templates/servicemonitor.yaml
@@ -27,7 +27,5 @@ spec:
   selector:
     matchLabels:
       app: {{ template "prometheus-pushgateway.name" . }}
-      chart: {{ template "prometheus-pushgateway.chart" . }}
       release: {{ .Release.Name }}
-      heritage: {{ .Release.Service }}
 {{- end -}}

--- a/stable/prometheus-pushgateway/values.yaml
+++ b/stable/prometheus-pushgateway/values.yaml
@@ -98,11 +98,11 @@ serviceMonitor:
   namespace: monitoring
   # fallback to the prometheus default unless specified
   # interval: 10s
-  ## Defaults to what's used if you follow CoreOS [Prometheus Install Instructions](https://github.com/helm/charts/tree/master/stable/prometheus-operator#tldr)
-  ## [Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#prometheus-operator-1)
-  ## [Kube Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#exporters)
-  selector:
-    prometheus: kube-prometheus
+
+  ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+  additionalLabels: {}
+
   # Retain the job and instance labels of the metrics pushed to the Pushgateway
   # [Scraping Pushgateway](https://github.com/prometheus/pushgateway#configure-the-pushgateway-as-a-target-to-scrape)
   honorLabels: true


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
Actual label selecting of servicemonitor is not usable. Namespace selector was missing too. 
- Adjusted labels and selectors to match by default. 
- Added possibility to add extra labels for customized prometheus setups. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
