### PR TITLE
[metallb] remove deprecations, fix indents

### DIFF
--- a/stable/metallb/Chart.yaml
+++ b/stable/metallb/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.12.0
+version: 0.12.1
 name: metallb
 appVersion: 0.8.1
 description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters

--- a/stable/metallb/templates/controller.yaml
+++ b/stable/metallb/templates/controller.yaml
@@ -23,30 +23,30 @@ spec:
         chart: {{ template "metallb.chart" . }}
         app: {{ template "metallb.name" . }}
         component: controller
-{{- if .Values.prometheus.scrapeAnnotations }}
+      {{- if .Values.prometheus.scrapeAnnotations }}
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "7472"
-{{- end }}
+      {{- end }}
     spec:
+      priorityClassName: metallb 
       serviceAccountName: {{ template "metallb.controllerServiceAccountName" . }}
       terminationGracePeriodSeconds: 0
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534 # nobody
+      {{- with .Values.controller.nodeSelector }}
       nodeSelector:
-        "beta.kubernetes.io/os": linux
-        {{- with .Values.controller.nodeSelector }}
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.controller.tolerations }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.controller.affinity }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: controller
         image: {{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}
@@ -58,7 +58,7 @@ spec:
         - name: monitoring
           containerPort: 7472
         resources:
-{{ toYaml .Values.controller.resources | indent 10 }}
+          {{ toYaml .Values.controller.resources | nindent 10 }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/stable/metallb/templates/controller.yaml
+++ b/stable/metallb/templates/controller.yaml
@@ -29,7 +29,6 @@ spec:
         prometheus.io/port: "7472"
       {{- end }}
     spec:
-      priorityClassName: metallb 
       serviceAccountName: {{ template "metallb.controllerServiceAccountName" . }}
       terminationGracePeriodSeconds: 0
       securityContext:

--- a/stable/metallb/templates/speaker.yaml
+++ b/stable/metallb/templates/speaker.yaml
@@ -28,16 +28,13 @@ spec:
         prometheus.io/port: "7472"
 {{- end }}
     spec:
+      priorityClassName: metallb
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       serviceAccountName: {{ template "metallb.speakerServiceAccountName" . }}
       terminationGracePeriodSeconds: 0
       hostNetwork: true
-{{- if gt (len .Values.speaker.initContainers) 0 }}
-      initContainers:
-{{ toYaml .Values.speaker.initContainers | indent 8 }}
-{{- end }}
       containers:
       - name: speaker
         image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag }}
@@ -58,7 +55,7 @@ spec:
         - name: monitoring
           containerPort: 7472
         resources:
-{{ toYaml .Values.speaker.resources | indent 10 }}
+          {{ toYaml .Values.speaker.resources | nindent 10 }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -69,16 +66,15 @@ spec:
             - NET_ADMIN
             - NET_RAW
             - SYS_ADMIN
+      {{- with .Values.speaker.nodeSelector }}
       nodeSelector:
-        "beta.kubernetes.io/os": linux
-        {{- with .Values.speaker.nodeSelector }}
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.speaker.tolerations }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.speaker.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.speaker.affinity }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.speaker.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}

--- a/stable/metallb/templates/speaker.yaml
+++ b/stable/metallb/templates/speaker.yaml
@@ -28,7 +28,6 @@ spec:
         prometheus.io/port: "7472"
 {{- end }}
     spec:
-      priorityClassName: metallb
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule


### PR DESCRIPTION
removed `beta.kubernetes.io/os`, for it is deprecated and  targeted for removal in v1.18.
see https://kubernetes.io/docs/setup/release/notes/#deprecations-and-removals

also fixed some (n)indents