### PR TITLE
[stable/nginx-ingress] Now possible to define namespaces to scrape by prometheus

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.24.7
+version: 1.25.0
 appVersion: 0.26.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -139,6 +139,7 @@ Parameter | Description | Default
 `controller.metrics.serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`
 `controller.metrics.serviceMonitor.honorLabels` | honorLabels chooses the metric's labels on collisions with target labels. | `false`
 `controller.metrics.serviceMonitor.namespace` | namespace where servicemonitor resource should be created | `the same namespace as nginx ingress`
+`controller.metrics.serviceMonitor.namespaceSelector` | [namespaceSelector](https://github.com/coreos/prometheus-operator/blob/v0.34.0/Documentation/api.md#namespaceselector) to configure what namespaces to scrape | `will scrape the helm release namespace only`
 `controller.metrics.serviceMonitor.scrapeInterval` | interval between Prometheus scraping | `30s`
 `controller.metrics.prometheusRule.enabled` | Set this to `true` to create prometheusRules for Prometheus operator | `false`
 `controller.metrics.prometheusRule.additionalLabels` | Additional labels that can be used so prometheusRules will be discovered by Prometheus | `{}`

--- a/stable/nginx-ingress/templates/controller-servicemonitor.yaml
+++ b/stable/nginx-ingress/templates/controller-servicemonitor.yaml
@@ -22,9 +22,14 @@ spec:
       {{- if .Values.controller.metrics.serviceMonitor.honorLabels }}
       honorLabels: true
       {{- end }}
+  {{- if .Values.controller.metrics.serviceMonitor.namespaceSelector }}
+  namespaceSelector:
+{{ toYaml .Values.controller.metrics.serviceMonitor.namespaceSelector | indent 4 -}}
+  {{ else }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "nginx-ingress.name" . }}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -364,6 +364,11 @@ controller:
       enabled: false
       additionalLabels: {}
       namespace: ""
+      namespaceSelector: {}
+      # Default: scrape .Release.Namespace only
+      # To scrape all, use the following:
+      # namespaceSelector:
+      #   any: true
       scrapeInterval: 30s
       # honorLabels: true
 


### PR DESCRIPTION
Signed-off-by: Emil Marklund <emil.marklund@vkmedia.se>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
no

#### What this PR does / why we need it:
add capability to define namespaceselector for metric scraping. Now it defaults to only scraping the namespace where nginx-ingress was deployed, without a possibility to customize.

#### Which issue this PR fixes

#### Special notes for your reviewer:
There are two confusing namespace variables in this chart,  `controller.metrics.serviceMonitor.namespace` (where should the serviceMonitor be deployed? has nothing to do with what will be scraped, just organization of kubernetes resources) and `controller.metrics.prometheusRule.namespace` (where should PrometheusRules be deployed? just another matter of organizing kubernetes resources - very unlikely that someone would want to configure this differently than `controller.metrics.serviceMonitor.namespace`). These two confused me a bit while searching how to configure servicemonitor scrape all namespaces.

Admittedly, adding yet another namespace variable (as this PR does) adds more confusion, but I would suggest combining `controller.metrics.serviceMonitor.namespace` and `controller.metrics.prometheusRule.namespace` into one variable. Something like `controller.metrics.resourceNamespace`. How this best is done, I don't know. Mark the two for deprecation in some matter and in a major version bump, remove them?

Also, I would suggest a better default for namespace scraping to be "scrape all nginx-ingresses in all namespaces"
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
