### PR TITLE
stable/jenkins: option to set existing secret with Google Application Default Credentials

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.9.2
+version: 1.9.3
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -371,21 +371,23 @@ Adds a backup CronJob for jenkins, along with required RBAC resources.
 
 ### Backup Values
 
-| Parameter                              | Description                                            | Default                           |
-| -------------------------------------- | ------------------------------------------------------ | --------------------------------- |
-| `backup.enabled`                       | Enable the use of a backup CronJob                     | `false`                           |
-| `backup.schedule`                      | Schedule to run jobs                                   | `0 2 * * *`                       |
-| `backup.annotations`                   | Backup pod annotations                                 | iam.amazonaws.com/role: `jenkins` |
-| `backup.image.repo`                    | Backup image repository                                | `maorfr/kube-tasks`               |
-| `backup.image.tag`                     | Backup image tag                                       | `0.2.0`                           |
-| `backup.extraArgs`                     | Additional arguments for kube-tasks                    | `[]`                              |
-| `backup.existingSecret`                | Environment variables to add to the cronjob container  | {}                                |
-| `backup.existingSecret.*`              | Specify the secret name containing the AWS credentials | `jenkinsaws`                      |
-| `backup.existingSecret.*.awsaccesskey` | `secretKeyRef.key` used for `AWS_ACCESS_KEY_ID`        | `jenkins_aws_access_key`          |
-| `backup.existingSecret.*.awssecretkey` | `secretKeyRef.key` used for `AWS_SECRET_ACCESS_KEY`    | `jenkins_aws_secret_key`          |
-| `backup.env`                           | Backup environment variables                           | AWS_REGION: `us-east-1`           |
-| `backup.resources`                     | Backup CPU/Memory resource requests/limits             | Memory: `1Gi`, CPU: `1`           |
-| `backup.destination`                   | Destination to store backup artifacts                  | `s3://jenkins-data/backup`        |
+| Parameter                                | Description                                                       | Default                           |
+| ---------------------------------------- | ----------------------------------------------------------------- | --------------------------------- |
+| `backup.enabled`                         | Enable the use of a backup CronJob                                | `false`                           |
+| `backup.schedule`                        | Schedule to run jobs                                              | `0 2 * * *`                       |
+| `backup.labels`                          | Backup pod labels                                                 |                                   |
+| `backup.annotations`                     | Backup pod annotations                                            |                                   |
+| `backup.image.repo`                      | Backup image repository                                           | `maorfr/kube-tasks`               |
+| `backup.image.tag`                       | Backup image tag                                                  | `0.2.0`                           |
+| `backup.extraArgs`                       | Additional arguments for kube-tasks                               | `[]`                              |
+| `backup.existingSecret`                  | Environment variables to add to the cronjob container             | {}                                |
+| `backup.existingSecret.*`                | Specify the secret name containing the AWS or GCP credentials     | `jenkinsaws`                      |
+| `backup.existingSecret.*.awsaccesskey`   | `secretKeyRef.key` used for `AWS_ACCESS_KEY_ID`                   | `jenkins_aws_access_key`          |
+| `backup.existingSecret.*.awssecretkey`   | `secretKeyRef.key` used for `AWS_SECRET_ACCESS_KEY`               | `jenkins_aws_secret_key`          |
+| `backup.existingSecret.*.gcpcredentials` | Mounts secret as volume and sets `GOOGLE_APPLICATION_CREDENTIALS` | `credentials.json`                |
+| `backup.env`                             | Backup environment variables                                      |                                   |
+| `backup.resources`                       | Backup CPU/Memory resource requests/limits                        | Memory: `1Gi`, CPU: `1`           |
+| `backup.destination`                     | Destination to store backup artifacts                             | `s3://jenkins-data/backup`        |
 
 ### Restore from backup
 

--- a/stable/jenkins/templates/jenkins-backup-cronjob.yaml
+++ b/stable/jenkins/templates/jenkins-backup-cronjob.yaml
@@ -18,8 +18,14 @@ spec:
     spec:
       template:
         metadata:
+          {{- if .Values.backup.labels }}
+          labels:
+{{ toYaml .Values.backup.labels | trim | indent 12 }}
+          {{- end }}
+          {{- if .Values.backup.annotations }}
           annotations:
-            {{ toYaml .Values.backup.annotations }}
+{{ toYaml .Values.backup.annotations | trim | indent 12 }}
+          {{- end }}
         spec:
           restartPolicy: OnFailure
           serviceAccountName: {{ template "jenkins.fullname" . }}-backup
@@ -42,27 +48,54 @@ spec:
             {{- with .Values.backup.extraArgs }}
 {{ toYaml . | indent 12 }}
             {{- end }}
-            {{- with .Values.backup.env }}
             env:
-{{ toYaml . | indent 12 }}
+            {{- with .Values.backup.env }}
+{{ toYaml . | trim | indent 12 }}
             {{- end }}
             {{- if .Values.backup.existingSecret }}
             {{- range $key,$value := .Values.backup.existingSecret }}
+            {{- if $value.awsaccesskey }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ $key }}
                   key: {{ $value.awsaccesskey | quote }}
+            {{- end }}
+            {{- if $value.awssecretkey }}
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ $key }}
                   key: {{ $value.awssecretkey | quote}}
             {{- end }}
+            {{- if $value.gcpcredentials }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/var/run/secrets/{{ $key }}/{{ $value.gcpcredentials }}"
+            {{- end }}
+            {{- end }}
             {{- end }}
           {{- with .Values.backup.resources }}
             resources:
-{{ toYaml . | indent 14 }}
+{{ toYaml . | trim | indent 14 }}
+          {{- end }}
+            volumeMounts:
+          {{- if .Values.backup.existingSecret }}
+          {{- range $key,$value := .Values.backup.existingSecret }}
+          {{- if $value.gcpcredentials }}
+            - mountPath: /var/run/secrets/{{ $key }}
+              name: {{ $key }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          volumes:
+          {{- if .Values.backup.existingSecret }}
+          {{- range $key,$value := .Values.backup.existingSecret }}
+          {{- if $value.gcpcredentials }}
+          - name:  {{ $key }}
+            secret:
+              secretName:  {{ $key }}
+          {{- end }}
+          {{- end }}
           {{- end }}
           affinity:
             podAffinity:

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -485,10 +485,11 @@ backup:
   # Schedule to run jobs. Must be in cron time format
   # Ref: https://crontab.guru/
   schedule: "0 2 * * *"
+  labels:
   annotations:
     # Example for authorization to AWS S3 using kube2iam
     # Can also be done using environment variables
-    iam.amazonaws.com/role: "jenkins"
+    #iam.amazonaws.com/role: "jenkins"
   image:
     repository: "maorfr/kube-tasks"
     tag: "0.2.0"
@@ -504,10 +505,13 @@ backup:
   ## Use this key for AWS secret access key
      # awssecretkey: jenkins_aws_secret_key
   # Add additional environment variables
+   # jenkinsgcp:
+  ## Use this key for GCP credentials
+     # gcpcredentials: credentials.json
   env:
   # Example environment variable required for AWS credentials chain
-  - name: "AWS_REGION"
-    value: "us-east-1"
+  #- name: "AWS_REGION"
+  #  value: "us-east-1"
   resources:
     requests:
       memory: 1Gi

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -489,7 +489,7 @@ backup:
   annotations:
     # Example for authorization to AWS S3 using kube2iam
     # Can also be done using environment variables
-    #iam.amazonaws.com/role: "jenkins"
+    # iam.amazonaws.com/role: "jenkins"
   image:
     repository: "maorfr/kube-tasks"
     tag: "0.2.0"
@@ -510,8 +510,8 @@ backup:
      # gcpcredentials: credentials.json
   env:
   # Example environment variable required for AWS credentials chain
-  #- name: "AWS_REGION"
-  #  value: "us-east-1"
+  # - name: "AWS_REGION"
+  #   value: "us-east-1"
   resources:
     requests:
       memory: 1Gi


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
<!--
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.
-->

#### What this PR does / why we need it:

The chart had the option for specifying the existing secret containing the AWS credentials. The underlying code created AWS-specific environmental variables for backup POD. Despite of the fact that backup utility is able to copy files to different cloud storages, this helm chart could not configure Google Cloud Storage. Google application credentials are kept in a file, which has to be mounted to a pod. This PR adds an option to set `gcpcredentials` in `existingSecret` as follows:

```
 existingSecret:
    jenkins-service-account:
      gcpcredentials: application_default_credentials.json
```

Helm template then creates the necessary volume mounts and `GOOGLE_APPLICATION_CREDENTIALS` envrionmental variable. So with this change, developer now can configure either AWS or GCP storage. 

It also adds and option to set backup pod labels, which are necessary to apply custom network policies. For example, if default policy denies everything, an application then can define custom rules to whitelist the connections it needs. So it needs labels for that.

AWS-specific defaults have been commented for backup module, as they have to be set explicitly.

#### Checklist
<!--[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]-->
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/jenkins]`)
