### PR TITLE
[incubator/fluentd-cloudwatch] add annotations for Service Account

### DIFF
--- a/incubator/fluentd-cloudwatch/Chart.yaml
+++ b/incubator/fluentd-cloudwatch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd-cloudwatch
-version: 0.11.1
+version: 0.11.2
 appVersion: v1.7.3-debian-cloudwatch-1.0
 description: A Fluentd CloudWatch Helm chart for Kubernetes.
 home: https://www.fluentd.org/

--- a/incubator/fluentd-cloudwatch/README.md
+++ b/incubator/fluentd-cloudwatch/README.md
@@ -46,35 +46,36 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Fluentd Cloudwatch chart and their default values.
 
-| Parameter                    | Description                                                                     | Default                               |
-| ---------------------------- | ------------------------------------------------------------------------------- | --------------------------------------|
-| `image.repository`           | Image repository                                                                | `fluent/fluentd-kubernetes-daemonset` |
-| `image.tag`                  | Image tag                                                                       | `v1.3.3-debian-cloudwatch-1.0`        |
-| `image.pullPolicy`           | Image pull policy                                                               | `IfNotPresent`                        |
-| `resources.limits.cpu`       | CPU limit                                                                       | `100m`                                |
-| `resources.limits.memory`    | Memory limit                                                                    | `200Mi`                               |
-| `resources.requests.cpu`     | CPU request                                                                     | `100m`                                |
-| `resources.requests.memory`  | Memory request                                                                  | `200Mi`                               |
-| `hostNetwork`                | Host network                                                                    | `false`                               |
-| `podAnnotations`             | Annotations                                                                     | `{}`                                  |
-| `podSecurityContext`         | Security Context                                                                | `{}`                                  |
-| `awsRegion`                  | AWS Cloudwatch region                                                           | `us-east-1`                           |
-| `awsRole`                    | AWS IAM Role To Use                                                             | `nil`                                 |
-| `awsAccessKeyId`             | AWS Access Key Id of a AWS user with a policy to access Cloudwatch              | `nil`                                 |
-| `awsSecretAccessKey`         | AWS Secret Access Key of a AWS user with a policy to access Cloudwatch          | `nil`                                 |
-| `data`                       | Fluentd ConfigMap values. The main configuration is defined under `fluent.conf` | `example configuration`               |
-| `logGroupName`               | AWS Cloudwatch log group                                                        | `kubernetes`                          |
-| `rbac.create`                | If true, create & use RBAC resources                                            | `false`                               |
-| `rbac.serviceAccountName`    | existing ServiceAccount to use (ignored if rbac.create=true)                    | `default`                             |
-| `rbac.pspEnabled`            | PodSecuritypolicy                                                               | `false`                               |
-| `tolerations`                | Add tolerations                                                                 | `[]`                                  |
-| `extraVars`                  | Add pod environment variables (must be specified as a single line object)       | `[]`                                  |
-| `updateStrategy`             | Define daemonset update strategy                                                | `OnDelete`                            |
-| `nodeSelector`               | Node labels for pod assignment                                                  | `{}`                                  |
-| `affinity`                   | Node affinity for pod assignment                                                | `{}`                                  |
-| `priorityClassName`          | Set priority class for daemon set                                               | `nil`                                 |
-| `busybox.repository`         | Image repository of busybox                                                     | `busybox`                             |
-| `busybox.tag`                | Image tag of busybox                                                            | `1.31.0`                              |
+| Parameter                        | Description                                                                     | Default                               |
+| -------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------|
+| `image.repository`               | Image repository                                                                | `fluent/fluentd-kubernetes-daemonset` |
+| `image.tag`                      | Image tag                                                                       | `v1.3.3-debian-cloudwatch-1.0`        |
+| `image.pullPolicy`               | Image pull policy                                                               | `IfNotPresent`                        |
+| `resources.limits.cpu`           | CPU limit                                                                       | `100m`                                |
+| `resources.limits.memory`        | Memory limit                                                                    | `200Mi`                               |
+| `resources.requests.cpu`         | CPU request                                                                     | `100m`                                |
+| `resources.requests.memory`      | Memory request                                                                  | `200Mi`                               |
+| `hostNetwork`                    | Host network                                                                    | `false`                               |
+| `podAnnotations`                 | Annotations                                                                     | `{}`                                  |
+| `podSecurityContext`             | Security Context                                                                | `{}`                                  |
+| `awsRegion`                      | AWS Cloudwatch region                                                           | `us-east-1`                           |
+| `awsRole`                        | AWS IAM Role To Use                                                             | `nil`                                 |
+| `awsAccessKeyId`                 | AWS Access Key Id of a AWS user with a policy to access Cloudwatch              | `nil`                                 |
+| `awsSecretAccessKey`             | AWS Secret Access Key of a AWS user with a policy to access Cloudwatch          | `nil`                                 |
+| `data`                           | Fluentd ConfigMap values. The main configuration is defined under `fluent.conf` | `example configuration`               |
+| `logGroupName`                   | AWS Cloudwatch log group                                                        | `kubernetes`                          |
+| `rbac.create`                    | If true, create & use RBAC resources                                            | `false`                               |
+| `rbac.serviceAccountName`        | existing ServiceAccount to use (ignored if rbac.create=true)                    | `default`                             |
+| `rbac.serviceAccountAnnotations` | annotations to add to the service account (if rbac.create=true)                 | `{}`                                  |
+| `rbac.pspEnabled`                | PodSecuritypolicy                                                               | `false`                               |
+| `tolerations`                    | Add tolerations                                                                 | `[]`                                  |
+| `extraVars`                      | Add pod environment variables (must be specified as a single line object)       | `[]`                                  |
+| `updateStrategy`                 | Define daemonset update strategy                                                | `OnDelete`                            |
+| `nodeSelector`                   | Node labels for pod assignment                                                  | `{}`                                  |
+| `affinity`                       | Node affinity for pod assignment                                                | `{}`                                  |
+| `priorityClassName`              | Set priority class for daemon set                                               | `nil`                                 |
+| `busybox.repository`             | Image repository of busybox                                                     | `busybox`                             |
+| `busybox.tag`                    | Image tag of busybox                                                            | `1.31.0`                              |
 
 
 If using fluentd-kubernetes-daemonset v0.12.43-cloudwatch, the container runs as user fluentd. To be able to write pos files to the host system, you'll need to run fluentd as root. Add the following extraVars value to run as root.

--- a/incubator/fluentd-cloudwatch/templates/serviceaccount.yaml
+++ b/incubator/fluentd-cloudwatch/templates/serviceaccount.yaml
@@ -8,4 +8,8 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.rbac.serviceAccountAnnotations }}
+  annotations:
+{{ toYaml .Values.rbac.serviceAccountAnnotations | indent 4 }}
+  {{- end }}
 {{- end }}

--- a/incubator/fluentd-cloudwatch/values.yaml
+++ b/incubator/fluentd-cloudwatch/values.yaml
@@ -65,7 +65,8 @@ rbac:
   ## If true, create and use RBAC resources
   create: false
   pspEnabled: false
-
+  ## Annotations to add to the service account if rbac.create is true
+  serviceAccountAnnotations: {}
   ## Ignored if rbac.create is true
   serviceAccountName: default
 # Add extra environment variables if specified (must be specified as a single line object and be quoted)


### PR DESCRIPTION
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

No

#### What this PR does / why we need it:

This PR adds a value for service account annotations. The reason being so that I can add the annotation `eks.amazonaws.com/role-arn`, which will allow the fluentd pods to assume the role to write to CloudWatch, without the role having to be attached to/assumed by the EC2 worker node. See [here](https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/).

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
