### PR TITLE
[stable/external-dns] add azure cloud in configuration.

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.10.2
+version: 2.10.3
 appVersion: 0.5.17
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -70,6 +70,7 @@ The following table lists the configurable parameters of the external-dns chart 
 | `aws.zoneTags`                      | When using the AWS provider, filter for zones with these tags                                            | `[]`                                                        |
 | `aws.preferCNAME`                   | When using the AWS provider, replaces Alias recors with CNAME (options: true, false)                     | `[]`                                                        |
 | `azure.secretName`                  | When using the Azure provider, set the secret containing the `azure.json` file                           | `""`                                                        |
+| `azure.clound`                      | When using the Azure provider, set the Azure Clound                                                      | `""`                                                        |
 | `azure.resourceGroup`               | When using the Azure provider, set the Azure Resource Group                                              | `""`                                                        |
 | `azure.tenantId`                    | When using the Azure provider, set the Azure Tenant ID                                                   | `""`                                                        |
 | `azure.subscriptionId`              | When using the Azure provider, set the Azure Subscription ID                                             | `""`                                                        |

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -70,7 +70,7 @@ The following table lists the configurable parameters of the external-dns chart 
 | `aws.zoneTags`                      | When using the AWS provider, filter for zones with these tags                                            | `[]`                                                        |
 | `aws.preferCNAME`                   | When using the AWS provider, replaces Alias recors with CNAME (options: true, false)                     | `[]`                                                        |
 | `azure.secretName`                  | When using the Azure provider, set the secret containing the `azure.json` file                           | `""`                                                        |
-| `azure.clound`                      | When using the Azure provider, set the Azure Clound                                                      | `""`                                                        |
+| `azure.cloud`                       | When using the Azure provider, set the Azure Clound                                                      | `""`                                                        |
 | `azure.resourceGroup`               | When using the Azure provider, set the Azure Resource Group                                              | `""`                                                        |
 | `azure.tenantId`                    | When using the Azure provider, set the Azure Tenant ID                                                   | `""`                                                        |
 | `azure.subscriptionId`              | When using the Azure provider, set the Azure Subscription ID                                             | `""`                                                        |

--- a/stable/external-dns/templates/_helpers.tpl
+++ b/stable/external-dns/templates/_helpers.tpl
@@ -124,6 +124,9 @@ source_profile = default
 
 {{- define "external-dns.azure-credentials" -}}
 {
+  {{- if .Values.azure.cloud }}
+  "cloud": "{{ .Values.azure.cloud }}",
+  {{- end}}
   "tenantId": "{{ .Values.azure.tenantId }}",
   "subscriptionId": "{{ .Values.azure.subscriptionId }}",
   "resourceGroup": "{{ .Values.azure.resourceGroup }}",

--- a/stable/external-dns/values-production.yaml
+++ b/stable/external-dns/values-production.yaml
@@ -89,6 +89,9 @@ azure:
   secretName: ""
   ## Azure resource group to use
   ##
+  cloud: ""
+  ## Azure Cloud to use
+  ##
   resourceGroup: ""
   ## Azure tenant ID to use
   ##

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -88,6 +88,9 @@ azure:
   secretName: ""
   ## Azure resource group to use
   ##
+  cloud: ""
+  ## Azure Cloud to use
+  ##
   resourceGroup: ""
   ## Azure tenant ID to use
   ##


### PR DESCRIPTION
Signed-off-by: Eric Yang <ericyang879@gmail.com>

#### Is this a new chart
Nope

#### What this PR does / why we need it:
this PR added the missing configuration for azure cloud environment in external-dns chart.
without this configuration, the external-dns won't be able to work with `AzureChinaCloud`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
