### PR TITLE
[incubator/aws-node-termination-handler] added aws-node-termination-handler chart

### DIFF
--- a/incubator/aws-node-termination-handler/Chart.yaml
+++ b/incubator/aws-node-termination-handler/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+name: aws-node-termination-handler
+description: A Helm chart for AWS node termination handler
+version: 0.1.0
+appVersion: "v1.0.0"
+home: https://github.com/aws/aws-node-termination-handler
+sources:
+  - https://github.com/aws/aws-node-termination-handler
+keywords:
+  - aws
+  - ec2
+  - spot
+maintainers:
+  - name: eddycharly
+    email: ceb@agriconomie.com

--- a/incubator/aws-node-termination-handler/OWNERS
+++ b/incubator/aws-node-termination-handler/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- eddycharly
+reviewers:
+- eddycharly

--- a/incubator/aws-node-termination-handler/README.md
+++ b/incubator/aws-node-termination-handler/README.md
@@ -1,0 +1,57 @@
+
+
+aws-node-termination-handler
+============================
+
+## Description
+
+A Helm chart for AWS node termination handler
+
+The **AWS Node Termination Handler** is an operational [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/)
+built to run on any Kubernetes cluster using AWS [EC2 Spot Instances](https://aws.amazon.com/ec2/spot/).
+When a user starts the termination handler, the handler watches the AWS [instance metadata service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+for [spot instance interruptions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html) within a customer's account.
+If a termination notice is received for an instance that’s running on the cluster, the termination handler begins a multi-step cordon and drain process for the node.
+
+You can run the termination handler on any Kubernetes cluster running on AWS,
+including clusters created with Amazon [Elastic Kubernetes Service](https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html).
+
+You can override default values, see [Chart Values](#chart-values) section.
+
+## Installation
+
+```bash
+helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+helm install incubator/aws-node-termination-handler
+```
+
+## Version
+
+Current chart version is `0.1.0`
+
+## Source
+
+Source code can be found [here](https://github.com/aws/aws-node-termination-handler)
+
+
+
+## Chart Values
+
+
+| Key | Type | Description | Default |
+|-----|------|-------------|---------|
+| fullnameOverride | string | full name override | `""` |
+| image.pullPolicy | string | controller container image pull policy | `"IfNotPresent"` |
+| image.repository | string | container image repository | `"amazon/aws-node-termination-handler"` |
+| image.tag | string | container image tag | `"v1.0.0"` |
+| nameOverride | string | name override | `""` |
+| podAnnotations | object | pod annotations | `{}` |
+| podLabels | object | pod labels | `{}` |
+| priorityClassName | string | priority class name (see https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption) | `""` |
+| rbac.create | bool | if true, create & use RBAC resources | `true` |
+| rbac.serviceAccountAnnotations | object |  | `{}` |
+| rbac.serviceAccountName | string | service account annotations | `"default"` |
+| resources | object | pod resource requests & limits | `{}` |
+
+
+Specify each parameter using the --set key=value[,key=value] argument to helm install.

--- a/incubator/aws-node-termination-handler/README.md.gotmpl
+++ b/incubator/aws-node-termination-handler/README.md.gotmpl
@@ -1,0 +1,45 @@
+{{ define "chart.valuesTable" }}
+| Key | Type | Description | Default |
+|-----|------|-------------|---------|
+{{- range .Values }}
+| {{ .Key }} | {{ .Type }} | {{ .Description }} | {{ .Default }} |
+{{- end }}
+{{ end }}
+
+{{ template "chart.header" . }}
+
+## Description
+
+{{ template "chart.description" . }}
+
+The **AWS Node Termination Handler** is an operational [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/)
+built to run on any Kubernetes cluster using AWS [EC2 Spot Instances](https://aws.amazon.com/ec2/spot/).
+When a user starts the termination handler, the handler watches the AWS [instance metadata service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+for [spot instance interruptions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html) within a customer's account.
+If a termination notice is received for an instance that’s running on the cluster, the termination handler begins a multi-step cordon and drain process for the node.
+
+You can run the termination handler on any Kubernetes cluster running on AWS,
+including clusters created with Amazon [Elastic Kubernetes Service](https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html).
+
+You can override default values, see [Chart Values](#chart-values) section.
+
+## Installation
+
+```bash
+helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+helm install incubator/aws-node-termination-handler
+```
+
+## Version
+
+{{ template "chart.versionLine" . }}
+
+## Source
+
+{{ template "chart.sourceLinkLine" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+Specify each parameter using the --set key=value[,key=value] argument to helm install.

--- a/incubator/aws-node-termination-handler/templates/NOTES.txt
+++ b/incubator/aws-node-termination-handler/templates/NOTES.txt
@@ -1,0 +1,3 @@
+To verify that aws-node-termination-handler has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ include "aws-node-termination-handler.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"

--- a/incubator/aws-node-termination-handler/templates/_helpers.tpl
+++ b/incubator/aws-node-termination-handler/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "aws-node-termination-handler.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "aws-node-termination-handler.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "aws-node-termination-handler.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/aws-node-termination-handler/templates/cluster-role-binding.yaml
+++ b/incubator/aws-node-termination-handler/templates/cluster-role-binding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "aws-node-termination-handler.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "aws-node-termination-handler.name" . }}
+    helm.sh/chart: {{ include "aws-node-termination-handler.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "aws-node-termination-handler.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "aws-node-termination-handler.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/incubator/aws-node-termination-handler/templates/cluster-role.yaml
+++ b/incubator/aws-node-termination-handler/templates/cluster-role.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.rbac.create }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "aws-node-termination-handler.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "aws-node-termination-handler.name" . }}
+    helm.sh/chart: {{ include "aws-node-termination-handler.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+- apiGroups:
+    - ''
+  resources:
+    - nodes
+  verbs:
+    - get
+    - patch
+    - update
+- apiGroups:
+    - ''
+  resources:
+    - pods
+  verbs:
+    - list
+- apiGroups:
+    - ''
+  resources:
+    - pods/eviction
+  verbs:
+    - create
+- apiGroups:
+    - extensions
+  resources:
+    - replicasets
+    - daemonsets
+  verbs:
+    - get
+- apiGroups:
+    - apps
+  resources:
+    - daemonsets
+  verbs:
+    - get
+    - delete
+{{- end }}

--- a/incubator/aws-node-termination-handler/templates/daemon-set.yaml
+++ b/incubator/aws-node-termination-handler/templates/daemon-set.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "aws-node-termination-handler.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "aws-node-termination-handler.name" . }}
+    helm.sh/chart: {{ include "aws-node-termination-handler.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "aws-node-termination-handler.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "aws-node-termination-handler.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8}}
+{{- end }}
+{{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8}}
+{{- end }}
+    spec:
+{{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+{{- end }}
+      serviceAccountName: {{ if .Values.rbac.create }}{{ include "aws-node-termination-handler.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      containers:
+        - name: node-termination-handler
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SPOT_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          resources:
+{{ toYaml .Values.resources | indent 12 }}

--- a/incubator/aws-node-termination-handler/templates/service-account.yaml
+++ b/incubator/aws-node-termination-handler/templates/service-account.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "aws-node-termination-handler.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "aws-node-termination-handler.name" . }}
+    helm.sh/chart: {{ include "aws-node-termination-handler.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.rbac.serviceAccountAnnotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/incubator/aws-node-termination-handler/values.yaml
+++ b/incubator/aws-node-termination-handler/values.yaml
@@ -1,0 +1,39 @@
+image:
+  # image.repository -- container image repository
+  repository: amazon/aws-node-termination-handler
+  # image.tag -- container image tag
+  tag: "v1.0.0"
+  # image.pullPolicy -- controller container image pull policy
+  pullPolicy: IfNotPresent
+
+rbac:
+  # rbac.create -- if true, create & use RBAC resources
+  create: true
+  # rbac.serviceAccountName -- service account used by the daemon set (ignored if rbac.create=true)
+  serviceAccountName: default
+  # rbac.serviceAccountName -- service account annotations
+  serviceAccountAnnotations: {}
+
+# resources -- pod resource requests & limits
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 64Mi
+  #   memory: 50m
+
+# podAnnotations -- pod annotations
+podAnnotations: {}
+
+# podLabels -- pod labels
+podLabels: {}
+
+# nameOverride -- name override
+nameOverride: ""
+
+# fullnameOverride -- full name override
+fullnameOverride: ""
+
+# priorityClassName -- priority class name (see https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption)
+priorityClassName: ""


### PR DESCRIPTION
I added the aws-node-termination-handler chart to the incubator repository.

This chart bootstraps the deployment of a daemonset to gracefully handle ec2 spot instance interruptions.

This is based on the official [aws-node-termination-handler](https://github.com/aws/aws-node-termination-handler) repository.
