### PR TITLE
[stable/datadog] Fix java settings for 6.15

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog
-version: 1.38.4
-appVersion: 6.14.0
+version: 1.39.0
+appVersion: 6.15.0
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/templates/datadog-yaml-configmap.yaml
+++ b/stable/datadog/templates/datadog-yaml-configmap.yaml
@@ -38,11 +38,11 @@ data:
       apm_non_local_traffic: true
 
     {{- with $v := splitn "." 2 .Values.image.tag }}
-    {{ if and (ge $v._0 "1") (ge $v._1 "15") }}
-    # Enable java container awareness (agent version >= 1.15)
+    {{ if and (ge $v._0 "6") (ge $v._1 "15") }}
+    # Enable java container awareness (agent version >= 6.15)
     jmx_use_container_support: true
     {{ else }}
-    # Enable java cgroup memory awareness (agent version < 1.15)
+    # Enable java cgroup memory awareness (agent version < 6.15)
     jmx_use_cgroup_memory_limit: true
     {{ end }}
     {{- end }}

--- a/stable/datadog/templates/datadog-yaml-configmap.yaml
+++ b/stable/datadog/templates/datadog-yaml-configmap.yaml
@@ -37,7 +37,14 @@ data:
       enabled: false
       apm_non_local_traffic: true
 
-    # Use java cgroup memory awareness
+    {{- with $v := splitn "." 2 .Values.image.tag }}
+    {{ if and (ge $v._0 "1") (ge $v._1 "15") }}
+    # Enable java container awareness (agent version >= 1.15)
+    jmx_use_container_support: true
+    {{ else }}
+    # Enable java cgroup memory awareness (agent version < 1.15)
     jmx_use_cgroup_memory_limit: true
+    {{ end }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -16,9 +16,9 @@ image:
 
   ## @param tag - string - required
   ## Define the Agent version to use.
-  ## Use 6.14.0-jmx to enable jmx fetch collection
+  ## Use 6.15.0-jmx to enable jmx fetch collection
   #
-  tag: 6.14.0
+  tag: 6.15.0
 
   ## @param pullPolicy - string - required
   ## The Kubernetes pull policy.
@@ -703,8 +703,14 @@ daemonset:
   #     enabled: false
   #     apm_non_local_traffic: true
   #
-  #   # Use java cgroup memory awareness
-  #   jmx_use_cgroup_memory_limit: true
+  #   # Enable java cgroup handling. Only one of those options should be enabled,
+  #   # depending on the agent version you are using along that chart.
+  #
+  #   # agent version < 1.15
+  #   # jmx_use_cgroup_memory_limit: true
+  #
+  #   # agent version >= 1.15
+  #   # jmx_use_container_support: true
 
 deployment:
   ## @param enabled - boolean - required

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -706,10 +706,10 @@ daemonset:
   #   # Enable java cgroup handling. Only one of those options should be enabled,
   #   # depending on the agent version you are using along that chart.
   #
-  #   # agent version < 1.15
+  #   # agent version < 6.15
   #   # jmx_use_cgroup_memory_limit: true
   #
-  #   # agent version >= 1.15
+  #   # agent version >= 6.15
   #   # jmx_use_container_support: true
 
 deployment:


### PR DESCRIPTION
#### What this PR does / why we need it:
It updates the default configmap so that relevant java settings are set according to the image tag.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
