### PR TITLE
[stable/prometheus-operator] Refactor jobLabel values to improve consistency and adaptability

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,9 +12,8 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.2.0
-appVersion: 0.34.0
-tillerVersion: ">=2.12.0"
+version: 6.7.3
+appVersion: 0.31.1
 home: https://github.com/coreos/prometheus-operator
 keywords:
 - operator

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -513,7 +513,8 @@ For a full list of configurable values please refer to the [Grafana chart](https
 | `kubelet.serviceMonitor.metricRelabelings` | The `metric_relabel_configs` for scraping kubelet. | `` |
 | `kubelet.serviceMonitor.relabelings` | The `relabel_configs` for scraping kubelet. | `` |
 | `nodeExporter.enabled` | Deploy the `prometheus-node-exporter` and scrape it | `true` |
-| `nodeExporter.jobLabel` | The name of the label on the target service to use as the job name in prometheus. See `prometheus-node-exporter.podLabels.jobLabel=node-exporter` default | `jobLabel` |
+| `nodeExporter.serviceMonitor.jobLabel` | The name of the label on the target service to use as the job name in prometheus. See `prometheus-node-exporter.podLabels.jobLabel=node-exporter` default | `jobLabel` |
+| `nodeExporter.serviceMonitor.metricRelabelings` | Metric relablings for the `prometheus-node-exporter` ServiceMonitor | `[]` |
 | `nodeExporter.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
 | `nodeExporter.serviceMonitor.scrapeTimeout` | How long until a scrape request times out. If not set, the Prometheus default scape timeout is used | `nil` |
 | `nodeExporter.serviceMonitor.metricRelabelings` | Metric relablings for the `prometheus-node-exporter` ServiceMonitor | `[]` |

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -426,10 +426,40 @@ For a full list of configurable values please refer to the [Grafana chart](https
 ### Exporters
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
+| `kubeApiServer.enabled` | Deploy `serviceMonitor` to scrape the Kubernetes API server | `true` |
+| `kubeApiServer.relabelings` | Relablings for the API Server ServiceMonitor | `[]` |
+| `kubeApiServer.tlsConfig.serverName` | Name of the server to use when validating TLS certificate | `kubernetes` |
+| `kubeApiServer.tlsConfig.insecureSkipVerify` | Skip TLS certificate validation when scraping | `false` |
+| `kubeApiServer.serviceMonitor.jobLabel` | The name of the label on the target service to use as the job name in prometheus | `component` |
+| `kubeApiServer.serviceMonitor.selector` | The service selector | `{"matchLabels":{"component":"apiserver","provider":"kubernetes"}}` |
+| `kubeApiServer.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
+| `kubeApiServer.serviceMonitor.relabelings` | The `relabel_configs` for scraping the Kubernetes API server. | `` |
+| `kubeApiServer.serviceMonitor.metricRelabelings` | The `metric_relabel_configs` for scraping the Kubernetes API server. | `` |
+| `kubelet.enabled` | Deploy servicemonitor to scrape the kubelet service. See also `prometheusOperator.kubeletService` | `true` |
+| `kubelet.namespace` | Namespace where the kubelet is deployed. See also `prometheusOperator.kubeletService.namespace` | `kube-system` |
+| `kubelet.serviceMonitor.jobLabel` | The name of the label on the target service to use as the job name in prometheus | `k8s-app` |
+| `kubelet.serviceMonitor.https` | Enable scraping of the kubelet over HTTPS. For more information, see https://github.com/coreos/prometheus-operator/issues/926 | `true` |
+| `kubelet.serviceMonitor.cAdvisorMetricRelabelings` | The `metric_relabel_configs` for scraping cAdvisor. | `` |
+| `kubelet.serviceMonitor.cAdvisorRelabelings` | The `relabel_configs` for scraping cAdvisor. | `` |
+| `kubelet.serviceMonitor.metricRelabelings` | The `metric_relabel_configs` for scraping kubelet. | `` |
+| `kubelet.serviceMonitor.relabelings` | The `relabel_configs` for scraping kubelet. | `` |
+| `kubelet.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
+| `kubeControllerManager.enabled` | Deploy a `service` and `serviceMonitor` to scrape the Kubernetes controller-manager | `true` |
+| `kubeControllerManager.endpoints` | Endpoints where Controller-manager runs. Provide this if running Controller-manager outside the cluster | `[]` |
+| `kubeControllermanager.service.port` | Controller-manager port for the service runs on | `10252` |
+| `kubeControllermanager.service.targetPort` | Controller-manager targetPort for the service runs on | `10252` |
+| `kubeControllermanager.service.selector` | Controller-manager service selector | `{"component" : "kube-controller-manager" }` |
+| `kubeControllermanager.serviceMonitor.jobLabel` | The name of the label on the target service to use as the job name in prometheus | `jobLabel` |
+| `kubeControllermanager.serviceMonitor.https` | Controller-manager service scrape over https | `false` |
+| `kubeControllermanager.serviceMonitor.serverName` | Name of the server to use when validating TLS certificate | `null` |
+| `kubeControllermanager.serviceMonitor.insecureSkipVerify` | Skip TLS certificate validation when scraping | `null` |
+| `kubeControllermanager.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
+| `kubeControllermanager.serviceMonitor.metricRelabelings` | The `metric_relabel_configs` for scraping the scheduler. | `` |
+| `kubeControllermanager.serviceMonitor.relabelings` | The `relabel_configs` for scraping the scheduler. | `` |
 | `coreDns.enabled` | Deploy coreDns scraping components. Use either this or kubeDns | true |
 | `coreDns.service.port` | CoreDns port | `9153` |
 | `coreDns.service.selector` | CoreDns service selector | `{"k8s-app" : "kube-dns" }` |
-| `coreDns.service.targetPort` | CoreDns targetPort | `9153` |
+| `coreDns.serviceMonitor.jobLabel` | The name of the label on the target service to use as the job name in prometheus | `jobLabel` |
 | `coreDns.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
 | `coreDns.serviceMonitor.metricRelabelings` | The `metric_relabel_configs` for scraping CoreDns. | `` |
 | `coreDns.serviceMonitor.relabelings` | The `relabel_configs` for scraping CoreDNS. | `` |
@@ -461,8 +491,7 @@ For a full list of configurable values please refer to the [Grafana chart](https
 | `kubeDns.service.skydns.port` | Skydns service port | `10055` |
 | `kubeDns.service.skydns.targetPort` | Skydns service targetPort | `10055` |
 | `kubeDns.service.selector` | kubeDns service selector | `{"k8s-app" : "kube-dns" }` |
-| `kubeDns.serviceMonitor.dnsmasqMetricRelabelings` | The `metric_relabel_configs` for scraping dnsmasq kubeDns. | `` |
-| `kubeDns.serviceMonitor.dnsmasqRelabelings` | The `relabel_configs` for scraping dnsmasq kubeDns. | `` |
+| `kubeDns.serviceMonitor.jobLabel` | The name of the label on the target service to use as the job name in prometheus | `jobLabel` |
 | `kubeDns.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
 | `kubeDns.serviceMonitor.metricRelabelings` | The `metric_relabel_configs` for scraping kubeDns. | `` |
 | `kubeDns.serviceMonitor.relabelings` | The `relabel_configs` for scraping kubeDns. | `` |
@@ -470,7 +499,10 @@ For a full list of configurable values please refer to the [Grafana chart](https
 | `kubeEtcd.endpoints` | Endpoints where etcd runs. Provide this if running etcd outside the cluster | `[]` |
 | `kubeEtcd.service.port` | Etcd port | `4001` |
 | `kubeEtcd.service.selector` | Selector for etcd if running inside the cluster | `{"component":"etcd"}` |
-| `kubeEtcd.service.targetPort` | Etcd targetPort | `4001` |
+| `kubeEtcd.serviceMonitor.jobLabel` | The name of the label on the target service to use as the job name in prometheus | `jobLabel` |
+| `kubeEtcd.serviceMonitor.scheme` | Etcd servicemonitor scheme | `http` |
+| `kubeEtcd.serviceMonitor.insecureSkipVerify` | Skip validating etcd TLS certificate when scraping | `false` |
+| `kubeEtcd.serviceMonitor.serverName` | Etcd server name to validate certificate against when scraping | `""` |
 | `kubeEtcd.serviceMonitor.caFile` | Certificate authority file to use when connecting to etcd. See `prometheus.prometheusSpec.secrets` | `""` |
 | `kubeEtcd.serviceMonitor.certFile` | Client certificate file to use when connecting to etcd. See `prometheus.prometheusSpec.secrets` | `""` |
 | `kubeEtcd.serviceMonitor.insecureSkipVerify` | Skip validating etcd TLS certificate when scraping | `false` |
@@ -493,14 +525,23 @@ For a full list of configurable values please refer to the [Grafana chart](https
 | `kubeScheduler.endpoints` | Endpoints where scheduler runs. Provide this if running scheduler outside the cluster | `[]` |
 | `kubeScheduler.service.port` | Scheduler port for the service runs on | `10251` |
 | `kubeScheduler.service.selector` | Scheduler service selector | `{"component" : "kube-scheduler" }` |
-| `kubeScheduler.service.targetPort` | Scheduler targetPort for the service runs on | `10251` |
+| `kubeScheduler.serviceMonitor.jobLabel` | The name of the label on the target service to use as the job name in prometheus | `jobLabel` |
 | `kubeScheduler.serviceMonitor.https` | Scheduler service scrape over https | `false` |
 | `kubeScheduler.serviceMonitor.insecureSkipVerify` | Skip TLS certificate validation when scraping | `null` |
 | `kubeScheduler.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
 | `kubeScheduler.serviceMonitor.metricRelabelings` | The `metric_relabel_configs` for scraping the Kubernetes scheduler. | `` |
 | `kubeScheduler.serviceMonitor.relabelings` | The `relabel_configs` for scraping the Kubernetes scheduler. | `` |
-| `kubeScheduler.serviceMonitor.serverName` | Name of the server to use when validating TLS certificate | `null` |
+| `kubeProxy.enabled` | Deploy a `service` and `serviceMonitor` to scrape the Kubernetes proxy | `true` |
+| `kubeProxy.service.port` | Kubernetes proxy port for the service runs on | `10249` |
+| `kubeProxy.service.targetPort` | Kubernetes proxy targetPort for the service runs on | `10249` |
+| `kubeProxy.service.selector` | Kubernetes proxy service selector | `{"k8s-app" : "kube-proxy" }` |
+| `kubeProxy.serviceMonitor.jobLabel` | The name of the label on the target service to use as the job name in prometheus | `jobLabel` |
+| `kubeProxy.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
+| `kubeProxy.serviceMonitor.https` | Kubernetes proxy service scrape over https | `false` |
+| `kubeProxy.serviceMonitor.metricRelabelings` | The `metric_relabel_configs` for scraping the Kubernetes proxy. | `` |
+| `kubeProxy.serviceMonitor.relabelings` | The `relabel_configs` for scraping the Kubernetes proxy. | `` |
 | `kubeStateMetrics.enabled` | Deploy the `kube-state-metrics` chart and configure a servicemonitor to scrape | `true` |
+| `kubeStateMetrics.serviceMonitor.jobLabel` | The name of the label on the target service to use as the job name in prometheus | `app.kubernetes.io/name` |
 | `kubeStateMetrics.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
 | `kubeStateMetrics.serviceMonitor.metricRelabelings` | Metric relablings for the `kube-state-metrics` ServiceMonitor | `[]` |
 | `kubeStateMetrics.serviceMonitor.relabelings` | The `relabel_configs` for scraping `kube-state-metrics`. | `` |
@@ -513,7 +554,7 @@ For a full list of configurable values please refer to the [Grafana chart](https
 | `kubelet.serviceMonitor.metricRelabelings` | The `metric_relabel_configs` for scraping kubelet. | `` |
 | `kubelet.serviceMonitor.relabelings` | The `relabel_configs` for scraping kubelet. | `` |
 | `nodeExporter.enabled` | Deploy the `prometheus-node-exporter` and scrape it | `true` |
-| `nodeExporter.serviceMonitor.jobLabel` | The name of the label on the target service to use as the job name in prometheus. See `prometheus-node-exporter.podLabels.jobLabel=node-exporter` default | `jobLabel` |
+| `nodeExporter.serviceMonitor.jobLabel` | The name of the label on the target service to use as the job name in prometheus. See `prometheus-node-exporter.podLabels.jobLabel=node-exporter` default | `node-exporter` |
 | `nodeExporter.serviceMonitor.metricRelabelings` | Metric relablings for the `prometheus-node-exporter` ServiceMonitor | `[]` |
 | `nodeExporter.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
 | `nodeExporter.serviceMonitor.scrapeTimeout` | How long until a scrape request times out. If not set, the Prometheus default scape timeout is used | `nil` |

--- a/stable/prometheus-operator/templates/exporters/core-dns/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/core-dns/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-coredns
 {{ include "prometheus-operator.labels" . | indent 4 }}
 spec:
-  jobLabel: jobLabel
+  jobLabel: {{ default "jobLabel" .Values.coreDns.serviceMonitor.jobLabel }}
   selector:
     matchLabels:
       app: {{ template "prometheus-operator.name" . }}-coredns

--- a/stable/prometheus-operator/templates/exporters/kube-api-server/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-api-server/servicemonitor.yaml
@@ -27,7 +27,7 @@ spec:
       caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
       serverName: {{ .Values.kubeApiServer.tlsConfig.serverName }}
       insecureSkipVerify: {{ .Values.kubeApiServer.tlsConfig.insecureSkipVerify }}
-  jobLabel: {{ .Values.kubeApiServer.serviceMonitor.jobLabel }}
+  jobLabel: {{ default "component" .Values.kubeApiServer.serviceMonitor.jobLabel }}
   namespaceSelector:
     matchNames:
     - default

--- a/stable/prometheus-operator/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-kube-controller-manager
 {{ include "prometheus-operator.labels" . | indent 4 }}
 spec:
-  jobLabel: jobLabel
+  jobLabel: {{ default "jobLabel" .Values.kubeControllerManager.serviceMonitor.jobLabel }}
   selector:
     matchLabels:
       app: {{ template "prometheus-operator.name" . }}-kube-controller-manager

--- a/stable/prometheus-operator/templates/exporters/kube-dns/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-dns/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-kube-dns
 {{ include "prometheus-operator.labels" . | indent 4 }}
 spec:
-  jobLabel: jobLabel
+  jobLabel: {{ default "jobLabel" .Values.kubeDns.serviceMonitor.jobLabel }}
   selector:
     matchLabels:
       app: {{ template "prometheus-operator.name" . }}-kube-dns

--- a/stable/prometheus-operator/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-kube-etcd
 {{ include "prometheus-operator.labels" . | indent 4 }}
 spec:
-  jobLabel: jobLabel
+  jobLabel: {{ default "jobLabel" .Values.kubeEtcd.serviceMonitor.jobLabel }}
   selector:
     matchLabels:
       app: {{ template "prometheus-operator.name" . }}-kube-etcd

--- a/stable/prometheus-operator/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-kube-proxy
 {{ include "prometheus-operator.labels" . | indent 4 }}
 spec:
-  jobLabel: jobLabel
+  jobLabel: {{ default "jobLabel" .Values.kubeProxy.serviceMonitor.jobLabel }}
   selector:
     matchLabels:
       app: {{ template "prometheus-operator.name" . }}-kube-proxy

--- a/stable/prometheus-operator/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-kube-scheduler
 {{ include "prometheus-operator.labels" . | indent 4 }}
 spec:
-  jobLabel: jobLabel
+  jobLabel: {{ default "jobLabel" .Values.kubeScheduler.serviceMonitor.jobLabel }}
   selector:
     matchLabels:
       app: {{ template "prometheus-operator.name" . }}-kube-scheduler

--- a/stable/prometheus-operator/templates/exporters/kube-state-metrics/serviceMonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-state-metrics/serviceMonitor.yaml
@@ -8,7 +8,7 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-kube-state-metrics
 {{ include "prometheus-operator.labels" . | indent 4 }}
 spec:
-  jobLabel: app.kubernetes.io/name
+  jobLabel: {{ default "app.kubernetes.io/name" .Values.kubeStateMetrics.serviceMonitor.jobLabel }}
   endpoints:
   - port: http
     {{- if .Values.kubeStateMetrics.serviceMonitor.interval }}

--- a/stable/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
@@ -76,7 +76,7 @@ spec:
 {{ toYaml .Values.kubelet.serviceMonitor.cAdvisorRelabelings | indent 4 }}
 {{- end }}
   {{- end }}
-  jobLabel: k8s-app
+  jobLabel: {{ default "k8s-app" .Values.kubelet.serviceMonitor.jobLabel }}
   namespaceSelector:
     matchNames:
     - {{ .Values.kubelet.namespace }}

--- a/stable/prometheus-operator/templates/exporters/node-exporter/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/node-exporter/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-node-exporter
 {{ include "prometheus-operator.labels" . | indent 4 }}
 spec:
-  jobLabel: {{ .Values.nodeExporter.jobLabel }}
+  jobLabel: {{ default "node-exporter" .Values.nodeExporter.serviceMonitor.jobLabel }}
   selector:
     matchLabels:
       app: prometheus-node-exporter

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -502,6 +502,9 @@ kubeApiServer:
   #   replacement: kubernetes.default.svc:443
 
   serviceMonitor:
+    # Specify a ServiceMonitor JobLabel, default: component
+    jobLabel: component
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
@@ -517,9 +520,6 @@ kubeApiServer:
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
 
-    # Specify a ServiceMonitor JobLabel, default: component
-    jobLabel: component
-
 ## Component scraping the kubelet and kubelet-hosted cAdvisor
 ##
 kubelet:
@@ -527,6 +527,9 @@ kubelet:
   namespace: kube-system
 
   serviceMonitor:
+    # Specify a ServiceMonitor JobLabel, default: k8s-app
+    jobLabel: k8s-app
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
@@ -582,9 +585,6 @@ kubelet:
     #   replacement: $1
     #   action: replace
 
-    # Specify a ServiceMonitor JobLabel, default: k8s-app
-    jobLabel: k8s-app
-
 ## Component scraping the kube controller manager
 ##
 kubeControllerManager:
@@ -606,6 +606,9 @@ kubeControllerManager:
     #   component: kube-controller-manager
 
   serviceMonitor:
+    # Specify a ServiceMonitor JobLabel, default: jobLabel
+    jobLabel: jobLabel
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
@@ -638,9 +641,6 @@ kubeControllerManager:
     #   replacement: $1
     #   action: replace
 
-    # Specify a ServiceMonitor JobLabel, default: jobLabel
-    jobLabel: jobLabel
-
 ## Component scraping coreDns. Use either this or kubeDns
 ##
 coreDns:
@@ -651,6 +651,9 @@ coreDns:
     # selector:
     #   k8s-app: kube-dns
   serviceMonitor:
+    # Specify a ServiceMonitor Job Label, default: jobLabel
+    jobLabel: jobLabel
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
@@ -672,9 +675,6 @@ coreDns:
     #   replacement: $1
     #   action: replace
 
-    # Specify a ServiceMonitor Job Label, default: jobLabel
-    jobLabel: jobLabel
-
 ## Component scraping kubeDns. Use either this or coreDns
 ##
 kubeDns:
@@ -689,6 +689,9 @@ kubeDns:
     # selector:
     #   k8s-app: kube-dns
   serviceMonitor:
+    # Specify a ServiceMonitor JobLabel, default: jobLabel
+    jobLabel: jobLabel
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
@@ -724,9 +727,6 @@ kubeDns:
     #   replacement: $1
     #   action: replace
 
-    # Specify a ServiceMonitor JobLabel, default: jobLabel
-    jobLabel: jobLabel
-
 ## Component scraping etcd
 ##
 kubeEtcd:
@@ -759,6 +759,9 @@ kubeEtcd:
   ##   keyFile: /etc/prometheus/secrets/etcd-client-cert/etcd-client-key
   ##
   serviceMonitor:
+    # Specify a ServiceMonitor JobLabel, default: jobLabel
+    jobLabel: jobLabel
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
@@ -786,10 +789,6 @@ kubeEtcd:
     #   replacement: $1
     #   action: replace
 
-    # Specify a ServiceMonitor JobLabel, default: jobLabel
-    jobLabel: jobLabel
-
-
 ## Component scraping kube scheduler
 ##
 kubeScheduler:
@@ -811,6 +810,9 @@ kubeScheduler:
     #   component: kube-scheduler
 
   serviceMonitor:
+    # Specify a ServiceMonitor JobLabel, default: jobLabel
+    jobLabel: jobLabel
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
@@ -842,10 +844,6 @@ kubeScheduler:
     #   replacement: $1
     #   action: replace
 
-    # Specify a ServiceMonitor JobLabel, default: jobLabel
-    jobLabel: jobLabel
-
-
 ## Component scraping kube proxy
 ##
 kubeProxy:
@@ -865,6 +863,9 @@ kubeProxy:
     #   k8s-app: kube-proxy
 
   serviceMonitor:
+    # Specify a ServiceMonitor JobLabel, default: jobLabel
+    jobLabel: jobLabel
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
@@ -888,15 +889,14 @@ kubeProxy:
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
 
-    # Specify a ServiceMonitor JobLabel, default: jobLabel
-    jobLabel: jobLabel
-
-
 ## Component scraping kube state metrics
 ##
 kubeStateMetrics:
   enabled: true
   serviceMonitor:
+    # Specify a ServiceMonitor JobLabel, default: app.kubernetes.io/name
+    jobLabel: app.kubernetes.io/name
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
@@ -918,9 +918,6 @@ kubeStateMetrics:
     #   replacement: $1
     #   action: replace
 
-    # Specify a ServiceMonitor JobLabel, default: app.kubernetes.io/name
-    jobLabel: app.kubernetes.io/name
-
 ## Configuration for kube-state-metrics subchart
 ##
 kube-state-metrics:
@@ -935,6 +932,11 @@ nodeExporter:
   enabled: true
 
   serviceMonitor:
+    ## Specify a ServiceMonitor JobLabel, default: node-exporter
+    ## Use the value configured in prometheus-node-exporter.podLabels
+    ##
+    jobLabel: node-exporter
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
@@ -961,11 +963,6 @@ nodeExporter:
     #   target_label: nodename
     #   replacement: $1
     #   action: replace
-
-    ## Specify a ServiceMonitor JobLabel, default: node-exporter
-    ## Use the value configured in prometheus-node-exporter.podLabels
-    ##
-    jobLabel: node-exporter
 
 ## Configuration for prometheus-node-exporter subchart
 ##

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -505,7 +505,6 @@ kubeApiServer:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
-    jobLabel: component
     selector:
       matchLabels:
         component: apiserver
@@ -517,6 +516,9 @@ kubeApiServer:
     # - action: keep
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
+
+    # Specify a ServiceMonitor JobLabel, default: component
+    jobLabel: component
 
 ## Component scraping the kubelet and kubelet-hosted cAdvisor
 ##
@@ -580,6 +582,9 @@ kubelet:
     #   replacement: $1
     #   action: replace
 
+    # Specify a ServiceMonitor JobLabel, default: k8s-app
+    jobLabel: k8s-app
+
 ## Component scraping the kube controller manager
 ##
 kubeControllerManager:
@@ -633,6 +638,9 @@ kubeControllerManager:
     #   replacement: $1
     #   action: replace
 
+    # Specify a ServiceMonitor JobLabel, default: jobLabel
+    jobLabel: jobLabel
+
 ## Component scraping coreDns. Use either this or kubeDns
 ##
 coreDns:
@@ -663,6 +671,9 @@ coreDns:
     #   target_label: nodename
     #   replacement: $1
     #   action: replace
+
+    # Specify a ServiceMonitor Job Label, default: jobLabel
+    jobLabel: jobLabel
 
 ## Component scraping kubeDns. Use either this or coreDns
 ##
@@ -712,6 +723,9 @@ kubeDns:
     #   target_label: nodename
     #   replacement: $1
     #   action: replace
+
+    # Specify a ServiceMonitor JobLabel, default: jobLabel
+    jobLabel: jobLabel
 
 ## Component scraping etcd
 ##
@@ -772,6 +786,9 @@ kubeEtcd:
     #   replacement: $1
     #   action: replace
 
+    # Specify a ServiceMonitor JobLabel, default: jobLabel
+    jobLabel: jobLabel
+
 
 ## Component scraping kube scheduler
 ##
@@ -825,6 +842,9 @@ kubeScheduler:
     #   replacement: $1
     #   action: replace
 
+    # Specify a ServiceMonitor JobLabel, default: jobLabel
+    jobLabel: jobLabel
+
 
 ## Component scraping kube proxy
 ##
@@ -868,6 +888,9 @@ kubeProxy:
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
 
+    # Specify a ServiceMonitor JobLabel, default: jobLabel
+    jobLabel: jobLabel
+
 
 ## Component scraping kube state metrics
 ##
@@ -895,6 +918,9 @@ kubeStateMetrics:
     #   replacement: $1
     #   action: replace
 
+    # Specify a ServiceMonitor JobLabel, default: app.kubernetes.io/name
+    jobLabel: app.kubernetes.io/name
+
 ## Configuration for kube-state-metrics subchart
 ##
 kube-state-metrics:
@@ -907,10 +933,6 @@ kube-state-metrics:
 ##
 nodeExporter:
   enabled: true
-
-  ## Use the value configured in prometheus-node-exporter.podLabels
-  ##
-  jobLabel: jobLabel
 
   serviceMonitor:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
@@ -939,6 +961,11 @@ nodeExporter:
     #   target_label: nodename
     #   replacement: $1
     #   action: replace
+
+    ## Specify a ServiceMonitor JobLabel, default: node-exporter
+    ## Use the value configured in prometheus-node-exporter.podLabels
+    ##
+    jobLabel: node-exporter
 
 ## Configuration for prometheus-node-exporter subchart
 ##


### PR DESCRIPTION
#### What this PR does / why we need it:
It keeps the job labelling consistency across all exporters (KubeEtcd, KubeProxy, KubeAPIServer, Kubelet, etc.). It aims to be backwards compatible, by keeping all previously hardcoded values as default. 

Although in the case of the `nodeExporter` the default value of the `jobLabel` has been changed to match the desired effect of actually matching `the value configured in prometheus-node-exporter.podLabels` as specified by the documentation.

#### Special notes for your reviewer:
This aims to improve readability by making sure that in all exports it maintains the same logic of being able to define the jobLabel instead of just on some.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
