### PR TITLE
[stable/prometheus-operator] Refactor jobLabel values to improve consistency and adaptability

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.2.0
+version: 8.2.1
 appVersion: 0.34.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -430,6 +430,7 @@ For a full list of configurable values please refer to the [Grafana chart](https
 | `coreDns.service.port` | CoreDns port | `9153` |
 | `coreDns.service.selector` | CoreDns service selector | `{"k8s-app" : "kube-dns" }` |
 | `coreDns.service.targetPort` | CoreDns targetPort | `9153` |
+| `coreDns.serviceMonitor.jobLabel` | The name of the label on the target service to use as the job name in prometheus | `jobLabel` |
 | `coreDns.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
 | `coreDns.serviceMonitor.metricRelabelings` | The `metric_relabel_configs` for scraping CoreDns. | `` |
 | `coreDns.serviceMonitor.relabelings` | The `relabel_configs` for scraping CoreDNS. | `` |
@@ -449,6 +450,7 @@ For a full list of configurable values please refer to the [Grafana chart](https
 | `kubeControllerManager.service.port` | Controller-manager port for the service runs on | `10252` |
 | `kubeControllerManager.service.selector` | Controller-manager service selector | `{"component" : "kube-controller-manager" }` |
 | `kubeControllerManager.service.targetPort` | Controller-manager targetPort for the service runs on | `10252` |
+| `kubeControllermanager.serviceMonitor.jobLabel` | The name of the label on the target service to use as the job name in prometheus | `jobLabel` |
 | `kubeControllerManager.serviceMonitor.https` | Controller-manager service scrape over https | `false` |
 | `kubeControllerManager.serviceMonitor.insecureSkipVerify` | Skip TLS certificate validation when scraping | `null` |
 | `kubeControllerManager.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
@@ -461,6 +463,7 @@ For a full list of configurable values please refer to the [Grafana chart](https
 | `kubeDns.service.skydns.port` | Skydns service port | `10055` |
 | `kubeDns.service.skydns.targetPort` | Skydns service targetPort | `10055` |
 | `kubeDns.service.selector` | kubeDns service selector | `{"k8s-app" : "kube-dns" }` |
+| `kubeDns.serviceMonitor.jobLabel` | The name of the label on the target service to use as the job name in prometheus | `jobLabel` |
 | `kubeDns.serviceMonitor.dnsmasqMetricRelabelings` | The `metric_relabel_configs` for scraping dnsmasq kubeDns. | `` |
 | `kubeDns.serviceMonitor.dnsmasqRelabelings` | The `relabel_configs` for scraping dnsmasq kubeDns. | `` |
 | `kubeDns.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
@@ -471,6 +474,7 @@ For a full list of configurable values please refer to the [Grafana chart](https
 | `kubeEtcd.service.port` | Etcd port | `4001` |
 | `kubeEtcd.service.selector` | Selector for etcd if running inside the cluster | `{"component":"etcd"}` |
 | `kubeEtcd.service.targetPort` | Etcd targetPort | `4001` |
+| `kubeEtcd.serviceMonitor.jobLabel` | The name of the label on the target service to use as the job name in prometheus | `jobLabel` |
 | `kubeEtcd.serviceMonitor.caFile` | Certificate authority file to use when connecting to etcd. See `prometheus.prometheusSpec.secrets` | `""` |
 | `kubeEtcd.serviceMonitor.certFile` | Client certificate file to use when connecting to etcd. See `prometheus.prometheusSpec.secrets` | `""` |
 | `kubeEtcd.serviceMonitor.insecureSkipVerify` | Skip validating etcd TLS certificate when scraping | `false` |
@@ -485,6 +489,7 @@ For a full list of configurable values please refer to the [Grafana chart](https
 | `kubeProxy.service.port` | Kubernetes proxy port for the service runs on | `10249` |
 | `kubeProxy.service.selector` | Kubernetes proxy service selector | `{"k8s-app" : "kube-proxy" }` |
 | `kubeProxy.service.targetPort` | Kubernetes proxy targetPort for the service runs on | `10249` |
+| `kubeProxy.serviceMonitor.jobLabel` | The name of the label on the target service to use as the job name in prometheus | `jobLabel` |
 | `kubeProxy.serviceMonitor.https` | Kubernetes proxy service scrape over https | `false` |
 | `kubeProxy.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
 | `kubeProxy.serviceMonitor.metricRelabelings` | The `metric_relabel_configs` for scraping the Kubernetes proxy. | `` |
@@ -494,6 +499,7 @@ For a full list of configurable values please refer to the [Grafana chart](https
 | `kubeScheduler.service.port` | Scheduler port for the service runs on | `10251` |
 | `kubeScheduler.service.selector` | Scheduler service selector | `{"component" : "kube-scheduler" }` |
 | `kubeScheduler.service.targetPort` | Scheduler targetPort for the service runs on | `10251` |
+| `kubeScheduler.serviceMonitor.jobLabel` | The name of the label on the target service to use as the job name in prometheus | `jobLabel` |
 | `kubeScheduler.serviceMonitor.https` | Scheduler service scrape over https | `false` |
 | `kubeScheduler.serviceMonitor.insecureSkipVerify` | Skip TLS certificate validation when scraping | `null` |
 | `kubeScheduler.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
@@ -506,6 +512,7 @@ For a full list of configurable values please refer to the [Grafana chart](https
 | `kubeStateMetrics.serviceMonitor.relabelings` | The `relabel_configs` for scraping `kube-state-metrics`. | `` |
 | `kubelet.enabled` | Deploy servicemonitor to scrape the kubelet service. See also `prometheusOperator.kubeletService` | `true` |
 | `kubelet.namespace` | Namespace where the kubelet is deployed. See also `prometheusOperator.kubeletService.namespace` | `kube-system` |
+| `kubelet.serviceMonitor.jobLabel` | The name of the label on the target service to use as the job name in prometheus | `k8s-app` |
 | `kubelet.serviceMonitor.cAdvisorMetricRelabelings` | The `metric_relabel_configs` for scraping cAdvisor. | `` |
 | `kubelet.serviceMonitor.cAdvisorRelabelings` | The `relabel_configs` for scraping cAdvisor. | `` |
 | `kubelet.serviceMonitor.https` | Enable scraping of the kubelet over HTTPS. For more information, see https://github.com/coreos/prometheus-operator/issues/926 | `true` |
@@ -513,7 +520,7 @@ For a full list of configurable values please refer to the [Grafana chart](https
 | `kubelet.serviceMonitor.metricRelabelings` | The `metric_relabel_configs` for scraping kubelet. | `` |
 | `kubelet.serviceMonitor.relabelings` | The `relabel_configs` for scraping kubelet. | `` |
 | `nodeExporter.enabled` | Deploy the `prometheus-node-exporter` and scrape it | `true` |
-| `nodeExporter.jobLabel` | The name of the label on the target service to use as the job name in prometheus. See `prometheus-node-exporter.podLabels.jobLabel=node-exporter` default | `jobLabel` |
+| `nodeExporter.serviceMonitor.jobLabel` | The name of the label on the target service to use as the job name in prometheus. See `prometheus-node-exporter.podLabels.jobLabel=node-exporter` default | `node-exporter` |
 | `nodeExporter.serviceMonitor.interval` | Scrape interval. If not set, the Prometheus default scrape interval is used | `nil` |
 | `nodeExporter.serviceMonitor.scrapeTimeout` | How long until a scrape request times out. If not set, the Prometheus default scape timeout is used | `nil` |
 | `nodeExporter.serviceMonitor.metricRelabelings` | Metric relablings for the `prometheus-node-exporter` ServiceMonitor | `[]` |

--- a/stable/prometheus-operator/templates/exporters/core-dns/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/core-dns/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-coredns
 {{ include "prometheus-operator.labels" . | indent 4 }}
 spec:
-  jobLabel: jobLabel
+  jobLabel: {{ default "jobLabel" .Values.coreDns.serviceMonitor.jobLabel }}
   selector:
     matchLabels:
       app: {{ template "prometheus-operator.name" . }}-coredns

--- a/stable/prometheus-operator/templates/exporters/kube-api-server/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-api-server/servicemonitor.yaml
@@ -27,7 +27,7 @@ spec:
       caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
       serverName: {{ .Values.kubeApiServer.tlsConfig.serverName }}
       insecureSkipVerify: {{ .Values.kubeApiServer.tlsConfig.insecureSkipVerify }}
-  jobLabel: {{ .Values.kubeApiServer.serviceMonitor.jobLabel }}
+  jobLabel: {{ default "component" .Values.kubeApiServer.serviceMonitor.jobLabel }}
   namespaceSelector:
     matchNames:
     - default

--- a/stable/prometheus-operator/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-kube-controller-manager
 {{ include "prometheus-operator.labels" . | indent 4 }}
 spec:
-  jobLabel: jobLabel
+  jobLabel: {{ default "jobLabel" .Values.kubeControllerManager.serviceMonitor.jobLabel }}
   selector:
     matchLabels:
       app: {{ template "prometheus-operator.name" . }}-kube-controller-manager

--- a/stable/prometheus-operator/templates/exporters/kube-dns/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-dns/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-kube-dns
 {{ include "prometheus-operator.labels" . | indent 4 }}
 spec:
-  jobLabel: jobLabel
+  jobLabel: {{ default "jobLabel" .Values.kubeDns.serviceMonitor.jobLabel }}
   selector:
     matchLabels:
       app: {{ template "prometheus-operator.name" . }}-kube-dns

--- a/stable/prometheus-operator/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-kube-etcd
 {{ include "prometheus-operator.labels" . | indent 4 }}
 spec:
-  jobLabel: jobLabel
+  jobLabel: {{ default "jobLabel" .Values.kubeEtcd.serviceMonitor.jobLabel }}
   selector:
     matchLabels:
       app: {{ template "prometheus-operator.name" . }}-kube-etcd

--- a/stable/prometheus-operator/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-kube-proxy
 {{ include "prometheus-operator.labels" . | indent 4 }}
 spec:
-  jobLabel: jobLabel
+  jobLabel: {{ default "jobLabel" .Values.kubeProxy.serviceMonitor.jobLabel }}
   selector:
     matchLabels:
       app: {{ template "prometheus-operator.name" . }}-kube-proxy

--- a/stable/prometheus-operator/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-kube-scheduler
 {{ include "prometheus-operator.labels" . | indent 4 }}
 spec:
-  jobLabel: jobLabel
+  jobLabel: {{ default "jobLabel" .Values.kubeScheduler.serviceMonitor.jobLabel }}
   selector:
     matchLabels:
       app: {{ template "prometheus-operator.name" . }}-kube-scheduler

--- a/stable/prometheus-operator/templates/exporters/kube-state-metrics/serviceMonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kube-state-metrics/serviceMonitor.yaml
@@ -8,7 +8,7 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-kube-state-metrics
 {{ include "prometheus-operator.labels" . | indent 4 }}
 spec:
-  jobLabel: app.kubernetes.io/name
+  jobLabel: {{ default "app.kubernetes.io/name" .Values.kubeStateMetrics.serviceMonitor.jobLabel }}
   endpoints:
   - port: http
     {{- if .Values.kubeStateMetrics.serviceMonitor.interval }}

--- a/stable/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
@@ -76,7 +76,7 @@ spec:
 {{ toYaml .Values.kubelet.serviceMonitor.cAdvisorRelabelings | indent 4 }}
 {{- end }}
   {{- end }}
-  jobLabel: k8s-app
+  jobLabel: {{ default "k8s-app" .Values.kubelet.serviceMonitor.jobLabel }}
   namespaceSelector:
     matchNames:
     - {{ .Values.kubelet.namespace }}

--- a/stable/prometheus-operator/templates/exporters/node-exporter/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/node-exporter/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-node-exporter
 {{ include "prometheus-operator.labels" . | indent 4 }}
 spec:
-  jobLabel: {{ .Values.nodeExporter.jobLabel }}
+  jobLabel: {{ default "node-exporter" .Values.nodeExporter.serviceMonitor.jobLabel }}
   selector:
     matchLabels:
       app: prometheus-node-exporter

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -502,10 +502,12 @@ kubeApiServer:
   #   replacement: kubernetes.default.svc:443
 
   serviceMonitor:
+    # Specify a ServiceMonitor JobLabel, default: component
+    jobLabel: component
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
-    jobLabel: component
     selector:
       matchLabels:
         component: apiserver
@@ -525,6 +527,9 @@ kubelet:
   namespace: kube-system
 
   serviceMonitor:
+    # Specify a ServiceMonitor JobLabel, default: k8s-app
+    jobLabel: k8s-app
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
@@ -601,6 +606,9 @@ kubeControllerManager:
     #   component: kube-controller-manager
 
   serviceMonitor:
+    # Specify a ServiceMonitor JobLabel, default: jobLabel
+    jobLabel: jobLabel
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
@@ -643,6 +651,9 @@ coreDns:
     # selector:
     #   k8s-app: kube-dns
   serviceMonitor:
+    # Specify a ServiceMonitor Job Label, default: jobLabel
+    jobLabel: jobLabel
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
@@ -678,6 +689,9 @@ kubeDns:
     # selector:
     #   k8s-app: kube-dns
   serviceMonitor:
+    # Specify a ServiceMonitor JobLabel, default: jobLabel
+    jobLabel: jobLabel
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
@@ -745,6 +759,9 @@ kubeEtcd:
   ##   keyFile: /etc/prometheus/secrets/etcd-client-cert/etcd-client-key
   ##
   serviceMonitor:
+    # Specify a ServiceMonitor JobLabel, default: jobLabel
+    jobLabel: jobLabel
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
@@ -772,7 +789,6 @@ kubeEtcd:
     #   replacement: $1
     #   action: replace
 
-
 ## Component scraping kube scheduler
 ##
 kubeScheduler:
@@ -794,6 +810,9 @@ kubeScheduler:
     #   component: kube-scheduler
 
   serviceMonitor:
+    # Specify a ServiceMonitor JobLabel, default: jobLabel
+    jobLabel: jobLabel
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
@@ -825,7 +844,6 @@ kubeScheduler:
     #   replacement: $1
     #   action: replace
 
-
 ## Component scraping kube proxy
 ##
 kubeProxy:
@@ -845,6 +863,9 @@ kubeProxy:
     #   k8s-app: kube-proxy
 
   serviceMonitor:
+    # Specify a ServiceMonitor JobLabel, default: jobLabel
+    jobLabel: jobLabel
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
@@ -868,12 +889,14 @@ kubeProxy:
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
 
-
 ## Component scraping kube state metrics
 ##
 kubeStateMetrics:
   enabled: true
   serviceMonitor:
+    # Specify a ServiceMonitor JobLabel, default: app.kubernetes.io/name
+    jobLabel: app.kubernetes.io/name
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
@@ -908,11 +931,12 @@ kube-state-metrics:
 nodeExporter:
   enabled: true
 
-  ## Use the value configured in prometheus-node-exporter.podLabels
-  ##
-  jobLabel: jobLabel
-
   serviceMonitor:
+    ## Specify a ServiceMonitor JobLabel, default: node-exporter
+    ## Use the value configured in prometheus-node-exporter.podLabels
+    ##
+    jobLabel: node-exporter
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""


### PR DESCRIPTION
#### What this PR does / why we need it:
It keeps the job labelling consistency across all exporters (KubeEtcd, KubeProxy, KubeAPIServer, Kubelet, etc.). It aims to be backwards compatible, by keeping all previously hardcoded values as default. 

Although in the case of the `nodeExporter` the default value of the `jobLabel` has been changed to match the desired effect of actually matching `the value configured in prometheus-node-exporter.podLabels` as specified by the documentation.

#### Special notes for your reviewer:
This aims to improve readability by making sure that in all exports it maintains the same logic of being able to define the jobLabel instead of just on some.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
