### PR TITLE
[stable/aerospike] StatefulSet is now redeployed when confFile is updated

### DIFF
--- a/stable/aerospike/Chart.yaml
+++ b/stable/aerospike/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - aerospike
   - big-data
 home: http://aerospike.com
-version: 0.3.0
+version: 0.3.1
 icon: https://s3-us-west-1.amazonaws.com/aerospike-fd/wp-content/uploads/2016/06/Aerospike_square_logo.png
 sources:
 - https://github.com/aerospike/aerospike-server

--- a/stable/aerospike/README.md
+++ b/stable/aerospike/README.md
@@ -40,7 +40,7 @@ The chart can be customized using the following configurable parameters:
 | `annotations`                   | Map of annotations to add to the statefulset                    | `{}`                         |
 | `tolerations`                   | List of node taints to tolerate                                 | `[]`                         |
 | `persistentVolume`              | Config of persistent volumes for storage-engine                 | `{}`                         |
-| `confFile`                      | Config filename. This file should be included in the chart path | `aerospike.conf`             |
+| `confFile`                      | Config filename. This file should be included in the chart path. If the config is updated, the statefulset will be redeployed with the new config | `aerospike.conf`             |
 | `resources`                     | Resource requests and limits                                    | `{}`                         |
 | `nodeSelector`                  | Labels for pod assignment                                       | `{}`                         |
 | `terminationGracePeriodSeconds` | Wait time before forcefully terminating container               | `30`                         |

--- a/stable/aerospike/templates/statefulset.yaml
+++ b/stable/aerospike/templates/statefulset.yaml
@@ -26,6 +26,8 @@ spec:
       labels:
         app: {{ template "aerospike.name" . }}
         release: {{ .Release.Name }}
+      annotations:
+        checksum/config: {{ .Values.confFile | sha256sum }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       containers:
@@ -38,7 +40,7 @@ spec:
         {{ end }}
         {{ if .Values.args }}
         args:
-{         { toYaml .Values.args | nindent 10 }}
+          {{ toYaml .Values.args | nindent 10 }}
         {{ end }}
         ports:
         - containerPort: 3000


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Redeploys StatefulSet when config is updated. Makes for a more convenient workflow

#### Which issue this PR fixes
No related issue filed

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
