### PR TITLE
[incubator/vault] update storage default value to fix helm warnings

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.23.1
+version: 0.23.2
 appVersion: 1.2.3
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -258,7 +258,7 @@ vault:
         # tls_cert_file: /vault/tls/server.crt
         # tls_key_file: /vault/tls/server.key
     # See https://www.vaultproject.io/docs/configuration/storage/ for storage backends
-    storage: []
+    storage: {}
       # consul:
       #   address: ""
       #   path: ""


### PR DESCRIPTION
Signed-off-by: Stefan Schwarz <ssz@bitsbeats.com>

#### What this PR does / why we need it:

#### Which issue this PR fixes

Fixes warnings during template rendering, `vault.config.storage` is a hash.

```
2019/11/18 09:37:58 Warning: Merging destination map for chart 'vault'. The destination item 'storage' is a table and ignoring the source 'storage' as it has a non-table value of: []
```

#### Special notes for your reviewer:

Was partially fixed in #18243

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
