### PR TITLE
[stable/redis-ha] Fix double scraping redis pods by serviceMonitor

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.1.0
+version: 4.1.1
 appVersion: 5.0.5
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/redis-ha-service.yaml
+++ b/stable/redis-ha/templates/redis-ha-service.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ template "redis-ha.fullname" . }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
+{{- if and ( .Values.exporter.enabled ) ( .Values.exporter.serviceMonitor.enabled ) }}
+    servicemonitor: enabled
+{{- end }}
   annotations:
   {{- if .Values.serviceAnnotations }}
 {{ toYaml .Values.serviceAnnotations | indent 4 }}

--- a/stable/redis-ha/templates/redis-ha-servicemonitor.yaml
+++ b/stable/redis-ha/templates/redis-ha-servicemonitor.yaml
@@ -30,4 +30,5 @@ spec:
     matchLabels:
       app: {{ template "redis-ha.name" . }}
       release: {{ .Release.Name }}
+      servicemonitor: enabled
 {{- end }}


### PR DESCRIPTION
Add third label to serviceMonitor definition to select only one redis service (exclude redis-announce-* targets from scraping), add it only when exporter and servicemonitor are enabled in values.

Signed-off-by: Andrey Izotikov <andrsp@gmail.com>

#### Is this a new chart
> No

#### What this PR does / why we need it:
Fixes double scraping redis pods by serviceMonitor

#### Which issue this PR fixes
-

#### Special notes for your reviewer:
-

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md (no new variables)
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
