### PR TITLE
[stable/superset] Updated initFile script to use gunicorn to start server

### DIFF
--- a/stable/superset/values.yaml
+++ b/stable/superset/values.yaml
@@ -8,13 +8,13 @@ replicaCount: 1
 ## Set default image, imageTag, and imagePullPolicy.
 image:
   repository: "amancevice/superset"
-  tag: "0.28.1"
+  tag: "0.35.0"
   pullPolicy: "IfNotPresent"
   pullSecrets: []
 
 initFile: |-
   /usr/local/bin/superset-init --username admin --firstname admin --lastname user --email admin@fab.org --password admin
-  superset runserver
+  gunicorn superset:app
 
 configFile: |-
   #---------------------------------------------------------


### PR DESCRIPTION


#### What this PR does / why we need it:
`superset runserver` seems to be depreciated.
Updating the same with `gunicorn superset:app` to start the server. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #18951 

#### Special notes for your reviewer:
@alitari 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
