### PR TITLE
[stable/traefik] Add nodeSelector in the storeconfig-job.yaml 

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.79.0
+version: 1.79.1
 appVersion: 1.7.14
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/templates/storeconfig-job.yaml
+++ b/stable/traefik/templates/storeconfig-job.yaml
@@ -19,6 +19,8 @@ spec:
         chart: {{ template "traefik.chart" . }}
     spec:
       restartPolicy: Never
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
       containers:
         - name: storeconfig-job
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"


### PR DESCRIPTION
Propragate the nodeSelector value to the storeconfig-job.yaml in traefik to address issue mentioned here: 

https://github.com/helm/charts/issues/18865

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No

#### What this PR does / why we need it:

Propragate the nodeSelector value to the storeconfig-job.yaml, so that the storeconfig-job does not get scheduled to run on a  windows node in a heterogeneous cluster.

#### Which issue this PR fixes

https://github.com/helm/charts/issues/18865

#### Special notes for your reviewer:
/assign @jbdoumenjou

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
- [x] Chart version bumped