### PR TITLE
Prometheus node exporter namespace override

### DIFF
--- a/stable/prometheus-node-exporter/Chart.yaml
+++ b/stable/prometheus-node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.18.1
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 1.7.3
+version: 1.7.4
 home: https://github.com/prometheus/node_exporter/
 sources:
 - https://github.com/prometheus/node_exporter/

--- a/stable/prometheus-node-exporter/Chart.yaml
+++ b/stable/prometheus-node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.18.1
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 1.7.4
+version: 1.8.0
 home: https://github.com/prometheus/node_exporter/
 sources:
 - https://github.com/prometheus/node_exporter/

--- a/stable/prometheus-node-exporter/README.md
+++ b/stable/prometheus-node-exporter/README.md
@@ -67,6 +67,7 @@ The following table lists the configurable parameters of the Node Exporter chart
 | `prometheus.monitor.namespace` | namespace where servicemonitor resource should be created | `the same namespace as prometheus node exporter` | |
 | `prometheus.monitor.scrapeTimeout` | Timeout after which the scrape is ended | `10s` | |
 | `configmaps`                      | Allow mounting additional configmaps.                                                                                         | `[]`                                    |     |
+| `namespaceOverride`               | Override the deployment namespace     | `""` (`Release.Namespace`)             |  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-node-exporter/templates/NOTES.txt
+++ b/stable/prometheus-node-exporter/templates/NOTES.txt
@@ -1,15 +1,15 @@
 1. Get the application URL by running these commands:
 {{- if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "prometheus-node-exporter.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  export NODE_PORT=$(kubectl get --namespace {{ template "prometheus-node-exporter.namespace" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "prometheus-node-exporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ template "prometheus-node-exporter.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get svc -w {{ template "prometheus-node-exporter.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "prometheus-node-exporter.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  export SERVICE_IP=$(kubectl get svc --namespace {{ template "prometheus-node-exporter.namespace" . }} {{ template "prometheus-node-exporter.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "prometheus-node-exporter.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ template "prometheus-node-exporter.namespace" . }} -l "app={{ template "prometheus-node-exporter.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:9100 to use your application"
-  kubectl port-forward $POD_NAME 9100
+  kubectl port-forward --namespace {{ template "prometheus-node-exporter.namespace" . }} $POD_NAME 9100
 {{- end }}

--- a/stable/prometheus-node-exporter/templates/_helpers.tpl
+++ b/stable/prometheus-node-exporter/templates/_helpers.tpl
@@ -53,3 +53,14 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "prometheus-node-exporter.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}

--- a/stable/prometheus-node-exporter/templates/daemonset.yaml
+++ b/stable/prometheus-node-exporter/templates/daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "prometheus-node-exporter.fullname" . }}
+  namespace: {{ template "prometheus-node-exporter.namespace" . }}
   labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
 spec:
   selector:

--- a/stable/prometheus-node-exporter/templates/endpoints.yaml
+++ b/stable/prometheus-node-exporter/templates/endpoints.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   name: {{ template "prometheus-node-exporter.fullname" . }}
+  namespace: {{ template "prometheus-node-exporter.namespace" . }}
   labels:
 {{ include "prometheus-node-exporter.labels" . | indent 4 }}
 subsets:

--- a/stable/prometheus-node-exporter/templates/monitor.yaml
+++ b/stable/prometheus-node-exporter/templates/monitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-node-exporter.fullname" . }}
+  namespace: {{ template "prometheus-node-exporter.namespace" . }}
   labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
   {{- if .Values.prometheus.monitor.additionalLabels }}
 {{ toYaml .Values.prometheus.monitor.additionalLabels | indent 4 }}

--- a/stable/prometheus-node-exporter/templates/psp-clusterrole.yaml
+++ b/stable/prometheus-node-exporter/templates/psp-clusterrole.yaml
@@ -3,8 +3,9 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
   name: psp-{{ template "prometheus-node-exporter.fullname" . }}
+  namespace: {{ template "prometheus-node-exporter.namespace" . }}
+  labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
 rules:
 - apiGroups: ['extensions']
   resources: ['podsecuritypolicies']

--- a/stable/prometheus-node-exporter/templates/psp-clusterrole.yaml
+++ b/stable/prometheus-node-exporter/templates/psp-clusterrole.yaml
@@ -4,7 +4,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: psp-{{ template "prometheus-node-exporter.fullname" . }}
-  namespace: {{ template "prometheus-node-exporter.namespace" . }}
   labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
 rules:
 - apiGroups: ['extensions']

--- a/stable/prometheus-node-exporter/templates/psp-clusterrolebinding.yaml
+++ b/stable/prometheus-node-exporter/templates/psp-clusterrolebinding.yaml
@@ -3,8 +3,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
   name: psp-{{ template "prometheus-node-exporter.fullname" . }}
+  namespace: {{ template "prometheus-node-exporter.namespace" . }}
+  labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12,6 +13,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "prometheus-node-exporter.fullname" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "prometheus-node-exporter.namespace" . }}
 {{- end }}
 {{- end }}

--- a/stable/prometheus-node-exporter/templates/psp-clusterrolebinding.yaml
+++ b/stable/prometheus-node-exporter/templates/psp-clusterrolebinding.yaml
@@ -4,7 +4,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: psp-{{ template "prometheus-node-exporter.fullname" . }}
-  namespace: {{ template "prometheus-node-exporter.namespace" . }}
   labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/prometheus-node-exporter/templates/psp.yaml
+++ b/stable/prometheus-node-exporter/templates/psp.yaml
@@ -3,8 +3,9 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
   name: {{ template "prometheus-node-exporter.fullname" . }}
+  namespace: {{ template "prometheus-node-exporter.namespace" . }}
+  labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
 spec:
   privileged: false
   # Required to prevent escalations to root.

--- a/stable/prometheus-node-exporter/templates/service.yaml
+++ b/stable/prometheus-node-exporter/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "prometheus-node-exporter.fullname" . }}
+  namespace: {{ template "prometheus-node-exporter.namespace" . }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/stable/prometheus-node-exporter/templates/serviceaccount.yaml
+++ b/stable/prometheus-node-exporter/templates/serviceaccount.yaml
@@ -4,12 +4,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "prometheus-node-exporter.serviceAccountName" . }}
+  namespace: {{ template "prometheus-node-exporter.namespace" . }}
   labels:
     app: {{ template "prometheus-node-exporter.name" . }}
-    chart: {{ template "prometheus-node-exporter.chart" . }}    
+    chart: {{ template "prometheus-node-exporter.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-imagePullSecrets: 
+imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}
 {{- end -}}
 {{- end -}}

--- a/stable/prometheus-node-exporter/values.yaml
+++ b/stable/prometheus-node-exporter/values.yaml
@@ -105,3 +105,7 @@ extraHostVolumeMounts: []
 configmaps: []
 # - name: <configMapName>
 #   mountPath: <mountPath>
+
+## Override the deployment namespace
+##
+namespaceOverride: ""


### PR DESCRIPTION
What this PR does / why we need it:
It adds a namespaceOverride parameter, which allows this chart to be used in cases where templating is used across namespaces. By providing this parameter, the resulting templating will output to the specified namespace.

Special notes for your reviewer:
This change is needed for implementing https://github.com/helm/charts/issues/18837 and inspired by https://github.com/helm/charts/pull/15202

Checklist
- [x] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [stable/chart])

Mentioning the fine people taking care of this chart: @vsliouniaev @gianrubio 