### PR TITLE
stable/airflow Airflow pod distruption budget passed enabled key to the pdb

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 4.8.0
+version: 4.9.0
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -355,8 +355,8 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `airflow.schedulerNumRuns`               | -1 to loop indefinitively, 1 to restart after each exec |                           |
 | `airflow.webReplicas`                    | how many replicas for web server                        | `1`                       |
 | `airflow.config`                         | custom airflow configuration env variables              | `{}`                      |
-| `airflow.podDisruptionBudget.enabled`        | enable pod disruption budget                            | `true`                    |
-| `airflow.podDisruptionBudget.maxUnavailable` | control pod disruption budget                           | `1`                       |
+| `airflow.podDisruptionBudgetEnabled`     | enable pod disruption budget                            | `true`                    |
+| `airflow.podDisruptionBudget`            | control pod disruption budget                           | `{'maxUnavailable': 1}`   |
 | `airflow.extraEnv`                       | specify additional environment variables to mount       | `{}`                      |
 | `airflow.extraConfigmapMounts`           | Additional configMap volume mounts on the airflow pods. | `[]`                      |
 | `airflow.podAnnotations`                 | annotations for scheduler, worker and web pods          | `{}`                      |

--- a/stable/airflow/templates/poddisruptionbudget.yaml
+++ b/stable/airflow/templates/poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.airflow.podDisruptionBudget.enabled }}
+{{- if .Values.airflow.podDisruptionBudgetEnabled }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -109,8 +109,8 @@ airflow:
   config: {}
   ##
   ## Configure pod disruption budget for the scheduler
+  podDisruptionBudgetEnabled: true
   podDisruptionBudget:
-    enabled: true
     maxUnavailable: 1
   ## Add custom connections
   ## Use this to add Airflow connections for operators you use


### PR DESCRIPTION

#### Is this a new chart
no
#### What this PR does / why we need it:

The poddisruption budget enabled flag did not work since the whole podDisruptionBudget is passed in the template including the enabled flag. This breaks the helm chart. So I put the enabled in a different value 

#### Which issue this PR fixes
-
#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
