### PR TITLE
[stable/grafana] Namespace override

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 4.2.3
+version: 4.3.0
 appVersion: 6.5.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -155,6 +155,7 @@ This version requires Helm >= 2.12.0.
 | `testFramework.tag`                       | `test-framework` image tag.                    | `0.4.0`                                                |
 | `testFramework.securityContext`           | `test-framework` securityContext                | `{}`                                                   |
 | `downloadDashboards.env`                  | Environment variables to be passed to the `download-dashboards` container | `{}`                                                   |
+| `namespaceOverride`                       | Override the deployment namespace     | `""` (`Release.Namespace`)             |
 
 
 ### Example of extraVolumeMounts

--- a/stable/grafana/templates/NOTES.txt
+++ b/stable/grafana/templates/NOTES.txt
@@ -1,10 +1,10 @@
 1. Get your '{{ .Values.adminUser }}' user password by running:
 
-   kubectl get secret --namespace {{ .Release.Namespace }} {{ template "grafana.fullname" . }} -o jsonpath="{.data.admin-password}" | base64 --decode ; echo
+   kubectl get secret --namespace {{ template "grafana.namespace" . }} {{ template "grafana.fullname" . }} -o jsonpath="{.data.admin-password}" | base64 --decode ; echo
 
 2. The Grafana server can be accessed via port {{ .Values.service.port }} on the following DNS name from within your cluster:
 
-   {{ template "grafana.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+   {{ template "grafana.fullname" . }}.{{ template "grafana.namespace" . }}.svc.cluster.local
 {{ if .Values.ingress.enabled }}
    If you bind grafana to 80, please update values in values.yaml and reinstall:
    ```
@@ -29,17 +29,17 @@
 {{ else }}
    Get the Grafana URL to visit by running these commands in the same shell:
 {{ if contains "NodePort" .Values.service.type -}}
-     export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "grafana.fullname" . }})
-     export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+     export NODE_PORT=$(kubectl get --namespace {{ template "grafana.namespace" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "grafana.fullname" . }})
+     export NODE_IP=$(kubectl get nodes --namespace {{ template "grafana.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
      echo http://$NODE_IP:$NODE_PORT
 {{ else if contains "LoadBalancer" .Values.service.type -}}
    NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        You can watch the status of by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "grafana.fullname" . }}'
-     export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "grafana.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+        You can watch the status of by running 'kubectl get svc --namespace {{ template "grafana.namespace" . }} -w {{ template "grafana.fullname" . }}'
+     export SERVICE_IP=$(kubectl get svc --namespace {{ template "grafana.namespace" . }} {{ template "grafana.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
      http://$SERVICE_IP:{{ .Values.service.port -}}
 {{ else if contains "ClusterIP"  .Values.service.type }}
-     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "grafana.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-     kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 3000
+     export POD_NAME=$(kubectl get pods --namespace {{ template "grafana.namespace" . }} -l "app={{ template "grafana.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+     kubectl --namespace {{ template "grafana.namespace" . }} port-forward $POD_NAME 3000
 {{- end }}
 {{- end }}
 

--- a/stable/grafana/templates/_helpers.tpl
+++ b/stable/grafana/templates/_helpers.tpl
@@ -49,3 +49,14 @@ Create the name of the service account
     {{ default "default" .Values.serviceAccount.nameTest }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "grafana.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}

--- a/stable/grafana/templates/clusterrolebinding.yaml
+++ b/stable/grafana/templates/clusterrolebinding.yaml
@@ -15,7 +15,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "grafana.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "grafana.namespace" . }}
 roleRef:
   kind: ClusterRole
   name: {{ template "grafana.fullname" . }}-clusterrole

--- a/stable/grafana/templates/configmap-dashboard-provider.yaml
+++ b/stable/grafana/templates/configmap-dashboard-provider.yaml
@@ -12,7 +12,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
   name: {{ template "grafana.fullname" . }}-config-dashboards
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "grafana.namespace" . }}
 data:
   provider.yaml: |-
     apiVersion: 1

--- a/stable/grafana/templates/configmap.yaml
+++ b/stable/grafana/templates/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "grafana.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "grafana.namespace" . }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}

--- a/stable/grafana/templates/dashboards-json-configmap.yaml
+++ b/stable/grafana/templates/dashboards-json-configmap.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "grafana.fullname" $ }}-dashboards-{{ $provider }}
-  namespace: {{ template "grafana.namespace" . }}
+  namespace: {{ template "grafana.namespace" $ }}
   labels:
     app: {{ template "grafana.name" $ }}
     chart: {{ template "grafana.chart" $ }}

--- a/stable/grafana/templates/dashboards-json-configmap.yaml
+++ b/stable/grafana/templates/dashboards-json-configmap.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "grafana.fullname" $ }}-dashboards-{{ $provider }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ template "grafana.namespace" . }}
   labels:
     app: {{ template "grafana.name" $ }}
     chart: {{ template "grafana.chart" $ }}

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "grafana.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "grafana.namespace" . }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}

--- a/stable/grafana/templates/headless-service.yaml
+++ b/stable/grafana/templates/headless-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "grafana.fullname" . }}-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "grafana.namespace" . }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}

--- a/stable/grafana/templates/ingress.yaml
+++ b/stable/grafana/templates/ingress.yaml
@@ -7,7 +7,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "grafana.namespace" . }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}

--- a/stable/grafana/templates/poddisruptionbudget.yaml
+++ b/stable/grafana/templates/poddisruptionbudget.yaml
@@ -2,7 +2,8 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ template "grafana.name" . }} 
+  name: {{ template "grafana.name" . }}
+  namespace: {{ template "grafana.namespace" . }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}

--- a/stable/grafana/templates/podsecuritypolicy.yaml
+++ b/stable/grafana/templates/podsecuritypolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "grafana.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "grafana.namespace" . }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/stable/grafana/templates/pvc.yaml
+++ b/stable/grafana/templates/pvc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ template "grafana.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "grafana.namespace" . }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}

--- a/stable/grafana/templates/role.yaml
+++ b/stable/grafana/templates/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: {{ template "grafana.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "grafana.namespace" . }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/stable/grafana/templates/rolebinding.yaml
+++ b/stable/grafana/templates/rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: {{ template "grafana.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "grafana.namespace" . }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
@@ -20,7 +20,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "grafana.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "grafana.namespace" . }}
 {{- if .Values.rbac.namespaced }}
 roleRef:
   kind: Role

--- a/stable/grafana/templates/secret-env.yaml
+++ b/stable/grafana/templates/secret-env.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "grafana.fullname" . }}-env
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "grafana.namespace" . }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}

--- a/stable/grafana/templates/secret.yaml
+++ b/stable/grafana/templates/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "grafana.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "grafana.namespace" . }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}

--- a/stable/grafana/templates/service.yaml
+++ b/stable/grafana/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "grafana.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "grafana.namespace" . }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}

--- a/stable/grafana/templates/serviceaccount.yaml
+++ b/stable/grafana/templates/serviceaccount.yaml
@@ -12,5 +12,5 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
   name: {{ template "grafana.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "grafana.namespace" . }}
 {{- end }}

--- a/stable/grafana/templates/statefulset.yaml
+++ b/stable/grafana/templates/statefulset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "grafana.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "grafana.namespace" . }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}

--- a/stable/grafana/templates/tests/test-configmap.yaml
+++ b/stable/grafana/templates/tests/test-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "grafana.fullname" . }}-test
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "grafana.namespace" . }}
   labels:
     app: {{ template "grafana.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/grafana/templates/tests/test-podsecuritypolicy.yaml
+++ b/stable/grafana/templates/tests/test-podsecuritypolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "grafana.fullname" . }}-test
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "grafana.namespace" . }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/stable/grafana/templates/tests/test-role.yaml
+++ b/stable/grafana/templates/tests/test-role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "grafana.fullname" . }}-test
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "grafana.namespace" . }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/stable/grafana/templates/tests/test-rolebinding.yaml
+++ b/stable/grafana/templates/tests/test-rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "grafana.fullname" . }}-test
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "grafana.namespace" . }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
@@ -16,5 +16,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "grafana.serviceAccountNameTest" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "grafana.namespace" . }}
 {{- end }}

--- a/stable/grafana/templates/tests/test-serviceaccount.yaml
+++ b/stable/grafana/templates/tests/test-serviceaccount.yaml
@@ -8,5 +8,5 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "grafana.serviceAccountNameTest" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "grafana.namespace" . }}
 {{- end }}

--- a/stable/grafana/templates/tests/test.yaml
+++ b/stable/grafana/templates/tests/test.yaml
@@ -10,7 +10,7 @@ metadata:
     release: "{{ .Release.Name }}"
   annotations:
     "helm.sh/hook": test-success
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "grafana.namespace" . }}
 spec:
   serviceAccountName: {{ template "grafana.serviceAccountNameTest" . }}
   {{- if .Values.testFramework.securityContext }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -475,3 +475,7 @@ sidecar:
     # Otherwise the namespace in which the sidecar is running will be used.
     # It's also possible to specify ALL to search in all namespaces
     searchNamespace: null
+
+## Override the deployment namespace
+##
+namespaceOverride: ""


### PR DESCRIPTION
What this PR does / why we need it:
It adds a namespaceOverride parameter, which allows this chart to be used in cases where templating is used across namespaces. By providing this parameter, the resulting templating will output to the specified namespace.

Special notes for your reviewer:
This change is needed for implementing https://github.com/helm/charts/issues/18837 and inspired by https://github.com/helm/charts/pull/15202

Checklist
- [x] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [stable/chart])

Mentioning the fine people taking care of this chart: @zanhsieh @rtluckie @maorfr