### PR TITLE
[stable/kube-state-metrics] Namespace override

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - monitoring
 - prometheus
 - kubernetes
-version: 2.5.0
+version: 2.6.0
 appVersion: 1.9.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -69,3 +69,4 @@ $ helm install stable/kube-state-metrics
 | `prometheus.monitor.additionalLabels`        | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`                                       |
 | `prometheus.monitor.namespace`               | Namespace where servicemonitor resource should be created                             | `the same namespace as kube-state-metrics` |
 | `prometheus.monitor.honorLabels`             | Honor metric labels                                                                   | `false`                                    |
+| `namespaceOverride`                          | Override the deployment namespace                                                     | `""` (`Release.Namespace`)                 |

--- a/stable/kube-state-metrics/templates/NOTES.txt
+++ b/stable/kube-state-metrics/templates/NOTES.txt
@@ -3,7 +3,7 @@ The exposed metrics can be found here:
 https://github.com/kubernetes/kube-state-metrics/blob/master/docs/README.md#exposed-metrics
 
 The metrics are exported on the HTTP endpoint /metrics on the listening port.
-In your case, {{ template "kube-state-metrics.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/metrics
+In your case, {{ template "kube-state-metrics.fullname" . }}.{{ template "kube-state-metrics.namespace" . }}.svc.cluster.local:{{ .Values.service.port }}/metrics
 
 They are served either as plaintext or protobuf depending on the Accept header.
 They are designed to be consumed either by Prometheus itself or by a scraper that is compatible with scraping a Prometheus client endpoint.

--- a/stable/kube-state-metrics/templates/_helpers.tpl
+++ b/stable/kube-state-metrics/templates/_helpers.tpl
@@ -34,3 +34,14 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "kube-state-metrics.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}

--- a/stable/kube-state-metrics/templates/clusterrolebinding.yaml
+++ b/stable/kube-state-metrics/templates/clusterrolebinding.yaml
@@ -15,5 +15,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "kube-state-metrics.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "kube-state-metrics.namespace" . }}
 {{- end -}}

--- a/stable/kube-state-metrics/templates/deployment.yaml
+++ b/stable/kube-state-metrics/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kube-state-metrics.fullname" . }}
+  namespace: {{ template "kube-state-metrics.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/kube-state-metrics/templates/psp-clusterrolebinding.yaml
+++ b/stable/kube-state-metrics/templates/psp-clusterrolebinding.yaml
@@ -15,5 +15,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kube-state-metrics.fullname" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "kube-state-metrics.namespace" . }}
 {{- end }}

--- a/stable/kube-state-metrics/templates/service.yaml
+++ b/stable/kube-state-metrics/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kube-state-metrics.fullname" . }}
+  namespace: {{ template "kube-state-metrics.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/kube-state-metrics/templates/serviceaccount.yaml
+++ b/stable/kube-state-metrics/templates/serviceaccount.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
   name: {{ template "kube-state-metrics.fullname" . }}
+  namespace: {{ template "kube-state-metrics.namespace" . }}
 imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}
 {{- end -}}

--- a/stable/kube-state-metrics/templates/servicemonitor.yaml
+++ b/stable/kube-state-metrics/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-state-metrics.fullname" . }}
+  namespace: {{ template "kube-state-metrics.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -113,3 +113,7 @@ collectors:
 
 # Namespace to be enabled for collecting resources. By default all namespaces are collected.
 # namespace: ""
+
+## Override the deployment namespace
+##
+namespaceOverride: ""


### PR DESCRIPTION
What this PR does / why we need it:
It adds a namespaceOverride parameter, which allows this chart to be used in cases where templating is used across namespaces. By providing this parameter, the resulting templating will output to the specified namespace.

Special notes for your reviewer:
This change is needed for implementing https://github.com/helm/charts/issues/18837 and inspired by https://github.com/helm/charts/pull/15202

Checklist
- [x] DCO signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [stable/chart])

Mentioning the fine people taking care of this chart: @fiunchinho @tariq1890