### PR TITLE
[stable/verdaccio] Support Kubernetes v1.16 API

### DIFF
--- a/stable/verdaccio/Chart.yaml
+++ b/stable/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 0.7.3
+version: 0.8.0
 appVersion: 3.11.6
 home: http://www.verdaccio.org
 icon: https://raw.githubusercontent.com/verdaccio/verdaccio/master/assets/bitmap/logo/logo-twitter.png

--- a/stable/verdaccio/templates/deployment.yaml
+++ b/stable/verdaccio/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -16,6 +16,10 @@ spec:
     {{- else }}
     type: RollingUpdate
     {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "verdaccio.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       annotations:

--- a/stable/verdaccio/templates/ingress.yaml
+++ b/stable/verdaccio/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled }}
 {{- $serviceName := include "verdaccio.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "verdaccio.fullname" . }}


### PR DESCRIPTION
Hi @etiennetremel :wave: Hope we'll deal with that quickly :smile::+1: 

#### What this PR does / why we need it:

Updates resource's versions to support the Kubernetes v1.16 API

Currently the chart cannot be installed on a Kubernetes v1.16 cluster. For more details see:
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
