### PR TITLE
[stable/airflow] make the minReadySeconds changeable

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 4.7.0
+version: 4.8.0
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -375,6 +375,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `web.labels`                             | labels for the web deployment                           | `{}`                      |
 | `web.annotations`                        | annotations for the web deployment                      | `{}`                      |
 | `web.initialStartupDelay`                | amount of time webserver pod should sleep before initializing webserver             | `60`  |
+| `web.minReadySeconds`                    | minReadySeconds in the web deployment                   | `120`
 | `web.livenessProbe.periodSeconds`        | interval between probes                         | `60`  |
 | `web.livenessProbe.timeoutSeconds`       | time allowed for a result to return             | `1`  |
 | `web.livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful             | `1`  |

--- a/stable/airflow/templates/deployments-web.yaml
+++ b/stable/airflow/templates/deployments-web.yaml
@@ -17,7 +17,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.airflow.webReplicas }}
-  minReadySeconds: 120
+  minReadySeconds: {{ .Values.web.minReadySeconds }}
   strategy:
     # Smooth rolling update of the Web UI
     type: RollingUpdate

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -241,6 +241,7 @@ web:
   annotations: {}
   initialStartupDelay: "60"
   initialDelaySeconds: "360"
+  minReadySeconds: 120
   readinessProbe:
     periodSeconds: 60
     timeoutSeconds: 1


### PR DESCRIPTION
#### Is this a new chart
No
#### What this PR does / why we need it:

#### Which issue this PR fixes
Makes the minReadySeconds changeable

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
