### PR TITLE
[bitnami/mariadb] Allow provision existing PVC in MariaDB slaves

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb
-version: 7.0.1
+version: 7.1.0
 appVersion: 10.3.20
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -137,6 +137,9 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `slave.tolerations`                       | List of node taints to tolerate for (slave)         | `[]`                                                              |
 | `slave.updateStrategy`                    | Slave statefulset update strategy policy            | `RollingUpdate`                                                   |
 | `slave.persistence.enabled`               | Enable persistence using a `PersistentVolumeClaim`  | `true`                                                            |
+| `slave.persistence.existingClaim`         | Provide an existing `PersistentVolumeClaim`         | `nil`                                                             |
+| `slave.persistence.subPath`               | Subdirectory of the volume to mount                 | `nil`                                                             |
+| `slave.persistence.mountPath`             | Path to mount the volume at                         | `/bitnami/mariadb`                                                |
 | `slave.persistence.annotations`           | Persistent Volume Claim annotations                 | `{}`                                                              |
 | `slave.persistence.storageClass`          | Persistent Volume Storage Class                     | ``                                                                |
 | `slave.persistence.accessModes`           | Persistent Volume Access Modes                      | `[ReadWriteOnce]`                                                 |

--- a/stable/mariadb/templates/slave-statefulset.yaml
+++ b/stable/mariadb/templates/slave-statefulset.yaml
@@ -223,10 +223,14 @@ spec:
           configMap:
             name: {{ template "slave.fullname" . }}
         {{- end }}
-{{- if not .Values.slave.persistence.enabled }}
-        - name: "data"
+{{- if and .Values.slave.persistence.enabled .Values.slave.persistence.existingClaim }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.slave.persistence.existingClaim }}
+{{- else if not .Values.slave.persistence.enabled }}
+        - name: data
           emptyDir: {}
-{{- else }}
+{{- else if and .Values.slave.persistence.enabled (not .Values.slave.persistence.existingClaim) }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/stable/mariadb/values-production.yaml
+++ b/stable/mariadb/values-production.yaml
@@ -353,8 +353,24 @@ slave:
     ## If true, use a Persistent Volume Claim, If false, use emptyDir
     ##
     enabled: true
+    # Enable persistence using an existing PVC
+    # existingClaim:
+    # Subdirectory of the volume to mount
+    # subPath:
+    mountPath: /bitnami/mariadb
+    ## Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
     # storageClass: "-"
-    annotations:
+    ## Persistent Volume Claim annotations
+    ##
+    annotations: {}
+    ## Persistent Volume Access Mode
+    ##
     accessModes:
     - ReadWriteOnce
     ## Persistent Volume size

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -354,8 +354,24 @@ slave:
     ## If true, use a Persistent Volume Claim, If false, use emptyDir
     ##
     enabled: true
+    # Enable persistence using an existing PVC
+    # existingClaim:
+    # Subdirectory of the volume to mount
+    # subPath:
+    mountPath: /bitnami/mariadb
+    ## Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
     # storageClass: "-"
-    annotations:
+    ## Persistent Volume Claim annotations
+    ##
+    annotations: {}
+    ## Persistent Volume Access Mode
+    ##
     accessModes:
     - ReadWriteOnce
     ## Persistent Volume size


### PR DESCRIPTION
#### What this PR does / why we need it:
Allow provision an existing PVC in MariaDB slaves as it is allowed in the master

#### Which issue this PR fixes
  - fixes #19015

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
