### PR TITLE
[stable/jenkins] Update REQ_URL for jenkins configAutoReload sidecar

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.9.4
+version: 1.9.5
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -290,7 +290,7 @@ spec:
             - name: NAMESPACE
               value: "{{ .Values.master.sidecars.configAutoReload.searchNamespace | default .Release.Namespace }}"
             - name: REQ_URL
-              value: "http://localhost:8080/reload-configuration-as-code/?casc-reload-token=$(POD_NAME)"
+              value: "http://localhost:8080{{ .Values.master.jenkinsUriPrefix }}/configuration-as-code/reload"
             - name: REQ_METHOD
               value: "POST"
           resources:


### PR DESCRIPTION
#### What this PR does / why we need it:
The side car container kept giving me this error: POST request sent to http://localhost:8080/reload-configuration-as-code/?casc-reload-token=jenkins-c8d49444f-sg6j4. Response: 404 Not Found
So the configAutoReload wasn't working. When I changed it to the URL in my PR, it worked.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
