### PR TITLE
[stable/jaeger-operator] adding jaeger instance creation support

### DIFF
--- a/stable/jaeger-operator/Chart.yaml
+++ b/stable/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.10.2
+version: 2.11.0
 appVersion: 1.14.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/stable/jaeger-operator/README.md
+++ b/stable/jaeger-operator/README.md
@@ -46,12 +46,14 @@ The following table lists the configurable parameters of the jaeger-operator cha
 | `image.repository`      | Controller container image repository                                                                       | `jaegertracing/jaeger-operator` |
 | `image.tag`             | Controller container image tag                                                                              | `1.14.0`                        |
 | `image.pullPolicy`      | Controller container image pull policy                                                                      | `IfNotPresent`                  |
+| `jaeger.create`         | Jaeger instance will be created                                                                             | `false`                         |
+| `jaeger.spec`           | Jaeger instance specification                                                                               | `{}`                            |
 | `rbac.create`           | All required roles and rolebindings will be created                                                         | `true`                          |
 | `serviceAccount.create` | Service account to use                                                                                      | `true`                          |
 | `rbac.pspEnabled`       | Pod security policy for pod will be created and included in rbac role                                       | `false`                         |
 | `rbac.clusterRole`      | ClusterRole will be used by operator ServiceAccount                                                         | `false`                         |
-| `serviceAccount.name`   | Service account name to use. If not set and create is true, a name is generated using the fullname template | ``                              |
-| `resources`             | K8s pod resorces                                                                                            | `None`                          |
+| `serviceAccount.name`   | Service account name to use. If not set and create is true, a name is generated using the fullname template | `nil`                           |
+| `resources`             | K8s pod resources                                                                                           | `None`                          |
 | `nodeSelector`          | Node labels for pod assignment                                                                              | `{}`                            |
 | `tolerations`           | Toleration labels for pod assignment                                                                        | `[]`                            |
 | `affinity`              | Affinity settings for pod assignment                                                                        | `{}`                            |

--- a/stable/jaeger-operator/templates/jaeger.yaml
+++ b/stable/jaeger-operator/templates/jaeger.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.jaeger.create }}
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: {{ include "jaeger-operator.fullname" . }}-jaeger
+{{- with .Values.jaeger.spec }}
+spec:
+{{ toYaml . | indent 2}}
+{{- end }}
+{{- end }}

--- a/stable/jaeger-operator/values.yaml
+++ b/stable/jaeger-operator/values.yaml
@@ -6,6 +6,11 @@ image:
   tag: 1.14.0
   pullPolicy: IfNotPresent
 
+jaeger:
+  # Specifies whether Jaeger instance should be created
+  create: false
+  spec: {}
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true


### PR DESCRIPTION
#### What this PR does / why we need it:
Adding option to create a jaeger instance as part of operator lifecycle.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
