### PR TITLE
[stable/rabbitmq-ha] Support 'hostPath' persistent storage

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.8.0
-version: 1.36.4
+version: 1.37.0
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -88,7 +88,7 @@ and their default values.
 | `hostPath.chown`                               | Run an init-container as root to set ownership on the hostPath | `true`         |
 | `hostPath.type`                                | Type for a hostPath volume                                   | `DirectoryOrCreate` |
 | `hostPath.mnesiaDir`                           | If we use hostPath for persistent data, we must set the path for mnesia directory | `$RABBITMQ_MNESIA_BASE/mnesia`  | 
-| `hostPath.pluginsExpandDir`           | If we use hostPath for persistent data, we must set the path for plugins expand directory  | `$RABBITMQ_MNESIA_BASE/plugins-expand`  | 
+| `hostPath.pluginsExpandDir`           | If we use hostPath for persistent data, we must set the path to the plugins  | `$RABBITMQ_MNESIA_BASE/plugins-expand`  | 
 | `image.pullPolicy`                             | Image pull policy                                                                                                                                                                                     | `IfNotPresent`   |
 | `image.repository`                             | RabbitMQ container image repository                                                                                                                                                                   | `rabbitmq`                                                 |
 | `image.tag`                                    | RabbitMQ container image tag                                                                                                                                                                          | `3.8.0-alpine`                                            |

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -84,6 +84,16 @@ and their default values.
 | `definitions.policies`                         | HA policies to add to definitions.json | `""` |
 | `definitionsSource`                            | Use this key within an existing secret to reference the definitions specification | `"definitions.json"` |
 | `forceBoot`                                    | [Force](https://www.rabbitmq.com/rabbitmqctl.8.html#force_boot) the cluster to start even if it was shutdown in an unexpected order, preferring availability over integrity | `false` |
+| `hostPath.path`                                | Use this path on the host for data storage                   | `/data/rabbitmq-ha` |
+
+| `hostPath.chown`                               | Run an init-container as root to set ownership on the hostPath | `true`         |
+
+| `hostPath.type`                                | Type for a hostPath volume                                   | `DirectoryOrCreate` |
+
+| `hostPath.mnesiaDir`                           | If we use hostPath for persistent data, we must set the path for mnesia directory | `$RABBITMQ_MNESIA_BASE/mnesia`  | 
+
+| `hostPath.pluginsExpandDir`           | If we use hostPath for persistent data, we must set the path for plugins expand directory  | `$RABBITMQ_MNESIA_BASE/plugins-expand`  | 
+
 | `image.pullPolicy`                             | Image pull policy                                                                                                                                                                                     | `IfNotPresent`   |
 | `image.repository`                             | RabbitMQ container image repository                                                                                                                                                                   | `rabbitmq`                                                 |
 | `image.tag`                                    | RabbitMQ container image tag                                                                                                                                                                          | `3.8.0-alpine`                                            |

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -85,15 +85,10 @@ and their default values.
 | `definitionsSource`                            | Use this key within an existing secret to reference the definitions specification | `"definitions.json"` |
 | `forceBoot`                                    | [Force](https://www.rabbitmq.com/rabbitmqctl.8.html#force_boot) the cluster to start even if it was shutdown in an unexpected order, preferring availability over integrity | `false` |
 | `hostPath.path`                                | Use this path on the host for data storage                   | `/data/rabbitmq-ha` |
-
 | `hostPath.chown`                               | Run an init-container as root to set ownership on the hostPath | `true`         |
-
 | `hostPath.type`                                | Type for a hostPath volume                                   | `DirectoryOrCreate` |
-
 | `hostPath.mnesiaDir`                           | If we use hostPath for persistent data, we must set the path for mnesia directory | `$RABBITMQ_MNESIA_BASE/mnesia`  | 
-
 | `hostPath.pluginsExpandDir`           | If we use hostPath for persistent data, we must set the path for plugins expand directory  | `$RABBITMQ_MNESIA_BASE/plugins-expand`  | 
-
 | `image.pullPolicy`                             | Image pull policy                                                                                                                                                                                     | `IfNotPresent`   |
 | `image.repository`                             | RabbitMQ container image repository                                                                                                                                                                   | `rabbitmq`                                                 |
 | `image.tag`                                    | RabbitMQ container image tag                                                                                                                                                                          | `3.8.0-alpine`                                            |

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -55,6 +55,20 @@ spec:
 {{ toYaml .Values.securityContext | indent 10 }}
       serviceAccountName: {{ template "rabbitmq-ha.serviceAccountName" . }}
       initContainers:
+{{- if and .Values.hostPath.enabled .Values.hostPath.chown }}
+        - name: hostpath-chown
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          command:
+          - chown
+          - "{{ .Values.securityContext.runAsUser }}"
+          - /data
+          volumeMounts:
+          - name: data
+            mountPath: /data
+{{- end }}
         - name: bootstrap
           image: {{ .Values.busyboxImage.repository}}:{{ .Values.busyboxImage.tag}}
           imagePullPolicy: {{ .Values.busyboxImage.pullPolicy }}
@@ -262,7 +276,7 @@ spec:
       {{- if .Values.schedulerName }}
       schedulerName: "{{ .Values.schedulerName }}"
       {{- end }}
-      {{- if or (eq .Values.podAntiAffinity "hard") (Values.hostPath.enabled)  }}
+      {{- if or (eq .Values.podAntiAffinity "hard") (.Values.hostPath.enabled) }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -76,8 +76,15 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.name
+{{- if .Values.hostPath.enabled }}
+          - name: RABBITMQ_MNESIA_DIR
+            value: {{ .Values.hostPath.mnesiaDir }}
+          - name: RABBITMQ_PLUGINS_EXPAND_DIR
+            value: {{ .Values.hostPath.pluginsExpandDir }}
+{{- else }}
           - name: RABBITMQ_MNESIA_DIR
             value: /var/lib/rabbitmq/mnesia/rabbit@$(POD_NAME).{{ template "rabbitmq-ha.fullname" . }}-discovery.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+{{- end }}
           - name: RABBITMQ_ERLANG_COOKIE
             valueFrom:
               secretKeyRef:
@@ -178,6 +185,12 @@ spec:
                 secretKeyRef:
                   name: {{ template "rabbitmq-ha.secretName" . }}
                   key: rabbitmq-management-password
+{{- if .Values.hostPath.enabled }}
+            - name: RABBITMQ_MNESIA_DIR
+              value: {{ .Values.hostPath.mnesiaDir }}
+            - name: RABBITMQ_PLUGINS_EXPAND_DIR
+              value: {{ .Values.hostPath.pluginsExpandDir }}
+{{- end }}
             {{- if .Values.rabbitmqHipeCompile }}
             - name: RABBITMQ_HIPE_COMPILE
               value: {{ .Values.rabbitmqHipeCompile | quote }}
@@ -249,7 +262,7 @@ spec:
       {{- if .Values.schedulerName }}
       schedulerName: "{{ .Values.schedulerName }}"
       {{- end }}
-      {{- if eq .Values.podAntiAffinity "hard" }}
+      {{- if or (eq .Values.podAntiAffinity "hard") (Values.hostPath.enabled)  }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -317,6 +330,11 @@ spec:
         storageClassName: "{{ .Values.persistentVolume.storageClass }}"
       {{- end }}
       {{- end }}
+{{- else if .Values.hostPath.enabled }}
+        - name: {{ .Values.persistentVolume.name }}
+          hostPath:
+            path: {{ .Values.hostPath.path }}
+            type: {{ .Values.hostPath.type }}
 {{- else }}
         - name: {{ .Values.persistentVolume.name }}
           emptyDir: {}

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -408,7 +408,7 @@ hostPath:
   # security context
   chown: true
   type: DirectoryOrCreate
-  #We need to use path on all hosts to save data
+  # we need to use path on all hosts to save data
   mnesiaDir: $RABBITMQ_MNESIA_BASE/mnesia_dir
   pluginsExpandDir: $RABBITMQ_MNESIA_BASE/plugins-expand
 

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -396,11 +396,8 @@ persistentVolume:
   size: 8Gi
   annotations: {}
 
-# To use a hostPath for data:
-# 1. Set persistentVolume.enabled to false
-# 2. Add "ha-mode":"all" for all policies for queues and exchnges
-# 3. Add "ha-sync-mode":"automatic" for all policies for queues and exchnges
-# and define hostPath.path.
+# To use a hostPath for data, you need to set persistentVolume.enabled: false
+# and define hostPath.path
 # Warning: this might overwrite existing folders on the host system!
 hostPath:
   enabled: false
@@ -411,7 +408,7 @@ hostPath:
   # security context
   chown: true
   type: DirectoryOrCreate
-  #We need to use an universal path on all hosts to save data
+  #We need to use path on all hosts to save data
   mnesiaDir: $RABBITMQ_MNESIA_BASE/mnesia_dir
   pluginsExpandDir: $RABBITMQ_MNESIA_BASE/plugins-expand
 
@@ -579,5 +576,3 @@ clusterDomain: cluster.local
 podDisruptionBudget: {}
   # maxUnavailable: 1
   # minAvailable: 1
-
-#Add possibility to use hostPath for persistant data

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -405,15 +405,15 @@ persistentVolume:
 hostPath:
   enabled: false
   ## path is evaluated as template so placeholders are replaced
-  path: "/data/{{ .Release.Name }}"
+  path: /data/rabbitmq-ha
   # if chown is true, an init-container with root permissions is launched to
   # change the owner of the hostPath folder to the user defined in the
   # security context
   chown: true
+  type: DirectoryOrCreate
   #We need to use an universal path on all hosts to save data
   mnesiaDir: $RABBITMQ_MNESIA_BASE/mnesia_dir
   pluginsExpandDir: $RABBITMQ_MNESIA_BASE/plugins-expand
-  type: Directory
 
 
 ## Node labels for pod assignment

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -396,6 +396,26 @@ persistentVolume:
   size: 8Gi
   annotations: {}
 
+# To use a hostPath for data:
+# 1. Set persistentVolume.enabled to false
+# 2. Add "ha-mode":"all" for all policies for queues and exchnges
+# 3. Add "ha-sync-mode":"automatic" for all policies for queues and exchnges
+# and define hostPath.path.
+# Warning: this might overwrite existing folders on the host system!
+hostPath:
+  enabled: false
+  ## path is evaluated as template so placeholders are replaced
+  path: "/data/{{ .Release.Name }}"
+  # if chown is true, an init-container with root permissions is launched to
+  # change the owner of the hostPath folder to the user defined in the
+  # security context
+  chown: true
+  #We need to use an universal path on all hosts to save data
+  mnesiaDir: $RABBITMQ_MNESIA_BASE/mnesia_dir
+  pluginsExpandDir: $RABBITMQ_MNESIA_BASE/plugins-expand
+  type: Directory
+
+
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 ##
@@ -559,3 +579,5 @@ clusterDomain: cluster.local
 podDisruptionBudget: {}
   # maxUnavailable: 1
   # minAvailable: 1
+
+#Add possibility to use hostPath for persistant data


### PR DESCRIPTION
Support 'hostPath' persistent storage

#### What this PR does / why we need it:
In some cases, we need to use hostPath to store persistent data. 

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
