### PR TITLE
[stable/openldap] Provide custom ldif through a configmap

### DIFF
--- a/stable/openldap/Chart.yaml
+++ b/stable/openldap/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: openldap
 home: https://www.openldap.org
-version: 1.2.3
+version: 1.2.4
 appVersion: 2.4.48
 description: Community developed LDAP software
 icon: http://www.openldap.org/images/headers/LDAPworm.gif

--- a/stable/openldap/README.md
+++ b/stable/openldap/README.md
@@ -23,42 +23,43 @@ We use the docker images provided by https://github.com/osixia/docker-openldap. 
 
 The following table lists the configurable parameters of the openldap chart and their default values.
 
-| Parameter                          | Description                                                                                                                               | Default             |
-| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| `replicaCount`                     | Number of replicas                                                                                                                        | `1`                 |
-| `strategy`                         | Deployment strategy                                                                                                                       | `{}`                |
-| `image.repository`                 | Container image repository                                                                                                                | `osixia/openldap`   |
-| `image.tag`                        | Container image tag                                                                                                                       | `1.1.10`            |
-| `image.pullPolicy`                 | Container pull policy                                                                                                                     | `IfNotPresent`      |
-| `extraLabels`                      | Labels to add to the Resources                                                                                                            | `{}`                |
-| `podAnnotations`                   | Annotations to add to the pod                                                                                                             | `{}`                |
-| `existingSecret`                   | Use an existing secret for admin and config user passwords                                                                                | `""`                |
-| `service.annotations`              | Annotations to add to the service                                                                                                         | `{}`                |
-| `service.clusterIP`                | IP address to assign to the service                                                                                                       | `""`                |
-| `service.externalIPs`              | Service external IP addresses                                                                                                             | `[]`                |
-| `service.ldapPort`                 | External service port for LDAP                                                                                                            | `389`               |
-| `service.loadBalancerIP`           | IP address to assign to load balancer (if supported)                                                                                      | `""`                |
-| `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)                                                                           | `[]`                |
-| `service.sslLdapPort`              | External service port for SSL+LDAP                                                                                                        | `636`               |
-| `service.type`                     | Service type                                                                                                                              | `ClusterIP`         |
-| `env`                              | List of key value pairs as env variables to be sent to the docker image. See https://github.com/osixia/docker-openldap for available ones | `[see values.yaml]` |
-| `tls.enabled`                      | Set to enable TLS/LDAPS - should also set `tls.secret`                                                                                    | `false`             |
-| `tls.secret`                       | Secret containing TLS cert and key (eg, generated via cert-manager)                                                                       | `""`                |
-| `tls.CA.enabled`                   | Set to enable custom CA crt file - should also set `tls.CA.secret`                                                                        | `false`             |
-| `tls.CA.secret`                    | Secret containing CA certificate (ca.crt)                                                                                                 | `""`                |
-| `adminPassword`                    | Password for admin user. Unset to auto-generate the password                                                                              | None                |
-| `configPassword`                   | Password for config user. Unset to auto-generate the password                                                                             | None                |
-| `customLdifFiles`                  | Custom ldif files to seed the LDAP server. List of filename -> data pairs                                                                 | None                |
-| `persistence.enabled`              | Whether to use PersistentVolumes or not                                                                                                   | `false`             |
-| `persistence.storageClass`         | Storage class for PersistentVolumes.                                                                                                      | `<unset>`           |
-| `persistence.accessMode`           | Access mode for PersistentVolumes                                                                                                         | `ReadWriteOnce`     |
-| `persistence.size`                 | PersistentVolumeClaim storage size                                                                                                        | `8Gi`               |
-| `persistence.existingClaim`        | An Existing PVC name for openLDAPA volume                                                                                                 | None                |
-| `resources`                        | Container resource requests and limits in yaml                                                                                            | `{}`                |
-| `initResources`                    | initContainer resource requests and limits in yaml                                                                                        | `{}`                |
-| `test.enabled`                     | Conditionally provision test resources                                                                                                    | `false`             |
-| `test.image.repository`            | Test container image requires bats framework                                                                                              | `dduportal/bats`    |
-| `test.image.tag`                   | Test container tag                                                                                                                        | `0.4.0`             |
+| Parameter                          | Description                                                                                                                                    | Default             |
+| ---------------------------------- | -----------------------------------------------------------------------------------------------------------------------------------------      | ------------------- |
+| `replicaCount`                     | Number of replicas                                                                                                                             | `1`                 |
+| `strategy`                         | Deployment strategy                                                                                                                            | `{}`                |
+| `image.repository`                 | Container image repository                                                                                                                     | `osixia/openldap`   |
+| `image.tag`                        | Container image tag                                                                                                                            | `1.1.10`            |
+| `image.pullPolicy`                 | Container pull policy                                                                                                                          | `IfNotPresent`      |
+| `extraLabels`                      | Labels to add to the Resources                                                                                                                 | `{}`                |
+| `podAnnotations`                   | Annotations to add to the pod                                                                                                                  | `{}`                |
+| `existingSecret`                   | Use an existing secret for admin and config user passwords                                                                                     | `""`                |
+| `service.annotations`              | Annotations to add to the service                                                                                                              | `{}`                |
+| `service.clusterIP`                | IP address to assign to the service                                                                                                            | `""`                |
+| `service.externalIPs`              | Service external IP addresses                                                                                                                  | `[]`                |
+| `service.ldapPort`                 | External service port for LDAP                                                                                                                 | `389`               |
+| `service.loadBalancerIP`           | IP address to assign to load balancer (if supported)                                                                                           | `""`                |
+| `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)                                                                                | `[]`                |
+| `service.sslLdapPort`              | External service port for SSL+LDAP                                                                                                             | `636`               |
+| `service.type`                     | Service type                                                                                                                                   | `ClusterIP`         |
+| `env`                              | List of key value pairs as env variables to be sent to the docker image. See https://github.com/osixia/docker-openldap for available ones      | `[see values.yaml]` |
+| `tls.enabled`                      | Set to enable TLS/LDAPS - should also set `tls.secret`                                                                                         | `false`             |
+| `tls.secret`                       | Secret containing TLS cert and key (eg, generated via cert-manager)                                                                            | `""`                |
+| `tls.CA.enabled`                   | Set to enable custom CA crt file - should also set `tls.CA.secret`                                                                             | `false`             |
+| `tls.CA.secret`                    | Secret containing CA certificate (ca.crt)                                                                                                      | `""`                |
+| `adminPassword`                    | Password for admin user. Unset to auto-generate the password                                                                                   | None                |
+| `configPassword`                   | Password for config user. Unset to auto-generate the password                                                                                  | None                |
+| `customLdifFiles`                  | Custom ldif files to seed the LDAP server. List of filename -> data pairs                                                                      | None                |
+| `customLdifMap`                    | Name of a configmap containing custom ldif files to seed the LDAP server. If this and customLdifFiles are both defined, this takes preference. | None                |
+| `persistence.enabled`              | Whether to use PersistentVolumes or not                                                                                                        | `false`             |
+| `persistence.storageClass`         | Storage class for PersistentVolumes.                                                                                                           | `<unset>`           |
+| `persistence.accessMode`           | Access mode for PersistentVolumes                                                                                                              | `ReadWriteOnce`     |
+| `persistence.size`                 | PersistentVolumeClaim storage size                                                                                                             | `8Gi`               |
+| `persistence.existingClaim`        | An Existing PVC name for openLDAPA volume                                                                                                      | None                |
+| `resources`                        | Container resource requests and limits in yaml                                                                                                 | `{}`                |
+| `initResources`                    | initContainer resource requests and limits in yaml                                                                                             | `{}`                |
+| `test.enabled`                     | Conditionally provision test resources                                                                                                         | `false`             |
+| `test.image.repository`            | Test container image requires bats framework                                                                                                   | `dduportal/bats`    |
+| `test.image.tag`                   | Test container tag                                                                                                                             | `0.4.0`             |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/stable/openldap/templates/configmap-customldif.yaml
+++ b/stable/openldap/templates/configmap-customldif.yaml
@@ -2,7 +2,7 @@
 # A ConfigMap spec for openldap slapd that map directly to files under
 # /container/service/slapd/assets/config/bootstrap/ldif/custom
 #
-{{- if .Values.customLdifFiles }}
+{{- if and .Values.customLdifFiles (not .Values.customLdifMap) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/openldap/templates/deployment.yaml
+++ b/stable/openldap/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- if or .Values.customLdifFiles .Values.tls.enabled }}
       initContainers:
       {{- end }}
-      {{- if .Values.customLdifFiles }}
+      {{- if or .Values.customLdifFiles .Values.customLdifMap }}
       - name: {{ .Chart.Name }}-init-ldif
         image: busybox
         command: ['sh', '-c', 'cp /customldif/* /ldifworkingdir']
@@ -79,7 +79,7 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-{{- if .Values.customLdifFiles }}
+{{- if or .Values.customLdifFiles .Values.customLdifMap }}
           args: [--copy-service]
 {{- end }}
           ports:
@@ -99,7 +99,7 @@ spec:
             - name: data
               mountPath: /etc/ldap/slapd.d
               subPath: config-data
-            {{- if .Values.customLdifFiles }}
+            {{- if or .Values.customLdifFiles .Values.customLdifMap }}
             - name: ldifworkingdir
               mountPath: /container/service/slapd/assets/config/bootstrap/ldif/custom
             {{- end }}
@@ -145,10 +145,14 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
       volumes:
-        {{- if .Values.customLdifFiles }}
+        {{- if or .Values.customLdifFiles .Values.customLdifMap }}
         - name: customldif
           configMap:
+        {{- if and .Values.customLdifFiles (not .Values.customLdifMap) }}
             name: {{ template "openldap.fullname" . }}-customldif
+        {{- else }}
+            name: {{ .Values.customLdifMap }}
+        {{- end }}
         - name: ldifworkingdir
           emptyDir: {}
         {{- end }}

--- a/stable/openldap/values.yaml
+++ b/stable/openldap/values.yaml
@@ -67,6 +67,10 @@ env:
 # adminPassword: admin
 # configPassword: config
 
+# Custom openldap configuration configMap name, which takes preference if defined
+# over customLdifFiles.
+customLdifMap: ""
+
 # Custom openldap configuration files used to override default settings
 # customLdifFiles:
   # 01-default-users.ldif: |-


### PR DESCRIPTION
A new value: customLdifMap is the name of a configmap which contains
the equivalent of  customLdifFiles.

If both are defined the provided map takes preference.

  - fixes #19039 

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
