### PR TITLE
[stable/mongodb]  Respect the Release Name on initConfigMap.name setting

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 7.4.5
+version: 7.4.6
 appVersion: 4.0.13
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/templates/_helpers.tpl
+++ b/stable/mongodb/templates/_helpers.tpl
@@ -237,3 +237,14 @@ in the values file. If the name is not explicitly set it will take the "mongodb.
     {{ template "mongodb.fullname" .}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Returns the proper initConfigMap name with the release name
+*/}}
+{{- define "mongodb.initConfigMapName" -}}
+  {{- if .Values.initConfigMap -}}
+  {{- .Release.Name | trunc 63  -}}-{{ .Values.initConfigMap.name}}
+  {{- else -}}
+   ""
+  {{- end -}}
+{{- end -}}

--- a/stable/mongodb/templates/_helpers.tpl
+++ b/stable/mongodb/templates/_helpers.tpl
@@ -237,14 +237,3 @@ in the values file. If the name is not explicitly set it will take the "mongodb.
     {{ template "mongodb.fullname" .}}
   {{- end -}}
 {{- end -}}
-
-{{/*
-Returns the proper initConfigMap name with the release name
-*/}}
-{{- define "mongodb.initConfigMapName" -}}
-  {{- if .Values.initConfigMap -}}
-  {{- .Release.Name | trunc 63  -}}-{{ .Values.initConfigMap.name}}
-  {{- else -}}
-   ""
-  {{- end -}}
-{{- end -}}

--- a/stable/mongodb/templates/deployment-standalone.yaml
+++ b/stable/mongodb/templates/deployment-standalone.yaml
@@ -239,7 +239,7 @@ spec:
       {{- if (.Values.initConfigMap) }}
       - name: custom-init-scripts
         configMap:
-          name: {{ .Values.initConfigMap.name }}
+          name: {{ template "mongodb.initConfigMapName" $ }}
       {{- end }}
       - name: data
       {{- if .Values.persistence.enabled }}

--- a/stable/mongodb/templates/deployment-standalone.yaml
+++ b/stable/mongodb/templates/deployment-standalone.yaml
@@ -239,7 +239,7 @@ spec:
       {{- if (.Values.initConfigMap) }}
       - name: custom-init-scripts
         configMap:
-          name: {{ template "mongodb.initConfigMapName" $ }}
+          name: {{- tpl .Values.initConfigMap.name . }}
       {{- end }}
       - name: data
       {{- if .Values.persistence.enabled }}

--- a/stable/mongodb/templates/statefulset-primary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-primary-rs.yaml
@@ -264,7 +264,7 @@ spec:
         {{- if (.Values.initConfigMap) }}
         - name: custom-init-scripts
           configMap:
-            name: {{ .Values.initConfigMap.name }}
+            name: {{ template "mongodb.initConfigMapName" $ }}
         {{- end }}
         {{- if .Values.configmap }}
         - name: config

--- a/stable/mongodb/templates/statefulset-primary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-primary-rs.yaml
@@ -264,7 +264,7 @@ spec:
         {{- if (.Values.initConfigMap) }}
         - name: custom-init-scripts
           configMap:
-            name: {{ template "mongodb.initConfigMapName" $ }}
+            name: "{{- tpl .Values.initConfigMap.name . }}"
         {{- end }}
         {{- if .Values.configmap }}
         - name: config


### PR DESCRIPTION
@rydonius
@tompizmor
@sameersbn
@carrodher
@javsalgar
@juan131
@miguelaeh
@bitnami-bot 


**Description**

You allow the value of initConfigMap.name to be overridden as a value, but you don't prefix it with the Release.name.  That means in my parent chart I  have to hard code the release name. This  adds extra steps when I deploy different instances of my parent chart.


**Steps to reproduce the issue:**
my parent chart is call database.

in a parent chart values I put:
mongodb:
   initConfigMap:
       name:  database-init-scripts

helm install -n first helm/database
helm install -n second helm/database

**Describe the results you received:**

Config maps created:

   first-database-init-scripts
  second-database-init-scripts

Both installs fail because it is unable to  "database-init-scripts" config map for mongodb, because they are prefixed with the release name.



**Describe the results you expected:**
I expected the subchart mongodb to automatically prefix the configmap name with a Release.name so each instance will look in the correct configmap and successfully install my bootstrap data.




#### What this PR does / why we need it:
The chart allows you to provide a custom ConfigMap to be used for initialization of the mongodb.  The current setting doesn't prefix the config map with the release name. That means that when this is used as a subchart - either the value has to be overridden each time or the code will look in the wrong place.  Prefixing it with the Release.name fixes this and makes it behave in a way that is more contained.  




#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ X] Chart Version bumped
- [X ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
