### PR TITLE
[stable/datadog] Grant access to kubelet’s GET /stats/summary

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.38.3
+version: 1.38.4
 appVersion: 6.14.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/rbac.yaml
+++ b/stable/datadog/templates/rbac.yaml
@@ -78,6 +78,7 @@ rules:
   - nodes/metrics
   - nodes/spec
   - nodes/proxy
+  - nodes/stats
   verbs:
   - get
 - apiGroups:  # leader election check


### PR DESCRIPTION
With DataDog/integrations-core#5052, the datadog agent starts monitoring
the `stats/summary/` endpoint of the kubelet.
So, we need to grant it a role that allows it.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
