### PR TITLE
[stable/jenkins] enable agent master security

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.9.5 Enable remoting security
+
+`Manage Jenkins` -> `Configure Global Security` -> `Enable Agent → Master Access Control` is now enabled via configuration as code plugin
+
 ## 1.9.4 Option to set existing secret with Google Application Default Credentials
 
 Google application credentials are kept in a file, which has to be mounted to a pod. You can set `gcpcredentials` in `existingSecret` as follows:

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.9.4
+version: 1.9.5
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -73,6 +73,8 @@ Returns configuration as code default config
 {{- define "jenkins.casc.defaults" -}}
 jenkins:
   disableRememberMe: false
+  remotingSecurity:
+    enabled: true
   mode: NORMAL
   numExecutors: {{ .Values.master.numExecutors }}
   projectNamingStrategy: "standard"


### PR DESCRIPTION
#### What this PR does / why we need it:

It enables a recommended security feature:

`Manage Jenkins` -> `Configure Global Security` -> `Enable Agent → Master Access Control` is now enabled via configuration as code plugin

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - Part-of: #16931

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
