### PR TITLE
[stable/prometheus-pushgateway] support for Network Policies

### DIFF
--- a/stable/prometheus-pushgateway/Chart.yaml
+++ b/stable/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.2.5
+version: 1.2.6
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/stable/prometheus-pushgateway/README.md
+++ b/stable/prometheus-pushgateway/README.md
@@ -70,6 +70,8 @@ The following table lists the configurable parameters of the pushgateway chart a
 | `serviceMonitor.additionalLables` | Used to pass Labels that are required by the Installed Prometheus Operator                                                    | `{}`                              |
 | `serviceMonitor.honorLabels`      | if `true`, label conflicts are resolved by keeping label values from the scraped data                                         | `true`                            |
 | `podDisruptionBudget`             | If set, create a PodDisruptionBudget with the items in this map set in the spec                                               | ``                                |
+| `networkPolicy.allowAll`          | Allow connectivity from all pods in the cluster                                                                               | ``                                |
+| `networkPolicy.customSelectors`   | Allow connectivity from pods that match a list of podSelectors and namespaceSelectors                                         | ``                                |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-pushgateway/templates/_helpers.tpl
+++ b/stable/prometheus-pushgateway/templates/_helpers.tpl
@@ -52,3 +52,14 @@ Create default labels
 {{- $labels := dict "app" $labelApp "chart" $labelChart "release" .Release.Name "heritage" .Release.Service -}}
 {{ merge .extraLabels $labels | toYaml | indent 4 }}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for networkpolicy.
+*/}}
+{{- define "prometheus-pushgateway.networkPolicy.apiVersion" -}}
+{{- if semverCompare ">=1.4-0, <1.7-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/prometheus-pushgateway/templates/networkpolicy.yaml
+++ b/stable/prometheus-pushgateway/templates/networkpolicy.yaml
@@ -1,0 +1,27 @@
+{{ if .Values.networkPolicy }}
+apiVersion: {{ template "prometheus-pushgateway.networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+{{- if .Values.networkPolicy.customSelectors }}
+  name: ingress-allow-customselector-{{ template "prometheus-pushgateway.name" . }}
+{{- else if .Values.networkPolicy.allowAll }}
+  name: ingress-allow-all-{{ template "prometheus-pushgateway.name" . }}
+{{- else -}}
+{{- fail "One of `allowAll` or `customSelectors` must be specified." }}
+{{- end }}
+  labels:
+{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.podLabels) .  }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "prometheus-pushgateway.name" .}}
+  ingress:
+    - ports:
+      - port: {{ .Values.service.targetPort }}
+{{- if .Values.networkPolicy.customSelectors }}
+    - from:
+{{ toYaml .Values.networkPolicy.customSelectors | indent 8 }}
+{{- else if .Values.networkPolicy.allowAll }}
+    - {}
+{{- end -}}
+{{- end -}}

--- a/stable/prometheus-pushgateway/values.yaml
+++ b/stable/prometheus-pushgateway/values.yaml
@@ -114,3 +114,17 @@ serviceMonitor:
 # The values to set in the PodDisruptionBudget spec (minAvailable/maxUnavailable)
 # If not set then a PodDisruptionBudget will not be created
 podDisruptionBudget:
+
+# Configuration for clusters with restrictive network policies in place:
+# - allowAll allows access to the PushGateway from any namespace
+# - customSelector is a list of pod/namespaceSelectors to allow access from
+# These options are mutually exclusive and the latter will take precedence.
+networkPolicy:
+  # allowAll: true
+  # customSelectors:
+  #   - namespaceSelector:
+  #       matchLabels:
+  #         type: admin
+  #   - podSelector:
+  #       matchLabels:
+  #         app: myapp


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR creates a network policy allowing connections to the Prometheus PushGateway, which is useful in clusters with restrictive network policies.

It offers two options:
- open the gateway to all pods in the cluster
- open the gateway to a custom list of pod/namespace selectors

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
