### PR TITLE
[stable/prometheus] add failure and success threshold to probes

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 9.5.3
+version: 9.5.4
 appVersion: 2.13.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -104,12 +104,16 @@ spec:
               port: 9090
             initialDelaySeconds: {{ .Values.server.readinessProbeInitialDelay }}
             timeoutSeconds: {{ .Values.server.readinessProbeTimeout }}
+            failureThreshold: {{ .Values.server.readinessProbeFailureThreshold }}
+            successThreshold: {{ .Values.server.readinessProbeSuccessThreshold }}
           livenessProbe:
             httpGet:
               path: {{ .Values.server.prefixURL }}/-/healthy
               port: 9090
             initialDelaySeconds: {{ .Values.server.livenessProbeInitialDelay }}
             timeoutSeconds: {{ .Values.server.livenessProbeTimeout }}
+            failureThreshold: {{ .Values.server.livenessProbeFailureThreshold }}
+            successThreshold: {{ .Values.server.livenessProbeSuccessThreshold }}
           resources:
 {{ toYaml .Values.server.resources | indent 12 }}
           volumeMounts:

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -816,8 +816,12 @@ server:
   ##
   readinessProbeInitialDelay: 30
   readinessProbeTimeout: 30
+  readinessProbeFailureThreshold: 3
+  readinessProbeSuccessThreshold: 1
   livenessProbeInitialDelay: 30
   livenessProbeTimeout: 30
+  livenessProbeFailureThreshold: 3
+  livenessProbeSuccessThreshold: 1
 
   ## Prometheus server resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION


@mgoodness 
@gianrubio 

#### What this PR does / why we need it:

#### Which issue this PR fixes
- Add readinessProbeFailureThreshold
- Add readinessProbeSuccessThreshold
- Add livenessProbeFailureThreshold
- Add livenessProbeSuccessThreshold

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [-] Variables are documented in the README.md -> the others are also not documented?
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
