### PR TITLE
[stable/prometheus-operator] Fix fullnameOverride

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.2.2
+version: 8.2.3
 appVersion: 0.34.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -157,7 +157,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `defaultRules.rules.node` | Create Node default rules | `true` |
 | `defaultRules.rules.prometheus` | Create Prometheus  default rules| `true` |
 | `defaultRules.rules.time` | Create time default rules | `true` |
-| `fullNameOverride` | Provide a name to substitute for the full names of resources |`""`|
+| `fullnameOverride` | Provide a name to substitute for the full names of resources |`""`|
 | `global.imagePullSecrets` | Reference to one or more secrets to be used when pulling images | `[]` |
 | `global.rbac.create` | Create RBAC resources | `true` |
 | `global.rbac.pspEnabled` | Create pod security policy resources | `true` |


### PR DESCRIPTION
#### What this PR does / why we need it:

README change.

Correct the documentation for the `fullnameOverride` value field.

Used to be called `fullNameOverride`: I renamed it to `fullnameOverride` in the README.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
