### PR TITLE
[stable/elasticsearch-curator] Make helm hook job object have the same command as the CronJob

### DIFF
--- a/stable/elasticsearch-curator/Chart.yaml
+++ b/stable/elasticsearch-curator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "5.7.6"
 description: A Helm chart for Elasticsearch Curator
 name: elasticsearch-curator
-version: 2.1.1
+version: 2.1.2
 home: https://github.com/elastic/curator
 keywords:
 - curator

--- a/stable/elasticsearch-curator/templates/hooks/job.install.yaml
+++ b/stable/elasticsearch-curator/templates/hooks/job.install.yaml
@@ -49,7 +49,10 @@ spec:
     {{- if $.Values.extraVolumeMounts }}
 {{ toYaml $.Values.extraVolumeMounts | indent 12 }}
     {{- end }}
-          command: [ "curator" ]
+{{ if .Values.command }}
+          command:
+{{ toYaml .Values.command | indent 12 }}
+{{- end }}
           args: [ "--config", "/etc/es-curator/config.yml", "/etc/es-curator/action_file.yml" ]
           resources:
 {{ toYaml $.Values.resources | indent 12 }}


### PR DESCRIPTION
#### What this PR does / why we need it:
The helm hook Job did not use the same `command` as the CronJob. 

#### Which issue this PR fixes
Fixes #18994 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

@gianrubio @desaintmartin 
