### PR TITLE
Kong enterprise multiple ingress controllers deployment for multiple workspace support

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.27.0
+version: 0.28.0
 appVersion: 1.3

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -338,6 +338,21 @@ If your SMTP server requires authentication, you should the `username` and
 `smtp_password_secret` must be a Secret containing an `smtp_password` key whose
 value is your SMTP password.
 
+#### Workspaces
+
+Multiple Ingress Controllers pointing to the same database configuring different workspaces, requires the `ingresController.enabled: true`.
+
+Each workspace can be configure using the annotation `kubernetes.io/ingress.class` using the configured `ingressController.ingressClass` and the `workspace` name.
+
+For example:
+```yaml
+enterprise.workspaces:
+  - myworkspace-1
+  - myworkspace-2
+  ```
+Two ingress controllers will be created and can be configured with the `kubernetes.io/ingress.class:kong-myworkspace-1` and `kubernetes.io/ingress.class:kong-myworkspace-2` (apart from the default `kubernetes.io/ingress.class:kong`).
+
+
 ### DB-less Configuration
 
 
@@ -396,7 +411,7 @@ You can can learn about kong ingress custom resource definitions [here](https://
 | image.tag                          | Version of the ingress controller                                                     | 0.6.0                                                                        |
 | readinessProbe                     | Kong ingress controllers readiness probe                                              |                                                                              |
 | livenessProbe                      | Kong ingress controllers liveness probe                                               |                                                                              |
-| ingressClass                       | The ingress-class value for controller                                                | kong                                                                        |
+| ingressClass                       | The ingress-class value for controller                                                | kong                                                                         |
 | podDisruptionBudget.enabled        | Enable PodDisruptionBudget for ingress controller                                     | `false`                                                                      |
 | podDisruptionBudget.maxUnavailable | Represents the minimum number of Pods that can be unavailable (integer or percentage) | `50%`                                                                        |
 | podDisruptionBudget.minAvailable   | Represents the number of Pods that must be available (integer or percentage)          |                                                                              |
@@ -410,3 +425,8 @@ You can can learn about kong ingress custom resource definitions [here](https://
 
 - DB-less mode is enabled by default.
 - Kong is installed as an Ingress Controller for the cluster by default.
+
+### 0.28.0
+
+- Multiple Ingress Controllers Deployment for Kong Enterprise.If you are using Kong Enterprise, you can run multiple Ingress Controllers pointing to the same database and configuring different Workspaces inside Kong Enterprise.
+More info [here](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/concepts/deployment.md#multiple-ingress-controllers)

--- a/stable/kong/templates/controller-rbac-role.yaml
+++ b/stable/kong/templates/controller-rbac-role.yaml
@@ -28,7 +28,11 @@ rules:
       # Here: "<kong-ingress-controller-leader-nginx>-<nginx>"
       # This has to be adapted if you change either parameter
       # when launching the nginx-ingress-controller.
-      - "kong-ingress-controller-leader-{{ .Values.ingressController.ingressClass }}-{{ .Values.ingressController.ingressClass }}"
+      {{- $ingressClass:= .Values.ingressController.ingressClass }}
+      - "kong-ingress-controller-leader-{{ $ingressClass }}-{{ $ingressClass }}"
+      {{- range .Values.enterprise.workspaces }}
+      - "kong-ingress-controller-leader-{{ $ingressClass }}-{{ . }}-{{ $ingressClass }}-{{ . }}"
+      {{- end }}
     verbs:
       - get
       - update

--- a/stable/kong/templates/deployment-workspaces.yaml
+++ b/stable/kong/templates/deployment-workspaces.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.ingressController.enabled }}
+{{- range .Values.enterprise.workspaces -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ template "kong.fullname" $ }}-{{ . }}"
+  labels:
+    app: "{{ template "kong.name" $ }}-{{ . }}"
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+    component: app
+spec:
+  replicas: {{ $.Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "kong.name" $ }}-{{ . }}
+      release: {{ $.Release.Name }}
+      component: app
+  {{- if $.Values.updateStrategy }}
+  strategy:
+{{ toYaml $.Values.updateStrategy | indent 4 }}
+  {{- end }}
+
+  template:
+    metadata:
+      annotations:
+        {{- if $.Values.podAnnotations }}
+{{ toYaml $.Values.podAnnotations | indent 8 }}
+        {{- end }}
+      labels:
+        app: {{ template "kong.name" $ }}-{{ . }}
+        release: {{ $.Release.Name }}
+        component: app
+    spec:
+      serviceAccountName: {{ template "kong.serviceAccountName" $ }}
+      {{- if $.Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range $.Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      containers:
+      {{- include "kong.controller-container-workspace" (dict "root" $ "workspace" . ) | nindent 6 }}
+    {{- if $.Values.affinity }}
+      affinity:
+{{ toYaml $.Values.affinity | indent 8 }}
+    {{- end }}
+    {{- if $.Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml $.Values.nodeSelector | indent 8 }}
+    {{- end }}
+      tolerations:
+{{ toYaml $.Values.tolerations | indent 8 }}
+---
+{{- end }}
+{{- end }}

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -256,6 +256,10 @@ enterprise:
       # your SMTP password and specify its name here.
       smtp_username: ''  # e.g. postmaster@example.com
       smtp_password_secret: you-must-create-an-smtp-password
+  # When the ingress controller is enabled it can only configure the default workspace, 
+  # for multi workspace support set the list of workspaces (don't add the default workspace, is added by default).
+  # workspaces:
+  #   - myworkspace
 
 # Set runMigrations to run Kong migrations
 runMigrations: true

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -256,7 +256,7 @@ enterprise:
       # your SMTP password and specify its name here.
       smtp_username: ''  # e.g. postmaster@example.com
       smtp_password_secret: you-must-create-an-smtp-password
-  # When the ingress controller is enabled it can only configure the default workspace, 
+  # When the ingress controller is enabled it can only configure the default workspace,
   # for multi workspace support set the list of workspaces (don't add the default workspace, is added by default).
   # workspaces:
   #   - myworkspace


### PR DESCRIPTION
Adding support for configuring different workspaces with multiple ingress controller deployment when using kong enterprise. Multiple ingress deployment is documented [here](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/concepts/deployment.md#multiple-ingress-controllers) but not supported in the current helm chart.
We are using those modification in a customisation of the kong chart but would be great to keep using the original always trying to help with our feedback.