### PR TITLE
stable/prometheus-blackbox-exporter Add DaemonSet kind

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 3.1.0
+version: 3.2.0
 appVersion: 0.15.1
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/README.md
+++ b/stable/prometheus-blackbox-exporter/README.md
@@ -43,6 +43,7 @@ The following table lists the configurable parameters of the Blackbox-Exporter c
 
 | Parameter                                 | Description                                                                      | Default                                                                      |
 | ----------------------------------------- | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `kind`                                    | You can choose between `Deployment` or `DaemonSet`                               | `Deployment`                                                                 |
 | `config`                                  | Prometheus blackbox configuration                                                | {}                                                                           |
 | `secretConfig`                            | Whether to treat blackbox configuration as secret                                | `false`                                                                      |
 | `extraArgs`                               | Optional flags for blackbox                                                      | `[]`                                                                         |

--- a/stable/prometheus-blackbox-exporter/ci/daemonset-values.yml
+++ b/stable/prometheus-blackbox-exporter/ci/daemonset-values.yml
@@ -1,0 +1,1 @@
+kind: DaemonSet

--- a/stable/prometheus-blackbox-exporter/templates/daemonset.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/daemonset.yaml
@@ -1,6 +1,6 @@
-{{- if (eq .Values.kind "Deployment") }}
+{{- if (eq .Values.kind "DaemonSet") }}
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}
   labels:
@@ -59,13 +59,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             readOnlyRootFilesystem: {{ .Values.readOnlyRootFilesystem }}
-            {{- if .Values.allowIcmp }}
-            capabilities:
-              add: ["NET_RAW"]
-            {{- else }}
             runAsNonRoot: {{ .Values.runAsNonRoot  }}
             runAsUser: {{ .Values.runAsUser }}
-            {{- end }}
           args:
 {{- if .Values.config }}
             - "--config.file=/config/blackbox.yaml"

--- a/stable/prometheus-blackbox-exporter/values.yaml
+++ b/stable/prometheus-blackbox-exporter/values.yaml
@@ -1,5 +1,7 @@
 restartPolicy: Always
 
+kind: Deployment
+
 podDisruptionBudget: {}
   # maxUnavailable: 0
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
It adds the possibility to set the blackbox exporter as a DaemonSet instead of a Deployment. 

It's useful because you sometimes may want to see from which nodes you can reach some resources and which not.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

@desaintmartin @gianrubio 