### PR TITLE
stable/prometheus-operator: add missing labels to prometheus and to alertmanager

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -11,7 +11,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 7.2.1
+version: 7.2.2
 appVersion: 0.32.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/templates/alertmanager/service.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/service.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
     app: {{ template "prometheus-operator.name" . }}-alertmanager
 {{ include "prometheus-operator.labels" . | indent 4 }}
+{{- if .Values.alertmanager.service.labels }}
+{{ toYaml .Values.alertmanager.service.labels | indent 4 }}
+{{- end }}
 {{- if .Values.alertmanager.service.annotations }}
   annotations:
 {{ toYaml .Values.alertmanager.service.annotations | indent 4 }}

--- a/stable/prometheus-operator/templates/prometheus/service.yaml
+++ b/stable/prometheus-operator/templates/prometheus/service.yaml
@@ -8,6 +8,9 @@ metadata:
     app: {{ template "prometheus-operator.name" . }}-prometheus
     self-monitor: {{ .Values.prometheus.serviceMonitor.selfMonitor | quote }}
 {{ include "prometheus-operator.labels" . | indent 4 }}
+{{- if .Values.prometheus.service.labels }}
+{{ toYaml .Values.prometheus.service.labels | indent 4 }}
+{{- end }}
 {{- if .Values.prometheus.service.annotations }}
   annotations:
 {{ toYaml .Values.prometheus.service.annotations | indent 4 }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Service labels for prometheus and alertmanager could be set in the `values.yaml` but weren't reflected in their corresponding template file. 

