### PR TITLE
[stable/prometheus] Use current commit hash links to CRDs in README

### DIFF
--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -81,11 +81,11 @@ You should upgrade to Helm 2.14 + in order to avoid this issue. However, if you 
 
 1. Create CRDs
 ```console
-kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/alertmanager.crd.yaml
-kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/prometheus.crd.yaml
-kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/prometheusrule.crd.yaml
-kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/servicemonitor.crd.yaml
-kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/podmonitor.crd.yaml
+kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/ce72171c483921896d9370b3a8104c264fccdae7/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/ce72171c483921896d9370b3a8104c264fccdae7/example/prometheus-operator-crd/monitoring.coreos.com_prometheus.yaml
+kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/ce72171c483921896d9370b3a8104c264fccdae7/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/ce72171c483921896d9370b3a8104c264fccdae7/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/ce72171c483921896d9370b3a8104c264fccdae7/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
 ```
 
 2. Wait for CRDs to be created, which should only take a few seconds


### PR DESCRIPTION
This just broke my build. Please always use a perma link, plebs. See https://github.com/coreos/prometheus-operator/commit/ce72171c483921896d9370b3a8104c264fccdae7

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
Fix a README

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
Perhaps a CRD has changed and the operator needs an upgrade in general:

```console
$ kubectl get crd | grep coreos
alertmanagers.monitoring.coreos.com     2019-10-25T10:11:52Z
podmonitors.monitoring.coreos.com       2019-10-25T10:11:57Z
prometheus.monitoring.coreos.com        2019-11-25T09:56:56Z # new
prometheuses.monitoring.coreos.com      2019-10-25T10:11:54Z # old one
prometheusrules.monitoring.coreos.com   2019-10-25T10:11:55Z
servicemonitors.monitoring.coreos.com   2019-10-25T10:11:56Z
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
