### PR TITLE
[stable/mariadb] Improvements for test pod

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb
-version: 7.0.1
+version: 7.0.2
 appVersion: 10.3.20
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb
-version: 7.0.2
+version: 7.1.0
 appVersion: 10.3.20
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -185,6 +185,7 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `metrics.serviceMonitor.namespace`        | Optional namespace which Prometheus is running in   | `nil`                                                             |
 | `metrics.serviceMonitor.interval`         | How frequently to scrape metrics (use by default, falling back to Prometheus' default)  | `nil`                         |
 | `metrics.serviceMonitor.selector`         | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install   | `{ prometheus: kube-prometheus }` |
+| `tests.enabled`                           | Provide tests to check if connect and authentication is possible | `true`                                               |
 | `tests.resources`                         | Resource definition for the test-runner pod         | `nil`                                                             |
 | `tests.testFramework.image.registry`      | Test framework image registry (init container)      | `docker.io`                                                       |
 | `tests.testFramework.image.repository`    | Test framework image name                           | `dduportal/bats`                                                  |

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -185,6 +185,9 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `metrics.serviceMonitor.namespace`        | Optional namespace which Prometheus is running in   | `nil`                                                             |
 | `metrics.serviceMonitor.interval`         | How frequently to scrape metrics (use by default, falling back to Prometheus' default)  | `nil`                         |
 | `metrics.serviceMonitor.selector`         | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install   | `{ prometheus: kube-prometheus }` |
+| `testFramework.image.registry:`           | Init container "test-framework" image registry      | `docker.io`                                                       |
+| `testFramework.image.repository:`         | Init container "test-framework" image name          | `dduportal/bats`                                                  |
+| `testFramework.image.tag:`                | Init container "test-framework" image tag           | `0.4.0`                                                           |
 
 The above parameters map to the env variables defined in [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb). For more information please refer to the [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb) image documentation.
 

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -185,9 +185,11 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `metrics.serviceMonitor.namespace`        | Optional namespace which Prometheus is running in   | `nil`                                                             |
 | `metrics.serviceMonitor.interval`         | How frequently to scrape metrics (use by default, falling back to Prometheus' default)  | `nil`                         |
 | `metrics.serviceMonitor.selector`         | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install   | `{ prometheus: kube-prometheus }` |
-| `testFramework.image.registry:`           | Init container "test-framework" image registry      | `docker.io`                                                       |
-| `testFramework.image.repository:`         | Init container "test-framework" image name          | `dduportal/bats`                                                  |
-| `testFramework.image.tag:`                | Init container "test-framework" image tag           | `0.4.0`                                                           |
+| `tests.resources`                         | Resource definition for the test-runner pod         | `nil`                                                             |
+| `tests.testFramework.image.registry`      | Test framework image registry (init container)      | `docker.io`                                                       |
+| `tests.testFramework.image.repository`    | Test framework image name                           | `dduportal/bats`                                                  |
+| `tests.testFramework.image.tag`           | Test framework image tag                            | `0.4.0`                                                           |
+| `tests.testFramework.resources`           | Resource definition for the test framework          | `nil`                                                             |
 
 The above parameters map to the env variables defined in [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb). For more information please refer to the [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb) image documentation.
 

--- a/stable/mariadb/templates/_helpers.tpl
+++ b/stable/mariadb/templates/_helpers.tpl
@@ -164,10 +164,10 @@ imagePullSecrets:
 {{/*
 Return the proper test image name
 */}}
-{{- define "mariadb.testFramework.image" -}}
-{{- $registryName := .Values.testFramework.image.registry -}}
-{{- $repositoryName := .Values.testFramework.image.repository -}}
-{{- $tag := .Values.testFramework.image.tag | toString -}}
+{{- define "mariadb.tests.testFramework.image" -}}
+{{- $registryName := .Values.tests.testFramework.image.registry -}}
+{{- $repositoryName := .Values.tests.testFramework.image.repository -}}
+{{- $tag := .Values.tests.testFramework.image.tag | toString -}}
 {{/*
 Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
 but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.

--- a/stable/mariadb/templates/_helpers.tpl
+++ b/stable/mariadb/templates/_helpers.tpl
@@ -162,6 +162,29 @@ imagePullSecrets:
 {{- end -}}
 
 {{/*
+Return the proper test image name
+*/}}
+{{- define "mariadb.testFramework.image" -}}
+{{- $registryName := .Values.testFramework.image.registry -}}
+{{- $repositoryName := .Values.testFramework.image.repository -}}
+{{- $tag := .Values.testFramework.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the proper image name (for the init container volume-permissions image)
 */}}
 {{- define "mariadb.volumePermissions.image" -}}

--- a/stable/mariadb/templates/test-runner.yaml
+++ b/stable/mariadb/templates/test-runner.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tests.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -48,3 +49,4 @@ spec:
   - name: tools
     emptyDir: {}
   restartPolicy: Never
+{{- end }}

--- a/stable/mariadb/templates/test-runner.yaml
+++ b/stable/mariadb/templates/test-runner.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   initContainers:
     - name: "test-framework"
-      image: "dduportal/bats:0.4.0"
+      image: {{ template "mariadb.testFramework.image" . }}
       command:
         - "bash"
         - "-c"

--- a/stable/mariadb/templates/test-runner.yaml
+++ b/stable/mariadb/templates/test-runner.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   initContainers:
     - name: "test-framework"
-      image: {{ template "mariadb.testFramework.image" . }}
+      image: {{ template "mariadb.tests.testFramework.image" . }}
       command:
         - "bash"
         - "-c"
@@ -15,6 +15,9 @@ spec:
           set -ex
           # copy bats to tools dir
           cp -R /usr/local/libexec/ /tools/bats/
+      {{- if .Values.tests.testFramework.resources }}
+      resources: {{ toYaml .Values.tests.testFramework.resources | nindent 8 }}
+      {{- end }}
       volumeMounts:
       - mountPath: /tools
         name: tools
@@ -29,6 +32,9 @@ spec:
             secretKeyRef:
               name: {{ template "mariadb.secretName" . }}
               key: mariadb-root-password
+      {{- if .Values.tests.resources }}
+      resources: {{ toYaml .Values.tests.resources | nindent 8 }}
+      {{- end }}
       volumeMounts:
       - mountPath: /tests
         name: tests

--- a/stable/mariadb/templates/tests.yaml
+++ b/stable/mariadb/templates/tests.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tests.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,3 +8,4 @@ data:
     @test "Testing MariaDB is accessible" {
       mysql -h {{ template "mariadb.fullname" . }} -uroot -p$MARIADB_ROOT_PASSWORD -e 'show databases;'
     }
+{{- end }}

--- a/stable/mariadb/values-production.yaml
+++ b/stable/mariadb/values-production.yaml
@@ -533,3 +533,15 @@ metrics:
     ## [Kube Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#exporters)
     selector:
       prometheus: kube-prometheus
+
+## Bats Framework (= Bash Automated Testing System) is needed to test if MariaDB is accessible
+## See test-runner.yaml and tests.yaml for details.
+## To run the tests after the deployment, enter "helm test <release-name>".
+tests:
+  # resources: {}
+  testFramework:
+    image:
+      registry: docker.io
+      repository: dduportal/bats
+      tag: 0.4.0
+    # resources: {}

--- a/stable/mariadb/values-production.yaml
+++ b/stable/mariadb/values-production.yaml
@@ -538,6 +538,7 @@ metrics:
 ## See test-runner.yaml and tests.yaml for details.
 ## To run the tests after the deployment, enter "helm test <release-name>".
 tests:
+  enabled: true
   # resources: {}
   testFramework:
     image:

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -537,9 +537,13 @@ metrics:
       prometheus: kube-prometheus
 
 ## Bats Framework (= Bash Automated Testing System) is needed to test if MariaDB is accessible
-## See test-runner.yaml and tests.yaml
-testFramework:
-  image:
-    registry: docker.io
-    repository: dduportal/bats
-    tag: 0.4.0
+## See test-runner.yaml and tests.yaml for details.
+## To run the tests after the deployment, enter "helm test <release-name>".
+tests:
+  # resources: {}
+  testFramework:
+    image:
+      registry: docker.io
+      repository: dduportal/bats
+      tag: 0.4.0
+    # resources: {}

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -535,3 +535,11 @@ metrics:
     ## [Kube Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#exporters)
     selector:
       prometheus: kube-prometheus
+
+## Bats Framework (= Bash Automated Testing System) is needed to test if MariaDB is accessible
+## See test-runner.yaml and tests.yaml
+testFramework:
+  image:
+    registry: docker.io
+    repository: dduportal/bats
+    tag: 0.4.0

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -540,6 +540,7 @@ metrics:
 ## See test-runner.yaml and tests.yaml for details.
 ## To run the tests after the deployment, enter "helm test <release-name>".
 tests:
+  enabled: true
   # resources: {}
   testFramework:
     image:


### PR DESCRIPTION
The mariadb-test Pod uses the Bats Framework to verify if mariadb is up and accessible.
The current init container spec neither accept a globally overridden registry settings nor is it possible to override these settings only for this container.

Additionally I added:
- the possibility to enable/disable the tests completely
- the possibility to set resource requests/limits for the test pod

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
no

#### What this PR does / why we need it:

#### Which issue this PR fixes
`-`
#### Special notes for your reviewer:
`-`
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
