### PR TITLE
[stable/spring-cloud-data-flow] Added `deployer.imagePullPolicy` property

### DIFF
--- a/stable/spring-cloud-data-flow/Chart.yaml
+++ b/stable/spring-cloud-data-flow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Toolkit for building data processing pipelines.
 name: spring-cloud-data-flow
-version: 2.4.5
+version: 2.4.6
 appVersion: 2.2.2.RELEASE
 home: http://cloud.spring.io/spring-cloud-dataflow/
 sources:

--- a/stable/spring-cloud-data-flow/README.md
+++ b/stable/spring-cloud-data-flow/README.md
@@ -121,6 +121,7 @@ The following tables list the configurable parameters and their default values.
 | deployer.resourceLimits.memory              | Deployer resource limit for memory     | 1024Mi
 | deployer.readinessProbe.initialDelaySeconds | Deployer readiness probe initial delay | 120
 | deployer.livenessProbe.initialDelaySeconds  | Deployer liveness probe initial delay  | 90
+| deployer.imagePullPolicy                    | Deployer image pull policy             | IfNotPresent
 
 ### RabbitMQ Configuration
 

--- a/stable/spring-cloud-data-flow/templates/skipper-config.yaml
+++ b/stable/spring-cloud-data-flow/templates/skipper-config.yaml
@@ -30,6 +30,7 @@ data:
                       cpu: {{ .Values.deployer.resourceLimits.cpu }}
                     readinessProbeDelay: {{ .Values.deployer.readinessProbe.initialDelaySeconds }}
                     livenessProbeDelay: {{ .Values.deployer.livenessProbe.initialDelaySeconds }}
+                    imagePullPolicy: {{ .Values.deployer.imagePullPolicy }}
       datasource:
         url: 'jdbc:{{ template "scdf.database.scheme" . }}://{{ template "scdf.database.host" . }}:{{ template "scdf.database.port" . }}/{{ template "scdf.database.skipper" . }}'
         driverClassName: {{ template "scdf.database.driver" . }}

--- a/stable/spring-cloud-data-flow/values.yaml
+++ b/stable/spring-cloud-data-flow/values.yaml
@@ -64,6 +64,7 @@ deployer:
     initialDelaySeconds: 120
   livenessProbe:
     initialDelaySeconds: 90
+  imagePullPolicy: IfNotPresent
 
 rabbitmq:
   enabled: true


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds the option to specify the image pull policy for the deployer

#### Which issue this PR fixes
N/A
#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
