### PR TITLE
[stable/cockroachdb]: update version to v19.2.1

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 2.1.16
-appVersion: 19.1.5
+version: 2.1.17
+appVersion: 19.2.1
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png
 sources:

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -119,10 +119,10 @@ kubectl get pods \
 -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[0].image}{"\n"}'
 ```
 ```
-my-release-cockroachdb-0    cockroachdb/cockroach:v19.1.5
-my-release-cockroachdb-1    cockroachdb/cockroach:v19.1.5
-my-release-cockroachdb-2    cockroachdb/cockroach:v19.1.5
-my-release-cockroachdb-3    cockroachdb/cockroach:v19.1.5
+my-release-cockroachdb-0    cockroachdb/cockroach:v19.2.1
+my-release-cockroachdb-1    cockroachdb/cockroach:v19.2.1
+my-release-cockroachdb-2    cockroachdb/cockroach:v19.2.1
+my-release-cockroachdb-3    cockroachdb/cockroach:v19.2.1
 ```
 
 Resume normal operations.  Once you are comfortable that the stability and performance of the cluster is what you'd expect post upgrade, finalize it by running the following:
@@ -167,7 +167,7 @@ The following table lists the configurable parameters of the CockroachDB chart a
 | ------------------------------ | ------------------------------------------------ | ----------------------------------------- |
 | `Name`                         | Chart name                                       | `cockroachdb`                             |
 | `Image`                        | Container image name                             | `cockroachdb/cockroach`                   |
-| `ImageTag`                     | Container image tag                              | `v19.1.5`                                 |
+| `ImageTag`                     | Container image tag                              | `v19.2.1`                                 |
 | `ImagePullPolicy`              | Container pull policy                            | `Always`                                  |
 | `Replicas`                     | k8s statefulset replicas                         | `3`                                       |
 | `MaxUnavailable`               | k8s PodDisruptionBudget parameter                | `1`                                       |

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -5,7 +5,7 @@
 
 Name: "cockroachdb"
 Image: "cockroachdb/cockroach"
-ImageTag: "v19.1.5"
+ImageTag: "v19.2.1"
 ImagePullPolicy: "Always"
 Replicas: 3
 MaxUnavailable: 1


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:

This PR updates cockroachdb to v19.2.1, its latest stable version.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
