### PR TITLE
[stable/concourse] Deprecate the stable/concourse chart

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,8 +1,12 @@
 apiVersion: v1
 name: concourse
-version: 8.2.7
+# The concourse chart is deprecated and no longer maintained in the helm/charts repo.
+# The Concourse chart is now being maintained at github.com/concourse/concourse-chart
+# To un-deprecate a chart see the PROCESSES.md file.
+deprecated: true
+version: 8.3.7
 appVersion: 5.6.0
-description: Concourse is a simple and scalable CI system.
+description: DEPRECATED Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479
 keywords:
 - ci
@@ -12,11 +16,4 @@ home: https://concourse-ci.org/
 sources:
 - https://github.com/concourse/concourse
 - https://github.com/helm/charts
-maintainers:
-- name: cirocosta
-  email: cscosta@pivotal.io
-- name: william-tran
-  email: will@autonomic.ai
-- name: YoussB
-  email: byoussef@pivotal.io
 engine: gotpl

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -1,4 +1,6 @@
-# Concourse Helm Chart
+# Deprecated - Concourse Helm Chart
+
+The Concourse helm chart is deprecated. Future chart development is now at [github.com/concourse/concourse-chart](https://github.com/concourse/concourse-chart).
 
 [Concourse](https://concourse-ci.org/) is a simple and scalable CI system.
 

--- a/stable/concourse/templates/NOTES.txt
+++ b/stable/concourse/templates/NOTES.txt
@@ -1,4 +1,8 @@
 
+*******************
+****DEPRECATED*****
+*******************
+* The Concourse chart is deprecated. Future development has been moved to github.com/concourse/concourse-chart
 * Concourse can be accessed:
 
   * Within your cluster, at the following DNS name at port {{ .Values.concourse.web.bindPort }}:
@@ -70,3 +74,8 @@ Please see `README.md` for examples.
 
 {{- end }}
 {{- end }}
+
+*******************
+****DEPRECATED*****
+*******************
+* The Concourse chart is deprecated. Future development has been moved to github.com/concourse/concourse-chart


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR deprecates the `stable/concourse` chart. Future development of this chart is happening at [github.com/concourse/concourse-chart]

#### Which issue this PR fixes
fixes #18781 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

[github.com/concourse/concourse-chart]: https://github.com/concourse/concourse-chart

@cirocosta @YoussB 