### PR TITLE
[stable/prometheus-rabbitmq-exporter]: Add ability to set root CA certificate for AMQP exporter

### DIFF
--- a/stable/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/stable/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 0.5.3
+version: 0.6.0
 appVersion: v0.29.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/stable/prometheus-rabbitmq-exporter/README.md
+++ b/stable/prometheus-rabbitmq-exporter/README.md
@@ -65,6 +65,7 @@ The following table lists the configurable parameters and their default values.
 | `rabbitmq.output_format` | Log ouput format. TTY and JSON are suported                            | `TTY`                     |
 | `rabbitmq.timeout`       | timeout in seconds for retrieving data from management plugin          | `30`                      |
 | `rabbitmq.max_queues`    | max number of queues before we drop metrics (disabled if set to 0)     | `0`                       |
+| `rabbitmq.cafile_secret` | The name of the secret containing a `ca.pem` key with the root certificate's value. | `null`       |
 | `annotations`            | pod annotations for easier discovery                                   | {}                        |
 | `prometheus.monitor.enabled` | Set this to `true` to create ServiceMonitor for Prometheus operator | `false` |
 | `prometheus.monitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | {} |

--- a/stable/prometheus-rabbitmq-exporter/templates/deployment.yaml
+++ b/stable/prometheus-rabbitmq-exporter/templates/deployment.yaml
@@ -64,6 +64,10 @@ spec:
               value: "{{ .Values.rabbitmq.timeout }}"
             - name: MAX_QUEUES
               value: "{{ .Values.rabbitmq.max_queues }}"
+            {{- if .Values.rabbitmq.cafile_secret }}
+            - name: CAFILE
+              value: "/etc/ssl/certs/ca.pem"
+            {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
               name: publish
@@ -84,6 +88,12 @@ spec:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 10002
+          {{- if .Values.rabbitmq.cafile_secret }}
+          volumeMounts:
+          - name: mgmt-plugin-root-cafile
+            mountPath: "/etc/ssl/certs"
+            readOnly: true
+          {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -95,4 +105,10 @@ spec:
     {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- if .Values.rabbitmq.cafile_secret }}
+      volumes:
+      - name: mgmt-plugin-root-cafile
+        secret:
+          secretName: "{{ .Values.rabbitmq.cafile_secret }}"
     {{- end }}

--- a/stable/prometheus-rabbitmq-exporter/values.yaml
+++ b/stable/prometheus-rabbitmq-exporter/values.yaml
@@ -45,6 +45,7 @@ rabbitmq:
   output_format: "TTY"
   timeout: 30
   max_queues: 0
+  cafile_secret: null
 
 annotations: {}
 #  prometheus.io/scrape: "true"


### PR DESCRIPTION
Signed-off-by: Michael Hill <mhill@betterview.net>

#### Is this a new chart
No.

#### What this PR does / why we need it:
This adds the ability for one to specify a custom root CA certificate when using the prometheus-rabbitmq-exporter with external AMQP providers like compose.io or cloudamqp.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
