### PR TITLE
[stable/prometheus] server.env default value should be an array

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 9.7.3
+version: 9.7.4
 appVersion: 2.13.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -615,7 +615,7 @@ server:
   ##     secretKeyRef:
   ##       name: mysecret
   ##       key: username
-  env: {}
+  env: []
 
   extraFlags:
     - web.enable-lifecycle


### PR DESCRIPTION
#### What this PR does / why we need it:
It fixes the default value of `server.env` variable that should be an array

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
