### PR TITLE
[incubator/redis-cluster] New helm chart for redis distributed cluster

### DIFF
--- a/incubator/redis-cluster/Chart.yaml
+++ b/incubator/redis-cluster/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+name: redis-cluster
+home: http://redis.io/
+engine: gotpl
+keywords:
+- redis
+- keyvalue
+- database
+- cluster
+version: 0.0.1
+appVersion: 5.0.6
+description: Highly available Kubernetes implementation of Redis Cluster
+icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png
+maintainers:
+- email: zhaoshan@inspur.com
+  name: zhaoshan
+details:
+  This Helm chart provides a Redis Cluster implementation
+sources:
+- https://redis.io/download
+- https://github.com/docker-library/redis

--- a/incubator/redis-cluster/Chart.yaml
+++ b/incubator/redis-cluster/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 - cluster
 version: 0.0.1
 appVersion: 5.0.6
-description: Highly available Kubernetes implementation of Redis Cluster
+description: Distributed highly available Kubernetes implementation of Redis Cluster
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png
 maintainers:
 - email: zhaoshan@inspur.com

--- a/incubator/redis-cluster/OWNERS
+++ b/incubator/redis-cluster/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- zhaoshan86
+reviewers:
+- zhaoshan86

--- a/incubator/redis-cluster/README.md
+++ b/incubator/redis-cluster/README.md
@@ -1,0 +1,129 @@
+# Redis
+
+[Redis](http://redis.io/) is an advanced key-value cache and store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets, sorted sets, bitmaps and hyperloglogs.
+
+## TL;DR;
+
+```bash
+$ helm install stable/redis-cluster
+```
+
+## Introduction
+
+This chart bootstraps a [Redis](https://redis.io) highly available distributed cluster in a [Kubernetes](http://kubernetes.io) cluster using the Helm package manager.
+
+## Prerequisites
+
+- Kubernetes 1.8+ with Beta APIs enabled
+- PV provisioner support in the underlying infrastructure
+
+## Installing the Chart
+
+To install the chart
+
+```bash
+$ helm install incubator/redis-cluster
+```
+
+The command deploys Redis Cluster on the Kubernetes cluster in the default configuration. By default this chart install 3 shards and one replica for each shard. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the deployment:
+
+```bash
+$ helm delete <chart-name>
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Note
+By default this chart install 3 shards and one replica for each shard:
+ * In this chart, one statefulset means one shard (include master and replicas), the statefulset would be dynamic created when shard number changes.
+ * The shard number must be equal or greater than 3, or the cluter will create failed.
+ * By now, the chart support scale-out (add shards), but the data in cluster won't resharding automatically. You must reshard the data manually.
+ * If you want to scale-in the cluster, you must reshard the data and remove the node from cluster carefully first, then run `helm upgrade` command to decrease the shard number.
+
+## Configuration
+
+The following table lists the configurable parameters of the Redis chart and their default values.
+
+| Parameter                        | Description                                                                             | Default                 |
+|:---------------------------------|:----------------------------------------------------------------------------------------|:------------------------|
+| `image.name`                     | Redis image                                                                             | `redis`                 |
+| `image.tag`                      | Redis image tag                                                                         | `5.0.6`                 |
+| `image.pullPolicy`               | Redis image pullPolicy                                                                  | `Always`                |
+| `shards`                         | Shards of Redis Cluster, must be equal or greater than 3                                | `3`                     |
+| `shardReplicas`                  | Replicas of each shard                                                                  | `1`                     |
+| `labels`                         | Custom labels for the redis pod                                                         | `{}`                    |
+| `redis.port`                     | Port to access the redis service                                                        | `6379`                  |
+| `redis.customConfig`             | Allows for custom redis.conf files to be applied.                                       | ``                      |
+| `redis.resources`                | CPU/Memory for redis server resource requests/limits                                    | `{}`                    |
+| `auth`                           | Configures redis with AUTH (`redisPassword` to be set)                                  | ``                      |
+| `nodeSelector`                   | Node labels for pod assignment                                                          | `{}`                    |
+| `tolerations`                    | Toleration labels for pod assignment                                                    | `[]`                    |
+| `hardAntiAffinity`               | Whether the Redis server pods in one shard should be forced to run on separate nodes.   | `false`                 |
+| `persistentVolume.enabled`       | Whether create a volume to store data                                                   | `false`                 |
+| `persistentVolume.storageClass`  | Type of persistent volume claim                                                         | `-`                     |
+| `persistentVolume.accessModes`   | ReadWriteOnce or ReadOnly                                                               | `ReadWriteOnce`         |
+| `persistentVolume.size`          | Size of persistent volume claim                                                         | `1Gi`                   |
+| `persistentVolume.annotations`   | Annotations of persistent volume claim                                                  | `{}`                    |
+| `sysctl.enabled`                 | Enable an init container to modify Kernel settings                                      | `false`                 |
+| `sysctl.command`                 | sysctl command to execute                                                               | []                      |
+| `sysctl.image`                   | sysctl Init container image name                                                        | `busybox`               |
+| `sysctl.tag`                     | sysctlImage Init container image tag                                                    | `1.31.1`                |
+| `sysctl.pullPolicy`              | sysctlImage Init container image pull policy                                            | `Always`                |
+| `sysctl.mountHostSys`            | Whether Mount the host `/sys` folder to `/host-sys`                                     | `false`                 |                                                                                                                                                        | `false`                                                                                    |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install \
+  --set image=redis \
+  --set tag=5.0.6 \
+    incubator/redis-cluster
+```
+
+The above command sets the Redis server within `default` namespace.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install -f values.yaml stable/redis-cluster
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Custom Redis options
+
+This chart allows for most redis or sentinel config options to be passed as a key value pair through the `values.yaml` under `redis.customConfig`. See links below for all available options.
+
+[Example redis.conf](http://download.redis.io/redis-stable/redis.conf)
+
+For example `repl-timeout 60` would be added to the `redis.customConfig` section of the `values.yaml` as:
+
+```yml
+redis:
+  customConfig: |
+    repl-timeout 60
+```
+
+## Host Kernel Settings
+Redis may require some changes in the kernel of the host machine to work as expected, in particular increasing the `somaxconn` value and disabling transparent huge pages.
+To do so, you can set up a privileged initContainer with the `sysctl` config values, for example:
+```
+sysctl:
+  enabled: true
+  image: busybox
+  tag: 1.31.1
+  mountHostSys: true
+  command:
+    - /bin/sh
+    - -xc
+    - |-
+      sysctl -w net.core.somaxconn=10000
+      echo never > /host-sys/kernel/mm/transparent_hugepage/enabled
+```
+

--- a/incubator/redis-cluster/templates/NOTES.txt
+++ b/incubator/redis-cluster/templates/NOTES.txt
@@ -1,0 +1,33 @@
+Redis cluster can be accessed via port {{ .Values.redis.port }} on the following DNS names from within your cluster:
+{{- $fullName := include "redis-cluster.fullname" . }}
+{{- $shards := int (toString .Values.shards) }}
+{{- $replicas := int (toString (add .Values.shardReplicas 1)) }}
+{{- $root := . }}
+{{- range $i := until $shards }}
+{{- range $j := until $replicas }}
+{{ $fullName }}-shard{{ $i }}-announce-{{ $j }}.{{ $root.Release.Namespace }}.svc.cluster.local
+{{- end }}
+{{- end }}
+
+To connect to your Redis Cluster:
+
+{{- if .Values.auth }}
+1. To retrieve the redis password:
+   echo $(kubectl get secret {{ template "redis-cluster.fullname" . }} -o "jsonpath={.data['auth']}" | base64 --decode)
+   
+2. Run a Redis pod that you can use as a client:
+
+   kubectl exec -it {{ include "redis-cluster.fullname" . }}-shard0-0 sh -n {{ .Release.Namespace }}
+
+3. Connect using the Redis CLI (inside container):
+
+   redis-cli -a <REDIS-PASS-FROM-SECRET> -c -h {{ include "redis-cluster.fullname" . }}-shard0-announce-0.{{ .Release.Namespace }}.svc.cluster.local -p {{ .Values.redis.port }}
+{{- else }}
+1. Run a Redis pod that you can use as a client:
+
+   kubectl exec -it {{ include "redis-cluster.fullname" . }}-shard0-0 sh -n {{ .Release.Namespace }}
+   
+2. Connect using the Redis CLI:
+
+  redis-cli -c -h {{ include "redis-cluster.fullname" . }}-shard0-announce-0.{{ .Release.Namespace }}.svc.cluster.local -p {{ .Values.redis.port }}
+{{- end }}

--- a/incubator/redis-cluster/templates/_helpers.tpl
+++ b/incubator/redis-cluster/templates/_helpers.tpl
@@ -1,0 +1,73 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "redis-cluster.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "redis-cluster.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+Return sysctl image
+*/}}
+{{- define "redis.sysctl.image" -}}
+{{- $registryName :=  default "docker.io" .Values.sysctlImage.registry -}}
+{{- $tag := default "latest" .Values.sysctlImage.tag | toString -}}
+{{- printf "%s/%s:%s" $registryName .Values.sysctlImage.repository $tag -}}
+{{- end -}}
+
+{{- /*
+Credit: @technosophos
+https://github.com/technosophos/common-chart/
+labels.standard prints the standard Helm labels.
+The standard labels are frequently used in metadata.
+*/ -}}
+{{- define "labels.standard" -}}
+app: {{ template "redis-cluster.name" . }}
+heritage: {{ .Release.Service | quote }}
+release: {{ .Release.Name | quote }}
+chart: {{ template "chartref" . }}
+{{- end -}}
+
+{{- /*
+Credit: @technosophos
+https://github.com/technosophos/common-chart/
+chartref prints a chart name and version.
+It does minimal escaping for use in Kubernetes labels.
+Example output:
+  zookeeper-1.2.3
+  wordpress-3.2.1_20170219
+*/ -}}
+{{- define "chartref" -}}
+  {{- replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "redis-cluster.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "redis-cluster.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/incubator/redis-cluster/templates/cluster-announce-service.yaml
+++ b/incubator/redis-cluster/templates/cluster-announce-service.yaml
@@ -1,0 +1,36 @@
+{{- $fullName := include "redis-cluster.fullname" . }}
+{{- $shards := int (toString .Values.shards) }}
+{{- $replicas := int (toString (add .Values.shardReplicas 1)) }}
+{{- $root := . }}
+{{- range $i := until $shards }}
+{{- range $j := until $replicas }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-shard{{ $i }}-announce-{{ $j }}
+  labels:
+{{ include "labels.standard" $root | indent 4 }}
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  {{- if $root.Values.serviceAnnotations }}
+{{ toYaml $root.Values.serviceAnnotations | indent 4 }}
+  {{- end }}
+spec:
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+  - name: server
+    port: {{ $root.Values.redis.port }}
+    protocol: TCP
+    targetPort: redis
+  - name: cluster-bus
+    port: 16379
+    protocol: TCP
+    targetPort: cluster-bus
+  selector:
+    release: {{ $root.Release.Name }}
+    app: {{ include "redis-cluster.name" $root }}
+    "statefulset.kubernetes.io/pod-name": {{ $fullName }}-shard{{ $i }}-{{ $j }}
+{{- end }}
+{{- end }}

--- a/incubator/redis-cluster/templates/cluster-configmap.yaml
+++ b/incubator/redis-cluster/templates/cluster-configmap.yaml
@@ -1,0 +1,303 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "redis-cluster.fullname" . }}-configmap
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ template "redis-cluster.fullname" . }}
+data:
+  redis.conf: |
+    {{- if .Values.redis.customConfig }}
+{{ tpl .Values.redis.customConfig . | indent 4 }}
+    {{- end}}
+    dir "/data"
+    port 6379
+    cluster-enabled yes
+    cluster-config-file "/data/conf/nodes.conf"
+    cluster-node-timeout 5000
+
+  create-cluster.sh: |
+    #!/bin/sh
+    SHARDS={{ .Values.shards }}
+    REPLICA={{ .Values.shardReplicas }}
+    PORT={{ .Values.redis.port }}
+    MASTER_TEMPFILE=/tmp/master_ips.txt
+    SLAVE_TEMPFILE=/tmp/slave_ips.txt
+    CLUSTER_TEMPFILE=/tmp/cluster_info.txt
+    
+    check_nodes_ready() {
+      if [ "`timeout 2 redis-cli -h "$1" -p ${PORT}{{ if .Values.auth }} -a "$AUTH" --no-auth-warning{{ end }} ping`" != "PONG" ];then
+          echo "  Node $1 is still not ready."
+          return 1
+      fi
+    }
+    
+    if [ $SHARDS -lt 3 ];then
+      echo "ERROR: The cluster must have 3 shards at least, only '$SHARDS' shards can not create the cluster."
+      exit 1
+    fi
+    
+    masters=""
+    slaves=""
+    shard_idx=0
+    
+    echo "# Generate service name of masters and slaves..."
+    while [ $shard_idx -lt $SHARDS ];
+    do
+      masters=${masters}"{{ template "redis-cluster.fullname" . }}-shard${shard_idx}-announce-0 "
+      replica_idx=1
+      while [ $replica_idx -le $REPLICA ];
+      do
+        slaves=${slaves}"{{ template "redis-cluster.fullname" . }}-shard${shard_idx}-announce-${replica_idx} "
+        replica_idx=`expr $replica_idx + 1`
+      done
+      shard_idx=`expr $shard_idx + 1`
+    done
+    echo "  Masters: $masters"
+    echo "  Slaves: $slaves"
+    
+    echo "# Checking if all nodes ready..."
+    # Check if all nodes ready
+    count=0
+    timeout=300
+    while [ $count -lt $timeout ]
+    do
+      ok=1
+      
+      for master in $masters
+      do
+        check_nodes_ready $master
+        if [ $? -ne 0 ];then
+          ok=0
+        fi
+      done
+      
+      for slave in $slaves
+      do
+        check_nodes_ready $slave
+        if [ $? -ne 0 ];then
+          ok=0
+        fi
+      done
+      
+      if [ $ok -eq 1 ];then
+        echo "  All nodes are ready to join into the cluster"
+        break;
+      fi
+      count=`expr $count + 1`
+      sleep 1
+    done
+    
+    if [ $count -ge $timeout ];then
+      echo "ERROR: Some nodes are not ready in $timeout seconds, can not create the cluster."
+      exit 1
+    fi
+    
+    echo "# Generate ip addresses of masters and slaves..."
+    >${MASTER_TEMPFILE}
+    >${SLAVE_TEMPFILE}
+    echo " Masters:"
+    for master in $masters
+    do
+      echo "$master `getent hosts $master | awk '{ print $1 }'`" |tee -a ${MASTER_TEMPFILE}
+    done
+    
+    echo " Slaves:"
+    for slave in $slaves
+    do
+      echo "$slave `getent hosts $slave | awk '{ print $1 }'`" |tee -a ${SLAVE_TEMPFILE}
+    done
+    
+    set -e
+    echo "# Create cluster with masters..."
+    # Create cluster with masters
+    create_cluster_cmd="redis-cli --cluster create "
+    while read hostname ip
+    do
+      create_cluster_cmd="${create_cluster_cmd}${ip}:${PORT} "
+    done <${MASTER_TEMPFILE}
+    
+    echo "  $create_cluster_cmd"
+    $create_cluster_cmd{{ if .Values.auth }} -a "$AUTH" --no-auth-warning{{ end }} <<-EOF
+    yes
+    EOF
+    
+    echo "  Cluster created successfully."
+    node_ip=`head -n 1 ${MASTER_TEMPFILE}|awk '{print $2}'`
+    redis-cli --cluster check ${node_ip}:${PORT}{{ if .Values.auth }} -a "$AUTH" --no-auth-warning{{ end }} |grep "M:" |tee ${CLUSTER_TEMPFILE}
+    
+    echo "# Join slaves into cluster..."
+    # Join slaves into cluster
+    cat ${SLAVE_TEMPFILE}|while read hostname ip
+    do
+      prefix=`echo ${hostname}|sed "s/-.$//"`
+      master_ip=`grep ${prefix} ${MASTER_TEMPFILE}|awk '{print $2}'`
+      master_id=`grep ${master_ip} ${CLUSTER_TEMPFILE}|awk '{print $2}'`
+      echo "  Join $hostname as slave of master $master_ip"
+      redis-cli --cluster add-node ${ip}:${PORT} ${node_ip}:${PORT} --cluster-slave --cluster-master-id ${master_id}{{ if .Values.auth }} -a "$AUTH" --no-auth-warning{{ end }}
+    done
+    
+    redis-cli --cluster check ${node_ip}:${PORT}{{ if .Values.auth }} -a "$AUTH" --no-auth-warning{{ end }}
+    echo "All nodes joined into cluster."
+    
+  scale-cluster.sh: |
+    #!/bin/sh
+    set -eu
+    
+    SHARDS={{ .Values.shards }}  
+    REPLICA={{ .Values.shardReplicas }}
+    NODE0_IP=`getent hosts {{ template "redis-cluster.fullname" . }}-shard0-announce-0 | awk '{ print $1 }'`
+    PORT={{ .Values.redis.port }}
+    MASTER_TEMPFILE=/tmp/master_ips.txt
+    SLAVE_TEMPFILE=/tmp/slave_ips.txt
+    CLUSTER_TEMPFILE=/tmp/cluster_info.txt
+    
+    echo "# Check how may shards cluster has..."
+    
+    redis-cli --cluster check ${NODE0_IP}:${PORT}{{ if .Values.auth }} -a "$AUTH" --no-auth-warning{{ end }} |grep "M:" |tee ${CLUSTER_TEMPFILE}
+    current_shards=`cat ${CLUSTER_TEMPFILE} | wc -l`
+    
+    check_nodes_ready() {
+      if [ "`timeout 2 redis-cli -h "$1" -p ${PORT}{{ if .Values.auth }} -a "$AUTH" --no-auth-warning{{ end }} ping`" != "PONG" ];then
+          echo "  Node $1 is still not ready."
+          return 1
+      fi
+    }
+    
+    if [ $current_shards -lt 3 ];then
+      echo "ERROR: The cluster have only $current_shards shards, less than 3 shards. please check the cluster state."
+      exit 1
+    fi    
+    
+    if [ $SHARDS -le $current_shards ];then
+      echo "No shard need to add into the cluster."
+      exit 0
+    fi
+    
+    masters=""
+    slaves=""
+    shard_idx=$current_shards
+    
+    echo "# Generate service name of new masters and slaves..."
+    while [ $shard_idx -lt $SHARDS ];
+    do
+      masters=${masters}"{{ template "redis-cluster.fullname" . }}-shard${shard_idx}-announce-0 "
+      replica_idx=1
+      while [ $replica_idx -le $REPLICA ];
+      do
+        slaves=${slaves}"{{ template "redis-cluster.fullname" . }}-shard${shard_idx}-announce-${replica_idx} "
+        replica_idx=`expr $replica_idx + 1`
+      done
+      shard_idx=`expr $shard_idx + 1`
+    done
+    echo "  Masters: $masters"
+    echo "  Slaves: $slaves"
+    
+    echo "# Checking if all nodes ready..."
+    set +e
+    # Check if all nodes ready
+    count=0
+    timeout=300
+    while [ $count -lt $timeout ]
+    do
+      ok=1
+      
+      for master in $masters
+      do
+        check_nodes_ready $master
+        if [ $? -ne 0 ];then
+          ok=0
+        fi
+      done
+      
+      for slave in $slaves
+      do
+        check_nodes_ready $slave
+        if [ $? -ne 0 ];then
+          ok=0
+        fi
+      done
+      
+      if [ $ok -eq 1 ];then
+        echo "  All nodes are ready to join into the cluster"
+        break;
+      fi
+      count=`expr $count + 1`
+      sleep 1
+    done
+    
+    if [ $count -ge $timeout ];then
+      echo "ERROR: Some nodes are not ready in $timeout seconds, can not create the cluster."
+      exit 1
+    fi
+    
+    echo "# Generate ip addresses of masters and slaves..."
+    >${MASTER_TEMPFILE}
+    >${SLAVE_TEMPFILE}
+    echo " Masters:"
+    for master in $masters
+    do
+      echo "$master `getent hosts $master | awk '{ print $1 }'`" |tee -a ${MASTER_TEMPFILE}
+    done
+    
+    echo " Slaves:"
+    for slave in $slaves
+    do
+      echo "$slave `getent hosts $slave | awk '{ print $1 }'`" |tee -a ${SLAVE_TEMPFILE}
+    done
+    
+    set -e
+    echo "# Join masters into cluster..."
+    cat ${MASTER_TEMPFILE}|while read hostname ip
+    do
+      echo "  Join $hostname as master into cluster."
+      redis-cli --cluster add-node ${ip}:${PORT} ${NODE0_IP}:${PORT}{{ if .Values.auth }} -a "$AUTH" --no-auth-warning{{ end }}
+    done
+    
+    # Wait for masters get their node id
+    echo "Get new masters node ID.."
+    set +e
+    >${CLUSTER_TEMPFILE}
+    cat ${MASTER_TEMPFILE}|while read hostname ip
+    do
+      timeout=300
+      count=0
+      while [ $count -lt $timeout ]
+      do
+        master_info=`redis-cli --cluster check ${NODE0_IP}:${PORT}{{ if .Values.auth }} -a "$AUTH" --no-auth-warning{{ end }} |grep "M:.*${ip}"` 
+        if [ $? -eq 0 ];then
+          echo "$master_info" |tee -a ${CLUSTER_TEMPFILE}
+          break
+        fi
+        sleep 1
+        count=`expr $count + 1`
+      done
+    done
+    
+    master_cnt=`cat ${MASTER_TEMPFILE} | wc -l`
+    master_id_cnt=`cat ${CLUSTER_TEMPFILE} | wc -l`
+    if [ $master_cnt -ne $master_id_cnt ];then
+      echo "ERROR: Some masters didn't get their ID."
+      exit 1
+    fi
+    
+    set -e
+    echo "# Join slaves into cluster..."
+    # Join slaves into cluster
+    cat ${SLAVE_TEMPFILE}|while read hostname ip
+    do
+      prefix=`echo ${hostname}|sed "s/-.$//"`
+      master_ip=`grep ${prefix} ${MASTER_TEMPFILE}|awk '{print $2}'`
+      master_id=`grep ${master_ip} ${CLUSTER_TEMPFILE}|awk '{print $2}'`
+      echo "  Join $hostname as slave of master $master_ip"
+      redis-cli --cluster add-node ${ip}:${PORT} ${NODE0_IP}:${PORT} --cluster-slave --cluster-master-id ${master_id}{{ if .Values.auth }} -a "$AUTH" --no-auth-warning{{ end }}
+    done
+    
+    redis-cli --cluster check ${NODE0_IP}:${PORT}{{ if .Values.auth }} -a "$AUTH" --no-auth-warning{{ end }}
+    echo "All nodes joined into cluster."
+    
+    
+    
+    

--- a/incubator/redis-cluster/templates/cluster-service.yaml
+++ b/incubator/redis-cluster/templates/cluster-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "redis-cluster.fullname" . }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+  annotations:
+  {{- if .Values.serviceAnnotations }}
+{{ toYaml .Values.serviceAnnotations | indent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: server
+    port: {{ .Values.redis.port }}
+    protocol: TCP
+    targetPort: redis
+  selector:
+    release: {{ .Release.Name }}
+    app: {{ template "redis-cluster.name" . }}
+    

--- a/incubator/redis-cluster/templates/cluster-statefulset.yaml
+++ b/incubator/redis-cluster/templates/cluster-statefulset.yaml
@@ -1,0 +1,205 @@
+{{- $fullName := include "redis-cluster.fullname" . }}
+{{- $shards := int (toString .Values.shards) }}
+{{- $root := . }}
+{{- range $i := until $shards }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "redis-cluster.fullname" $root }}-shard{{ $i }}
+  labels:
+    {{ template "redis-cluster.fullname" $root }}: shard{{ $i }}
+{{ include "labels.standard" $root | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      release: {{ $root.Release.Name }}
+      app: {{ template "redis-cluster.name" $root }}
+  serviceName: {{ template "redis-cluster.fullname" $root }}
+  replicas: {{ add (int (toString $root.Values.shardReplicas)) 1 }}
+  podManagementPolicy: OrderedReady
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+      labels:
+        release: {{ $root.Release.Name }}
+        app: {{ template "redis-cluster.name" $root }}
+        {{ template "redis-cluster.fullname" $root }}: shard{{ $i }}
+        {{- range $key, $value := $root.Values.labels }}
+        {{ $key }}: {{ $value }}
+        {{- end }}
+    spec:
+      {{- if $root.Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml $root.Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if $root.Values.tolerations }}
+      tolerations:
+{{ toYaml $root.Values.tolerations | indent 8 }}
+      {{- end }}
+      affinity:
+        podAntiAffinity:
+          {{- if $root.Values.hardAntiAffinity }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: {{ template "redis-cluster.name" $root }}
+                  release: {{ $root.Release.Name }}
+                  {{ template "redis-cluster.fullname" $root }}: shard{{ $i }}
+              topologyKey: kubernetes.io/hostname
+          {{- else }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: {{ template "redis-cluster.name" $root }}
+                  release: {{ $root.Release.Name }}
+                  {{ template "redis-cluster.fullname" $root }}: shard{{ $i }}
+              topologyKey: kubernetes.io/hostname
+          {{- end }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app:  {{ template "redis-cluster.name" $root }}
+                    release: {{ $root.Release.Name }}
+                    {{ template "redis-cluster.fullname" $root }}: shard{{ $i }}
+                topologyKey: failure-domain.beta.kubernetes.io/zone
+      securityContext:
+{{ toYaml $root.Values.securityContext | indent 8 }}
+      initContainers:
+      {{- if $root.Values.sysctl.enabled }}
+      - name: init-sysctl
+        image: {{ $root.Values.sysctl.image }}:{{ $root.Values.sysctl.tag }}
+        imagePullPolicy: {{ $root.Values.sysctl.pullPolicy }}
+        {{- if $root.Values.sysctl.mountHostSys }}
+        volumeMounts:
+        - name: host-sys
+          mountPath: /host-sys
+        {{- end }}
+        command:
+{{ toYaml $root.Values.sysctl.command | indent 10 }}
+        securityContext:
+          runAsNonRoot: false
+          privileged: true
+          runAsUser: 0
+      {{- end }}
+      - name: init-config
+        image: {{ $root.Values.image.name }}:{{ $root.Values.image.tag }}
+        imagePullPolicy: {{ $root.Values.image.pullPolicy }}
+        command: 
+        - sh
+        - "-c"
+        - |
+          #!/bin/sh
+          set -eu
+    
+          CONF_DIR="/data/conf"
+          mkdir -p ${CONF_DIR}
+          cp /configmap/* ${CONF_DIR}
+          INDEX="${HOSTNAME##*-}"
+          SERVICE="{{ template "redis-cluster.fullname" $root }}-shard{{ $i }}"
+          timeout=0
+          ANNOUNCE_IP=$(getent hosts "$SERVICE-announce-$INDEX" | awk '{ print $1 }')
+          while [ $timeout -lt 300 ]
+          do
+            if [ "$ANNOUNCE_IP" = "" ];then
+              ANNOUNCE_IP=$(getent hosts "$SERVICE-announce-$INDEX" | awk '{ print $1 }')
+            else
+              break
+            fi
+            timeout=`expr $timeout + 1`
+            sleep 1
+          done
+          if [ "$ANNOUNCE_IP" = "" ];then
+            echo "ERROR: Can not get ip for service $SERVICE."
+            exit 1
+          fi
+          echo "# Add cluster-announce-ip automatically when pod start." >>$CONF_DIR/redis.conf
+          echo "cluster-announce-ip $ANNOUNCE_IP" >>$CONF_DIR/redis.conf
+          {{- if $root.Values.auth }}
+          if [ "$AUTH" = "" ];then
+            echo "ERROR: The cluster requires authentication, but no password was set."
+            exit 1
+          else
+            echo "requirepass $AUTH" >>$CONF_DIR/redis.conf
+          fi
+          {{ else }}
+          echo "protected-mode no" >>$CONF_DIR/redis.conf
+          {{- end }}
+        env:
+        {{- if $root.Values.auth }}
+        - name: AUTH
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "redis-cluster.fullname" $root }}
+              key: auth
+        {{- end }}  
+        volumeMounts:
+        - mountPath: /data
+          name: data
+        - mountPath: /configmap
+          name: config
+      containers:
+      - name: redis
+        image: {{ $root.Values.image.name }}:{{ $root.Values.image.tag }}
+        imagePullPolicy: {{ $root.Values.image.pullPolicy }}
+        command:
+        - redis-server 
+        - "/data/conf/redis.conf"
+        livenessProbe:
+          tcpSocket:
+            port: {{ $root.Values.redis.port }}
+          initialDelaySeconds: 15
+        resources:
+{{ toYaml $root.Values.redis.resources | indent 10 }}
+        ports:
+        - name: redis
+          containerPort: 6379
+        - name: cluster-bus
+          containerPort: 16379
+        volumeMounts:
+        - mountPath: /data
+          name: data
+{{- if $root.Values.priorityClassName }}
+      priorityClassName: {{ $root.Values.priorityClassName }}
+{{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "redis-cluster.fullname" $root }}-configmap
+      {{- if $root.Values.sysctl.mountHostSys }}
+      - name: host-sys
+        hostPath:
+          path: /sys
+      {{- end }}
+{{- if $root.Values.persistentVolume.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+      annotations:
+      {{- range $key, $value := $root.Values.persistentVolume.annotations }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
+    spec:
+      accessModes:
+      {{- range $root.Values.persistentVolume.accessModes }}
+        - {{ . | quote }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ $root.Values.persistentVolume.size | quote }}
+    {{- if $root.Values.persistentVolume.storageClass }}
+    {{- if (eq "-" $root.Values.persistentVolume.storageClass) }}
+      storageClassName: ""
+    {{- else }}
+      storageClassName: "{{ $root.Values.persistentVolume.storageClass }}"
+    {{- end }}
+    {{- end }}
+{{- else }}
+      - name: data
+        emptyDir: {}
+{{- end }}
+{{- end }}

--- a/incubator/redis-cluster/templates/post-install-job.yaml
+++ b/incubator/redis-cluster/templates/post-install-job.yaml
@@ -1,0 +1,45 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ template "redis-cluster.fullname" . }}-post-install"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      name: "{{ template "redis-cluster.fullname" . }}-post-install"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "redis-cluster.fullname" . }}-configmap
+      containers:
+      - name: post-install-job
+        image: {{ .Values.image.name }}:{{ .Values.image.tag }}
+        command: 
+        - sh
+        - "/configmap/create-cluster.sh"
+        volumeMounts:
+        - mountPath: /configmap
+          name: config
+        env:
+        {{- if .Values.auth }}
+        - name: AUTH
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "redis-cluster.fullname" . }}
+              key: auth
+        {{- end }}  

--- a/incubator/redis-cluster/templates/post-upgrade-job.yaml
+++ b/incubator/redis-cluster/templates/post-upgrade-job.yaml
@@ -1,0 +1,45 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ template "redis-cluster.fullname" . }}-post-upgrade"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      name: "{{ template "redis-cluster.fullname" . }}-post-upgrade"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "redis-cluster.fullname" . }}-configmap
+      containers:
+      - name: post-upgrade-job
+        image: {{ .Values.image.name }}:{{ .Values.image.tag }}
+        command: 
+        - sh
+        - "/configmap/scale-cluster.sh"
+        volumeMounts:
+        - mountPath: /configmap
+          name: config
+        env:
+        {{- if .Values.auth }}
+        - name: AUTH
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "redis-cluster.fullname" . }}
+              key: auth
+        {{- end }}  

--- a/incubator/redis-cluster/templates/redis-auth-secret.yaml
+++ b/incubator/redis-cluster/templates/redis-auth-secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.auth -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "redis-cluster.fullname" . }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+type: Opaque
+data:
+  auth: {{ .Values.auth | b64enc | quote }}
+{{- end -}}

--- a/incubator/redis-cluster/templates/tests/test-connection.yaml
+++ b/incubator/redis-cluster/templates/tests/test-connection.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "redis-cluster.fullname" . }}-test-connection"
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
+spec:
+  containers:
+    - name: test
+      image: {{ .Values.image.name }}:{{ .Values.image.tag }}
+      command: 
+      - sh
+      - "-c"
+      - |
+        #!/bin/sh
+        if [ "`redis-cli -c -h "{{ include "redis-cluster.fullname" . }}-shard0-announce-0.{{ .Release.Namespace }}.svc.cluster.local" -p {{ .Values.redis.port }}{{ if .Values.auth }} -a "$AUTH" --no-auth-warning{{ end }} ping`" != "PONG" ];then
+          exit 1
+        fi
+  restartPolicy: Never

--- a/incubator/redis-cluster/templates/tests/test-connection.yaml
+++ b/incubator/redis-cluster/templates/tests/test-connection.yaml
@@ -16,7 +16,21 @@ spec:
       - "-c"
       - |
         #!/bin/sh
-        if [ "`redis-cli -c -h "{{ include "redis-cluster.fullname" . }}-shard0-announce-0.{{ .Release.Namespace }}.svc.cluster.local" -p {{ .Values.redis.port }}{{ if .Values.auth }} -a "$AUTH" --no-auth-warning{{ end }} ping`" != "PONG" ];then
+        set -eux
+        SHARDS={{ .Values.shards }}
+        REPLICAS={{ .Values.shardReplicas }}
+        redis-cli -h {{ include "redis-cluster.fullname" . }}-shard0-announce-0.{{ .Release.Namespace }}.svc.cluster.local -p {{ .Values.redis.port }}{{ if .Values.auth }} -a "$AUTH" --no-auth-warning{{ end }} cluster nodes >/tmp/cluster_nodes.tmp
+        masters=`grep "master" /tmp/cluster_nodes.tmp|wc -l`
+        if [  $masters -ne $SHARDS ];then
           exit 1
         fi
+        
+        slaves=`grep "slave" /tmp/cluster_nodes.tmp|wc -l`
+        real_replicas=`expr $slaves / $masters`
+        
+        # command 'expr' will round down the result, need to verify again.
+        if [ `expr $real_replicas * $masters` -ne $slaves ];then
+          exit 1
+        fi
+
   restartPolicy: Never

--- a/incubator/redis-cluster/values.yaml
+++ b/incubator/redis-cluster/values.yaml
@@ -1,6 +1,6 @@
 image:
   name: redis
-  tag: 5.0.6
+  tag: 5.0.6-alpine
   pullPolicy: IfNotPresent
 ## Shards number for redis cluster, must be equal or greater than 3
 shards: 3

--- a/incubator/redis-cluster/values.yaml
+++ b/incubator/redis-cluster/values.yaml
@@ -1,0 +1,109 @@
+image:
+  name: redis
+  tag: 5.0.6
+  pullPolicy: IfNotPresent
+## Shards number for redis cluster, must be equal or greater than 3
+shards: 3
+## Replicas of shard
+shardReplicas: 1
+
+## Kubernetes priorityClass name for the redis-cluster-server pod
+# priorityClassName: ""
+
+## Custom labels for the redis pod
+labels: {}
+
+## Use an alternate scheduler, e.g. "stork".
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+# schedulerName:
+
+## Redis specific configuration options
+redis:
+  port: 6379 
+  ## Configure resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: 
+   requests:
+     cpu: 100m
+     memory: 200Mi
+   limits:
+     cpu: 1000m 
+     memory: 700Mi
+  ## Custom redis.conf files used to override default settings. 
+  # customConfig: |
+      # Define configuration here
+
+## Configures redis with AUTH (requirepass conf params)
+auth: null
+
+## Node labels, tolerations for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+nodeSelector: {}
+tolerations: {}
+
+hardAntiAffinity: false
+
+persistentVolume:
+  enabled: false 
+  ## redis-cluster data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  storageClass: "-" 
+  accessModes:
+    - ReadWriteOnce
+  size: 1Gi 
+  annotations: {}
+
+sysctl:
+  enabled: false 
+  image: busybox
+  tag: 1.31.1
+  pullPolicy: Always
+  command: 
+  - /bin/sh
+  - -xc
+  - |
+    sysctl -w net.core.somaxconn=10000
+    echo never > /host-sys/kernel/mm/transparent_hugepage/enabled
+  mountHostSys: false
+
+# NOTE: Prometheus exporter is NOT SUPPORTED right now, Do Not use the configurations below!
+
+# Prometheus exporter specific configuration options
+#exporter:
+#  enabled: false
+#  image: oliver006/redis_exporter
+#  tag: v1.3.2
+#  pullPolicy: IfNotPresent
+#
+#  # prometheus port & scrape path
+#  port: 9121
+#  scrapePath: /metrics
+#
+#  # cpu/memory resource limits/requests
+#  resources: {}
+#
+#  # Additional args for redis exporter
+#  extraArgs: {}
+#
+#  serviceMonitor:
+#    # When set true then use a ServiceMonitor to configure scraping
+#    enabled: false
+#    # Set the namespace the ServiceMonitor should be deployed
+#    # namespace: monitoring
+#    # Set how frequently Prometheus should scrape
+#    # interval: 30s
+#    # Set path to redis-exporter telemtery-path
+#    # telemetryPath: /metrics
+#    # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
+#    # labels: {}
+#    # Set timeout for scrape
+#    # timeout: 10s
+    

--- a/incubator/redis-cluster/values.yaml
+++ b/incubator/redis-cluster/values.yaml
@@ -20,18 +20,18 @@ labels: {}
 
 ## Redis specific configuration options
 redis:
-  port: 6379 
+  port: 6379
   ## Configure resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
-  resources: 
-   requests:
-     cpu: 100m
-     memory: 200Mi
-   limits:
-     cpu: 1000m 
-     memory: 700Mi
-  ## Custom redis.conf files used to override default settings. 
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+    limits:
+      cpu: 1000m
+      memory: 700Mi
+  ## Custom redis.conf files used to override default settings.
   # customConfig: |
       # Define configuration here
 
@@ -47,7 +47,7 @@ tolerations: {}
 hardAntiAffinity: false
 
 persistentVolume:
-  enabled: false 
+  enabled: false
   ## redis-cluster data Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning
@@ -55,18 +55,18 @@ persistentVolume:
   ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
   ##   GKE, AWS & OpenStack)
   ##
-  storageClass: "-" 
+  storageClass: "-"
   accessModes:
     - ReadWriteOnce
-  size: 1Gi 
+  size: 1Gi
   annotations: {}
 
 sysctl:
-  enabled: false 
+  enabled: false
   image: busybox
   tag: 1.31.1
   pullPolicy: Always
-  command: 
+  command:
   - /bin/sh
   - -xc
   - |
@@ -77,7 +77,7 @@ sysctl:
 # NOTE: Prometheus exporter is NOT SUPPORTED right now, Do Not use the configurations below!
 
 # Prometheus exporter specific configuration options
-#exporter:
+# exporter:
 #  enabled: false
 #  image: oliver006/redis_exporter
 #  tag: v1.3.2
@@ -106,4 +106,3 @@ sysctl:
 #    # labels: {}
 #    # Set timeout for scrape
 #    # timeout: 10s
-    


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

There is no chart for Redis distributed cluster deployment right now. This chart can bootstrap a highly available Redis distributed cluster with at least 3 shards and some replicas. This chart can also scale-out by using helm upgrade command.

#### Special notes for your reviewer:

The main functions have been tested，some features (like prometheus exporter support) or optimizations will be added in later versions. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
