### PR TITLE
[stable/nginx-ingress] No empty string clusterip

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.25.1
+version: 1.25.2
 appVersion: 0.26.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -95,7 +95,7 @@ Parameter | Description | Default
 `controller.publishService.enabled` | if true, the controller will set the endpoint records on the ingress objects to reflect those on the service | `false`
 `controller.publishService.pathOverride` | override of the default publish-service name | `""`
 `controller.service.enabled` | if disabled no service will be created. This is especially useful when `controller.kind` is set to `DaemonSet` and `controller.daemonset.useHostPorts` is `true` | true
-`controller.service.clusterIP` | internal controller cluster service IP | `""`
+`controller.service.clusterIP` | internal controller cluster service IP | `nil`
 `controller.service.omitClusterIP` | To omit the `clusterIP` from the controller service | `false`
 `controller.service.externalIPs` | controller service external IP addresses. Do not set this when `controller.hostNetwork` is set to `true` and `kube-proxy` is used as there will be a port-conflict for port `80` | `[]`
 `controller.service.externalTrafficPolicy` | If `controller.service.type` is `NodePort` or `LoadBalancer`, set this to `Local` to enable [source IP preservation](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typenodeport) | `"Cluster"`
@@ -127,7 +127,7 @@ Parameter | Description | Default
 `controller.readinessProbe.port` | The port number that the readiness probe will listen on. | 10254
 `controller.metrics.enabled` | if `true`, enable Prometheus metrics | `false`
 `controller.metrics.service.annotations` | annotations for Prometheus metrics service | `{}`
-`controller.metrics.service.clusterIP` | cluster IP address to assign to service | `""`
+`controller.metrics.service.clusterIP` | cluster IP address to assign to service | `nil`
 `controller.metrics.service.omitClusterIP` | To omit the `clusterIP` from the metrics service | `false`
 `controller.metrics.service.externalIPs` | Prometheus metrics service external IP addresses | `[]`
 `controller.metrics.service.labels` | labels for metrics service | `{}`
@@ -150,7 +150,7 @@ Parameter | Description | Default
 `controller.admissionWebhooks.port` | Admission webhook port | `8080`
 `controller.admissionWebhooks.service.annotations` | Annotations for admission webhook service | `{}`
 `controller.admissionWebhooks.service.omitClusterIP` | To omit the `clusterIP` from the admission webhook service | `false`
-`controller.admissionWebhooks.service.clusterIP` | cluster IP address to assign to admission webhook service | `""`
+`controller.admissionWebhooks.service.clusterIP` | cluster IP address to assign to admission webhook service | `nil`
 `controller.admissionWebhooks.service.externalIPs` | Admission webhook service external IP addresses | `[]`
 `controller.admissionWebhooks.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `controller.admissionWebhooks.service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported) | `[]`
@@ -202,7 +202,7 @@ Parameter | Description | Default
 `defaultBackend.priorityClassName` | default backend  priorityClassName | `nil`
 `defaultBackend.podSecurityContext` | Security context policies to add to the default backend | `{}`
 `defaultBackend.service.annotations` | annotations for default backend service | `{}`
-`defaultBackend.service.clusterIP` | internal default backend cluster service IP | `""`
+`defaultBackend.service.clusterIP` | internal default backend cluster service IP | `nil`
 `defaultBackend.service.omitClusterIP` | To omit the `clusterIP` from the default backend service | `false`
 `defaultBackend.service.externalIPs` | default backend service external IP addresses | `[]`
 `defaultBackend.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`

--- a/stable/nginx-ingress/templates/controller-service.yaml
+++ b/stable/nginx-ingress/templates/controller-service.yaml
@@ -20,7 +20,7 @@ metadata:
   name: {{ template "nginx-ingress.controller.fullname" . }}
 spec:
 {{- if not .Values.controller.service.omitClusterIP }}
-  clusterIP: "{{ .Values.controller.service.clusterIP }}"
+  {{ with .Values.controller.service.clusterIP }}clusterIP: {{ quote . }}{{ end }}
 {{- end }}
 {{- if .Values.controller.service.externalIPs }}
   externalIPs:

--- a/stable/nginx-ingress/templates/controller-webhook-service.yaml
+++ b/stable/nginx-ingress/templates/controller-webhook-service.yaml
@@ -17,7 +17,7 @@ metadata:
   name: {{ template "nginx-ingress.controller.fullname" . }}-admission
 spec:
 {{- if not .Values.controller.admissionWebhooks.service.omitClusterIP }}
-  clusterIP: "{{ .Values.controller.admissionWebhooks.service.clusterIP }}"
+  {{ with .Values.controller.admissionWebhooks.service.clusterIP }}clusterIP: {{ quote . }}{{ end }}
 {{- end }}
 {{- if .Values.controller.admissionWebhooks.service.externalIPs }}
   externalIPs:

--- a/stable/nginx-ingress/templates/default-backend-service.yaml
+++ b/stable/nginx-ingress/templates/default-backend-service.yaml
@@ -17,7 +17,7 @@ metadata:
   name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
 spec:
 {{- if not .Values.defaultBackend.service.omitClusterIP }}
-  clusterIP: "{{ .Values.defaultBackend.service.clusterIP }}"
+  {{ with .Values.defaultBackend.service.clusterIP }}clusterIP: {{ quote . }}{{ end }}
 {{- end }}
 {{- if .Values.defaultBackend.service.externalIPs }}
   externalIPs:

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -228,7 +228,7 @@ controller:
     annotations: {}
     labels: {}
     omitClusterIP: false
-    clusterIP: ""
+    # clusterIP: ""
 
     ## List of IP addresses at which the controller services are available
     ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
@@ -318,7 +318,7 @@ controller:
     service:
       annotations: {}
       omitClusterIP: false
-      clusterIP: ""
+      # clusterIP: ""
       externalIPs: []
       loadBalancerIP: ""
       loadBalancerSourceRanges: []
@@ -348,7 +348,7 @@ controller:
       # prometheus.io/port: "10254"
 
       omitClusterIP: false
-      clusterIP: ""
+      # clusterIP: ""
 
       ## List of IP addresses at which the stats-exporter service is available
       ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
@@ -491,7 +491,7 @@ defaultBackend:
   service:
     annotations: {}
     omitClusterIP: false
-    clusterIP: ""
+    # clusterIP: ""
 
     ## List of IP addresses at which the default backend service is available
     ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips


### PR DESCRIPTION
Signed-off-by: Naseem <naseemkullah@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

#### What this PR does / why we need it:
Please see #19041 and https://github.com/helm/helm/issues/6378#issuecomment-557746499
helm3 introduces 3 way merge, i am stuck with a release where omitClusterIP was not set and is now managed by helm3. This would probably help

#### Special notes for your reviewer:
We may be able to remove the omitclusterIP workaround if we wish, provided nobody has hardcoded `clusterIP: ""` in their values files

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
