### PR TITLE
[stable/prometheus-operator] Add option configSecret for prometheus-operator

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.2.4
+version: 8.2.5
 appVersion: 0.34.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.2.5
+version: 8.3.0
 appVersion: 0.34.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -341,6 +341,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `alertmanager.alertmanagerSpec.additionalPeers` | AdditionalPeers allows injecting a set of additional Alertmanagers to peer with to form a highly available cluster. | `[]` |
 | `alertmanager.alertmanagerSpec.affinity` | Assign custom affinity rules to the alertmanager instance https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ | `{}` |
 | `alertmanager.alertmanagerSpec.configMaps` | ConfigMaps is a list of ConfigMaps in the same namespace as the Alertmanager object, which shall be mounted into the Alertmanager Pods. The ConfigMaps are mounted into /etc/alertmanager/configmaps/ | `[]` |
+| `alertmanager.alertmanagerSpec.`configSecret | ConfigSecret is the name of a Kubernetes Secret in the same namespace as the Alertmanager object, which contains configuration for this Alertmanager instance. Defaults to 'alertmanager-' The secret is mounted into /etc/alertmanager/config. | `""` |
 | `alertmanager.alertmanagerSpec.containers` | Containers allows injecting additional containers. This is meant to allow adding an authentication proxy to an Alertmanager pod. | `[]` |
 | `alertmanager.alertmanagerSpec.externalUrl` | The external URL the Alertmanager instances will be available under. This is necessary to generate correct URLs. This is necessary if Alertmanager is not served from root of a DNS name. | `""` |
 | `alertmanager.alertmanagerSpec.image.repository` | Base image that is used to deploy pods, without tag. | `quay.io/prometheus/alertmanager` |

--- a/stable/prometheus-operator/crds/crd-alertmanager.yaml
+++ b/stable/prometheus-operator/crds/crd-alertmanager.yaml
@@ -598,6 +598,12 @@ spec:
             baseImage:
               description: Base image that is used to deploy pods, without tag.
               type: string
+            configSecret:
+              description: ConfigSecret is the name of a Kubernetes Secret in the same
+                namespace as the Alertmanager object, which contains configuration for
+                this Alertmanager instance. Defaults to 'alertmanager-' The secret is
+                mounted into /etc/alertmanager/config.
+              type: string
             configMaps:
               description: ConfigMaps is a list of ConfigMaps in the same namespace
                 as the Alertmanager object, which shall be mounted into the Alertmanager

--- a/stable/prometheus-operator/templates/alertmanager/alertmanager.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/alertmanager.yaml
@@ -34,6 +34,9 @@ spec:
   secrets:
 {{ toYaml .Values.alertmanager.alertmanagerSpec.secrets | indent 4 }}
 {{- end }}
+{{- if .Values.alertmanager.alertmanagerSpec.configSecret }}
+  configSecret: {{ .Values.alertmanager.alertmanagerSpec.configSecret }}
+{{- end }}
 {{- if .Values.alertmanager.alertmanagerSpec.configMaps }}
   configMaps:
 {{ toYaml .Values.alertmanager.alertmanagerSpec.configMaps | indent 4 }}

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -257,7 +257,7 @@ alertmanager:
     ## ConfigSecret is the name of a Kubernetes Secret in the same namespace as the Alertmanager object, which contains configuration for
     ## this Alertmanager instance. Defaults to 'alertmanager-' The secret is mounted into /etc/alertmanager/config.
     ##
-    configSecret:
+    # configSecret:
 
     ## Define Log Format
     # Use logfmt (default) or json-formatted logging

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -254,6 +254,11 @@ alertmanager:
     ##
     configMaps: []
 
+    ## ConfigSecret is the name of a Kubernetes Secret in the same namespace as the Alertmanager object, which contains configuration for
+    ## this Alertmanager instance. Defaults to 'alertmanager-' The secret is mounted into /etc/alertmanager/config.
+    ##
+    configSecret:
+
     ## Define Log Format
     # Use logfmt (default) or json-formatted logging
     logFormat: logfmt


### PR DESCRIPTION
#### What this PR does / why we need it:

Add option configSecret for prometheus-operator which was added in version [0.34.0](https://github.com/coreos/prometheus-operator/blob/8d44e0990230144177f97cf62ae4f43b1c4e3168/CHANGELOG.md) of prometheus-operator

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
