### PR TITLE
[stable/nginx-ingress] Nginx ingress no empty quotes clusterIp

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.25.2
+version: 1.25.3
 appVersion: 0.26.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.25.3
+version: 1.26.0
 appVersion: 0.26.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.25.1
+version: 1.25.2
 appVersion: 0.26.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -95,7 +95,7 @@ Parameter | Description | Default
 `controller.publishService.enabled` | if true, the controller will set the endpoint records on the ingress objects to reflect those on the service | `false`
 `controller.publishService.pathOverride` | override of the default publish-service name | `""`
 `controller.service.enabled` | if disabled no service will be created. This is especially useful when `controller.kind` is set to `DaemonSet` and `controller.daemonset.useHostPorts` is `true` | true
-`controller.service.clusterIP` | internal controller cluster service IP | `""`
+`controller.service.clusterIP` | internal controller cluster service IP | `nil`
 `controller.service.omitClusterIP` | To omit the `clusterIP` from the controller service | `false`
 `controller.service.externalIPs` | controller service external IP addresses. Do not set this when `controller.hostNetwork` is set to `true` and `kube-proxy` is used as there will be a port-conflict for port `80` | `[]`
 `controller.service.externalTrafficPolicy` | If `controller.service.type` is `NodePort` or `LoadBalancer`, set this to `Local` to enable [source IP preservation](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typenodeport) | `"Cluster"`
@@ -127,7 +127,7 @@ Parameter | Description | Default
 `controller.readinessProbe.port` | The port number that the readiness probe will listen on. | 10254
 `controller.metrics.enabled` | if `true`, enable Prometheus metrics | `false`
 `controller.metrics.service.annotations` | annotations for Prometheus metrics service | `{}`
-`controller.metrics.service.clusterIP` | cluster IP address to assign to service | `""`
+`controller.metrics.service.clusterIP` | cluster IP address to assign to service | `nil`
 `controller.metrics.service.omitClusterIP` | To omit the `clusterIP` from the metrics service | `false`
 `controller.metrics.service.externalIPs` | Prometheus metrics service external IP addresses | `[]`
 `controller.metrics.service.labels` | labels for metrics service | `{}`
@@ -150,7 +150,7 @@ Parameter | Description | Default
 `controller.admissionWebhooks.port` | Admission webhook port | `8080`
 `controller.admissionWebhooks.service.annotations` | Annotations for admission webhook service | `{}`
 `controller.admissionWebhooks.service.omitClusterIP` | To omit the `clusterIP` from the admission webhook service | `false`
-`controller.admissionWebhooks.service.clusterIP` | cluster IP address to assign to admission webhook service | `""`
+`controller.admissionWebhooks.service.clusterIP` | cluster IP address to assign to admission webhook service | `nil`
 `controller.admissionWebhooks.service.externalIPs` | Admission webhook service external IP addresses | `[]`
 `controller.admissionWebhooks.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `controller.admissionWebhooks.service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported) | `[]`
@@ -202,7 +202,7 @@ Parameter | Description | Default
 `defaultBackend.priorityClassName` | default backend  priorityClassName | `nil`
 `defaultBackend.podSecurityContext` | Security context policies to add to the default backend | `{}`
 `defaultBackend.service.annotations` | annotations for default backend service | `{}`
-`defaultBackend.service.clusterIP` | internal default backend cluster service IP | `""`
+`defaultBackend.service.clusterIP` | internal default backend cluster service IP | `nil`
 `defaultBackend.service.omitClusterIP` | To omit the `clusterIP` from the default backend service | `false`
 `defaultBackend.service.externalIPs` | default backend service external IP addresses | `[]`
 `defaultBackend.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -318,3 +318,5 @@ Error: UPGRADE FAILED: Service "?????-controller" is invalid: spec.clusterIP: In
 ```
 
 Detail of how and why are in [this issue](https://github.com/helm/charts/pull/13646) but to resolve this you can set `xxxx.service.omitClusterIP` to `true` where `xxxx` is the service referenced in the error.
+
+As of version `1.26.0` of this chart, by simply not providing any clusterIP, no `invalid: spec.clusterIP: Invalid value: "": field is immutable` will happen since `clusterIP: ""` will not be rendered. If you do wish to provide a clusterIP value in your values file, ensure that it is quoted.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -96,7 +96,7 @@ Parameter | Description | Default
 `controller.publishService.pathOverride` | override of the default publish-service name | `""`
 `controller.service.enabled` | if disabled no service will be created. This is especially useful when `controller.kind` is set to `DaemonSet` and `controller.daemonset.useHostPorts` is `true` | true
 `controller.service.clusterIP` | internal controller cluster service IP | `nil`
-`controller.service.omitClusterIP` | To omit the `clusterIP` from the controller service | `false`
+`controller.service.omitClusterIP` | (Deprecated) To omit the `clusterIP` from the controller service | `false`
 `controller.service.externalIPs` | controller service external IP addresses. Do not set this when `controller.hostNetwork` is set to `true` and `kube-proxy` is used as there will be a port-conflict for port `80` | `[]`
 `controller.service.externalTrafficPolicy` | If `controller.service.type` is `NodePort` or `LoadBalancer`, set this to `Local` to enable [source IP preservation](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typenodeport) | `"Cluster"`
 `controller.service.healthCheckNodePort` | If `controller.service.type` is `NodePort` or `LoadBalancer` and `controller.service.externalTrafficPolicy` is set to `Local`, set this to [the managed health-check port the kube-proxy will expose](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typenodeport). If blank, a random port in the `NodePort` range will be assigned | `""`
@@ -128,7 +128,7 @@ Parameter | Description | Default
 `controller.metrics.enabled` | if `true`, enable Prometheus metrics | `false`
 `controller.metrics.service.annotations` | annotations for Prometheus metrics service | `{}`
 `controller.metrics.service.clusterIP` | cluster IP address to assign to service | `nil`
-`controller.metrics.service.omitClusterIP` | To omit the `clusterIP` from the metrics service | `false`
+`controller.metrics.service.omitClusterIP` | (Deprecated) To omit the `clusterIP` from the metrics service | `false`
 `controller.metrics.service.externalIPs` | Prometheus metrics service external IP addresses | `[]`
 `controller.metrics.service.labels` | labels for metrics service | `{}`
 `controller.metrics.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
@@ -149,7 +149,7 @@ Parameter | Description | Default
 `controller.admissionWebhooks.failurePolicy` | Failure policy for admission webhooks | `Fail`
 `controller.admissionWebhooks.port` | Admission webhook port | `8080`
 `controller.admissionWebhooks.service.annotations` | Annotations for admission webhook service | `{}`
-`controller.admissionWebhooks.service.omitClusterIP` | To omit the `clusterIP` from the admission webhook service | `false`
+`controller.admissionWebhooks.service.omitClusterIP` | (Deprecated) To omit the `clusterIP` from the admission webhook service | `false`
 `controller.admissionWebhooks.service.clusterIP` | cluster IP address to assign to admission webhook service | `nil`
 `controller.admissionWebhooks.service.externalIPs` | Admission webhook service external IP addresses | `[]`
 `controller.admissionWebhooks.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
@@ -203,7 +203,7 @@ Parameter | Description | Default
 `defaultBackend.podSecurityContext` | Security context policies to add to the default backend | `{}`
 `defaultBackend.service.annotations` | annotations for default backend service | `{}`
 `defaultBackend.service.clusterIP` | internal default backend cluster service IP | `nil`
-`defaultBackend.service.omitClusterIP` | To omit the `clusterIP` from the default backend service | `false`
+`defaultBackend.service.omitClusterIP` | (Deprecated) To omit the `clusterIP` from the default backend service | `false`
 `defaultBackend.service.externalIPs` | default backend service external IP addresses | `[]`
 `defaultBackend.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `defaultBackend.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
@@ -319,4 +319,4 @@ Error: UPGRADE FAILED: Service "?????-controller" is invalid: spec.clusterIP: In
 
 Detail of how and why are in [this issue](https://github.com/helm/charts/pull/13646) but to resolve this you can set `xxxx.service.omitClusterIP` to `true` where `xxxx` is the service referenced in the error.
 
-As of version `1.26.0` of this chart, by simply not providing any clusterIP, no `invalid: spec.clusterIP: Invalid value: "": field is immutable` will happen since `clusterIP: ""` will not be rendered. If you do wish to provide a clusterIP value in your values file, ensure that it is quoted.
+As of version `1.26.0` of this chart, by simply not providing any clusterIP value, `invalid: spec.clusterIP: Invalid value: "": field is immutable` will no longer occur since `clusterIP: ""` will not be rendered. If you do wish to provide a clusterIP value in your values file, ensure that it is quoted.

--- a/stable/nginx-ingress/templates/controller-metrics-service.yaml
+++ b/stable/nginx-ingress/templates/controller-metrics-service.yaml
@@ -20,7 +20,7 @@ metadata:
   name: {{ template "nginx-ingress.controller.fullname" . }}-metrics
 spec:
 {{- if not .Values.controller.metrics.service.omitClusterIP }}
-  clusterIP: "{{ .Values.controller.metrics.service.clusterIP }}"
+  {{ with .Values.controller.metrics.service.clusterIP }}clusterIP: {{ . }}{{ end }}
 {{- end }}
 {{- if .Values.controller.metrics.service.externalIPs }}
   externalIPs:

--- a/stable/nginx-ingress/templates/controller-service.yaml
+++ b/stable/nginx-ingress/templates/controller-service.yaml
@@ -20,7 +20,7 @@ metadata:
   name: {{ template "nginx-ingress.controller.fullname" . }}
 spec:
 {{- if not .Values.controller.service.omitClusterIP }}
-  clusterIP: "{{ .Values.controller.service.clusterIP }}"
+  {{ with .Values.controller.service.clusterIP }}clusterIP: {{ quote . }}{{ end }}
 {{- end }}
 {{- if .Values.controller.service.externalIPs }}
   externalIPs:

--- a/stable/nginx-ingress/templates/controller-service.yaml
+++ b/stable/nginx-ingress/templates/controller-service.yaml
@@ -20,7 +20,7 @@ metadata:
   name: {{ template "nginx-ingress.controller.fullname" . }}
 spec:
 {{- if not .Values.controller.service.omitClusterIP }}
-  {{ with .Values.controller.service.clusterIP }}clusterIP: {{ quote . }}{{ end }}
+  {{ with .Values.controller.service.clusterIP }}clusterIP: {{ . }}{{ end }}
 {{- end }}
 {{- if .Values.controller.service.externalIPs }}
   externalIPs:

--- a/stable/nginx-ingress/templates/controller-webhook-service.yaml
+++ b/stable/nginx-ingress/templates/controller-webhook-service.yaml
@@ -17,7 +17,7 @@ metadata:
   name: {{ template "nginx-ingress.controller.fullname" . }}-admission
 spec:
 {{- if not .Values.controller.admissionWebhooks.service.omitClusterIP }}
-  {{ with .Values.controller.admissionWebhooks.service.clusterIP }}clusterIP: {{ quote . }}{{ end }}
+  {{ with .Values.controller.admissionWebhooks.service.clusterIP }}clusterIP: {{ . }}{{ end }}
 {{- end }}
 {{- if .Values.controller.admissionWebhooks.service.externalIPs }}
   externalIPs:

--- a/stable/nginx-ingress/templates/controller-webhook-service.yaml
+++ b/stable/nginx-ingress/templates/controller-webhook-service.yaml
@@ -17,7 +17,7 @@ metadata:
   name: {{ template "nginx-ingress.controller.fullname" . }}-admission
 spec:
 {{- if not .Values.controller.admissionWebhooks.service.omitClusterIP }}
-  clusterIP: "{{ .Values.controller.admissionWebhooks.service.clusterIP }}"
+  {{ with .Values.controller.admissionWebhooks.service.clusterIP }}clusterIP: {{ quote . }}{{ end }}
 {{- end }}
 {{- if .Values.controller.admissionWebhooks.service.externalIPs }}
   externalIPs:

--- a/stable/nginx-ingress/templates/default-backend-service.yaml
+++ b/stable/nginx-ingress/templates/default-backend-service.yaml
@@ -17,7 +17,7 @@ metadata:
   name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
 spec:
 {{- if not .Values.defaultBackend.service.omitClusterIP }}
-  clusterIP: "{{ .Values.defaultBackend.service.clusterIP }}"
+  {{ with .Values.defaultBackend.service.clusterIP }}clusterIP: {{ quote . }}{{ end }}
 {{- end }}
 {{- if .Values.defaultBackend.service.externalIPs }}
   externalIPs:

--- a/stable/nginx-ingress/templates/default-backend-service.yaml
+++ b/stable/nginx-ingress/templates/default-backend-service.yaml
@@ -17,7 +17,7 @@ metadata:
   name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
 spec:
 {{- if not .Values.defaultBackend.service.omitClusterIP }}
-  {{ with .Values.defaultBackend.service.clusterIP }}clusterIP: {{ quote . }}{{ end }}
+  {{ with .Values.defaultBackend.service.clusterIP }}clusterIP: {{ . }}{{ end }}
 {{- end }}
 {{- if .Values.defaultBackend.service.externalIPs }}
   externalIPs:

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -228,7 +228,7 @@ controller:
     annotations: {}
     labels: {}
     omitClusterIP: false
-    clusterIP: ""
+    # clusterIP: ""
 
     ## List of IP addresses at which the controller services are available
     ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
@@ -318,7 +318,7 @@ controller:
     service:
       annotations: {}
       omitClusterIP: false
-      clusterIP: ""
+      # clusterIP: ""
       externalIPs: []
       loadBalancerIP: ""
       loadBalancerSourceRanges: []
@@ -348,7 +348,7 @@ controller:
       # prometheus.io/port: "10254"
 
       omitClusterIP: false
-      clusterIP: ""
+      # clusterIP: ""
 
       ## List of IP addresses at which the stats-exporter service is available
       ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
@@ -491,7 +491,7 @@ defaultBackend:
   service:
     annotations: {}
     omitClusterIP: false
-    clusterIP: ""
+    # clusterIP: ""
 
     ## List of IP addresses at which the default backend service is available
     ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -350,7 +350,7 @@ controller:
       # prometheus.io/port: "10254"
 
       ## Deprecated, instead simply do not provide a clusterIP value
-      omitClusterIP: false 
+      omitClusterIP: false
       # clusterIP: ""
 
       ## List of IP addresses at which the stats-exporter service is available
@@ -494,7 +494,7 @@ defaultBackend:
   service:
     annotations: {}
     ## Deprecated, instead simply do not provide a clusterIP value
-    omitClusterIP: false 
+    omitClusterIP: false
     # clusterIP: ""
 
     ## List of IP addresses at which the default backend service is available

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -227,7 +227,8 @@ controller:
 
     annotations: {}
     labels: {}
-    omitClusterIP: false # Deprecated, instead simply do not provide a clusterIP value
+    ## Deprecated, instead simply do not provide a clusterIP value
+    omitClusterIP: false
     # clusterIP: ""
 
     ## List of IP addresses at which the controller services are available
@@ -317,7 +318,8 @@ controller:
 
     service:
       annotations: {}
-      omitClusterIP: false # Deprecated, instead simply do not provide a clusterIP value
+      ## Deprecated, instead simply do not provide a clusterIP value
+      omitClusterIP: false
       # clusterIP: ""
       externalIPs: []
       loadBalancerIP: ""
@@ -347,7 +349,8 @@ controller:
       # prometheus.io/scrape: "true"
       # prometheus.io/port: "10254"
 
-      omitClusterIP: false # Deprecated, instead simply do not provide a clusterIP value
+      ## Deprecated, instead simply do not provide a clusterIP value
+      omitClusterIP: false 
       # clusterIP: ""
 
       ## List of IP addresses at which the stats-exporter service is available
@@ -490,7 +493,8 @@ defaultBackend:
 
   service:
     annotations: {}
-    omitClusterIP: false # Deprecated, instead simply do not provide a clusterIP value
+    ## Deprecated, instead simply do not provide a clusterIP value
+    omitClusterIP: false 
     # clusterIP: ""
 
     ## List of IP addresses at which the default backend service is available

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -227,7 +227,7 @@ controller:
 
     annotations: {}
     labels: {}
-    omitClusterIP: false
+    omitClusterIP: false # Deprecated, instead simply do not provide a clusterIP value
     # clusterIP: ""
 
     ## List of IP addresses at which the controller services are available
@@ -317,7 +317,7 @@ controller:
 
     service:
       annotations: {}
-      omitClusterIP: false
+      omitClusterIP: false # Deprecated, instead simply do not provide a clusterIP value
       # clusterIP: ""
       externalIPs: []
       loadBalancerIP: ""
@@ -347,7 +347,7 @@ controller:
       # prometheus.io/scrape: "true"
       # prometheus.io/port: "10254"
 
-      omitClusterIP: false
+      omitClusterIP: false # Deprecated, instead simply do not provide a clusterIP value
       # clusterIP: ""
 
       ## List of IP addresses at which the stats-exporter service is available
@@ -490,7 +490,7 @@ defaultBackend:
 
   service:
     annotations: {}
-    omitClusterIP: false
+    omitClusterIP: false # Deprecated, instead simply do not provide a clusterIP value
     # clusterIP: ""
 
     ## List of IP addresses at which the default backend service is available


### PR DESCRIPTION
#### What this PR does / why we need it:
Please see https://github.com/helm/charts/pull/19146

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #19041

#### Special notes for your reviewer:
#19146 was missing this, because if we keep `quote` we still get empty quotes as values for clusterIp.

As it stands we will still wind up with clusterIP: "" if no value is provided ... just {{ . }} is better since it will not add clusterIP to rendered files if no value is provided, but the user needs to quote any provided values themselves

Also forgot to do it for metrics service in previous PR

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
