### PR TITLE
[stable/parse] Use different services for the dashboard and the server

### DIFF
--- a/stable/parse/requirements.lock
+++ b/stable/parse/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mongodb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 7.4.5
+  version: 7.4.6
 digest: sha256:380fe3c8514cc2d19b28e5b1a79d83961fa9f9d7f438eba85425dbf8c0b89bbd
 generated: 2019-11-20T19:26:20.140934711Z

--- a/stable/parse/templates/NOTES.txt
+++ b/stable/parse/templates/NOTES.txt
@@ -16,20 +16,20 @@ Parse Server
 
   export SERVICE_HOST={{ $ingressHost.name }}
 
-{{- else if contains "NodePort" .Values.service.type }}
+{{- else if contains "NodePort" .Values.server.service.type }}
 
-  export NODE_PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" {{ include "parse.fullname" . }})
+  export NODE_PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" {{ include "parse.fullname" . }}-server)
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   export SERVICE_HOST=$NODE_IP:$NODE_PORT
 
-{{- else if contains "LoadBalancer" .Values.service.type }}
+{{- else if contains "LoadBalancer" .Values.server.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ include "parse.fullname" . }}'
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ include "parse.fullname" . }}-server'
 
-  export SERVICE_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "parse.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}"):{{ .Values.server.port }}
+  export SERVICE_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "parse.fullname" . }}-server --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}"):{{ .Values.server.port }}
 
-{{- else if contains "ClusterIP"  .Values.service.type }}
+{{- else if contains "ClusterIP"  .Values.server.service.type }}
 
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l app.kubernetes.io/name={{ template "parse.name" . }},app.kubernetes.io/component=server -o jsonpath="{.items[0].metadata.name}")
   kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 1337:1337 &
@@ -60,9 +60,9 @@ service:
 1. Get the Parse Server URL by running:
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ include "parse.fullname" . }}'
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ include "parse.fullname" . }}-server'
 
-  export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "parse.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "parse.fullname" . }}-server --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
 
 2. Complete your Parse Dashboard deployment by running:
 
@@ -77,15 +77,25 @@ service:
 
   You should be able to access Parse Dashboard through: {{- range .Values.ingress.dashboard.hosts }} {{ if .tls }}https{{ else }}http{{ end }}://{{ .name }} {{- end }}
 
-{{- else if eq .Values.service.type "ClusterIP" }}
+{{- else if eq .Values.dashboard.service.type "ClusterIP" }}
 
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l app.kubernetes.io/name={{ template "parse.name" . }},app.kubernetes.io/component=dashboard -o jsonpath="{.items[0].metadata.name}")
   kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 4040:4040 &
   echo "Parse Dashboard URL: http://127.0.0.1:4040/"
 
+{{- else if eq .Values.dashboard.service.type "NodePort" }}
+
+  export NODE_PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" {{ include "parse.fullname" . }}-dashboard)
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "Parse Dashboard URL: http://$NODE_IP:$NODE_PORT"
+
 {{- else }}
 
-  echo "Parse Dashboard URL: http://{{ include "parse.host" . }}/"
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ include "parse.fullname" . }}-dashboard'
+
+  export DASHBOARD_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "parse.fullname" . }}-dashboard --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}"):{{ .Values.server.port }}
+  echo "Parse Dashboard URL: http://$DASHBOARD_HOST/"
 
 {{- end }}
 

--- a/stable/parse/templates/_helpers.tpl
+++ b/stable/parse/templates/_helpers.tpl
@@ -65,10 +65,10 @@ Get the user defined LoadBalancerIP for this release.
 Note, returns 127.0.0.1 if using ClusterIP.
 */}}
 {{- define "parse.serviceIP" -}}
-{{- if eq .Values.service.type "ClusterIP" -}}
+{{- if eq .Values.server.service.type "ClusterIP" -}}
 127.0.0.1
 {{- else -}}
-{{- default "" .Values.service.loadBalancerIP -}}
+{{- default "" .Values.server.service.loadBalancerIP -}}
 {{- end -}}
 {{- end -}}
 

--- a/stable/parse/templates/dashboard-svc.yaml
+++ b/stable/parse/templates/dashboard-svc.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "parse.fullname" . }}-dashboard
+  labels: {{ include "parse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dashboard
+spec:
+  type: {{ .Values.dashboard.service.type }}
+  {{- if and (.Values.dashboard.service.loadBalancerIP) (eq .Values.dashboard.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.dashboard.service.loadBalancerIP | quote }}
+  {{- end }}
+  {{- if (or (eq .Values.dashboard.service.type "LoadBalancer") (eq .Values.dashboard.service.type "NodePort")) }}
+  externalTrafficPolicy: {{ .Values.dashboard.service.externalTrafficPolicy | quote }}
+  {{- end }}
+  ports:
+    - name: dashboard-http
+      port: {{ .Values.dashboard.service.port }}
+      targetPort: dashboard-http
+      {{- if (and (eq .Values.dashboard.service.type "NodePort") (not (empty .Values.dashboard.service.nodePorts.http)))}}
+      nodePort: {{ .Values.dashboard.service.nodePorts.http }}
+      {{- end }}
+  selector: {{ include "parse.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: dashboard

--- a/stable/parse/templates/ingress.yaml
+++ b/stable/parse/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
         paths:
           - path: {{ default "/" .path }}
             backend:
-              serviceName: {{ include "parse.fullname" $ }}
+              serviceName: {{ include "parse.fullname" $ }}-dashboard
               servicePort: dashboard-http
     {{- end }}
     {{- end }}
@@ -30,7 +30,7 @@ spec:
         paths:
           - path: {{ default "/" .path }}
             backend:
-              serviceName: {{ include "parse.fullname" $ }}
+              serviceName: {{ include "parse.fullname" $ }}-server
               servicePort: server-http
     {{- end }}
   tls:

--- a/stable/parse/templates/svc.yaml
+++ b/stable/parse/templates/svc.yaml
@@ -1,24 +1,23 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "parse.fullname" . }}
+  name: {{ include "parse.fullname" . }}-server
   labels: {{ include "parse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
 spec:
-  type: {{ .Values.service.type }}
-  {{- if and (.Values.service.loadBalancerIP) (eq .Values.service.type "LoadBalancer") }}
-  loadBalancerIP: {{ .Values.service.loadBalancerIP | quote }}
+  type: {{ .Values.server.service.type }}
+  {{- if and (.Values.server.service.loadBalancerIP) (eq .Values.server.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.server.service.loadBalancerIP | quote }}
   {{- end }}
-  {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
-  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
+  {{- if (or (eq .Values.server.service.type "LoadBalancer") (eq .Values.server.service.type "NodePort")) }}
+  externalTrafficPolicy: {{ .Values.server.service.externalTrafficPolicy | quote }}
   {{- end }}
   ports:
     - name: server-http
       port: {{ .Values.server.port }}
       targetPort: server-http
-    - name: dashboard-http
-      port: {{ .Values.service.port }}
-      targetPort: dashboard-http
-      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePorts.http)))}}
-      nodePort: {{ .Values.service.nodePorts.http }}
+      {{- if (and (eq .Values.server.service.type "NodePort") (not (empty .Values.server.service.nodePorts.http)))}}
+      nodePort: {{ .Values.server.service.nodePorts.http }}
       {{- end }}
   selector: {{ include "parse.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: server

--- a/stable/parse/values.yaml
+++ b/stable/parse/values.yaml
@@ -34,24 +34,6 @@ volumePermissions:
     #   - myRegistryKeySecretName
   resources: {}
 
-## Kubernetes serviceType for Parse Deployment
-## ref: http://kubernetes.io/docs/user-guide/services/#publishing-services---service-types
-##
-service:
-  type: LoadBalancer
-  # Parse dashboard HTTP Port
-  port: 80
-  ## loadBalancerIP:
-  ##
-  ## nodePorts:
-  ##   http: <to set explicitly, choose port between 30000-32767>
-  nodePorts:
-    http: ""
-  ## Enable client source IP preservation
-  ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
-  ##
-  externalTrafficPolicy: Cluster
-
 ## loadBalancerIP for the Parse Service (optional, cloud specific)
 ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
 ##
@@ -174,6 +156,22 @@ server:
   ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: {}
+  
+  ## Kubernetes serviceType for Parse Server
+  ## ref: http://kubernetes.io/docs/user-guide/services/#publishing-services---service-types
+  ##
+  service:
+    type: LoadBalancer
+    ## loadBalancerIP:
+    ##
+    ## nodePorts:
+    ##   http: <to set explicitly, choose port between 30000-32767>
+    nodePorts:
+      http: ""
+    ## Enable client source IP preservation
+    ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+    ##
+    externalTrafficPolicy: Cluster
 
 dashboard:
   ## Enable deployment of Parse Dashboard
@@ -273,6 +271,24 @@ dashboard:
   ## Name of a Secret containing extra env vars
   ##
   extraEnvVarsSecret:
+  
+  ## Kubernetes serviceType for Parse Dashboard
+  ## ref: http://kubernetes.io/docs/user-guide/services/#publishing-services---service-types
+  ##
+  service:
+    type: LoadBalancer
+    # Parse dashboard HTTP Port
+    port: 80
+    ## loadBalancerIP:
+    ##
+    ## nodePorts:
+    ##   http: <to set explicitly, choose port between 30000-32767>
+    nodePorts:
+      http: ""
+    ## Enable client source IP preservation
+    ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+    ##
+    externalTrafficPolicy: Cluster
 
 ## Configure the ingress resource that allows you to access the
 ## Parse installation.


### PR DESCRIPTION
#### What this PR does / why we need it:
Use different services for the server and the dashboard pods to allow Nginx Ingress to get the endpoints for the Ingress rules.

#### Checklist
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
