### PR TITLE
[stable/jenkins] Multiple agent podTemplates (2.0.0)

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,17 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 2.0.0 Multiple agent pod templates and containers
+
+- Allow multiple agent pod templates with multiple containers
+- Option to set agent's pod retention timeout
+- Option to set usage mode for agent: normal, exclusive, etc.
+
+### Breaking changes:
+
+- Agent dictionary object now includes a list of pod templates with multiple
+  containers. Please refer to `values.yaml` or `README.md` for further details.
+
 ## 1.9.4 Option to set existing secret with Google Application Default Credentials
 
 Google application credentials are kept in a file, which has to be mounted to a pod. You can set `gcpcredentials` in `existingSecret` as follows:
@@ -29,7 +40,7 @@ To quote from the plugin documentation:
 
 > Because granting these permissions for secrets is not something that should be done lightly it is highly advised for security reasons that you both create a unique service account to run Jenkins as, and run Jenkins in a unique namespace.
 
-Therefor this is disabled by default.
+Therefore this is disabled by default.
 
 ## 1.9.1 Update kubernetes plugin URL
 

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.9.4
+version: 2.0.0
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -180,28 +180,31 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 Some third-party systems, e.g. GitHub, use HTML-formatted data in their payload sent to a Jenkins webhooks, e.g. URL of a pull-request being built. To display such data as processed HTML instead of raw text set `master.enableRawHtmlMarkupFormatter` to true. This option requires installation of OWASP Markup Formatter Plugin (antisamy-markup-formatter). The plugin is **not** installed by default, please update `master.installPlugins`.
 
-### Jenkins Agent
+### Jenkins Kubernetes Agent
 
 | Parameter                  | Description                                     | Default                |
 | -------------------------- | ----------------------------------------------- | ---------------------- |
-| `agent.alwaysPullImage`    | Always pull agent container image before build  | `false`                |
-| `agent.customJenkinsLabels`| Append Jenkins labels to the agent              | `{}`                   |
-| `agent.enabled`            | Enable Kubernetes plugin jnlp-agent podTemplate | `true`                 |
-| `agent.image`              | Agent image name                                | `jenkins/jnlp-slave`   |
-| `agent.imagePullSecret`    | Agent image pull secret                         | Not set                |
-| `agent.tag`                | Agent image tag                                 | `3.27-1`               |
-| `agent.privileged`         | Agent privileged container                      | `false`                |
-| `agent.resources`          | Resources allocation (Requests and Limits)      | `{requests: {cpu: 512m, memory: 512Mi}, limits: {cpu: 512m, memory: 512Mi}}`|
-| `agent.volumes`            | Additional volumes                              | `[]`                   |
-| `agent.envVars`            | Environment variables for the agent Pod         | `[]`                   |
-| `agent.command`            | Executed command when side container starts     | Not set                |
-| `agent.args`               | Arguments passed to executed command            | Not set                |
-| `agent.sideContainerName`  | Side container name in agent                    | jnlp                   |
-| `agent.TTYEnabled`         | Allocate pseudo tty to the side container       | false                  |
-| `agent.containerCap`       | Maximum number of agent                         | 10                     |
-| `agent.podName`            | Agent Pod base name                             | Not set                |
-| `agent.idleMinutes`        | Allows the Pod to remain active for reuse       | 0                      |
-| `agent.yamlTemplate`       | The raw yaml of a Pod API Object to merge into the agent spec | Not set                |
+| `agent.enabled`                        | Enable Kubernetes plugin jnlp-agent podTemplate | `true`                 |
+| `agent.containerCap`                   | Maximum number of agent                         | 10                     |
+| `agent.podRetention`                   | Agent pods retention policy                     | `Never`                |
+| `agent.retentionTimeout`               | Time in minutes to retain pod after completion  | 5                      |
+| `agent.templates.*.name`               | Pod name for agent template                     | Not set                |
+| `agent.templates.*.componentName`      | Agent component name used for label creation    |                        |
+| `agent.templates.*.customJenkinsLabels`| Append Jenkins labels to the agent              | `{}`                   |
+| `agent.templates.*.imagePullSecret`    | Agent image pull secret                         | Not set                |
+| `agent.templates.*.idleMinutes`        | Allows the Pod to remain active for reuse       | 0                      |
+| `agent.templates.*.yamlTemplate`       | The raw yaml of a Pod API Object to merge into the agent spec | Not set                |
+| `agent.templates.*.volumes`            | Additional volumes                              | `[]`                   |
+| `agent.templates.*.envVars`            | Environment variables for the agent Pod         | `[]`                   |
+| `agent.templates.*.containers.*.name`       | Agent container name                            | `jnlp`                 |
+| `agent.templates.*.containers.*.image`      | Agent container image name                      | `jenkins/jnlp-slave`   |
+| `agent.templates.*.containers.*.tag`        | Agent container image tag                       | `3.27-1`               |
+| `agent.templates.*.containers.*.alwaysPullImage` | Always pull agent container image before build  | `false`                |
+| `agent.templates.*.containers.*.command`    | Executed command when side container starts     | Not set                |
+| `agent.templates.*.containers.*.args`       | Arguments passed to executed command            | Not set                |
+| `agent.templates.*.containers.*.TTYEnabled` | Allocate pseudo tty to the side container       | false                  |
+| `agent.templates.*.containers.*.privileged` | Agent privileged container                      | `false`                |
+| `agent.templates.*.containers.*.resources`  | Resources allocation (Requests and Limits)      | `{requests: {cpu: 512m, memory: 512Mi}, limits: {cpu: 512m, memory: 512Mi}}`|
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
@@ -220,10 +223,11 @@ Your Jenkins Agents will run as pods, and it's possible to inject volumes where 
 
 ```yaml
 agent:
-  volumes:
-  - type: Secret
-    secretName: jenkins-mysecrets
-    mountPath: /var/run/secrets/jenkins-mysecrets
+  templates:
+    - volumes:
+      - type: Secret
+        secretName: jenkins-mysecrets
+        mountPath: /var/run/secrets/jenkins-mysecrets
 ```
 
 The supported volume types are: `ConfigMap`, `EmptyDir`, `HostPath`, `Nfs`, `Pod`, `Secret`. Each type supports a different set of configurable attributes, defined by [the corresponding Java class](https://github.com/jenkinsci/kubernetes-plugin/tree/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes).

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -46,23 +46,24 @@ data:
           <name>kubernetes</name>
           <templates>
 {{- if .Values.agent.enabled }}
+{{- range $podTemplateIndex, $podTemplate := .Values.agent.templates }}
             <org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
               <inheritFrom></inheritFrom>
-              <name>{{ .Values.agent.podName }}</name>
+              <name>{{ $podTemplate.name }}</name>
               <instanceCap>2147483647</instanceCap>
-              <idleMinutes>{{ .Values.agent.idleMinutes }}</idleMinutes>
-              <label>{{ .Release.Name }}-{{ .Values.agent.componentName }} {{ .Values.agent.customJenkinsLabels  | join " " }}</label>
-              <serviceAccount>{{ include "jenkins.serviceAccountAgentName" . }}</serviceAccount>
+              <idleMinutes>{{ $podTemplate.idleMinutes }}</idleMinutes>
+              <label>{{ $.Release.Name }}-{{ $podTemplate.componentName }} {{ $podTemplate.customJenkinsLabels  | join " " }}</label>
+              <serviceAccount>{{ include "jenkins.serviceAccountAgentName" $ }}</serviceAccount>
               <nodeSelector>
                 {{- $local := dict "first" true }}
-                {{- range $key, $value := .Values.agent.nodeSelector }}
+                {{- range $key, $value := $podTemplate.nodeSelector }}
                   {{- if not $local.first }},{{- end }}
                   {{- $key }}={{ $value }}
                   {{- $_ := set $local "first" false }}
                 {{- end }}</nodeSelector>
-                <nodeUsageMode>NORMAL</nodeUsageMode>
+                <nodeUsageMode>{{ $podTemplate.usageMode | upper }}</nodeUsageMode>
               <volumes>
-{{- range $index, $volume := .Values.agent.volumes }}
+{{- range $index, $volume := $podTemplate.volumes }}
                 <org.csanchez.jenkins.plugins.kubernetes.volumes.{{ $volume.type }}Volume>
 {{- range $key, $value := $volume }}{{- if not (eq $key "type") }}
                   <{{ $key }}>{{ $value }}</{{ $key }}>
@@ -71,44 +72,46 @@ data:
 {{- end }}
               </volumes>
               <containers>
+{{- range $containerIndex, $container := $podTemplate.containers }}
                 <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
-                  <name>{{ .Values.agent.sideContainerName }}</name>
-{{- if .Values.agent.imageTag }}
-                  <image>{{ .Values.agent.image }}:{{ .Values.agent.imageTag }}</image>
+                  <name>{{ $container.name }}</name>
+{{- if $container.imageTag }}
+                  <image>{{ $container.image }}:{{ $container.imageTag }}</image>
 {{- else }}
-                  <image>{{ .Values.agent.image }}:{{ .Values.agent.tag }}</image>
+                  <image>{{ $container.image }}:{{ $container.tag }}</image>
 {{- end }}
-{{- if .Values.agent.privileged }}
+{{- if $container.privileged }}
                   <privileged>true</privileged>
 {{- else }}
                   <privileged>false</privileged>
 {{- end }}
-                  <alwaysPullImage>{{ .Values.agent.alwaysPullImage }}</alwaysPullImage>
+                  <alwaysPullImage>{{ $container.alwaysPullImage }}</alwaysPullImage>
                   <workingDir>/home/jenkins</workingDir>
-                  <command>{{ .Values.agent.command }}</command>
-{{- if .Values.agent.args }}
-                  <args>{{ .Values.agent.args }}</args>
+                  <command>{{ $container.command }}</command>
+{{- if $container.args }}
+                  <args>{{ $container.args }}</args>
 {{- else }}
                   <args>${computer.jnlpmac} ${computer.name}</args>
 {{- end }}
-                  <ttyEnabled>{{ .Values.agent.TTYEnabled }}</ttyEnabled>
+                  <ttyEnabled>{{ $container.TTYEnabled }}</ttyEnabled>
                   # Resources configuration is a little hacky. This was to prevent breaking
                   # changes, and should be cleanned up in the future once everybody had
                   # enough time to migrate.
-                  <resourceRequestCpu>{{.Values.agent.resources.requests.cpu}}</resourceRequestCpu>
-                  <resourceRequestMemory>{{.Values.agent.resources.requests.memory}}</resourceRequestMemory>
-                  <resourceLimitCpu>{{.Values.agent.resources.limits.cpu}}</resourceLimitCpu>
-                  <resourceLimitMemory>{{.Values.agent.resources.limits.memory}}</resourceLimitMemory>
+                  <resourceRequestCpu>{{$container.resources.requests.cpu}}</resourceRequestCpu>
+                  <resourceRequestMemory>{{$container.resources.requests.memory}}</resourceRequestMemory>
+                  <resourceLimitCpu>{{$container.resources.limits.cpu}}</resourceLimitCpu>
+                  <resourceLimitMemory>{{$container.resources.limits.memory}}</resourceLimitMemory>
                   <envVars>
                     <org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar>
                       <key>JENKINS_URL</key>
-                      <value>http://{{ template "jenkins.fullname" . }}.{{ template "jenkins.namespace" . }}.svc.{{.Values.clusterZone}}:{{.Values.master.servicePort}}{{ default "" .Values.master.jenkinsUriPrefix }}</value>
+                      <value>http://{{ template "jenkins.fullname" $ }}.{{ template "jenkins.namespace" $ }}.svc.{{$.Values.clusterZone}}:{{$.Values.master.servicePort}}{{ default "" $.Values.master.jenkinsUriPrefix }}</value>
                     </org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar>
                   </envVars>
                 </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
+{{- end }}
               </containers>
               <envVars>
-{{- range $index, $var := .Values.agent.envVars }}
+{{- range $index, $var := $podTemplate.envVars }}
                 <org.csanchez.jenkins.plugins.kubernetes.PodEnvVar>
                   <key>{{ $var.name }}</key>
                   <value>{{ $var.value }}</value>
@@ -116,21 +119,22 @@ data:
 {{- end }}
               </envVars>
               <annotations/>
-{{- if .Values.agent.imagePullSecretName }}
+{{- if $podTemplate.imagePullSecretName }}
               <imagePullSecrets>
                 <org.csanchez.jenkins.plugins.kubernetes.PodImagePullSecret>
-                  <name>{{ .Values.agent.imagePullSecretName }}</name>
+                  <name>{{ $podTemplate.imagePullSecretName }}</name>
                 </org.csanchez.jenkins.plugins.kubernetes.PodImagePullSecret>
               </imagePullSecrets>
 {{- else }}
               <imagePullSecrets/>
 {{- end }}
               <nodeProperties/>
-{{- if .Values.agent.yamlTemplate }}
-              <yaml>{{ tpl .Values.agent.yamlTemplate . | html | indent 4 | trim }}</yaml>
+{{- if $podTemplate.yamlTemplate }}
+              <yaml>{{ tpl $podTemplate.yamlTemplate $ | html | indent 4 | trim }}</yaml>
 {{- end }}
               <podRetention class="org.csanchez.jenkins.plugins.kubernetes.pod.retention.Default"/>
             </org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
+{{- end -}}
 {{- end -}}
           </templates>
           <serverUrl>https://kubernetes.default</serverUrl>
@@ -144,7 +148,7 @@ data:
           <jenkinsTunnel>{{ template "jenkins.fullname" . }}-agent:{{ .Values.master.slaveListenerPort }}</jenkinsTunnel>
 {{- end }}
           <containerCap>{{ .Values.agent.containerCap }}</containerCap>
-          <retentionTimeout>5</retentionTimeout>
+          <retentionTimeout>{{ .Values.agent.retentionTimeout }}</retentionTimeout>
           <connectTimeout>0</connectTimeout>
           <readTimeout>0</readTimeout>
           <podRetention class="org.csanchez.jenkins.plugins.kubernetes.pod.retention.{{ .Values.agent.podRetention }}"/>

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -358,70 +358,76 @@ master:
 
 agent:
   enabled: true
-  image: "jenkins/jnlp-slave"
-  tag: "3.27-1"
-  customJenkinsLabels: []
-  # name of the secret to be used for image pulling
-  imagePullSecretName:
-  componentName: "jenkins-slave"
-  privileged: false
-  resources:
-    requests:
-      cpu: "512m"
-      memory: "512Mi"
-    limits:
-      cpu: "512m"
-      memory: "512Mi"
-  # You may want to change this to true while testing a new image
-  alwaysPullImage: false
+  # Max number of spawned agent
+  containerCap: 10
   # Controls how agent pods are retained after the Jenkins build completes
   # Possible values: Always, Never, OnFailure
   podRetention: "Never"
-  # You can define the volumes that you want to mount for this container
-  # Allowed types are: ConfigMap, EmptyDir, HostPath, Nfs, Pod, Secret
-  # Configure the attributes as they appear in the corresponding Java class for that type
-  # https://github.com/jenkinsci/kubernetes-plugin/tree/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes
-  # Pod-wide ennvironment, these vars are visible to any container in the agent pod
-  envVars: []
-  # - name: PATH
-  #   value: /usr/local/bin
-  volumes: []
-  # - type: Secret
-  #   secretName: mysecret
-  #   mountPath: /var/myapp/mysecret
-  # - type: EmptyDir
-  #   mountPath: "/var/lib/containers"
-  #   memory: false
-  nodeSelector: {}
-  # Key Value selectors. Ex:
-  # jenkins-agent: v1
-
-  # Executed command when side container gets started
-  command:
-  args:
-  # Side container name
-  sideContainerName: "jnlp"
-  # Doesn't allocate pseudo TTY by default
-  TTYEnabled: false
-  # Max number of spawned agent
-  containerCap: 10
-  # Pod name
-  podName: "default"
-  # Allows the Pod to remain active for reuse until the configured number of
-  # minutes has passed since the last step was executed on it.
-  idleMinutes: 0
-  # Raw yaml template for the Pod. For example this allows usage of toleration for agent pods.
-  # https://github.com/jenkinsci/kubernetes-plugin#using-yaml-to-define-pod-templates
-  # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-  yamlTemplate: ""
-  # yamlTemplate: |-
-  #   apiVersion: v1
-  #   kind: Pod
-  #   spec:
-  #     tolerations:
-  #     - key: "key"
-  #       operator: "Equal"
-  #       value: "value"
+  # Time in minutes to retain pod after completion
+  retentionTimeout: 5
+  # podTemplates
+  templates:
+    - name: "default"
+      # Component name used for label creation
+      componentName: "jenkins-slave"
+      # Extra labels for agent
+      customJenkinsLabels: []
+      # name of the secret to be used for image pulling
+      imagePullSecretName:
+      # Set usage mode for agent: normal, exclusive, etc.
+      usageMode: "Normal"
+      # Allows the Pod to remain active for reuse until the configured number of
+      # minutes has passed since the last step was executed on it.
+      idleMinutes: 0
+      # Raw yaml template for the Pod. For example this allows usage of toleration for agent pods.
+      # https://github.com/jenkinsci/kubernetes-plugin#using-yaml-to-define-pod-templates
+      # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+      yamlTemplate: ""
+      # yamlTemplate: |-
+      #   apiVersion: v1
+      #   kind: Pod
+      #   spec:
+      #     tolerations:
+      #     - key: "key"
+      #       operator: "Equal"
+      #       value: "value"
+      # Pod-wide environment, these vars are visible to any container in the agent pod
+      envVars: []
+      # - name: PATH
+      #   value: /usr/local/bin
+      # You can define the volumes that you want to mount for this container
+      # Allowed types are: ConfigMap, EmptyDir, HostPath, Nfs, Pod, Secret
+      # Configure the attributes as they appear in the corresponding Java class for that type
+      # https://github.com/jenkinsci/kubernetes-plugin/tree/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes
+      volumes: []
+      # - type: Secret
+      #   secretName: mysecret
+      #   mountPath: /var/myapp/mysecret
+      # - type: EmptyDir
+      #   mountPath: "/var/lib/containers"
+      #   memory: false
+      nodeSelector: {}
+      # Key Value selectors. Ex:
+      # jenkins-agent: v1
+      containers:
+        - name: "jnlp"
+          image: "jenkins/jnlp-slave"
+          tag: "3.27-1"
+          # You may want to change this to true while testing a new image
+          alwaysPullImage: false
+          # Executed command when side container gets started
+          command:
+          args:
+          # Doesn't allocate pseudo TTY by default
+          TTYEnabled: false
+          privileged: false
+          resources:
+            requests:
+              cpu: "512m"
+              memory: "512Mi"
+            limits:
+              cpu: "512m"
+              memory: "512Mi"
 
 persistence:
   enabled: true


### PR DESCRIPTION
New feature for stable/jenkins, bumping version to 2.0.0 (Introduce breaking changes)

- Multiple Kubernetes agent templates can now be set, and each can include multiple containers.
- Option to set agent's pod retention timeout
- Option to set usage mode for agent: normal, exclusive, etc.

Here is an example with another `podTemplate` that uses docker-in-docker and combines two containers:

```yaml
agent:
  enabled: true
  containerCap: 10
  podRetention: Never
  retentionTimeout: 5
  templates:
  - name: default
    componentName: jenkins-slave
    customJenkinsLabels: []
    idleMinutes: 0
    imagePullSecretName:
    usageMode: Normal
    nodeSelector: {}
    yamlTemplate: ""
    envVars: []
    volumes: []
    containers:
      - name: jnlp
        image: jenkins/jnlp-slave
        tag: 3.27-1
        command:
        args:
        alwaysPullImage: false
        privileged: false
        TTYEnabled: false
        resources:
          requests:
            cpu: 512m
            memory: 512Mi
          limits:
            cpu: 512m
            memory: 512Mi

  - name: dind
    componentName: docker-build
    customJenkinsLabels: []
    idleMinutes: 0
    imagePullSecretName:
    usageMode: Exclusive
    nodeSelector: {}
    envVars: []
    volumes:
    - type: HostPath
      hostPath: /var/run/docker.sock
      mountPath: /var/run/docker.sock
    - type: EmptyDir
      mountPath: /opt/cwt/jenkins
      memory: false
    containers:
      - name: jnlp
        image: jenkins/jnlp-slave
        tag: 3.27-1
        command: /bin/sh -c
        args: cat
        alwaysPullImage: false
        privileged: false
        TTYEnabled: false
        resources:
          requests:
            cpu: 512m
            memory: 512Mi
          limits:
            cpu: 512m
            memory: 512Mi
      - name: docker
        image: docker
        tag: 19.03.5-dind
        command: /bin/sh -c
        args: cat
        alwaysPullImage: false
        privileged: true
        TTYEnabled: true
        resources:
          requests:
            cpu: 512m
            memory: 512Mi
          limits:
            cpu: 4096m
            memory: 2048Mi
```
