### PR TITLE
[incubator/cassandra-operator] Introduce crds directory for compatibi…

### DIFF
--- a/incubator/cassandra-operator/Chart.yaml
+++ b/incubator/cassandra-operator/Chart.yaml
@@ -5,7 +5,7 @@ name: cassandra-operator
 home: https://github.com/Orange-OpenSource/cassandra-k8s-operator
 sources:
   - https://github.com/Orange-OpenSource/cassandra-k8s-operator
-version: 0.3.2
+version: 0.3.3
 appVersion: 0.3.1-mater
 maintainers:
   - name: allamand

--- a/incubator/cassandra-operator/README.md
+++ b/incubator/cassandra-operator/README.md
@@ -26,6 +26,7 @@ The following tables lists the configurable parameters of the Cassandra Operator
 | `resources`                      | Pod resource requests & limits                   | `{}`                                      |
 | `metricService`                  | deploy service for metrics                       | `false`                                   |
 | `debug.enabled`                  | activate DEBUG log level                         | `false`                                   |
+| `createCustomResource`           | If false, do not create custom resource(do not require with Helm v3)   | `false`             |
 
 
 

--- a/incubator/cassandra-operator/crds/db_v1alpha1_cassandracluster_crd.yaml
+++ b/incubator/cassandra-operator/crds/db_v1alpha1_cassandracluster_crd.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.createCustomResource }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -14,4 +13,3 @@ spec:
     singular: cassandracluster
   scope: Namespaced
   version: v1alpha1
-{{- end }}

--- a/incubator/cassandra-operator/templates/crds.yaml
+++ b/incubator/cassandra-operator/templates/crds.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.createCustomResource }}
+{{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
+{{ $.Files.Get $path }}
+---
+{{- end }}
+{{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

- add crds dir for helm 3
- add `template/crds.yaml` for helm 2

Which issue this PR fixes
Related to Issue #19008

Special notes for your reviewer:
This is not a complete migration to Helm v3. This PR make the Chart installable with Helm 3.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
