### PR TITLE
[stable/ark] Introduce crds directory for compatibility with Helm v3

### DIFF
--- a/stable/ark/Chart.yaml
+++ b/stable/ark/Chart.yaml
@@ -6,7 +6,7 @@ appVersion: 0.10.2
 deprecated: true
 description: DEPRECATED A Helm chart for ark
 name: ark
-version: 4.2.2
+version: 4.2.3
 home: https://github.com/heptio/ark
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/stable/ark/README.md
+++ b/stable/ark/README.md
@@ -90,6 +90,7 @@ Parameter | Description | Default
 `metrics.serviceMonitor.enabled` | Set this to `true` to create ServiceMonitor for Prometheus operator | `false`
 `metrics.serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`
 `schedules` | A dict of schedules | `{}`
+`createCustomResource` | Create custom reousrce, set false if exist which not require if using Helm v3 | `false`
 
 
 ## How to

--- a/stable/ark/crds/backups.yaml
+++ b/stable/ark/crds/backups.yaml
@@ -1,12 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: volumesnapshotlocations.ark.heptio.com
+  name: backups.ark.heptio.com
   labels:
-    chart: {{ template "ark.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-    app: {{ template "ark.name" . }}
+    app: ark
   annotations:
     "helm.sh/hook": crd-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
@@ -15,5 +12,5 @@ spec:
   version: v1
   scope: Namespaced
   names:
-    plural: volumesnapshotlocations
-    kind: VolumeSnapshotLocation
+    plural: backups
+    kind: Backup

--- a/stable/ark/crds/backupstoragelocations.yaml
+++ b/stable/ark/crds/backupstoragelocations.yaml
@@ -1,12 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: podvolumebackups.ark.heptio.com
+  name: backupstoragelocations.ark.heptio.com
   labels:
-    chart: {{ template "ark.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-    app: {{ template "ark.name" . }}
+    app: ark
   annotations:
     "helm.sh/hook": crd-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
@@ -15,5 +12,5 @@ spec:
   version: v1
   scope: Namespaced
   names:
-    plural: podvolumebackups
-    kind: PodVolumeBackup
+    plural: backupstoragelocations
+    kind: BackupStorageLocation

--- a/stable/ark/crds/deletebackuprequests.yaml
+++ b/stable/ark/crds/deletebackuprequests.yaml
@@ -1,12 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: resticrepositories.ark.heptio.com
+  name: deletebackuprequests.ark.heptio.com
   labels:
-    chart: {{ template "ark.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-    app: {{ template "ark.name" . }}
+    app: ark
   annotations:
     "helm.sh/hook": crd-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
@@ -15,5 +12,5 @@ spec:
   version: v1
   scope: Namespaced
   names:
-    plural: resticrepositories
-    kind: ResticRepository
+    plural: deletebackuprequests
+    kind: DeleteBackupRequest

--- a/stable/ark/crds/downloadrequests.yaml
+++ b/stable/ark/crds/downloadrequests.yaml
@@ -1,12 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: podvolumerestores.ark.heptio.com
+  name: downloadrequests.ark.heptio.com
   labels:
-    chart: {{ template "ark.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-    app: {{ template "ark.name" . }}
+    app: ark
   annotations:
     "helm.sh/hook": crd-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
@@ -15,5 +12,5 @@ spec:
   version: v1
   scope: Namespaced
   names:
-    plural: podvolumerestores
-    kind: PodVolumeRestore
+    plural: downloadrequests
+    kind: DownloadRequest

--- a/stable/ark/crds/podvolumebackups.yaml
+++ b/stable/ark/crds/podvolumebackups.yaml
@@ -1,12 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: downloadrequests.ark.heptio.com
+  name: podvolumebackups.ark.heptio.com
   labels:
-    chart: {{ template "ark.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-    app: {{ template "ark.name" . }}
+    app: ark
   annotations:
     "helm.sh/hook": crd-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
@@ -15,5 +12,5 @@ spec:
   version: v1
   scope: Namespaced
   names:
-    plural: downloadrequests
-    kind: DownloadRequest
+    plural: podvolumebackups
+    kind: PodVolumeBackup

--- a/stable/ark/crds/podvolumerestores.yaml
+++ b/stable/ark/crds/podvolumerestores.yaml
@@ -1,12 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: backups.ark.heptio.com
+  name: podvolumerestores.ark.heptio.com
   labels:
-    chart: {{ template "ark.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-    app: {{ template "ark.name" . }}
+    app: ark
   annotations:
     "helm.sh/hook": crd-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
@@ -15,5 +12,5 @@ spec:
   version: v1
   scope: Namespaced
   names:
-    plural: backups
-    kind: Backup
+    plural: podvolumerestores
+    kind: PodVolumeRestore

--- a/stable/ark/crds/resticrepositories.yaml
+++ b/stable/ark/crds/resticrepositories.yaml
@@ -1,12 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: deletebackuprequests.ark.heptio.com
+  name: resticrepositories.ark.heptio.com
   labels:
-    chart: {{ template "ark.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-    app: {{ template "ark.name" . }}
+    app: ark
   annotations:
     "helm.sh/hook": crd-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
@@ -15,5 +12,5 @@ spec:
   version: v1
   scope: Namespaced
   names:
-    plural: deletebackuprequests
-    kind: DeleteBackupRequest
+    plural: resticrepositories
+    kind: ResticRepository

--- a/stable/ark/crds/restores.yaml
+++ b/stable/ark/crds/restores.yaml
@@ -1,12 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: backupstoragelocations.ark.heptio.com
+  name: restores.ark.heptio.com
   labels:
-    chart: {{ template "ark.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-    app: {{ template "ark.name" . }}
+    app: ark
   annotations:
     "helm.sh/hook": crd-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
@@ -15,5 +12,5 @@ spec:
   version: v1
   scope: Namespaced
   names:
-    plural: backupstoragelocations
-    kind: BackupStorageLocation
+    plural: restores
+    kind: Restore

--- a/stable/ark/crds/schedules.yaml
+++ b/stable/ark/crds/schedules.yaml
@@ -3,10 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   name: schedules.ark.heptio.com
   labels:
-    chart: {{ template "ark.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-    app: {{ template "ark.name" . }}
+    app: ark
   annotations:
     "helm.sh/hook": crd-install
     "helm.sh/hook-delete-policy": "before-hook-creation"

--- a/stable/ark/crds/volumesnapshotlocations.yaml
+++ b/stable/ark/crds/volumesnapshotlocations.yaml
@@ -1,12 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: restores.ark.heptio.com
+  name: volumesnapshotlocations.ark.heptio.com
   labels:
-    chart: {{ template "ark.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-    app: {{ template "ark.name" . }}
+    app: ark
   annotations:
     "helm.sh/hook": crd-install
     "helm.sh/hook-delete-policy": "before-hook-creation"
@@ -15,5 +12,5 @@ spec:
   version: v1
   scope: Namespaced
   names:
-    plural: restores
-    kind: Restore
+    plural: volumesnapshotlocations
+    kind: VolumeSnapshotLocation

--- a/stable/ark/templates/crds.yaml
+++ b/stable/ark/templates/crds.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.createCustomResource }}
+{{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
+{{ $.Files.Get $path }}
+---
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Signed-off-by: Xiang Dai <764524258@qq.com>

#### What this PR does / why we need it:

- add crds dir for helm 3
- add `template/crds.yaml` for helm 2

Which issue this PR fixes
Related to Issue #19008

Special notes for your reviewer:
This is not a complete migration to Helm v3. This PR make the Chart installable with Helm 3.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped