### PR TITLE
remove an extra curly brace in service.yaml file

### DIFF
--- a/incubator/zookeeper/templates/service.yaml
+++ b/incubator/zookeeper/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
     chart: {{ template "zookeeper.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- if .Values.service.annotations }}}
+{{- if .Values.service.annotations }}
   annotations:
 {{- with .Values.service.annotations }}
 {{ toYaml . | indent 4 }}


### PR DESCRIPTION
in zookeeper service.yaml file there was an extra curly brace in if condition, so if we provide annotations in value.yaml file this extra curly brace gets appended to value of heritage field in labels which leads to an error while installing helm. 