### PR TITLE
[stable/fluentd] adding option to mount extra volumes

### DIFF
--- a/stable/fluentd/Chart.yaml
+++ b/stable/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Fluentd Elasticsearch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd
-version: 2.2.1
+version: 2.3.0
 appVersion: v2.4.0
 home: https://www.fluentd.org/
 sources:

--- a/stable/fluentd/README.md
+++ b/stable/fluentd/README.md
@@ -57,6 +57,8 @@ Parameter | Description | Default
 `image.tag` | Image tag | `v2.4.0`
 `imagePullSecrets` | Specify image pull secrets | `nil` (does not add image pull secrets to deployed pods)
 `extraEnvVars` | Adds additional environment variables to the deployment (in yaml syntax) | `{}` See [values.yaml](values.yaml)
+`extraVolumeMounts` | Mount extra volumes (in yaml syntax) | `` See [values.yaml](values.yaml)
+`extraVolumes` | Extra volumes (in yaml syntax) | `` See [values.yaml](values.yaml)
 `ingress.enabled` | enable ingress | `false`
 `ingress.labels` | list of labels for the ingress rule | See [values.yaml](values.yaml)
 `ingress.annotations` | list of annotations for the ingress rule | `kubernetes.io/ingress.class: nginx` See [values.yaml](values.yaml)

--- a/stable/fluentd/templates/deployment.yaml
+++ b/stable/fluentd/templates/deployment.yaml
@@ -97,6 +97,9 @@ spec:
           mountPath: /etc/fluent/config.d
         - name: buffer
           mountPath: "/var/log/fluentd-buffers"
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+{{- end }}
       serviceAccountName: {{ template "fluentd.fullname" . }}
       volumes:
         - name: config-volume-{{ template "fluentd.fullname" . }}
@@ -111,6 +114,9 @@ spec:
         - name: buffer  
           emptyDir: {}
         {{- end }}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
+{{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/stable/fluentd/values.yaml
+++ b/stable/fluentd/values.yaml
@@ -27,6 +27,16 @@ extraEnvVars:
 #        name: secret_name
 #        key: secret_key
 
+# extraVolumes:
+#   - name: es-certs
+#     secret:
+#       defaultMode: 420
+#       secretName: es-certs
+# extraVolumeMounts:
+#   - name: es-certs
+#     mountPath: /certs
+#     readOnly: true
+
 plugins:
   enabled: false
   pluginsList: []


### PR DESCRIPTION
#### What this PR does / why we need it:
Extra volumes are required on `tls` usage are config expects fs paths, see https://docs.fluentd.org/output/forward#tls_client_private_key_passphrase.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
