### PR TITLE
[stable/redis Add JSON Schema

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 10.1.0
+version: 10.2.0
 appVersion: 5.0.7
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/values.schema.json
+++ b/stable/redis/values.schema.json
@@ -1,0 +1,212 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "usePassword": {
+      "type": "boolean",
+      "title": "Use password authentication",
+      "form": true
+    },
+    "password": {
+      "type": "string",
+      "title": "Password",
+      "form": true,
+      "description": "Defaults to a random 10-character alphanumeric string if not set",
+      "hidden": {
+        "condition": false,
+        "value": "usePassword"
+      }
+    },
+    "cluster": {
+      "type": "object",
+      "title": "Cluster Settings",
+      "form": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "form": true,
+          "title": "Enable master-slave",
+          "description": "Enable master-slave architecture"
+        },
+        "slaveCount": {
+          "type": "integer",
+          "title": "Slave Replicas",
+          "form": true,
+          "hidden": {
+            "condition": false,
+            "value": "cluster.enabled"
+          }
+        }
+      }
+    },
+    "master": {
+      "type": "object",
+      "title": "Master replicas settings",
+      "form": true,
+      "properties": {
+        "persistence": {
+          "type": "object",
+          "title": "Persistence for master replicas",
+          "form": true,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "form": true,
+              "title": "Enable persistence",
+              "description": "Enable persistence using Persistent Volume Claims"
+            },
+            "size": {
+              "type": "string",
+              "title": "Persistent Volume Size",
+              "form": true,
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 100,
+              "sliderUnit": "Gi",
+              "hidden": {
+                "condition": false,
+                "value": "master.persistence.enabled"
+              }
+            }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "title": "Requested Resources for master replicas",
+          "form": true,
+          "properties": {
+            "requests": {
+              "type": "object",
+              "properties": {
+                "memory": {
+                  "type": "string",
+                  "form": true,
+                  "render": "slider",
+                  "title": "Memory Request",
+                  "sliderMin": 10,
+                  "sliderMax": 2048,
+                  "sliderUnit": "Mi"
+                },
+                "cpu": {
+                  "type": "string",
+                  "form": true,
+                  "render": "slider",
+                  "title": "CPU Request",
+                  "sliderMin": 10,
+                  "sliderMax": 2000,
+                  "sliderUnit": "m"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "slave": {
+      "type": "object",
+      "title": "Slave replicas settings",
+      "form": true,
+      "hidden": {
+        "condition": false,
+        "value": "cluster.enabled"
+      },
+      "properties": {
+        "persistence": {
+          "type": "object",
+          "title": "Persistence for slave replicas",
+          "form": true,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "form": true,
+              "title": "Enable persistence",
+              "description": "Enable persistence using Persistent Volume Claims"
+            },
+            "size": {
+              "type": "string",
+              "title": "Persistent Volume Size",
+              "form": true,
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 100,
+              "sliderUnit": "Gi",
+              "hidden": {
+                "condition": false,
+                "value": "slave.persistence.enabled"
+              }
+            }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "title": "Requested Resources for slave replicas",
+          "form": true,
+          "properties": {
+            "requests": {
+              "type": "object",
+              "properties": {
+                "memory": {
+                  "type": "string",
+                  "form": true,
+                  "render": "slider",
+                  "title": "Memory Request",
+                  "sliderMin": 10,
+                  "sliderMax": 2048,
+                  "sliderUnit": "Mi"
+                },
+                "cpu": {
+                  "type": "string",
+                  "form": true,
+                  "render": "slider",
+                  "title": "CPU Request",
+                  "sliderMin": 10,
+                  "sliderMax": 2000,
+                  "sliderUnit": "m"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "volumePermissions": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "form": true,
+          "title": "Enable Init Containers",
+          "description": "Change the owner of the persist volume mountpoint to RunAsUser:fsGroup"
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "form": true,
+      "title": "Prometheus metrics details",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Create Prometheus metrics exporter",
+          "description": "Create a side-car container to expose Prometheus metrics",
+          "form": true
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Create Prometheus Operator ServiceMonitor",
+              "description": "Create a ServiceMonitor to track metrics using Prometheus Operator",
+              "form": true,
+              "hidden": {
+                "condition": false,
+                "value": "metrics.enabled"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/stable/redis/values.schema.json
+++ b/stable/redis/values.schema.json
@@ -69,36 +69,6 @@
               }
             }
           }
-        },
-        "resources": {
-          "type": "object",
-          "title": "Requested Resources for master replicas",
-          "form": true,
-          "properties": {
-            "requests": {
-              "type": "object",
-              "properties": {
-                "memory": {
-                  "type": "string",
-                  "form": true,
-                  "render": "slider",
-                  "title": "Memory Request",
-                  "sliderMin": 10,
-                  "sliderMax": 2048,
-                  "sliderUnit": "Mi"
-                },
-                "cpu": {
-                  "type": "string",
-                  "form": true,
-                  "render": "slider",
-                  "title": "CPU Request",
-                  "sliderMin": 10,
-                  "sliderMax": 2000,
-                  "sliderUnit": "m"
-                }
-              }
-            }
-          }
         }
       }
     },
@@ -136,36 +106,6 @@
               }
             }
           }
-        },
-        "resources": {
-          "type": "object",
-          "title": "Requested Resources for slave replicas",
-          "form": true,
-          "properties": {
-            "requests": {
-              "type": "object",
-              "properties": {
-                "memory": {
-                  "type": "string",
-                  "form": true,
-                  "render": "slider",
-                  "title": "Memory Request",
-                  "sliderMin": 10,
-                  "sliderMax": 2048,
-                  "sliderUnit": "Mi"
-                },
-                "cpu": {
-                  "type": "string",
-                  "form": true,
-                  "render": "slider",
-                  "title": "CPU Request",
-                  "sliderMin": 10,
-                  "sliderMax": 2000,
-                  "sliderUnit": "m"
-                }
-              }
-            }
-          }
         }
       }
     },
@@ -176,7 +116,7 @@
           "type": "boolean",
           "form": true,
           "title": "Enable Init Containers",
-          "description": "Change the owner of the persist volume mountpoint to RunAsUser:fsGroup"
+          "description": "Use an init container to set required folder permissions on the data volume before mounting it in the final destination"
         }
       }
     },

--- a/stable/redmine/Chart.yaml
+++ b/stable/redmine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redmine
-version: 13.7.0
+version: 13.6.0
 appVersion: 4.0.5
 description: A flexible project management web application.
 keywords:

--- a/stable/redmine/Chart.yaml
+++ b/stable/redmine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redmine
-version: 13.6.0
+version: 13.7.0
 appVersion: 4.0.5
 description: A flexible project management web application.
 keywords:


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### Is this a new chart

No

**Description of the change**

This PR includes a basic JSON schema for the Redis chart. It doesn't cover all the possible values of the chart but just the ones that, in my opinion, are more likely to be modified.

This is valid for Helm 3 to validate some values and, at the same time, for Kubeapps to render a simple form so the chart containing it is easier to configure and deploy. See https://github.com/kubeapps/kubeapps/blob/master/docs/developer/basic-form-support.md for more information.

This is an example of the file rendered by Kubeapps:

![Screenshot 2019-11-28 at 16 33 36](https://user-images.githubusercontent.com/6740773/69818459-15e5c800-11fd-11ea-9ead-43c0cbfa93b9.png)

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)