### PR TITLE
[stable/postgresql] Change templates/networkpolicy.yaml in order to implement what is really described in values files

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 7.7.0
+version: 7.7.1
 appVersion: 11.6.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/networkpolicy.yaml
+++ b/stable/postgresql/templates/networkpolicy.yaml
@@ -22,15 +22,15 @@ spec:
         - podSelector:
             matchLabels:
               {{ template "postgresql.fullname" . }}-client: "true"
+          {{- if .Values.networkPolicy.explicitNamespacesSelector }}
+          namespaceSelector:
+{{ toYaml .Values.networkPolicy.explicitNamespacesSelector | indent 12 }}
+          {{- end }}
         - podSelector:
             matchLabels:
               app: {{ template "postgresql.name" . }}
               release: {{ .Release.Name | quote }}
               role: slave
-        {{- if .Values.networkPolicy.explicitNamespacesSelector }}
-        - namespaceSelector:
-{{ toYaml .Values.networkPolicy.explicitNamespacesSelector | indent 12 }}
-        {{- end }}
       {{- end }}
     # Allow prometheus scrapes
     - ports:

--- a/stable/postgresql/values-production.yaml
+++ b/stable/postgresql/values-production.yaml
@@ -351,10 +351,10 @@ networkPolicy:
   ##
   allowExternal: true
 
-  ## if explicitNamespacesSelector is missing or set to {}, only Pods that are in the networkPolicy's namespace
-  ## and that match other criteria, the ones that can be selected by one of the podSelectors, can reach the DB.
-  ## But sometimes, we want the DB to be accessible from other namespaces, in this case, we can use this
-  ## LabelSelector to select these namespaces, note that the networkPolicy's should also be explicitly added.
+  ## if explicitNamespacesSelector is missing or set to {}, only client Pods that are in the networkPolicy's namespace
+  ## and that match other criteria, the ones that have the good label, can reach the DB.
+  ## But sometimes, we want the DB to be accessible to clients from other namespaces, in this case, we can use this
+  ## LabelSelector to select these namespaces, note that the networkPolicy's namespace should also be explicitly added.
   ##
   # explicitNamespacesSelector:
     # matchLabels:

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -359,10 +359,10 @@ networkPolicy:
   ##
   allowExternal: true
 
-  ## if explicitNamespacesSelector is missing or set to {}, only Pods that are in the networkPolicy's namespace
-  ## and that match other criteria, the ones that can be selected by one of the podSelectors, can reach the DB.
-  ## But sometimes, we want the DB to be accessible from other namespaces, in this case, we can use this
-  ## LabelSelector to select these namespaces, note that the networkPolicy's should also be explicitly added.
+  ## if explicitNamespacesSelector is missing or set to {}, only client Pods that are in the networkPolicy's namespace
+  ## and that match other criteria, the ones that have the good label, can reach the DB.
+  ## But sometimes, we want the DB to be accessible to clients from other namespaces, in this case, we can use this
+  ## LabelSelector to select these namespaces, note that the networkPolicy's namespace should also be explicitly added.
   ##
   # explicitNamespacesSelector:
     # matchLabels:


### PR DESCRIPTION
#### Which issue this PR fixes
  - fixes 77b484efe678c8837c39e22d01287c3d5fdc44f1, see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#networkpolicyingressrule-v1beta1-extensions : `explicitNamespacesSelector` is meant to provide namespaces (networkpolicy's and extra ones) from which clients (with `{{ template "postgresql.fullname" . }}-client: "true"` label) can reach the DB; it's an AND and not and OR.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
