### PR TITLE
[Nextcloud] Support k8s 1.16

### DIFF
--- a/stable/nextcloud/Chart.yaml
+++ b/stable/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nextcloud
-version: 1.8.1
+version: 1.8.2
 appVersion: 17.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/nextcloud/requirements.lock
+++ b/stable/nextcloud/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.4.3
+  version: 7.1.0
 - name: redis
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 8.0.12
-digest: sha256:538090f5752bbbec4dca0189ed8b6835ede0e2e39164e50320629510c603dc5d
-generated: "2019-06-24T19:41:25.184162+02:00"
+  version: 10.0.1
+digest: sha256:88489b3a1a5bf1cd3f9e264e540f8c3515d40020bb1073f3bb281f0da56efc3f
+generated: "2019-11-28T12:08:10.111637339+01:00"

--- a/stable/nextcloud/requirements.yaml
+++ b/stable/nextcloud/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
-  version: ~6.4.0
+  version: ~7.1.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: mariadb.enabled
 - name: redis
-  version: ~8.0.12
+  version: ~10.0.1
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: redis.enabled


### PR DESCRIPTION
@billimek, @chrisingenhaag:


#### Is this a new chart

No

#### What this PR does / why we need it:

#### Which issue this PR fixes

This PR updates the chart dependencies to versions that support k8s 1.16.
Needed because the old versions of the redis and mariadb charts
contain calls to [deprecated APIs](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/).

I.e., installing the current NC chart  v1.8.1 with enabled mariadb to a kubernetes v1.16.3 cluster fails:

```
root@varac-test:~# helm install --name nc-test --set mariadb.enabled=true stable/nextcloud
Error: validation failed: unable to recognize "": no matches for kind "StatefulSet" in version "apps/v1beta1"

root@varac-test:~# kubectl get nodes
NAME         STATUS   ROLES                      AGE   VERSION
varac-test   Ready    controlplane,etcd,worker   30d   v1.16.3

root@varac-test:~# helm version
Client: &version.Version{SemVer:"v2.16.1", GitCommit:"bbdfe5e7803a12bbdf97e94cd847859890cf4050", GitTreeState:"clean"}
Server: &version.Version{SemVer:"v2.16.1", GitCommit:"bbdfe5e7803a12bbdf97e94cd847859890cf4050", GitTreeState:"clean"}
```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
