### PR TITLE
[stable/newrelic-infrastructure] fix unprivileged cache directory

### DIFF
--- a/stable/newrelic-infrastructure/Chart.yaml
+++ b/stable/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 0.13.12
+version: 0.13.13
 appVersion: 1.10.2
 home: https://hub.docker.com/r/newrelic/infrastructure-k8s/
 source:

--- a/stable/newrelic-infrastructure/templates/daemonset.yaml
+++ b/stable/newrelic-infrastructure/templates/daemonset.yaml
@@ -85,10 +85,6 @@ spec:
             - name: NRIA_LOG_FILE
               value: {{ .Values.logFile }}
             {{- end }}
-            {{- if not .Values.privileged }}
-            - name: "DISCOVERY_CACHE_DIR"
-              value: "/tmp/nr-kubernetes"
-            {{- end }}
           volumeMounts:
             {{- if .Values.config }}
             - name: config
@@ -109,6 +105,8 @@ spec:
             - mountPath: /var/db/newrelic-infra/user_data
               name: tmpfs-user-data
             - mountPath: /tmp
+              name: tmpfs-tmp
+            - mountPath: /var/cache/nr-kubernetes
               name: tmpfs-tmp
             {{- end }}
           {{- if .Values.resources }}
@@ -132,6 +130,8 @@ spec:
         - name: tmpfs-user-data
           emptyDir: {}
         - name: tmpfs-tmp
+          emptyDir: {}
+        - name: tmpfs-cache
           emptyDir: {}
         {{- end }}
         {{- if .Values.config }}


### PR DESCRIPTION
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

No

#### What this PR does / why we need it:

This PR fixes an issue with the unprivileged New Relic Kubernetes Integration, where the cache directory has not been properly set. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
