### PR TITLE
[stable/mongodb] Add JSON Schema

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 7.4.6
+version: 7.5.0
 appVersion: 4.0.13
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/values.schema.json
+++ b/stable/mongodb/values.schema.json
@@ -17,14 +17,16 @@
         "value": "usePassword"
       }
     },
-    "mongodbUsername": {
-      "type": "string",
-      "title": "MongoDB custom user",
-      "form": true
-    },
     "mongodbDatabase": {
       "type": "string",
       "title": "MongoDB custom database",
+      "description": "Name of the custom database to be created during the 1st initialization of MongoDB",
+      "form": true
+    },
+    "mongodbUsername": {
+      "type": "string",
+      "title": "MongoDB custom user",
+      "description": "Name of the custom user to be created during the 1st initialization of MongoDB. This user only has permissions on the MongoDB custom database",
       "form": true
     },
     "mongodbPassword": {
@@ -100,6 +102,10 @@
     },
     "volumePermissions": {
       "type": "object",
+      "hidden": {
+        "condition": false,
+        "value": "persistence.enabled"
+      },
       "properties": {
         "enabled": {
           "type": "boolean",

--- a/stable/mongodb/values.schema.json
+++ b/stable/mongodb/values.schema.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "usePassword": {
+      "type": "boolean",
+      "title": "Enable password authentication",
+      "form": true
+    },
+    "mongodbRootPassword": {
+      "type": "string",
+      "title": "MongoDB admin password",
+      "form": true,
+      "description": "Defaults to a random 10-character alphanumeric string if not set",
+      "hidden": {
+        "condition": false,
+        "value": "usePassword"
+      }
+    },
+    "mongodbUsername": {
+      "type": "string",
+      "title": "MongoDB custom user",
+      "form": true
+    },
+    "mongodbDatabase": {
+      "type": "string",
+      "title": "MongoDB custom database",
+      "form": true
+    },
+    "mongodbPassword": {
+      "type": "string",
+      "title": "Password for MongoDB custom user",
+      "form": true,
+      "description": "Defaults to a random 10-character alphanumeric string if not set",
+      "hidden": {
+        "condition": false,
+        "value": "usePassword"
+      }
+    },
+    "replicaSet": {
+      "type": "object",
+      "title": "Replicaset configuration",
+      "form": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "form": true,
+          "title": "Enable replicaset configuration"
+        },
+        "replicas": {
+          "type": "object",
+          "title": "Number of replicas",
+          "form": true,
+          "hidden": {
+            "condition": false,
+            "value": "replicaSet.enabled"
+          },
+          "properties": {
+            "secondary": {
+              "type": "integer",
+              "title": "Secondary node replicas",
+              "description": "Number of secondary node replicas to deploy",
+              "form": true
+            },
+            "arbiter": {
+              "type": "integer",
+              "title": "Arbiter node replicas",
+              "description": "Number of arbiter node replicas to deploy",
+              "form": true
+            }
+          }
+        }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "title": "Persistence configuration",
+      "form": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "form": true,
+          "title": "Enable persistence",
+          "description": "Enable persistence using Persistent Volume Claims"
+        },
+        "size": {
+          "type": "string",
+          "title": "Persistent Volume Size",
+          "form": true,
+          "render": "slider",
+          "sliderMin": 1,
+          "sliderMax": 100,
+          "sliderUnit": "Gi",
+          "hidden": {
+            "condition": false,
+            "value": "persistence.enabled"
+          }
+        }
+      }
+    },
+    "volumePermissions": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "form": true,
+          "title": "Enable Init Containers",
+          "description": "Use an init container to set required folder permissions on the data volume before mounting it in the final destination"
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "form": true,
+      "title": "Prometheus metrics details",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Create Prometheus metrics exporter",
+          "description": "Create a side-car container to expose Prometheus metrics",
+          "form": true
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Create Prometheus Operator ServiceMonitor",
+              "description": "Create a ServiceMonitor to track metrics using Prometheus Operator",
+              "form": true,
+              "hidden": {
+                "condition": false,
+                "value": "metrics.enabled"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### Is this a new chart

No

**Description of the change**

This PR includes a basic JSON schema for the MongoDB chart. It doesn't cover all the possible values of the chart but just the ones that, in my opinion, are more likely to be modified.

This is valid for Helm 3 to validate some values and, at the same time, for Kubeapps to render a simple form so the chart containing it is easier to configure and deploy. See https://github.com/kubeapps/kubeapps/blob/master/docs/developer/basic-form-support.md for more information.

This is an example of the file rendered by Kubeapps:

<img width="609" alt="Screenshot 2019-11-29 at 12 05 47" src="https://user-images.githubusercontent.com/6740773/69865123-b17c4480-12a0-11ea-9d5f-d84b57022dac.png">


**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)