### PR TITLE
[incubator/buzzfeed-sso] Added New Value To Enable / Disable The Ingress

### DIFF
--- a/incubator/buzzfeed-sso/Chart.yaml
+++ b/incubator/buzzfeed-sso/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Single sign-on for your Kubernetes services using Google OAuth
 name: buzzfeed-sso
-version: 0.1.1
+version: 0.1.2
 appVersion: 2.0.0
 home: https://github.com/buzzfeed/sso
 sources:

--- a/incubator/buzzfeed-sso/README.md
+++ b/incubator/buzzfeed-sso/README.md
@@ -89,6 +89,7 @@ Parameter | Description | Default
 `image.repository` | container image repository | `buzzfeed/sso`
 `image.tag` | container image tag | `v1.2.0`
 `image.pullPolicy` | container image pull policy | `IfNotPresent`
+`ingress.enabled` | set to true to enable the ingress | `true`
 `ingress.annotations` | ingress load balancer annotations | `{}`
 `ingress.extraLabels` | extra ingress labels | `{}`
 `ingress.hosts` | proxied hosts | `[]`

--- a/incubator/buzzfeed-sso/templates/ingress.yaml
+++ b/incubator/buzzfeed-sso/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled }}
 {{- if ne .Values.auth.domain "<your_auth_domain>" -}}
 {{- $fullName := include "buzzfeed-sso.fullname" . -}}
 {{- $authDomain := .Values.auth.domain -}}
@@ -52,4 +53,5 @@ spec:
             backend:
               serviceName: {{ $fullName }}-auth
               servicePort: http
+{{- end }}
 {{- end }}

--- a/incubator/buzzfeed-sso/values.yaml
+++ b/incubator/buzzfeed-sso/values.yaml
@@ -82,6 +82,7 @@ image:
   pullPolicy: IfNotPresent
 
 ingress:
+  enabled: true
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # certmanager.k8s.io/cluster-issuer: my-letsencrypt-issuer


### PR DESCRIPTION
### What this PR does / why we need it:

Adds a new value to support enabling / disabling the ingress (default = true). This is useful in cases where you are using a Gateway instead of an Ingress.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

@darioblanco @komljen