### PR TITLE
[stable/postgresql] Prefix port names with protocol to comply with Istio

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 7.7.3
+version: 8.0.0
 appVersion: 11.6.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -401,6 +401,12 @@ $ helm upgrade my-release bitnami/influxdb \
 
 > Note: you need to substitute the placeholders _[POSTGRESQL_PASSWORD]_, and _[REPLICATION_PASSWORD]_ with the values obtained from instructions in the installation notes.
 
+## 8.0.0
+
+Prefixes the port names with their protocols to comply with Istio conventions.
+
+If you depend on the port names in your setup, make sure to update them to reflect this change.
+
 ## 7.1.0
 
 Adds support for LDAP configuration.

--- a/stable/postgresql/templates/metrics-svc.yaml
+++ b/stable/postgresql/templates/metrics-svc.yaml
@@ -16,9 +16,9 @@ spec:
   loadBalancerIP: {{ .Values.metrics.service.loadBalancerIP }}
   {{- end }}
   ports:
-    - name: metrics
+    - name: http-metrics
       port: 9187
-      targetPort: metrics
+      targetPort: http-metrics
   selector:
     app: {{ template "postgresql.name" . }}
     release: {{ .Release.Name }}

--- a/stable/postgresql/templates/servicemonitor.yaml
+++ b/stable/postgresql/templates/servicemonitor.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-    - port: metrics
+    - port: http-metrics
       {{- if .Values.metrics.serviceMonitor.interval }}
       interval: {{ .Values.metrics.serviceMonitor.interval }}
       {{- end }}

--- a/stable/postgresql/templates/statefulset-slaves.yaml
+++ b/stable/postgresql/templates/statefulset-slaves.yaml
@@ -166,7 +166,7 @@ spec:
                   key: postgresql-password
             {{- end }}
           ports:
-            - name: postgresql
+            - name: tcp-postgresql
               containerPort: {{ template "postgresql.port" . }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -234,7 +234,7 @@ spec:
               value: {{ .Values.ldap.url }}
             {{- end}}
           ports:
-            - name: postgresql
+            - name: tcp-postgresql
               containerPort: {{ template "postgresql.port" . }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
@@ -328,7 +328,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: metrics
+              port: http-metrics
             initialDelaySeconds: {{ .Values.metrics.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.metrics.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.metrics.livenessProbe.timeoutSeconds }}
@@ -339,7 +339,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /
-              port: metrics
+              port: http-metrics
             initialDelaySeconds: {{ .Values.metrics.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.metrics.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.metrics.readinessProbe.timeoutSeconds }}
@@ -358,7 +358,7 @@ spec:
           args: ["--extend.query-path", "/conf/custom-metrics.yaml"]
             {{- end }}
           ports:
-            - name: metrics
+            - name: http-metrics
               containerPort: 9187
           {{- if .Values.metrics.resources }}
           resources: {{- toYaml .Values.metrics.resources | nindent 12 }}

--- a/stable/postgresql/templates/svc-headless.yaml
+++ b/stable/postgresql/templates/svc-headless.yaml
@@ -11,9 +11,9 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: postgresql
+    - name: tcp-postgresql
       port: {{ template "postgresql.port" . }}
-      targetPort: postgresql
+      targetPort: tcp-postgresql
   selector:
     app: {{ template "postgresql.name" . }}
     release: {{ .Release.Name | quote }}

--- a/stable/postgresql/templates/svc-read.yaml
+++ b/stable/postgresql/templates/svc-read.yaml
@@ -18,9 +18,9 @@ spec:
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
   ports:
-    - name: postgresql
+    - name: tcp-postgresql
       port:  {{ template "postgresql.port" . }}
-      targetPort: postgresql
+      targetPort: tcp-postgresql
       {{- if .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}

--- a/stable/postgresql/templates/svc.yaml
+++ b/stable/postgresql/templates/svc.yaml
@@ -26,9 +26,9 @@ spec:
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
   ports:
-    - name: postgresql
+    - name: tcp-postgresql
       port: {{ template "postgresql.port" . }}
-      targetPort: postgresql
+      targetPort: tcp-postgresql
       {{- if .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Istio requires service port names to be prefixed with the protocol: https://istio.io/docs/ops/deployment/requirements/

#### Special notes for your reviewer:
None

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
