### PR TITLE
[stable/mariadb] Add JSON Schema

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb
-version: 7.1.0
+version: 7.2.0
 appVersion: 10.3.20
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/values.schema.json
+++ b/stable/mariadb/values.schema.json
@@ -20,14 +20,16 @@
     "db": {
       "type": "object",
       "properties": {
-        "user": {
-          "type": "string",
-          "title": "MariaDB custom user",
-          "form": true
-        },
         "name": {
           "type": "string",
           "title": "MariaDB custom database",
+          "description": "Name of the custom database to be created during the 1st initialization of MariaDB",
+          "form": true
+        },
+        "user": {
+          "type": "string",
+          "title": "MariaDB custom user",
+          "description": "Name of the custom user to be created during the 1st initialization of MariaDB. This user only has permissions on the MariaDB custom database",
           "form": true
         },
         "password": {

--- a/stable/mariadb/values.schema.json
+++ b/stable/mariadb/values.schema.json
@@ -1,0 +1,167 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "rootUser": {
+      "type": "object",
+      "properties": {
+        "password": {
+          "type": "string",
+          "title": "MariaDB admin password",
+          "form": true,
+          "description": "Defaults to a random 10-character alphanumeric string if not set",
+          "hidden": {
+            "condition": false,
+            "value": "usePassword"
+          }
+        }
+      }
+    },
+    "db": {
+      "type": "object",
+      "properties": {
+        "user": {
+          "type": "string",
+          "title": "MariaDB custom user",
+          "form": true
+        },
+        "name": {
+          "type": "string",
+          "title": "MariaDB custom database",
+          "form": true
+        },
+        "password": {
+          "type": "string",
+          "title": "Password for MariaDB custom user",
+          "form": true,
+          "description": "Defaults to a random 10-character alphanumeric string if not set",
+          "hidden": {
+            "condition": false,
+            "value": "usePassword"
+          }
+        }
+      }
+    },
+    "replication": {
+      "type": "object",
+      "title": "Replication configuration",
+      "form": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "form": true,
+          "title": "Enable replication configuration"
+        }
+      }
+    },
+    "master": {
+      "type": "object",
+      "title": "Master replicas settings",
+      "form": true,
+      "properties": {
+        "persistence": {
+          "type": "object",
+          "title": "Persistence for master replicas",
+          "form": true,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "form": true,
+              "title": "Enable persistence",
+              "description": "Enable persistence using Persistent Volume Claims"
+            },
+            "size": {
+              "type": "string",
+              "title": "Persistent Volume Size",
+              "form": true,
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 100,
+              "sliderUnit": "Gi",
+              "hidden": {
+                "condition": false,
+                "value": "persistence.enabled"
+              }
+            }
+          }
+        }
+      }
+    },
+    "slave": {
+      "type": "object",
+      "title": "Slave replicas settings",
+      "form": true,
+      "hidden": {
+        "condition": false,
+        "value": "replication.enabled"
+      },
+      "properties": {
+        "persistence": {
+          "type": "object",
+          "title": "Persistence for slave replicas",
+          "form": true,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "form": true,
+              "title": "Enable persistence",
+              "description": "Enable persistence using Persistent Volume Claims"
+            },
+            "size": {
+              "type": "string",
+              "title": "Persistent Volume Size",
+              "form": true,
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 100,
+              "sliderUnit": "Gi",
+              "hidden": {
+                "condition": false,
+                "value": "persistence.enabled"
+              }
+            }
+          }
+        }
+      }
+    },
+    "volumePermissions": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "form": true,
+          "title": "Enable Init Containers",
+          "description": "Use an init container to set required folder permissions on the data volume before mounting it in the final destination"
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "form": true,
+      "title": "Prometheus metrics details",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Create Prometheus metrics exporter",
+          "description": "Create a side-car container to expose Prometheus metrics",
+          "form": true
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Create Prometheus Operator ServiceMonitor",
+              "description": "Create a ServiceMonitor to track metrics using Prometheus Operator",
+              "form": true,
+              "hidden": {
+                "condition": false,
+                "value": "metrics.enabled"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### Is this a new chart

No

**Description of the change**

This PR includes a basic JSON schema for the MariaDB chart. It doesn't cover all the possible values of the chart but just the ones that, in my opinion, are more likely to be modified.

This is valid for Helm 3 to validate some values and, at the same time, for Kubeapps to render a simple form so the chart containing it is easier to configure and deploy. See https://github.com/kubeapps/kubeapps/blob/master/docs/developer/basic-form-support.md for more information.

This is an example of the file rendered by Kubeapps:

![Screenshot 2019-11-29 at 15 11 19](https://user-images.githubusercontent.com/6740773/69874178-a7673f80-12ba-11ea-8d39-67f6907bf4b9.png)

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)