### PR TITLE
[stable/drupal] Add JSON Schema & standardize ingress configuration

### DIFF
--- a/stable/drupal/Chart.yaml
+++ b/stable/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 6.0.2
+version: 6.1.0
 appVersion: 8.7.10
 description: One of the most versatile open source content management systems.
 keywords:

--- a/stable/drupal/README.md
+++ b/stable/drupal/README.md
@@ -49,67 +49,67 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Drupal chart and their default values.
 
-| Parameter                         | Description                                | Default                                                   |
-| --------------------------------- | ------------------------------------------ | --------------------------------------------------------- |
-| `global.imageRegistry`            | Global Docker image registry               | `nil`                                                     |
-| `global.imagePullSecrets`         | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
-| `global.storageClass`                     | Global storage class for dynamic provisioning                                               | `nil`                                                        |
-| `image.registry`                  | Drupal image registry                      | `docker.io`                                               |
-| `image.repository`                | Drupal Image name                          | `bitnami/drupal`                                          |
-| `image.tag`                       | Drupal Image tag                           | `{TAG_NAME}`                                              |
-| `image.pullPolicy`                | Drupal image pull policy                   | `IfNotPresent`                                            |
-| `image.pullSecrets`               | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)  |
-| `nameOverride`                    | String to partially override drupal.fullname template with a string (will prepend the release name) | `nil` |
-| `fullnameOverride`                | String to fully override drupal.fullname template with a string                                     | `nil` |
-| `drupalProfile`                   | Drupal installation profile                | `standard`                                                |
-| `drupalUsername`                  | User of the application                    | `user`                                                    |
-| `drupalPassword`                  | Application password                       | _random 10 character long alphanumeric string_            |
-| `drupalEmail`                     | Admin email                                | `user@example.com`                                        |
-| `allowEmptyPassword`              | Allow DB blank passwords                   | `yes`                                                     |
-| `extraVars`                       | Extra environment variables                | `nil`                                                     |
-| `ingress.enabled`                 | Enable ingress controller resource         | `false`                                                   |
-| `ingress.hosts[0].name`           | Hostname to your Drupal installation       | `drupal.local`                                            |
-| `ingress.hosts[0].path`           | Path within the url structure              | `/`                                                       |
-| `ingress.hosts[0].tls`            | Utilize TLS backend in ingress             | `false`                                                   |
-| `ingress.hosts[0].certManager`    | Add annotations for cert-manager           | `false`                                                   |
-| `ingress.hosts[0].tlsSecret`      | TLS Secret (certificates)                  | `drupal.local-tls-secret`                                 |
-| `ingress.hosts[0].annotations`    | Annotations for this host's ingress record | `[]`                                                      |
-| `ingress.secrets[0].name`         | TLS Secret Name                            | `nil`                                                     |
-| `ingress.secrets[0].certificate`  | TLS Secret Certificate                     | `nil`                                                     |
-| `ingress.secrets[0].key`          | TLS Secret Key                             | `nil`                                                     |
-| `externalDatabase.host`           | Host of the external database              | `nil`                                                     |
-| `externalDatabase.user`           | Existing username in the external db       | `bn_drupal`                                               |
-| `externalDatabase.password`       | Password for the above username            | `nil`                                                     |
-| `externalDatabase.database`       | Name of the existing database              | `bitnami_drupal`                                          |
-| `mariadb.enabled`                 | Whether to use the MariaDB chart           | `true`                                                    |
-| `mariadb.rootUser.password`       | MariaDB admin password                     | `nil`                                                     |
-| `mariadb.db.name`                 | Database name to create                    | `bitnami_drupal`                                          |
-| `mariadb.db.user`                 | Database user to create                    | `bn_drupal`                                               |
-| `mariadb.db.password`             | Password for the database                  | _random 10 character long alphanumeric string_            |
-| `service.type`                    | Kubernetes Service type                    | `LoadBalancer`                                            |
-| `service.port`                    | Service HTTP port                          | `80`                                                      |
-| `service.httpsPort`               | Service HTTPS port                         | `443`                                                     |
-| `service.externalTrafficPolicy`   | Enable client source IP preservation       | `Cluster`                                                 |
-| `service.nodePorts.http`          | Kubernetes http node port                  | `""`                                                      |
-| `service.nodePorts.https`         | Kubernetes https node port                 | `""`                                                      |
-| `persistence.enabled`             | Enable persistence using PVC               | `true`                                                    |
-| `persistence.drupal.storageClass` | PVC Storage Class for Drupal volume        | `nil` (uses alpha storage class annotation)               |
-| `persistence.drupal.accessMode`   | PVC Access Mode for Drupal volume          | `ReadWriteOnce`                                           |
-| `persistence.drupal.existingClaim`| An Existing PVC name                       | `nil`                                                     |
-| `persistence.drupal.hostPath`     | Host mount path for Drupal volume          | `nil` (will not mount to a host path)                     |
-| `persistence.drupal.size`         | PVC Storage Request for Drupal volume      | `8Gi`                                                     |
-| `resources`                       | CPU/Memory resource requests/limits        | Memory: `512Mi`, CPU: `300m`                              |
-| `volumeMounts.drupal.mountPath`   | Drupal data volume mount path              | `/bitnami/drupal`                                         |
-| `podAnnotations`                  | Pod annotations                            | `{}`                                                      |
-| `affinity`                        | Map of node/pod affinities                 | `{}`                                                      |
-| `metrics.enabled`                 | Start a side-car prometheus exporter       | `false`                                                   |
-| `metrics.image.registry`          | Apache exporter image registry             | `docker.io`                                               |
-| `metrics.image.repository`        | Apache exporter image name                 | `bitnami/apache-exporter`                                 |
-| `metrics.image.tag`               | Apache exporter image tag                  | `{TAG_NAME}`                                              |
-| `metrics.image.pullPolicy`        | Image pull policy                          | `IfNotPresent`                                            |
-| `metrics.image.pullSecrets`       | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)      |
-| `metrics.podAnnotations`          | Additional annotations for Metrics exporter pod  | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
-| `metrics.resources`               | Exporter resource requests/limit           | {}                                                         |
+| Parameter                          | Description                                           | Default                                                      |
+| ---------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------ |
+| `global.imageRegistry`             | Global Docker image registry                          | `nil`                                                        |
+| `global.imagePullSecrets`          | Global Docker registry secret names as an array       | `[]` (does not add image pull secrets to deployed pods)      |
+| `global.storageClass`              | Global storage class for dynamic provisioning         | `nil`                                                        |
+| `image.registry`                   | Drupal image registry                                 | `docker.io`                                                  |
+| `image.repository`                 | Drupal Image name                                     | `bitnami/drupal`                                             |
+| `image.tag`                        | Drupal Image tag                                      | `{TAG_NAME}`                                                 |
+| `image.pullPolicy`                 | Drupal image pull policy                              | `IfNotPresent`                                               |
+| `image.pullSecrets`                | Specify docker-registry secret names as an array      | `[]` (does not add image pull secrets to deployed pods)      |
+| `nameOverride`                     | String to partially override drupal.fullname template | `nil`                                                        |
+| `fullnameOverride`                 | String to fully override drupal.fullname template     | `nil`                                                        |
+| `drupalProfile`                    | Drupal installation profile                           | `standard`                                                   |
+| `drupalUsername`                   | User of the application                               | `user`                                                       |
+| `drupalPassword`                   | Application password                                  | _random 10 character long alphanumeric string_               |
+| `drupalEmail`                      | Admin email                                           | `user@example.com`                                           |
+| `allowEmptyPassword`               | Allow DB blank passwords                              | `yes`                                                        |
+| `extraVars`                        | Extra environment variables                           | `nil`                                                        |
+| `ingress.enabled`                  | Enable ingress controller resource                    | `false`                                                      |
+| `ingress.certManager`              | Add annotations for cert-manager                      | `false`                                                      |
+| `ingress.hostname`                 | Default host for the ingress resource                 | `drupal.local`                                               |
+| `ingress.annotations`              | Ingress annotations                                   | `{}`                                                         |
+| `ingress.hosts[0].name`            | Hostname to your Drupal installation                  | `nil`                                                        |
+| `ingress.hosts[0].path`            | Path within the url structure                         | `nil`                                                        |
+| `ingress.tls[0].hosts[0]`          | TLS hosts                                             | `nil`                                                        |
+| `ingress.tls[0].secretName`        | TLS Secret (certificates)                             | `nil`                                                        |
+| `ingress.secrets[0].name`          | TLS Secret Name                                       | `nil`                                                        |
+| `ingress.secrets[0].certificate`   | TLS Secret Certificate                                | `nil`                                                        |
+| `ingress.secrets[0].key`           | TLS Secret Key                                        | `nil`                                                        |
+| `externalDatabase.user`            | Existing username in the external db                  | `bn_drupal`                                                  |
+| `externalDatabase.password`        | Password for the above username                       | `nil`                                                        |
+| `externalDatabase.database`        | Name of the existing database                         | `bitnami_drupal`                                             |
+| `mariadb.enabled`                  | Whether to use the MariaDB chart                      | `true`                                                       |
+| `mariadb.rootUser.password`        | MariaDB admin password                                | `nil`                                                        |
+| `mariadb.db.name`                  | Database name to create                               | `bitnami_drupal`                                             |
+| `mariadb.db.user`                  | Database user to create                               | `bn_drupal`                                                  |
+| `mariadb.db.password`              | Password for the database                             | _random 10 character long alphanumeric string_               |
+| `service.type`                     | Kubernetes Service type                               | `LoadBalancer`                                               |
+| `service.port`                     | Service HTTP port                                     | `80`                                                         |
+| `service.httpsPort`                | Service HTTPS port                                    | `443`                                                        |
+| `service.externalTrafficPolicy`    | Enable client source IP preservation                  | `Cluster`                                                    |
+| `service.nodePorts.http`           | Kubernetes http node port                             | `""`                                                         |
+| `service.nodePorts.https`          | Kubernetes https node port                            | `""`                                                         |
+| `persistence.enabled`              | Enable persistence using PVC                          | `true`                                                       |
+| `persistence.drupal.storageClass`  | PVC Storage Class for Drupal volume                   | `nil` (uses alpha storage class annotation)                  |
+| `persistence.drupal.accessMode`    | PVC Access Mode for Drupal volume                     | `ReadWriteOnce`                                              |
+| `persistence.drupal.existingClaim` | An Existing PVC name                                  | `nil`                                                        |
+| `persistence.drupal.hostPath`      | Host mount path for Drupal volume                     | `nil` (will not mount to a host path)                        |
+| `persistence.drupal.size`          | PVC Storage Request for Drupal volume                 | `8Gi`                                                        |
+| `resources`                        | CPU/Memory resource requests/limits                   | Memory: `512Mi`, CPU: `300m`                                 |
+| `volumeMounts.drupal.mountPath`    | Drupal data volume mount path                         | `/bitnami/drupal`                                            |
+| `podAnnotations`                   | Pod annotations                                       | `{}`                                                         |
+| `affinity`                         | Map of node/pod affinities                            | `{}`                                                         |
+| `metrics.enabled`                  | Start a side-car prometheus exporter                  | `false`                                                      |
+| `metrics.image.registry`           | Apache exporter image registry                        | `docker.io`                                                  |
+| `metrics.image.repository`         | Apache exporter image name                            | `bitnami/apache-exporter`                                    |
+| `metrics.image.tag`                | Apache exporter image tag                             | `{TAG_NAME}`                                                 |
+| `metrics.image.pullPolicy`         | Image pull policy                                     | `IfNotPresent`                                               |
+| `metrics.image.pullSecrets`        | Specify docker-registry secret names as an array      | `[]` (does not add image pull secrets to deployed pods)      |
+| `metrics.podAnnotations`           | Additional annotations for Metrics exporter pod       | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
+| `metrics.resources`                | Exporter resource requests/limit                      | {}                                                           |
 
 The above parameters map to the env variables defined in [bitnami/drupal](http://github.com/bitnami/bitnami-docker-drupal). For more information please refer to the [bitnami/drupal](http://github.com/bitnami/bitnami-docker-drupal) image documentation.
 

--- a/stable/drupal/templates/ingress.yaml
+++ b/stable/drupal/templates/ingress.yaml
@@ -1,38 +1,41 @@
 {{- if .Values.ingress.enabled -}}
-{{- range .Values.ingress.hosts }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: "{{- printf "%s-%s" .name $.Release.Name | trunc 63 | trimSuffix "-" -}}"
+  name: {{ template "drupal.fullname" . }}
   labels:
-    app: {{ template "drupal.fullname" $ }}
-    chart: {{ template "drupal.chart" $ }}
-    release: "{{ $.Release.Name }}"
-    heritage: "{{ $.Release.Service }}"
+    app: {{ template "drupal.fullname" . }}
+    chart: {{ template "drupal.chart" . }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
   annotations:
-    {{- if .certManager }}
+    {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"
     {{- end }}
-    {{- range $key, $value := .annotations }}
+    {{- range $key, $value := .Values.ingress.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
   rules:
+    {{- if .Values.ingress.hostname }}
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+        - path: /
+          backend:
+            serviceName: {{ template "drupal.fullname" $ }}
+            servicePort: http
+    {{- end }}
+    {{- range .Values.ingress.hosts }}
     - host: {{ .name }}
       http:
         paths:
-          - path: {{ default "/" .path }}
-            backend:
-              serviceName: {{ template "drupal.fullname" $ }}
-              servicePort: 80
-{{- if .tls }}
-  tls:
-  - hosts:
-    - {{ .name }}
-    secretName: {{ .tlsSecret }}
+        - path: {{ default "/" .path }}
+          backend:
+            serviceName: "{{ template "drupal.fullname" $ }}"
+            servicePort: http
+    {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls: {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
 {{- end }}
----
-{{- end }}
-{{- end }}
-
-

--- a/stable/drupal/templates/tls-secrets.yaml
+++ b/stable/drupal/templates/tls-secrets.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  labels:
+    app: {{ template "drupal.fullname" $ }}
+    chart: {{ template "drupal.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .certificate | b64enc }}
+  tls.key: {{ .key | b64enc }}
+{{- end }}
+{{- end }}

--- a/stable/drupal/values.schema.json
+++ b/stable/drupal/values.schema.json
@@ -21,14 +21,19 @@
     "persistence": {
       "type": "object",
       "properties": {
-        "size": {
-          "type": "string",
-          "title": "Persistent Volume Size",
-          "form": true,
-          "render": "slider",
-          "sliderMin": 1,
-          "sliderMax": 100,
-          "sliderUnit": "Gi"
+        "drupal": {
+          "type": "object",
+          "properties": {
+            "size": {
+              "type": "string",
+              "title": "Persistent Volume Size",
+              "form": true,
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 100,
+              "sliderUnit": "Gi"
+            }
+          }
         }
       }
     },

--- a/stable/drupal/values.schema.json
+++ b/stable/drupal/values.schema.json
@@ -1,0 +1,170 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "drupalUsername": {
+      "type": "string",
+      "title": "Username",
+      "form": true
+    },
+    "drupalPassword": {
+      "type": "string",
+      "title": "Password",
+      "form": true,
+      "description": "Defaults to a random 10-character alphanumeric string if not set"
+    },
+    "drupalEmail": {
+      "type": "string",
+      "title": "Admin email",
+      "form": true
+    },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "string",
+          "title": "Persistent Volume Size",
+          "form": true,
+          "render": "slider",
+          "sliderMin": 1,
+          "sliderMax": 100,
+          "sliderUnit": "Gi"
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "form": true,
+      "title": "Ingress Details",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "form": true,
+          "title": "Use a custom hostname",
+          "description": "Enable the ingress resource that allows you to access the Drupal installation."
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "hidden": {
+            "condition": false,
+            "value": "ingress.enabled"
+          }
+        }
+      }
+    },
+    "mariadb": {
+      "type": "object",
+      "title": "MariaDB Details",
+      "form": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Use a new MariaDB database hosted in the cluster",
+          "form": true,
+          "description": "Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database switch this off and configure the external database details"
+        },
+        "master": {
+          "type": "object",
+          "properties": {
+            "persistence": {
+              "type": "object",
+              "properties": {
+                "size": {
+                  "type": "string",
+                  "title": "Volume Size",
+                  "form": true,
+                  "hidden": {
+                    "condition": false,
+                    "value": "mariadb.enabled"
+                  },
+                  "render": "slider",
+                  "sliderMin": 1,
+                  "sliderMax": 100,
+                  "sliderUnit": "Gi"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "externalDatabase": {
+      "type": "object",
+      "title": "External Database Details",
+      "description": "If MariaDB is disabled. Use this section to specify the external database details",
+      "form": true,
+      "hidden": "mariadb.enabled",
+      "properties": {
+        "host": {
+          "type": "string",
+          "form": true,
+          "title": "Database Host"
+        },
+        "user": {
+          "type": "string",
+          "form": true,
+          "title": "Database Username"
+        },
+        "password": {
+          "type": "string",
+          "form": true,
+          "title": "Database Password"
+        },
+        "database": {
+          "type": "string",
+          "form": true,
+          "title": "Database Name"
+        },
+        "port": {
+          "type": "integer",
+          "form": true,
+          "title": "Database Port"
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "title": "Requested Resources",
+      "description": "Configure resource requests",
+      "form": true,
+      "properties": {
+        "requests": {
+          "type": "object",
+          "properties": {
+            "memory": {
+              "type": "string",
+              "form": true,
+              "render": "slider",
+              "title": "Memory Request",
+              "sliderMin": 10,
+              "sliderMax": 2048,
+              "sliderUnit": "Mi"
+            },
+            "cpu": {
+              "type": "string",
+              "form": true,
+              "render": "slider",
+              "title": "CPU Request",
+              "sliderMin": 10,
+              "sliderMax": 2000,
+              "sliderUnit": "m"
+            }
+          }
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Enable Metrics",
+          "description": "Prometheus Exporter / Metrics",
+          "form": true
+        }
+      }
+    }
+  }
+}

--- a/stable/drupal/values.yaml
+++ b/stable/drupal/values.yaml
@@ -149,30 +149,53 @@ service:
 ##
 ingress:
   ## Set to true to enable ingress record generation
+  ##
   enabled: false
 
-  ## The list of hostnames to be covered with this ingress record.
-  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
-  hosts:
-  - name: drupal.local
+  ## Set this to true in order to add the corresponding annotations for cert-manager
+  ##
+  certManager: false
 
-    ## Set this to true in order to enable TLS on the ingress record
-    ## A side effect of this will be that the backend drupal service will be connected at port 443
-    tls: false
+  ## When the ingress is enabled, a host pointing to this will be created
+  ##
+  hostname: drupal.local
 
-    ## Set this to true in order to add the corresponding annotations for cert-manager
-    certManager: false
+  ## Ingress annotations done as key:value pairs
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ##
+  ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+  ##
+  annotations: {}
+  #  kubernetes.io/ingress.class: nginx
 
-    ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
-    tlsSecret: drupal.local-tls
+  ## The list of additional hostnames to be covered with this ingress record.
+  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+  ## hosts:
+  ## - name: drupal.local
+  ##   path: /
 
-    ## Ingress annotations done as key:value pairs
-    ## For a full list of possible ingress annotations, please see
-    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
-    ##
-    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
-    annotations:
-    #  kubernetes.io/ingress.class: nginx
+  ## The tls configuration for the ingress
+  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## tls:
+  ## - hosts:
+  ##     - drupal.local
+  ##   secretName: drupal.local-tls
+
+  secrets:
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
+  ##
+  ## name should line up with a tlsSecret set further up
+  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+  ##
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  # - name: drupal.local-tls
+  #   key:
+  #   certificate:
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### Is this a new chart

No

**Description of the change**

This PR includes a basic JSON schema for the Drupal chart. It doesn't cover all the possible values of the chart but just the ones that, in my opinion, are more likely to be modified.

This is valid for Helm 3 to validate some values and, at the same time, for Kubeapps to render a simple form so the chart containing it is easier to configure and deploy. See https://github.com/kubeapps/kubeapps/blob/master/docs/developer/basic-form-support.md for more information.

This is an example of the file rendered by Kubeapps:

![Screenshot 2019-11-29 at 15 35 15](https://user-images.githubusercontent.com/6740773/69875767-33c73180-12be-11ea-8e39-b8024dca4b09.png)

This PR also standardizes the way we configure Ingress.

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)