### PR TITLE
[stable/prometheus] Fix issue with alertmanager name reference

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 9.3.1
+version: 9.3.2
 appVersion: 2.13.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 9.5.5
+version: 9.5.4
 appVersion: 2.13.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 9.3.2
+version: 9.5.5
 appVersion: 2.13.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/server-configmap.yaml
+++ b/stable/prometheus/templates/server-configmap.yaml
@@ -50,7 +50,7 @@ data:
           regex: {{ template "prometheus.name" $root }}
           action: keep
         - source_labels: [__meta_kubernetes_pod_label_component]
-          regex: alertmanager
+          regex: {{ $root.Values.alertmanager.name }}
           action: keep
         - source_labels: [__meta_kubernetes_pod_container_port_number]
           regex:


### PR DESCRIPTION
#### What this PR does / why we need it:
If alertmanager gets a different name then communication fails between prometheus and alertmanager. This PR fixes this issue.

#### Which issue this PR fixes
No issue created yet 

#### Special notes for your reviewer:
- n/a

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
