### PR TITLE
[stable/joomla] Add JSON Schema & standardize ingress configuration

### DIFF
--- a/stable/joomla/Chart.yaml
+++ b/stable/joomla/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: joomla
-version: 7.0.1
+version: 7.1.0
 appVersion: 3.9.13
 description: PHP content management system (CMS) for publishing web content
 keywords:

--- a/stable/joomla/README.md
+++ b/stable/joomla/README.md
@@ -49,88 +49,89 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Joomla! chart and their default values.
 
-| Parameter                            | Description                                                                                         | Default                                                      |
-| ------------------------------------ | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `global.imageRegistry`               | Global Docker image registry                                                                        | `nil`                                                        |
-| `global.imagePullSecrets`            | Global Docker registry secret names as an array                                                     | `[]` (does not add image pull secrets to deployed pods)      |
-| `global.storageClass`                     | Global storage class for dynamic provisioning                                               | `nil`                                                        |
-| `image.registry`                     | Joomla! image registry                                                                              | `docker.io`                                                  |
-| `image.repository`                   | Joomla! Image name                                                                                  | `bitnami/joomla`                                             |
-| `image.tag`                          | Joomla! Image tag                                                                                   | `{TAG_NAME}`                                                 |
-| `image.pullPolicy`                   | Image pull policy                                                                                   | `Always`                                                     |
-| `image.pullSecrets`                  | Specify docker-registry secret names as an array                                                    | `[]` (does not add image pull secrets to deployed pods)      |
-| `nameOverride`                       | String to partially override joomla.fullname template with a string (will prepend the release name) | `nil`                                                        |
-| `fullnameOverride`                   | String to fully override joomla.fullname template with a string                                     | `nil`                                                        |
-| `joomlaUsername`                     | User of the application                                                                             | `user`                                                       |
-| `joomlaPassword`                     | Application password                                                                                | _random 10 character long alphanumeric string_               |
-| `joomlaEmail`                        | Admin email                                                                                         | `user@example.com`                                           |
-| `smtpHost`                           | SMTP host                                                                                           | `nil`                                                        |
-| `smtpPort`                           | SMTP port                                                                                           | `nil`                                                        |
-| `smtpUser`                           | SMTP user                                                                                           | `nil`                                                        |
-| `smtpPassword`                       | SMTP password                                                                                       | `nil`                                                        |
-| `smtpUsername`                       | User name for SMTP emails                                                                           | `nil`                                                        |
-| `smtpProtocol`                       | SMTP protocol [`tls`, `ssl`]                                                                        | `nil`                                                        |
-| `allowEmptyPassword`                 | Allow DB blank passwords                                                                            | `yes`                                                        |
-| `externalDatabase.host`              | Host of the external database                                                                       | `nil`                                                        |
-| `externalDatabase.port`              | Port of the external database                                                                       | `3306`                                                       |
-| `externalDatabase.user`              | Existing username in the external db                                                                | `bn_joomla`                                                  |
-| `externalDatabase.password`          | Password for the above username                                                                     | `nil`                                                        |
-| `externalDatabase.database`          | Name of the existing database                                                                       | `bitnami_joomla`                                             |
-| `mariadb.enabled`                    | Whether to use the MariaDB chart                                                                    | `true`                                                       |
-| `mariadb.image.registry`             | MariaDB image registry                                                                              | `docker.io`                                                  |
-| `mariadb.image.repository`           | MariaDB image name                                                                                  | `bitnami/mariadb`                                            |
-| `mariadb.image.tag`                  | MariaDB image tag                                                                                   | `{TAG_NAME}`                                                 |
-| `mariadb.replication.enabled`        | Whether to use MariaDB master and slave                                                             | `false`                                                      |
-| `mariadb.db.name`                    | Database name to create                                                                             | `bitnami_joomla`                                             |
-| `mariadb.db.user`                    | Database user to create                                                                             | `bn_joomla`                                                  |
-| `mariadb.db.password`                | Password for the database                                                                           | `nil`                                                        |
-| `mariadb.root.password`              | MariaDB admin password                                                                              | `nil`                                                        |
-| `service.type`                       | Kubernetes Service type                                                                             | `LoadBalancer`                                               |
-| `service.port`                       | Service HTTP port                                                                                   | `80`                                                         |
-| `service.httpsPort`                  | Service HTTPS port                                                                                  | `443`                                                        |
-| `service.loadBalancer`               | Kubernetes LoadBalancerIP to request                                                                | `nil`                                                        |
-| `service.externalTrafficPolicy`      | Enable client source IP preservation                                                                | `Cluster`                                                    |
-| `service.nodePorts.http`             | Kubernetes http node port                                                                           | `""`                                                         |
-| `service.nodePorts.https`            | Kubernetes https node port                                                                          | `""`                                                         |
-| `ingress.enabled`                    | Enable ingress controller resource                                                                  | `false`                                                      |
-| `ingress.hosts[0].name`              | Hostname to your Joomla! installation                                                               | `joomla.local`                                               |
-| `ingress.hosts[0].path`              | Path within the url structure                                                                       | `/`                                                          |
-| `ingress.hosts[0].tls`               | Utilize TLS backend in ingress                                                                      | `false`                                                      |
-| `ingress.hosts[0].certManager `      | Add annotations for cert-manager                                                                    | `false`                                                      |
-| `ingress.hosts[0].tlsSecret`         | TLS Secret (certificates)                                                                           | `joomla.local-tls-secret`                                    |
-| `ingress.hosts[0].annotations`       | Annotations for this host's ingress record                                                          | `[]`                                                         |
-| `ingress.secrets[0].name`            | TLS Secret Name                                                                                     | `nil`                                                        |
-| `ingress.secrets[0].certificate`     | TLS Secret Certificate                                                                              | `nil`                                                        |
-| `ingress.secrets[0].key`             | TLS Secret Key                                                                                      | `nil`                                                        |
-| `persistence.enabled`                | Enable persistence using PVC                                                                        | `true`                                                       |
-| `persistence.joomla.storageClass`    | PVC Storage Class for Joomla! volume                                                                | `nil` (uses alpha storage annotation)                        |
-| `persistence.joomla.accessMode`      | PVC Access Mode for Joomla! volume                                                                  | `ReadWriteOnce`                                              |
-| `persistence.joomla.size`            | PVC Storage Request for Joomla! volume                                                              | `8Gi`                                                        |
-| `resources`                          | CPU/Memory resource requests/limits                                                                 | Memory: `512Mi`, CPU: `300m`                                 |
-| `livenessProbe.enabled`              | Enable/disable the liveness probe                                                                   | `true`                                                       |
-| `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                                            | 120                                                          |
-| `livenessProbe.periodSeconds`        | How often to perform the probe                                                                      | 10                                                           |
-| `livenessProbe.timeoutSeconds`       | When the probe times out                                                                            | 5                                                            |
-| `livenessProbe.failureThreshold`     | Minimum consecutive failures to be considered failed                                                | 6                                                            |
-| `livenessProbe.successThreshold`     | Minimum consecutive successes to be considered successful                                           | 1                                                            |
-| `readinessProbe.enabled`             | Enable/disable the readiness probe                                                                  | `true`                                                       |
-| `readinessProbe.initialDelaySeconds` | Delay before readinessProbe is initiated                                                            | 30                                                           |
-| `readinessProbe.periodSeconds   `    | How often to perform the probe                                                                      | 10                                                           |
-| `readinessProbe.timeoutSeconds`      | When the probe times out                                                                            | 5                                                            |
-| `readinessProbe.failureThreshold`    | Minimum consecutive failures to be considered failed                                                | 6                                                            |
-| `readinessProbe.successThreshold`    | Minimum consecutive successes to be considered successful                                           | 1                                                            |
-| `nodeSelector`                       | Node labels for pod assignment                                                                      | `{}`                                                         |
-| `tolerations`                        | List of node taints to tolerate                                                                     | `[]`                                                         |
-| `affinity`                           | Map of node/pod affinities                                                                          | `{}`                                                         |
-| `podAnnotations`                     | Pod annotations                                                                                     | `{}`                                                         |
-| `metrics.enabled`                    | Start a side-car prometheus exporter                                                                | `false`                                                      |
-| `metrics.image.registry`             | Apache exporter image registry                                                                      | `docker.io`                                                  |
-| `metrics.image.repository`           | Apache exporter image name                                                                          | `bitnami/apache-exporter`                                    |
-| `metrics.image.tag`                  | Apache exporter image tag                                                                           | `{TAG_NAME}`                                                 |
-| `metrics.image.pullPolicy`           | Image pull policy                                                                                   | `IfNotPresent`                                               |
-| `metrics.image.pullSecrets`          | Specify docker-registry secret names as an array                                                    | `[]` (does not add image pull secrets to deployed            |
-| `metrics.podAnnotations`             | Additional annotations for Metrics exporter pod                                                     | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
-| `metrics.resources`                  | Exporter resource requests/limit                                                                    | {}                                                           |
+| Parameter                            | Description                                               | Default                                                      |
+| ------------------------------------ | --------------------------------------------------------- | ------------------------------------------------------------ |
+| `global.imageRegistry`               | Global Docker image registry                              | `nil`                                                        |
+| `global.imagePullSecrets`            | Global Docker registry secret names as an array           | `[]` (does not add image pull secrets to deployed pods)      |
+| `global.storageClass`                | Global storage class for dynamic provisioning             | `nil`                                                        |
+| `image.registry`                     | Joomla! image registry                                    | `docker.io`                                                  |
+| `image.repository`                   | Joomla! Image name                                        | `bitnami/joomla`                                             |
+| `image.tag`                          | Joomla! Image tag                                         | `{TAG_NAME}`                                                 |
+| `image.pullPolicy`                   | Image pull policy                                         | `Always`                                                     |
+| `image.pullSecrets`                  | Specify docker-registry secret names as an array          | `[]` (does not add image pull secrets to deployed pods)      |
+| `nameOverride`                       | String to partially override joomla.fullname template     | `nil`                                                        |
+| `fullnameOverride`                   | String to fully override joomla.fullname template         | `nil`                                                        |
+| `joomlaUsername`                     | User of the application                                   | `user`                                                       |
+| `joomlaPassword`                     | Application password                                      | _random 10 character long alphanumeric string_               |
+| `joomlaEmail`                        | Admin email                                               | `user@example.com`                                           |
+| `smtpHost`                           | SMTP host                                                 | `nil`                                                        |
+| `smtpPort`                           | SMTP port                                                 | `nil`                                                        |
+| `smtpUser`                           | SMTP user                                                 | `nil`                                                        |
+| `smtpPassword`                       | SMTP password                                             | `nil`                                                        |
+| `smtpUsername`                       | User name for SMTP emails                                 | `nil`                                                        |
+| `smtpProtocol`                       | SMTP protocol [`tls`, `ssl`]                              | `nil`                                                        |
+| `allowEmptyPassword`                 | Allow DB blank passwords                                  | `yes`                                                        |
+| `externalDatabase.host`              | Host of the external database                             | `nil`                                                        |
+| `externalDatabase.port`              | Port of the external database                             | `3306`                                                       |
+| `externalDatabase.user`              | Existing username in the external db                      | `bn_joomla`                                                  |
+| `externalDatabase.password`          | Password for the above username                           | `nil`                                                        |
+| `externalDatabase.database`          | Name of the existing database                             | `bitnami_joomla`                                             |
+| `mariadb.enabled`                    | Whether to use the MariaDB chart                          | `true`                                                       |
+| `mariadb.image.registry`             | MariaDB image registry                                    | `docker.io`                                                  |
+| `mariadb.image.repository`           | MariaDB image name                                        | `bitnami/mariadb`                                            |
+| `mariadb.image.tag`                  | MariaDB image tag                                         | `{TAG_NAME}`                                                 |
+| `mariadb.replication.enabled`        | Whether to use MariaDB master and slave                   | `false`                                                      |
+| `mariadb.db.name`                    | Database name to create                                   | `bitnami_joomla`                                             |
+| `mariadb.db.user`                    | Database user to create                                   | `bn_joomla`                                                  |
+| `mariadb.db.password`                | Password for the database                                 | `nil`                                                        |
+| `mariadb.root.password`              | MariaDB admin password                                    | `nil`                                                        |
+| `service.type`                       | Kubernetes Service type                                   | `LoadBalancer`                                               |
+| `service.port`                       | Service HTTP port                                         | `80`                                                         |
+| `service.httpsPort`                  | Service HTTPS port                                        | `443`                                                        |
+| `service.loadBalancer`               | Kubernetes LoadBalancerIP to request                      | `nil`                                                        |
+| `service.externalTrafficPolicy`      | Enable client source IP preservation                      | `Cluster`                                                    |
+| `service.nodePorts.http`             | Kubernetes http node port                                 | `""`                                                         |
+| `service.nodePorts.https`            | Kubernetes https node port                                | `""`                                                         |
+| `ingress.enabled`                    | Enable ingress controller resource                        | `false`                                                      |
+| `ingress.certManager`                | Add annotations for cert-manager                          | `false`                                                      |
+| `ingress.hostname`                   | Default host for the ingress resource                     | `joomla.local`                                               |
+| `ingress.annotations`                | Ingress annotations                                       | `[]`                                                         |
+| `ingress.hosts[0].name`              | Hostname to your Joomla! installation                     | `nil`                                                        |
+| `ingress.hosts[0].path`              | Path within the url structure                             | `nil`                                                        |
+| `ingress.tls[0].hosts[0]`            | TLS hosts                                                 | `nil`                                                        |
+| `ingress.tls[0].secretName`          | TLS Secret (certificates)                                 | `nil`                                                        |
+| `ingress.secrets[0].name`            | TLS Secret Name                                           | `nil`                                                        |
+| `ingress.secrets[0].certificate`     | TLS Secret Certificate                                    | `nil`                                                        |
+| `ingress.secrets[0].key`             | TLS Secret Key                                            | `nil`                                                        |
+| `persistence.enabled`                | Enable persistence using PVC                              | `true`                                                       |
+| `persistence.joomla.storageClass`    | PVC Storage Class for Joomla! volume                      | `nil` (uses alpha storage annotation)                        |
+| `persistence.joomla.accessMode`      | PVC Access Mode for Joomla! volume                        | `ReadWriteOnce`                                              |
+| `persistence.joomla.size`            | PVC Storage Request for Joomla! volume                    | `8Gi`                                                        |
+| `resources`                          | CPU/Memory resource requests/limits                       | Memory: `512Mi`, CPU: `300m`                                 |
+| `livenessProbe.enabled`              | Enable/disable the liveness probe                         | `true`                                                       |
+| `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                  | 120                                                          |
+| `livenessProbe.periodSeconds`        | How often to perform the probe                            | 10                                                           |
+| `livenessProbe.timeoutSeconds`       | When the probe times out                                  | 5                                                            |
+| `livenessProbe.failureThreshold`     | Minimum consecutive failures to be considered failed      | 6                                                            |
+| `livenessProbe.successThreshold`     | Minimum consecutive successes to be considered successful | 1                                                            |
+| `readinessProbe.enabled`             | Enable/disable the readiness probe                        | `true`                                                       |
+| `readinessProbe.initialDelaySeconds` | Delay before readinessProbe is initiated                  | 30                                                           |
+| `readinessProbe.periodSeconds   `    | How often to perform the probe                            | 10                                                           |
+| `readinessProbe.timeoutSeconds`      | When the probe times out                                  | 5                                                            |
+| `readinessProbe.failureThreshold`    | Minimum consecutive failures to be considered failed      | 6                                                            |
+| `readinessProbe.successThreshold`    | Minimum consecutive successes to be considered successful | 1                                                            |
+| `nodeSelector`                       | Node labels for pod assignment                            | `{}`                                                         |
+| `tolerations`                        | List of node taints to tolerate                           | `[]`                                                         |
+| `affinity`                           | Map of node/pod affinities                                | `{}`                                                         |
+| `podAnnotations`                     | Pod annotations                                           | `{}`                                                         |
+| `metrics.enabled`                    | Start a side-car prometheus exporter                      | `false`                                                      |
+| `metrics.image.registry`             | Apache exporter image registry                            | `docker.io`                                                  |
+| `metrics.image.repository`           | Apache exporter image name                                | `bitnami/apache-exporter`                                    |
+| `metrics.image.tag`                  | Apache exporter image tag                                 | `{TAG_NAME}`                                                 |
+| `metrics.image.pullPolicy`           | Image pull policy                                         | `IfNotPresent`                                               |
+| `metrics.image.pullSecrets`          | Specify docker-registry secret names as an array          | `[]` (does not add image pull secrets to deployed            |
+| `metrics.podAnnotations`             | Additional annotations for Metrics exporter pod           | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
+| `metrics.resources`                  | Exporter resource requests/limit                          | {}                                                           |
 
 The above parameters map to the env variables defined in [bitnami/joomla](http://github.com/bitnami/bitnami-docker-joomla). For more information please refer to the [bitnami/joomla](http://github.com/bitnami/bitnami-docker-joomla) image documentation.
 

--- a/stable/joomla/templates/ingress.yaml
+++ b/stable/joomla/templates/ingress.yaml
@@ -1,19 +1,18 @@
 {{- if .Values.ingress.enabled }}
-{{- range .Values.ingress.hosts }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "joomla.fullname" $ }}
+  name: {{ template "joomla.fullname" . }}
   labels:
-    app: {{ template "joomla.fullname" $ }}
-    chart: {{ template "joomla.chart" $ }}
-    release: {{ $.Release.Name | quote }}
-    heritage: {{ $.Release.Service | quote }}
+    app: {{ template "joomla.fullname" . }}
+    chart: {{ template "joomla.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
   annotations:
     {{- if .tls }}
     ingress.kubernetes.io/secure-backends: "true"
     {{- end }}
-    {{- if .certManager }}
+    {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"
     {{- end }}
     {{- range $key, $value := .annotations }}
@@ -21,19 +20,25 @@ metadata:
     {{- end }}
 spec:
   rules:
+  {{- if .Values.ingress.hostname }}
+  - host: {{ .Values.ingress.hostname }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: "{{ template "joomla.fullname" . }}"
+          servicePort: http
+  {{- end }}
+  {{- range .Values.ingress.hosts }}
   - host: {{ .name }}
     http:
       paths:
-        - path: {{ default "/" .path }}
-          backend:
-            serviceName: {{ template "joomla.fullname" $ }}
-            servicePort: 80
-{{- if .tls }}
-  tls:
-  - hosts:
-    - {{ .name }}
-    secretName: {{ .tlsSecret }}
-{{- end }}
----
-{{- end }}
+      - path: {{ default "/" .path }}
+        backend:
+          serviceName: "{{ template "joomla.fullname" $ }}"
+          servicePort: http
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls: {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/stable/joomla/values.schema.json
+++ b/stable/joomla/values.schema.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "joomlaUsername": {
+      "type": "string",
+      "title": "Username",
+      "form": true
+    },
+    "joomlaPassword": {
+      "type": "string",
+      "title": "Password",
+      "form": true,
+      "description": "Defaults to a random 10-character alphanumeric string if not set"
+    },
+    "joomlaEmail": {
+      "type": "string",
+      "title": "Admin email",
+      "form": true
+    },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "joomla": {
+          "type": "object",
+          "properties": {
+            "size": {
+              "type": "string",
+              "title": "Persistent Volume Size",
+              "form": true,
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 100,
+              "sliderUnit": "Gi"
+            }
+          }
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "form": true,
+      "title": "Ingress Details",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "form": true,
+          "title": "Use a custom hostname",
+          "description": "Enable the ingress resource that allows you to access the Joomla! installation."
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "hidden": {
+            "condition": false,
+            "value": "ingress.enabled"
+          }
+        }
+      }
+    },
+    "mariadb": {
+      "type": "object",
+      "title": "MariaDB Details",
+      "form": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Use a new MariaDB database hosted in the cluster",
+          "form": true,
+          "description": "Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database switch this off and configure the external database details"
+        },
+        "master": {
+          "type": "object",
+          "properties": {
+            "persistence": {
+              "type": "object",
+              "properties": {
+                "size": {
+                  "type": "string",
+                  "title": "Volume Size",
+                  "form": true,
+                  "hidden": {
+                    "condition": false,
+                    "value": "mariadb.enabled"
+                  },
+                  "render": "slider",
+                  "sliderMin": 1,
+                  "sliderMax": 100,
+                  "sliderUnit": "Gi"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "externalDatabase": {
+      "type": "object",
+      "title": "External Database Details",
+      "description": "If MariaDB is disabled. Use this section to specify the external database details",
+      "form": true,
+      "hidden": "mariadb.enabled",
+      "properties": {
+        "host": {
+          "type": "string",
+          "form": true,
+          "title": "Database Host"
+        },
+        "user": {
+          "type": "string",
+          "form": true,
+          "title": "Database Username"
+        },
+        "password": {
+          "type": "string",
+          "form": true,
+          "title": "Database Password"
+        },
+        "database": {
+          "type": "string",
+          "form": true,
+          "title": "Database Name"
+        },
+        "port": {
+          "type": "integer",
+          "form": true,
+          "title": "Database Port"
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "title": "Requested Resources",
+      "description": "Configure resource requests",
+      "form": true,
+      "properties": {
+        "requests": {
+          "type": "object",
+          "properties": {
+            "memory": {
+              "type": "string",
+              "form": true,
+              "render": "slider",
+              "title": "Memory Request",
+              "sliderMin": 10,
+              "sliderMax": 2048,
+              "sliderUnit": "Mi"
+            },
+            "cpu": {
+              "type": "string",
+              "form": true,
+              "render": "slider",
+              "title": "CPU Request",
+              "sliderMin": 10,
+              "sliderMax": 2000,
+              "sliderUnit": "m"
+            }
+          }
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Enable Metrics",
+          "description": "Prometheus Exporter / Metrics",
+          "form": true
+        }
+      }
+    }
+  }
+}

--- a/stable/joomla/values.yaml
+++ b/stable/joomla/values.yaml
@@ -186,31 +186,39 @@ service:
 ##
 ingress:
   ## Set to true to enable ingress record generation
+  ##
   enabled: false
 
-  ## The list of hostnames to be covered with this ingress record.
-  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
-  hosts:
-  - name: joomla.local
+  ## Set this to true in order to add the corresponding annotations for cert-manager
+  ##
+  certManager: false
 
-    ## Set this to true in order to enable TLS on the ingress record
-    ## A side effect of this will be that the backend joomla service will be connected at port 443
-    tls: false
+  ## When the ingress is enabled, a host pointing to this will be created
+  ##
+  hostname: joomla.local
 
-    ## Set this to true in order to add the corresponding annotations for cert-manager
-    certManager: false
+  ## Ingress annotations done as key:value pairs
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ##
+  ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+  ##
+  annotations: {}
+  #  kubernetes.io/ingress.class: nginx
 
-    ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
-    tlsSecret: joomla.local-tls
+  ## The list of additional hostnames to be covered with this ingress record.
+  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+  ## hosts:
+  ## - name: joomla.local
+  ##   path: /
 
-    ## Ingress annotations done as key:value pairs
-    ## For a full list of possible ingress annotations, please see
-    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
-    ##
-    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
-    ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
-    annotations:
-    #  kubernetes.io/ingress.class: nginx
+  ## The tls configuration for the ingress
+  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## tls:
+  ## - hosts:
+  ##     - joomla.local
+  ##   secretName: joomla.local-tls
 
   secrets:
   ## If you're providing your own certificates, please use this to add the certificates as secrets


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### Is this a new chart

No

**Description of the change**

This PR includes a basic JSON schema for the Drupal chart. It doesn't cover all the possible values of the chart but just the ones that, in my opinion, are more likely to be modified.

This is valid for Helm 3 to validate some values and, at the same time, for Kubeapps to render a simple form so the chart containing it is easier to configure and deploy. See https://github.com/kubeapps/kubeapps/blob/master/docs/developer/basic-form-support.md for more information.

This is an example of the file rendered by Kubeapps:

![Screenshot 2019-11-29 at 15 51 47](https://user-images.githubusercontent.com/6740773/69876632-5d815800-12c0-11ea-8013-bf84b4a3ef5d.png)

This PR also standardizes the way we configure Ingress.

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)