### PR TITLE
[incubator/jaeger] Make TTL for cassandra data configurable

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.15.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.13.4
+version: 0.14.0
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -250,6 +250,8 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `schema.mode`                            | Schema mode (prod or test)          |  `prod`                                  |
 | `schema.pullPolicy`                      | Schema image pullPolicy             |  `IfNotPresent`                          |
 | `schema.activeDeadlineSeconds`           | Deadline in seconds for cassandra schema creation job to complete |  `120`                            |
+| `schema.traceTtl`                     | Time to live for trace data in seconds      |  `nil`                                |
+| `schema.dependenciesTtl`              | Time to live for dependencies data in seconds  |  `nil`                          |
 | `serviceAccounts.agent.create`              | Create service account   |  `true`                                  |
 | `serviceAccounts.agent.name`              | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template  |  ``                                  |
 | `serviceAccounts.cassandraSchema.create`              | Create service account   |  `true`                                  |

--- a/incubator/jaeger/templates/cassandra-schema-job.yaml
+++ b/incubator/jaeger/templates/cassandra-schema-job.yaml
@@ -45,6 +45,14 @@ spec:
             secretKeyRef:
               name: {{ if .Values.storage.cassandra.existingSecret }}{{ .Values.storage.cassandra.existingSecret }}{{- else }}{{ include "jaeger.fullname" . }}-cassandra{{- end }}
               key: password
+      {{- if .Values.schema.traceTtl }}
+        - name: TRACE_TTL
+          value: {{ .Values.schema.traceTtl | quote }}
+      {{- end }}
+      {{- if .Values.schema.dependenciesTtl }}
+        - name: DEPENDENCIES_TTL
+          value: {{ .Values.schema.dependenciesTtl | quote }}
+      {{- end }}
         resources:
 {{ toYaml .Values.schema.resources | indent 10 }}
       restartPolicy: OnFailure

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -88,8 +88,10 @@ schema:
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
-  # Deadline for cassandra schema creation job
+  ## Deadline for cassandra schema creation job
   activeDeadlineSeconds: 120
+  # traceTtl: 172800
+  # dependenciesTtl: 0
 
 # Begin: Override values on the Elasticsearch subchart to customize for Jaeger
 elasticsearch:


### PR DESCRIPTION
Please see https://github.com/jaegertracing/jaeger/blob/master/plugin/storage/cassandra/schema/create.sh for more info

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
