### PR TITLE
[stable/prometheus-rabbitmq-exporter] Fix ServiceMonitor + adds alerts

### DIFF
--- a/stable/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/stable/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 0.5.3
+version: 0.5.4
 appVersion: v0.29.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/stable/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/stable/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 0.5.4
+version: 0.5.5
 appVersion: v0.29.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/stable/prometheus-rabbitmq-exporter/templates/prometheusrule.yaml
+++ b/stable/prometheus-rabbitmq-exporter/templates/prometheusrule.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.prometheus.rules.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "prometheus-rabbitmq-exporter.fullname" . }}
+  labels:
+    app: {{ template "prometheus-rabbitmq-exporter.name" . }}
+    chart: {{ template "prometheus-rabbitmq-exporter.chart" . }}
+    heritage: {{ .Release.Service }}
+  {{- if .Values.prometheus.rules.additionalLabels }}
+{{ toYaml .Values.prometheus.rules.additionalLabels | indent 4 }}
+  {{- end }}
+spec:
+  groups:
+  - name: rabbitmq
+    rules:
+    - alert: RabbitmqDown
+      expr: |
+        absent(rabbitmq_up == 1)
+      for: 1m
+      labels:
+        severity: critical
+    - alert: RabbitmqNotRunning
+      expr: |
+        rabbitmq_running{self="1"} != 1
+      for: 1m
+      labels:
+        severity: critical
+    - alert: RabbitmqMessages
+      expr: |
+        rabbitmq_queue_messages > 250
+      for: 10m
+      labels:
+        severity: warning
+    - alert: RabbitmqMessages
+      expr: |
+        rabbitmq_queue_messages > 500
+      for: 10m
+      labels:
+        severity: critical
+    - alert: RabbitmqPartition
+      expr: |
+        rabbitmq_partitions{self="1"} != 0
+      for: 1m
+      labels:
+        severity: critical
+{{- end }}

--- a/stable/prometheus-rabbitmq-exporter/templates/service.yaml
+++ b/stable/prometheus-rabbitmq-exporter/templates/service.yaml
@@ -13,7 +13,7 @@ spec:
     - port: {{ .Values.service.externalPort }}
       targetPort: publish
       protocol: TCP
-      name: publish
+      name: rabbitmq-exporter
   selector:
     app: {{ template "prometheus-rabbitmq-exporter.name" . }}
     release: {{ .Release.Name }}

--- a/stable/prometheus-rabbitmq-exporter/values.yaml
+++ b/stable/prometheus-rabbitmq-exporter/values.yaml
@@ -57,3 +57,6 @@ prometheus:
     additionalLabels: {}
     interval: 15s
     namespace: []
+  rules:
+    enabled: false
+    additionalLabels: {}


### PR DESCRIPTION
This fixes the ServiceMonitor which was broken in the past commit.  It also adds some basic alertings.