### PR TITLE
[incubator/jaeger]Option to provide sampling strategies file

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.15.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.13.4
+version: 0.14.0
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.15.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.14.0
+version: 0.15.0
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -222,6 +222,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `collector.service.type`                 | Service type                        |  `ClusterIP`                             |
 | `collector.service.zipkinPort`           | Zipkin port for JSON/thrift HTTP    |  `9411`                                  |
 | `collector.extraConfigmapMounts`         | Additional collector configMap mounts |  `[]`                                  |
+| `collector.samplingConfig`         | [Sampling strategies json file](https://www.jaegertracing.io/docs/latest/sampling/#collector-sampling-configuration) |  `nil`                                  |
 | `elasticsearch.rbac.create`              | To enable RBAC                      |  `false`                                 |
 | `fullnameOverride`                       | Override full name                  |  `nil`                                 |
 | `hotrod.enabled`                         | Enables the Hotrod demo app         |  `false`                                 |

--- a/incubator/jaeger/templates/collector-configmap.yaml
+++ b/incubator/jaeger/templates/collector-configmap.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.collector.samplingConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "jaeger.fullname" . }}-sampling-strategies
+  labels:
+    app.kubernetes.io/name: {{ include "jaeger.name" . }}
+    helm.sh/chart: {{ include "jaeger.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: collector
+data:
+  strategies.json: |-
+{{ tpl .Values.collector.samplingConfig . | indent 4 }}
+{{- end }}
+

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -24,8 +24,9 @@ spec:
     type: Recreate
   template:
     metadata:
-{{- if .Values.collector.podAnnotations }}
       annotations:
+        checksum/config-env: {{ include (print $.Template.BasePath "/collector-configmap.yaml") . | sha256sum }}
+{{- if .Values.collector.podAnnotations }}
 {{ toYaml .Values.collector.podAnnotations | indent 8 }}
 {{- end }}
       labels:
@@ -82,6 +83,10 @@ spec:
           - name: ES_USERNAME
             value: {{ .Values.storage.elasticsearch.user }}
           {{- end }}
+          {{- if .Values.collector.samplingConfig}}
+          - name: SAMPLING_STRATEGIES_FILE
+            value: /etc/conf/strategies.json
+          {{- end }}
         ports:
         - containerPort: {{ .Values.collector.service.grpcPort }}
           name: grpc
@@ -115,6 +120,10 @@ spec:
             subPath: {{ .subPath }}
             readOnly: {{ .readOnly }}
         {{- end }}
+        {{- if .Values.collector.samplingConfig}}
+          - name: strategies
+            mountPath: /etc/conf/
+        {{- end }}
       dnsPolicy: {{ .Values.collector.dnsPolicy }}
       restartPolicy: Always
       volumes:
@@ -123,4 +132,10 @@ spec:
           configMap:
             name: {{ .configMap }}
       {{- end }}
+      {{- if .Values.collector.samplingConfig}}
+        - name: strategies
+          configMap:
+            name: {{ include "jaeger.fullname" . }}-sampling-strategies
+      {{- end }}
+
 {{- end -}}

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -182,6 +182,37 @@ collector:
   #   subPath: ""
   #   configMap: jaeger-tls
   #   readOnly: true
+  # samplingConfig: |-
+  #   {
+  #     "service_strategies": [
+  #       {
+  #         "service": "foo",
+  #         "type": "probabilistic",
+  #         "param": 0.8,
+  #         "operation_strategies": [
+  #           {
+  #             "operation": "op1",
+  #             "type": "probabilistic",
+  #             "param": 0.2
+  #           },
+  #           {
+  #             "operation": "op2",
+  #             "type": "probabilistic",
+  #             "param": 0.4
+  #           }
+  #         ]
+  #       },
+  #       {
+  #         "service": "bar",
+  #         "type": "ratelimiting",
+  #         "param": 5
+  #       }
+  #     ],
+  #     "default_strategy": {
+  #       "type": "probabilistic",
+  #       "param": 1
+  #     }
+  #   }
 
 query:
   enabled: true


### PR DESCRIPTION


#### What this PR does / why we need it:
Allows users to pass along a sampling strategies file as per https://www.jaegertracing.io/docs/1.15/sampling/#collector-sampling-configuration

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
