### PR TITLE
[stable/dex] Enabling to control whether cluster role and cluster role binding will be created

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 2.4.1
+version: 2.4.2
 appVersion: 2.19.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 2.4.2
+version: 2.5.0
 appVersion: 2.19.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/README.md
+++ b/stable/dex/README.md
@@ -84,6 +84,7 @@ Parameters introduced starting from v2
 | `config.web.tlsKey` | Maps to the dex config `web.tlsKey` param | `/etc/dex/tls/https/server/tls.key` |
 | `config.expiry.signingKeys` | Maps to the dex config `expiry.signingKeys` param | `6h` |
 | `config.expiry.idTokens` | Maps to the dex config `expiry.idTokens` param | `24h` |
+| `crd.create` | Whether to create cluster role and cluster role binding needed to enable dex to create its CRDs. Depends on `rbac.create` | `true` |
 | `grpc` | Enable dex grpc endpoint | `true` |
 | `https` | Enable TLS termination for the dex http endpoint | `false` |
 | `ports.grpc.containerPort` | grpc port listened by the dex | `5000` |
@@ -92,6 +93,7 @@ Parameters introduced starting from v2
 | `ports.web.containerPort` | http/https port listened by the dex | `5556` |
 | `ports.web.nodePort` | K8S Service node port for the dex http/https listener | `32000` |
 | `ports.web.servicePort` | K8S Service port for the dex http/https listener | `32000` |
+| `rbac.create` | If `true`, create & use RBAC resources | `true` |
 | `service.loadBalancerIP` | IP override for K8S LoadBalancer Service | `""` |
 
 

--- a/stable/dex/README.md
+++ b/stable/dex/README.md
@@ -84,7 +84,7 @@ Parameters introduced starting from v2
 | `config.web.tlsKey` | Maps to the dex config `web.tlsKey` param | `/etc/dex/tls/https/server/tls.key` |
 | `config.expiry.signingKeys` | Maps to the dex config `expiry.signingKeys` param | `6h` |
 | `config.expiry.idTokens` | Maps to the dex config `expiry.idTokens` param | `24h` |
-| `crd.create` | Whether to create cluster role and cluster role binding needed to enable dex to create its CRDs. Depends on `rbac.create` | `true` |
+| `crd.present` | Whether dex's CRDs are already present (if not cluster role and cluster role binding will be created to enable dex to create them). Depends on `rbac.create` | `false` |
 | `grpc` | Enable dex grpc endpoint | `true` |
 | `https` | Enable TLS termination for the dex http endpoint | `false` |
 | `ports.grpc.containerPort` | grpc port listened by the dex | `5000` |

--- a/stable/dex/templates/clusterrole.yaml
+++ b/stable/dex/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and .Values.rbac.create .Values.crd.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/stable/dex/templates/clusterrole.yaml
+++ b/stable/dex/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create .Values.crd.create }}
+{{- if and .Values.rbac.create (not .Values.crd.present) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/stable/dex/templates/clusterrolebinding.yaml
+++ b/stable/dex/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create .Values.crd.create }}
+{{- if and .Values.rbac.create (not .Values.crd.present) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/stable/dex/templates/clusterrolebinding.yaml
+++ b/stable/dex/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and .Values.rbac.create .Values.crd.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/stable/dex/templates/role.yaml
+++ b/stable/dex/templates/role.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.rbac.create }}
-{{- if or .Values.certs.grpc.create .Values.certs.web.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -8,6 +7,10 @@ metadata:
   name: {{ template "dex.fullname" . }}
   namespace: {{ .Release.Namespace }}
 rules:
+- apiGroups: ["dex.coreos.com"] # API group created by dex
+  resources: ["*"]
+  verbs: ["*"]
+{{- if or .Values.certs.grpc.create .Values.certs.web.create }}
 - apiGroups: [""]
   resources: ["configmaps", "secrets"]
   verbs: ["create", "delete"]

--- a/stable/dex/templates/role.yaml
+++ b/stable/dex/templates/role.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.rbac.create }}
+{{- if or .Values.certs.grpc.create .Values.certs.web.create .Values.crd.present }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -7,12 +8,15 @@ metadata:
   name: {{ template "dex.fullname" . }}
   namespace: {{ .Release.Namespace }}
 rules:
+{{- if .Values.crd.present }}
 - apiGroups: ["dex.coreos.com"] # API group created by dex
   resources: ["*"]
   verbs: ["*"]
+{{- end -}}
 {{- if or .Values.certs.grpc.create .Values.certs.web.create }}
 - apiGroups: [""]
   resources: ["configmaps", "secrets"]
   verbs: ["create", "delete"]
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stable/dex/templates/rolebinding.yaml
+++ b/stable/dex/templates/rolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.rbac.create }}
+{{- if or .Values.certs.grpc.create .Values.certs.web.create .Values.crd.present }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -14,4 +15,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "dex.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end -}}
 {{- end -}}

--- a/stable/dex/templates/rolebinding.yaml
+++ b/stable/dex/templates/rolebinding.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.rbac.create }}
-{{- if or .Values.certs.grpc.create .Values.certs.web.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -15,5 +14,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "dex.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
-{{- end -}}
 {{- end -}}

--- a/stable/dex/values.yaml
+++ b/stable/dex/values.yaml
@@ -116,8 +116,9 @@ rbac:
   create: true
 
 crd:
-  # Specifies whether cluster role and cluster role binding should be created in order to enable dex to create its CRDs
-  create: true
+  # Specifies whether dex's CRDs are already present (if not cluster role and cluster role binding will be created
+  # to enable dex to create them). Depends on rbac.create
+  present: false
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created

--- a/stable/dex/values.yaml
+++ b/stable/dex/values.yaml
@@ -115,6 +115,10 @@ rbac:
   # Specifies whether RBAC resources should be created
   create: true
 
+crd:
+  # Specifies whether cluster role and cluster role binding should be created in order to enable dex to create its CRDs
+  create: true
+
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true


### PR DESCRIPTION
**Is this a new chart**
No

**What this PR does / why we need it:**
This PR enables to control whether cluster role and cluster role binding will be created when setting `rbac.create` to `true` by setting `crd.present` to `true`/`false`
I needed this since I'm running dex in a multi tenant (namespace) environment in which user tenants cannot have cluster role. The cluster role is needed in order to enable dex to create its CRDs, but creating CRDs should happen only once, so with this new value I can give only the "admin" tenant's dex the cluster role, and spawn dex on the "user" tenants without the cluster role.

**Which issue this PR fixes**
(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)

- fixes #

**Special notes for your reviewer:**

**Checklist**

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [stable/mychartname])