### PR TITLE
[stable/nextcloud] Add annotations at pod/deployment level

### DIFF
--- a/stable/nextcloud/Chart.yaml
+++ b/stable/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nextcloud
-version: 1.9.0
+version: 1.9.1
 appVersion: 17.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/nextcloud/README.md
+++ b/stable/nextcloud/README.md
@@ -135,6 +135,8 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `readinessProbe.timeoutSeconds`                              | When the probe times out                                | `5`                                                     |
 | `readinessProbe.failureThreshold`                            | Minimum consecutive failures for the probe              | `3`                                                     |
 | `readinessProbe.successThreshold`                            | Minimum consecutive successes for the probe             | `1`                                                     |
+| `deploymentAnnotations`                                      | Annotations to be added at 'deployment' level           | not set                                                 |
+| `podAnnotations`                                             | Annotations to be added at 'pod' level                  | not set                                                 |
 
 > **Note**:
 >

--- a/stable/nextcloud/templates/deployment.yaml
+++ b/stable/nextcloud/templates/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
     helm.sh/chart: {{ include "nextcloud.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml .Values.deploymentAnnotations | indent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
@@ -23,6 +27,10 @@ spec:
         {{- if .Values.redis.enabled }}
         {{ template "nextcloud.redis.fullname" . }}-client: "true"
         {{- end }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
It adds annotations at "pod" and "deployment" level to nextcloud. This is usefull to 'mark' deployments for other tools (like automated backup tools).

#### Which issue this PR fixes
  - fixes #19292

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
