### PR TITLE
[stable/redmine] Add JSON Schema & standardize ingress configuration

### DIFF
--- a/stable/redmine/Chart.yaml
+++ b/stable/redmine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redmine
-version: 13.9.0
+version: 14.0.0
 appVersion: 4.0.5
 description: A flexible project management web application.
 keywords:

--- a/stable/redmine/Chart.yaml
+++ b/stable/redmine/Chart.yaml
@@ -4,19 +4,19 @@ version: 13.8.0
 appVersion: 4.0.5
 description: A flexible project management web application.
 keywords:
-- redmine
-- project management
-- www
-- http
-- web
-- application
-- ruby
-- rails
+  - redmine
+  - project management
+  - www
+  - http
+  - web
+  - application
+  - ruby
+  - rails
 home: http://www.redmine.org/
 icon: https://bitnami.com/assets/stacks/redmine/img/redmine-stack-220x234.png
 sources:
-- https://github.com/bitnami/bitnami-docker-redmine
+  - https://github.com/bitnami/bitnami-docker-redmine
 maintainers:
-- name: Bitnami
-  email: containers@bitnami.com
+  - name: Bitnami
+    email: containers@bitnami.com
 engine: gotpl

--- a/stable/redmine/Chart.yaml
+++ b/stable/redmine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redmine
-version: 13.8.0
+version: 13.9.0
 appVersion: 4.0.5
 description: A flexible project management web application.
 keywords:

--- a/stable/redmine/Chart.yaml
+++ b/stable/redmine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redmine
-version: 13.9.0
+version: 13.8.0
 appVersion: 4.0.5
 description: A flexible project management web application.
 keywords:

--- a/stable/redmine/README.md
+++ b/stable/redmine/README.md
@@ -57,88 +57,89 @@ helm install --name my-release stable/redmine --set databaseType.mariadb=false,d
 
 The following table lists the configurable parameters of the Redmine chart and their default values.
 
-|            Parameter                |              Description                   |                          Default                        |
-| ----------------------------------- | ------------------------------------------ | ------------------------------------------------------- |
-| `global.imageRegistry`              | Global Docker image registr  y             | `nil`                                                   |
-| `global.imagePullSecrets`           | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
-| `global.storageClass`                     | Global storage class for dynamic provisioning                                               | `nil`                                                        |
-| `image.registry`                    | Redmine image registry                     | `docker.io`                                             |
-| `image.repository`                  | Redmine image name                         | `bitnami/redmine`                                       |
-| `image.tag`                         | Redmine image tag                          | `{TAG_NAME}`                                            |
-| `image.pullPolicy`                  | Image pull policy                          | `IfNotPresent`                                          |
-| `image.pullSecrets`                 | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)   |
-| `nameOverride`                      | String to partially override redmine.fullname template with a string (will prepend the release name) | `nil`     |
-| `fullnameOverride`                  | String to fully override redmine.fullname template with a string                                     | `nil`     |
-| `redmineUsername`                   | User of the application                    | `user`                                                  |
-| `redminePassword`                   | Application password                       | _random 10 character long alphanumeric string_          |
-| `redmineEmail`                      | Admin email                                | `user@example.com`                                      |
-| `redmineLanguage`                   | Redmine default data language              | `en`                                                    |
-| `extraVars`                         | Environment variables, passed to redmine   | `nil`                                                   |
-| `smtpHost`                          | SMTP host                                  | `nil`                                                   |
-| `smtpPort`                          | SMTP port                                  | `nil`                                                   |
-| `smtpUser`                          | SMTP user                                  | `nil`                                                   |
-| `smtpPassword`                      | SMTP password                              | `nil`                                                   |
-| `smtpTls`                           | Use TLS encryption with SMTP               | `nil`                                                   |
-| `existingSecret`                    | Use existing secret for password details (`redminePassword`, `smtpPassword` and `externalDatabase.password` will be ignored and picked up from this secret). It must contain the keys `redmine-password` and `smtp-password` when `postgresql.enabled=true` or `mariadb.enabled=true`. In case `postgresql.enabled=false` and `mariadb.enabled=false` it must contain the key `external-db-password`.
- | `nil`                        |
-| `databaseType.postgresql`           | Select PostgreSQL as database              | `false`                                                 |
-| `databaseType.mariadb`              | Select MariaDB as database                 | `true`                                                  |
-| `mariadb.enabled`                   | Whether to deploy a MariaDB server to satisfy the applications database requirements     | `true`    |
-| `mariadb.rootUser.password`         | MariaDB admin password                     | `nil`                                                   |
-| `postgresql.enabled`                | Whether to deploy a PostgreSQL server to satisfy the applications database requirements  | `false`   |
-| `postgresql.postgresqlDatabase`     | PostgreSQL database                        | `bitnami_redmine`                                       |
-| `postgresql.postgresqlUsername`     | PostgreSQL user                            | `bn_redmine`                                            |
-| `postgresql.postgresqlPassword`     | PostgreSQL password                        | `nil`                                                   |
-| `externalDatabase.host`             | Host of the external database              | `localhost`                                             |
-| `externalDatabase.name`             | Name of the external database              | `localhost`                                             |
-| `externalDatabase.user`             | External db user                           | `user`                                                  |
-| `externalDatabase.password`         | Password for the db user                   | `""`                                                    |
-| `externalDatabase.port`             | Database port number                       | `3306`                                                  |
-| `service.type`                      | Kubernetes Service type                    | `LoadBalancer`                                          |
-| `service.port`                      | Service HTTP port                          | `80`                                                    |
-| `service.nodePorts.http`            | Kubernetes http node port                  | `""`                                                    |
-| `service.externalTrafficPolicy`     | Enable client source IP preservation       | `Cluster`                                               |
-| `service.loadBalancerIP`            | LoadBalancer service IP address            | `""`                                                    |
-| `service.loadBalancerSourceRanges`  | An array of load balancer sources          | `0.0.0.0/0`                                             |
-| `serviceAccount.create`             | Specifies whether a ServiceAccount should be created | `false`                                       |
-| `serviceAccount.name`               | The name of the ServiceAccount to create   | Generated using the redmine.fullname template         |
-| `ingress.enabled`                   | Enable or disable the ingress              | `false`                                                 |
-| `ingress.hosts[0].name`             | Hostname to your Redmine installation      | `redmine.local`                                       |
-| `ingress.hosts[0].path`             | Path within the url structure              | `/`                                                     |
-| `ingress.hosts[0].tls`              | Utilize TLS backend in ingress             | `false`                                                 |
-| `ingress.hosts[0].certManager`      | Add annotations for cert-manager           | `false`                                                 |
-| `ingress.hosts[0].tlsSecret`        | TLS Secret (certificates)                  | `redmine.local-tls-secret`                              |
-| `ingress.hosts[0].annotations`      | Annotations for this host's ingress record | `[]`                                                    |
-| `ingress.secrets[0].name`           | TLS Secret Name                            | `nil`                                                   |
-| `ingress.secrets[0].certificate`    | TLS Secret Certificate                     | `nil`                                                   |
-| `ingress.secrets[0].key`            | TLS Secret Key                             | `nil`                                                   |
-| `nodeSelector`                      | Node labels for pod assignment             | `{}`                                                    |
-| `tolerations`                       | List of node taints to tolerate            | `{}`                                                    |
-| `affinity`                          | Map of node/pod affinities                 | `{}`                                                    |
-| `podAnnotations`                    | Pod annotations                            | `{}`                                                    |
-| `persistence.enabled`               | Enable persistence using PVC               | `true`                                                  |
-| `persistence.existingClaim`         | The name of an existing PVC                | `nil`                                                   |
-| `persistence.storageClass`          | PVC Storage Class                          | `nil` (uses alpha storage class annotation)             |
-| `persistence.accessMode`            | PVC Access Mode                            | `ReadWriteOnce`                                         |
-| `persistence.size`                  | PVC Storage Request                        | `8Gi`                                                   |
-| `podDisruptionBudget.enabled`       | Pod Disruption Budget toggle               | `false`                                                 |
-| `podDisruptionBudget.minAvailable`  | Minimum available pods                     | `nil`                                                   |
-| `podDisruptionBudget.maxUnavailable`| Maximum unavailable pods                   | `nil`                                                   |
-| `replicas`                          | The number of pod replicas                 | `1`                                                     |
-| `resources`                         | Resources allocation (Requests and Limits) | `{}`                                                    |
-| `securityContext`                   | SecurityContext                            | `{}`                                                    |
-| `livenessProbe.enabled`             | would you like a livenessProbe to be enabled                                                | `true` |
-| `livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated                                                    | 300    |
-| `livenessProbe.periodSeconds`       | How often to perform the probe                                                              | 10     |
-| `livenessProbe.timeoutSeconds`      | When the probe times out                                                                    | 5      |
-| `livenessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed | 1      |
-| `livenessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded.  | 3      |
-| `readinessProbe.enabled`            | would you like a readinessProbe to be enabled                                               | `true` |
-| `readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated                                                   | 5      |
-| `readinessProbe.periodSeconds`      | How often to perform the probe                                                              | 10     |
-| `readinessProbe.timeoutSeconds`     | When the probe times out                                                                    | 1      |
-| `readinessProbe.successThreshold`   | Minimum consecutive successes for the probe to be considered successful after having failed | 1      |
-| `readinessProbe.failureThreshold`   | Minimum consecutive failures for the probe to be considered failed after having succeeded.  | 3      |
+| Parameter                            | Description                                                                | Default                                                 |
+| ------------------------------------ | -------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `global.imageRegistry`               | Global Docker image registr  y                                             | `nil`                                                   |
+| `global.imagePullSecrets`            | Global Docker registry secret names as an array                            | `[]` (does not add image pull secrets to deployed pods) |
+| `global.storageClass`                | Global storage class for dynamic provisioning                              | `nil`                                                   |
+| `image.registry`                     | Redmine image registry                                                     | `docker.io`                                             |
+| `image.repository`                   | Redmine image name                                                         | `bitnami/redmine`                                       |
+| `image.tag`                          | Redmine image tag                                                          | `{TAG_NAME}`                                            |
+| `image.pullPolicy`                   | Image pull policy                                                          | `IfNotPresent`                                          |
+| `image.pullSecrets`                  | Specify docker-registry secret names as an array                           | `[]` (does not add image pull secrets to deployed pods) |
+| `nameOverride`                       | String to partially override redmine.fullname template                     | `nil`                                                   |
+| `fullnameOverride`                   | String to fully override redmine.fullname template                         | `nil`                                                   |
+| `redmineUsername`                    | User of the application                                                    | `user`                                                  |
+| `redminePassword`                    | Application password                                                       | _random 10 character long alphanumeric string_          |
+| `redmineEmail`                       | Admin email                                                                | `user@example.com`                                      |
+| `redmineLanguage`                    | Redmine default data language                                              | `en`                                                    |
+| `extraVars`                          | Environment variables, passed to redmine                                   | `nil`                                                   |
+| `smtpHost`                           | SMTP host                                                                  | `nil`                                                   |
+| `smtpPort`                           | SMTP port                                                                  | `nil`                                                   |
+| `smtpUser`                           | SMTP user                                                                  | `nil`                                                   |
+| `smtpPassword`                       | SMTP password                                                              | `nil`                                                   |
+| `smtpTls`                            | Use TLS encryption with SMTP                                               | `nil`                                                   |
+| `existingSecret`                     | Use existing secret for password details                                   | `nil`                                                   |
+| `existingSecret`                     | Use existing secret for password details (`redminePassword`, `smtpPassword` and `externalDatabase.password` will be ignored and picked up from this secret). It must contain the keys `redmine-password` and `smtp-password` when `postgresql.enabled=true` or `mariadb.enabled=true`. In case `postgresql.enabled=false` and `mariadb.enabled=false` it must contain the key `external-db-password` | `nil`                                                   |
+| `databaseType.postgresql`            | Select PostgreSQL as database                                              | `false`                                                 |
+| `databaseType.mariadb`               | Select MariaDB as database                                                 | `true`                                                  |
+| `mariadb.enabled`                    | Whether to deploy a MariaDB server to satisfy the database requirements    | `true`                                                  |
+| `mariadb.rootUser.password`          | MariaDB admin password                                                     | `nil`                                                   |
+| `postgresql.enabled`                 | Whether to deploy a PostgreSQL server to satisfy the database requirements | `false`                                                 |
+| `postgresql.postgresqlDatabase`      | PostgreSQL database                                                        | `bitnami_redmine`                                       |
+| `postgresql.postgresqlUsername`      | PostgreSQL user                                                            | `bn_redmine`                                            |
+| `postgresql.postgresqlPassword`      | PostgreSQL password                                                        | `nil`                                                   |
+| `externalDatabase.host`              | Host of the external database                                              | `localhost`                                             |
+| `externalDatabase.name`              | Name of the external database                                              | `localhost`                                             |
+| `externalDatabase.user`              | External db user                                                           | `user`                                                  |
+| `externalDatabase.password`          | Password for the db user                                                   | `""`                                                    |
+| `externalDatabase.port`              | Database port number                                                       | `3306`                                                  |
+| `service.type`                       | Kubernetes Service type                                                    | `LoadBalancer`                                          |
+| `service.port`                       | Service HTTP port                                                          | `80`                                                    |
+| `service.nodePorts.http`             | Kubernetes http node port                                                  | `""`                                                    |
+| `service.externalTrafficPolicy`      | Enable client source IP preservation                                       | `Cluster`                                               |
+| `service.loadBalancerIP`             | LoadBalancer service IP address                                            | `""`                                                    |
+| `service.loadBalancerSourceRanges`   | An array of load balancer sources                                          | `0.0.0.0/0`                                             |
+| `serviceAccount.create`              | Specifies whether a ServiceAccount should be created                       | `false`                                                 |
+| `serviceAccount.name`                | The name of the ServiceAccount to create                                   | Generated using the `redmine.fullname` macro            |
+| `ingress.enabled`                    | Enable ingress controller resource                                         | `false`                                                 |
+| `ingress.certManager`                | Add annotations for cert-manager                                           | `false`                                                 |
+| `ingress.hostname`                   | Default host for the ingress resource                                      | `redmine.local`                                         |
+| `ingress.annotations`                | Ingress annotations                                                        | `{}`                                                    |
+| `ingress.hosts[0].name`              | Hostname to your Redmine installation                                      | `nil`                                                   |
+| `ingress.hosts[0].path`              | Path within the url structure                                              | `nil`                                                   |
+| `ingress.tls[0].hosts[0]`            | TLS hosts                                                                  | `nil`                                                   |
+| `ingress.tls[0].secretName`          | TLS Secret (certificates)                                                  | `nil`                                                   |
+| `ingress.secrets[0].name`            | TLS Secret Name                                                            | `nil`                                                   |
+| `ingress.secrets[0].certificate`     | TLS Secret Certificate                                                     | `nil`                                                   |
+| `ingress.secrets[0].key`             | TLS Secret Key                                                             | `nil`                                                   |
+| `nodeSelector`                       | Node labels for pod assignment                                             | `{}`                                                    |
+| `tolerations`                        | List of node taints to tolerate                                            | `{}`                                                    |
+| `affinity`                           | Map of node/pod affinities                                                 | `{}`                                                    |
+| `podAnnotations`                     | Pod annotations                                                            | `{}`                                                    |
+| `persistence.enabled`                | Enable persistence using PVC                                               | `true`                                                  |
+| `persistence.existingClaim`          | The name of an existing PVC                                                | `nil`                                                   |
+| `persistence.storageClass`           | PVC Storage Class                                                          | `nil` (uses alpha storage class annotation)             |
+| `persistence.accessMode`             | PVC Access Mode                                                            | `ReadWriteOnce`                                         |
+| `persistence.size`                   | PVC Storage Request                                                        | `8Gi`                                                   |
+| `podDisruptionBudget.enabled`        | Pod Disruption Budget toggle                                               | `false`                                                 |
+| `podDisruptionBudget.minAvailable`   | Minimum available pods                                                     | `nil`                                                   |
+| `podDisruptionBudget.maxUnavailable` | Maximum unavailable pods                                                   | `nil`                                                   |
+| `replicas`                           | The number of pod replicas                                                 | `1`                                                     |
+| `resources`                          | Resources allocation (Requests and Limits)                                 | `{}`                                                    |
+| `securityContext`                    | SecurityContext                                                            | `{}`                                                    |
+| `livenessProbe.enabled`              | would you like a livenessProbe to be enabled                               | `true`                                                  |
+| `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                   | 300                                                     |
+| `livenessProbe.periodSeconds`        | How often to perform the probe                                             | 10                                                      |
+| `livenessProbe.timeoutSeconds`       | When the probe times out                                                   | 5                                                       |
+| `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe                                | 1                                                       |
+| `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe                                 | 3                                                       |
+| `readinessProbe.enabled`             | would you like a readinessProbe to be enabled                              | `true`                                                  |
+| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                  | 5                                                       |
+| `readinessProbe.periodSeconds`       | How often to perform the probe                                             | 10                                                      |
+| `readinessProbe.timeoutSeconds`      | When the probe times out                                                   | 1                                                       |
+| `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe                                | 1                                                       |
+| `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe                                 | 3                                                       |
 
 The above parameters map to the env variables defined in [bitnami/redmine](http://github.com/bitnami/bitnami-docker-redmine). For more information please refer to the [bitnami/redmine](http://github.com/bitnami/bitnami-docker-redmine) image documentation.
 

--- a/stable/redmine/README.md
+++ b/stable/redmine/README.md
@@ -103,11 +103,12 @@ The following table lists the configurable parameters of the Redmine chart and t
 | `ingress.enabled`                    | Enable ingress controller resource                                         | `false`                                                 |
 | `ingress.certManager`                | Add annotations for cert-manager                                           | `false`                                                 |
 | `ingress.hostname`                   | Default host for the ingress resource                                      | `redmine.local`                                         |
+| `ingress.tls`                        | Enable TLS configuration                                                   | `false`                                                 |
 | `ingress.annotations`                | Ingress annotations                                                        | `{}`                                                    |
-| `ingress.hosts[0].name`              | Hostname to your Redmine installation                                      | `nil`                                                   |
-| `ingress.hosts[0].path`              | Path within the url structure                                              | `nil`                                                   |
-| `ingress.tls[0].hosts[0]`            | TLS hosts                                                                  | `nil`                                                   |
-| `ingress.tls[0].secretName`          | TLS Secret (certificates)                                                  | `nil`                                                   |
+| `ingress.extraHosts[0].name`         | Extra hosts for your Redmine installation                                  | `nil`                                                   |
+| `ingress.extraHosts[0].path`         | Path within the url structure                                              | `nil`                                                   |
+| `ingress.extraTls[0].hosts[0]`       | Extra TLS hosts                                                            | `nil`                                                   |
+| `ingress.extraTls[0].secretName`     | TLS Secret (certificates) for extra TLS hosts                              | `nil`                                                   |
 | `ingress.secrets[0].name`            | TLS Secret Name                                                            | `nil`                                                   |
 | `ingress.secrets[0].certificate`     | TLS Secret Certificate                                                     | `nil`                                                   |
 | `ingress.secrets[0].key`             | TLS Secret Key                                                             | `nil`                                                   |

--- a/stable/redmine/README.md
+++ b/stable/redmine/README.md
@@ -195,6 +195,13 @@ $ helm install --name test --set persistence.existingClaim=PVC_REDMINE,mariadb.p
 
 ## Upgrading
 
+### 14.0.0
+
+- Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
+- The `databaseType` parameters is no longer an object but a string. Allowed values are "mariadb" and "postgresql".
+- Ingress configuration was standardized to simplify the way to configure the main host.
+- Ports names were prefixed with the protocol to comply with Istio (see https://istio.io/docs/ops/deployment/requirements/).
+
 ### 13.0.0
 
 Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.

--- a/stable/redmine/README.md
+++ b/stable/redmine/README.md
@@ -47,10 +47,10 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Using PostgreSQL instead of MariaDB
 
-This chart includes the option to use a PostgreSQL database for Redmine instead of MariaDB. To use this, MariaDB must be explicitly disabled and PostgreSQL enabled:
+This chart includes the option to use a PostgreSQL database for Redmine instead of MariaDB. To use this, set the `databaseType` parameter to `postgresql`:
 
 ```
-helm install --name my-release stable/redmine --set databaseType.mariadb=false,databaseType.postgresql=true
+helm install --name my-release stable/redmine --set databaseType=postgresql
 ```
 
 ## Parameters
@@ -79,10 +79,8 @@ The following table lists the configurable parameters of the Redmine chart and t
 | `smtpUser`                           | SMTP user                                                                  | `nil`                                                   |
 | `smtpPassword`                       | SMTP password                                                              | `nil`                                                   |
 | `smtpTls`                            | Use TLS encryption with SMTP                                               | `nil`                                                   |
-| `existingSecret`                     | Use existing secret for password details                                   | `nil`                                                   |
 | `existingSecret`                     | Use existing secret for password details (`redminePassword`, `smtpPassword` and `externalDatabase.password` will be ignored and picked up from this secret). It must contain the keys `redmine-password` and `smtp-password` when `postgresql.enabled=true` or `mariadb.enabled=true`. In case `postgresql.enabled=false` and `mariadb.enabled=false` it must contain the key `external-db-password` | `nil`                                                   |
-| `databaseType.postgresql`            | Select PostgreSQL as database                                              | `false`                                                 |
-| `databaseType.mariadb`               | Select MariaDB as database                                                 | `true`                                                  |
+| `databaseType`                       | Select database type                                                       | `mariadb` (allowed values: "mariadb" and "postgresql")  |
 | `mariadb.enabled`                    | Whether to deploy a MariaDB server to satisfy the database requirements    | `true`                                                  |
 | `mariadb.rootUser.password`          | MariaDB admin password                                                     | `nil`                                                   |
 | `postgresql.enabled`                 | Whether to deploy a PostgreSQL server to satisfy the database requirements | `false`                                                 |

--- a/stable/redmine/requirements.lock
+++ b/stable/redmine/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 7.0.1
+  version: 7.3.0
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 7.1.0
-digest: sha256:c5ed9aba5b8df7c81b029047541d0b75e26b4d7eaf34ea03e09f4d76ac4cc6d4
-generated: 2019-11-13T14:28:05.572733842Z
+  version: 8.0.0
+digest: sha256:35e88b466a4a45bf4e8c4a69a2738788dbc73168a37218e524c7fe3a18650e9e
+generated: "2019-12-11T12:51:11.722378+01:00"

--- a/stable/redmine/requirements.yaml
+++ b/stable/redmine/requirements.yaml
@@ -4,6 +4,6 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: mariadb.enabled
 - name: postgresql
-  version: 7.x.x
+  version: 8.x.x
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: postgresql.enabled

--- a/stable/redmine/templates/NOTES.txt
+++ b/stable/redmine/templates/NOTES.txt
@@ -32,11 +32,11 @@ You have 4 alternatives:
 {{- $port:=.Values.service.port | toString }}
   echo "Redmine URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/"
 
-{{- else if .Values.ingress.enabled }}
+{{- else if and .Values.ingress.enabled .Values.ingress.hostname }}
 
-  {{- range .Values.ingress.hosts }}
-    echo "Redmine URL: http://{{ .name }}/"
-  {{- end }}
+  You should be able to access your new Redmine installation through
+
+  http://{{- .Values.ingress.hostname }}/
 
 {{- else if contains "ClusterIP" .Values.service.type }}
 

--- a/stable/redmine/templates/NOTES.txt
+++ b/stable/redmine/templates/NOTES.txt
@@ -1,4 +1,4 @@
-{{- if and (not .Values.databaseType.mariadb) (not .Values.databaseType.postgresql) }}
+{{- if and (not (eq .Values.databaseType "mariadb")) (not (eq .Values.databaseType "postgresql")) }}
 ################################################################################
 ### ERROR: You did not indicate MariaDB nor PostgreSQL as the database       ###
 ###        server to use.                                                    ###
@@ -6,10 +6,10 @@
 
 You have 4 alternatives:
 
-  a) Use MariaDB as database creating a new MariaDB server: set `databaseType.mariadb=true` and `mariadb.enabled=true`
-  b) Use MariaDB as database using a external MariaDB server: set `databaseType.mariadb=true` and `mariadb.enabled=false`
-  c) Use PostgreSQL as database creating a new PostgreSQL server: set `databaseType.postgresql=true` and `postgresql.enabled=true`
-  d) Use PostgreSQL as database using a external PostgreSQL server: `databaseType.postgresql=true` and `postgresql.enabled=false`
+  a) Use MariaDB as database creating a new MariaDB server: set `databaseType=mariadb` and `mariadb.enabled=true`
+  b) Use MariaDB as database using a external MariaDB server: set `databaseType=mariadb` and `mariadb.enabled=false`
+  c) Use PostgreSQL as database creating a new PostgreSQL server: set `databaseType=postgresql` and `postgresql.enabled=true`
+  d) Use PostgreSQL as database using a external PostgreSQL server: `databaseType=postgresql` and `postgresql.enabled=false`
 
 {{- else }}
 

--- a/stable/redmine/templates/NOTES.txt
+++ b/stable/redmine/templates/NOTES.txt
@@ -15,7 +15,14 @@ You have 4 alternatives:
 
 1. Get the Redmine URL:
 
-{{- if contains "NodePort" .Values.service.type }}
+{{- if and .Values.ingress.enabled .Values.ingress.hostname }}
+
+  export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
+  echo "Redmine URL: http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.hostname }}/"
+  echo "$CLUSTER_IP  {{ .Values.ingress.hostname }}" | sudo tee -a /etc/hosts
+
+
+{{- else if contains "NodePort" .Values.service.type }}
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "redmine.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
@@ -31,12 +38,6 @@ You have 4 alternatives:
 
 {{- $port:=.Values.service.port | toString }}
   echo "Redmine URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/"
-
-{{- else if and .Values.ingress.enabled .Values.ingress.hostname }}
-
-  You should be able to access your new Redmine installation through
-
-  http://{{- .Values.ingress.hostname }}/
 
 {{- else if contains "ClusterIP" .Values.service.type }}
 

--- a/stable/redmine/templates/_helpers.tpl
+++ b/stable/redmine/templates/_helpers.tpl
@@ -47,6 +47,24 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Common labels
+*/}}
+{{- define "redmine.labels" -}}
+app.kubernetes.io/name: {{ template "redmine.name" . }}
+helm.sh/chart: {{ template "redmine.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Labels to use on deploy.spec.selector.matchLabels and svc.spec.selector
+*/}}
+{{- define "redmine.matchLabels" -}}
+app.kubernetes.io/name: {{ template "redmine.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
 Return the proper Redmine image name
 */}}
 {{- define "redmine.image" -}}

--- a/stable/redmine/templates/deployment.yaml
+++ b/stable/redmine/templates/deployment.yaml
@@ -1,4 +1,3 @@
-{{- if or .Values.databaseType.mariadb .Values.databaseType.postgresql }}
 apiVersion: {{ template "redmine.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
@@ -48,7 +47,7 @@ spec:
         {{- if .Values.extraVars }}
 {{ toYaml .Values.extraVars | indent 8 }}
         {{- end }}
-        {{- if .Values.databaseType.mariadb }}
+        {{- if eq .Values.databaseType "mariadb" }}
         - name: REDMINE_DB_MYSQL
         {{- if .Values.mariadb.enabled }}
           value: {{ template "redmine.mariadb.fullname" . }}
@@ -64,7 +63,7 @@ spec:
         {{- else }}
           value: {{ .Values.externalDatabase.host | quote }}
         {{- end }}
-        {{- else if .Values.databaseType.postgresql }}
+        {{- else if eq .Values.databaseType "postgresql" }}
         - name: REDMINE_DB_POSTGRES
         {{- if .Values.postgresql.enabled }}
           value: {{ template "redmine.postgresql.fullname" . }}
@@ -81,7 +80,7 @@ spec:
           value: {{ .Values.externalDatabase.host | quote }}
         {{- end }}
         {{- end }}
-        {{- if or (and .Values.databaseType.mariadb (not .Values.mariadb.enabled)) (and .Values.databaseType.postgresql (not .Values.postgresql.enabled)) }}
+        {{- if or (and (eq .Values.databaseType "mariadb") (not .Values.mariadb.enabled)) (and (eq .Values.databaseType "postgresql") (not .Values.postgresql.enabled)) }}
         - name: REDMINE_DB_NAME
           value: {{ .Values.externalDatabase.name | quote }}
         - name: REDMINE_DB_USERNAME
@@ -169,4 +168,3 @@ spec:
       securityContext:
 {{ toYaml . | indent 8 }}
       {{- end }}
-{{- end }}

--- a/stable/redmine/templates/deployment.yaml
+++ b/stable/redmine/templates/deployment.yaml
@@ -2,23 +2,14 @@ apiVersion: {{ template "redmine.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "redmine.fullname" . }}
-  labels:
-    app: {{ template "redmine.fullname" . }}
-    chart: {{ template "redmine.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  labels: {{- include "redmine.labels" . | nindent 4 }}
 spec:
   selector:
-    matchLabels:
-      app: {{ template "redmine.fullname" . }}
-      release: "{{ .Release.Name }}"
+    matchLabels: {{- include "redmine.matchLabels" . | nindent 6 }}
   replicas: {{ .Values.replicas }}
   template:
     metadata:
-      labels:
-        app: {{ template "redmine.fullname" . }}
-        chart: {{ template "redmine.chart" . }}
-        release: "{{ .Release.Name }}"
+      labels: {{- include "redmine.labels" . | nindent 8 }}
       {{- if .Values.podAnnotations }}
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
@@ -128,13 +119,13 @@ spec:
           value: {{ .Values.smtpTls | quote }}
         {{- end }}
         ports:
-        - name: http
+        - name: http-redmine
           containerPort: 3000
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
             path: /
-            port: http
+            port: http-redmine
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -145,7 +136,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: http
+            port: http-redmine
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/stable/redmine/templates/ingress.yaml
+++ b/stable/redmine/templates/ingress.yaml
@@ -17,25 +17,53 @@ metadata:
     {{- end }}
 spec:
   rules:
-  {{- if .Values.ingress.hostname }}
-  - host: {{ .Values.ingress.hostname }}
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: "{{ template "redmine.fullname" . }}"
-          servicePort: http
-  {{- end }}
-  {{- range .Values.ingress.hosts }}
-  - host: {{ .name }}
-    http:
-      paths:
-      - path: {{ default "/" .path }}
-        backend:
-          serviceName: "{{ template "redmine.fullname" $ }}"
-          servicePort: http
-  {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls: {{- toYaml .Values.ingress.tls | nindent 4 }}
+    {{- if .Values.ingress.hostname }}
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+        - path: /
+          backend:
+            serviceName: "{{ template "redmine.fullname" . }}"
+            servicePort: http
+    {{- end }}
+    {{- range .Values.ingress.extraHosts }}
+    - host: {{ .name }}
+      http:
+        paths:
+        - path: {{ default "/" .path }}
+          backend:
+            serviceName: "{{ template "redmine.fullname" $ }}"
+            servicePort: http
+    {{- end }}
+    ## The block below is deprecated and must removed on 3.0.0
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .name }}
+      http:
+        paths:
+        - path: {{ default "/" .path }}
+          backend:
+            serviceName: {{ template "redmine.fullname" $ }}
+            servicePort: http
+    {{- end }}
+    ## end of block
+  {{- if or .Values.ingress.tls .Values.ingress.extraTls .Values.ingress.hosts }}
+  tls:
+    ## The block below is deprecated and must removed on 3.0.0
+    {{- range .Values.ingress.hosts }}
+    {{- if .tls }}
+    - hosts:
+        - {{ .name }}
+      secretName: {{ .tlsSecret }}
+    {{- end }}
+    {{- end }}
+    ## end of block
+    {{- if .Values.ingress.tls }}
+    - hosts:
+        - {{ .Values.ingress.hostname }}
+      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+    {{- end }}
+    {{- if .Values.ingress.extraTls }}
+    {{- toYaml .Values.ingress.extraTls | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/stable/redmine/templates/ingress.yaml
+++ b/stable/redmine/templates/ingress.yaml
@@ -3,11 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "redmine.fullname" . }}
-  labels:
-    app: {{ template "redmine.fullname" . }}
-    chart: {{ template "redmine.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  labels: {{- include "redmine.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"
@@ -35,28 +31,8 @@ spec:
             serviceName: "{{ template "redmine.fullname" $ }}"
             servicePort: http
     {{- end }}
-    ## The block below is deprecated and must removed on 3.0.0
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .name }}
-      http:
-        paths:
-        - path: {{ default "/" .path }}
-          backend:
-            serviceName: {{ template "redmine.fullname" $ }}
-            servicePort: http
-    {{- end }}
-    ## end of block
   {{- if or .Values.ingress.tls .Values.ingress.extraTls .Values.ingress.hosts }}
   tls:
-    ## The block below is deprecated and must removed on 3.0.0
-    {{- range .Values.ingress.hosts }}
-    {{- if .tls }}
-    - hosts:
-        - {{ .name }}
-      secretName: {{ .tlsSecret }}
-    {{- end }}
-    {{- end }}
-    ## end of block
     {{- if .Values.ingress.tls }}
     - hosts:
         - {{ .Values.ingress.hostname }}

--- a/stable/redmine/templates/ingress.yaml
+++ b/stable/redmine/templates/ingress.yaml
@@ -1,16 +1,15 @@
 {{- if .Values.ingress.enabled }}
-{{- range .Values.ingress.hosts }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: "{{- printf "%s-%s" .name $.Release.Name | trunc 63 | trimSuffix "-" | replace "." "-" -}}"
+  name: {{ template "redmine.fullname" . }}
   labels:
-    app: {{ template "redmine.fullname" $ }}
-    chart: {{ template "redmine.chart" $ }}
-    release: "{{ $.Release.Name }}"
-    heritage: "{{ $.Release.Service }}"
+    app: {{ template "redmine.fullname" . }}
+    chart: {{ template "redmine.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
   annotations:
-    {{- if .certManager }}
+    {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"
     {{- end }}
     {{- range $key, $value := .annotations }}
@@ -18,19 +17,25 @@ metadata:
     {{- end }}
 spec:
   rules:
+  {{- if .Values.ingress.hostname }}
+  - host: {{ .Values.ingress.hostname }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: "{{ template "redmine.fullname" . }}"
+          servicePort: http
+  {{- end }}
+  {{- range .Values.ingress.hosts }}
   - host: {{ .name }}
     http:
       paths:
       - path: {{ default "/" .path }}
         backend:
-          serviceName: {{ template "redmine.fullname" $ }}
-          servicePort: 80
-{{- if .tls }}
-  tls:
-    - secretName: {{ .tlsSecret }}
-      hosts:
-        - {{ .name }}
-{{- end }}
----
-{{- end }}
+          serviceName: "{{ template "redmine.fullname" $ }}"
+          servicePort: http
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls: {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/stable/redmine/templates/pdb.yaml
+++ b/stable/redmine/templates/pdb.yaml
@@ -3,11 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "redmine.fullname" . }}
-  labels:
-    app: {{ template "redmine.fullname" . }}
-    chart: {{ template "redmine.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  labels: {{- include "redmine.labels" . | nindent 4 }}
 spec:
   {{- if .Values.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
@@ -16,8 +12,5 @@ spec:
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   {{- end }}
   selector:
-    matchLabels:
-      app: {{ template "redmine.name" . }}
-      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-      release: "{{ .Release.Name }}"
+    matchLabels: {{- include "redmine.matchLabels" . | nindent 6 }}
 {{- end }}

--- a/stable/redmine/templates/pvc.yaml
+++ b/stable/redmine/templates/pvc.yaml
@@ -3,11 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "redmine.fullname" . }}
-  labels:
-    app: {{ template "redmine.fullname" . }}
-    chart: {{ template "redmine.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  labels: {{- include "redmine.labels" . | nindent 4 }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/stable/redmine/templates/secrets.yaml
+++ b/stable/redmine/templates/secrets.yaml
@@ -16,7 +16,7 @@ data:
   redmine-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
   smtp-password: {{ default "" .Values.smtpPassword | b64enc | quote }}
-  {{- if or (and .Values.databaseType.mariadb (not .Values.mariadb.enabled)) (and .Values.databaseType.postgresql (not .Values.postgresql.enabled)) }}
+  {{- if or (and (eq .Values.databaseType "mariadb") (not .Values.mariadb.enabled)) (and (eq .Values.databaseType "postgresql") (not .Values.postgresql.enabled)) }}  
   {{- if .Values.externalDatabase.password }}
   external-db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
   {{- else }}

--- a/stable/redmine/templates/secrets.yaml
+++ b/stable/redmine/templates/secrets.yaml
@@ -3,11 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "redmine.fullname" . }}
-  labels:
-    app: {{ template "redmine.fullname" . }}
-    chart: {{ template "redmine.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  labels: {{- include "redmine.labels" . | nindent 4 }}
 type: Opaque
 data:
   {{- if .Values.redminePassword }}
@@ -16,7 +12,7 @@ data:
   redmine-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
   smtp-password: {{ default "" .Values.smtpPassword | b64enc | quote }}
-  {{- if or (and (eq .Values.databaseType "mariadb") (not .Values.mariadb.enabled)) (and (eq .Values.databaseType "postgresql") (not .Values.postgresql.enabled)) }}  
+  {{- if or (and (eq .Values.databaseType "mariadb") (not .Values.mariadb.enabled)) (and (eq .Values.databaseType "postgresql") (not .Values.postgresql.enabled)) }}
   {{- if .Values.externalDatabase.password }}
   external-db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
   {{- else }}

--- a/stable/redmine/templates/serviceaccount.yaml
+++ b/stable/redmine/templates/serviceaccount.yaml
@@ -3,9 +3,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "redmine.serviceAccountName" . }}
-  labels:
-    app: {{ template "redmine.fullname" . }}
-    chart: {{ template "redmine.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  labels: {{- include "redmine.labels" . | nindent 4 }}
 {{- end }}

--- a/stable/redmine/templates/svc.yaml
+++ b/stable/redmine/templates/svc.yaml
@@ -2,11 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "redmine.fullname" . }}
-  labels:
-    app: {{ template "redmine.fullname" . }}
-    chart: {{ template "redmine.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  labels: {{- include "redmine.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
@@ -19,11 +15,10 @@ spec:
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
   ports:
-    - name: http
+    - name: http-redmine
       port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: http-redmine
       {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePorts.http)))}}
       nodePort: {{ .Values.service.nodePorts.http }}
       {{- end }}
-  selector:
-    app: {{ template "redmine.fullname" . }}
+  selector: {{- include "redmine.matchLabels" . | nindent 4 }}

--- a/stable/redmine/templates/tls-secrets.yaml
+++ b/stable/redmine/templates/tls-secrets.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  labels:
+    app: {{ template "redmine.fullname" . }}
+    chart: {{ template "redmine.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .certificate | b64enc }}
+  tls.key: {{ .key | b64enc }}
+---
+{{- end }}
+{{- end }}

--- a/stable/redmine/templates/tls-secrets.yaml
+++ b/stable/redmine/templates/tls-secrets.yaml
@@ -4,11 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}
-  labels:
-    app: {{ template "redmine.fullname" . }}
-    chart: {{ template "redmine.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  labels: {{- include "redmine.labels" . | nindent 4 }}
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .certificate | b64enc }}

--- a/stable/redmine/values.schema.json
+++ b/stable/redmine/values.schema.json
@@ -67,21 +67,10 @@
       }
     },
     "databaseType": {
-      "type": "object",
+      "type": "string",
       "form": true,
       "title": "Database Type",
-      "properties": {
-        "mariadb": {
-          "type": "boolean",
-          "title": "Use MariaDB as database",
-          "form": true
-        },
-        "postgresql": {
-          "type": "boolean",
-          "title": "Use PostgreSQL as database",
-          "form": true
-        }
-      }
+      "description": "Allowed values: \"mariadb\" and \"postgresql\""
     },
     "mariadb": {
       "type": "object",
@@ -89,7 +78,7 @@
       "form": true,
       "hidden": {
         "condition": false,
-        "value": "databaseType.mariadb"
+        "value": "eq databaseType \"mariadb\""
       },
       "properties": {
         "enabled": {
@@ -129,7 +118,7 @@
       "form": true,
       "hidden": {
         "condition": false,
-        "value": "databaseType.postgresql"
+        "value": "eq databaseType \"mariadb\""
       },
       "properties": {
         "enabled": {
@@ -163,7 +152,7 @@
       "title": "External Database Details",
       "description": "If MariaDB is disabled. Use this section to specify the external database details",
       "form": true,
-      "hidden": "mariadb.enabled and postgresql.enabled",
+      "hidden": "and mariadb.enabled postgresql.enabled",
       "properties": {
         "host": {
           "type": "string",

--- a/stable/redmine/values.schema.json
+++ b/stable/redmine/values.schema.json
@@ -63,12 +63,32 @@
             "condition": false,
             "value": "ingress.enabled"
           }
+        },
+        "tls": {
+          "type": "boolean",
+          "form": true,
+          "title": "Enable TLS configuration",
+          "hidden": {
+            "condition": false,
+            "value": "ingress.enabled"
+          }
+        },
+        "certManager": {
+          "type": "boolean",
+          "form": true,
+          "title": "Use cert-manager to auto-generate the TLS certificate",
+          "description": "Add the corresponding annotations for cert-manager to auto-generate the TLS certificate",
+          "hidden": {
+            "condition": false,
+            "value": "ingress.enabled"
+          }
         }
       }
     },
     "databaseType": {
       "type": "string",
       "form": true,
+      "enum": ["mariadb", "postgresql"],
       "title": "Database Type",
       "description": "Allowed values: \"mariadb\" and \"postgresql\""
     },
@@ -77,8 +97,8 @@
       "title": "MariaDB Details",
       "form": true,
       "hidden": {
-        "condition": false,
-        "value": "eq databaseType \"mariadb\""
+        "condition": "postgresql",
+        "value": "databaseType"
       },
       "properties": {
         "enabled": {
@@ -117,8 +137,8 @@
       "title": "PostgreSQL Details",
       "form": true,
       "hidden": {
-        "condition": false,
-        "value": "eq databaseType \"mariadb\""
+        "condition": "mariadb",
+        "value": "databaseType"
       },
       "properties": {
         "enabled": {
@@ -144,40 +164,6 @@
               "sliderUnit": "Gi"
             }
           }
-        }
-      }
-    },
-    "externalDatabase": {
-      "type": "object",
-      "title": "External Database Details",
-      "description": "If MariaDB is disabled. Use this section to specify the external database details",
-      "form": true,
-      "hidden": "and mariadb.enabled postgresql.enabled",
-      "properties": {
-        "host": {
-          "type": "string",
-          "form": true,
-          "title": "Database Host"
-        },
-        "user": {
-          "type": "string",
-          "form": true,
-          "title": "Database Username"
-        },
-        "password": {
-          "type": "string",
-          "form": true,
-          "title": "Database Password"
-        },
-        "database": {
-          "type": "string",
-          "form": true,
-          "title": "Database Name"
-        },
-        "port": {
-          "type": "integer",
-          "form": true,
-          "title": "Database Port"
         }
       }
     }

--- a/stable/redmine/values.schema.json
+++ b/stable/redmine/values.schema.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "redmineUsername": {
+      "type": "string",
+      "title": "Username",
+      "form": true
+    },
+    "redminePassword": {
+      "type": "string",
+      "title": "Password",
+      "form": true,
+      "description": "Defaults to a random 10-character alphanumeric string if not set"
+    },
+    "redmineEmail": {
+      "type": "string",
+      "title": "Admin email",
+      "form": true
+    },
+    "persistence": {
+      "type": "object",
+      "title": "Persistence for Redmine replicas",
+      "form": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "form": true,
+          "title": "Enable persistence",
+          "description": "Enable persistence using Persistent Volume Claims"
+        },
+        "size": {
+          "type": "string",
+          "title": "Persistent Volume Size",
+          "form": true,
+          "render": "slider",
+          "sliderMin": 1,
+          "sliderMax": 100,
+          "sliderUnit": "Gi",
+          "hidden": {
+            "condition": false,
+            "value": "persistence.enabled"
+          }
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "form": true,
+      "title": "Ingress Details",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "form": true,
+          "title": "Use a custom hostname",
+          "description": "Enable the ingress resource that allows you to access the Redmine installation."
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "hidden": {
+            "condition": false,
+            "value": "ingress.enabled"
+          }
+        }
+      }
+    },
+    "databaseType": {
+      "type": "object",
+      "form": true,
+      "title": "Database Type",
+      "properties": {
+        "mariadb": {
+          "type": "boolean",
+          "title": "Use MariaDB as database",
+          "form": true
+        },
+        "postgresql": {
+          "type": "boolean",
+          "title": "Use PostgreSQL as database",
+          "form": true
+        }
+      }
+    },
+    "mariadb": {
+      "type": "object",
+      "title": "MariaDB Details",
+      "form": true,
+      "hidden": {
+        "condition": false,
+        "value": "databaseType.mariadb"
+      },
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Use a new MariaDB database hosted in the cluster",
+          "form": true,
+          "description": "Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database switch this off and configure the external database details"
+        },
+        "master": {
+          "type": "object",
+          "properties": {
+            "persistence": {
+              "type": "object",
+              "properties": {
+                "size": {
+                  "type": "string",
+                  "title": "Volume Size",
+                  "form": true,
+                  "hidden": {
+                    "condition": false,
+                    "value": "mariadb.enabled"
+                  },
+                  "render": "slider",
+                  "sliderMin": 1,
+                  "sliderMax": 100,
+                  "sliderUnit": "Gi"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "postgresql": {
+      "type": "object",
+      "title": "PostgreSQL Details",
+      "form": true,
+      "hidden": {
+        "condition": false,
+        "value": "databaseType.postgresql"
+      },
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Use a new PostgreSQL database hosted in the cluster",
+          "form": true,
+          "description": "Whether to deploy a postgresql server to satisfy the applications database requirements. To use an external database switch this off and configure the external database details"
+        },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "size": {
+              "type": "string",
+              "title": "Volume Size",
+              "form": true,
+              "hidden": {
+                "condition": false,
+                "value": "postgresql.enabled"
+              },
+              "render": "slider",
+              "sliderMin": 1,
+              "sliderMax": 100,
+              "sliderUnit": "Gi"
+            }
+          }
+        }
+      }
+    },
+    "externalDatabase": {
+      "type": "object",
+      "title": "External Database Details",
+      "description": "If MariaDB is disabled. Use this section to specify the external database details",
+      "form": true,
+      "hidden": "mariadb.enabled and postgresql.enabled",
+      "properties": {
+        "host": {
+          "type": "string",
+          "form": true,
+          "title": "Database Host"
+        },
+        "user": {
+          "type": "string",
+          "form": true,
+          "title": "Database Username"
+        },
+        "password": {
+          "type": "string",
+          "form": true,
+          "title": "Database Password"
+        },
+        "database": {
+          "type": "string",
+          "form": true,
+          "title": "Database Name"
+        },
+        "port": {
+          "type": "integer",
+          "form": true,
+          "title": "Database Port"
+        }
+      }
+    }
+  }
+}

--- a/stable/redmine/values.yaml
+++ b/stable/redmine/values.yaml
@@ -223,30 +223,38 @@ ingress:
   ##
   hostname: redmine.local
 
-  ## Ingress annotations done as key:value pairs
-  ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ## Enable TLS configuration for the hostname defined at ingress.hostname parameter
+  ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.ingress.hostname }}
+  ## You can use the ingress.secrets parameter to create this TLS secret or relay on cert-manager to create it
   ##
-  ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+  tls: false
+
+  ## Ingress annotations done as key:value pairs
+  ## For a full list of possible ingress annotations,
+  ## please see https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ##
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
   ##
-  annotations: {}
-  #  kubernetes.io/ingress.class: nginx
+  annotations:
+    # kubernetes.io/ingress.class: nginx
+    ## Keep the connection open with the API server even if idle (the default is 60 seconds)
+    ## Setting it to 10 minutes which should be enough for our current use case of deploying/upgrading/deleting apps
+    ##
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
 
   ## The list of additional hostnames to be covered with this ingress record.
   ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
-  ## hosts:
+  ## extraHosts:
   ## - name: redmine.local
   ##   path: /
 
-  ## The tls configuration for the ingress
+  ## The tls configuration for additional hostnames to be covered with this ingress record.
   ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-  ## tls:
+  ## extraTls:
   ## - hosts:
   ##     - redmine.local
   ##   secretName: redmine.local-tls
 
-  secrets:
   ## If you're providing your own certificates, please use this to add the certificates as secrets
   ## key and certificate should start with -----BEGIN CERTIFICATE----- or
   ## -----BEGIN RSA PRIVATE KEY-----
@@ -256,9 +264,25 @@ ingress:
   ##
   ## It is also possible to create and manage the certificates outside of this helm chart
   ## Please see README.md for more information
-  # - name: redmine.local-tls
-  #   key:
-  #   certificate:
+  ##
+  secrets: []
+  ## - name: redmine.local-tls
+  ##   key:
+  ##   certificate:
+
+  ## DEPRECATED: to be removed on 3.0.0
+  ## The list of hostnames to be covered with this ingress record.
+  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
+  ##
+  hosts:
+    - name: redmine.local
+      path: /
+      ## Set this to true in order to enable TLS on the ingress record
+      ##
+      tls: false
+      ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+      ##
+      tlsSecret: redmine.local-tls
 
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/

--- a/stable/redmine/values.yaml
+++ b/stable/redmine/values.yaml
@@ -270,20 +270,6 @@ ingress:
   ##   key:
   ##   certificate:
 
-  ## DEPRECATED: to be removed on 3.0.0
-  ## The list of hostnames to be covered with this ingress record.
-  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
-  ##
-  hosts:
-    - name: redmine.local
-      path: /
-      ## Set this to true in order to enable TLS on the ingress record
-      ##
-      tls: false
-      ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
-      ##
-      tlsSecret: redmine.local-tls
-
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##

--- a/stable/redmine/values.yaml
+++ b/stable/redmine/values.yaml
@@ -75,12 +75,10 @@ redmineLanguage: en
 #   - name: NAMI_DEBUG
 #     value: --log-level trace
 
-## Database configuration. Please note that only one of the following databases should be selected.
+## Database type. Allowed values: "mariadb" and "postgresql"
 ## ref: https://github.com/bitnami/bitnami-docker-redmine#run-the-application-using-postgresql-database
 ##
-databaseType:
-  mariadb: true
-  postgresql: false
+databaseType: mariadb
 
 ##
 ## MariaDB chart configuration

--- a/stable/redmine/values.yaml
+++ b/stable/redmine/values.yaml
@@ -165,8 +165,8 @@ postgresql:
     size: 8Gi
 
 ## All of these values are only used when:
-## a) mariadb.enabled is set to false and databaseType.mariadb is set to true
-## b) postgresql.enabled is set to false and databaseType.postgresql is set to true
+## a) mariadb.enabled is set to false and databaseType=mariadb
+## b) postgresql.enabled is set to false and databaseType=postgresql
 externalDatabase:
   ## Database host
   host: localhost

--- a/stable/redmine/values.yaml
+++ b/stable/redmine/values.yaml
@@ -214,30 +214,53 @@ service:
 ##
 ingress:
   ## Set to true to enable ingress record generation
+  ##
   enabled: false
 
-  ## The list of hostnames to be covered with this ingress record.
-  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
-  hosts:
-  - name: redmine.local
+  ## Set this to true in order to add the corresponding annotations for cert-manager
+  ##
+  certManager: false
 
-    ## Set this to true in order to enable TLS on the ingress record
-    ## A side effect of this will be that the backend redmine service will be connected at port 443
-    tls: false
+  ## When the ingress is enabled, a host pointing to this will be created
+  ##
+  hostname: redmine.local
 
-    ## Set this to true in order to add the corresponding annotations for cert-manager
-    certManager: false
+  ## Ingress annotations done as key:value pairs
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ##
+  ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+  ##
+  annotations: {}
+  #  kubernetes.io/ingress.class: nginx
 
-    ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
-    tlsSecret: redmine.local-tls
+  ## The list of additional hostnames to be covered with this ingress record.
+  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+  ## hosts:
+  ## - name: redmine.local
+  ##   path: /
 
-    ## Ingress annotations done as key:value pairs
-    ## For a full list of possible ingress annotations, please see
-    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
-    ##
-    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
-    annotations:
-    #  kubernetes.io/ingress.class: nginx
+  ## The tls configuration for the ingress
+  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## tls:
+  ## - hosts:
+  ##     - redmine.local
+  ##   secretName: redmine.local-tls
+
+  secrets:
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
+  ##
+  ## name should line up with a tlsSecret set further up
+  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+  ##
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  # - name: redmine.local-tls
+  #   key:
+  #   certificate:
 
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### Is this a new chart

No

**Description of the change**

This PR includes a basic JSON schema for the Redmine chart. It doesn't cover all the possible values of the chart but just the ones that, in my opinion, are more likely to be modified.

This is valid for Helm 3 to validate some values and, at the same time, for Kubeapps to render a simple form so the chart containing it is easier to configure and deploy. See https://github.com/kubeapps/kubeapps/blob/master/docs/developer/basic-form-support.md for more information.

This is an example of the file rendered by Kubeapps:

![Screenshot 2019-12-02 at 13 50 51](https://user-images.githubusercontent.com/6740773/69960996-1b982200-150b-11ea-92f5-89e1400231d1.png)

This PR also standardizes the way we configure Ingress.

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)