### PR TITLE
[stable/minio] add PodDisruptionBudget

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: MinIO is a high performance distributed object storage server, designed for large-scale private cloud infrastructure.
 name: minio
-version: 3.0.2
+version: 3.0.3
 appVersion: RELEASE.2019-08-07T01-59-21Z
 keywords:
 - storage

--- a/stable/minio/templates/poddisruptionbudget.yaml
+++ b/stable/minio/templates/poddisruptionbudget.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: minio
+  labels:
+    app: {{ template "minio.name" . }}
+spec:
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      app: {{ template "minio.name" . }}
+{{- end }}

--- a/stable/minio/templates/post-install-create-bucket-job.yaml
+++ b/stable/minio/templates/post-install-create-bucket-job.yaml
@@ -4,7 +4,7 @@ kind: Job
 metadata:
   name: {{ template "minio.fullname" . }}-make-bucket-job
   labels:
-    app: {{ template "minio.name" . }}
+    app: {{ template "minio.name" . }}-make-bucket-job
     chart: {{ template "minio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/stable/minio/values.yaml
+++ b/stable/minio/values.yaml
@@ -265,6 +265,13 @@ networkPolicy:
   enabled: false
   allowExternal: true
 
+## PodDisruptionBudget settings
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+##
+podDisruptionBudget:
+  enabled: false
+  maxUnavailable: 1
+
 ## Specify the service account to use for the Minio pods. If 'create' is set to 'false'
 ## and 'name' is left unspecified, the account 'default' will be used.
 serviceAccount:


### PR DESCRIPTION
#### What this PR does / why we need it:
* add configurable PDB for minio
* change label for post-install-create-bucket-job because
  until https://github.com/kubernetes/kubernetes/pull/85553 is merged,
  PDB will also detect the minio-create-bucket-job and
  PDB won't work correctly (https://github.com/kubernetes/kubernetes/issues/77383)


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
