### PR TITLE
[stable/rabbitmq] Add NetworkPolicy simple support.

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.13.1
+version: 6.14.0
 appVersion: 3.8.2
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -119,10 +119,10 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `replicas`                                   | Replica count                                    | `1`                                                     |
 | `priorityClassName`                          | Pod priority class name                          | ``                                                      |
 | `networkPolicy.enabled`                      | Enable NetworkPolicy                             | `false`                                                 |
-| `networkPolicy.allowExternal`                | Don't require client label for connections       | `s`                                                  |
+| `networkPolicy.allowExternal`                | Don't require client label for connections       | `true`                                                  |
 | `networkPolicy.additionalRules`              | Additional NetworkPolicy rules                   | `nil`                                                   |
 | `nodeSelector`                               | Node labels for pod assignment                   | {}                                                      |
-| `affinity`                                    | Affinity settings for pod assignment              | {}                                                      |
+| `affinity`                                   | Affinity settings for pod assignment             | {}                                                      |
 | `tolerations`                                | Toleration labels for pod assignment             | []                                                      |
 | `updateStrategy`                             | Statefulset update strategy policy               | `RollingUpdate`                                         |
 | `ingress.enabled`                            | Enable ingress resource for Management console   | `false`                                                 |

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -118,8 +118,11 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `resources`                                  | resource needs and limits to apply to the pod    | {}                                                      |
 | `replicas`                                   | Replica count                                    | `1`                                                     |
 | `priorityClassName`                          | Pod priority class name                          | ``                                                      |
+| `networkPolicy.enabled`                      | Enable NetworkPolicy                             | `false`                                                 |
+| `networkPolicy.allowExternal`                | Don't require client label for connections       | `s`                                                  |
+| `networkPolicy.additionalRules`              | Additional NetworkPolicy rules                   | `nil`                                                   |
 | `nodeSelector`                               | Node labels for pod assignment                   | {}                                                      |
-| `affinity`                                   | Affinity settings for pod assignment             | {}                                                      |
+| `affinity`                                    | Affinity settings for pod assignment              | {}                                                      |
 | `tolerations`                                | Toleration labels for pod assignment             | []                                                      |
 | `updateStrategy`                             | Statefulset update strategy policy               | `RollingUpdate`                                         |
 | `ingress.enabled`                            | Enable ingress resource for Management console   | `false`                                                 |

--- a/stable/rabbitmq/ci/default-values.yaml
+++ b/stable/rabbitmq/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# Leave this file empty to ensure that CI runs builds against the default configuration in values.yaml.

--- a/stable/rabbitmq/ci/networkpolicy-values.yaml
+++ b/stable/rabbitmq/ci/networkpolicy-values.yaml
@@ -1,0 +1,11 @@
+networkPolicy:
+  enable: true
+  allowExternal: false
+  additionalRules:
+    - matchLabels:
+      - role: foo
+    - matchExpressions:
+      - key: role
+        operator: In
+        values:
+          - bar

--- a/stable/rabbitmq/templates/networkpolicy.yaml
+++ b/stable/rabbitmq/templates/networkpolicy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.networkPolicy.enabled }}
 kind: NetworkPolicy
-apiVersion: {{ template "rabbitmq.networkPolicy.apiVersion" . }}
+apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ template "rabbitmq.fullname" . }}
   labels:
@@ -16,9 +16,8 @@ spec:
   ingress:
     # Allow inbound connections
 
-    # EPMD
     - ports:
-        - port: 4369
+        - port: 4369  # EPMD
         - port: {{ .Values.service.port }}
         - port: {{ .Values.service.tlsPort }}
         - port: {{ .Values.service.distPort }}

--- a/stable/rabbitmq/templates/networkpolicy.yaml
+++ b/stable/rabbitmq/templates/networkpolicy.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ template "rabbitmq.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ template "rabbitmq.fullname" . }}
+  labels:
+    app: {{ template "rabbitmq.name" . }}
+    chart: {{ template "rabbitmq.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "rabbitmq.name" . }}
+      release: {{ .Release.Name | quote }}
+  ingress:
+    # Allow inbound connections
+
+    # EPMD
+    - ports:
+        - port: 4369
+        - port: {{ .Values.service.port }}
+        - port: {{ .Values.service.tlsPort }}
+        - port: {{ .Values.service.distPort }}
+        - port: {{ .Values.service.managerPort }}
+
+      {{- if not .Values.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels:
+              {{ template "rabbitmq.fullname" . }}-client: "true"
+        {{- with .Values.networkPolicy.additionalRules }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
+      {{- end }}
+
+    # Allow prometheus scrapes
+    - ports:
+        - port: {{ .Values.metrics.port }}
+{{- end }}

--- a/stable/rabbitmq/values-production.yaml
+++ b/stable/rabbitmq/values-production.yaml
@@ -265,6 +265,31 @@ resources:
     memory: 256Mi
     cpu: 100m
 
+
+networkPolicy:
+  ## Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+  ##
+  enabled: false
+
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## client label will have network access to the port RabbitMQ is listening
+  ## on. When true, RabbitMQ will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  allowExternal: true
+
+  ## Additional NetworkPolicy Ingress "from" rules to set. Note that all rules are OR-ed.
+  ##
+  # additionalRules:
+  #  - matchLabels:
+  #    - role: frontend
+  #  - matchExpressions:
+  #    - key: role
+  #      operator: In
+  #      values:
+  #        - frontend
+
 ## Replica count, set to 3 to provide a default available cluster
 replicas: 3
 

--- a/stable/rabbitmq/values-production.yaml
+++ b/stable/rabbitmq/values-production.yaml
@@ -265,7 +265,6 @@ resources:
     memory: 256Mi
     cpu: 100m
 
-
 networkPolicy:
   ## Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -262,6 +262,30 @@ persistence:
 ##
 resources: {}
 
+networkPolicy:
+  ## Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+  ##
+  enabled: false
+
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## client label will have network access to the ports RabbitMQ is listening
+  ## on. When true, RabbitMQ will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  allowExternal: true
+
+  ## Additional NetworkPolicy Ingress "from" rules to set. Note that all rules are OR-ed.
+  ##
+  # additionalRules:
+  #  - matchLabels:
+  #    - role: frontend
+  #  - matchExpressions:
+  #    - key: role
+  #      operator: In
+  #      values:
+  #        - frontend
+
 ## Replica count, set to 1 to provide a default available cluster
 replicas: 1
 


### PR DESCRIPTION
#### Special notes for your reviewer:

By default, only a single rule for all ports. This may be too permissive, but it is a start.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
