### PR TITLE
[stable/prometheus-cloudwatch-exporter] remove api caps check for ServiceMonitor creation

### DIFF
--- a/stable/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/stable/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.6.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.5.0
+version: 0.5.1
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/stable/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.serviceMonitor.enabled ) }}
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
The ServiceMonitor does not get created in my cluster, even though the API version `monitoring.coreos.com/v1` exists. I still have to investigate the reason why the check with `.Capabilities.APIVersions.Has` does not work.

However I think that this check is redundant, there is already a helm property `serviceMonitor.enabled` which must be enabled by the user explicitly. In case the API version is not supported in the cluster, I would rather like to see an error message when installing the chart, instead of not having the ServiceMonitor created without any warnings.

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
