### PR TITLE
[stable/graylog] Remove privileged initContainer mode; update Graylog version

### DIFF
--- a/stable/graylog/Chart.yaml
+++ b/stable/graylog/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: graylog
 home: https://www.graylog.org
-version: 1.3.10
-appVersion: 3.1.2-1
+version: 1.4.0
+appVersion: 3.1
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:
 - graylog

--- a/stable/graylog/README.md
+++ b/stable/graylog/README.md
@@ -98,7 +98,7 @@ The following table lists the configurable parameters of the Graylog chart and t
 
 | Parameter                               | Description                                                                                                                                           | Default                               |
 |-----------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
-| `graylog.image.repository`              | `graylog` image repository   | `graylog/graylog:3.1.2-1`                 |
+| `graylog.image.repository`              | `graylog` image repository   | `graylog/graylog:3.1`                 |
 | `graylog.imagePullPolicy`               | Image pull policy                                                                                                                                     | `IfNotPresent`                        |
 | `graylog.replicas`                      | The number of Graylog instances in the cluster. The chart will automatic create assign master to one of replicas                                      | `2`                                   |
 | `graylog.resources`                     | CPU/Memory resource requests/limits                                                                                                                   | Memory: `1024Mi`, CPU: `500m`         |

--- a/stable/graylog/templates/NOTES.txt
+++ b/stable/graylog/templates/NOTES.txt
@@ -5,18 +5,18 @@ To connect to your Graylog server:
 {{- range .Values.graylog.ingress.hosts }}
   http://{{ . }}
 {{- end }}
-{{- else if contains "NodePort" .Values.graylog.service.type }}
+{{- else if eq "NodePort" .Values.graylog.service.type }}
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "graylog.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.graylog.service.type }}
+{{- else if eq "LoadBalancer" .Values.graylog.service.type }}
 
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get svc -w {{ template "graylog.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "graylog.fullname" . }}-web -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ default 9000 .Values.graylog.service.port }}
-{{- else if contains "ClusterIP" .Values.graylog.service.type }}
+{{- else if eq "ClusterIP" .Values.graylog.service.type }}
 
   Graylog Web Interface uses JavaScript to get detail of each node. The client JavaScript cannot communicate to node when service type is `ClusterIP`. 
   If you want to access Graylog Web Interface, you need to enable Ingress.
@@ -36,11 +36,11 @@ To send logs to graylog:
 {{- if .Values.graylog.input.tcp }}
 1. TCP
 
-{{- if contains "NodePort" .Values.graylog.input.tcp.service.type }}
+{{- if eq "NodePort" .Values.graylog.input.tcp.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "graylog.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo $NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.graylog.input.tcp.service.type }}
+{{- else if eq "LoadBalancer" .Values.graylog.input.tcp.service.type }}
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "graylog.fullname" . }}-tcp -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   {{- range .Values.graylog.input.tcp.ports }}
   echo "{{ .name }} on $SERVICE_IP:{{ .port }}"
@@ -49,7 +49,7 @@ To send logs to graylog:
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get svc -w {{ template "graylog.fullname" . }}-tcp'
 
-{{- else if contains "ClusterIP" .Values.graylog.input.tcp.service.type }}
+{{- else if eq "ClusterIP" .Values.graylog.input.tcp.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "graylog.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   {{- range .Values.graylog.input.tcp.ports }}
   Run the command
@@ -61,11 +61,11 @@ To send logs to graylog:
 {{- if .Values.graylog.input.udp }}
 2. UDP
 
-{{- if contains "NodePort" .Values.graylog.input.udp.service.type }}
+{{- if eq "NodePort" .Values.graylog.input.udp.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "graylog.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo $NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.graylog.input.udp.service.type }}
+{{- else if eq "LoadBalancer" .Values.graylog.input.udp.service.type }}
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "graylog.fullname" . }}-udp -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   {{- range .Values.graylog.input.udp.ports }}
   echo "{{ .name }} on $SERVICE_IP:{{ .port }}"
@@ -74,7 +74,7 @@ To send logs to graylog:
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get svc -w {{ template "graylog.fullname" . }}-udp'
 
-{{- else if contains "ClusterIP" .Values.graylog.input.udp.service.type }}
+{{- else if eq "ClusterIP" .Values.graylog.input.udp.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "graylog.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   {{- range .Values.graylog.input.udp.ports }}
   Run the command

--- a/stable/graylog/templates/job.yaml
+++ b/stable/graylog/templates/job.yaml
@@ -21,8 +21,13 @@ spec:
     spec:
       containers:
       - name: {{ template "graylog.fullname" . }}-provisioner-job
-        image: alpine:latest
-        command: ["/bin/sh"]
+        image: "alpine"
+        imagePullPolicy: "IfNotPresent"
+        command:
+          - /bin/sh
+          - -c
+          - |
+            apk update && apk add --no-cache curl bash && bash /configmap/script.sh
         env:
           - name: GRAYLOG_PASSWORD_SECRET
             valueFrom:
@@ -30,10 +35,6 @@ spec:
                 name: {{ .Values.existingRootSecret | default (include "graylog.fullname" .) }}
 
                 key: graylog-password-secret
-        args:
-          - -c
-          - |
-            apk update && apk add --no-cache curl bash && bash /configmap/script.sh
         volumeMounts:
           - name: configmap
             mountPath: /configmap

--- a/stable/graylog/templates/master-service.yaml
+++ b/stable/graylog/templates/master-service.yaml
@@ -23,7 +23,7 @@ spec:
 {{- end }}
       protocol: TCP
       targetPort: 9000
-{{- if contains "NodePort" .Values.graylog.service.type }}
+{{- if eq "NodePort" .Values.graylog.service.type }}
   {{- if .Values.graylog.service.nodePort }}
       nodePort:  {{ .Values.graylog.service.nodePort }}
   {{- end }}

--- a/stable/graylog/templates/statefulset.yaml
+++ b/stable/graylog/templates/statefulset.yaml
@@ -16,7 +16,7 @@ spec:
       app.kubernetes.io/name: {{ template "graylog.name" . }}
       app.kubernetes.io/instance: "{{ .Release.Name }}"
       app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-  updateStrategy: 
+  updateStrategy:
     type: {{ .Values.graylog.updateStrategy }}
   template:
     metadata:
@@ -53,8 +53,8 @@ spec:
 {{- end }}
       initContainers:
         - name: "setup"
-          image: "busybox"
-          imagePullPolicy: IfNotPresent
+          image: "alpine"
+          imagePullPolicy: "IfNotPresent"
           # Graylog journal will recursive in every subdirectories. Any invalid format directories will cause errors
           command:
             - /bin/sh
@@ -72,12 +72,10 @@ spec:
               GRAYLOG_HOME=/usr/share/graylog
               chown -R 1100:1100 ${GRAYLOG_HOME}/data/
           env:
-            {{- range $key, $value :=  .Values.graylog.init.env }}
+            {{- range $key, $value := .Values.graylog.init.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-          securityContext:
-            privileged: true
           volumeMounts:
             - name: journal
               mountPath: /usr/share/graylog/data/journal
@@ -111,7 +109,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.existingRootSecret | default (include "graylog.fullname" .) }}
                   key: graylog-password-sha2
-            {{- range $key, $value :=  .Values.graylog.env }}
+            {{- range $key, $value := .Values.graylog.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
@@ -175,8 +173,7 @@ spec:
                   - bash
                   - -ec
                   - |
-                      ROOT_PASSWORD=`/k8s/kubectl get secret {{ template "graylog.fullname" . }} -o "jsonpath={.data['graylog-password-secret']}" | base64 -d`
-                      curl -XPOST -sS -u "{{ .Values.graylog.rootUsername }}:${ROOT_PASSWORD}" -H "X-Requested-By: {{ template "graylog.fullname" . }}" "localhost:9000/api/system/shutdown/shutdown"
+                    curl -XPOST -sS -u "{{ .Values.graylog.rootUsername }}:${GRAYLOG_PASSWORD_SECRET}" -H "X-Requested-By: {{ template "graylog.fullname" . }}" "localhost:9000/api/system/shutdown/shutdown"
       terminationGracePeriodSeconds: {{ default 30 .Values.graylog.terminationGracePeriodSeconds }}
       volumes:
         - name: config

--- a/stable/graylog/templates/tcp-service.yaml
+++ b/stable/graylog/templates/tcp-service.yaml
@@ -21,7 +21,7 @@ spec:
       port: {{ .port }}
       protocol: TCP
       targetPort: {{ .port }}
-    {{- if contains "NodePort" $.Values.graylog.input.tcp.service.type }}
+    {{- if eq "NodePort" $.Values.graylog.input.tcp.service.type }}
       {{- if .nodePort }}
       nodePort:  {{ .nodePort }}
       {{- end }}

--- a/stable/graylog/templates/udp-service.yaml
+++ b/stable/graylog/templates/udp-service.yaml
@@ -21,7 +21,7 @@ spec:
       port: {{ .port }}
       protocol: UDP
       targetPort: {{ .port }}
-    {{- if contains "NodePort" $.Values.graylog.input.udp.service.type }}
+    {{- if eq "NodePort" $.Values.graylog.input.udp.service.type }}
       {{- if .nodePort }}
       nodePort:  {{ .nodePort }}
       {{- end }}

--- a/stable/graylog/templates/web-service.yaml
+++ b/stable/graylog/templates/web-service.yaml
@@ -19,7 +19,7 @@ spec:
       port: {{ default 9000 .Values.graylog.service.port }}
       protocol: TCP
       targetPort: 9000
-{{- if contains "NodePort" .Values.graylog.service.type }}
+{{- if eq "NodePort" .Values.graylog.service.type }}
   {{- if .Values.graylog.service.nodePort }}
       nodePort:  {{ .Values.graylog.service.nodePort }}
   {{- end }}

--- a/stable/graylog/values.yaml
+++ b/stable/graylog/values.yaml
@@ -30,8 +30,7 @@ graylog:
   ## Make sure you strict with the `x` version of Graylog where `x` is ${version}-${x}
   ##
   image:
-    # repository: "graylog/graylog:2.5.1-3"
-    repository: "graylog/graylog:3.1.2-1"
+    repository: "graylog/graylog:3.1"
     pullPolicy: "IfNotPresent"
 
   ## Number of Graylog instance


### PR DESCRIPTION
#### What this PR does / why we need it:

Removed unnecessary privileged mode for init container. Updated Graylog to the latest 3.1 version. Changed init container image from busybox to alpine as alpine supports http(s)_proxy variables (install behind proxy server). Removed kubectl in preStop hook as we already have root password in environment variable and can execute curl without kubectl support.

My goal is to completely remove need for kubectl as Graylog knows how to setup master node without it.

https://docs.graylog.org/en/3.1/pages/installation/docker.html#kubernetes-automatic-master-selection

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
