### PR TITLE
[stable/sonatype-nexus] Fix trailing white space trimming in service template

### DIFF
--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 1.21.0
+version: 1.21.1
 appVersion: 3.17.0-01
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/templates/service.yaml
+++ b/stable/sonatype-nexus/templates/service.yaml
@@ -25,7 +25,7 @@ spec:
   {{- end }}
   {{- with .Values.service.ports  }}
 {{ toYaml . | indent 2 }}
-  {{- end -}}
+  {{- end }}
   selector:
     app: {{ template "nexus.name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
#### Is this a new chart
no

#### What this PR does / why we need it:
templates/service.yaml is not rendered correctly (can be tested by setting `service.enabled: true`), because a trailing white space trimming pulls the following line into the wrong context. Helm bails out with:
```Error: YAML parse error on sonatype-nexus/templates/service.yaml: error converting YAML to JSON: yaml: line 18: mapping values are not allowed in this context```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
