### PR TITLE
[stable/external-dns] Add ServiceMonitor object

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.11.0
+version: 2.12.0
 appVersion: 0.5.17
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -158,7 +158,10 @@ The following table lists the configurable parameters of the external-dns chart 
 | `livenessProbe`                     | Deployment Liveness Probe                                                                                | See `values.yaml`                                           |
 | `readinessProbe`                    | Deployment Readiness Probe                                                                               | See `values.yaml`                                           |
 | `metrics.enabled`                   | Enable prometheus to access external-dns metrics endpoint                                                | `false`                                                     |
-| `metrics.podAnnotations`            | Annotations for enabling prometheus to access the metrics endpoint                                       | {`prometheus.io/scrape: "true",prometheus.io/port: "7979"`} |
+| `metrics.podAnnotations`            | Annotations for enabling prometheus to access the metrics endpoint                                       |                                          |
+| `metrics.serviceMonitor.enabled`            | Create ServiceMonitor object                                                                     | `false`                                                     |
+| `metrics.serviceMonitor.additionalLabels`            | Additional labels for ServiceMonitor object                                             | `{}`                                                     |
+| `metrics.serviceMonitor.pollInterval`                | Poll interval set in ServiceMonitor object                                              | `30s`                                                     |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -159,9 +159,10 @@ The following table lists the configurable parameters of the external-dns chart 
 | `readinessProbe`                    | Deployment Readiness Probe                                                                               | See `values.yaml`                                           |
 | `metrics.enabled`                   | Enable prometheus to access external-dns metrics endpoint                                                | `false`                                                     |
 | `metrics.podAnnotations`            | Annotations for enabling prometheus to access the metrics endpoint                                       |                                          |
-| `metrics.serviceMonitor.enabled`            | Create ServiceMonitor object                                                                     | `false`                                                     |
-| `metrics.serviceMonitor.additionalLabels`            | Additional labels for ServiceMonitor object                                             | `{}`                                                     |
-| `metrics.serviceMonitor.pollInterval`                | Poll interval set in ServiceMonitor object                                              | `30s`                                                     |
+| `metrics.serviceMonitor.enabled`    | Create ServiceMonitor object                                                                             | `false`                                                     |
+| `metrics.serviceMonitor.selector`   | Additional labels for ServiceMonitor object                                                              | `{}`                                                     |
+| `metrics.serviceMonitor.interval`   | Interval at which metrics should be scraped                                                              | `30s`                                                     |
+| `metrics.serviceMonitor.scrapeTimeout`   | Timeout after which the scrape is ended                                                             | `30s`                                                     |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/external-dns/templates/servicemonitor.yaml
+++ b/stable/external-dns/templates/servicemonitor.yaml
@@ -3,15 +3,23 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "external-dns.fullname" . }}
+  {{- with .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ . }}
+  {{- end }}
   labels: {{ include "external-dns.labels" . | nindent 4 }}
-    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
-    {{ toYaml .Values.metrics.serviceMonitor.additionalLabels | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.selector }}
+    {{ toYaml . | nindent 4 }}
     {{- end }}
 spec:
   endpoints:
     - port: http
       path: /metrics
-      interval: {{ .Values.metrics.serviceMonitor.pollInterval }}
+      {{- with .Values.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/stable/external-dns/templates/servicemonitor.yaml
+++ b/stable/external-dns/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "external-dns.fullname" . }}
+  labels: {{ include "external-dns.labels" . | nindent 4 }}
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
+    {{ toYaml .Values.metrics.serviceMonitor.additionalLabels | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.metrics.serviceMonitor.pollInterval }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels: {{ include "external-dns.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/stable/external-dns/values-production.yaml
+++ b/stable/external-dns/values-production.yaml
@@ -422,3 +422,30 @@ metrics:
   enabled: true
   ## Metrics exporter pod Annotation and Labels
   ##
+  # podAnnotations:
+  #   prometheus.io/scrape: "true"
+  #   prometheus.io/port: "7979"
+
+  ## Prometheus Operator ServiceMonitor configuration
+  ##
+  serviceMonitor:
+    enabled: false
+    ## Namespace in which Prometheus is running
+    ##
+    # namespace: monitoring
+
+    ## Interval at which metrics should be scraped.
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    # interval: 10s
+
+    ## Timeout after which the scrape is ended
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    # scrapeTimeout: 10s
+
+    ## ServiceMonitor selector labels
+    ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
+    ##
+    # selector:
+    #   prometheus: my-prometheus

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -421,7 +421,30 @@ metrics:
   enabled: false
   ## Metrics exporter pod Annotation and Labels
   ##
+  # podAnnotations:
+  #   prometheus.io/scrape: "true"
+  #   prometheus.io/port: "7979"
+
+  ## Prometheus Operator ServiceMonitor configuration
+  ##
   serviceMonitor:
     enabled: false
-    additionalLabels: {}
-    pollInterval: 30s
+    ## Namespace in which Prometheus is running
+    ##
+    # namespace: monitoring
+
+    ## Interval at which metrics should be scraped.
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    # interval: 10s
+
+    ## Timeout after which the scrape is ended
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    # scrapeTimeout: 10s
+
+    ## ServiceMonitor selector labels
+    ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
+    ##
+    # selector:
+    #   prometheus: my-prometheus

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -421,3 +421,7 @@ metrics:
   enabled: false
   ## Metrics exporter pod Annotation and Labels
   ##
+  serviceMonitor:
+    enabled: false
+    additionalLabels: {}
+    pollInterval: 30s


### PR DESCRIPTION
Signed-off-by: Rostyslav Sotnychenko <me@sota.sh>

#### What this PR does / why we need it:

#### Which issue this PR fixes
`ServiceMonitor` is an object from Prometheus Operator used to monitor your apps instead of annotations.

#### Special notes for your reviewer:
I've update default value of `metrics.podAnnotations` to match the actual behavior.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
