### PR TITLE
[stable/mariadb] Fix JSON schema

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb
-version: 7.2.0
+version: 7.2.1
 appVersion: 10.3.20
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -81,7 +81,7 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `existingSecret`                          | Use existing secret for password details (`rootUser.password`, `db.password`, `replication.password` will be ignored and picked up from this secret). The secret has to contain the keys `mariadb-root-password`, `mariadb-replication-password` and `mariadb-password`. | `nil`                        |
 | `rootUser.password`                       | Password for the `root` user. Ignored if existing secret is provided. | _random 10 character alphanumeric string_       |
 | `rootUser.forcePassword`                  | Force users to specify a password                   | `false`                                                           |
-| `db.user`                                 | Username of new user to create                      | `nil`                                                             |
+| `db.user`                                 | Username of new user to create                      | `""`                                                             |
 | `db.password`                             | Password for the new user. Ignored if existing secret is provided.    | _random 10 character alphanumeric string if `db.user` is defined_ |
 | `db.forcePassword`                        | Force users to specify a password                   | `false`                                                           |
 | `db.name`                                 | Name for new database to create                     | `my_database`                                                     |

--- a/stable/mariadb/templates/master-statefulset.yaml
+++ b/stable/mariadb/templates/master-statefulset.yaml
@@ -116,7 +116,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "mariadb.secretName" . }}
                   key: mariadb-root-password
-            {{- if .Values.db.user }}
+            {{- if not (empty .Values.db.user) }}
             - name: MARIADB_USER
               value: "{{ .Values.db.user }}"
             - name: MARIADB_PASSWORD

--- a/stable/mariadb/templates/secrets.yaml
+++ b/stable/mariadb/templates/secrets.yaml
@@ -10,15 +10,15 @@ metadata:
     heritage: {{ .Release.Service | quote }}
 type: Opaque
 data:
-  {{- if .Values.rootUser.password }}
+  {{- if not (empty .Values.rootUser.password) }}
   mariadb-root-password: "{{ .Values.rootUser.password | b64enc }}"
   {{- else if (not .Values.rootUser.forcePassword) }}
   mariadb-root-password: "{{ randAlphaNum 10 | b64enc }}"
   {{ else }}
   mariadb-root-password: {{ required "A MariaDB Root Password is required!" .Values.rootUser.password }}
   {{- end }}
-  {{- if .Values.db.user }}
-  {{- if .Values.db.password }}
+  {{- if not (empty .Values.db.user) }}
+  {{- if not (empty .Values.db.password) }}
   mariadb-password: "{{ .Values.db.password | b64enc }}"
   {{- else if (not .Values.db.forcePassword) }}
   mariadb-password: "{{ randAlphaNum 10 | b64enc }}"
@@ -27,7 +27,7 @@ data:
   {{- end }}
   {{- end }}
   {{- if .Values.replication.enabled }}
-  {{- if .Values.replication.password }}
+  {{- if not (empty .Values.replication.password) }}
   mariadb-replication-password: "{{ .Values.replication.password | b64enc }}"
   {{- else if (not .Values.replication.forcePassword) }}
   mariadb-replication-password: "{{ randAlphaNum 10 | b64enc }}"

--- a/stable/mariadb/values-production.yaml
+++ b/stable/mariadb/values-production.yaml
@@ -109,7 +109,7 @@ rootUser:
   ## MariaDB admin password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
   ##
-  password:
+  password: ""
   ##
   ## Option to force users to specify a password. That is required for 'helm upgrade' to work properly.
   ## If it is not force, a random password will be generated.
@@ -119,8 +119,8 @@ db:
   ## MariaDB username and password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb#creating-a-database-user-on-first-run
   ##
-  user:
-  password:
+  user: ""
+  password: ""
   ## Password is ignored if existingSecret is specified.
   ## Database to create
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb#creating-a-database-on-first-run
@@ -142,7 +142,7 @@ replication:
   ## MariaDB replication user password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-up-a-replication-cluster
   ##
-  password:
+  password: ""
   ## Password is ignored if existingSecret is specified.
   ##
   ## Option to force users to specify a password. That is required for 'helm upgrade' to work properly.

--- a/stable/mariadb/values-production.yaml
+++ b/stable/mariadb/values-production.yaml
@@ -19,7 +19,7 @@
 image:
   registry: docker.io
   repository: bitnami/mariadb
-  tag: 10.3.20-debian-9-r0
+  tag: 10.3.20-debian-9-r17
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -445,7 +445,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mysqld-exporter
-    tag: 0.12.1-debian-9-r96
+    tag: 0.12.1-debian-9-r121
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -109,7 +109,7 @@ rootUser:
   ## MariaDB admin password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
   ##
-  password:
+  password: ""
   ##
   ## Option to force users to specify a password. That is required for 'helm upgrade' to work properly.
   ## If it is not force, a random password will be generated.
@@ -119,8 +119,8 @@ db:
   ## MariaDB username and password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb#creating-a-database-user-on-first-run
   ##
-  user:
-  password:
+  user: ""
+  password: ""
   ## Password is ignored if existingSecret is specified.
   ## Database to create
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb#creating-a-database-on-first-run
@@ -142,7 +142,7 @@ replication:
   ## MariaDB replication user password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-up-a-replication-cluster
   ##
-  password:
+  password: ""
   ## Password is ignored if existingSecret is specified.
   ##
   ## Option to force users to specify a password. That is required for 'helm upgrade' to work properly.

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -19,7 +19,7 @@
 image:
   registry: docker.io
   repository: bitnami/mariadb
-  tag: 10.3.20-debian-9-r0
+  tag: 10.3.20-debian-9-r17
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -447,7 +447,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mysqld-exporter
-    tag: 0.12.1-debian-9-r96
+    tag: 0.12.1-debian-9-r121
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### Is this a new chart

No

#### What this PR does / why we need it:

This PR fixes the JSON schema by ensuring the credentials parameters are strings (even if they're empty). This way, the `helm3 lint`, `helm3 template` commands won't report any warning/error.

Previous error:

```
- db.user: Invalid type. Expected: string, given: null
- db.password: Invalid type. Expected: string, given: null
- rootUser.password: Invalid type. Expected: string, given: null
```

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
