### PR TITLE
[stable/drupal] Fix JSON schema

### DIFF
--- a/stable/drupal/Chart.yaml
+++ b/stable/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 6.1.0
+version: 6.1.1
 appVersion: 8.7.10
 description: One of the most versatile open source content management systems.
 keywords:

--- a/stable/drupal/requirements.lock
+++ b/stable/drupal/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 7.0.1
+  version: 7.2.0
 digest: sha256:cd64413a4a697ccf85c0091e9c55cdc5876938ddced84c05d37c57ff9abc5864
-generated: 2019-11-13T11:38:39.597624486Z
+generated: 2019-12-03T15:14:34.585879215Z

--- a/stable/drupal/values.yaml
+++ b/stable/drupal/values.yaml
@@ -60,21 +60,23 @@ drupalEmail: user@example.com
 ## ref: https://github.com/bitnami/bitnami-docker-drupal#environment-variables
 allowEmptyPassword: "yes"
 
-##
 ## External database configuration
 ##
 externalDatabase:
   ## Database host
-  # host:
+  host: localhost
+
+  ## Database host
+  port: 3306
 
   ## Database user
-  # user: bn_drupal
+  user: bn_drupal
 
   ## Database password
-  # password:
+  password: ""
 
   ## Database name
-  # database: bitnami_drupal
+  database: bitnami_drupal
 
 ##
 ## MariaDB chart configuration

--- a/stable/drupal/values.yaml
+++ b/stable/drupal/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/drupal
-  tag: 8.7.10-debian-9-r0
+  tag: 8.7.10-debian-9-r11
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -287,7 +287,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.7.0-debian-9-r109
+    tag: 0.7.0-debian-9-r129
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### Is this a new chart

No

#### What this PR does / why we need it:

This PR fixes the JSON schema by ensuring the 'externalDatabase' object exists. This way, the `helm3 lint`, `helm3 template` commands won't report any warning/error.

Previous error:

```
[ERROR] values.yaml: - externalDatabase: Invalid type. Expected: object, given: null
```

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
