### PR TITLE
[stable/redis] Fix JSON schema

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 10.2.0
+version: 10.2.1
 appVersion: 5.0.7
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/_helpers.tpl
+++ b/stable/redis/templates/_helpers.tpl
@@ -193,9 +193,9 @@ Get the password key to be retrieved from Redis secret.
 Return Redis password
 */}}
 {{- define "redis.password" -}}
-{{- if .Values.global.redis.password }}
+{{- if not (empty .Values.global.redis.password) }}
     {{- .Values.global.redis.password -}}
-{{- else if .Values.password -}}
+{{- else if not (empty .Values.password) -}}
     {{- .Values.password -}}
 {{- else -}}
     {{- randAlphaNum 10 -}}

--- a/stable/redis/values-production.yaml
+++ b/stable/redis/values-production.yaml
@@ -18,7 +18,7 @@ image:
   ## Bitnami Redis image tag
   ## ref: https://github.com/bitnami/bitnami-docker-redis#supported-tags-and-respective-dockerfile-links
   ##
-  tag: 5.0.7-debian-9-r0
+  tag: 5.0.7-debian-9-r12
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -60,7 +60,7 @@ sentinel:
     ## Bitnami Redis image tag
     ## ref: https://github.com/bitnami/bitnami-docker-redis-sentinel#supported-tags-and-respective-dockerfile-links
     ##
-    tag: 5.0.6-debian-9-r6
+    tag: 5.0.7-debian-9-r10
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -467,7 +467,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/redis-exporter
-    tag: 1.3.4-debian-9-r4
+    tag: 1.3.4-debian-9-r15
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -193,7 +193,7 @@ usePassword: true
 ## Defaults to a random 10-character alphanumeric string if not set and usePassword is true
 ## ref: https://github.com/bitnami/bitnami-docker-redis#setting-the-server-password-on-first-run
 ##
-password:
+password: ""
 ## Use existing secret (ignores previous password)
 # existingSecret:
 ## Password key to be retrieved from Redis secret

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -18,7 +18,7 @@ image:
   ## Bitnami Redis image tag
   ## ref: https://github.com/bitnami/bitnami-docker-redis#supported-tags-and-respective-dockerfile-links
   ##
-  tag: 5.0.7-debian-9-r0
+  tag: 5.0.7-debian-9-r12
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -60,7 +60,7 @@ sentinel:
     ## Bitnami Redis image tag
     ## ref: https://github.com/bitnami/bitnami-docker-redis-sentinel#supported-tags-and-respective-dockerfile-links
     ##
-    tag: 5.0.6-debian-9-r6
+    tag: 5.0.7-debian-9-r10
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -467,7 +467,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/redis-exporter
-    tag: 1.3.4-debian-9-r4
+    tag: 1.3.4-debian-9-r15
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### Is this a new chart

No

#### What this PR does / why we need it:

This PR fixes the JSON schema by ensuring the credentials parameters are strings (even if they're empty). This way, the `helm3 lint`, `helm3 template` commands won't report any warning/error.

Previous error:

```
==> Linting stable/redis
[ERROR] values.yaml: - password: Invalid type. Expected: string, given: null


Error: 1 chart(s) linted, 1 chart(s) failed
```

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
