### PR TITLE
[stable/redis-ha] Fix extraArgs option for redis-ha exporter

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.1.3
+version: 4.1.4
 appVersion: 5.0.5
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/stable/redis-ha/templates/redis-ha-statefulset.yaml
@@ -218,7 +218,7 @@ spec:
         image: "{{ .Values.exporter.image }}:{{ .Values.exporter.tag }}"
         imagePullPolicy: {{ .Values.exporter.pullPolicy }}
         args:
-        {{- range $key, $value := .Values.extraArgs }}
+        {{- range $key, $value := .Values.exporter.extraArgs }}
           - --{{ $key }}={{ $value }}
         {{- end }}
         env:


### PR DESCRIPTION
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

This PR will fix a typo in the redis-ha-statefulset template. 

As the documentation said, you can use the `exporter.extraArgs` option. In the chart template it used `Values.extraArgs` instead of `Values.exporter.extraArgs`.