### PR TITLE
[stable/cockroachdb] Fix statefulset resource templating

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 3.0.0
+version: 3.0.1
 appVersion: 19.2.1
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/templates/statefulset.yaml
+++ b/stable/cockroachdb/templates/statefulset.yaml
@@ -253,7 +253,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 2
         {{- with .Values.statefulset.resources }}
-          resources: {{- toYaml . | indent 12 }}
+          resources: {{- toYaml . | nindent 12 }}
         {{- end }}
       volumes:
         - name: datadir


### PR DESCRIPTION
An accidental use of `indent` instead of `nindent` caused us to not be able
to create statefulsets with resource requests or limits, due to a YAML
templating error.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
