### PR TITLE
[stable/velero] Update Velero to v1.2.0

### DIFF
--- a/stable/velero/Chart.yaml
+++ b/stable/velero/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.1.0
+appVersion: 1.2.0
 description: A Helm chart for velero
 name: velero
-version: 2.5.0
+version: 2.6.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/stable/velero/README.md
+++ b/stable/velero/README.md
@@ -1,8 +1,14 @@
 # Velero-server
 
-This helm chart installs Velero version v1.1.0
-https://github.com/vmware-tanzu/velero/tree/v1.1.0
+This helm chart installs Velero version v1.2.0
+https://github.com/vmware-tanzu/velero/tree/v1.120
 
+
+## Upgrading to v1.2.0
+
+As of v1.0.0, Velero is no longer backwards-compatible with Heptio Ark.
+
+The [instructions found here](https://velero.io/docs/v1.2.0/upgrade-to-1.2/) will assist you in upgrading from version v1.1.0 to v1.2.0
 
 ## Upgrading to v1.1.0
 
@@ -26,7 +32,7 @@ The [instructions found here](https://velero.io/docs/v0.11.0/migrating-to-velero
 
 ### Secret for cloud provider credentials
 Velero server needs an IAM service account in order to run, if you don't have it you must create it.
-Please follow the official documentation: https://velero.io/docs/v1.0.0/install-overview/
+Please follow the official documentation: https://velero.io/docs/v1.2.0/install-overview/
 
 Don't forget the step to create the secret
 ```
@@ -35,7 +41,7 @@ kubectl create secret generic cloud-credentials --namespace <VELERO_NAMESPACE> -
 
 ### Configuration
 Please change the values.yaml according to your setup
-See here for the official documentation https://velero.io/docs/v1.0.0/install-overview/
+See here for the official documentation https://velero.io/docs/v1.2.0/install-overview/
 
 #### Required Parameters
 Parameter | Description | Default | Required
@@ -56,8 +62,8 @@ Parameter | Description | Default | Required
 #### All Parameters
 Parameter | Description | Default
 --- | --- | ---
-`image.repository` | Image repository | `gcr.io/heptio-images/velero`
-`image.tag` | Image tag | `v1.0.0`
+`image.repository` | Image repository | `velero/velero`
+`image.tag` | Image tag | `v1.2.0`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `podAnnotations` | Annotations for the Velero server pod | `{}`
 `rbac.create` | If true, create and use RBAC resources | `true`

--- a/stable/velero/values.yaml
+++ b/stable/velero/values.yaml
@@ -5,8 +5,8 @@
 # Details of the container image to use in the Velero deployment & daemonset (if
 # enabling restic). Required.
 image:
-  repository: gcr.io/heptio-images/velero
-  tag: v1.1.0
+  repository: velero/velero
+  tag: v1.2.0
   pullPolicy: IfNotPresent
 
 # Annotations to add to the Velero deployment's pod template. Optional.


### PR DESCRIPTION
Signed-off-by: Clint Moyer <contact@clintmoyer.com>

#### Is this a new chart

Existing chart for Velero

#### What this PR does / why we need it:

Updates Velero to latest version 1.2.0 which represents fairly significant changes to the upstream project. Mainly the backend providers have been migrated to separate repositories (such as [velero-plugin-for-aws](https://github.com/vmware-tanzu/velero-plugin-for-aws)). Backends are now used as plugins to a generic API.

#### Checklist

- [x] DCO
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name
