### PR TITLE
[stable/verdaccio] Render clusterIP only if set

### DIFF
--- a/stable/verdaccio/Chart.yaml
+++ b/stable/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 0.7.2
+version: 0.7.3
 appVersion: 3.11.6
 home: http://www.verdaccio.org
 icon: https://raw.githubusercontent.com/verdaccio/verdaccio/master/assets/bitmap/logo/logo-twitter.png

--- a/stable/verdaccio/templates/service.yaml
+++ b/stable/verdaccio/templates/service.yaml
@@ -12,7 +12,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+{{- if .Values.service.clusterIP }}
   clusterIP: "{{ .Values.service.clusterIP }}"
+{{- end }}
 {{- if .Values.service.externalIPs }}
   externalIPs:
 {{ toYaml .Values.service.externalIPs | indent 4 }}


### PR DESCRIPTION
#### What this PR does / why we need it:
After deploying verdaccio with the default value for the clusterIP, the service fails to apply subsequent updates due to the field being immutable.
This can cause problems for automation (deployment tools i.e. kubectl exit with non-zero returncode).
It also prevents changes from being applied to the service when an existing verdaccio release is upgraded.

#### Special notes for your reviewer:
Hi @etiennetremel this should be a trivial change.
I deployed it in microk8s 1.16 and in Google Kubernetes Engine 1.12.
To deploy in 1.16 I had to edit the Deployment manifest to use apiVersion: apps/v1, which is an unrelated issue.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)