### PR TITLE
[stable/prometheus-operator] Service labels shall also be reflected on prometheus-operator

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.3.1
+version: 8.3.2
 appVersion: 0.34.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/templates/prometheus-operator/service.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/service.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
     app: {{ template "prometheus-operator.name" . }}-operator
 {{ include "prometheus-operator.labels" . | indent 4 }}
+{{- if .Values.prometheusOperator.service.labels }}
+{{ toYaml .Values.prometheusOperator.service.labels | indent 4 }}
+{{- end }}
 {{- if .Values.prometheusOperator.service.annotations }}
   annotations:
 {{ toYaml .Values.prometheusOperator.service.annotations | indent 4 }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Same as for #19102. Service labels from the `values.yaml` shall exist in the service template. In this case this was missing for the prometheus-operator template.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
