### PR TITLE
[stable/sentry]: adds extra AWS S3 variables used in configmap

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 3.1.5
+version: 3.1.6
 appVersion: 9.1.2
 keywords:
   - debugging

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -147,6 +147,9 @@ Parameter                                            | Description              
 `filestore.s3.secretKey`                             | S3 secret key                                                                                              | `nil`
 `filestore.s3.bucketName`                            | The name of the S3 bucket                                                                                  | `nil`
 `filestore.s3.endpointUrl`                           | The endpoint url of the S3 (using for "MinIO S3 Backend")                                                  | `nil`
+`filestore.s3.signature_version`                     | S3 signature version (optional)                                                                            | `nil`
+`filestore.s3.region_name`                           | S3 region name (optional)                                                                                  | `nil`
+`filestore.s3.default_acl`                           | S3 default acl (optional)                                                                                  | `nil`
 `config.configYml`                                   | Sentry config.yml file                                                                                     | ``
 `config.sentryConfPy`                                | Sentry sentry.conf.py file                                                                                 | ``
 `metrics.enabled`                                    | Start an exporter for sentry metrics                                                                       | `false`

--- a/stable/sentry/templates/configmap.yaml
+++ b/stable/sentry/templates/configmap.yaml
@@ -80,7 +80,9 @@ data:
       secret_key: '{{ .Values.filestore.s3.secretKey }}'
       bucket_name: '{{ .Values.filestore.s3.bucketName }}'
       endpoint_url: '{{ .Values.filestore.s3.endpointUrl }}'
-
+      signature_version: '{{ .Values.filestore.s3.signature_version }}'
+      region_name: '{{ .Values.filestore.s3.region_name }}'
+      default_acl: '{{ .Values.filestore.s3.default_acl }}'
     {{ end }}
 
 {{ .Values.config.configYml | indent 4 }}

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -161,6 +161,9 @@ filestore:
   #  secretKey:
   #  bucketName:
   #  endpointUrl:
+  #  signature_version:
+  #  region_name:
+  #  default_acl:
 
 ## Configure ingress resource that allow you to access the
 ## Sentry installation. Set up the URL


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds extra configmap variables, which are required to configure S3 bucket stored not in a default AWS region

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
