### PR TITLE
[stable/grafana] Fix syntax error in dashboards configmap

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 4.1.0
+version: 4.1.1
 appVersion: 6.5.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/dashboards-json-configmap.yaml
+++ b/stable/grafana/templates/dashboards-json-configmap.yaml
@@ -17,7 +17,7 @@ data:
 {{- $dashboardFound := false }}
 {{- range $key, $value := $dashboards }}
 {{- if (or (hasKey $value "json") (hasKey $value "file")) }}
-{{- $dashboardFound = true }}
+{{- $dashboardFound := true }}
 {{ print $key | indent 2 }}.json:
 {{- if hasKey $value "json" }}
     |-


### PR DESCRIPTION
Signed-off-by: Devin Young <devin@devinyoungweb.com>

#### Is this a new chart

No

#### What this PR does / why we need it:

This fixes a syntax error caused by commit 39723f2 resulting in `helm install` failing.

#### Which issue this PR fixes

  - fixes #18215

#### Special notes for your reviewer:

Maintainers to review:

- @zanhsieh 
- @rtluckie 
- @maorfr 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
