### PR TITLE
Incubator/jaeger/cassandra tls fix

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.15.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.15.0
+version: 0.15.1
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -277,6 +277,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `storage.cassandra.host`                 | Provisioned cassandra host          |  `cassandra`                             |
 | `storage.cassandra.password`             | Provisioned cassandra password  (ignored if storage.cassandra.existingSecret set)     |  `password`                              |
 | `storage.cassandra.port`                 | Provisioned cassandra port          |  `9042`                                  |
+| `storage.cassandra.tls`                  | Provisioned cassandra connection protocol |  `false`                           |
 | `storage.cassandra.usePassword`                 | Use password          |  `true`                                 |
 | `storage.cassandra.user`                 | Provisioned cassandra username      |  `user`                                  |
 | `storage.elasticsearch.existingSecret`                 | Name of existing password secret object (for password authentication)          |  `nil`                                 |

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -277,7 +277,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `storage.cassandra.host`                 | Provisioned cassandra host          |  `cassandra`                             |
 | `storage.cassandra.password`             | Provisioned cassandra password  (ignored if storage.cassandra.existingSecret set)     |  `password`                              |
 | `storage.cassandra.port`                 | Provisioned cassandra port          |  `9042`                                  |
-| `storage.cassandra.tls`                  | Provisioned cassandra connection protocol |  `false`                           |
+| `storage.cassandra.tls`                  | Provisioned cassandra connection protocol (false for non-TLS, true for TLS) |  `false`                           |
 | `storage.cassandra.usePassword`                 | Use password          |  `true`                                 |
 | `storage.cassandra.user`                 | Provisioned cassandra username      |  `user`                                  |
 | `storage.elasticsearch.existingSecret`                 | Name of existing password secret object (for password authentication)          |  `nil`                                 |

--- a/incubator/jaeger/templates/cassandra-schema-job.yaml
+++ b/incubator/jaeger/templates/cassandra-schema-job.yaml
@@ -38,6 +38,8 @@ spec:
           value: {{ .Values.cassandra.config.dc_name | quote }}
         - name: CASSANDRA_PORT
           value: {{ .Values.storage.cassandra.port | quote }}
+        - name: CASSANDRA_TLS
+          value: {{ .Values.storage.cassandra.tls }}
         - name: CASSANDRA_USERNAME
           value: {{ .Values.storage.cassandra.user }}
         - name: CASSANDRA_PASSWORD

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -60,6 +60,8 @@ spec:
             value: {{ template "cassandra.host" . }}
           - name: CASSANDRA_PORT
             value: {{ .Values.storage.cassandra.port | quote }}
+          - name: CASSANDRA_TLS
+            value: {{ .Values.storage.cassandra.tls }}
           - name: CASSANDRA_KEYSPACE
             value: {{ printf "%s_%s" "jaeger_v1" .Values.cassandra.config.dc_name | quote }}
           - name: CASSANDRA_USERNAME

--- a/incubator/jaeger/templates/query-deploy.yaml
+++ b/incubator/jaeger/templates/query-deploy.yaml
@@ -59,6 +59,8 @@ spec:
             value: {{ template "cassandra.host" . }}
           - name: CASSANDRA_PORT
             value: {{ .Values.storage.cassandra.port | quote }}
+          - name: CASSANDRA_TLS
+            value: {{ .Values.storage.cassandra.tls }}
           - name: CASSANDRA_KEYSPACE
             value: {{ printf "%s_%s" "jaeger_v1" .Values.cassandra.config.dc_name | quote }}
           - name: CASSANDRA_USERNAME

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -40,6 +40,7 @@ storage:
     user: user
     usePassword: true
     password: password
+    tls: false
     ## Use existing secret (ignores previous password)
     # existingSecret:
   elasticsearch:


### PR DESCRIPTION
Signed-off-by: Pedro Silva <pedro.silva@softruck.com>

#### What this PR does / why we need it:
- Jaeger users may need to connect to Cassandra clusters using SSL

#### Which issue this PR fixes

#### Special notes for your reviewer:
@dvonthenen 
@mikelorant 
@naseemkullah 
@pavelnikolov 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
