### PR TITLE
stable/postgresql Ternary function is removed to avoid parsing error in Google Cloud

### DIFF
--- a/stable/postgresql/templates/statefulset-slaves.yaml
+++ b/stable/postgresql/templates/statefulset-slaves.yaml
@@ -114,7 +114,7 @@ spec:
           {{- end }}
           env:
             - name: BITNAMI_DEBUG
-              value: {{ ternary "true" "false" .Values.image.debug | quote }}
+              value: {{ .Values.image.debug | quote }}
             - name: POSTGRESQL_VOLUME_DIR
               value: "{{ .Values.persistence.mountPath }}"
             - name: POSTGRESQL_PORT_NUMBER

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -118,7 +118,7 @@ spec:
           {{- end }}
           env:
             - name: BITNAMI_DEBUG
-              value: {{ ternary "true" "false" .Values.image.debug | quote }}
+              value: {{ .Values.image.debug | quote }}
             - name: POSTGRESQL_PORT_NUMBER
               value: "{{ template "postgresql.port" . }}"
             - name: POSTGRESQL_VOLUME_DIR


### PR DESCRIPTION
Deployer. Google deployer doesn't support ternary function, so if
deployment uses this chart, it will fail:
"Error: parse error in "artifactory-ha/charts/postgresql/templates/statefulset.yaml": template: artifactory-ha/charts/postgresql/templates/statefulset.yaml:76: function "ternary" not defined"
There is no benefits of using ternary here, default value is False


#### What this PR does / why we need it:
Users who want to use Postgresql chart in Google deployer won't be able to deploy their apps. We currently have this problem with Artifactory deployments and have to remove ternary every time. 

#### Checklist
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

@desaintmartin 