### PR TITLE
[stable/mariadb] Mariadb credentials as mounted files

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,20 +1,20 @@
 apiVersion: v1
 name: mariadb
-version: 7.2.1
+version: 7.3.0
 appVersion: 10.3.20
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:
-- mariadb
-- mysql
-- database
-- sql
-- prometheus
+  - mariadb
+  - mysql
+  - database
+  - sql
+  - prometheus
 home: https://mariadb.org
 icon: https://bitnami.com/assets/stacks/mariadb/img/mariadb-stack-220x234.png
 sources:
-- https://github.com/bitnami/bitnami-docker-mariadb
-- https://github.com/prometheus/mysqld_exporter
+  - https://github.com/bitnami/bitnami-docker-mariadb
+  - https://github.com/prometheus/mysqld_exporter
 maintainers:
-- name: Bitnami
-  email: containers@bitnami.com
+  - name: Bitnami
+    email: containers@bitnami.com
 engine: gotpl

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -48,149 +48,152 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the MariaDB chart and their default values.
 
-|             Parameter                     |                     Description                     |                              Default                              |
-|-------------------------------------------|-----------------------------------------------------|-------------------------------------------------------------------|
-| `global.imageRegistry`                    | Global Docker image registry                        | `nil`                                                             |
-| `global.imagePullSecrets`                 | Global Docker registry secret names as an array     | `[]` (does not add image pull secrets to deployed pods)           |
-| `global.storageClass`                     | Global storage class for dynamic provisioning       | `nil`                                                             |
-| `image.registry`                          | MariaDB image registry                              | `docker.io`                                                       |
-| `image.repository`                        | MariaDB Image name                                  | `bitnami/mariadb`                                                 |
-| `image.tag`                               | MariaDB Image tag                                   | `{TAG_NAME}`                                                      |
-| `image.pullPolicy`                        | MariaDB image pull policy                           | `IfNotPresent`                                                    |
-| `image.pullSecrets`                       | Specify docker-registry secret names as an array    | `[]` (does not add image pull secrets to deployed pods)           |
-| `image.debug`                             | Specify if debug logs should be enabled             | `false`                                                           |
-| `nameOverride`                            | String to partially override mariadb.fullname template with a string (will prepend the release name) | `nil`            |
-| `fullnameOverride`                        | String to fully override mariadb.fullname template with a string                                     | `nil`            |
-| `volumePermissions.enabled`               | Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work) | `false`             |
-| `volumePermissions.image.registry`        | Init container volume-permissions image registry    | `docker.io`                                                       |
-| `volumePermissions.image.repository`      | Init container volume-permissions image name        | `bitnami/minideb`                                                 |
-| `volumePermissions.image.tag`             | Init container volume-permissions image tag         | `stretch`                                                         |
-| `volumePermissions.image.pullPolicy`      | Init container volume-permissions image pull policy | `Always`                                                          |
-| `volumePermissions.resources`             | Init container resource requests/limit              | `nil`                                                             |
-| `service.type`                            | Kubernetes service type                             | `ClusterIP`                                                       |
-| `service.clusterIp.master`                | Specific cluster IP for master when service type is cluster IP. Use None for headless service | `nil`                   |
-| `service.clusterIp.slave`                 | Specific cluster IP for slave when service type is cluster IP. Use None for headless service | `nil`                    |
-| `service.port`                            | MySQL service port                                  | `3306`                                                            |
-| `serviceAccount.create`                   | Specifies whether a ServiceAccount should be created | `false`                                                          |
-| `serviceAccount.name`                     | The name of the ServiceAccount to create            | Generated using the mariadb.fullname template                     |
-| `schedulerName`                           | Name of the k8s scheduler (other than default)      | `nil`                                                             |
-| `rbac.create`                             | Create and use RBAC resources                       | `false`                                                           |
-| `securityContext.enabled`                 | Enable security context                             | `true`                                                            |
-| `securityContext.fsGroup`                 | Group ID for the container                          | `1001`                                                            |
-| `securityContext.runAsUser`               | User ID for the container                           | `1001`                                                            |
-| `existingSecret`                          | Use existing secret for password details (`rootUser.password`, `db.password`, `replication.password` will be ignored and picked up from this secret). The secret has to contain the keys `mariadb-root-password`, `mariadb-replication-password` and `mariadb-password`. | `nil`                        |
-| `rootUser.password`                       | Password for the `root` user. Ignored if existing secret is provided. | _random 10 character alphanumeric string_       |
-| `rootUser.forcePassword`                  | Force users to specify a password                   | `false`                                                           |
-| `db.user`                                 | Username of new user to create                      | `""`                                                             |
-| `db.password`                             | Password for the new user. Ignored if existing secret is provided.    | _random 10 character alphanumeric string if `db.user` is defined_ |
-| `db.forcePassword`                        | Force users to specify a password                   | `false`                                                           |
-| `db.name`                                 | Name for new database to create                     | `my_database`                                                     |
-| `replication.enabled`                     | MariaDB replication enabled                         | `true`                                                            |
-| `replication.user`                        |MariaDB replication user                             | `replicator`                                                      |
-| `replication.password`                    | MariaDB replication user password. Ignored if existing secret is provided. | _random 10 character alphanumeric string_  |
-| `replication.forcePassword`               | Force users to specify a password                   | `false`                                                           |
-| `initdbScripts`                           | Dictionary of initdb scripts                        | `nil`                                                             |
-| `initdbScriptsConfigMap`                  | ConfigMap with the initdb scripts (Note: Overrides `initdbScripts`) | `nil`                                             |
-| `master.annotations[].key`                | key for the the annotation list item                |  `nil`                                                            |
-| `master.annotations[].value`              | value for the the annotation list item              |  `nil`                                                            |
-| `master.extraFlags`                       | MariaDB master additional command line flags        |  `nil`                                                            |
-| `master.affinity`                         | Master affinity (in addition to master.antiAffinity when set)  | `{}`                                                   |
-| `master.antiAffinity`                     | Master pod anti-affinity policy                     | `soft`                                                            |
-| `master.nodeSelector`                     | Master node labels for pod assignment               | `{}`                                                              |
-| `master.tolerations`                      | List of node taints to tolerate (master)            | `[]`                                                              |
-| `master.updateStrategy`                   | Master statefulset update strategy policy           | `RollingUpdate`                                                   |
-| `master.persistence.enabled`              | Enable persistence using PVC                        | `true`                                                            |
-| `master.persistence.existingClaim`        | Provide an existing `PersistentVolumeClaim`         | `nil`                                                             |
-| `master.persistence.subPath`              | Subdirectory of the volume to mount                 | `nil`                                                             |
-| `master.persistence.mountPath`            | Path to mount the volume at                         | `/bitnami/mariadb`                                                |
-| `master.persistence.annotations`          | Persistent Volume Claim annotations                 | `{}`                                                              |
-| `master.persistence.storageClass`         | Persistent Volume Storage Class                     | ``                                                                |
-| `master.persistence.accessModes`          | Persistent Volume Access Modes                      | `[ReadWriteOnce]`                                                 |
-| `master.persistence.size`                 | Persistent Volume Size                              | `8Gi`                                                             |
-| `master.extraInitContainers`              | Additional init containers as a string to be passed to the `tpl` function (master) |                                    |
-| `master.extraEnvVars`                     | Array containing extra env vars to configure MariaDB master replicas          | `nil`                                   |
-| `master.config`                           | Config file for the MariaDB Master server           | `_default values in the values.yaml file_`                        |
-| `master.resources`                        | CPU/Memory resource requests/limits for master node | `{}`                                                              |
-| `master.livenessProbe.enabled`            | Turn on and off liveness probe (master)             | `true`                                                            |
-| `master.livenessProbe.initialDelaySeconds`| Delay before liveness probe is initiated (master)   | `120`                                                             |
-| `master.livenessProbe.periodSeconds`      | How often to perform the probe (master)             | `10`                                                              |
-| `master.livenessProbe.timeoutSeconds`     | When the probe times out (master)                   | `1`                                                               |
-| `master.livenessProbe.successThreshold`   | Minimum consecutive successes for the probe (master)| `1`                                                               |
-| `master.livenessProbe.failureThreshold`   | Minimum consecutive failures for the probe (master) | `3`                                                               |
-| `master.readinessProbe.enabled`           | Turn on and off readiness probe (master)            | `true`                                                            |
-| `master.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated (master) | `30`                                                              |
-| `master.readinessProbe.periodSeconds`     | How often to perform the probe (master)             | `10`                                                              |
-| `master.readinessProbe.timeoutSeconds`    | When the probe times out (master)                   | `1`                                                               |
-| `master.readinessProbe.successThreshold`  | Minimum consecutive successes for the probe (master)| `1`                                                               |
-| `master.readinessProbe.failureThreshold`  | Minimum consecutive failures for the probe (master) | `3`                                                               |
-| `master.podDisruptionBudget.enabled`      | If true, create a pod disruption budget for master pods. | `false`                                                      |
-| `master.podDisruptionBudget.minAvailable` | Minimum number / percentage of pods that should remain scheduled | `1`                                                  |
-| `master.podDisruptionBudget.maxUnavailable`| Maximum number / percentage of pods that may be made unavailable | `nil`                                               |
-| `master.service.annotations`              | Master service annotations                          | `{}`                                                              |
-| `slave.replicas`                          | Desired number of slave replicas                    | `1`                                                               |
-| `slave.annotations[].key`                 | key for the the annotation list item                | `nil`                                                             |
-| `slave.annotations[].value`               | value for the the annotation list item              | `nil`                                                             |
-| `slave.extraFlags`                        | MariaDB slave additional command line flags         | `nil`                                                             |
-| `slave.affinity`                          | Slave affinity (in addition to slave.antiAffinity when set) | `{}`                                                      |
-| `slave.antiAffinity`                      | Slave pod anti-affinity policy                      | `soft`                                                            |
-| `slave.nodeSelector`                      | Slave node labels for pod assignment                | `{}`                                                              |
-| `slave.tolerations`                       | List of node taints to tolerate for (slave)         | `[]`                                                              |
-| `slave.updateStrategy`                    | Slave statefulset update strategy policy            | `RollingUpdate`                                                   |
-| `slave.persistence.enabled`               | Enable persistence using a `PersistentVolumeClaim`  | `true`                                                            |
-| `slave.persistence.annotations`           | Persistent Volume Claim annotations                 | `{}`                                                              |
-| `slave.persistence.storageClass`          | Persistent Volume Storage Class                     | ``                                                                |
-| `slave.persistence.accessModes`           | Persistent Volume Access Modes                      | `[ReadWriteOnce]`                                                 |
-| `slave.persistence.size`                  | Persistent Volume Size                              | `8Gi`                                                             |
-| `slave.extraInitContainers`               | Additional init containers as a string to be passed to the `tpl` function (slave)  | `nil`                              |
-| `slave.extraEnvVars`                      | Array containing extra env vars to configure MariaDB slave replicas          | `nil`                                    |
-| `slave.config`                            | Config file for the MariaDB Slave replicas          | `_default values in the values.yaml file_`                        |
-| `slave.resources`                         | CPU/Memory resource requests/limits for slave node  | `{}`                                                              |
-| `slave.livenessProbe.enabled`             | Turn on and off liveness probe (slave)              | `true`                                                            |
-| `slave.livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated (slave)    | `120`                                                             |
-| `slave.livenessProbe.periodSeconds`       | How often to perform the probe (slave)              | `10`                                                              |
-| `slave.livenessProbe.timeoutSeconds`      | When the probe times out (slave)                    | `1`                                                               |
-| `slave.livenessProbe.successThreshold`    | Minimum consecutive successes for the probe (slave) | `1`                                                               |
-| `slave.livenessProbe.failureThreshold`    | Minimum consecutive failures for the probe (slave)  | `3`                                                               |
-| `slave.readinessProbe.enabled`            | Turn on and off readiness probe (slave)             | `true`                                                            |
-| `slave.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated (slave)   | `45`                                                              |
-| `slave.readinessProbe.periodSeconds`      | How often to perform the probe (slave)              | `10`                                                              |
-| `slave.readinessProbe.timeoutSeconds`     | When the probe times out (slave)                    | `1`                                                               |
-| `slave.readinessProbe.successThreshold`   | Minimum consecutive successes for the probe (slave) | `1`                                                               |
-| `slave.readinessProbe.failureThreshold`   | Minimum consecutive failures for the probe (slave)  | `3`                                                               |
-| `slave.podDisruptionBudget.enabled`       | If true, create a pod disruption budget for slave pods. | `false`                                                       |
-| `slave.podDisruptionBudget.minAvailable`  | Minimum number / percentage of pods that should remain scheduled | `1`                                                  |
-| `slave.podDisruptionBudget.maxUnavailable`| Maximum number / percentage of pods that may be made unavailable | `nil`                                                |
-| `slave.service.annotations`               | Slave service annotations                           | `{}`                                                              |
-| `metrics.enabled`                         | Start a side-car prometheus exporter                | `false`                                                           |
-| `metrics.image.registry`                  | Exporter image registry                             | `docker.io`                                                       |
-| `metrics.image.repository`                | Exporter image name                                 | `bitnami/mysqld-exporter`                                         |
-| `metrics.image.tag`                       | Exporter image tag                                  | `{TAG_NAME}`                                                      |
-| `metrics.image.pullPolicy`                | Exporter image pull policy                          | `IfNotPresent`                                                    |
-| `metrics.resources`                       | Exporter resource requests/limit                    | `nil`                                                             |
-| `metrics.extraArgs.master`                | Extra args to be passed to mysqld_exporter          | `[]`                                                              |
-| `metrics.extraArgs.slave`                 | Extra args to be passed to mysqld_exporter          | `[]`                                                              |
-| `metrics.livenessProbe.enabled`            | Turn on and off liveness probe (metrics)             | `true`                                                          |
-| `metrics.livenessProbe.initialDelaySeconds`| Delay before liveness probe is initiated (metrics)   | `120`                                                           |
-| `metrics.livenessProbe.periodSeconds`      | How often to perform the probe (metrics)             | `10`                                                            |
-| `metrics.livenessProbe.timeoutSeconds`     | When the probe times out (metrics)                   | `1`                                                             |
-| `metrics.livenessProbe.successThreshold`   | Minimum consecutive successes for the probe (metrics)| `1`                                                             |
-| `metrics.livenessProbe.failureThreshold`   | Minimum consecutive failures for the probe (metrics) | `3`                                                             |
-| `metrics.readinessProbe.enabled`           | Turn on and off readiness probe (metrics)            | `true`                                                          |
-| `metrics.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated (metrics) | `30`                                                            |
-| `metrics.readinessProbe.periodSeconds`     | How often to perform the probe (metrics)             | `10`                                                            |
-| `metrics.readinessProbe.timeoutSeconds`    | When the probe times out (metrics)                   | `1`                                                             |
-| `metrics.readinessProbe.successThreshold`  | Minimum consecutive successes for the probe (metrics)| `1`                                                             |
-| `metrics.readinessProbe.failureThreshold`  | Minimum consecutive failures for the probe (metrics) | `3`                                                             |
-| `metrics.serviceMonitor.enabled`          | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)  | `false`       |
-| `metrics.serviceMonitor.namespace`        | Optional namespace which Prometheus is running in   | `nil`                                                             |
-| `metrics.serviceMonitor.interval`         | How frequently to scrape metrics (use by default, falling back to Prometheus' default)  | `nil`                         |
-| `metrics.serviceMonitor.selector`         | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install   | `{ prometheus: kube-prometheus }` |
-| `tests.enabled`                           | Provide tests to check if connect and authentication is possible | `true`                                               |
-| `tests.resources`                         | Resource definition for the test-runner pod         | `nil`                                                             |
-| `tests.testFramework.image.registry`      | Test framework image registry (init container)      | `docker.io`                                                       |
-| `tests.testFramework.image.repository`    | Test framework image name                           | `dduportal/bats`                                                  |
-| `tests.testFramework.image.tag`           | Test framework image tag                            | `0.4.0`                                                           |
-| `tests.testFramework.resources`           | Resource definition for the test framework          | `nil`                                                             |
+| Parameter                                   | Description                                         | Default                                                           |
+|---------------------------------------------|-----------------------------------------------------|-------------------------------------------------------------------|
+| `global.imageRegistry`                      | Global Docker image registry                        | `nil`                                                             |
+| `global.imagePullSecrets`                   | Global Docker registry secret names as an array     | `[]` (does not add image pull secrets to deployed pods)           |
+| `global.storageClass`                       | Global storage class for dynamic provisioning       | `nil`                                                             |
+| `image.registry`                            | MariaDB image registry                              | `docker.io`                                                       |
+| `image.repository`                          | MariaDB Image name                                  | `bitnami/mariadb`                                                 |
+| `image.tag`                                 | MariaDB Image tag                                   | `{TAG_NAME}`                                                      |
+| `image.pullPolicy`                          | MariaDB image pull policy                           | `IfNotPresent`                                                    |
+| `image.pullSecrets`                         | Specify docker-registry secret names as an array    | `[]` (does not add image pull secrets to deployed pods)           |
+| `image.debug`                               | Specify if debug logs should be enabled             | `false`                                                           |
+| `nameOverride`                              | String to partially override mariadb.fullname template with a string (will prepend the release name) | `nil`            |
+| `fullnameOverride`                          | String to fully override mariadb.fullname template with a string                                     | `nil`            |
+| `volumePermissions.enabled`                 | Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work) | `false`             |
+| `volumePermissions.image.registry`          | Init container volume-permissions image registry    | `docker.io`                                                       |
+| `volumePermissions.image.repository`        | Init container volume-permissions image name        | `bitnami/minideb`                                                 |
+| `volumePermissions.image.tag`               | Init container volume-permissions image tag         | `stretch`                                                         |
+| `volumePermissions.image.pullPolicy`        | Init container volume-permissions image pull policy | `Always`                                                          |
+| `volumePermissions.resources`               | Init container resource requests/limit              | `nil`                                                             |
+| `service.type`                              | Kubernetes service type                             | `ClusterIP`                                                       |
+| `service.clusterIp.master`                  | Specific cluster IP for master when service type is cluster IP. Use None for headless service | `nil`                   |
+| `service.clusterIp.slave`                   | Specific cluster IP for slave when service type is cluster IP. Use None for headless service | `nil`                    |
+| `service.port`                              | MySQL service port                                  | `3306`                                                            |
+| `serviceAccount.create`                     | Specifies whether a ServiceAccount should be created | `false`                                                          |
+| `serviceAccount.name`                       | The name of the ServiceAccount to create            | Generated using the mariadb.fullname template                     |
+| `schedulerName`                             | Name of the k8s scheduler (other than default)      | `nil`                                                             |
+| `rbac.create`                               | Create and use RBAC resources                       | `false`                                                           |
+| `securityContext.enabled`                   | Enable security context                             | `true`                                                            |
+| `securityContext.fsGroup`                   | Group ID for the container                          | `1001`                                                            |
+| `securityContext.runAsUser`                 | User ID for the container                           | `1001`                                                            |
+| `existingSecret`                            | Use existing secret for password details (`rootUser.password`, `db.password`, `replication.password` will be ignored and picked up from this secret). The secret has to contain the keys `mariadb-root-password`, `mariadb-replication-password` and `mariadb-password`. | `nil`                        |
+| `rootUser.password`                         | Password for the `root` user. Ignored if existing secret is provided. | _random 10 character alphanumeric string_       |
+| `rootUser.forcePassword`                    | Force users to specify a password                   | `false`                                                           |
+| `rootUser.injectSecretsAsVolume`            | Mount admin user password as a file instead of using an environment variable | `false`                                  |
+| `db.name`                                   | Name for new database to create                     | `my_database`                                                     |
+| `db.user`                                   | Username of new user to create                      | `""`                                                              |
+| `db.password`                               | Password for the new user. Ignored if existing secret is provided.    | _random 10 character alphanumeric string if `db.user` is defined_ |
+| `db.forcePassword`                          | Force users to specify a password                   | `false`                                                           |
+| `db.injectSecretsAsVolume`                  | Mount user password as a file instead of using an environment variable | `false`                                        |
+| `replication.enabled`                       | MariaDB replication enabled                         | `true`                                                            |
+| `replication.user`                          | MariaDB replication user                            | `replicator`                                                      |
+| `replication.password`                      | MariaDB replication user password. Ignored if existing secret is provided. | _random 10 character alphanumeric string_  |
+| `replication.forcePassword`                 | Force users to specify a password                   | `false`                                                           |
+| `replication.injectSecretsAsVolume`         | Mount replication user password as a file instead of using an environment variable | `false`                            |
+| `initdbScripts`                             | Dictionary of initdb scripts                        | `nil`                                                             |
+| `initdbScriptsConfigMap`                    | ConfigMap with the initdb scripts (Note: Overrides `initdbScripts`) | `nil`                                             |
+| `master.annotations[].key`                  | key for the the annotation list item                |  `nil`                                                            |
+| `master.annotations[].value`                | value for the the annotation list item              |  `nil`                                                            |
+| `master.extraFlags`                         | MariaDB master additional command line flags        |  `nil`                                                            |
+| `master.affinity`                           | Master affinity (in addition to master.antiAffinity when set)  | `{}`                                                   |
+| `master.antiAffinity`                       | Master pod anti-affinity policy                     | `soft`                                                            |
+| `master.nodeSelector`                       | Master node labels for pod assignment               | `{}`                                                              |
+| `master.tolerations`                        | List of node taints to tolerate (master)            | `[]`                                                              |
+| `master.updateStrategy`                     | Master statefulset update strategy policy           | `RollingUpdate`                                                   |
+| `master.persistence.enabled`                | Enable persistence using PVC                        | `true`                                                            |
+| `master.persistence.existingClaim`          | Provide an existing `PersistentVolumeClaim`         | `nil`                                                             |
+| `master.persistence.subPath`                | Subdirectory of the volume to mount                 | `nil`                                                             |
+| `master.persistence.mountPath`              | Path to mount the volume at                         | `/bitnami/mariadb`                                                |
+| `master.persistence.annotations`            | Persistent Volume Claim annotations                 | `{}`                                                              |
+| `master.persistence.storageClass`           | Persistent Volume Storage Class                     | ``                                                                |
+| `master.persistence.accessModes`            | Persistent Volume Access Modes                      | `[ReadWriteOnce]`                                                 |
+| `master.persistence.size`                   | Persistent Volume Size                              | `8Gi`                                                             |
+| `master.extraInitContainers`                | Additional init containers as a string to be passed to the `tpl` function (master) |                                    |
+| `master.extraEnvVars`                       | Array containing extra env vars to configure MariaDB master replicas          | `nil`                                   |
+| `master.config`                             | Config file for the MariaDB Master server           | `_default values in the values.yaml file_`                        |
+| `master.resources`                          | CPU/Memory resource requests/limits for master node | `{}`                                                              |
+| `master.livenessProbe.enabled`              | Turn on and off liveness probe (master)             | `true`                                                            |
+| `master.livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated (master)   | `120`                                                             |
+| `master.livenessProbe.periodSeconds`        | How often to perform the probe (master)             | `10`                                                              |
+| `master.livenessProbe.timeoutSeconds`       | When the probe times out (master)                   | `1`                                                               |
+| `master.livenessProbe.successThreshold`     | Minimum consecutive successes for the probe (master)| `1`                                                               |
+| `master.livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe (master) | `3`                                                               |
+| `master.readinessProbe.enabled`             | Turn on and off readiness probe (master)            | `true`                                                            |
+| `master.readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated (master)  | `30`                                                              |
+| `master.readinessProbe.periodSeconds`       | How often to perform the probe (master)             | `10`                                                              |
+| `master.readinessProbe.timeoutSeconds`      | When the probe times out (master)                   | `1`                                                               |
+| `master.readinessProbe.successThreshold`    | Minimum consecutive successes for the probe (master)| `1`                                                               |
+| `master.readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe (master) | `3`                                                               |
+| `master.podDisruptionBudget.enabled`        | If true, create a pod disruption budget for master pods. | `false`                                                      |
+| `master.podDisruptionBudget.minAvailable`   | Minimum number / percentage of pods that should remain scheduled | `1`                                                  |
+| `master.podDisruptionBudget.maxUnavailable` | Maximum number / percentage of pods that may be made unavailable | `nil`                                                |
+| `master.service.annotations`                | Master service annotations                          | `{}`                                                              |
+| `slave.replicas`                            | Desired number of slave replicas                    | `1`                                                               |
+| `slave.annotations[].key`                   | key for the the annotation list item                | `nil`                                                             |
+| `slave.annotations[].value`                 | value for the the annotation list item              | `nil`                                                             |
+| `slave.extraFlags`                          | MariaDB slave additional command line flags         | `nil`                                                             |
+| `slave.affinity`                            | Slave affinity (in addition to slave.antiAffinity when set) | `{}`                                                      |
+| `slave.antiAffinity`                        | Slave pod anti-affinity policy                      | `soft`                                                            |
+| `slave.nodeSelector`                        | Slave node labels for pod assignment                | `{}`                                                              |
+| `slave.tolerations`                         | List of node taints to tolerate for (slave)         | `[]`                                                              |
+| `slave.updateStrategy`                      | Slave statefulset update strategy policy            | `RollingUpdate`                                                   |
+| `slave.persistence.enabled`                 | Enable persistence using a `PersistentVolumeClaim`  | `true`                                                            |
+| `slave.persistence.annotations`             | Persistent Volume Claim annotations                 | `{}`                                                              |
+| `slave.persistence.storageClass`            | Persistent Volume Storage Class                     | ``                                                                |
+| `slave.persistence.accessModes`             | Persistent Volume Access Modes                      | `[ReadWriteOnce]`                                                 |
+| `slave.persistence.size`                    | Persistent Volume Size                              | `8Gi`                                                             |
+| `slave.extraInitContainers`                 | Additional init containers as a string to be passed to the `tpl` function (slave)  | `nil`                              |
+| `slave.extraEnvVars`                        | Array containing extra env vars to configure MariaDB slave replicas          | `nil`                                    |
+| `slave.config`                              | Config file for the MariaDB Slave replicas          | `_default values in the values.yaml file_`                        |
+| `slave.resources`                           | CPU/Memory resource requests/limits for slave node  | `{}`                                                              |
+| `slave.livenessProbe.enabled`               | Turn on and off liveness probe (slave)              | `true`                                                            |
+| `slave.livenessProbe.initialDelaySeconds`   | Delay before liveness probe is initiated (slave)    | `120`                                                             |
+| `slave.livenessProbe.periodSeconds`         | How often to perform the probe (slave)              | `10`                                                              |
+| `slave.livenessProbe.timeoutSeconds`        | When the probe times out (slave)                    | `1`                                                               |
+| `slave.livenessProbe.successThreshold`      | Minimum consecutive successes for the probe (slave) | `1`                                                               |
+| `slave.livenessProbe.failureThreshold`      | Minimum consecutive failures for the probe (slave)  | `3`                                                               |
+| `slave.readinessProbe.enabled`              | Turn on and off readiness probe (slave)             | `true`                                                            |
+| `slave.readinessProbe.initialDelaySeconds`  | Delay before readiness probe is initiated (slave)   | `45`                                                              |
+| `slave.readinessProbe.periodSeconds`        | How often to perform the probe (slave)              | `10`                                                              |
+| `slave.readinessProbe.timeoutSeconds`       | When the probe times out (slave)                    | `1`                                                               |
+| `slave.readinessProbe.successThreshold`     | Minimum consecutive successes for the probe (slave) | `1`                                                               |
+| `slave.readinessProbe.failureThreshold`     | Minimum consecutive failures for the probe (slave)  | `3`                                                               |
+| `slave.podDisruptionBudget.enabled`         | If true, create a pod disruption budget for slave pods. | `false`                                                       |
+| `slave.podDisruptionBudget.minAvailable`    | Minimum number / percentage of pods that should remain scheduled | `1`                                                  |
+| `slave.podDisruptionBudget.maxUnavailable`  | Maximum number / percentage of pods that may be made unavailable | `nil`                                                |
+| `slave.service.annotations`                 | Slave service annotations                           | `{}`                                                              |
+| `metrics.enabled`                           | Start a side-car prometheus exporter                | `false`                                                           |
+| `metrics.image.registry`                    | Exporter image registry                             | `docker.io`                                                       |
+| `metrics.image.repository`                  | Exporter image name                                 | `bitnami/mysqld-exporter`                                         |
+| `metrics.image.tag`                         | Exporter image tag                                  | `{TAG_NAME}`                                                      |
+| `metrics.image.pullPolicy`                  | Exporter image pull policy                          | `IfNotPresent`                                                    |
+| `metrics.resources`                         | Exporter resource requests/limit                    | `nil`                                                             |
+| `metrics.extraArgs.master`                  | Extra args to be passed to mysqld_exporter          | `[]`                                                              |
+| `metrics.extraArgs.slave`                   | Extra args to be passed to mysqld_exporter          | `[]`                                                              |
+| `metrics.livenessProbe.enabled`             | Turn on and off liveness probe (metrics)              | `true`                                                          |
+| `metrics.livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated (metrics)    | `120`                                                           |
+| `metrics.livenessProbe.periodSeconds`       | How often to perform the probe (metrics)              | `10`                                                            |
+| `metrics.livenessProbe.timeoutSeconds`      | When the probe times out (metrics)                    | `1`                                                             |
+| `metrics.livenessProbe.successThreshold`    | Minimum consecutive successes for the probe (metrics) | `1`                                                             |
+| `metrics.livenessProbe.failureThreshold`    | Minimum consecutive failures for the probe (metrics)  | `3`                                                             |
+| `metrics.readinessProbe.enabled`            | Turn on and off readiness probe (metrics)             | `true`                                                          |
+| `metrics.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated (metrics)   | `30`                                                            |
+| `metrics.readinessProbe.periodSeconds`      | How often to perform the probe (metrics)              | `10`                                                            |
+| `metrics.readinessProbe.timeoutSeconds`     | When the probe times out (metrics)                    | `1`                                                             |
+| `metrics.readinessProbe.successThreshold`   | Minimum consecutive successes for the probe (metrics) | `1`                                                             |
+| `metrics.readinessProbe.failureThreshold`   | Minimum consecutive failures for the probe (metrics)  | `3`                                                             |
+| `metrics.serviceMonitor.enabled`            | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)  | `false`       |
+| `metrics.serviceMonitor.namespace`          | Optional namespace which Prometheus is running in     | `nil`                                                           |
+| `metrics.serviceMonitor.interval`           | How frequently to scrape metrics (use by default, falling back to Prometheus' default)  | `nil`                         |
+| `metrics.serviceMonitor.selector`           | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install   | `{ prometheus: kube-prometheus }` |
+| `tests.enabled`                             | Provide tests to check if connect and authentication is possible | `true`                                               |
+| `tests.resources`                           | Resource definition for the test-runner pod           | `nil`                                                           |
+| `tests.testFramework.image.registry`        | Test framework image registry (init container)        | `docker.io`                                                     |
+| `tests.testFramework.image.repository`      | Test framework image name                             | `dduportal/bats`                                                |
+| `tests.testFramework.image.tag`             | Test framework image tag                              | `0.4.0`                                                         |
+| `tests.testFramework.resources`             | Resource definition for the test framework            | `nil`                                                           |
 
 The above parameters map to the env variables defined in [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb). For more information please refer to the [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb) image documentation.
 
@@ -224,23 +227,32 @@ Bitnami will release a new chart updating its containers if a new version of the
 
 This chart includes a `values-production.yaml` file where you can find some parameters oriented to production configuration in comparison to the regular `values.yaml`. You can use this file instead of the default one.
 
-- Force users to specify a password:
+- Force users to specify a password and mount secrets as volumes instead of using environment variables:
+
 ```diff
 - rootUser.forcePassword: false
+- rootUser.injectSecretsAsVolume: false
 + rootUser.forcePassword: true
++ rootUser.injectSecretsAsVolume: true
 - db.forcePassword: false
+- db.injectSecretsAsVolume: false
 + db.forcePassword: true
++ db.injectSecretsAsVolume: true
 - replication.forcePassword: false
+- replication.injectSecretsAsVolume: false
 + replication.forcePassword: true
++ replication.injectSecretsAsVolume: true
 ```
 
 - Desired number of slave replicas:
+
 ```diff
 - slave.replicas: 1
 + slave.replicas: 2
 ```
 
 - Start a side-car prometheus exporter:
+
 ```diff
 - metrics.enabled: false
 + metrics.enabled: true

--- a/stable/mariadb/templates/master-statefulset.yaml
+++ b/stable/mariadb/templates/master-statefulset.yaml
@@ -224,7 +224,7 @@ spec:
           env:
             {{- if .Values.rootUser.injectSecretsAsVolume }}
             - name: MARIADB_ROOT_PASSWORD_FILE
-              value: "/opt/bitnami/mariadb/secrets/mariadb-root-password"
+              value: "/opt/bitnami/mysqld-exporter/secrets/mariadb-root-password"
             {{- else }}
             - name: MARIADB_ROOT_PASSWORD
               valueFrom:
@@ -240,8 +240,7 @@ spec:
               if [ -f "${MARIADB_ROOT_PASSWORD_FILE:-}" ]; then
                   password_aux=$(cat $MARIADB_ROOT_PASSWORD_FILE)
               fi
-              DATA_SOURCE_NAME="root:$password_aux@(localhost:3306)/"
-              /bin/mysqld_exporter
+              DATA_SOURCE_NAME="root:${password_aux}@(localhost:3306)/" /bin/mysqld_exporter
               {{- range .Values.metrics.extraArgs.master }}
               {{ . }}
               {{- end }}
@@ -276,7 +275,7 @@ spec:
           {{- if .Values.rootUser.injectSecretsAsVolume }}
           volumeMounts:
             - name: mariadb-credentials
-              mountPath: /opt/bitnami/mariadb/secrets/
+              mountPath: /opt/bitnami/mysqld-exporter/secrets/
           {{- end }}
         {{- end }}
       volumes:

--- a/stable/mariadb/templates/master-statefulset.yaml
+++ b/stable/mariadb/templates/master-statefulset.yaml
@@ -121,6 +121,7 @@ spec:
                   name: {{ template "mariadb.secretName" . }}
                   key: mariadb-root-password
             {{- end }}
+            {{- if not (empty .Values.db.user) }}
             - name: MARIADB_USER
               value: "{{ .Values.db.user }}"
             {{- if .Values.db.injectSecretsAsVolume }}
@@ -165,11 +166,11 @@ spec:
                 - sh
                 - -c
                 - |
-                  if [[ -n $MARIADB_ROOT_PASSWORD_FILE ]]; then
-                      password_aux=`cat ${MARIADB_ROOT_PASSWORD_FILE}`
-                      export MARIADB_ROOT_PASSWORD=$password_aux
+                  password_aux="${MARIADB_ROOT_PASSWORD:-}"
+                  if [ -f "${MARIADB_ROOT_PASSWORD_FILE:-}" ]; then
+                      password_aux=$(cat $MARIADB_ROOT_PASSWORD_FILE)
                   fi
-                  exec mysqladmin status -uroot -p$MARIADB_ROOT_PASSWORD
+                  mysqladmin status -uroot -p$password_aux
             initialDelaySeconds: {{ .Values.master.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.master.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.master.livenessProbe.timeoutSeconds }}
@@ -183,11 +184,11 @@ spec:
                 - sh
                 - -c
                 - |
-                  if [[ -n $MARIADB_ROOT_PASSWORD_FILE ]]; then
-                      password_aux=`cat ${MARIADB_ROOT_PASSWORD_FILE}`
-                      export MARIADB_ROOT_PASSWORD=$password_aux
+                  password_aux="${MARIADB_ROOT_PASSWORD:-}"
+                  if [ -f "${MARIADB_ROOT_PASSWORD_FILE:-}" ]; then
+                      password_aux=$(cat $MARIADB_ROOT_PASSWORD_FILE)
                   fi
-                  exec mysqladmin status -uroot -p$MARIADB_ROOT_PASSWORD
+                  mysqladmin status -uroot -p$password_aux
             initialDelaySeconds: {{ .Values.master.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.master.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.master.readinessProbe.timeoutSeconds }}
@@ -234,12 +235,12 @@ spec:
           command:
             - sh
             - -c
-            - >-
-              if [[ -n $MARIADB_ROOT_PASSWORD_FILE ]]; then
-                  password_aux=`cat ${MARIADB_ROOT_PASSWORD_FILE}`
-                  export MARIADB_ROOT_PASSWORD=$password_aux
+            - |
+              password_aux="${MARIADB_ROOT_PASSWORD:-}"
+              if [ -f "${MARIADB_ROOT_PASSWORD_FILE:-}" ]; then
+                  password_aux=$(cat $MARIADB_ROOT_PASSWORD_FILE)
               fi
-              DATA_SOURCE_NAME="root:$MARIADB_ROOT_PASSWORD@(localhost:3306)/"
+              DATA_SOURCE_NAME="root:$password_aux@(localhost:3306)/"
               /bin/mysqld_exporter
               {{- range .Values.metrics.extraArgs.master }}
               {{ . }}

--- a/stable/mariadb/templates/master-statefulset.yaml
+++ b/stable/mariadb/templates/master-statefulset.yaml
@@ -111,19 +111,28 @@ spec:
             - name: MARIADB_EXTRA_FLAGS
               value: "{{ .Values.master.extraFlags }}"
             {{- end }}
+            {{- if .Values.rootUser.injectSecretsAsVolume }}
+            - name: MARIADB_ROOT_PASSWORD_FILE
+              value: "/opt/bitnami/mariadb/secrets/mariadb-root-password"
+            {{- else }}
             - name: MARIADB_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mariadb.secretName" . }}
                   key: mariadb-root-password
-            {{- if not (empty .Values.db.user) }}
+            {{- end }}
             - name: MARIADB_USER
               value: "{{ .Values.db.user }}"
+            {{- if .Values.db.injectSecretsAsVolume }}
+            - name: MARIADB_PASSWORD_FILE
+              value: "/opt/bitnami/mariadb/secrets/mariadb-password"
+            {{- else }}
             - name: MARIADB_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mariadb.secretName" . }}
                   key: mariadb-password
+            {{- end }}
             {{- end }}
             - name: MARIADB_DATABASE
               value: "{{ .Values.db.name }}"
@@ -132,11 +141,16 @@ spec:
               value: "master"
             - name: MARIADB_REPLICATION_USER
               value: "{{ .Values.replication.user }}"
+            {{- if .Values.replication.injectSecretsAsVolume }}
+            - name: MARIADB_REPLICATION_PASSWORD_FILE
+              value: "/opt/bitnami/mariadb/secrets/mariadb-replication-password"
+            {{- else }}
             - name: MARIADB_REPLICATION_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mariadb.secretName" . }}
                   key: mariadb-replication-password
+            {{- end }}
             {{- end }}
             {{- if .Values.master.extraEnvVars }}
             {{- tpl (toYaml .Values.master.extraEnvVars) $ | nindent 12 }}
@@ -147,7 +161,15 @@ spec:
           {{- if .Values.master.livenessProbe.enabled }}
           livenessProbe:
             exec:
-              command: ["sh", "-c", "exec mysqladmin status -uroot -p$MARIADB_ROOT_PASSWORD"]
+              command:
+                - sh
+                - -c
+                - |
+                  if [[ -n $MARIADB_ROOT_PASSWORD_FILE ]]; then
+                      password_aux=`cat ${MARIADB_ROOT_PASSWORD_FILE}`
+                      export MARIADB_ROOT_PASSWORD=$password_aux
+                  fi
+                  exec mysqladmin status -uroot -p$MARIADB_ROOT_PASSWORD
             initialDelaySeconds: {{ .Values.master.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.master.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.master.livenessProbe.timeoutSeconds }}
@@ -157,7 +179,15 @@ spec:
           {{- if .Values.master.readinessProbe.enabled }}
           readinessProbe:
             exec:
-              command: ["sh", "-c", "exec mysqladmin status -uroot -p$MARIADB_ROOT_PASSWORD"]
+              command:
+                - sh
+                - -c
+                - |
+                  if [[ -n $MARIADB_ROOT_PASSWORD_FILE ]]; then
+                      password_aux=`cat ${MARIADB_ROOT_PASSWORD_FILE}`
+                      export MARIADB_ROOT_PASSWORD=$password_aux
+                  fi
+                  exec mysqladmin status -uroot -p$MARIADB_ROOT_PASSWORD
             initialDelaySeconds: {{ .Values.master.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.master.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.master.readinessProbe.timeoutSeconds }}
@@ -182,20 +212,33 @@ spec:
               mountPath: /opt/bitnami/mariadb/conf/my.cnf
               subPath: my.cnf
             {{- end }}
+            {{- if or .Values.rootUser.injectSecretsAsVolume .Values.db.injectSecretsAsVolume .Values.replication.injectSecretsAsVolume }}
+            - name: mariadb-credentials
+              mountPath: /opt/bitnami/mariadb/secrets/
+            {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
           image: {{ template "mariadb.metrics.image" . }}
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
           env:
+            {{- if .Values.rootUser.injectSecretsAsVolume }}
+            - name: MARIADB_ROOT_PASSWORD_FILE
+              value: "/opt/bitnami/mariadb/secrets/mariadb-root-password"
+            {{- else }}
             - name: MARIADB_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mariadb.secretName" . }}
                   key: mariadb-root-password
+            {{- end }}
           command:
             - sh
             - -c
             - >-
+              if [[ -n $MARIADB_ROOT_PASSWORD_FILE ]]; then
+                  password_aux=`cat ${MARIADB_ROOT_PASSWORD_FILE}`
+                  export MARIADB_ROOT_PASSWORD=$password_aux
+              fi
               DATA_SOURCE_NAME="root:$MARIADB_ROOT_PASSWORD@(localhost:3306)/"
               /bin/mysqld_exporter
               {{- range .Values.metrics.extraArgs.master }}
@@ -229,6 +272,11 @@ spec:
           {{- if .Values.metrics.resources }}
           resources: {{ toYaml .Values.metrics.resources | nindent 12 }}
           {{- end }}
+          {{- if .Values.rootUser.injectSecretsAsVolume }}
+          volumeMounts:
+            - name: mariadb-credentials
+              mountPath: /opt/bitnami/mariadb/secrets/
+          {{- end }}
         {{- end }}
       volumes:
         {{- if .Values.master.config }}
@@ -240,6 +288,24 @@ spec:
         - name: custom-init-scripts
           configMap:
             name: {{ template "mariadb.initdbScriptsCM" . }}
+        {{- end }}
+        {{- if or .Values.rootUser.injectSecretsAsVolume .Values.db.injectSecretsAsVolume .Values.replication.injectSecretsAsVolume }}
+        - name: mariadb-credentials
+          secret:
+            secretName: {{ template "mariadb.fullname" . }}
+            items:
+              {{- if .Values.rootUser.injectSecretsAsVolume }}
+              - key: mariadb-root-password
+                path: mariadb-root-password
+              {{- end }}
+              {{- if .Values.db.injectSecretsAsVolume }}
+              - key: mariadb-password
+                path: mariadb-password
+              {{- end }}
+              {{- if .Values.replication.injectSecretsAsVolume }}
+              - key: mariadb-replication-password
+                path: mariadb-replication-password
+              {{- end }}
         {{- end }}
 {{- if and .Values.master.persistence.enabled .Values.master.persistence.existingClaim }}
         - name: data

--- a/stable/mariadb/templates/slave-statefulset.yaml
+++ b/stable/mariadb/templates/slave-statefulset.yaml
@@ -155,11 +155,11 @@ spec:
                 - sh
                 - -c
                 - |
-                  if [[ -n $MARIADB_MASTER_ROOT_PASSWORD_FILE ]]; then
-                      password_aux=`cat ${MARIADB_MASTER_ROOT_PASSWORD_FILE}`
-                      export MARIADB_MASTER_ROOT_PASSWORD=$password_aux
+                  password_aux="${MARIADB_MASTER_ROOT_PASSWORD:-}"
+                  if [ -f "${MARIADB_MASTER_ROOT_PASSWORD_FILE:-}" ]; then
+                      password_aux=$(cat $MARIADB_MASTER_ROOT_PASSWORD_FILE)
                   fi
-                  exec mysqladmin status -uroot -p$MARIADB_MASTER_ROOT_PASSWORD
+                  mysqladmin status -uroot -p$password_aux
             initialDelaySeconds: {{ .Values.slave.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.slave.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.slave.livenessProbe.timeoutSeconds }}
@@ -173,11 +173,11 @@ spec:
                 - sh
                 - -c
                 - |
-                  if [[ -n $MARIADB_MASTER_ROOT_PASSWORD_FILE ]]; then
-                      password_aux=`cat ${MARIADB_MASTER_ROOT_PASSWORD_FILE}`
-                      export MARIADB_MASTER_ROOT_PASSWORD=$password_aux
+                  password_aux="${MARIADB_MASTER_ROOT_PASSWORD:-}"
+                  if [ -f "${MARIADB_MASTER_ROOT_PASSWORD_FILE:-}" ]; then
+                      password_aux=$(cat $MARIADB_MASTER_ROOT_PASSWORD_FILE)
                   fi
-                  exec mysqladmin status -uroot -p$MARIADB_MASTER_ROOT_PASSWORD
+                  mysqladmin status -uroot -p$password_aux
             initialDelaySeconds: {{ .Values.slave.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.slave.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.slave.readinessProbe.timeoutSeconds }}
@@ -217,12 +217,12 @@ spec:
           command:
             - sh
             - -c
-            - >-
-              if [[ -n $MARIADB_ROOT_PASSWORD_FILE ]]; then
-                  password_aux=`cat ${MARIADB_ROOT_PASSWORD_FILE}`
-                  export MARIADB_ROOT_PASSWORD=$password_aux
+            - |
+              password_aux="${MARIADB_ROOT_PASSWORD:-}"
+              if [ -f "${MARIADB_ROOT_PASSWORD_FILE:-}" ]; then
+                  password_aux=$(cat $MARIADB_ROOT_PASSWORD_FILE)
               fi
-              DATA_SOURCE_NAME="root:$MARIADB_ROOT_PASSWORD@(localhost:3306)/"
+              DATA_SOURCE_NAME="root:$password_aux@(localhost:3306)/"
               /bin/mysqld_exporter
               {{- range .Values.metrics.extraArgs.slave }}
               {{ . }}

--- a/stable/mariadb/templates/slave-statefulset.yaml
+++ b/stable/mariadb/templates/slave-statefulset.yaml
@@ -120,18 +120,28 @@ spec:
               value: "{{ .Values.service.port }}"
             - name: MARIADB_MASTER_ROOT_USER
               value: "root"
+            {{- if .Values.rootUser.injectSecretsAsVolume }}
+            - name: MARIADB_MASTER_ROOT_PASSWORD_FILE
+              value: "/opt/bitnami/mariadb/secrets/mariadb-root-password"
+            {{- else }}
             - name: MARIADB_MASTER_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mariadb.secretName" . }}
                   key: mariadb-root-password
+            {{- end }}
             - name: MARIADB_REPLICATION_USER
               value: "{{ .Values.replication.user }}"
+            {{- if .Values.replication.injectSecretsAsVolume }}
+            - name: MARIADB_REPLICATION_PASSWORD_FILE
+              value: "/opt/bitnami/mariadb/secrets/mariadb-replication-password"
+            {{- else }}
             - name: MARIADB_REPLICATION_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mariadb.secretName" . }}
                   key: mariadb-replication-password
+            {{- end }}
             {{- if .Values.slave.extraEnvVars }}
             {{- tpl (toYaml .Values.slave.extraEnvVars) $ | nindent 12 }}
             {{- end }}
@@ -141,7 +151,15 @@ spec:
           {{- if .Values.slave.livenessProbe.enabled }}
           livenessProbe:
             exec:
-              command: ["sh", "-c", "exec mysqladmin status -uroot -p$MARIADB_MASTER_ROOT_PASSWORD"]
+              command:
+                - sh
+                - -c
+                - |
+                  if [[ -n $MARIADB_MASTER_ROOT_PASSWORD_FILE ]]; then
+                      password_aux=`cat ${MARIADB_MASTER_ROOT_PASSWORD_FILE}`
+                      export MARIADB_MASTER_ROOT_PASSWORD=$password_aux
+                  fi
+                  exec mysqladmin status -uroot -p$MARIADB_MASTER_ROOT_PASSWORD
             initialDelaySeconds: {{ .Values.slave.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.slave.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.slave.livenessProbe.timeoutSeconds }}
@@ -151,7 +169,15 @@ spec:
           {{- if .Values.slave.readinessProbe.enabled }}
           readinessProbe:
             exec:
-              command: ["sh", "-c", "exec mysqladmin status -uroot -p$MARIADB_MASTER_ROOT_PASSWORD"]
+              command:
+                - sh
+                - -c
+                - |
+                  if [[ -n $MARIADB_MASTER_ROOT_PASSWORD_FILE ]]; then
+                      password_aux=`cat ${MARIADB_MASTER_ROOT_PASSWORD_FILE}`
+                      export MARIADB_MASTER_ROOT_PASSWORD=$password_aux
+                  fi
+                  exec mysqladmin status -uroot -p$MARIADB_MASTER_ROOT_PASSWORD
             initialDelaySeconds: {{ .Values.slave.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.slave.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.slave.readinessProbe.timeoutSeconds }}
@@ -169,20 +195,33 @@ spec:
               mountPath: /opt/bitnami/mariadb/conf/my.cnf
               subPath: my.cnf
             {{- end }}
+            {{- if or .Values.rootUser.injectSecretsAsVolume .Values.replication.injectSecretsAsVolume }}
+            - name: mariadb-credentials
+              mountPath: /opt/bitnami/mariadb/secrets/
+            {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
           image: {{ template "mariadb.metrics.image" . }}
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
           env:
+            {{- if .Values.rootUser.injectSecretsAsVolume }}
+            - name: MARIADB_ROOT_PASSWORD_FILE
+              value: "/opt/bitnami/mariadb/secrets/mariadb-root-password"
+            {{- else }}
             - name: MARIADB_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mariadb.secretName" . }}
                   key: mariadb-root-password
+            {{- end }}
           command:
             - sh
             - -c
             - >-
+              if [[ -n $MARIADB_ROOT_PASSWORD_FILE ]]; then
+                  password_aux=`cat ${MARIADB_ROOT_PASSWORD_FILE}`
+                  export MARIADB_ROOT_PASSWORD=$password_aux
+              fi
               DATA_SOURCE_NAME="root:$MARIADB_ROOT_PASSWORD@(localhost:3306)/"
               /bin/mysqld_exporter
               {{- range .Values.metrics.extraArgs.slave }}
@@ -216,12 +255,31 @@ spec:
           {{- if .Values.metrics.resources }}
           resources: {{ toYaml .Values.metrics.resources | nindent 12 }}
           {{- end }}
+          {{- if .Values.rootUser.injectSecretsAsVolume }}
+          volumeMounts:
+            - name: mariadb-credentials
+              mountPath: /opt/bitnami/mariadb/secrets/
+          {{- end }}
         {{- end }}
       volumes:
         {{- if .Values.slave.config }}
         - name: config
           configMap:
             name: {{ template "slave.fullname" . }}
+        {{- end }}
+        {{- if or .Values.rootUser.injectSecretsAsVolume .Values.replication.injectSecretsAsVolume }}
+        - name: mariadb-credentials
+          secret:
+            secretName: {{ template "mariadb.fullname" . }}
+            items:
+              {{- if .Values.rootUser.injectSecretsAsVolume }}
+              - key: mariadb-root-password
+                path: mariadb-root-password
+              {{- end }}
+              {{- if .Values.replication.injectSecretsAsVolume }}
+              - key: mariadb-replication-password
+                path: mariadb-replication-password
+              {{- end }}
         {{- end }}
 {{- if not .Values.slave.persistence.enabled }}
         - name: "data"

--- a/stable/mariadb/templates/slave-statefulset.yaml
+++ b/stable/mariadb/templates/slave-statefulset.yaml
@@ -206,7 +206,7 @@ spec:
           env:
             {{- if .Values.rootUser.injectSecretsAsVolume }}
             - name: MARIADB_ROOT_PASSWORD_FILE
-              value: "/opt/bitnami/mariadb/secrets/mariadb-root-password"
+              value: "/opt/bitnami/mysqld-exporter/secrets/mariadb-root-password"
             {{- else }}
             - name: MARIADB_ROOT_PASSWORD
               valueFrom:
@@ -222,8 +222,7 @@ spec:
               if [ -f "${MARIADB_ROOT_PASSWORD_FILE:-}" ]; then
                   password_aux=$(cat $MARIADB_ROOT_PASSWORD_FILE)
               fi
-              DATA_SOURCE_NAME="root:$password_aux@(localhost:3306)/"
-              /bin/mysqld_exporter
+              DATA_SOURCE_NAME="root:${password_aux}@(localhost:3306)/" /bin/mysqld_exporter
               {{- range .Values.metrics.extraArgs.slave }}
               {{ . }}
               {{- end }}
@@ -258,7 +257,7 @@ spec:
           {{- if .Values.rootUser.injectSecretsAsVolume }}
           volumeMounts:
             - name: mariadb-credentials
-              mountPath: /opt/bitnami/mariadb/secrets/
+              mountPath: /opt/bitnami/mysqld-exporter/secrets/
           {{- end }}
         {{- end }}
       volumes:

--- a/stable/mariadb/values-production.yaml
+++ b/stable/mariadb/values-production.yaml
@@ -19,7 +19,7 @@
 image:
   registry: docker.io
   repository: bitnami/mariadb
-  tag: 10.3.20-debian-9-r18
+  tag: 10.3.20-debian-9-r19
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -459,7 +459,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mysqld-exporter
-    tag: 0.12.1-debian-9-r121
+    tag: 0.12.1-debian-9-r123
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/stable/mariadb/values-production.yaml
+++ b/stable/mariadb/values-production.yaml
@@ -19,7 +19,7 @@
 image:
   registry: docker.io
   repository: bitnami/mariadb
-  tag: 10.3.20-debian-9-r17
+  tag: 10.3.20-debian-9-r18
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/stable/mariadb/values-production.yaml
+++ b/stable/mariadb/values-production.yaml
@@ -90,7 +90,6 @@ serviceAccount:
 ## Role Based Access
 ## Ref: https://kubernetes.io/docs/admin/authorization/rbac/
 ##
-
 rbac:
   create: false
 
@@ -102,39 +101,52 @@ securityContext:
   fsGroup: 1001
   runAsUser: 1001
 
-# # Use existing secret (ignores root, db and replication passwords)
+## Use existing secret (ignores root, db and replication passwords)
+##
 # existingSecret:
 
+## MariaDB admin credentials
+##
 rootUser:
   ## MariaDB admin password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
   ##
   password: ""
-  ##
   ## Option to force users to specify a password. That is required for 'helm upgrade' to work properly.
   ## If it is not force, a random password will be generated.
+  ##
   forcePassword: true
+  ## Mount admin password as a file instead of using an environment variable
+  ##
+  injectSecretsAsVolume: true
 
+## Custom user/db credentials
+##
 db:
   ## MariaDB username and password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb#creating-a-database-user-on-first-run
   ##
   user: ""
   password: ""
-  ## Password is ignored if existingSecret is specified.
   ## Database to create
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb#creating-a-database-on-first-run
   ##
   name: my_database
   ## Option to force users to specify a password. That is required for 'helm upgrade' to work properly.
   ## If it is not force, a random password will be generated.
+  ##
   forcePassword: true
+  ## Mount user password as a file instead of using an environment variable
+  ##
+  injectSecretsAsVolume: true
 
+## Replication configuration
+##
 replication:
   ## Enable replication. This enables the creation of replicas of MariaDB. If false, only a
   ## master deployment would be created
-  enabled: true
   ##
+  enabled: true
   ## MariaDB replication user
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-up-a-replication-cluster
   ##
@@ -143,11 +155,13 @@ replication:
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-up-a-replication-cluster
   ##
   password: ""
-  ## Password is ignored if existingSecret is specified.
-  ##
   ## Option to force users to specify a password. That is required for 'helm upgrade' to work properly.
   ## If it is not force, a random password will be generated.
+  ##
   forcePassword: true
+  ## Mount replication user password as a file instead of using an environment variable
+  ##
+  injectSecretsAsVolume: true
 
 ## initdb scripts
 ## Specify dictionary of scripts to be run at first boot

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -19,7 +19,7 @@
 image:
   registry: docker.io
   repository: bitnami/mariadb
-  tag: 10.3.20-debian-9-r17
+  tag: 10.3.20-debian-9-r18
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -19,7 +19,7 @@
 image:
   registry: docker.io
   repository: bitnami/mariadb
-  tag: 10.3.20-debian-9-r18
+  tag: 10.3.20-debian-9-r19
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -461,7 +461,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mysqld-exporter
-    tag: 0.12.1-debian-9-r121
+    tag: 0.12.1-debian-9-r123
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -90,7 +90,6 @@ serviceAccount:
 ## Role Based Access
 ## Ref: https://kubernetes.io/docs/admin/authorization/rbac/
 ##
-
 rbac:
   create: false
 
@@ -102,39 +101,52 @@ securityContext:
   fsGroup: 1001
   runAsUser: 1001
 
-# # Use existing secret (ignores root, db and replication passwords)
+## Use existing secret (ignores root, db and replication passwords)
+##
 # existingSecret:
 
+## MariaDB admin credentials
+##
 rootUser:
   ## MariaDB admin password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
   ##
   password: ""
-  ##
   ## Option to force users to specify a password. That is required for 'helm upgrade' to work properly.
   ## If it is not force, a random password will be generated.
+  ##
   forcePassword: false
+  ## Mount admin password as a file instead of using an environment variable
+  ##
+  injectSecretsAsVolume: false
 
+## Custom user/db credentials
+##
 db:
   ## MariaDB username and password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb#creating-a-database-user-on-first-run
   ##
   user: ""
   password: ""
-  ## Password is ignored if existingSecret is specified.
   ## Database to create
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb#creating-a-database-on-first-run
   ##
   name: my_database
   ## Option to force users to specify a password. That is required for 'helm upgrade' to work properly.
   ## If it is not force, a random password will be generated.
+  ##
   forcePassword: false
+  ## Mount user password as a file instead of using an environment variable
+  ##
+  injectSecretsAsVolume: false
 
+## Replication configuration
+##
 replication:
   ## Enable replication. This enables the creation of replicas of MariaDB. If false, only a
   ## master deployment would be created
-  enabled: true
   ##
+  enabled: true
   ## MariaDB replication user
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-up-a-replication-cluster
   ##
@@ -143,11 +155,13 @@ replication:
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-up-a-replication-cluster
   ##
   password: ""
-  ## Password is ignored if existingSecret is specified.
-  ##
   ## Option to force users to specify a password. That is required for 'helm upgrade' to work properly.
   ## If it is not force, a random password will be generated.
+  ##
   forcePassword: false
+  ## Mount replication user password as a file instead of using an environment variable
+  ##
+  injectSecretsAsVolume: false
 
 ## initdb scripts
 ## Specify dictionary of scripts to be run at first boot


### PR DESCRIPTION
### Is this a new chart

No

#### What this PR does / why we need it:

This PR allows passing MariaDB credentials using mounted secrets, instead of declaring environment variables.

#### Which issue this PR fixes

  - fixes https://github.com/helm/charts/issues/19254

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
