### PR TITLE
[stable/prometheus-operator] round percents for TargetDown

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.3.2
+version: 8.3.3
 appVersion: 0.34.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/templates/prometheus/rules/general.rules.yaml
+++ b/stable/prometheus-operator/templates/prometheus/rules/general.rules.yaml
@@ -24,7 +24,7 @@ spec:
     - alert: TargetDown
       annotations:
         message: '{{`{{ $value }}`}}% of the {{`{{ $labels.job }}`}} targets are down.'
-      expr: 100 * (count(up == 0) BY (job) / count(up) BY (job)) > 10
+      expr: round(100 * (count(up == 0) BY (job) / count(up) BY (job)) > 10)
       for: 10m
       labels:
         severity: warning


### PR DESCRIPTION
I'm always feeling strange seeing an alert: `33.33333333333333% of the kubelet targets are down.` 

Let's make is just `33% of the kubelet targets are down.`

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

no

#### What this PR does / why we need it:

This PR adds `round` to one of prometheus-operator alerts, so it produces more human-readable notification.

#### Which issue this PR fixes

  - fixes #19395

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
