### PR TITLE
[stable/weave-scope] Fixes apiVersion typo for K8s 1.16

### DIFF
--- a/stable/weave-scope/Chart.yaml
+++ b/stable/weave-scope/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: weave-scope
-version: 1.1.6
+version: 1.1.7
 appVersion: 1.11.6
 description: A Helm chart for the Weave Scope cluster visualizer.
 keywords:

--- a/stable/weave-scope/charts/weave-scope-agent/Chart.yaml
+++ b/stable/weave-scope/charts/weave-scope-agent/Chart.yaml
@@ -1,6 +1,6 @@
 description: A Helm chart for the Weave Scope cluster visualizer node agent.
 name: weave-scope-agent
-version: 1.1.6
+version: 1.1.7
 appVersion: 1.11.6
 keywords:
   - containers

--- a/stable/weave-scope/charts/weave-scope-cluster-agent/Chart.yaml
+++ b/stable/weave-scope/charts/weave-scope-cluster-agent/Chart.yaml
@@ -1,6 +1,6 @@
 description: A Helm chart for the Weave Scope cluster visualizer node agent.
 name: weave-scope-cluster-agent
-version: 1.1.6
+version: 1.1.7
 appVersion: 1.11.6
 keywords:
   - containers

--- a/stable/weave-scope/charts/weave-scope-cluster-agent/templates/deployment.yaml
+++ b/stable/weave-scope/charts/weave-scope-cluster-agent/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
       app: {{ template "toplevel.name" . }}
       release: {{ .Release.Name }}
       component: cluster-agent
-  updateStrategy:
+  strategy:
     type: RollingUpdate
   template:
     metadata:

--- a/stable/weave-scope/charts/weave-scope-frontend/Chart.yaml
+++ b/stable/weave-scope/charts/weave-scope-frontend/Chart.yaml
@@ -1,7 +1,7 @@
 description: A Helm chart for the Weave Scope cluster visualizer frontend.
 name: weave-scope-frontend
-version: 1.1.5
-appVersion: 1.11.5
+version: 1.1.7
+appVersion: 1.11.6
 keywords:
   - containers
   - dashboard

--- a/stable/weave-scope/charts/weave-scope-frontend/templates/deployment.yaml
+++ b/stable/weave-scope/charts/weave-scope-frontend/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.enabled -}}
-apiVersion: apps/v1beta1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
* Fixes a bug introduced in #17525 - see https://github.com/helm/charts/pull/17525#issuecomment-556069627 for the context
* Fixes a typo `updateStrategy` -> `strategy` in a _Deployment_ which now gets reported on in _Helm 3.0_
* Bumps chart version(s), including the previously missed one `weave-scope-frontend/Chart.yaml`
