### PR TITLE
[stable/kong] Add support for validating admission webhook

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.27.2
+version: 0.28.0
 appVersion: 1.3

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -396,13 +396,23 @@ You can can learn about kong ingress custom resource definitions [here](https://
 | image.tag                          | Version of the ingress controller                                                     | 0.6.0                                                                        |
 | readinessProbe                     | Kong ingress controllers readiness probe                                              |                                                                              |
 | livenessProbe                      | Kong ingress controllers liveness probe                                               |                                                                              |
-| ingressClass                       | The ingress-class value for controller                                                | kong                                                                        |
+| ingressClass                       | The ingress-class value for controller                                                | kong                                                                         |
 | podDisruptionBudget.enabled        | Enable PodDisruptionBudget for ingress controller                                     | `false`                                                                      |
 | podDisruptionBudget.maxUnavailable | Represents the minimum number of Pods that can be unavailable (integer or percentage) | `50%`                                                                        |
 | podDisruptionBudget.minAvailable   | Represents the number of Pods that must be available (integer or percentage)          |                                                                              |
+| admissionWebhook.enabled           | Whether to enable the validating admission webhook                                    | false                                                                        |
+| admissionWebhook.failurePolicy     | How unrecognized errors from the admission endpoint are handled (Ignore or Fail)      | Fail                                                                         |
+| admissionWebhook.port              | The port the ingress controller will listen on for admission webhooks                 | 8080                                                                         |
 
 
 ## Changelog
+
+### 0.28.0
+
+#### New Features
+
+- Added support for the Validating Admission Webhook with the Ingress Controller.
+
 ### 0.27.2
 
 #### Fixes

--- a/stable/kong/ci/ingressController-with-webhook.yaml
+++ b/stable/kong/ci/ingressController-with-webhook.yaml
@@ -1,0 +1,5 @@
+# CI test for Ingress controller basic installation and admission webhook
+ingressController:
+  enabled: true
+  admissionWebhook:
+    enabled: true

--- a/stable/kong/templates/admission-webhook.yaml
+++ b/stable/kong/templates/admission-webhook.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.ingressController.admissionWebhook.enabled }}
+{{- $cn := printf "%s.%s.svc" ( include "kong.service.validationWebhook" . ) .Release.Namespace }}
+{{- $ca := genCA "kong-admission-ca" 3650 -}}
+{{- $cert := genSignedCert $cn nil nil 3650 $ca -}}
+kind: ValidatingWebhookConfiguration
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+{{- end }}
+metadata:
+  name: {{ template "kong.fullname" . }}-validations
+  labels:
+    app: {{ template "kong.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+webhooks:
+- name: validations.kong.konghq.com
+  failurePolicy: {{ .Values.ingressController.admissionWebhook.failurePolicy }}
+  rules:
+  - apiGroups:
+    - configuration.konghq.com
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kongconsumers
+    - kongplugins
+  clientConfig:
+    caBundle: {{ b64enc $ca.Cert }}
+    service:
+      name: {{ template "kong.service.validationWebhook" . }}
+      namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kong.service.validationWebhook" . }}
+  labels:
+    app: {{ template "kong.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  ports:
+  - name: webhook
+    port: 443
+    protocol: TCP
+    targetPort: webhook
+  selector:
+    app: {{ template "kong.name" . }}
+    release: {{ .Release.Name }}
+    component: app
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "kong.fullname" . }}-validation-webhook-keypair
+  labels:
+    app: {{ template "kong.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ b64enc $cert.Cert }}
+  tls.key: {{ b64enc $cert.Key }}
+{{ end }}

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -220,6 +220,11 @@ spec:
         - name: metrics
           containerPort: 9542
           protocol: TCP
+        {{- if .Values.ingressController.admissionWebhook.enabled }}
+        - name: webhook
+          containerPort: {{ .Values.ingressController.admissionWebhook.port }}
+          protocol: TCP
+        {{- end }}
         {{- if .Values.enterprise.enabled }}
         {{- if .Values.manager.http.enabled }}
         - name: manager

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -412,6 +412,11 @@ ingressController:
 
   installCRDs: true
 
+  admissionWebhook:
+    enabled: false
+    failurePolicy: Fail
+    port: 8080
+
   rbac:
     # Specifies whether RBAC resources should be created
     create: true


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Enables the use of the kong ingress controller's validating admission webhook:
* [docs](https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/deployment/admission-webhook.md)
* [official manifest](https://github.com/Kong/kubernetes-ingress-controller/blob/master/deploy/manifests/validation-webhook-configuration.yaml)

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

* I tested this on Kubernetes 1.14 and it worked fine. I'm not yet able to test on 1.15, where the v1 admission registration API is available.

* Currently the cert and key are just generated within the chart. I used the [OPA chart's webhook template](https://github.com/helm/charts/blob/master/stable/opa/templates/webhookconfiguration.yaml) as inspiration.

* I setup the new values to be flexible enough that we could later support either an externally provided cert and key or using cert-manager.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
