### PR TITLE
[stable/elasticsearch-curator] Add missing '$' for the .Values.command variable

### DIFF
--- a/stable/elasticsearch-curator/Chart.yaml
+++ b/stable/elasticsearch-curator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "5.7.6"
 description: A Helm chart for Elasticsearch Curator
 name: elasticsearch-curator
-version: 2.1.2
+version: 2.1.3
 home: https://github.com/elastic/curator
 keywords:
 - curator

--- a/stable/elasticsearch-curator/templates/hooks/job.install.yaml
+++ b/stable/elasticsearch-curator/templates/hooks/job.install.yaml
@@ -49,9 +49,9 @@ spec:
     {{- if $.Values.extraVolumeMounts }}
 {{ toYaml $.Values.extraVolumeMounts | indent 12 }}
     {{- end }}
-{{ if .Values.command }}
+{{ if $.Values.command }}
           command:
-{{ toYaml .Values.command | indent 12 }}
+{{ toYaml $.Values.command | indent 12 }}
 {{- end }}
           args: [ "--config", "/etc/es-curator/config.yml", "/etc/es-curator/action_file.yml" ]
           resources:


### PR DESCRIPTION
Fixes #19166

Signed-off-by: Michael Dop <michael.p.dop@gmail.com>

#### Checklist
- [ x ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ x ] Chart Version bumped
- [ x ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
