### PR TITLE
[incubator/solr] Add image pullSecrets

### DIFF
--- a/incubator/solr/Chart.yaml
+++ b/incubator/solr/Chart.yaml
@@ -2,7 +2,7 @@
 
 apiVersion: "v1"
 name: "solr"
-version: "1.3.2"
+version: "1.3.3"
 appVersion: "7.7.2"
 description: "A helm chart to install Apache Solr: http://lucene.apache.org/solr/"
 keywords:

--- a/incubator/solr/README.md
+++ b/incubator/solr/README.md
@@ -25,6 +25,7 @@ The following table shows the configuration options for the Solr helm chart:
 
 | Parameter                                     | Description                           | Default Value                                                       |
 | --------------------------------------------- | ------------------------------------- | --------------------------------------------------------------------- |
+| `global.imagePullSecrets`                     | Global Docker registry secret names as an array       | `[]` (does not add image pull secrets to deployed pods)      |
 | `port`                                        | The port that Solr will listen on | `8983`                                                                |
 | `replicaCount`                                | The number of replicas in the Solr statefulset | `3`                                                                   |
 | `javaMem`                                     | JVM memory settings to pass to Solr | `-Xms2g -Xmx3g`                                                       |
@@ -34,6 +35,7 @@ The following table shows the configuration options for the Solr helm chart:
 | `image.repository`                            | The repository to pull the docker image from| `solr`                                                                |
 | `image.tag`                                   | The tag on the repository to pull | `7.7.2`                                                               |
 | `image.pullPolicy`                            | Solr pod pullPolicy | `IfNotPresent`                                                              |
+| `image.pullSecrets`                           | Specify docker-registry secret names as an array      | `[]` (does not add image pull secrets to deployed pods)      |
 | `livenessProbe.initialDelaySeconds`           | Initial Delay for Solr pod liveness probe | `20`                                                                  |
 | `livenessProbe.periodSeconds`                 | Poll rate for liveness probe | `10`                                                                  |
 | `readinessProbe.initialDelaySeconds`          | Initial Delay for Solr pod readiness probe | `15`                                                                  |
@@ -61,6 +63,7 @@ The following table shows the configuration options for the Solr helm chart:
 | `service.type`                                | The type of service for the solr client service | `ClusterIP`                                                           |
 | `service.annotations`                         | Annotations to apply to the solr client service | `{}` |
 | `exporter.enabled`                            | Whether to enable the Solr Prometheus exporter | `false`                                                               |
+| `exporter.image.pullSecrets`                  | Specify docker-registry secret names as an array      | `[]` (does not add image pull secrets to deployed pods)      |
 | `exporter.configFile`                         | The path in the docker image that the exporter loads the config from | `/opt/solr/contrib/prometheus-exporter/conf/solr-exporter-config.xml` |
 | `exporter.updateStrategy`                     | Update strategy for the exporter deployment | `{}` |
 | `exporter.podAnnotations`                     | Annotations to set on the exporter pods | `{}`

--- a/incubator/solr/templates/_helpers.tpl
+++ b/incubator/solr/templates/_helpers.tpl
@@ -89,3 +89,38 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/chart: {{ include "solr.chart" . }}
 {{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "solr.imagePullSecrets" -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
+Also, we can not use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- else if or .Values.image.pullSecrets .Values.exporter.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.exporter.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- else if or .Values.image.pullSecrets .Values.exporter.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.exporter.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/incubator/solr/templates/exporter-deployment.yaml
+++ b/incubator/solr/templates/exporter-deployment.yaml
@@ -47,6 +47,7 @@ spec:
       annotations:
 {{ toYaml .Values.exporter.podAnnotations | indent 8 }}
     spec:
+{{- include "solr.imagePullSecrets" . | indent 6 }}    
       affinity:
 {{ tpl (toYaml .Values.affinity) .  | indent 8 }}
       containers:

--- a/incubator/solr/templates/statefulset.yaml
+++ b/incubator/solr/templates/statefulset.yaml
@@ -26,6 +26,7 @@ spec:
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
+{{- include "solr.imagePullSecrets" . | indent 6 }}
       {{- if .Values.schedulerName }}
       schedulerName: "{{ .Values.schedulerName }}"
       {{- end }}

--- a/incubator/solr/values.yaml
+++ b/incubator/solr/values.yaml
@@ -1,4 +1,11 @@
 ---
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imagePullSecrets
+##
+# global:
+#   imagePullSecrets:
+#     - myRegistryKeySecretName
 
 # Which port should solr listen on
 port: 8983
@@ -24,6 +31,13 @@ image:
   repository: solr
   tag: 7.7.2
   pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistryKeySecretName
+
 
 # Solr pod liveness
 livenessProbe:
@@ -87,6 +101,13 @@ service:
 
 # Configuration for the solr prometheus exporter
 exporter:
+  image: {}
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  #   pullSecrets:
+  #     - myRegistryKeySecretName
   enabled: false  # Deploy the exporter
   configFile: "/opt/solr/contrib/prometheus-exporter/conf/solr-exporter-config.xml"  # The config file to point the exporter to
   updateStrategy: {}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

In most of the stable charts there exists values for image pull secrets. These are currently missing in solr, so its not possible to use this chart with custom images or just self hosted registries/proxies.

#### Special notes for your reviewer:
@ian-thebridge-lucidworks Most comments are copied from stable/drupal, but the exact comments are found in many other stable charts as well.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
