### PR TITLE
[stable/redis-ha] Improve testpods

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.2.0
+version: 4.2.1
 appVersion: 5.0.6
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/README.md
+++ b/stable/redis-ha/README.md
@@ -143,6 +143,7 @@ The following table lists the configurable parameters of the Redis chart and the
 | `sysctlImage.mountHostSys`| Mount the host `/sys` folder to `/host-sys`                                                                                                                                                              | `false`                                                                                    |
 | `sysctlImage.resources`   | sysctlImage resources                                                                                                                                                                                    | `{}`                                                                                       |
 | `schedulerName`           | Alternate scheduler name                                                                                                                                                                                 | `nil`                                                                                      |
+| `tests.enabled`           | Deploy onetime test pods                                                                                                                                                                                 | `true`                                                                                      |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/redis-ha/templates/tests/test-redis-ha-configmap.yaml
+++ b/stable/redis-ha/templates/tests/test-redis-ha-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ template "redis-ha.fullname" . }}-configmap-test
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
   annotations:

--- a/stable/redis-ha/templates/tests/test-redis-ha-configmap.yaml
+++ b/stable/redis-ha/templates/tests/test-redis-ha-configmap.yaml
@@ -15,6 +15,8 @@ spec:
     args:
     - --shell=sh
     - /readonly-config/init.sh
+    securityContext:
+      runAsUser: 1
     volumeMounts:
     - name: config
       mountPath: /readonly-config

--- a/stable/redis-ha/templates/tests/test-redis-ha-configmap.yaml
+++ b/stable/redis-ha/templates/tests/test-redis-ha-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tests.enabled -}}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -22,3 +23,4 @@ spec:
     configMap:
       name: {{ template "redis-ha.fullname" . }}-configmap
   restartPolicy: Never
+{{- end -}}

--- a/stable/redis-ha/templates/tests/test-redis-ha-configmap.yaml
+++ b/stable/redis-ha/templates/tests/test-redis-ha-configmap.yaml
@@ -15,12 +15,12 @@ spec:
     args:
     - --shell=sh
     - /readonly-config/init.sh
-    securityContext:
-      runAsUser: 1
     volumeMounts:
     - name: config
       mountPath: /readonly-config
       readOnly: true
+  securityContext:
+{{ toYaml .Values.securityContext | indent 4 }}
   volumes:
   - name: config
     configMap:

--- a/stable/redis-ha/templates/tests/test-redis-ha-pod.yaml
+++ b/stable/redis-ha/templates/tests/test-redis-ha-pod.yaml
@@ -16,5 +16,7 @@ spec:
       - sh
       - -c
       - redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.redis.port }} info server
+    securityContext:
+      runAsUser: 1
   restartPolicy: Never
 {{- end -}}

--- a/stable/redis-ha/templates/tests/test-redis-ha-pod.yaml
+++ b/stable/redis-ha/templates/tests/test-redis-ha-pod.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tests.enabled -}}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -15,3 +16,4 @@ spec:
       - -c
       - redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.redis.port }} info server
   restartPolicy: Never
+{{- end -}}

--- a/stable/redis-ha/templates/tests/test-redis-ha-pod.yaml
+++ b/stable/redis-ha/templates/tests/test-redis-ha-pod.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ template "redis-ha.fullname" . }}-service-test
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
   annotations:

--- a/stable/redis-ha/templates/tests/test-redis-ha-pod.yaml
+++ b/stable/redis-ha/templates/tests/test-redis-ha-pod.yaml
@@ -16,7 +16,7 @@ spec:
       - sh
       - -c
       - redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.redis.port }} info server
-    securityContext:
-      runAsUser: 1
+  securityContext:
+{{ toYaml .Values.securityContext | indent 4 }}
   restartPolicy: Never
 {{- end -}}

--- a/stable/redis-ha/values.yaml
+++ b/stable/redis-ha/values.yaml
@@ -313,3 +313,7 @@ hostPath:
   # change the owner of the hostPath folder to the user defined in the
   # security context
   chown: true
+
+# By default, testing pods are run after deployments
+tests:
+  enabled: true


### PR DESCRIPTION
#### What this PR does / why we need it:

The redis-ha chart creates 2 test pods which verify that the deployed redis is actually responding. 

This PR aims to improve those pods in 3 areas: 

1. Those (one-time) pods lie around afterwards and at least one might even have run into an error since it tried to check the redis before it was deployed (when not using helm lifecycle hooks but only helm template). Therefore, I made it configurable if the pods are created at all (testing.enabled: true/false) to be able to just switch them off when needed. 

2. The other manifests do install in the namespace given helm as release namespace. The test pods are installed into the current default namespace. I changed that so that the testing pods are put into the release namespace, too. 

3. The test pods try to run as root by default, which breaks in clusters with podSecurityPolicies enabled. From what they do, they can easily run as a non-privileged user. 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
