### PR TITLE
[incubator/solr] Add volume to solr for plugins

### DIFF
--- a/incubator/solr/Chart.yaml
+++ b/incubator/solr/Chart.yaml
@@ -2,7 +2,7 @@
 
 apiVersion: "v1"
 name: "solr"
-version: "1.3.2"
+version: "1.3.3"
 appVersion: "7.7.2"
 description: "A helm chart to install Apache Solr: http://lucene.apache.org/solr/"
 keywords:

--- a/incubator/solr/README.md
+++ b/incubator/solr/README.md
@@ -60,6 +60,9 @@ The following table shows the configuration options for the Solr helm chart:
 | `tls.certSecret.certPath`                     | The key in the Kubernetes secret that contains the TLS certificate | `tls.crt`                                                             |
 | `service.type`                                | The type of service for the solr client service | `ClusterIP`                                                           |
 | `service.annotations`                         | Annotations to apply to the solr client service | `{}` |
+| `plugins.storageClassName`                    | The name of the storage class for the Solr Plugins PVC | `nil`                                                             |
+| `plugins.storageSize`                         | The size of the Plugins PVC | `nil`                                                                |
+| `plugins.accessModes`                         | The access mode of the Plugins PVC| `nil`                                                       |
 | `exporter.enabled`                            | Whether to enable the Solr Prometheus exporter | `false`                                                               |
 | `exporter.configFile`                         | The path in the docker image that the exporter loads the config from | `/opt/solr/contrib/prometheus-exporter/conf/solr-exporter-config.xml` |
 | `exporter.updateStrategy`                     | Update strategy for the exporter deployment | `{}` |

--- a/incubator/solr/templates/_helpers.tpl
+++ b/incubator/solr/templates/_helpers.tpl
@@ -73,6 +73,15 @@ Create chart name and version as used by the chart label.
 {{ printf "%s-%s" (include "solr.fullname" .) "pvc" | trunc 63 | trimSuffix "-"  }}
 {{- end -}}
 
+
+{{/*
+  Define the name of the solr PVC for plugins
+*/}}
+{{- define "solr.pvc-plugin-name" -}}
+{{ printf "%s-%s" .Release.Name "plugin-pvc" | trunc 63 | trimSuffix "-"  }}
+{{- end -}}
+
+
 {{/*
   Define the name of the solr.xml configmap
 */}}

--- a/incubator/solr/templates/statefulset.yaml
+++ b/incubator/solr/templates/statefulset.yaml
@@ -48,6 +48,11 @@ spec:
             secretName: {{ .Values.tls.caSecret.name }}
 {{- end }}
 {{- end }}
+{{- if .Values.plugins }}
+        - name: {{ include "solr.pvc-plugin-name" . }}
+          persistentVolumeClaim:
+            claimName: {{ include "solr.pvc-plugin-name" . }}
+{{- end }}            
         - name: solr-xml
           configMap:
             name: {{ include "solr.configmap-name" . }}
@@ -202,6 +207,10 @@ spec:
             - name: "keystore-volume"
               mountPath: "/etc/ssl/keystores"
 {{ end }}
+{{- if .Values.plugins }}
+            - name: {{ include "solr.pvc-plugin-name" . }}
+              mountPath: "/opt/solr/server/home/lib"
+{{- end }}
   volumeClaimTemplates:
     - metadata:
         name: {{ include "solr.pvc-name" . }}

--- a/incubator/solr/values.yaml
+++ b/incubator/solr/values.yaml
@@ -103,3 +103,10 @@ exporter:
   service:
     type: "ClusterIP"
     annotations: {}
+
+## Additional jars volume for plugins
+#  plugins:
+#   storageClassName: ""
+#   storageSize: "100Mi"
+#   accessModes:
+#     - "ReadWriteMany"


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds a additional PVC to store plugins.
It is a single PVC which should support `ReadWriteMany` or `ReadOnlyMany` to share additional solr libaries/plugins to be added to all nodes. See https://lucene.apache.org/solr/guide/8_2/resource-and-plugin-loading.html

This approach uses the `on a filesystem accessible to Solr nodes` option, as adding the libs to zookeeper is not implemented, even if the docs say differently and the BlobStore doesn't work if you want to add/use the libs already in `solrconfig.xml` from your collections.

To use the libs added into that volume you can use the following in the `solrconfig.xml`:
```<lib dir="../lib" regex=".*\.jar" />```

After that all libs can be used in the solr deployment.

#### Special notes for your reviewer:

@ian-thebridge-lucidworks I first tried to use a config map with binaryData, but some plugins can get bigger (e.g. mariadb-lib) and exceeds the k8s limit (`data: Too long: must have at most 1048576 characters`)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
