### PR TITLE
[stable/kube-state-metrics] add releaseNamespace option to restrict metrics collection to release namespace

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - monitoring
 - prometheus
 - kubernetes
-version: 2.4.1
+version: 2.4.2
 appVersion: 1.8.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -66,3 +66,4 @@ $ helm install stable/kube-state-metrics
 | `prometheus.monitor.additionalLabels`   | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`                                       |
 | `prometheus.monitor.namespace`          | Namespace where servicemonitor resource should be created                             | `the same namespace as kube-state-metrics` |
 | `prometheus.monitor.honorLabels`        | Honor metric labels                                                                   | `false`                                    |
+| `releaseNamespace`                      | Only collect metrics in the release namespace (overrides .Values.namespace)      | `false`                                    |

--- a/stable/kube-state-metrics/templates/deployment.yaml
+++ b/stable/kube-state-metrics/templates/deployment.yaml
@@ -113,7 +113,9 @@ spec:
 {{  if .Values.collectors.verticalpodautoscalers  }}
         - --collectors=verticalpodautoscalers
 {{  end  }}
-{{ if .Values.namespace }}
+{{ if .Values.releaseNamespace }}
+        - --namespace={{ .Release.Namespace }}
+{{ else if .Values.namespace }}
         - --namespace={{ .Values.namespace }}
 {{ end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -109,3 +109,6 @@ collectors:
 
 # Namespace to be enabled for collecting resources. By default all namespaces are collected.
 # namespace: ""
+
+# Only collect metrics in the release namespace (overrides .Values.namespace)
+releaseNamespace: false


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds `releaseNamespace` option to override `namespace` option and set it to `Release.Namespace`

Since limiting kube-state-metrics to the release namespace is the main use case for the `--namespace` command argument, we should be able to achieve this without hardcoding a namespace in `.Values.namespace`
Users will still be able to specify a custom namespace using the `namespace` option

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
