### PR TITLE
[stable/drone] added the ability to override DRONE_RPC_SERVER

### DIFF
--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 2.3.1
+version: 2.3.2
 appVersion: 1.6.1
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/stable/drone/README.md
+++ b/stable/drone/README.md
@@ -109,6 +109,7 @@ The following table lists the configurable parameters of the drone charts and th
 | `agent.readinessProbe` | Not currently used  | `{}` |
 | `agent.volumes`             | Additional volumes to make available to agent (shared by dind if used)                        | `nil`                       |
 | `agent.volumeMounts`        | Mount points for volumes                                                                      | `nil`                       |
+| `agent.rpcServerOverride`   | Override rpc server url                                                                       | `nil`                       |
 | `dind.enabled`              | Enable or disable **DinD**                                                                    | `true`                      |
 | `dind.driver`               | **DinD** storage driver                                                                       | `overlay2`                  |
 | `dind.volumeMounts`         | Mount points for volumes (defined in agent.volumes)                                           | `nil`                       |

--- a/stable/drone/templates/_helpers.tpl
+++ b/stable/drone/templates/_helpers.tpl
@@ -15,6 +15,17 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this
 {{ end }}
 
 {{/*
+Allow overwrite of rpc server.
+*/}}
+{{ define "drone.rpcServer" }}
+{{- if .Values.agent.rpcServerOverride -}}
+  {{ .Values.agent.rpcServerOverride }}
+{{- else -}}
+  {{ printf "http://%s" (include "drone.fullname" .) }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "drone.serviceAccountName" -}}

--- a/stable/drone/templates/deployment-agent.yaml
+++ b/stable/drone/templates/deployment-agent.yaml
@@ -54,7 +54,7 @@ spec:
           protocol: TCP
         env:
           - name: DRONE_RPC_SERVER
-            value: http://{{ template "drone.fullname" . }}
+            value: {{ template "drone.rpcServer" . }}
           - name: DRONE_RPC_SECRET
             valueFrom:
               secretKeyRef:

--- a/stable/drone/templates/deployment-agent.yaml
+++ b/stable/drone/templates/deployment-agent.yaml
@@ -54,7 +54,7 @@ spec:
           protocol: TCP
         env:
           - name: DRONE_RPC_SERVER
-            value: {{ template "drone.rpcServer" . }}
+            value: "{{ template "drone.rpcServer" . }}"
           - name: DRONE_RPC_SECRET
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
Signed-off-by: Davíð Örn Jóhannsson @davideagle <davideaglephotos@gmail.com>
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Adding the ability to overwrite DRONE_RPC_SERVER environment variable. We use an ingress to for the RPC server in order to allow EC2 build agents to access the RPC server running in kubernetes.

Values.agent.rpcServerOverride: http://server

@zakkg3 @christian-roggia @paulczar 


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [x] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
