### PR TITLE
Add redis authoration configuration in prometheus-redis-exporter chart

### DIFF
--- a/stable/prometheus-redis-exporter/templates/deployment.yaml
+++ b/stable/prometheus-redis-exporter/templates/deployment.yaml
@@ -42,6 +42,17 @@ spec:
           env:
             - name: REDIS_ADDR
               value: {{ .Values.redisAddress }}
+          {{- if .Values.auth.enabled }}
+            - name: REDIS_PASSWORD
+            {{- if .Values.auth.secret.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.secret.name }}
+                  key: {{ .Values.secret.key }}
+            {{- else }}
+              value: {{ .Values.auth.redisPassword }}
+            {{- end }}
+          {{- end }}
 {{- if .Values.script }}
             - name: REDIS_EXPORTER_SCRIPT
               value: /script/script.lua

--- a/stable/prometheus-redis-exporter/values.yaml
+++ b/stable/prometheus-redis-exporter/values.yaml
@@ -58,3 +58,13 @@ serviceMonitor:
 # script:
 #   configmap: prometheus-redis-exporter-script
 #   keyname: script
+
+auth:
+  # when redis use password to attach
+  enabled: false
+  # redis password stored in Secret
+  secret:
+    name: ""
+    key: ""
+  # when redis password not be stored in Secret, point it directly
+  redisPassword: ""


### PR DESCRIPTION
Signed-off-by: 朱晨捷 <zhuchenjie@hikvision.com.cn>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.
no
#### What this PR does / why we need it:
There is no redis password configuration in prometheus-redis-exporter chart.

#### Which issue this PR fixes


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
