### PR TITLE
[stable/velero] Add service account annotations

### DIFF
--- a/stable/velero/Chart.yaml
+++ b/stable/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.2.0
 description: A Helm chart for velero
 name: velero
-version: 2.6.0
+version: 2.6.1
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/stable/velero/README.md
+++ b/stable/velero/README.md
@@ -67,9 +67,9 @@ Parameter | Description | Default
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `podAnnotations` | Annotations for the Velero server pod | `{}`
 `rbac.create` | If true, create and use RBAC resources | `true`
-`server.serviceAccount.create` | Whether a new service account name that the server will use should be created | `true`
-`server.serviceAccount.name` | Service account to be used for the server. If not set and `rbac.server.serviceAccount.create` is `true` a name is generated using the fullname template | ``
-`server.serviceAccount.annotations` | Annotations to be added to the created service account | `{}`
+`serviceAccount.server.create` | Whether a new service account name that the server will use should be created | `true`
+`serviceAccount.server.name` | Service account to be used for the server. If not set and `serviceAccount.server.create` is `true` a name is generated using the fullname template | ``
+`serviceAccount.server.annotations` | Annotations to be added to the created service account | `{}`
 `resources` | Resource requests and limits | `{}`
 `initContainers` | InitContainers and their specs to start with the deployment pod | `[]`
 `tolerations` | List of node taints to tolerate | `[]`

--- a/stable/velero/README.md
+++ b/stable/velero/README.md
@@ -67,8 +67,9 @@ Parameter | Description | Default
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `podAnnotations` | Annotations for the Velero server pod | `{}`
 `rbac.create` | If true, create and use RBAC resources | `true`
-`rbac.server.serviceAccount.create` | Whether a new service account name that the server will use should be created | `true`
-`rbac.server.serviceAccount.name` | Service account to be used for the server. If not set and `rbac.server.serviceAccount.create` is `true` a name is generated using the fullname template | ``
+`server.serviceAccount.create` | Whether a new service account name that the server will use should be created | `true`
+`server.serviceAccount.name` | Service account to be used for the server. If not set and `rbac.server.serviceAccount.create` is `true` a name is generated using the fullname template | ``
+`server.serviceAccount.annotations` | Annotations to be added to the created service account | `{}`
 `resources` | Resource requests and limits | `{}`
 `initContainers` | InitContainers and their specs to start with the deployment pod | `[]`
 `tolerations` | List of node taints to tolerate | `[]`

--- a/stable/velero/templates/serviceaccount-server.yaml
+++ b/stable/velero/templates/serviceaccount-server.yaml
@@ -8,4 +8,8 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "velero.chart" . }}
+  {{- with .Values.serviceAccount.server.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/stable/velero/values.yaml
+++ b/stable/velero/values.yaml
@@ -145,6 +145,7 @@ rbac:
 # Information about the Kubernetes service account Velero uses.
 serviceAccount:
   server:
+    annotations: {}
     create: true
     name:
 


### PR DESCRIPTION
#### What this PR does / why we need it:
 - Adds the ability to specify annotations on the created service account
 - Also fixes other `serviceAccount` variables, as they are no longer nested under `rbac:`
#### Which issue this PR fixes
As of 1.14 on EKS, IAM Roles can be assumed directly by service accounts. This is done through the use of annotations on the ServiceAccount. There may be other use cases as well

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/helm/charts/19459)
<!-- Reviewable:end -->
