### PR TITLE
[stable/prometheus-cloudwatch-exporter] Add service account annotations

### DIFF
--- a/stable/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/stable/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.6.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.5.0
+version: 0.5.1
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -67,6 +67,7 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | `aws.secret.includesSessionToken` | Whether or not the pre-created secret contains an AWS STS session token |                             |
 | `config`                          | Cloudwatch exporter configuration                                       | `example configuration`     |
 | `rbac.create`                     | If true, create & use RBAC resources                                    | `false`                     |
+| `serviceAccount.annotations`      | Add annotations to the created service account                          | `{}`                        |
 | `serviceAccount.create`           | Specifies whether a service account should be created.                  | `true`                      |
 | `serviceAccount.name`             | Name of the service account.                                            |                             |
 | `tolerations`                     | Add tolerations                                                         | `[]`                        |

--- a/stable/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
@@ -8,4 +8,8 @@ metadata:
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}    
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -59,6 +59,8 @@ aws:
   aws_secret_access_key:
 
 serviceAccount:
+  # Add annotations to the created service account
+  annotations: {}
   # Specifies whether a ServiceAccount should be created
   create: true
   # The name of the ServiceAccount to use.


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds `serviceAccount.annotations` to add annotations to the generated service account. As of 1.14, EKS allos binding IAM roles directly to a service account, through the use of annotations. There may be other use cases as well

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/helm/charts/19460)
<!-- Reviewable:end -->
