### PR TITLE
[stable/rabbitmq] Fix metrics service port.

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.14.1
+version: 6.14.2
 appVersion: 3.8.2
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/templates/svc.yaml
+++ b/stable/rabbitmq/templates/svc.yaml
@@ -62,7 +62,7 @@ spec:
 {{- if .Values.metrics.enabled }}
   - name: metrics
     port: {{ .Values.metrics.port }}
-    targetPort: 9090
+    targetPort: metrics
     {{- if (eq .Values.service.type "ClusterIP") }}
     nodePort: null
     {{- end }}


### PR DESCRIPTION
Incompatibility between https://github.com/helm/charts/pull/16302 and https://github.com/helm/charts/pull/16302.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
