### PR TITLE
[stable/prestashop] multi release support

### DIFF
--- a/stable/prestashop/Chart.yaml
+++ b/stable/prestashop/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prestashop
-version: 9.0.2
+version: 9.1.0
 appVersion: 1.7.6-2
 description: A popular open source ecommerce solution. Professional tools are easily accessible to increase online sales including instant guest checkout, abandoned cart reminders and automated Email marketing.
 keywords:

--- a/stable/prestashop/templates/svc.yaml
+++ b/stable/prestashop/templates/svc.yaml
@@ -30,3 +30,4 @@ spec:
       {{- end }}
   selector:
     app: "{{ template "prestashop.name" . }}"
+    release: "{{ .Release.Name }}"


### PR DESCRIPTION
Signed-off-by: Andrejs Volkovs <andrey@printify.com>

#### What this PR does / why we need it:

@bitnami-bot 

Support multiple releases of Prestashop. Currently, k8s service selects Pods by
`selector.app: "{{ template "prestashop.name" . }}"` where `template "prestashop.name"` is the same for all releases e.g. `prestashop`.

Using selector `template "prestashop.name"` and `.Release.name` would allow service to select individual release pods.

#### Special notes for your reviewer:

Not sure if using `selector.app: "{{ template "prestashop.fullname" . }}"` is a better idea instead of combining name and release, but it would require more changes to the codebase.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
