### PR TITLE
[stable/spring-cloud-data-flow] Add task scheduler launcher url

### DIFF
--- a/stable/spring-cloud-data-flow/Chart.yaml
+++ b/stable/spring-cloud-data-flow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Toolkit for building data processing pipelines.
 name: spring-cloud-data-flow
-version: 2.5.0
+version: 2.5.1
 appVersion: 2.3.0.RELEASE
 home: http://cloud.spring.io/spring-cloud-dataflow/
 sources:

--- a/stable/spring-cloud-data-flow/templates/server-deployment.yaml
+++ b/stable/spring-cloud-data-flow/templates/server-deployment.yaml
@@ -84,6 +84,8 @@ spec:
           value: {{ .Values.features.batch.enabled | quote }}
         - name: SPRING_CLOUD_DATAFLOW_FEATURES_SCHEDULES_ENABLED
           value: {{ .Values.features.batch.enabled | quote }}
+        - name: SPRING_CLOUD_DATAFLOW_TASK_SCHEDULER_TASK_LAUNCHER_URL
+          value: 'docker://springcloud/spring-cloud-dataflow-scheduler-task-launcher:{{ .Values.server.version }}'
       volumes:
         - name: database
           secret:


### PR DESCRIPTION
#### What this PR does / why we need it:

- add SPRING_CLOUD_DATAFLOW_TASK_SCHEDULER_TASK_LAUNCHER_URL to server env vars

Signed-off-by: Chris Schaefer <cschaefer@pivotal.io>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
