### PR TITLE
stable/atlantis [19474]: correct format on defaultTFVersion value

### DIFF
--- a/stable/atlantis/Chart.yaml
+++ b/stable/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.8.2"
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 3.9.0
+version: 3.9.1
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/stable/atlantis/values.yaml
+++ b/stable/atlantis/values.yaml
@@ -111,7 +111,7 @@ image:
 allowForkPRs: false
 
 ## defaultTFVersion set the default terraform version to be used in atlantis server
-# defaultTFVersion: v0.12.0
+# defaultTFVersion: 0.12.0
 
 # disableApplyAll disables running `atlantis apply` without any flags
 disableApplyAll: false


### PR DESCRIPTION
@jkodroff @callmeradical @jeff-knurek @lkysow @anubhavmishra 

#### What this PR does / why we need it:
The defaultTFVersion example in the values.yaml config shows the incorrect format for the URL to have Atlantis download Terraform.

With the example format, downloads will fail with these messages:

> downloading terraform version 0.11.10: open /atlantis-data/bin/terraform0.11.10: permission denied

> 2019/12/07 17:25:01+0000 [EROR] terraform_client.go:151 server: Could not download terraform
> 0.11.10

#### Which issue this PR fixes
  - fixes #19474

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
