### PR TITLE
[stable/kong] use volumes for runtime data

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.29.0
+version: 0.30.0
 appVersion: 1.3

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -408,6 +408,19 @@ You can can learn about kong ingress custom resource definitions [here](https://
 
 ## Changelog
 
+### 0.30.0
+
+#### Improvements
+
+- Create and mount emptyDir volumes for `/tmp` and `/kong_prefix` to allow for read-only root filesystem securityContexts and PodSecurityPolicys.
+- Update stock PodSecurityPolicy to allow emptyDir access.
+- Override the standard `/usr/local/kong` prefix to the mounted emptyDir at `/kong_prefix` in `.Values.env`.
+- Add securityContext injection points to template. By default, it sets Kong pods to run with UID 1000.
+
+#### Fixes
+
+- Correct behavior for the Vitals toggle. Vitals defaults to on in all current Kong Enterprise releases, and the existing template only created the Vitals environment variable if `.Values.enterprise.enabled == true`. Inverted template to create it (and set it to "off") if that setting is instead disabled.
+
 ### 0.29.0
 
 #### New Features

--- a/stable/kong/templates/_helpers.tpl
+++ b/stable/kong/templates/_helpers.tpl
@@ -166,6 +166,10 @@ The name of the service used for the ingress controller's validation webhook
 {{- end -}}
 
 {{- define "kong.volumes" -}}
+- name: {{ template "kong.fullname" . }}-prefix-dir
+  emptyDir: {}
+- name: {{ template "kong.fullname" . }}-tmp
+  emptyDir: {}
 {{- range .Values.plugins.configMaps }}
 - name: kong-plugin-{{ .pluginName }}
   configMap:
@@ -201,6 +205,10 @@ The name of the service used for the ingress controller's validation webhook
 {{- end -}}
 
 {{- define "kong.volumeMounts" -}}
+- name: {{ template "kong.fullname" . }}-prefix-dir
+  mountPath: /kong_prefix/
+- name: {{ template "kong.fullname" . }}-tmp
+  mountPath: /tmp
 - name: custom-nginx-template-volume
   mountPath: /kong
 {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
@@ -214,10 +222,12 @@ The name of the service used for the ingress controller's validation webhook
 {{- range .Values.plugins.configMaps }}
 - name:  kong-plugin-{{ .pluginName }}
   mountPath: /opt/kong/plugins/{{ .pluginName }}
+  readOnly: true
 {{- end }}
 {{- range .Values.plugins.secrets }}
 - name:  kong-plugin-{{ .pluginName }}
   mountPath: /opt/kong/plugins/{{ .pluginName }}
+  readOnly: true
 {{- end }}
 {{- end -}}
 
@@ -315,4 +325,11 @@ Retrieve Kong Enterprise license from a secret and make it available in env vars
     secretKeyRef:
       name: {{ .Values.enterprise.license_secret }}
       key: license
+{{- end -}}
+
+{{/*
+Use the Pod security context defined in Values or set the UID by default
+*/}}
+{{- define "kong.podsecuritycontext" -}}
+{{ .Values.securityContext | toYaml }}
 {{- end -}}

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -110,9 +110,9 @@ spec:
         - name: KONG_NGINX_DAEMON
           value: "off"
         {{- if .Values.enterprise.enabled }}
-        {{- if .Values.enterprise.vitals.enabled }}
+        {{- if not .Values.enterprise.vitals.enabled }}
         - name: KONG_VITALS
-          value: "on"
+          value: "off"
         {{- end }}
         {{- if .Values.enterprise.portal.enabled }}
         - name: KONG_PORTAL
@@ -287,6 +287,8 @@ spec:
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
     {{- end }}
+      securityContext:
+      {{- include "kong.podsecuritycontext" . | nindent 8 }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/stable/kong/templates/migrations-post-upgrade.yaml
+++ b/stable/kong/templates/migrations-post-upgrade.yaml
@@ -78,6 +78,8 @@ spec:
         command: [ "/bin/sh", "-c", "kong migrations finish" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
+      securityContext:
+      {{- include "kong.podsecuritycontext" . | nindent 6 }}
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}

--- a/stable/kong/templates/migrations-pre-upgrade.yaml
+++ b/stable/kong/templates/migrations-pre-upgrade.yaml
@@ -78,6 +78,8 @@ spec:
         command: [ "/bin/sh", "-c", "kong migrations up" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
+      securityContext:
+      {{- include "kong.podsecuritycontext" . | nindent 6 }}
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}

--- a/stable/kong/templates/migrations.yaml
+++ b/stable/kong/templates/migrations.yaml
@@ -73,6 +73,8 @@ spec:
         command: [ "/bin/sh", "-c", "kong migrations bootstrap" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
+      securityContext:
+      {{- include "kong.podsecuritycontext" . | nindent 6 }}
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}

--- a/stable/kong/templates/psp.yaml
+++ b/stable/kong/templates/psp.yaml
@@ -23,6 +23,7 @@ spec:
   volumes:
     - 'configMap'
     - 'secret'
+    - 'emptyDir'
   allowPrivilegeEscalation: false
   hostNetwork: false
   hostIPC: false

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -283,6 +283,7 @@ env:
   admin_error_log: /dev/stderr
   admin_gui_error_log: /dev/stderr
   portal_api_error_log: /dev/stderr
+  prefix: /kong_prefix/
 
 # If you want to specify resources, uncomment the following
 # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
@@ -345,6 +346,10 @@ podDisruptionBudget:
 
 podSecurityPolicy:
   enabled: false
+
+# securityContext for Kong pods.
+securityContext:
+  runAsUser: 1000
 
 # Kong has a choice of either Postgres or Cassandra as a backend datatstore.
 # This chart allows you to choose either of them with the `database.type`


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
These changes allow enforcing Kubernetes security policies that restrict writes to the root filesystem by mounting emptyDir volumes over directories that Kong needs to write to at runtime.

#### Special notes for your reviewer:
At present, Kong Enterprise has a bug where it still attempts to write to /usr/local/kong, so this does not allow using it with a read-only root. It should work once that bug is addressed. Older versions (<=0.36-2) furthermore have issues with non-standard prefixes. 1.3+ should not encounter issues with the non-standard prefix, and I did not encounter any testing with these changes in place while still allowing root writes.

Core should work with the change and a read-only root as is.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
