### PR TITLE
[stable/kured] Add metrics port to containerSpec to allow annotations-based prometheus scraping

### DIFF
--- a/stable/kured/Chart.yaml
+++ b/stable/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.2.0"
 description: A Helm chart for kured
 name: kured
-version: 1.4.1
+version: 1.4.2
 home: https://github.com/weaveworks/kured
 maintainers:
   - name: plumdog

--- a/stable/kured/README.md
+++ b/stable/kured/README.md
@@ -36,3 +36,14 @@ extraArgs:
   bar-baz: 2
 ```
 becomes `/usr/bin/kured ... --foo=1 --bar-baz=2`.
+
+## Prometheus Metrics
+
+Kured exposes a single prometheus metric indicating whether a reboot is required or not (see [kured docs](https://github.com/weaveworks/kured#prometheus-metrics)) for details. It can be scraped with the following set of annotations:
+
+```yaml
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/path: "/metrics"
+  prometheus.io/port: "8080"
+```

--- a/stable/kured/templates/daemonset.yaml
+++ b/stable/kured/templates/daemonset.yaml
@@ -61,6 +61,9 @@ spec:
             - --{{ $key }}
             {{- end }}
           {{- end }}
+          ports:
+            - containerPort: 8080
+              name: metrics          
           env:
             # Pass in the name of the node on which this pod is scheduled
             # for use with drain/uncordon operations and lock acquisition


### PR DESCRIPTION
#### What this PR does / why we need it:
Kured exposes a prometheus metrics endpoint. This is however not declared in the daemonset. When prometheus is told via pod annotations to scrape port 8080, it cannot discover the correct port and tries to scrape port 80 instead, which results in an error. By declaring the metrics port, scraping annotations will work as expected. Also see https://github.com/prometheus/prometheus/issues/3826#issuecomment-380736580 for details.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
