### PR TITLE
[stable/opa] Fix default OPA values.yaml and update to latest

### DIFF
--- a/stable/opa/Chart.yaml
+++ b/stable/opa/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
-appVersion: 0.14.1
+appVersion: 0.15.1
 description: Open source, general-purpose policy engine. Enforce fine-grained invariants over arbitrary Kubernetes resources.
 name: opa
 keywords:
 - opa
 - admission control
 - policy
-version: 1.12.0
+version: 1.13.0
 home: https://www.openpolicyagent.org
 icon: https://raw.githubusercontent.com/open-policy-agent/opa/master/logo/logo.png
 sources:

--- a/stable/opa/values.yaml
+++ b/stable/opa/values.yaml
@@ -5,15 +5,15 @@
 # https://www.openpolicyagent.org/docs/configuration.html for more details.
 # Default value is no default config. For custom config, the opa key
 # needs to include the opa config yaml, eg:
-# opa:
-#   services:
-#     controller:
-#       url: https://some.bundle.host
-#   bundle:
-#     service: controller
-#     name: some-bundle-name.tgz
-#   default_decision: "/some_bundle_name/main"
-opa: false
+opa:
+  services:
+    controller:
+      url: 'https://www.openpolicyagent.org'
+  bundles:
+    quickstart:
+      service: controller
+      resource: /bundles/helm-kubernetes-quickstart
+  default_decision: /helm_kubernetes_quickstart/main
 
 # Setup the webhook using cert-manager
 certManager:

--- a/stable/opa/values.yaml
+++ b/stable/opa/values.yaml
@@ -103,7 +103,7 @@ authz:
 
 # Docker image and tag to deploy.
 image: openpolicyagent/opa
-imageTag: 0.14.1
+imageTag: 0.15.1
 imagePullPolicy: IfNotPresent
 
 # Port to which the opa pod will bind itself
@@ -114,7 +114,7 @@ port: 443
 mgmt:
   enabled: true
   image: openpolicyagent/kube-mgmt
-  imageTag: 0.9
+  imageTag: "0.10"
   imagePullPolicy: IfNotPresent
   extraArgs: []
   resources: {}


### PR DESCRIPTION
This PR unwinds some breaking changes introduced in https://github.com/helm/charts/pull/17947 that made the default `values.yaml` stop working.

As described in the README the default configuration uses a quick start policy bundle to help deployers get started. This change changes the default `opa` config in `values.yaml` to be configured to use the quick start bundle.

This also bumps the OPA and kube-mgmt versions to their latest releases.