### PR TITLE
stable/fluent-bit: add input.systemd.stripUnderscores

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.8.2
+version: 2.8.3
 appVersion: 1.3.2
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -124,6 +124,7 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `input.systemd.filters.systemdUnit` | Please see https://docs.fluentbit.io/manual/input/systemd | `[docker.service, kubelet.service`, `node-problem-detector.service]`                                       |
 | `input.systemd.maxEntries`         | Please see https://docs.fluentbit.io/manual/input/systemd | `1000`                             |
 | `input.systemd.readFromTail`       | Please see https://docs.fluentbit.io/manual/input/systemd | `true`                             |
+| `input.systemd.stripUnderscores`       | Please see https://docs.fluentbit.io/manual/input/systemd | `false`                             |
 | `input.systemd.tag`                | Please see https://docs.fluentbit.io/manual/input/systemd | `host.*`                           |
 | `rbac.create`                      | Specifies whether RBAC resources should be created.   | `true`                                 |
 | `rbac.pspEnabled`                  | Specifies whether a PodSecurityPolicy should be created. | `false`                             |

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -49,6 +49,7 @@ data:
 {{- end }}
         Max_Entries     {{ .Values.input.systemd.maxEntries }}
         Read_From_Tail  {{ .Values.input.systemd.readFromTail }}
+        Strip_Underscores  {{ .Values.input.systemd.stripUnderscores }}
 {{- end }}
 {{ .Values.extraEntries.input | indent 8 }}
 

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -233,6 +233,7 @@ input:
         - node-problem-detector.service
     maxEntries: 1000
     readFromTail: true
+    stripUnderscores: false
     tag: host.*
 
 filter:


### PR DESCRIPTION
#### What this PR does / why we need it:
  "This options needed because kibana ignore fields with underscores at
  beginning."

#### Which issue this PR fixes
- fix upstream issue: https://github.com/fluent/fluent-bit/issues/638

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)