### PR TITLE
[stable/percona-xtradb-cluster] Added affinity to the StatefulSet

### DIFF
--- a/stable/percona-xtradb-cluster/Chart.yaml
+++ b/stable/percona-xtradb-cluster/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: percona-xtradb-cluster
-version: 1.0.3
+version: 1.0.4
 appVersion: 5.7.19
 description: free, fully compatible, enhanced, open source drop-in replacement for
   MySQL with Galera Replication (xtradb)

--- a/stable/percona-xtradb-cluster/README.md
+++ b/stable/percona-xtradb-cluster/README.md
@@ -52,6 +52,7 @@ The following table lists the configurable parameters of the Percona chart and t
 
 | Parameter                  | Description                        | Default                                                    |
 | -----------------------    | ---------------------------------- | ---------------------------------------------------------- |
+| `affinity`                 | statefulset pod affinities (requires Kubernetes >=1.6) | {}                                     |
 | `image.repository`         | `percona-xtradb-cluster` image Repo.                 | 5.7.19 release                                        |
 | `image.tag`                 | `percona-xtradb-cluster` image tag.                 | `percona/percona-xtradb-cluster` |
 | `image.pullPolicy`          | Image pull policy                  | `IfNotPresent` |

--- a/stable/percona-xtradb-cluster/templates/statefulset.yaml
+++ b/stable/percona-xtradb-cluster/templates/statefulset.yaml
@@ -25,6 +25,10 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     {{- end }}
     spec:
+{{- if .Values.affinity }}
+      affinity:
+{{- toYaml .Values.affinity | nindent 8 }}
+{{- end }}
       initContainers:
       - name: "remove-lost-found"
         image: "busybox:1.25.0"

--- a/stable/percona-xtradb-cluster/values.yaml
+++ b/stable/percona-xtradb-cluster/values.yaml
@@ -1,5 +1,9 @@
 # Default values for Percona XtraDB Cluster
 
+## Affinity and anti-affinity
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
 ## percona image and version
 ## ref: https://hub.docker.com/r/percona/percona-xtradb-cluster/tags/
 image:


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR gaves posibility to add affinity and anti-affinity rules for the StatefulSet and  effectivily manages pods based on node labels and topology keys.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
