### PR TITLE
[incubator/jaeger] Added support for setting the KEYSPACE environment variable

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.15.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.17.2
+version: 0.17.3
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -313,6 +313,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `schema.pullPolicy`                      | Schema image pullPolicy             |  `IfNotPresent`                          |
 | `schema.activeDeadlineSeconds`           | Deadline in seconds for cassandra schema creation job to complete |  `120`                            |
 | `schema.traceTtl`                     | Time to live for trace data in seconds      |  `nil`                                |
+| `schema.keyspace`                     | Set implicit keyspace name      |  `nil`                                |
 | `schema.dependenciesTtl`              | Time to live for dependencies data in seconds  |  `nil`                          |
 | `serviceAccounts.agent.create`              | Create service account   |  `true`                                  |
 | `serviceAccounts.agent.name`              | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template  |  ``                                  |

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -313,7 +313,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `schema.pullPolicy`                      | Schema image pullPolicy             |  `IfNotPresent`                          |
 | `schema.activeDeadlineSeconds`           | Deadline in seconds for cassandra schema creation job to complete |  `120`                            |
 | `schema.traceTtl`                     | Time to live for trace data in seconds      |  `nil`                                |
-| `schema.keyspace`                     | Set implicit keyspace name      |  `nil`                                |
+| `schema.keyspace`                     | Set explicit keyspace name      |  `nil`                                |
 | `schema.dependenciesTtl`              | Time to live for dependencies data in seconds  |  `nil`                          |
 | `serviceAccounts.agent.create`              | Create service account   |  `true`                                  |
 | `serviceAccounts.agent.name`              | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template  |  ``                                  |

--- a/incubator/jaeger/templates/cassandra-schema-job.yaml
+++ b/incubator/jaeger/templates/cassandra-schema-job.yaml
@@ -49,6 +49,10 @@ spec:
             secretKeyRef:
               name: {{ if .Values.storage.cassandra.existingSecret }}{{ .Values.storage.cassandra.existingSecret }}{{- else }}{{ include "jaeger.fullname" . }}-cassandra{{- end }}
               key: password
+      {{- if .Values.schema.keyspace }}
+        - name: KEYSPACE
+          value: {{ .Values.schema.keyspace | quote }}
+      {{- end }}
       {{- if .Values.schema.traceTtl }}
         - name: TRACE_TTL
           value: {{ .Values.schema.traceTtl | quote }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Added support for explicitly setting keyspace name when creating cassandra schema

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
