### PR TITLE
[stable/cockroachdb] Option to choose the schedulerName

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 3.0.1
+version: 3.0.2
 appVersion: 19.2.1
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -101,7 +101,7 @@ Set the `cluster.preserve_downgrade_option` cluster setting, where `$current_ver
 
 Exit the shell and delete the temp Pod:
 ```sql
-> \q 
+> \q
 ```
 
 Kick off the upgrade process by changing to the new Docker image, where `$new_version` is the version being upgraded to:
@@ -200,76 +200,77 @@ Verify that no Pod is deleted and then upgrade as normal. A new StatefulSet will
 The following table lists the configurable parameters of the CockroachDB chart and their default values.
 For details see the `values.yml` file.
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `clusterDomain` | Cluster's default DNS domain | `cluster.local` |
-| `conf.attrs`                 | CockroachDB node attributes                      | `[]`    |
-| `conf.cache`                 | Size of CockroachDB's in-memory cache            | `25%`   |
-| `conf.cluster-name`          | Name of CockroachDB cluster                      | `""`    |
-| `conf.disable-cluster-name-verification` | Disable CockroachDB cluster name verification | `no` |
-| `conf.join`                  | List of already-existing CockroachDB instances   | `[]`    |
-| `conf.max-disk-temp-storage` | Max storage capacity for temp data               | `0`     |
-| `conf.max-offset`            | Max allowed clock offset for CockroachDB cluster | `500ms` |
-| `conf.max-sql-memory`        | Max memory to use processing SQL querie          | `25%`   |
-| `conf.locality`              | Locality attribute for this deployment           | `""`    |
-| `conf.single-node`           | Disable CockroachDB clustering (standalone mode) | `no`    |
-| `conf.sql-audit-dir`         | Directory for SQL audit log                      | `""`    |
-| `conf.port`                  | CockroachDB primary serving port in Pods         | `26257` |
-| `conf.http-port`             | CockroachDB HTTP port in Pods                    | `8080`  |
-| `image.repository`  | Container image name  | `cockroachdb/cockroach` |
-| `image.tag`         | Container image tag   | `v19.2.1`               |
-| `image.pullPolicy`  | Container pull policy | `IfNotPresent`          |
-| `image.credentials` | `registry`, `user` and `pass` credentials to pull private image | `{}` |
-| `statefulset.replicas`              | StatefulSet replicas number                            | `3`        |
-| `statefulset.updateStrategy`        | Update strategy for StatefulSet Pods                   | `{"type": "RollingUpdate"}` |
-| `statefulset.podManagementPolicy`   | `OrderedReady`/`Parallel` Pods creation/deletion order | `Parallel` |
-| `statefulset.budget.maxUnavailable` | k8s PodDisruptionBudget parameter                      | `1`        |
-| `statefulset.args`                | Extra command-line arguments                   | `[]` |
-| `statefulset.env`                 | Extra env vars                                 | `[]` |
-| `statefulset.secretMounts`        | Additional Secrets to mount at cluster members | `[]` |
-| `statefulset.labels`      | Additional labels of StatefulSet and its Pods | `{"app.kubernetes.io/component": "cockroachdb"}` |
-| `statefulset.annotations` | Additional annotations of StatefulSet Pods    | `{}` |
-| `statefulset.nodeAffinity`           | [Node affinity rules][2] of StatefulSet Pods      | `{}`   |
-| `statefulset.podAffinity`            | [Inter-Pod affinity rules][1] of StatefulSet Pods | `{}`   |
-| `statefulset.podAntiAffinity`        | [Anti-affinity rules][1] of StatefulSet Pods      | auto   |
-| `statefulset.podAntiAffinity.type`   | Type of auto [anti-affinity rules][1]             | `soft` |
-| `statefulset.podAntiAffinity.weight` | Weight for `soft` auto [anti-affinity rules][1]   | `100`  |
-| `statefulset.nodeSelector`           | Node labels for StatefulSet Pods assignment       | `{}`   |
-| `statefulset.tolerations`            | Node taints to tolerate by StatefulSet Pods       | `[]`   |
-| `statefulset.resources`              | Resource requests and limits for StatefulSet Pods | `{}`   |
-| `service.ports.grpc.external.port` | CockroachDB primary serving port in Services          | `26257`         |
-| `service.ports.grpc.external.name` | CockroachDB primary serving port name in Services     | `grpc`          |
-| `service.ports.grpc.internal.port` | CockroachDB inter-communication port in Services      | `26257`         |
-| `service.ports.grpc.internal.name` | CockroachDB inter-communication port name in Services | `grpc-internal` |
-| `service.ports.http.port`          | CockroachDB HTTP port in Services                     | `8080`          |
-| `service.ports.http.name`          | CockroachDB HTTP port name in Services                | `http`          |
-| `service.public.type`        | Public Service type                      | `ClusterIP` |
-| `service.public.labels`      | Additional labels of public Service      | `{"app.kubernetes.io/component": "cockroachdb"}` |
-| `service.public.annotations` | Additional annotations of public Service | `{}`        |
-| `service.discovery.labels`      | Additional labels of discovery Service      | `{"app.kubernetes.io/component": "cockroachdb"}` |
-| `service.discovery.annotations` | Additional annotations of discovery Service | `{}` |
-| `storage.hostPath`                      | Absolute path on host to store data             | `""`    |
-| `storage.persistentVolume.enabled`      | Whether to use PersistentVolume to store data   | `yes`   |
-| `storage.persistentVolume.size`         | PersistentVolume size                           | `100Gi` |
-| `storage.persistentVolume.storageClass` | PersistentVolume class                          | `""`    |
-| `storage.persistentVolume.labels`       | Additional labels of PersistentVolumeClaim      | `{}`    |
-| `storage.persistentVolume.annotations`  | Additional annotations of PersistentVolumeClaim | `{}`    |
-| `init.labels`       | Additional labels of init Job and its Pod            | `{"app.kubernetes.io/component": "init"}` |
-| `init.annotations`  | Additional labels of the Pod of init Job             | `{}` |
-| `init.affinity`     | [Affinity rules][2] of init Job Pod                  | `{}` |
-| `init.nodeSelector` | Node labels for init Job Pod assignment              | `{}` |
-| `init.tolerations`  | Node taints to tolerate by init Job Pod              | `[]` |
-| `init.resources`    | Resource requests and limits for the Pod of init Job | `{}` |
-| `tls.enabled`                | Whether to run securely using TLS certificates    | `no`  |
-| `tls.serviceAccount.create`  | Whether to create a new RBAC service account      | `yes` |
-| `tls.serviceAccount.name`    | Name of RBAC service account to use               | `""`  |
-| `tls.init.image.repository`  | Image to use for requesting TLS certificates      | `cockroachdb/cockroach-k8s-request-cert` |
-| `tls.init.image.tag`         | Image tag to use for requesting TLS certificates  | `0.4`          |
-| `tls.init.image.pullPolicy`  | Requesting TLS certificates container pull policy | `IfNotPresent` |
-| `tls.init.image.credentials` | `registry`, `user` and `pass` credentials to pull private image | `{}` |
-| `networkPolicy.enabled`      | Enable NetworkPolicy for CockroachDB's Pods                   | `no` |
-| `networkPolicy.ingress.grpc` | Whitelist resources to access gRPC port of CockroachDB's Pods | `[]` |
-| `networkPolicy.ingress.http` | Whitelist resources to access gRPC port of CockroachDB's Pods | `[]` |
+| Parameter                                | Description                                                     | Default                                          |
+| ---------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------ |
+| `clusterDomain`                          | Cluster's default DNS domain                                    | `cluster.local`                                  |
+| `conf.attrs`                             | CockroachDB node attributes                                     | `[]`                                             |
+| `conf.cache`                             | Size of CockroachDB's in-memory cache                           | `25%`                                            |
+| `conf.cluster-name`                      | Name of CockroachDB cluster                                     | `""`                                             |
+| `conf.disable-cluster-name-verification` | Disable CockroachDB cluster name verification                   | `no`                                             |
+| `conf.join`                              | List of already-existing CockroachDB instances                  | `[]`                                             |
+| `conf.max-disk-temp-storage`             | Max storage capacity for temp data                              | `0`                                              |
+| `conf.max-offset`                        | Max allowed clock offset for CockroachDB cluster                | `500ms`                                          |
+| `conf.max-sql-memory`                    | Max memory to use processing SQL querie                         | `25%`                                            |
+| `conf.locality`                          | Locality attribute for this deployment                          | `""`                                             |
+| `conf.single-node`                       | Disable CockroachDB clustering (standalone mode)                | `no`                                             |
+| `conf.sql-audit-dir`                     | Directory for SQL audit log                                     | `""`                                             |
+| `conf.port`                              | CockroachDB primary serving port in Pods                        | `26257`                                          |
+| `conf.http-port`                         | CockroachDB HTTP port in Pods                                   | `8080`                                           |
+| `image.repository`                       | Container image name                                            | `cockroachdb/cockroach`                          |
+| `image.tag`                              | Container image tag                                             | `v19.2.1`                                        |
+| `image.pullPolicy`                       | Container pull policy                                           | `IfNotPresent`                                   |
+| `image.credentials`                      | `registry`, `user` and `pass` credentials to pull private image | `{}`                                             |
+| `statefulset.replicas`                   | StatefulSet replicas number                                     | `3`                                              |
+| `statefulset.schedulerName`              | Custom scheduler name                                           | `default`                                        |
+| `statefulset.updateStrategy`             | Update strategy for StatefulSet Pods                            | `{"type": "RollingUpdate"}`                      |
+| `statefulset.podManagementPolicy`        | `OrderedReady`/`Parallel` Pods creation/deletion order          | `Parallel`                                       |
+| `statefulset.budget.maxUnavailable`      | k8s PodDisruptionBudget parameter                               | `1`                                              |
+| `statefulset.args`                       | Extra command-line arguments                                    | `[]`                                             |
+| `statefulset.env`                        | Extra env vars                                                  | `[]`                                             |
+| `statefulset.secretMounts`               | Additional Secrets to mount at cluster members                  | `[]`                                             |
+| `statefulset.labels`                     | Additional labels of StatefulSet and its Pods                   | `{"app.kubernetes.io/component": "cockroachdb"}` |
+| `statefulset.annotations`                | Additional annotations of StatefulSet Pods                      | `{}`                                             |
+| `statefulset.nodeAffinity`               | [Node affinity rules][2] of StatefulSet Pods                    | `{}`                                             |
+| `statefulset.podAffinity`                | [Inter-Pod affinity rules][1] of StatefulSet Pods               | `{}`                                             |
+| `statefulset.podAntiAffinity`            | [Anti-affinity rules][1] of StatefulSet Pods                    | auto                                             |
+| `statefulset.podAntiAffinity.type`       | Type of auto [anti-affinity rules][1]                           | `soft`                                           |
+| `statefulset.podAntiAffinity.weight`     | Weight for `soft` auto [anti-affinity rules][1]                 | `100`                                            |
+| `statefulset.nodeSelector`               | Node labels for StatefulSet Pods assignment                     | `{}`                                             |
+| `statefulset.tolerations`                | Node taints to tolerate by StatefulSet Pods                     | `[]`                                             |
+| `statefulset.resources`                  | Resource requests and limits for StatefulSet Pods               | `{}`                                             |
+| `service.ports.grpc.external.port`       | CockroachDB primary serving port in Services                    | `26257`                                          |
+| `service.ports.grpc.external.name`       | CockroachDB primary serving port name in Services               | `grpc`                                           |
+| `service.ports.grpc.internal.port`       | CockroachDB inter-communication port in Services                | `26257`                                          |
+| `service.ports.grpc.internal.name`       | CockroachDB inter-communication port name in Services           | `grpc-internal`                                  |
+| `service.ports.http.port`                | CockroachDB HTTP port in Services                               | `8080`                                           |
+| `service.ports.http.name`                | CockroachDB HTTP port name in Services                          | `http`                                           |
+| `service.public.type`                    | Public Service type                                             | `ClusterIP`                                      |
+| `service.public.labels`                  | Additional labels of public Service                             | `{"app.kubernetes.io/component": "cockroachdb"}` |
+| `service.public.annotations`             | Additional annotations of public Service                        | `{}`                                             |
+| `service.discovery.labels`               | Additional labels of discovery Service                          | `{"app.kubernetes.io/component": "cockroachdb"}` |
+| `service.discovery.annotations`          | Additional annotations of discovery Service                     | `{}`                                             |
+| `storage.hostPath`                       | Absolute path on host to store data                             | `""`                                             |
+| `storage.persistentVolume.enabled`       | Whether to use PersistentVolume to store data                   | `yes`                                            |
+| `storage.persistentVolume.size`          | PersistentVolume size                                           | `100Gi`                                          |
+| `storage.persistentVolume.storageClass`  | PersistentVolume class                                          | `""`                                             |
+| `storage.persistentVolume.labels`        | Additional labels of PersistentVolumeClaim                      | `{}`                                             |
+| `storage.persistentVolume.annotations`   | Additional annotations of PersistentVolumeClaim                 | `{}`                                             |
+| `init.labels`                            | Additional labels of init Job and its Pod                       | `{"app.kubernetes.io/component": "init"}`        |
+| `init.annotations`                       | Additional labels of the Pod of init Job                        | `{}`                                             |
+| `init.affinity`                          | [Affinity rules][2] of init Job Pod                             | `{}`                                             |
+| `init.nodeSelector`                      | Node labels for init Job Pod assignment                         | `{}`                                             |
+| `init.tolerations`                       | Node taints to tolerate by init Job Pod                         | `[]`                                             |
+| `init.resources`                         | Resource requests and limits for the Pod of init Job            | `{}`                                             |
+| `tls.enabled`                            | Whether to run securely using TLS certificates                  | `no`                                             |
+| `tls.serviceAccount.create`              | Whether to create a new RBAC service account                    | `yes`                                            |
+| `tls.serviceAccount.name`                | Name of RBAC service account to use                             | `""`                                             |
+| `tls.init.image.repository`              | Image to use for requesting TLS certificates                    | `cockroachdb/cockroach-k8s-request-cert`         |
+| `tls.init.image.tag`                     | Image tag to use for requesting TLS certificates                | `0.4`                                            |
+| `tls.init.image.pullPolicy`              | Requesting TLS certificates container pull policy               | `IfNotPresent`                                   |
+| `tls.init.image.credentials`             | `registry`, `user` and `pass` credentials to pull private image | `{}`                                             |
+| `networkPolicy.enabled`                  | Enable NetworkPolicy for CockroachDB's Pods                     | `no`                                             |
+| `networkPolicy.ingress.grpc`             | Whitelist resources to access gRPC port of CockroachDB's Pods   | `[]`                                             |
+| `networkPolicy.ingress.http`             | Whitelist resources to access gRPC port of CockroachDB's Pods   | `[]`                                             |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/cockroachdb/templates/statefulset.yaml
+++ b/stable/cockroachdb/templates/statefulset.yaml
@@ -50,6 +50,7 @@ spec:
         - name: {{ template "cockroachdb.fullname" . }}.init-certs.registry
       {{- end }}
     {{- end }}
+      schedulerName: {{ .Values.statefulset.schedulerName }}
     {{- if .Values.tls.enabled }}
       serviceAccountName: {{ template "cockroachdb.tls.serviceAccount.name" . }}
       initContainers:

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -140,6 +140,7 @@ statefulset:
   updateStrategy:
     type: RollingUpdate
   podManagementPolicy: Parallel
+  schedulerName: default
   budget:
     maxUnavailable: 1
 


### PR DESCRIPTION
#### What this PR does / why we need it:
On some kubernetes installation we can have different schedulers. This PR allows to set this parameter.

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
