### PR TITLE
[stable/telegraph] Added Support for volume mounts on deployment

### DIFF
--- a/stable/telegraf/Chart.yaml
+++ b/stable/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf
-version: 1.2.0
+version: 1.3.0
 appVersion: 1.12
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/stable/telegraf/templates/deployment.yaml
+++ b/stable/telegraf/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /etc/telegraf
+        {{- range .Values.volumeMounts}}
+        - name: {{ .name }}
+          mountPath: {{ .mountPath }}
+        {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
@@ -42,3 +46,6 @@ spec:
       - name: config
         configMap:
           name: {{ include "telegraf.fullname" . }}
+      {{- if .Values.volumeMounts }}
+{{ toYaml .Values.volumeMounts | indent 6 }}
+      {{- end}}


### PR DESCRIPTION
Signed-off-by: DaneJensen <dane.jensen@target.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Adds support for volume mounting to the telegraph helm chart.  It is needed to mount certs and other secrets.

#### Which issue this PR fixes
Option to volume mount was not available for this helm chart

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
 - there was no variable documentation
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
