### PR TITLE
[stable/spinnaker] allow for extra s3 args

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.22.1
+version: 1.22.3
 appVersion: 1.16.2
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/configmap/halyard-config.yaml
+++ b/stable/spinnaker/templates/configmap/halyard-config.yaml
@@ -67,6 +67,9 @@ data:
       {{- if .Values.s3.secretKey }}
       --secret-access-key \
       {{- end }}
+      {{- range .Values.s3.extraArgs }}
+      {{- . }} \
+      {{- end }}
 
     $HAL_COMMAND config storage edit --type s3
     {{ end }}

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -283,6 +283,9 @@ s3:
   # accessKey: ""
   # secretKey: ""
   # assumeRole: "<role to assume>"
+  ## Here you can pass extra arguments to configure s3 storage options
+  extraArgs: []
+  #  - "--path-style-access true"
 
 # Azure Storage Account
 azs:


### PR DESCRIPTION
This helps when a deployer is using a self hosted s3 alternative and needs to add extra options such as `--path-style-access true`.

Signed-off-by: Paul Czarkowski <username.taken@gmail.com>



#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
