### PR TITLE
[stable/consul] fix gossip configuration parameter name in README

### DIFF
--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: consul
 home: https://github.com/hashicorp/consul
-version: 3.9.3
+version: 3.9.4
 appVersion: 1.5.3
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/stable/consul/README.md
+++ b/stable/consul/README.md
@@ -38,7 +38,7 @@ The following table lists the configurable parameters of the consul chart and th
 | `DisableHostNodeId`     | Disable Node Id creation (uses random)| `false`                                                    |
 | `joinPeers`             | Set list of hosts for -retry-join     | `[]`                                                       |
 | `joinWan`               | Set list of hosts for -retry-join-wan | `[]`                                                       |
-| `EncryptGossip`         | Whether or not gossip is encrypted    | `true`                                                     |
+| `Gossip.Encrypt`         | Whether or not gossip is encrypted    | `true`                                                     |
 | `GossipKey`             | Gossip-key to use by all members      | `nil`                                                      |
 | `Storage`               | Persistent volume size                | `1Gi`                                                      |
 | `StorageClass`          | Persistent volume storage class       | `nil`                                                      |


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix gossip configuration parameter name to `Gossip.Encrypt`.
There are no `EncryptGossip` variable. 


#### Which issue this PR fixes
  - fixes #dunno

#### Special notes for your reviewer:
* https://github.com/helm/charts/blob/master/stable/consul/values.yaml#L60
* https://github.com/helm/charts/blob/master/stable/consul/templates/consul-statefulset.yaml#L134
* https://github.com/helm/charts/blob/master/stable/consul/templates/consul-statefulset.yaml#L240
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
