### PR TITLE
[stable/stolon] Add custom labels support for servicemonitor

### DIFF
--- a/stable/stolon/Chart.yaml
+++ b/stable/stolon/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stolon
-version: 1.5.2
+version: 1.5.3
 appVersion: 0.13.0
 description: Stolon - PostgreSQL cloud native High Availability.
 home: https://github.com/sorintlab/stolon

--- a/stable/stolon/README.md
+++ b/stable/stolon/README.md
@@ -55,18 +55,19 @@ Kubernetes is the default store backend. `consul`, `etcdv2` or `etcdv3` can also
 | `store.kubeResourceKind`                | Kubernetes resource kind (only for kubernetes) | `configmap`                                                  |
 | `pgParameters`                          | [`postgresql.conf`][pgconf] options used during cluster creation | `{}`                                       |
 | `ports`                                 | Ports to expose on pods                        | `{"stolon":{"containerPort": 5432},"metrics":{"containerPort": 8080}}`|
-| `serviceMonitor.enabled`                | Creates a Prometheus serviceMonitor and service object | `false`|
-| `serviceMonitor.namespace`              | Set to use a different value than the release namespace for deploying the ServiceMonitor object | `nil` |
-| `serviceMonitor.interval`               | Set to use a different value than the default Prometheus scrape interval | `nil` |
-| `serviceMonitor.scrapeTimeout`          | Set to use a different value than the default Prometheus scrape timeout | `nil` |
+| `serviceMonitor.enabled`                | Creates a Prometheus serviceMonitor and service object | `false`                                              |
+| `serviceMonitor.labels`                 | Overrides the default labels added by chart to the ServiceMonitor with labels specified. | `{}`               |
+| `serviceMonitor.namespace`              | Set to use a different value than the release namespace for deploying the ServiceMonitor object | `nil`       |
+| `serviceMonitor.interval`               | Set to use a different value than the default Prometheus scrape interval | `nil`                              |
+| `serviceMonitor.scrapeTimeout`          | Set to use a different value than the default Prometheus scrape timeout | `nil`                               |
 | `job.autoCreateCluster`                 | Set to `false` to force-disable auto-cluster-creation which may clear pre-existing postgres db data | `true`  |
 | `job.autoUpdateClusterSpec`             | Set to `false` to force-disable auto-cluster-spec-update | `true`                                             |
 | `clusterSpec`                           | Stolon cluster spec [reference](https://github.com/sorintlab/stolon/blob/master/doc/cluster_spec.md) | `{}`   |
 | `tls.enabled`                           | Enable tls support to postgresql               | `false`                                                      |
-| `tls.rootCa`                            | Ca certificate                                | `""`                                                         |
+| `tls.rootCa`                            | Ca certificate                                 | `""`                                                         |
 | `tls.serverCrt`                         | Server cerfificate                             | `""`                                                         |
 | `tls.serverKey`                         | Server key                                     | `""`                                                         |
-| `tls.existingSecret`                    | Existing secret with certificate content to stolon credentials | `""`                                                         |
+| `tls.existingSecret`                    | Existing secret with certificate content to stolon credentials | `""`                                         |
 | `keeper.uid_prefix`                     | Keeper prefix name                             | `keeper`                                                     |
 | `keeper.replicaCount`                   | Number of keeper nodes                         | `2`                                                          |
 | `keeper.resources`                      | Keeper resource requests/limit                 | `{}`                                                         |

--- a/stable/stolon/templates/metrics-servicemonitor.yaml
+++ b/stable/stolon/templates/metrics-servicemonitor.yaml
@@ -4,10 +4,14 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "stolon.fullname" . }}
   labels:
+  {{- if .Values.serviceMonitor.labels }}
+    {{ toYaml .Values.serviceMonitor.labels | nindent 4 }}
+  {{- else }}
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- end }}
   {{- if .Values.serviceMonitor.namespace }}
   namespace: {{ .Values.serviceMonitor.namespace }}
   {{- end }}

--- a/stable/stolon/values.yaml
+++ b/stable/stolon/values.yaml
@@ -69,6 +69,8 @@ ports:
 serviceMonitor:
   # When set to true then use a ServiceMonitor to collect metrics
   enabled: false
+  # Custom labels to use in the ServiceMonitor to be matched with a specific Prometheus
+  labels: {}
   # Set the namespace the ServiceMonitor should be deployed to
   # namespace: default
   # Set how frequently Prometheus should scrape


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
The PR #18212 introduced ServiceMonitor support for this chart. However, ServiceMonitor resources are usually created outside the namespace of the release and require a specific set of labels to be selected by the Prometheus operator. This missing feature is introduced in this PR. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
