### PR TITLE
[stable/wordpress] adds loadBalancerSourceRanges to service

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 8.0.2
+version: 8.0.3
 appVersion: 5.3.1
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -98,6 +98,7 @@ The following table lists the configurable parameters of the WordPress chart and
 | `service.port`                            | Service HTTP port                                                             | `80`                                                         |
 | `service.httpsPort`                       | Service HTTPS port                                                            | `443`                                                        |
 | `service.httpsTargetPort`                 | Service Target HTTPS port                                                     | `https`                                                      |
+| `service.loadBalancerSourceRanges`        | Restricts access for LoadBalancer (only with `service.type: LoadBalancer`)    | `[]`                                                         |
 | `service.metricsPort`                     | Service Metrics port                                                          | `9117`                                                       |
 | `service.externalTrafficPolicy`           | Enable client source IP preservation                                          | `Cluster`                                                    |
 | `service.nodePorts.http`                  | Kubernetes http node port                                                     | `""`                                                         |

--- a/stable/wordpress/templates/svc.yaml
+++ b/stable/wordpress/templates/svc.yaml
@@ -16,6 +16,12 @@ spec:
   {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
   {{- end }}
+  {{- if (and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges) }}
+  loadBalancerSourceRanges:
+  {{- with .Values.service.loadBalancerSourceRanges }}
+{{ toYaml . | indent 4 }}
+  {{- end }}
+  {{- end }}
   ports:
     - name: http
       port: {{ .Values.service.port }}

--- a/stable/wordpress/values-production.yaml
+++ b/stable/wordpress/values-production.yaml
@@ -236,6 +236,9 @@ service:
   ##
   externalTrafficPolicy: Local
   annotations: {}
+  ## Limits which cidr blocks can connect to service's load balancer
+  ## Only valid if service.type: LoadBalancer
+  loadBalancerSourceRanges: []
   ## Extra ports to expose (normally used with the `sidecar` value)
   # extraPorts:
 

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -236,6 +236,9 @@ service:
   ##
   externalTrafficPolicy: Cluster
   annotations: {}
+  ## Limits which cidr blocks can connect to service's load balancer
+  ## Only valid if service.type: LoadBalancer
+  loadBalancerSourceRanges: []
   ## Extra ports to expose (normally used with the `sidecar` value)
   # extraPorts:
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows restricting LoadBalancer service to specific CIDR ranges. Useful for restricting access to only CDNs such as CloudFlare

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
