### PR TITLE
[stable/prometheus] Update readiness and liveness probe path for prometheus pushgateway

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 9.6.0
+version: 9.6.1
 appVersion: 2.13.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/pushgateway-deployment.yaml
+++ b/stable/prometheus/templates/pushgateway-deployment.yaml
@@ -43,9 +43,9 @@ spec:
           readinessProbe:
             httpGet:
             {{- if (index .Values "pushgateway" "extraArgs" "web.route-prefix") }}
-              path: /{{ index .Values "pushgateway" "extraArgs" "web.route-prefix" }}/#/status
+              path: /{{ index .Values "pushgateway" "extraArgs" "web.route-prefix" }}/-/ready
             {{- else }}
-              path: /#/status
+              path: /-/ready
             {{- end }}
               port: 9091
             initialDelaySeconds: 10

--- a/stable/prometheus/templates/pushgateway-deployment.yaml
+++ b/stable/prometheus/templates/pushgateway-deployment.yaml
@@ -40,6 +40,16 @@ spec:
           {{- end }}
           ports:
             - containerPort: 9091
+          livenessProbe:
+            httpGet:
+            {{- if (index .Values "pushgateway" "extraArgs" "web.route-prefix") }}
+              path: /{{ index .Values "pushgateway" "extraArgs" "web.route-prefix" }}/-/healthy
+            {{- else }}
+              path: /-/healthy
+            {{- end }}
+              port: 9091
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
           readinessProbe:
             httpGet:
             {{- if (index .Values "pushgateway" "extraArgs" "web.route-prefix") }}


### PR DESCRIPTION
Signed-off-by: Ato Araki <ato.araki@gmail.com>

#### What this PR does / why we need it:

I replaced the prometheus pushgateway readiness and liveness probe path to use  `/-/ready` and `/-/healthy` instead of `/#/status` page.
We found that `/#/status` page consumes high CPU and memory because this page returns entire metrics. 

The pushgateway document is here: https://github.com/prometheus/pushgateway/blob/200975deebb7ecef359294db164ecd2ee6649aaa/README.md#management-api

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
