### PR TITLE
[incubator/zookeeper] Fix zookeeper service template

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 2.1.1
+version: 2.1.2
 appVersion: 3.5.5
 kubeVersion: "^1.10.0-0"
 description: Centralized service for maintaining configuration information, naming,

--- a/incubator/zookeeper/templates/service.yaml
+++ b/incubator/zookeeper/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
     chart: {{ template "zookeeper.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- if .Values.service.annotations }}}
+{{- if .Values.service.annotations }}
   annotations:
 {{- with .Values.service.annotations }}
 {{ toYaml . | indent 4 }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

The zookeeper chart deployment would fail/break when we add service annotations. The issue is #19555.

Once merged this PR is merged, it will do the following:

- Remove the extra erroneous `}` on the zookeeper service template.

- Chart version bumped to `2.1.2`

#### Which issue this PR fixes
  - fixes #19555 

#### Special notes for your reviewer: nil

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name
