### PR TITLE
[stable/prometheus] Add option to configure AlertManagers for Prometheus server

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 9.5.2
+version: 9.5.3
 appVersion: 2.13.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -291,6 +291,7 @@ Parameter | Description | Default
 `server.emptyDir.sizeLimit` | emptyDir sizeLimit if a Persistent Volume is not used | `""`
 `server.podAnnotations` | annotations to be added to Prometheus server pods | `{}`
 `server.podLabels` | labels to be added to Prometheus server pods | `{}`
+`server.alertmanagers` | Prometheus AlertManager configuration for the Prometheus server | `{}`
 `server.deploymentAnnotations` | annotations to be added to Prometheus server deployment | `{}`
 `server.podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}` |
 `server.replicaCount` | desired number of Prometheus server pods | `1`

--- a/stable/prometheus/templates/server-configmap.yaml
+++ b/stable/prometheus/templates/server-configmap.yaml
@@ -38,6 +38,9 @@ data:
 {{ $root.Values.alertRelabelConfigs | toYaml  | trimSuffix "\n" | indent 6 }}
 {{- end }}
       alertmanagers:
+{{- if $root.Values.server.alertmanagers }}
+{{ toYaml $root.Values.server.alertmanagers | indent 8 }}
+{{- else }}
       - kubernetes_sd_configs:
           - role: pod
         tls_config:
@@ -59,6 +62,7 @@ data:
         - source_labels: [__meta_kubernetes_pod_container_port_number]
           regex:
           action: drop
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -772,6 +772,10 @@ server:
   ##
   podLabels: {}
 
+  ## Prometheus AlertManager configuration
+  ##
+  alertmanagers: {}
+
   ## Specify if a Pod Security Policy for node-exporter must be created
   ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
   ##

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -774,7 +774,7 @@ server:
 
   ## Prometheus AlertManager configuration
   ##
-  alertmanagers: {}
+  alertmanagers: []
 
   ## Specify if a Pod Security Policy for node-exporter must be created
   ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/


### PR DESCRIPTION
#### What this PR does / why we need it:
Currently, the only way to connect the Prometheus server to Prometheus AlertManagers is through service discovery. This PR adds a new option to configure custom AlertManager configurations for the Prometheus server.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
