### PR TITLE
[stable/velero] Remove leading pound sign for helm function call

### DIFF
--- a/stable/velero/Chart.yaml
+++ b/stable/velero/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.2.0
 description: A Helm chart for velero
 name: velero
-version: 2.7.0
+version: 2.8.0
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:

--- a/stable/velero/templates/crds.yaml
+++ b/stable/velero/templates/crds.yaml
@@ -1,5 +1,5 @@
 {{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
-{{ $.Files.Get $path }}
+{{ .Files.Get $path }}
 ---
 {{- end }}
 


### PR DESCRIPTION
Signed-off-by: Cai Cooper <caicooper82@gmail.com>

#### What this PR does / why we need it:
When templating stable/velero v2.7.0 chart we notice that only 1 crd was copied into the template/crds.yaml. It appears as if the .Files.Get use shouldn't require `$`.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
