### PR TITLE
[stable/datadog] update docker images version

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: datadog
-version: 1.38.7
-appVersion: 6.14.0
+version: 1.38.8
+appVersion: "6"
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/templates/agent-apiservice.yaml
+++ b/stable/datadog/templates/agent-apiservice.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 spec:
   service:
     name: {{ template "datadog.fullname" . }}-cluster-agent-metrics-api

--- a/stable/datadog/templates/agent-clusterchecks-deployment.yaml
+++ b/stable/datadog/templates/agent-clusterchecks-deployment.yaml
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 spec:
   replicas: {{ .Values.clusterchecksDeployment.replicas }}
   strategy:

--- a/stable/datadog/templates/agent-clusterchecks-rbac.yaml
+++ b/stable/datadog/templates/agent-clusterchecks-rbac.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
   name: {{ template "datadog.fullname" . }}-cluster-checks
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -34,6 +34,6 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
   name: {{ template "datadog.fullname" . }}-cluster-checks
 {{- end -}}

--- a/stable/datadog/templates/agent-rbac.yaml
+++ b/stable/datadog/templates/agent-rbac.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
   name: {{ template "datadog.fullname" . }}-cluster-agent
 rules:
 - apiGroups:
@@ -88,7 +88,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
   name: {{ template "datadog.fullname" . }}-cluster-agent
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -111,7 +111,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
   name: {{ template "datadog.fullname" . }}-cluster-agent
 {{- end }}
 
@@ -129,7 +129,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
   name: {{ template "datadog.fullname" . }}-cluster-agent:system:auth-delegator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/datadog/templates/agent-secret.yaml
+++ b/stable/datadog/templates/agent-secret.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 type: Opaque
 data:
   {{ if .Values.clusterAgent.token -}}

--- a/stable/datadog/templates/agent-services.yaml
+++ b/stable/datadog/templates/agent-services.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 spec:
   type: ClusterIP
   selector:
@@ -38,7 +38,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 spec:
   type: {{ .Values.clusterAgent.metricsProvider.service.type }}
   selector:

--- a/stable/datadog/templates/checksd-configmap.yaml
+++ b/stable/datadog/templates/checksd-configmap.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
   annotations:
     checksum/checksd-config: {{ tpl (toYaml .Values.datadog.checksd) . | sha256sum }}
 data:

--- a/stable/datadog/templates/cluster-agent-confd-configmap.yaml
+++ b/stable/datadog/templates/cluster-agent-confd-configmap.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
   annotations:
     checksum/confd-config: {{ tpl (toYaml .Values.clusterAgent.confd) . | sha256sum }}
 data:

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 spec:
   replicas: {{ .Values.clusterAgent.replicas }}
   strategy:

--- a/stable/datadog/templates/confd-configmap.yaml
+++ b/stable/datadog/templates/confd-configmap.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
   annotations:
     checksum/confd-config: {{ tpl (toYaml .Values.datadog.confd) . | sha256sum }}
     checksum/autoconf-config: {{ tpl (toYaml .Values.datadog.autoconf) . | sha256sum }}

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -19,7 +19,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 spec:
   selector:
     matchLabels:

--- a/stable/datadog/templates/datadog-yaml-configmap.yaml
+++ b/stable/datadog/templates/datadog-yaml-configmap.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
   annotations:
     {{- if .Values.daemonset.customAgentConfig }}
     checksum/agent-config: {{ tpl (toYaml .Values.daemonset.customAgentConfig) . | sha256sum }}
@@ -37,7 +37,17 @@ data:
       enabled: false
       apm_non_local_traffic: true
 
-    # Use java cgroup memory awareness
+    {{- $version := (.Values.image.tag | toString | trimSuffix "-jmx") }}
+    {{- $length := len (split "." $version ) -}} 
+    {{- if and (eq $length 1) (ge $version "6") -}}  # tag 6 was introduce with 6.15
+    {{- $version = "6.15" }}  
+    {{- end -}}
+    {{ if semverCompare ">=6.15" $version }}
+    # Enable java container awareness (agent version >= 6.15)
+    jmx_use_container_support: true
+    {{ else }}
+    # Enable java cgroup memory awareness (agent version < 6.15)
     jmx_use_cgroup_memory_limit: true
+    {{ end }}
   {{- end }}
 {{- end }}

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -19,7 +19,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 spec:
   selector:
     matchLabels:

--- a/stable/datadog/templates/hpa-rbac.yaml
+++ b/stable/datadog/templates/hpa-rbac.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
   name: {{ template "datadog.fullname" . }}-cluster-agent-external-metrics-reader
 rules:
 - apiGroups:
@@ -35,7 +35,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
   name: {{ template "datadog.fullname" . }}-cluster-agent-external-metrics-reader
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -58,7 +58,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
   name: "{{ template "datadog.fullname" . }}-cluster-agent"
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/datadog/templates/rbac.yaml
+++ b/stable/datadog/templates/rbac.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
   name: {{ template "datadog.fullname" . }}
 rules:
 {{- if not .Values.clusterAgent.enabled }}
@@ -101,7 +101,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
   name: {{ template "datadog.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -125,6 +125,6 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
   name: {{ template "datadog.fullname" . }}
 {{- end -}}

--- a/stable/datadog/templates/secrets.yaml
+++ b/stable/datadog/templates/secrets.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 type: Opaque
 data:
   api-key: {{ default "MISSING" .Values.datadog.apiKey | b64enc | quote }}
@@ -38,7 +38,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 type: Opaque
 data:
   app-key: {{ default "MISSING" .Values.datadog.appKey | b64enc | quote }}

--- a/stable/datadog/templates/service.yaml
+++ b/stable/datadog/templates/service.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
   {{- if .Values.deployment.service.annotations }}
   annotations:
 {{ toYaml .Values.deployment.service.annotations | indent 4 }}

--- a/stable/datadog/templates/system-probe-configmap.yaml
+++ b/stable/datadog/templates/system-probe-configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 data:
   system-probe.yaml: |
     system_probe_config:
@@ -39,7 +39,7 @@ metadata:
     app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 data:
   system-probe-seccomp.json: |
     {

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -16,9 +16,9 @@ image:
 
   ## @param tag - string - required
   ## Define the Agent version to use.
-  ## Use 6.14.0-jmx to enable jmx fetch collection
+  ## Use 6-jmx to enable jmx fetch collection
   #
-  tag: 6.14.0
+  tag: "6"
 
   ## @param pullPolicy - string - required
   ## The Kubernetes pull policy.
@@ -338,7 +338,7 @@ clusterAgent:
   containerName: cluster-agent
   image:
     repository: datadog/cluster-agent
-    tag: 1.3.2
+    tag: 1.4.0
     pullPolicy: IfNotPresent
 
   ## @param token - string - required
@@ -703,8 +703,14 @@ daemonset:
   #     enabled: false
   #     apm_non_local_traffic: true
   #
-  #   # Use java cgroup memory awareness
-  #   jmx_use_cgroup_memory_limit: true
+  #   # Enable java cgroup handling. Only one of those options should be enabled,
+  #   # depending on the agent version you are using along that chart.
+  #
+  #   # agent version < 6.15
+  #   # jmx_use_cgroup_memory_limit: true
+  #
+  #   # agent version >= 6.15
+  #   # jmx_use_container_support: true
 
 deployment:
   ## @param enabled - boolean - required


### PR DESCRIPTION
#### What this PR does / why we need it:

Update in `stable/datadog` the default docker image versions:
* cluster-agent version is defaulted to: `1.4.0` 
* agent version is defaulted to: `6` (which correspond to the latest agent 6 release)

* add logic for jmx configuration for agent version >= 6.15

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
