### PR TITLE
[stable/traefik] Allow custom caServer for ACME and allow string type for acme.staging

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.84.0
+version: 1.85.0
 appVersion: 1.7.20
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -150,6 +150,7 @@ The following table lists the configurable parameters of the Traefik chart and t
 | `acme.email`                           | Email address to be used in certificates obtained from Let's Encrypt                                                         | `admin@example.com`                               |
 | `acme.onHostRule`                      | Whether to generate a certificate for each frontend with Host rule                                                           | `true`                                            |
 | `acme.staging`                         | Whether to get certs from Let's Encrypt's staging environment                                                                | `true`                                            |
+| `acme.caServer`                        | (Advanced) Specify a custom ACME server endpoint. Overrides `acme.staging` behavior if specified.    | `nil` |
 | `acme.logging`                         | Display debug log messages from the ACME client library                                                                      | `false`                                           |
 | `acme.domains.enabled`                 | Enable certificate creation by default for specific domain                                                                   | `false`                                           |
 | `acme.domains.domainsList`             | List of domains & (optional) subject names                                                                                   | `[]`                                              |

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -298,7 +298,7 @@ data:
     {{- if .Values.acme.caServer }}
     caServer = {{ .Values.acme.caServer | quote }}
     {{- else }}
-      {{- if or (eq .Values.acme.staging true) (eq .Values.acme.staging "true") }}
+      {{- if eq (toString (.Values.acme.staging)) "true" }}
     caServer = "https://acme-staging-v02.api.letsencrypt.org/directory"
       {{- end }}
     {{- end -}}

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -295,7 +295,7 @@ data:
     {{- end }}
     entryPoint = "https"
     onHostRule = {{ .Values.acme.onHostRule }}
-    {{- if .Values.acme.staging }}
+    {{- if or (eq .Values.acme.staging true) (eq .Values.acme.staging "true") }}
     caServer = "https://acme-staging-v02.api.letsencrypt.org/directory"
     {{- end }}
     {{- if .Values.acme.logging }}

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -295,9 +295,13 @@ data:
     {{- end }}
     entryPoint = "https"
     onHostRule = {{ .Values.acme.onHostRule }}
-    {{- if or (eq .Values.acme.staging true) (eq .Values.acme.staging "true") }}
+    {{- if .Values.acme.caServer }}
+    caServer = {{ .Values.acme.caServer | quote }}
+    {{- else }}
+      {{- if or (eq .Values.acme.staging true) (eq .Values.acme.staging "true") }}
     caServer = "https://acme-staging-v02.api.letsencrypt.org/directory"
-    {{- end }}
+      {{- end }}
+    {{- end -}}
     {{- if .Values.acme.logging }}
     acmeLogging = true
     {{- end }}

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -223,11 +223,9 @@ acme:
   email: admin@example.com
   onHostRule: true
   staging: true
-  
   ## Specify a custom ACME server endpoint
   ## Optional
   # caServer: https://acme-staging-v02.api.letsencrypt.org/directory
-  
   logging: false
   # Configure a Let's Encrypt certificate to be managed by default.
   # This is the only way to request wildcard certificates (works only with dns challenge).

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -223,6 +223,11 @@ acme:
   email: admin@example.com
   onHostRule: true
   staging: true
+  
+  ## Specify a custom ACME server endpoint
+  ## Optional
+  # caServer: https://acme-staging-v02.api.letsencrypt.org/directory
+  
   logging: false
   # Configure a Let's Encrypt certificate to be managed by default.
   # This is the only way to request wildcard certificates (works only with dns challenge).


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

This PR introduces the 2 following changes:

* New value `acme.caServer`which allows to specify a custom caServer for ACME (instead of the Let's Encrypt staging and production servers). 
  * Use case: specify a local Pebble or another ACME alternative than Let's Encrypt.
  * This value override `acme.staging` if set. This is documented.

* Allow the value `acme.staging` to be set up both as a string and as a boolean, to allow usage with k3s's helm-controller (ref. https://github.com/rancher/k3s/issues/276).

#### Which issue this PR fixes

  - fixes https://community.containo.us/t/k3s-v1-0-traefik-letsencrypt-ssl-443-working-example/3064/7

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
