### PR TITLE
[stable/opa] Fix opa not working with helm 3 if securityContext is enabled

### DIFF
--- a/stable/opa/Chart.yaml
+++ b/stable/opa/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - opa
 - admission control
 - policy
-version: 1.13.1
+version: 1.13.2
 home: https://www.openpolicyagent.org
 icon: https://raw.githubusercontent.com/open-policy-agent/opa/master/logo/logo.png
 sources:

--- a/stable/opa/templates/deployment.yaml
+++ b/stable/opa/templates/deployment.yaml
@@ -164,7 +164,11 @@ spec:
 {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
-        {{- toYaml .Values.securityContext | nindent 8 }}
+        {{- range $key, $val := .Values.securityContext }}
+        {{- if ne $key "enabled" }}
+        {{ $key }}: {{ toYaml $val | nindent 10 }}
+        {{- end }}
+        {{- end }}
       {{- end }}
       serviceAccountName: {{ template "opa.serviceAccountName" .}}
       volumes:


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
The OPA deployment template checks `securityContext.enabled` and if `true` adds the entire `securityContext` dictionary. As of Helm 3 this is validated against `io.k8s.api.core.v1.PodSecurityContext` but the `enabled` flag itself is not a valid field for that type, so validation fails.

This PR keeps the check of the `enabled` field for backwards compatibility, but then filters it from the output.

#### Which issue this PR fixes
None

#### Special notes for your reviewer:
None

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
