### PR TITLE
[stable/prometheus-pushgateway] Update readiness liveness probe path for prometheus pushgateway

### DIFF
--- a/stable/prometheus-pushgateway/Chart.yaml
+++ b/stable/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.2.6
+version: 1.2.7
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/stable/prometheus-pushgateway/templates/deployment.yaml
+++ b/stable/prometheus-pushgateway/templates/deployment.yaml
@@ -37,13 +37,13 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /#/status
+              path: /-/healthy
               port: 9091
             initialDelaySeconds: 10
             timeoutSeconds: 10
           readinessProbe:
             httpGet:
-              path: /#/status
+              path: /-/ready
               port: 9091
             initialDelaySeconds: 10
             timeoutSeconds: 10


### PR DESCRIPTION
Signed-off-by: Ato Araki <ato.araki@gmail.com>

#### What this PR does / why we need it:

This PR separated from #19554

I replaced the prometheus pushgateway readiness and liveness probe path to use  `/-/ready` and `/-/healthy` instead of `/#/status` page.
We found that `/#/status` page consumes high CPU and memory because this page returns entire metrics. 

The pushgateway document is here: https://github.com/prometheus/pushgateway/blob/200975deebb7ecef359294db164ecd2ee6649aaa/README.md#management-api

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
