### PR TITLE
[stable/redis-ha] Add maxclients option for sentinel configuration

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.3.1
+version: 4.3.2
 appVersion: 5.0.6
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/_configs.tpl
+++ b/stable/redis-ha/templates/_configs.tpl
@@ -22,7 +22,11 @@
 {{- else }}
     dir "/data"
     {{- range $key, $value := .Values.sentinel.config }}
-    sentinel {{ $key }} {{ template "redis-ha.masterGroupName" $ }} {{ $value }}
+    {{- if eq "maxclients" $key  }}
+        {{ $key }} {{ $value }}
+    {{- else }}
+        sentinel {{ $key }} {{ template "redis-ha.masterGroupName" $ }} {{ $value }}
+    {{- end }}
     {{- end }}
 {{- if .Values.auth }}
     sentinel auth-pass {{ template "redis-ha.masterGroupName" . }} replace-default-auth

--- a/stable/redis-ha/values.yaml
+++ b/stable/redis-ha/values.yaml
@@ -166,12 +166,13 @@ sentinel:
   config:
     ## Additional sentinel conf options can be added below. Only options that
     ## are expressed in the format simialar to 'sentinel xxx mymaster xxx' will
-    ## be properly templated.
+    ## be properly templated expect maxclients option.
     ## For available options see http://download.redis.io/redis-stable/sentinel.conf
     down-after-milliseconds: 10000
     ## Failover timeout value in milliseconds
     failover-timeout: 180000
     parallel-syncs: 5
+    maxclients: 10000
 
   ## Custom sentinel.conf files used to override default settings. If this file is
   ## specified then the sentinel.config above will be ignored.


### PR DESCRIPTION
## What this PR does / why we need it:

This PR aims to add a very important option (`maxclients`) for sentinel.
At this time it's not possible to add `maxclients` option without writing a custom config.
This option in redis is by default 1000. If you have a very large number of connexion, you need to edit this setting.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
