### PR TITLE
[stable/hackmd] Fix API path of Ingress

### DIFF
--- a/stable/hackmd/Chart.yaml
+++ b/stable/hackmd/Chart.yaml
@@ -1,6 +1,6 @@
 name: hackmd
 apiVersion: v1
-version: "1.2.2"
+version: "1.2.3"
 appVersion: "1.3.0-alpine"
 description: Realtime collaborative markdown notes on all platforms.
 icon: https://hackmd.io/favicon.png

--- a/stable/hackmd/templates/ingress.yaml
+++ b/stable/hackmd/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "hackmd.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: apps/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/stable/hackmd/templates/ingress.yaml
+++ b/stable/hackmd/templates/ingress.yaml
@@ -2,7 +2,11 @@
 {{- $fullName := include "hackmd.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
#### What this PR does / why we need it:

There is no Ingress in apps/v1 (https://github.com/helm/charts/pull/17716).

* 1.14 added support for Ingress in networking.k8s.io/v1beta1
* 1.20 will drop support for Ingress in extensions/v1beta1

~So this chart will only work with Kubernetes 1.14+.
If this is not acceptable we need to go back extensions/v1beta1 for now.~

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
