### PR TITLE
[stable/influxdb] Set the default user from an existing secret

### DIFF
--- a/stable/influxdb/Chart.yaml
+++ b/stable/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 3.0.2
+version: 3.0.3
 appVersion: 1.7.6
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/stable/influxdb/Chart.yaml
+++ b/stable/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 3.0.3
+version: 3.1.0
 appVersion: 1.7.6
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/stable/influxdb/README.md
+++ b/stable/influxdb/README.md
@@ -81,6 +81,8 @@ To handle this setup on startup, a job can be enabled in `values.yaml` by settin
 
 Make sure to uncomment or configure the job settings after enabling it. If a password is not set, a random password will be generated.
 
+Alternatively, if `.Values.setDefaultUser.user.existingSecret` is set the user and password are obtained from an existing Secret, the expected keys are `influxdb-user` and `influxdb-password`. Use this variable  if you need to check in the `values.yaml` in a repository to avoid exposing your secrets. 
+
 ## Upgrading
 
 ### From < 1.0.0 To >= 1.0.0

--- a/stable/influxdb/templates/NOTES.txt
+++ b/stable/influxdb/templates/NOTES.txt
@@ -18,10 +18,25 @@ To tail the logs for the InfluxDB pod run the following:
 
 To retrieve the default user name:
 
+{{- if .Values.setDefaultUser.user.existingSecret }}
+
+- echo $(kubectl get secret {{ .Values.setDefaultUser.user.existingSecret }} -o "jsonpath={.data['influxdb-user']}" --namespace {{ .Release.Namespace }} | base64 --decode)
+
+{{- else }}
+
 - echo $(kubectl get secret {{ template "influxdb.fullname" . }}-auth -o "jsonpath={.data['influxdb-user']}" --namespace {{ .Release.Namespace }} | base64 --decode)
+
+{{- end }}
 
 To retrieve the default user password:
 
+{{- if .Values.setDefaultUser.user.existingSecret }}
+
+- echo $(kubectl get secret {{ .Values.setDefaultUser.user.existingSecret }} -o "jsonpath={.data['influxdb-password']}" --namespace {{ .Release.Namespace }} | base64 --decode)
+
+{{- else }}
+
 - echo $(kubectl get secret {{ template "influxdb.fullname" . }}-auth -o "jsonpath={.data['influxdb-password']}" --namespace {{ .Release.Namespace }} | base64 --decode)
 
+{{- end }}
 {{- end }}

--- a/stable/influxdb/templates/post-install-set-auth.yaml
+++ b/stable/influxdb/templates/post-install-set-auth.yaml
@@ -26,12 +26,20 @@ spec:
           - name: INFLUXDB_USER
             valueFrom:
               secretKeyRef:
+                {{- if .Values.setDefaultUser.user.existingSecret }}
+                name: {{ .Values.setDefaultUser.user.existingSecret -}}
+                {{ else }}
                 name: {{ template "influxdb.fullname" . }}-auth
+                {{- end }}
                 key: influxdb-user
           - name: INFLUXDB_PASSWORD
             valueFrom:
               secretKeyRef:
+                {{- if .Values.setDefaultUser.user.existingSecret }}
+                name: {{ .Values.setDefaultUser.user.existingSecret -}}
+                {{ else }}
                 name: {{ template "influxdb.fullname" . }}-auth
+                {{- end }}
                 key: influxdb-password
         args:
           - "/bin/sh"

--- a/stable/influxdb/templates/secret.yaml
+++ b/stable/influxdb/templates/secret.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.setDefaultUser.enabled -}}
-{{- if .Values.setDefaultUser.user.existingSecret -}}
-{{- else -}}
+{{- if not (.Values.setDefaultUser.user.existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/influxdb/templates/secret.yaml
+++ b/stable/influxdb/templates/secret.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.setDefaultUser.enabled -}}
+{{- if .Values.setDefaultUser.user.existingSecret -}}
+{{- else -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -15,4 +17,5 @@ data:
   influxdb-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
   influxdb-user: {{ .Values.setDefaultUser.user.username | b64enc | quote }}
+{{- end -}}
 {{- end -}}

--- a/stable/influxdb/values.yaml
+++ b/stable/influxdb/values.yaml
@@ -87,6 +87,11 @@ setDefaultUser:
     ## Default: (Randomly generated 10 characters of AlphaNum)
     # password:
 
+    ## The user name and password are obtained from an existing secret. The expected
+    ## keys are `influxdb-user` and `influxdb-password`.
+    ## If set, the username and password values above are ignored.
+    # existingSecret: influxdb-auth
+
     ## User privileges
     ## Default: "WITH ALL PRIVILEGES"
     privileges: "WITH ALL PRIVILEGES"


### PR DESCRIPTION
#### What this PR does / why we need it:
Set the default user name and password in InfluxDB from an existing secret. 

When using a GitOps workflow we cannot check in a `values.yaml` that contains secrets. In my case, the secret with the InfluxDB user name and password is created by the `vault-secrets-operator` and we need the option to use an existing secret instead of creating one.

The randomly generated password option did not work for me. I'm currently using Argo CD and it keeps out-of-sync every time the password changes, see https://argoproj.github.io/argo-cd/user-guide/diffing/. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
