### PR TITLE
[stable/datadog] Fixes issue with configmap not being loaded

### DIFF
--- a/stable/datadog/templates/container-trace-agent.yaml
+++ b/stable/datadog/templates/container-trace-agent.yaml
@@ -24,6 +24,11 @@
   volumeMounts:
     - name: config
       mountPath: /etc/datadog-agent
+    {{- if .Values.daemonset.useConfigMap }}
+    - name: {{ template "datadog.fullname" . }}-datadog-yaml
+      mountPath: /etc/datadog-agent/datadog.yaml
+      subPath: datadog.yaml
+    {{- end }}
   livenessProbe:
     tcpSocket:
       port: 8126


### PR DESCRIPTION
We need to load the configmap into trace agent container

