### PR TITLE
[stable/grafana] Support env valueFrom entries

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 4.1.3
+version: 4.2.0
 appVersion: 6.5.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -92,6 +92,7 @@ This version requires Helm >= 2.12.0.
 | `initChownData.resources`                 | init-chown-data pod resource requests & limits | `{}`                                                   |
 | `schedulerName`                           | Alternate scheduler name                      | `nil`                                                   |
 | `env`                                     | Extra environment variables passed to pods    | `{}`                                                    |
+| `envValueFrom`                            | Environment variables from alternate sources. See the API docs on [EnvVarSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvarsource-v1-core) for format details.  | `{}` |
 | `envFromSecret`                           | Name of a Kubernetes secret (must be manually created in the same namespace) containing values to be added to the environment | `""` |
 | `envRenderSecret`                         | Sensible environment variables passed to pods and stored as secret | `{}`                               |
 | `extraSecretMounts`                       | Additional grafana server secret mounts       | `[]`                                                    |

--- a/stable/grafana/templates/_pod.tpl
+++ b/stable/grafana/templates/_pod.tpl
@@ -254,6 +254,11 @@ containers:
       - name: "{{ $key }}"
         value: "{{ $value }}"
 {{- end }}
+    {{- range $key, $value := .Values.envValueFrom }}
+      - name: {{ $key | quote }}
+        valueFrom:
+{{ toYaml $value | indent 10 }}
+    {{- end }}
     {{- if .Values.envFromSecret }}
     envFrom:
       - secretRef:

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -247,6 +247,16 @@ admin:
 ## Extra environment variables that will be pass onto deployment pods
 env: {}
 
+## "valueFrom" environment variable references that will be added to deployment pods
+## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvarsource-v1-core
+## Renders in container spec as:
+##   env:
+##     ...
+##     - name: <key>
+##       valueFrom:
+##         <value rendered as YAML>
+envValueFrom: {}
+
 ## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
 ## This can be useful for auth tokens, etc
 envFromSecret: ""


### PR DESCRIPTION
#### Is this a new chart

Nope!

#### What this PR does / why we need it:

Currently the grafana chart only supports `env` entries of the form:

```yaml
env:
  - name: key
     value: value
```

But this is limiting - I need to be able to use `valueFrom` as well:

```yaml
env:
  - name: key
    valueFrom:
      fieldRef:
        fieldPath: status.podIP
```

This PR allows for this second form.

Ideally there would be a single field (maybe `extraEnv`?) that would allow both forms to be specified, but it would overlap with the current `env` field, and replacing `env` would be a breaking change.

#### Special notes for your reviewer:

I'm not 100% sure this is the best method to achieve this - I'm open to suggestions!

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

Signed-off-by: Dave Henderson <dhenderson@gmail.com>
