### PR TITLE
[stable/telegraf] Add health output and probes

### DIFF
--- a/stable/telegraf/Chart.yaml
+++ b/stable/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf
-version: 1.3.0
+version: 1.4.0
 appVersion: 1.12
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/stable/telegraf/templates/_helpers.tpl
+++ b/stable/telegraf/templates/_helpers.tpl
@@ -67,43 +67,96 @@ Create chart name and version as used by the chart label.
 
 {{- define "outputs" -}}
 {{- range $outputIdx, $configObject := . -}}
-{{- range $output, $config := . }}
-    [[outputs.{{ $output }}]]
-  {{- if $config }}
-  {{- $tp := typeOf $config -}}
-  {{- if eq $tp "map[string]interface {}" -}}
-    {{- range $key, $value := $config -}}
-      {{- $tp := typeOf $value }}
-      {{- if eq $tp "string"}}
+    {{- range $output, $config := . -}}
+
+    [[outputs.{{- $output }}]]
+    {{- if $config -}}
+    {{- $tp := typeOf $config -}}
+    {{- if eq $tp "map[string]interface {}" -}}
+        {{- range $key, $value := $config -}}
+          {{- $tp := typeOf $value -}}
+          {{- if eq $tp "string" }}
       {{ $key }} = {{ $value | quote }}
-      {{- end }}
-      {{- if eq $tp "float64"}}
+          {{- end }}
+          {{- if eq $tp "float64" }}
       {{ $key }} = {{ $value | int64 }}
-      {{- end }}
-      {{- if eq $tp "int"}}
+          {{- end }}
+          {{- if eq $tp "int" }}
       {{ $key }} = {{ $value | int64 }}
-      {{- end }}
-      {{- if eq $tp "bool"}}
+          {{- end }}
+          {{- if eq $tp "bool" }}
       {{ $key }} = {{ $value }}
-      {{- end }}
-      {{- if eq $tp "[]interface {}" }}
+          {{- end }}
+          {{- if eq $tp "[]interface {}" }}
       {{ $key }} = [
-          {{- $numOut := len $value }}
-          {{- $numOut := sub $numOut 1 }}
-          {{- range $b, $val := $value }}
-            {{- $i := int64 $b }}
-            {{- if eq $i $numOut }}
+              {{- $numOut := len $value }}
+              {{- $numOut := sub $numOut 1 }}
+              {{- range $b, $val := $value }}
+                {{- $i := int64 $b }}
+                {{- $tp := typeOf $val }}
+                {{- if eq $i $numOut }}
+                  {{- if eq $tp "string" }}
         {{ $val | quote }}
-            {{- else }}
+                  {{- end }}
+                  {{- if eq $tp "float64" }}
+        {{ $val | int64 }}
+                  {{- end }}
+                {{- else }}
+                  {{- if eq $tp "string" }}
         {{ $val | quote }},
+                  {{- end}}
+                  {{- if eq $tp "float64" }}
+        {{ $val | int64 }},
+                  {{- end }}
+                {{- end }}
+              {{- end }}
+      ]
+          {{- end }}
+        {{- end }}
+        {{- range $key, $value := $config -}}
+          {{- $tp := typeOf $value -}}
+          {{- if eq $tp "map[string]interface {}" }}
+      [[outputs.{{ $output }}.{{ $key }}]]
+            {{- range $k, $v := $value }}
+              {{- $tps := typeOf $v }}
+              {{- if eq $tps "string" }}
+        {{ $k }} = {{ $v | quote }}
+              {{- end }}
+              {{- if eq $tps "float64" }}
+        {{ $k }} = {{ $v | int64 }}.0
+              {{- end }}
+              {{- if eq $tps "int64" }}
+        {{ $k }} = {{ $v | int64 }}
+              {{- end }}
+              {{- if eq $tps "bool" }}
+        {{ $k }} = {{ $v }}
+              {{- end }}
+              {{- if eq $tps "[]interface {}"}}
+        {{ $k }} = [
+                {{- $numOut := len $value }}
+                {{- $numOut := sub $numOut 1 }}
+                {{- range $b, $val := $v }}
+                  {{- $i := int64 $b }}
+                  {{- if eq $i $numOut }}
+            {{ $val | quote }}
+                  {{- else }}
+            {{ $val | quote }},
+                  {{- end }}
+                {{- end }}
+        ]
+              {{- end }}
+              {{- if eq $tps "map[string]interface {}"}}
+        [[outputs.{{ $output }}.{{ $key }}.{{ $k }}]]
+                {{- range $foo, $bar := $v }}
+            {{ $foo }} = {{ $bar | quote }}
+                {{- end }}
+              {{- end }}
             {{- end }}
           {{- end }}
-      ]
-      {{- end }}
+          {{- end }}
     {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
+    {{- end }}
+    {{ end }}
 {{- end }}
 {{- end -}}
 

--- a/stable/telegraf/templates/deployment.yaml
+++ b/stable/telegraf/templates/deployment.yaml
@@ -38,6 +38,21 @@ spec:
         - name: {{ .name }}
           mountPath: {{ .mountPath }}
         {{- end }}
+        {{- range $objectKey, $objectValue := .Values.config.outputs }}
+        {{- range $key, $value := . -}}
+        {{- $tp := typeOf $value -}}
+        {{- if eq $key "health" }}
+        livenessProbe:
+          httpGet:
+            path: /
+            port: {{ trimPrefix "http://:" $value.service_address | int64 }}
+        readinessProbe:
+          httpGet:
+            path: /
+            port: {{ trimPrefix "http://:" $value.service_address | int64 }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}

--- a/stable/telegraf/templates/service.yaml
+++ b/stable/telegraf/templates/service.yaml
@@ -15,6 +15,16 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
+  {{- range $objectKey, $objectValue := .Values.config.outputs }}
+  {{- range $key, $value := . -}}
+  {{- $tp := typeOf $value -}}
+  {{- if eq $key "health" }}
+  - port: {{ trimPrefix "http://:" $value.service_address | int64 }}
+    targetPort: {{ trimPrefix "http://:" $value.service_address | int64 }}
+    name: "health"
+    {{- end }}
+  {{- end }}
+  {{- end }}
   {{- range $objectKey, $objectValue := .Values.config.inputs }}
   {{- range $key, $value := . -}}
     {{- $tp := typeOf $value -}}

--- a/stable/telegraf/values.yaml
+++ b/stable/telegraf/values.yaml
@@ -60,6 +60,13 @@ config:
             problem: 2
             critical: 3
   outputs:
+    - health:
+        service_address: "http://:8888"
+        compares:
+          field: buffer_size
+          lt: 5000.0
+        contains:
+          field: buffer_size
     - influxdb:
         urls:
           - "http://influxdb.monitoring.svc:8086"


### PR DESCRIPTION
Signed-off-by: Cees-Jan Kiewiet <ceesjank@gmail.com>

#### What this PR does / why we need it:

Currently the Telegraf chart doesn't have support for liveness and readyness probes. This PR adds support for it using the health output.

#### Special notes for your reviewer:

During testing this locally on minikube it was a little wonky. Before merging this I'd like to do some further testing on a real cluster and adjusting the given defaults first.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
