### PR TITLE
[stable/datadog] Allow dots in cluster names

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.38.12
+version: 1.38.13
 appVersion: "6"
 description: DataDog Agent
 keywords:

--- a/stable/datadog/ci/cluster-name.yaml
+++ b/stable/datadog/ci/cluster-name.yaml
@@ -1,0 +1,4 @@
+# Empty values file for testing default parameters.
+
+datadog:
+  clusterName: kubernetes-cluster.example.com

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -101,8 +101,8 @@ spec:
             value: "kube_services"
           {{- end }}
           {{- if .Values.datadog.clusterName }}
-          {{- if not (regexMatch "^[a-z]([a-z0-9\\-]{0,38}[a-z0-9])?$" .Values.datadog.clusterName) }}
-          {{- fail "Your `clusterName` isn’t valid. It must start with a lowercase letter followed by up to 39 lowercase letters, numbers, or hyphens and cannot end with a hyphen."}}
+          {{- if not (regexMatch "^([a-z]([a-z0-9\\-]{0,38}[a-z0-9])?\\.)*([a-z]([a-z0-9\\-]{0,38}[a-z0-9])?)$" .Values.datadog.clusterName) }}
+          {{- fail "Your `clusterName` isn’t valid. It must be dot-separated tokens where a token start with a lowercase letter followed by up to 39 lowercase letters, numbers, or hyphens and cannot end with a hyphen."}}
           {{- end}}
           - name: DD_CLUSTER_NAME
             value: {{ .Values.datadog.clusterName | quote }}

--- a/stable/datadog/templates/container-agent.yaml
+++ b/stable/datadog/templates/container-agent.yaml
@@ -15,8 +15,8 @@
   env:
     {{- include "containers-common-env" . | nindent 4 }}
     {{- if .Values.datadog.clusterName }}
-    {{- if not (regexMatch "^[a-z]([a-z0-9\\-]{0,38}[a-z0-9])?$" .Values.datadog.clusterName) }}
-    {{- fail "Your `clusterName` isn’t valid. It must start with a lowercase letter followed by up to 39 lowercase letters, numbers, or hyphens and cannot end with a hyphen."}}
+    {{- if not (regexMatch "^([a-z]([a-z0-9\\-]{0,38}[a-z0-9])?\\.)*([a-z]([a-z0-9\\-]{0,38}[a-z0-9])?)$" .Values.datadog.clusterName) }}
+    {{- fail "Your `clusterName` isn’t valid. It must be dot-separated tokens where a token start with a lowercase letter followed by up to 39 lowercase letters, numbers, or hyphens and cannot end with a hyphen."}}
     {{- end}}
     - name: DD_CLUSTER_NAME
       value: {{ .Values.datadog.clusterName | quote }}

--- a/stable/datadog/templates/container-agents.yaml
+++ b/stable/datadog/templates/container-agents.yaml
@@ -26,8 +26,8 @@
           name: {{ template "datadog.apiSecretName" . }}
           key: api-key
     {{- if .Values.datadog.clusterName }}
-    {{- if not (regexMatch "^[a-z]([a-z0-9\\-]{0,38}[a-z0-9])?$" .Values.datadog.clusterName) }}
-    {{- fail "Your `clusterName` isn’t valid. It must start with a lowercase letter followed by up to 39 lowercase letters, numbers, or hyphens and cannot end with a hyphen."}}
+    {{- if not (regexMatch "^([a-z]([a-z0-9\\-]{0,38}[a-z0-9])?\\.)*([a-z]([a-z0-9\\-]{0,38}[a-z0-9])?)$" .Values.datadog.clusterName) }}
+    {{- fail "Your `clusterName` isn’t valid. It must be dot-separated tokens where a token start with a lowercase letter followed by up to 39 lowercase letters, numbers, or hyphens and cannot end with a hyphen."}}
     {{- end}}
     - name: DD_CLUSTER_NAME
       value: {{ .Values.datadog.clusterName | quote }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -71,11 +71,11 @@ datadog:
 
   ## @param clusterName - string - optional
   ## Set a unique cluster name to allow scoping hosts and Cluster Checks easily
-  ## The name must be unique and can be up to 40 characters with the following restrictions:
+  ## The name must be unique and must be dot-separated tokens where a token can be up to 40 characters with the following restrictions:
   ## * Lowercase letters, numbers, and hyphens only.
   ## * Must start with a letter.
   ## * Must end with a number or a letter.
-  ## These are the same rules as the one enforced by GKE on the same cluster name parameter:
+  ## Compared to the rules of GKE, dots are allowed whereas they are not allowed on GKE:
   ## https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#Cluster.FIELDS.name
   #
   # clusterName: <CLUSTER_NAME>


### PR DESCRIPTION
#### What this PR does / why we need it:

A recent change added a validation on cluster names (#19327) to enforce the same [restrictions as the ones enforced by GKE](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#Cluster.FIELDS.name).

However, [some users are already using domains as cluster-names](https://github.com/helm/charts/pull/19327#issuecomment-565535449).

This PR allows dots inside the cluster names so that domains are valid cluster names.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
