### PR TITLE
[stable/prometheus-blackbox-exporter] Allow scraping multiple targets

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 2.0.0
+version: 3.0.0
 appVersion: 0.15.1
 home: https://github.com/prometheus/blackbox_exporter
 sources:
@@ -15,3 +15,5 @@ maintainers:
     email: cedric@desaintmartin.fr
   - name: gianrubio
     email: gianrubio@gmail.com
+  - name: rsotnychenko
+    email: me@sota.sh

--- a/stable/prometheus-blackbox-exporter/README.md
+++ b/stable/prometheus-blackbox-exporter/README.md
@@ -41,44 +41,48 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Blackbox-Exporter chart and their default values.
 
-|               Parameter                |                    Description                    |            Default            |
-| -------------------------------------- | ------------------------------------------------- | ----------------------------- |
-| `config`                               | Prometheus blackbox configuration                 | {}                            |
-| `secretConfig`                         | Whether to treat blackbox configuration as secret | `false`                       |
-| `extraArgs`                            | Optional flags for blackbox                       | `[]`                          |
-| `extraConfigmapMounts`                 | Additional configmap mounts                       | `[]`                          |
-| `extraSecretMounts`                    | Additional secret mounts                          | `[]`                          |
-| `image.repository`                     | container image repository                        | `prom/blackbox-exporter`      |
-| `image.tag`                            | container image tag                               | `v0.15.1`                     |
-| `image.pullPolicy`                     | container image pull policy                       | `IfNotPresent`                |
-| `image.pullSecrets`                    | container image pull secrets                      | `[]`                          |
-| `ingress.annotations`                  | Ingress annotations                               | None                          |
-| `ingress.enabled`                      | Enables Ingress                                   | `false`                       |
-| `ingress.hosts`                        | Ingress accepted hostnames                        | None                          |
-| `ingress.tls`                          | Ingress TLS configuration                         | None                          |
-| `nodeSelector`                         | node labels for pod assignment                    | `{}`                          |
-| `runAsUser`                            | User to run blackbox-exporter container as        | `1000`                        |
-| `readOnlyRootFilesystem`               | Set blackbox-exporter file-system to read-only    | `true`                        |
-| `runAsNonRoot`                         | Run blackbox-exporter as non-root                 | `true`                        |
-| `tolerations`                          | node tolerations for pod assignment               | `[]`                          |
-| `affinity`                             | node affinity for pod assignment                  | `{}`                          |
-| `podAnnotations`                       | annotations to add to each pod                    | `{}`                          |
-| `podDisruptionBudget`                  | pod disruption budget                             | `{}`         |
-| `priorityClassName`                    | priority class name                               | None                          |
-| `resources`                            | pod resource requests & limits                    | `{}`                          |
-| `restartPolicy`                        | container restart policy                          | `Always`                      |
-| `service.annotations`                  | annotations for the service                       | `{}`                          |
-| `service.labels`                       | additional labels for the service                 | None                          |
-| `service.type`                         | type of service to create                         | `ClusterIP`                   |
-| `service.port`                         | port for the blackbox http service                | `9115`                        |
-| `service.externalIPs`                  | list of external ips                              | []                            |
-| `serviceMonitor.enabled`               | If true, a ServiceMonitor CRD is created for a prometheus operator | `false`      |
-| `serviceMonitor.labels`                | Labels for prometheus operator                    | `{}`                          |
-| `serviceMonitor.interval`              | Interval for prometheus operator endpoint         | `30s`                         |
-| `serviceMonitor.module`                | The module that blackbox will use if serviceMonitor is enabled | `http_2xx` |
-| `serviceMonitor.url`                   | The URL that blackbox will scrape if serviceMonitor is enabled | `http://example.com/healthz` |
-| `serviceMonitor.urlHumanReadable`      | Optional human readable URL that will appear in Prometheus / AlertManager | `nil` |
-| `strategy`                             | strategy used to replace old Pods with new ones   | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0},"type":"RollingUpdate"}` |
+| Parameter                                 | Description                                                                      | Default                                                                      |
+| ----------------------------------------- | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `config`                                  | Prometheus blackbox configuration                                                | {}                                                                           |
+| `secretConfig`                            | Whether to treat blackbox configuration as secret                                | `false`                                                                      |
+| `extraArgs`                               | Optional flags for blackbox                                                      | `[]`                                                                         |
+| `image.repository`                        | container image repository                                                       | `prom/blackbox-exporter`                                                     |
+| `image.tag`                               | container image tag                                                              | `v0.15.1`                                                                    |
+| `image.pullPolicy`                        | container image pull policy                                                      | `IfNotPresent`                                                               |
+| `image.pullSecrets`                       | container image pull secrets                                                     | `[]`                                                                         |
+| `ingress.annotations`                     | Ingress annotations                                                              | None                                                                         |
+| `ingress.enabled`                         | Enables Ingress                                                                  | `false`                                                                      |
+| `ingress.hosts`                           | Ingress accepted hostnames                                                       | None                                                                         |
+| `ingress.tls`                             | Ingress TLS configuration                                                        | None                                                                         |
+| `nodeSelector`                            | node labels for pod assignment                                                   | `{}`                                                                         |
+| `runAsUser`                               | User to run blackbox-exporter container as                                       | `1000`                                                                       |
+| `readOnlyRootFilesystem`                  | Set blackbox-exporter file-system to read-only                                   | `true`                                                                       |
+| `runAsNonRoot`                            | Run blackbox-exporter as non-root                                                | `true`                                                                       |
+| `tolerations`                             | node tolerations for pod assignment                                              | `[]`                                                                         |
+| `affinity`                                | node affinity for pod assignment                                                 | `{}`                                                                         |
+| `podAnnotations`                          | annotations to add to each pod                                                   | `{}`                                                                         |
+| `podDisruptionBudget`                     | pod disruption budget                                                            | `{}`                                                                         |
+| `priorityClassName`                       | priority class name                                                              | None                                                                         |
+| `resources`                               | pod resource requests & limits                                                   | `{}`                                                                         |
+| `restartPolicy`                           | container restart policy                                                         | `Always`                                                                     |
+| `service.annotations`                     | annotations for the service                                                      | `{}`                                                                         |
+| `service.labels`                          | additional labels for the service                                                | None                                                                         |
+| `service.type`                            | type of service to create                                                        | `ClusterIP`                                                                  |
+| `service.port`                            | port for the blackbox http service                                               | `9115`                                                                       |
+| `service.externalIPs`                     | list of external ips                                                             | []                                                                           |
+| `serviceMonitor.enabled`                  | If true, a ServiceMonitor CRD is created for a prometheus operator               | `false`                                                                      |
+| `serviceMonitor.defaults.labels`          | Labels for prometheus operator                                                   | `{}`                                                                         |
+| `serviceMonitor.defaults.interval`        | Interval for prometheus operator endpoint                                        | `30s`                                                                        |
+| `serviceMonitor.defaults.scrapeTimeout`   | Scrape timeout for prometheus operator endpoint                                  | `30s`                                                                        |
+| `serviceMonitor.defaults.module`          | The module that blackbox will use if serviceMonitor is enabled                   | `http_2xx`                                                                   |
+| `serviceMonitor.targets.[]`               | List of targets to scrape                                                        | `[]`                                                                         |
+| `serviceMonitor.targets.[].name`          | Human readable name for the job. It will also appear in job labels in Prometheus | `example`                                                                    |
+| `serviceMonitor.targets.[].url`           | The URL that blackbox will scrape if serviceMonitor is enabled                   | `http://example.com/healthz`                                                 |
+| `serviceMonitor.targets.[].labels`        | See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.labels }`                                        |
+| `serviceMonitor.targets.[].interval`      | See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.interval }}`                                     |
+| `serviceMonitor.targets.[].scrapeTimeout` | See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.scrateTimeout }}`                                |
+| `serviceMonitor.targets.[].module`        | See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.module }}`                                       |
+| `strategy`                                | strategy used to replace old Pods with new ones                                  | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0},"type":"RollingUpdate"}` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-blackbox-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/servicemonitor.yaml
@@ -1,45 +1,43 @@
 {{- if .Values.serviceMonitor.enabled }}
+{{- range .Values.serviceMonitor.targets }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+  name: {{ template "prometheus-blackbox-exporter.fullname" $ }}-{{ .name }}
   labels:
-    app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" . }}
-    {{- if .Values.serviceMonitor.labels }}
-    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" $ }}
+    {{- if or $.Values.serviceMonitor.defaults.labels .labels }}
+    {{- toYaml (.labels | default $.Values.serviceMonitor.defaults.labels) | nindent 4 }}
     {{- end }}
 spec:
   endpoints:
   - port: http
     scheme: http
     path: "/probe"
-    interval: {{ .Values.serviceMonitor.interval }}
-    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    interval: {{ .interval | default $.Values.serviceMonitor.defaults.interval }}
+    scrapeTimeout: {{ .scrapeTimeout | default $.Values.serviceMonitor.defaults.scrapeTimeout }}
     params:
       module:
-      - {{ .Values.serviceMonitor.module }}
+      - {{ .module | default $.Values.serviceMonitor.defaults.module }}
       target:
-      - {{ .Values.serviceMonitor.url }}
+      - {{ .url }}
     metricRelabelings:
       - sourceLabels: [__address__]
         targetLabel: __param_target
       - sourceLabels: [__param_target]
         targetLabel: instance
       - targetLabel: target
-        {{- if .Values.serviceMonitor.urlHumanReadable }}
-        replacement: {{ .Values.serviceMonitor.urlHumanReadable }}
-        {{- else }}
-        replacement: {{ .Values.serviceMonitor.url }}
-        {{- end }}
-  jobLabel: "{{ .Release.Name }}"
+        replacement: {{ .name }}
+  jobLabel: "{{ $.Release.Name }}"
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ include "prometheus-blackbox-exporter.name" $ }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ $.Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/stable/prometheus-blackbox-exporter/values.yaml
+++ b/stable/prometheus-blackbox-exporter/values.yaml
@@ -109,5 +109,9 @@ serviceMonitor:
     module: http_2xx
 
   targets:
-#    - name: example # Human readable URL that will appear in Prometheus / AlertManager
-#      url: http://example.com/healthz # The URL that blackbox will scrape
+#    - name: example                    # Human readable URL that will appear in Prometheus / AlertManager
+#      url: http://example.com/healthz  # The URL that blackbox will scrape
+#      labels: {}                       # List of labels for ServiceMonitor. Overrides value set in `defaults`
+#      interval: 60s                    # Scraping interval. Overrides value set in `defaults`
+#      scrapeTimeout: 60s               # Scrape timeout. Overrides value set in `defaults`
+#      module: http_2xx                 # Module used for scraping. Overrides value set in `defaults`

--- a/stable/prometheus-blackbox-exporter/values.yaml
+++ b/stable/prometheus-blackbox-exporter/values.yaml
@@ -100,11 +100,14 @@ serviceMonitor:
   ## https://github.com/coreos/prometheus-operator
   ##
   enabled: false
-  labels: {}
-  interval: 30s
-  scrapeTimeout: 30s
-  module: http_2xx
-  # The URL that blackbox will scrape
-  url: http://example.com/healthz
-  # Optional human readable URL that will appear in Prometheus / AlertManager
-  urlHumanReadable:  # www.changemeoriwillfail.com
+
+  # Default values that will be used for all ServiceMonitors created by `targets`
+  defaults:
+    labels: {}
+    interval: 30s
+    scrapeTimeout: 30s
+    module: http_2xx
+
+  targets:
+#    - name: example # Human readable URL that will appear in Prometheus / AlertManager
+#      url: http://example.com/healthz # The URL that blackbox will scrape


### PR DESCRIPTION
Signed-off-by: Rostyslav Sotnychenko <me@sota.sh>

#### What this PR does / why we need it:
Currently you may monitor only a single target with `prometheus-blackbox-exporter` chart, which is not very practical. This PR adds ability for monitoring of multiple targets.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
