### PR TITLE
[stable/kong] Allow environment variables to be set on kong ingress controller

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.28.0
+version: 0.29.0
 appVersion: 1.3

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -396,6 +396,7 @@ You can can learn about kong ingress custom resource definitions [here](https://
 | image.tag                          | Version of the ingress controller                                                     | 0.6.0                                                                        |
 | readinessProbe                     | Kong ingress controllers readiness probe                                              |                                                                              |
 | livenessProbe                      | Kong ingress controllers liveness probe                                               |                                                                              |
+| env                                | Specify Kong Ingress Controller configuration via environment variables               |                                                                              |
 | ingressClass                       | The ingress-class value for controller                                                | kong                                                                         |
 | podDisruptionBudget.enabled        | Enable PodDisruptionBudget for ingress controller                                     | `false`                                                                      |
 | podDisruptionBudget.maxUnavailable | Represents the minimum number of Pods that can be unavailable (integer or percentage) | `50%`                                                                        |
@@ -406,6 +407,12 @@ You can can learn about kong ingress custom resource definitions [here](https://
 
 
 ## Changelog
+
+### 0.29.0
+
+#### New Features
+
+- Add support for specifying Ingress Controller environment variables.
 
 ### 0.28.0
 

--- a/stable/kong/ci/ingressController-with-webhook.yaml
+++ b/stable/kong/ci/ingressController-with-webhook.yaml
@@ -3,3 +3,5 @@ ingressController:
   enabled: true
   admissionWebhook:
     enabled: true
+  env:
+    kong_admin_header: "foo:bar"

--- a/stable/kong/templates/_helpers.tpl
+++ b/stable/kong/templates/_helpers.tpl
@@ -153,6 +153,18 @@ The name of the service used for the ingress controller's validation webhook
 {{- end -}}
 {{- end -}}
 
+{{- define "kong.ingressController.env" -}}
+{{- range $key, $val := .Values.ingressController.env }}
+- name: CONTROLLER_{{ $key | upper}}
+{{- $valueType := printf "%T" $val -}}
+{{ if eq $valueType "map[string]interface {}" }}
+{{ toYaml $val | indent 2 -}}
+{{- else }}
+  value: {{ $val | quote -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "kong.volumes" -}}
 {{- range .Values.plugins.configMaps }}
 - name: kong-plugin-{{ .pluginName }}
@@ -277,6 +289,7 @@ The name of the service used for the ingress controller's validation webhook
       fieldRef:
         apiVersion: v1
         fieldPath: metadata.namespace
+{{- include "kong.ingressController.env" .  | indent 2 }}
   image: "{{ .Values.ingressController.image.repository }}:{{ .Values.ingressController.image.tag }}"
   imagePullPolicy: {{ .Values.image.pullPolicy }}
   readinessProbe:

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -417,6 +417,9 @@ ingressController:
     failurePolicy: Fail
     port: 8080
 
+  # Specify Kong Ingress Controller configuration via environment variables
+  env: {}
+
   rbac:
     # Specifies whether RBAC resources should be created
     create: true


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
Allows the ingress controller container's environment variables to be set. This allows us to use the `CONTROLLER_*` env vars to customize flags. My main motiviation for this is to set the [admin header flag](https://github.com/Kong/kubernetes-ingress-controller/blob/31e175f0cae8b01597aae48f0cbe6846d6cebbc9/cli/ingress-controller/flags.go#L123).

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
I chose to allow env vars to be set rather than args because that is how the kong pod itself takes its configuration. I copied the kong.env snippet for this.

I realize the `CONTROLLER_*` env var support is only in master and not a stable release yet, but I figured it was better in the long term to have this setup than to use args.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
