### PR TITLE
[stable/jaeger-operator]  deprecate jaeger operator

### DIFF
--- a/stable/jaeger-operator/Chart.yaml
+++ b/stable/jaeger-operator/Chart.yaml
@@ -7,8 +7,3 @@ deprecated: true
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg
 source: https://github.com/jaegertracing/jaeger-operator
-maintainers:
-  - email: ctadeu@gmail.com
-    name: cpanato
-  - email: batazor111@gmail.com
-    name: batazor

--- a/stable/jaeger-operator/Chart.yaml
+++ b/stable/jaeger-operator/Chart.yaml
@@ -1,8 +1,9 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.12.1
+version: 2.12.2
 appVersion: 1.15.1
+deprecated: true
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg
 source: https://github.com/jaegertracing/jaeger-operator

--- a/stable/jaeger-operator/README.md
+++ b/stable/jaeger-operator/README.md
@@ -1,4 +1,4 @@
-# jaeger-operator
+# DEPRECATED - jaeger-operator
 
 [jaeger-operator](https://github.com/jaegertracing/jaeger-operator) is a Kubernetes operator.
 

--- a/stable/jaeger-operator/README.md
+++ b/stable/jaeger-operator/README.md
@@ -1,5 +1,15 @@
 # DEPRECATED - jaeger-operator
 
+**This chart has been deprecated and moved to its new home:**
+
+- **GitHub repo:** https://github.com/jaegertracing/helm-charts
+- **Charts repo:** https://jaegertracing.github.io/helm-charts
+
+To add the repo:
+```
+$ helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
+```
+
 [jaeger-operator](https://github.com/jaegertracing/jaeger-operator) is a Kubernetes operator.
 
 ## Install


### PR DESCRIPTION
#### What this PR does / why we need it:
Deprecate Jaeger Operator chart.
The chart has moved to https://github.com/jaegertracing/helm-charts/tree/master/charts/jaeger-operator

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

/assign @scottrigby 