### PR TITLE
[incubator/jaeger] deprecate jaeger

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -1,8 +1,9 @@
 apiVersion: v1
 appVersion: 1.15.1
+deprecated: true
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.17.3
+version: 0.17.4
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -13,12 +13,3 @@ home: https://jaegertracing.io
 icon: https://camo.githubusercontent.com/afa87494e0753b4b1f5719a2f35aa5263859dffb/687474703a2f2f6a61656765722e72656164746865646f63732e696f2f656e2f6c61746573742f696d616765732f6a61656765722d766563746f722e737667
 sources:
   - https://hub.docker.com/u/jaegertracing/
-maintainers:
-  - name: dvonthenen
-    email: david.vonthenen@dell.com
-  - name: mikelorant
-    email: michael.lorant@fairfaxmedia.com.au
-  - name: naseemkullah
-    email: naseem@transit.app
-  - name: pavelnikolov
-    email: pavel.nikolov@fairfaxmedia.com.au

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -1,4 +1,14 @@
-# Jaeger
+# DEPRECATED Jaeger
+
+**This chart has been deprecated and moved to its new home:**
+
+- **GitHub repo:** https://github.com/jaegertracing/helm-charts
+- **Charts repo:** https://jaegertracing.github.io/helm-charts
+
+To add the repo:
+```
+$ helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
+```
 
 [Jaeger](http://jaeger.readthedocs.io/en/latest/) is a distributed tracing system.
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Deprecate Jaeger chart.
The chart has moved to https://github.com/jaegertracing/helm-charts/tree/master/charts/jaeger

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

/assign @scottrigby 