### PR TITLE
[stable/cert-manager] add api version

### DIFF
--- a/stable/cert-manager/Chart.yaml
+++ b/stable/cert-manager/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 name: cert-manager
 version: v0.6.7
 appVersion: v0.6.2


### PR DESCRIPTION
Update to prevent `helm lint` errors

```
==> Linting cert-manager
[ERROR] Chart.yaml: apiVersion is required
Error: 1 chart(s) linted, 1 chart(s) failed
```