### PR TITLE
[stable/instana-agent] Chart version 1.0.19

### DIFF
--- a/stable/instana-agent/Chart.yaml
+++ b/stable/instana-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: instana-agent
-version: 1.0.18
+version: 1.0.19
 appVersion: 1.0
 description: Instana Agent for Kubernetes
 home: https://www.instana.com/

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -105,6 +105,8 @@ spec:
               mountPath: /sys
             - name: var-log
               mountPath: /var/log
+            - name: var-lib
+              mountPath: /var/lib/containers/storage
             - name: machine-id
               mountPath: /etc/machine-id
             - name: configuration
@@ -116,6 +118,7 @@ spec:
             {{- end }}
           livenessProbe:
             httpGet:
+              host: 127.0.0.1
               path: /status
               port: 42699
             initialDelaySeconds: 75
@@ -147,6 +150,7 @@ spec:
               memory: 64Mi
           livenessProbe:
             httpGet:
+              host: 127.0.0.1
               path: /status
               port: 42699
             initialDelaySeconds: 75
@@ -173,6 +177,9 @@ spec:
         - name: var-log
           hostPath:
             path: /var/log
+        - name: var-lib
+          hostPath:
+            path: /var/lib/containers/storage
         - name: machine-id
           hostPath:
             path: /etc/machine-id

--- a/stable/instana-agent/templates/podsecuritypolicy.yaml
+++ b/stable/instana-agent/templates/podsecuritypolicy.yaml
@@ -30,6 +30,8 @@ spec:
       readOnly: false
     - pathPrefix: "/etc/machine-id"
       readOnly: false
+    - pathPrefix: "/var/lib/containers/storage"
+      readOnly: false
     {{- if .Values.agent.host.repository }}
     - pathPrefix: {{ .Values.agent.host.repository }}
       readOnly: false

--- a/stable/instana-agent/values.yaml
+++ b/stable/instana-agent/values.yaml
@@ -26,7 +26,7 @@ agent:
     # agent.image.name is the name of the container image of the Instana agent.
     name: instana/agent
     # agent.image.tag is the tag name of the agent container image.
-    tag: 1.0.29
+    tag: 1.0.42
     # agent.image.pullPolicy specifies when to pull the image container.
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This changeset includes:
- Mount `/var/lib/containers/storage` in the `DaemonSet` for CRI-O support
- Specify host in the `livenessProbe` for both the `instana-agent` and `leader-elector` containers
- Update the `instana/agent` image tag to the latest available `1.0.42` that's on DockerHub as of Dec 16 2019 (https://hub.docker.com/r/instana/agent/tags)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
