### PR TITLE
[stable/fluentd] Fix incorrect table default

### DIFF
--- a/stable/fluentd/Chart.yaml
+++ b/stable/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Fluentd Elasticsearch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd
-version: 2.3.2
+version: 2.3.3
 appVersion: v2.4.0
 home: https://www.fluentd.org/
 sources:

--- a/stable/fluentd/values.yaml
+++ b/stable/fluentd/values.yaml
@@ -82,7 +82,7 @@ ingress:
 #       protocol: TCP
 #       servicePort: 9880
 #       path: /
-  tls: {}
+  tls: []
   # Secrets must be manually created in the namespace.
 #    - secretName: http-input-tls
 #      hosts:


### PR DESCRIPTION
#### What this PR does / why we need it:
The values.yaml specifies filling out the TLS section with a list, not a table. This allows that to happen, since overwriting a table with a list fails.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
