### PR TITLE
[stable/ghost] support nodeSelector

### DIFF
--- a/stable/ghost/Chart.yaml
+++ b/stable/ghost/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ghost
-version: 9.0.3
+version: 9.0.4
 appVersion: 3.1.1
 description: A simple, powerful publishing platform that allows you to share your stories with the world
 keywords:

--- a/stable/ghost/README.md
+++ b/stable/ghost/README.md
@@ -116,6 +116,7 @@ The following table lists the configurable parameters of the Ghost chart and the
 | `persistence.size`                  | PVC Storage Request for Ghost volume                          | `8Gi`                                                    |
 | `persistence.path`                  | Path to mount the volume at, to use other images              | `/bitnami`                                               |
 | `resources`                         | CPU/Memory resource requests/limits                           | Memory: `512Mi`, CPU: `300m`                             |
+| `nodeSelector`                      | Node selector for pod assignment                              | `{}`                                                     |
 | `affinity`                          | Map of node/pod affinities                                    | `{}`                                                     |
 
 The above parameters map to the env variables defined in [bitnami/ghost](http://github.com/bitnami/bitnami-docker-ghost). For more information please refer to the [bitnami/ghost](http://github.com/bitnami/bitnami-docker-ghost) image documentation.

--- a/stable/ghost/templates/deployment.yaml
+++ b/stable/ghost/templates/deployment.yaml
@@ -172,8 +172,12 @@ spec:
       {{- else }}
         emptyDir: {}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end -}}

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -265,6 +265,11 @@ ingress:
   #   key:
   #   certificate:
 
+## Node selector for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+##
+nodeSelector: {}
+
 ## Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ##


### PR DESCRIPTION
### What this PR does / why we need it:

The `stable/ghost` chart did not support `--set nodeSelector."beta\.kubernetes\.io/arch"=amd64` or similar `nodeSelector` overrides.


[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
