### PR TITLE
[stable/kong] add security restrictions

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.31.2
+version: 0.32.0
 appVersion: 1.4

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -410,6 +410,20 @@ You can can learn about kong ingress custom resource definitions [here](https://
 
 ## Changelog
 
+### 0.32.0
+
+#### Improvements
+
+- Create and mount emptyDir volumes for `/tmp` and `/kong_prefix` to allow for read-only root filesystem securityContexts and PodSecurityPolicys.
+- Use read-only mounts for custom plugin volumes.
+- Update stock PodSecurityPolicy to allow emptyDir access.
+- Override the standard `/usr/local/kong` prefix to the mounted emptyDir at `/kong_prefix` in `.Values.env`.
+- Add securityContext injection points to template. By default, it sets Kong pods to run with UID 1000.
+
+#### Fixes
+
+- Correct behavior for the Vitals toggle. Vitals defaults to on in all current Kong Enterprise releases, and the existing template only created the Vitals environment variable if `.Values.enterprise.enabled == true`. Inverted template to create it (and set it to "off") if that setting is instead disabled.
+
 ### 0.31.0
 
 #### Breaking changes

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -423,6 +423,7 @@ You can can learn about kong ingress custom resource definitions [here](https://
 #### Fixes
 
 - Correct behavior for the Vitals toggle. Vitals defaults to on in all current Kong Enterprise releases, and the existing template only created the Vitals environment variable if `.Values.enterprise.enabled == true`. Inverted template to create it (and set it to "off") if that setting is instead disabled.
+- Correct an issue where custom plugin configurations would block Kong from starting.
 
 ### 0.31.0
 

--- a/stable/kong/templates/_helpers.tpl
+++ b/stable/kong/templates/_helpers.tpl
@@ -166,6 +166,10 @@ The name of the service used for the ingress controller's validation webhook
 {{- end -}}
 
 {{- define "kong.volumes" -}}
+- name: {{ template "kong.fullname" . }}-prefix-dir
+  emptyDir: {}
+- name: {{ template "kong.fullname" . }}-tmp
+  emptyDir: {}
 {{- range .Values.plugins.configMaps }}
 - name: kong-plugin-{{ .pluginName }}
   configMap:
@@ -201,6 +205,10 @@ The name of the service used for the ingress controller's validation webhook
 {{- end -}}
 
 {{- define "kong.volumeMounts" -}}
+- name: {{ template "kong.fullname" . }}-prefix-dir
+  mountPath: /kong_prefix/
+- name: {{ template "kong.fullname" . }}-tmp
+  mountPath: /tmp
 - name: custom-nginx-template-volume
   mountPath: /kong
 {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
@@ -214,10 +222,12 @@ The name of the service used for the ingress controller's validation webhook
 {{- range .Values.plugins.configMaps }}
 - name:  kong-plugin-{{ .pluginName }}
   mountPath: /opt/kong/plugins/{{ .pluginName }}
+  readOnly: true
 {{- end }}
 {{- range .Values.plugins.secrets }}
 - name:  kong-plugin-{{ .pluginName }}
   mountPath: /opt/kong/plugins/{{ .pluginName }}
+  readOnly: true
 {{- end }}
 {{- end -}}
 
@@ -315,4 +325,11 @@ Retrieve Kong Enterprise license from a secret and make it available in env vars
     secretKeyRef:
       name: {{ .Values.enterprise.license_secret }}
       key: license
+{{- end -}}
+
+{{/*
+Use the Pod security context defined in Values or set the UID by default
+*/}}
+{{- define "kong.podsecuritycontext" -}}
+{{ .Values.securityContext | toYaml }}
 {{- end -}}

--- a/stable/kong/templates/_helpers.tpl
+++ b/stable/kong/templates/_helpers.tpl
@@ -255,14 +255,16 @@ The name of the service used for the ingress controller's validation webhook
     value: {{ template "kong.postgresql.fullname" . }}
   - name: KONG_PG_PORT
     value: "{{ .Values.postgresql.service.port }}"
-  - name: KONG_LUA_PACKAGE_PATH
-    value: "/opt/?.lua;;"
   - name: KONG_PG_PASSWORD
     valueFrom:
       secretKeyRef:
         name: {{ template "kong.postgresql.fullname" . }}
         key: postgresql-password
   {{- end }}
+  - name: KONG_LUA_PACKAGE_PATH
+    value: "/opt/?.lua;;"
+  - name: KONG_PLUGINS
+    value: {{ template "kong.plugins" . }}
   {{- include "kong.env" .  | nindent 2 }}
   command: [ "/bin/sh", "-c", "until kong start; do echo 'waiting for db'; sleep 1; done; kong stop" ]
   volumeMounts:

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -110,9 +110,9 @@ spec:
         - name: KONG_NGINX_DAEMON
           value: "off"
         {{- if .Values.enterprise.enabled }}
-        {{- if .Values.enterprise.vitals.enabled }}
+        {{- if not .Values.enterprise.vitals.enabled }}
         - name: KONG_VITALS
-          value: "on"
+          value: "off"
         {{- end }}
         {{- if .Values.enterprise.portal.enabled }}
         - name: KONG_PORTAL
@@ -292,6 +292,8 @@ spec:
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
     {{- end }}
+      securityContext:
+      {{- include "kong.podsecuritycontext" . | nindent 8 }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/stable/kong/templates/migrations-post-upgrade.yaml
+++ b/stable/kong/templates/migrations-post-upgrade.yaml
@@ -78,6 +78,8 @@ spec:
         command: [ "/bin/sh", "-c", "kong migrations finish" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
+      securityContext:
+      {{- include "kong.podsecuritycontext" . | nindent 6 }}
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}

--- a/stable/kong/templates/migrations-pre-upgrade.yaml
+++ b/stable/kong/templates/migrations-pre-upgrade.yaml
@@ -78,6 +78,8 @@ spec:
         command: [ "/bin/sh", "-c", "kong migrations up" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
+      securityContext:
+      {{- include "kong.podsecuritycontext" . | nindent 6 }}
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}

--- a/stable/kong/templates/migrations.yaml
+++ b/stable/kong/templates/migrations.yaml
@@ -73,6 +73,8 @@ spec:
         command: [ "/bin/sh", "-c", "kong migrations bootstrap" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
+      securityContext:
+      {{- include "kong.podsecuritycontext" . | nindent 6 }}
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}

--- a/stable/kong/templates/psp.yaml
+++ b/stable/kong/templates/psp.yaml
@@ -23,6 +23,7 @@ spec:
   volumes:
     - 'configMap'
     - 'secret'
+    - 'emptyDir'
   allowPrivilegeEscalation: false
   hostNetwork: false
   hostIPC: false

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -286,6 +286,7 @@ env:
   admin_error_log: /dev/stderr
   admin_gui_error_log: /dev/stderr
   portal_api_error_log: /dev/stderr
+  prefix: /kong_prefix/
 
 # If you want to specify resources, uncomment the following
 # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
@@ -348,6 +349,10 @@ podDisruptionBudget:
 
 podSecurityPolicy:
   enabled: false
+
+# securityContext for Kong pods.
+securityContext:
+  runAsUser: 1000
 
 # Kong has a choice of either Postgres or Cassandra as a backend datatstore.
 # This chart allows you to choose either of them with the `database.type`


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
This PR adds several security settings to our default configuration, primarily intended to allow read-only root filesystems and non-root execution in the future:
* Allow enforcing Kubernetes security policies that restrict writes to the root filesystem by mounting emptyDir volumes over directories that Kong needs to write to at runtime. Accordingly, update the stock PSP to allow emptyDir writes.
* Change plugin code mounts to read-only. These should never require runtime modification, and allowing it presents a potential attack vector, as Kong reloads code when sent a SIGHUP.
* Add securityContext injection points to Kong pods and provide a default context that runs Kong with UID 1000.
* Fix an unrelated minor issue with the Vitals toggle.

#### Special notes for your reviewer:
* At present, Kong Enterprise has a bug where it still attempts to write to /usr/local/kong, so this does not allow using it with a read-only root. It should work once that bug is addressed. Older versions (<=0.36-2) furthermore have unrelated issues with non-standard prefixes. 1.3+ should not encounter issues with the non-standard prefix, and I did not encounter any testing with these changes in place while still allowing root writes. Core should work with the change and a read-only root as is.
* The official Kong Docker images [have an apparent bug](https://github.com/Kong/docker-kong/issues/313) where Kong is run as a non-root user, but that user is not given access to the prefix directory (we hardcode the default directory). If Kong is initially run as root without using the entrypoint script, the prefix is created with a `.kong_env` that non-root users cannot access, preventing non-root startup after. The script runs `kong prepare` as root before attempting to run Kong as non-root.
* I encountered some issues testing Enterprise deployments after the addition of the securityContext and read-only plugin volumes. As best I can tell, these are due to something else I broke in my test environment, not this changeset. Please review these changes and confirm if they look acceptable, but hold off on merger. I'll continue to try and determine the root cause of my test issues and confirm if it's something unrelated.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
