### PR TITLE
[stable/wordpress] allow users to enable/disable the health checks

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 8.0.4
+version: 8.1.0
 appVersion: 5.3.2
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -49,113 +49,115 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the WordPress chart and their default values.
 
-|            Parameter                      |                                  Description                                  |                           Default                            |
-| ----------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `global.imageRegistry`                    | Global Docker image registry                                                  | `nil`                                                        |
-| `global.imagePullSecrets`                 | Global Docker registry secret names as an array                               | `[]` (does not add image pull secrets to deployed pods)      |
-| `global.storageClass`                     | Global storage class for dynamic provisioning                                 | `nil`                                                        |
-| `image.registry`                          | WordPress image registry                                                      | `docker.io`                                                  |
-| `image.repository`                        | WordPress image name                                                          | `bitnami/wordpress`                                          |
-| `image.tag`                               | WordPress image tag                                                           | `{TAG_NAME}`                                                 |
-| `image.pullPolicy`                        | Image pull policy                                                             | `IfNotPresent`                                               |
-| `image.pullSecrets`                       | Specify docker-registry secret names as an array                              | `[]` (does not add image pull secrets to deployed pods)      |
-| `nameOverride`                            | String to partially override wordpress.fullname template with a string (will prepend the release name) | `nil`                               |
-| `fullnameOverride`                        | String to fully override wordpress.fullname template with a string                                     | `nil`                               |
-| `wordpressSkipInstall`                    | Skip wizard installation                                                      | `false`                                                      |
-| `wordpressUsername`                       | User of the application                                                       | `user`                                                       |
-| `wordpressPassword`                       | Application password                                                          | _random 10 character long alphanumeric string_               |
-| `wordpressEmail`                          | Admin email                                                                   | `user@example.com`                                           |
-| `wordpressFirstName`                      | First name                                                                    | `FirstName`                                                  |
-| `wordpressLastName`                       | Last name                                                                     | `LastName`                                                   |
-| `wordpressBlogName`                       | Blog name                                                                     | `User's Blog!`                                               |
-| `wordpressTablePrefix`                    | Table prefix                                                                  | `wp_`                                                        |
-| `wordpressScheme`                         | Scheme to generate application URLs [`http`, `https`]                         | `http`                                                       |
-| `allowEmptyPassword`                      | Allow DB blank passwords                                                      | `true`                                                       |
-| `allowOverrideNone`                       | Set Apache AllowOverride directive to None                                    | `false`                                                      |
-| `customHTAccessCM`                        | Configmap with custom wordpress-htaccess.conf directives                      | `nil`                                                        |
-| `smtpHost`                                | SMTP host                                                                     | `nil`                                                        |
-| `smtpPort`                                | SMTP port                                                                     | `nil`                                                        |
-| `smtpUser`                                | SMTP user                                                                     | `nil`                                                        |
-| `smtpPassword`                            | SMTP password                                                                 | `nil`                                                        |
-| `smtpUsername`                            | User name for SMTP emails                                                     | `nil`                                                        |
-| `smtpProtocol`                            | SMTP protocol [`tls`, `ssl`, `none`]                                          | `nil`                                                        |
-| `replicaCount`                            | Number of WordPress Pods to run                                               | `1`                                                          |
-| `extraEnv`                                | Additional container environment variables                                    | `[]`                                                         |
-| `extraVolumeMounts`                       | Additional volume mounts                                                      | `[]`                                                         |
-| `extraVolumes`                            | Additional volumes                                                            | `[]`                                                         |
-| `mariadb.enabled`                         | Deploy MariaDB container(s)                                                   | `true`                                                       |
-| `mariadb.rootUser.password`               | MariaDB admin password                                                        | `nil`                                                        |
-| `mariadb.db.name`                         | Database name to create                                                       | `bitnami_wordpress`                                          |
-| `mariadb.db.user`                         | Database user to create                                                       | `bn_wordpress`                                               |
-| `mariadb.db.password`                     | Password for the database                                                     | _random 10 character long alphanumeric string_               |
-| `externalDatabase.host`                   | Host of the external database                                                 | `localhost`                                                  |
-| `externalDatabase.user`                   | Existing username in the external db                                          | `bn_wordpress`                                               |
-| `externalDatabase.password`               | Password for the above username                                               | `nil`                                                        |
-| `externalDatabase.database`               | Name of the existing database                                                 | `bitnami_wordpress`                                          |
-| `externalDatabase.port`                   | Database port number                                                          | `3306`                                                       |
-| `service.annotations`                     | Service annotations                                                           | `{}`                                                         |
-| `service.type`                            | Kubernetes Service type                                                       | `LoadBalancer`                                               |
-| `service.port`                            | Service HTTP port                                                             | `80`                                                         |
-| `service.httpsPort`                       | Service HTTPS port                                                            | `443`                                                        |
-| `service.httpsTargetPort`                 | Service Target HTTPS port                                                     | `https`                                                      |
-| `service.loadBalancerSourceRanges`        | Restricts access for LoadBalancer (only with `service.type: LoadBalancer`)    | `[]`                                                         |
-| `service.metricsPort`                     | Service Metrics port                                                          | `9117`                                                       |
-| `service.externalTrafficPolicy`           | Enable client source IP preservation                                          | `Cluster`                                                    |
-| `service.nodePorts.http`                  | Kubernetes http node port                                                     | `""`                                                         |
-| `service.nodePorts.https`                 | Kubernetes https node port                                                    | `""`                                                         |
-| `service.nodePorts.metrics`               | Kubernetes metrics node port                                                  | `""`                                                         |
-| `service.extraPorts`                      | Extra ports to expose in the service (normally used with the `sidecar` value) | `nil`                                                        |
-| `healthcheckHttps`                        | Use https for liveliness and readiness                                        | `false`                                                      |
-| `livenessProbe.initialDelaySeconds`       | Delay before liveness probe is initiated                                      | `120`                                                        |
-| `livenessProbe.periodSeconds`             | How often to perform the probe                                                | `10`                                                         |
-| `livenessProbe.timeoutSeconds`            | When the probe times out                                                      | `5`                                                          |
-| `livenessProbe.failureThreshold`          | Minimum consecutive failures for the probe                                    | `6`                                                          |
-| `livenessProbe.successThreshold`          | Minimum consecutive successes for the probe                                   | `1`                                                          |
-| `livenessProbeHeaders`                    | Headers to use for livenessProbe                                              | `nil`                                                        |
-| `readinessProbe.initialDelaySeconds`      | Delay before readiness probe is initiated                                     | `30`                                                         |
-| `readinessProbe.periodSeconds`            | How often to perform the probe                                                | `10`                                                         |
-| `readinessProbe.timeoutSeconds`           | When the probe times out                                                      | `5`                                                          |
-| `readinessProbe.failureThreshold`         | Minimum consecutive failures for the probe                                    | `6`                                                          |
-| `readinessProbe.successThreshold`         | Minimum consecutive successes for the probe                                   | `1`                                                          |
-| `readinessProbeHeaders`                   | Headers to use for readinessProbe                                             | `nil`                                                        |
-| `ingress.enabled`                         | Enable ingress controller resource                                            | `false`                                                      |
-| `ingress.certManager`                     | Add annotations for cert-manager                                              | `false`                                                      |
-| `ingress.hostname`                        | Default host for the ingress resource                                         | `wordpress.local`                                            |
-| `ingress.annotations`                     | Ingress annotations                                                           | `[]`                                                         |
-| `ingress.hosts[0].name`                   | Hostname to your Wordpress installation                                       | `wordpress.local`                                            |
-| `ingress.hosts[0].path`                   | Path within the url structure                                                 | `/`                                                          |
-| `ingress.tls[0].hosts[0]`                 | TLS hosts                                                                     | `wordpress.local`                                            |
-| `ingress.tls[0].secretName`               | TLS Secret (certificates)                                                     | `wordpress.local-tls`                                        |
-| `ingress.secrets[0].name`                 | TLS Secret Name                                                               | `nil`                                                        |
-| `ingress.secrets[0].certificate`          | TLS Secret Certificate                                                        | `nil`                                                        |
-| `ingress.secrets[0].key`                  | TLS Secret Key                                                                | `nil`                                                        |
-| `schedulerName`                           | Name of the alternate scheduler                                               | `nil`                                                        |
-| `persistence.enabled`                     | Enable persistence using PVC                                                  | `true`                                                       |
-| `persistence.existingClaim`               | Enable persistence using an existing PVC                                      | `nil`                                                        |
-| `persistence.storageClass`                | PVC Storage Class                                                             | `nil` (uses alpha storage class annotation)                  |
-| `persistence.accessMode`                  | PVC Access Mode                                                               | `ReadWriteOnce`                                              |
-| `persistence.size`                        | PVC Storage Request                                                           | `10Gi`                                                       |
-| `nodeSelector`                            | Node labels for pod assignment                                                | `{}`                                                         |
-| `tolerations`                             | List of node taints to tolerate                                               | `[]`                                                         |
-| `affinity`                                | Map of node/pod affinities                                                    | `{}`                                                         |
-| `podAnnotations`                          | Pod annotations                                                               | `{}`                                                         |
-| `metrics.enabled`                         | Start a side-car prometheus exporter                                          | `false`                                                      |
-| `metrics.image.registry`                  | Apache exporter image registry                                                | `docker.io`                                                  |
-| `metrics.image.repository`                | Apache exporter image name                                                    | `bitnami/apache-exporter`                                    |
-| `metrics.image.tag`                       | Apache exporter image tag                                                     | `{TAG_NAME}`                                                 |
-| `metrics.image.pullPolicy`                | Image pull policy                                                             | `IfNotPresent`                                               |
-| `metrics.image.pullSecrets`               | Specify docker-registry secret names as an array                              | `[]` (does not add image pull secrets to deployed pods)      |
-| `metrics.podAnnotations`                  | Additional annotations for Metrics exporter pod                               | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
-| `metrics.resources`                       | Exporter resource requests/limit                                              | `{}`                                                         |
-| `metrics.serviceMonitor.enabled`          | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator  | `false`                                                      |
-| `metrics.serviceMonitor.namespace`        | Namespace where servicemonitor resource should be created                     | `nil`                                                        |
-| `metrics.serviceMonitor.interval`         | Specify the interval at which metrics should be scraped                       | `30s`                                                        |
-| `metrics.serviceMonitor.scrapeTimeout`    | Specify the timeout after which the scrape is ended                           | `nil`                                                        |
-| `metrics.serviceMonitor.relabellings`     | Specify Metric Relabellings to add to the scrape endpoint                     | `nil`                                                        |
-| `metrics.serviceMonitor.honorLabels`      | honorLabels chooses the metric's labels on collisions with target labels.     | `false`                                                      |
-| `metrics.serviceMonitor.additionalLabels` | Used to pass Labels that are required by the Installed Prometheus Operator    | `{}`                                                         |
-| `sidecars`                                | Attach additional containers to the pod                                       | `nil`                                                        |
-| `updateStrategy`                          | Set up update strategy                                                        | `RollingUpdate`                                              |
+|                 Parameter                 |                                              Description                                               |                           Default                            |
+|-------------------------------------------|--------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `global.imageRegistry`                    | Global Docker image registry                                                                           | `nil`                                                        |
+| `global.imagePullSecrets`                 | Global Docker registry secret names as an array                                                        | `[]` (does not add image pull secrets to deployed pods)      |
+| `global.storageClass`                     | Global storage class for dynamic provisioning                                                          | `nil`                                                        |
+| `image.registry`                          | WordPress image registry                                                                               | `docker.io`                                                  |
+| `image.repository`                        | WordPress image name                                                                                   | `bitnami/wordpress`                                          |
+| `image.tag`                               | WordPress image tag                                                                                    | `{TAG_NAME}`                                                 |
+| `image.pullPolicy`                        | Image pull policy                                                                                      | `IfNotPresent`                                               |
+| `image.pullSecrets`                       | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods)      |
+| `nameOverride`                            | String to partially override wordpress.fullname template with a string (will prepend the release name) | `nil`                                                        |
+| `fullnameOverride`                        | String to fully override wordpress.fullname template with a string                                     | `nil`                                                        |
+| `wordpressSkipInstall`                    | Skip wizard installation                                                                               | `false`                                                      |
+| `wordpressUsername`                       | User of the application                                                                                | `user`                                                       |
+| `wordpressPassword`                       | Application password                                                                                   | _random 10 character long alphanumeric string_               |
+| `wordpressEmail`                          | Admin email                                                                                            | `user@example.com`                                           |
+| `wordpressFirstName`                      | First name                                                                                             | `FirstName`                                                  |
+| `wordpressLastName`                       | Last name                                                                                              | `LastName`                                                   |
+| `wordpressBlogName`                       | Blog name                                                                                              | `User's Blog!`                                               |
+| `wordpressTablePrefix`                    | Table prefix                                                                                           | `wp_`                                                        |
+| `wordpressScheme`                         | Scheme to generate application URLs [`http`, `https`]                                                  | `http`                                                       |
+| `allowEmptyPassword`                      | Allow DB blank passwords                                                                               | `true`                                                       |
+| `allowOverrideNone`                       | Set Apache AllowOverride directive to None                                                             | `false`                                                      |
+| `customHTAccessCM`                        | Configmap with custom wordpress-htaccess.conf directives                                               | `nil`                                                        |
+| `smtpHost`                                | SMTP host                                                                                              | `nil`                                                        |
+| `smtpPort`                                | SMTP port                                                                                              | `nil`                                                        |
+| `smtpUser`                                | SMTP user                                                                                              | `nil`                                                        |
+| `smtpPassword`                            | SMTP password                                                                                          | `nil`                                                        |
+| `smtpUsername`                            | User name for SMTP emails                                                                              | `nil`                                                        |
+| `smtpProtocol`                            | SMTP protocol [`tls`, `ssl`, `none`]                                                                   | `nil`                                                        |
+| `replicaCount`                            | Number of WordPress Pods to run                                                                        | `1`                                                          |
+| `extraEnv`                                | Additional container environment variables                                                             | `[]`                                                         |
+| `extraVolumeMounts`                       | Additional volume mounts                                                                               | `[]`                                                         |
+| `extraVolumes`                            | Additional volumes                                                                                     | `[]`                                                         |
+| `mariadb.enabled`                         | Deploy MariaDB container(s)                                                                            | `true`                                                       |
+| `mariadb.rootUser.password`               | MariaDB admin password                                                                                 | `nil`                                                        |
+| `mariadb.db.name`                         | Database name to create                                                                                | `bitnami_wordpress`                                          |
+| `mariadb.db.user`                         | Database user to create                                                                                | `bn_wordpress`                                               |
+| `mariadb.db.password`                     | Password for the database                                                                              | _random 10 character long alphanumeric string_               |
+| `externalDatabase.host`                   | Host of the external database                                                                          | `localhost`                                                  |
+| `externalDatabase.user`                   | Existing username in the external db                                                                   | `bn_wordpress`                                               |
+| `externalDatabase.password`               | Password for the above username                                                                        | `nil`                                                        |
+| `externalDatabase.database`               | Name of the existing database                                                                          | `bitnami_wordpress`                                          |
+| `externalDatabase.port`                   | Database port number                                                                                   | `3306`                                                       |
+| `service.annotations`                     | Service annotations                                                                                    | `{}`                                                         |
+| `service.type`                            | Kubernetes Service type                                                                                | `LoadBalancer`                                               |
+| `service.port`                            | Service HTTP port                                                                                      | `80`                                                         |
+| `service.httpsPort`                       | Service HTTPS port                                                                                     | `443`                                                        |
+| `service.httpsTargetPort`                 | Service Target HTTPS port                                                                              | `https`                                                      |
+| `service.loadBalancerSourceRanges`        | Restricts access for LoadBalancer (only with `service.type: LoadBalancer`)                             | `[]`                                                         |
+| `service.metricsPort`                     | Service Metrics port                                                                                   | `9117`                                                       |
+| `service.externalTrafficPolicy`           | Enable client source IP preservation                                                                   | `Cluster`                                                    |
+| `service.nodePorts.http`                  | Kubernetes http node port                                                                              | `""`                                                         |
+| `service.nodePorts.https`                 | Kubernetes https node port                                                                             | `""`                                                         |
+| `service.nodePorts.metrics`               | Kubernetes metrics node port                                                                           | `""`                                                         |
+| `service.extraPorts`                      | Extra ports to expose in the service (normally used with the `sidecar` value)                          | `nil`                                                        |
+| `healthcheckHttps`                        | Use https for liveliness and readiness                                                                 | `false`                                                      |
+| `livenessProbe.enabled`                   | Enable/disable livenessProbe                                                                          | `true`                                                       |
+| `livenessProbe.initialDelaySeconds`       | Delay before liveness probe is initiated                                                               | `120`                                                        |
+| `livenessProbe.periodSeconds`             | How often to perform the probe                                                                         | `10`                                                         |
+| `livenessProbe.timeoutSeconds`            | When the probe times out                                                                               | `5`                                                          |
+| `livenessProbe.failureThreshold`          | Minimum consecutive failures for the probe                                                             | `6`                                                          |
+| `livenessProbe.successThreshold`          | Minimum consecutive successes for the probe                                                            | `1`                                                          |
+| `livenessProbeHeaders`                    | Headers to use for livenessProbe                                                                       | `nil`                                                        |
+| `readiness.enabled`                       | Enable/disable readinessProbe                                                                          | `true`                                                       |
+| `readinessProbe.initialDelaySeconds`      | Delay before readiness probe is initiated                                                              | `30`                                                         |
+| `readinessProbe.periodSeconds`            | How often to perform the probe                                                                         | `10`                                                         |
+| `readinessProbe.timeoutSeconds`           | When the probe times out                                                                               | `5`                                                          |
+| `readinessProbe.failureThreshold`         | Minimum consecutive failures for the probe                                                             | `6`                                                          |
+| `readinessProbe.successThreshold`         | Minimum consecutive successes for the probe                                                            | `1`                                                          |
+| `readinessProbeHeaders`                   | Headers to use for readinessProbe                                                                      | `nil`                                                        |
+| `ingress.enabled`                         | Enable ingress controller resource                                                                     | `false`                                                      |
+| `ingress.certManager`                     | Add annotations for cert-manager                                                                       | `false`                                                      |
+| `ingress.hostname`                        | Default host for the ingress resource                                                                  | `wordpress.local`                                            |
+| `ingress.annotations`                     | Ingress annotations                                                                                    | `[]`                                                         |
+| `ingress.hosts[0].name`                   | Hostname to your Wordpress installation                                                                | `wordpress.local`                                            |
+| `ingress.hosts[0].path`                   | Path within the url structure                                                                          | `/`                                                          |
+| `ingress.tls[0].hosts[0]`                 | TLS hosts                                                                                              | `wordpress.local`                                            |
+| `ingress.tls[0].secretName`               | TLS Secret (certificates)                                                                              | `wordpress.local-tls`                                        |
+| `ingress.secrets[0].name`                 | TLS Secret Name                                                                                        | `nil`                                                        |
+| `ingress.secrets[0].certificate`          | TLS Secret Certificate                                                                                 | `nil`                                                        |
+| `ingress.secrets[0].key`                  | TLS Secret Key                                                                                         | `nil`                                                        |
+| `schedulerName`                           | Name of the alternate scheduler                                                                        | `nil`                                                        |
+| `persistence.enabled`                     | Enable persistence using PVC                                                                           | `true`                                                       |
+| `persistence.existingClaim`               | Enable persistence using an existing PVC                                                               | `nil`                                                        |
+| `persistence.storageClass`                | PVC Storage Class                                                                                      | `nil` (uses alpha storage class annotation)                  |
+| `persistence.accessMode`                  | PVC Access Mode                                                                                        | `ReadWriteOnce`                                              |
+| `persistence.size`                        | PVC Storage Request                                                                                    | `10Gi`                                                       |
+| `nodeSelector`                            | Node labels for pod assignment                                                                         | `{}`                                                         |
+| `tolerations`                             | List of node taints to tolerate                                                                        | `[]`                                                         |
+| `affinity`                                | Map of node/pod affinities                                                                             | `{}`                                                         |
+| `podAnnotations`                          | Pod annotations                                                                                        | `{}`                                                         |
+| `metrics.enabled`                         | Start a side-car prometheus exporter                                                                   | `false`                                                      |
+| `metrics.image.registry`                  | Apache exporter image registry                                                                         | `docker.io`                                                  |
+| `metrics.image.repository`                | Apache exporter image name                                                                             | `bitnami/apache-exporter`                                    |
+| `metrics.image.tag`                       | Apache exporter image tag                                                                              | `{TAG_NAME}`                                                 |
+| `metrics.image.pullPolicy`                | Image pull policy                                                                                      | `IfNotPresent`                                               |
+| `metrics.image.pullSecrets`               | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods)      |
+| `metrics.podAnnotations`                  | Additional annotations for Metrics exporter pod                                                        | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
+| `metrics.resources`                       | Exporter resource requests/limit                                                                       | `{}`                                                         |
+| `metrics.serviceMonitor.enabled`          | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                           | `false`                                                      |
+| `metrics.serviceMonitor.namespace`        | Namespace where servicemonitor resource should be created                                              | `nil`                                                        |
+| `metrics.serviceMonitor.interval`         | Specify the interval at which metrics should be scraped                                                | `30s`                                                        |
+| `metrics.serviceMonitor.scrapeTimeout`    | Specify the timeout after which the scrape is ended                                                    | `nil`                                                        |
+| `metrics.serviceMonitor.relabellings`     | Specify Metric Relabellings to add to the scrape endpoint                                              | `nil`                                                        |
+| `metrics.serviceMonitor.honorLabels`      | honorLabels chooses the metric's labels on collisions with target labels.                              | `false`                                                      |
+| `metrics.serviceMonitor.additionalLabels` | Used to pass Labels that are required by the Installed Prometheus Operator                             | `{}`                                                         |
+| `sidecars`                                | Attach additional containers to the pod                                                                | `nil`                                                        |
+| `updateStrategy`                          | Set up update strategy                                                                                 | `RollingUpdate`                                              |
 
 The above parameters map to the env variables defined in [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress). For more information please refer to the [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress) image documentation.
 

--- a/stable/wordpress/templates/deployment.yaml
+++ b/stable/wordpress/templates/deployment.yaml
@@ -139,7 +139,13 @@ spec:
           containerPort: 80
         - name: https
           containerPort: 443
+        {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           httpGet:
             path: /wp-login.php
             port: {{ ternary "https" "http" .Values.healthcheckHttps }}
@@ -150,8 +156,14 @@ spec:
             httpHeaders:
 {{ toYaml .Values.livenessProbeHeaders | indent 14 }}
           {{- end }}
-{{ toYaml .Values.livenessProbe | indent 10 }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           httpGet:
             path: /wp-login.php
             port: {{ ternary "https" "http" .Values.healthcheckHttps }}
@@ -162,7 +174,7 @@ spec:
             httpHeaders:
 {{ toYaml .Values.readinessProbeHeaders | indent 14 }}
           {{- end }}
-{{ toYaml .Values.readinessProbe | indent 10 }}
+        {{- end }}
         volumeMounts:
         - mountPath: /bitnami/wordpress
           name: wordpress-data

--- a/stable/wordpress/values-production.yaml
+++ b/stable/wordpress/values-production.yaml
@@ -248,12 +248,15 @@ healthcheckHttps: false
 ## Configure extra options for liveness and readiness probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
 livenessProbe:
+  enabled: true
   initialDelaySeconds: 120
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 6
   successThreshold: 1
+
 readinessProbe:
+  enabled: true
   initialDelaySeconds: 30
   periodSeconds: 10
   timeoutSeconds: 5

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -248,12 +248,15 @@ healthcheckHttps: false
 ## Configure extra options for liveness and readiness probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
 livenessProbe:
+  enabled: true
   initialDelaySeconds: 120
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 6
   successThreshold: 1
+
 readinessProbe:
+  enabled: true
   initialDelaySeconds: 30
   periodSeconds: 10
   timeoutSeconds: 5


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

This PR allows wordpress users disable the healthchecks. This is particularly useful for development purposes 

Ref: https://github.com/bitnami/bitnami-docker-wordpress/issues/198

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)