### PR TITLE
[stable/fluentd] Enable use of statefulset without autoscaling

### DIFF
--- a/stable/fluentd/Chart.yaml
+++ b/stable/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Fluentd Elasticsearch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd
-version: 2.3.3
+version: 2.4.0
 appVersion: v2.4.0
 home: https://www.fluentd.org/
 sources:

--- a/stable/fluentd/README.md
+++ b/stable/fluentd/README.md
@@ -44,6 +44,7 @@ The following table lists the configurable parameters of the fluentd chart and t
 
 Parameter | Description | Default
 --- | --- | ---
+`useStatefulSet` | Deploy as a StatefulSet regardless of whether autoscaling is enabled | `nil`
 `affinity` | node/pod affinities | `{}`
 `configMaps` | Fluentd configuration | See [values.yaml](values.yaml)
 `output.host` | output host | `elasticsearch-client.default.svc.cluster.local`

--- a/stable/fluentd/templates/deployment.yaml
+++ b/stable/fluentd/templates/deployment.yaml
@@ -1,5 +1,6 @@
+{{- $statefulSet := or (.Values.autoscaling.enabled) (.Values.useStatefulSet) -}}
 apiVersion: apps/v1
-{{- if .Values.autoscaling.enabled}}
+{{- if $statefulSet }}
 kind: StatefulSet
 {{- else}}
 kind: Deployment
@@ -111,7 +112,7 @@ spec:
           configMap:
             name: {{ template "fluentd.fullname" . }}
             defaultMode: 0777
-        {{- if and .Values.persistence.enabled (not .Values.autoscaling.enabled) }}
+        {{- if and .Values.persistence.enabled (not $statefulSet) }}
         - name: buffer
           persistentVolumeClaim:
             claimName: {{ template "fluentd.fullname" . }}
@@ -134,7 +135,7 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-{{- if and .Values.persistence.enabled (.Values.autoscaling.enabled) }}
+{{- if and .Values.persistence.enabled ($statefulSet) }}
   volumeClaimTemplates:
   - metadata:
       name: buffer

--- a/stable/fluentd/templates/pvc.yaml
+++ b/stable/fluentd/templates/pvc.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.persistence.enabled (not .Values.autoscaling.enabled) -}}
+{{- $statefulSet := or (.Values.autoscaling.enabled) (.Values.useStatefulSet) -}}
+{{- if and .Values.persistence.enabled (not $statefulSet) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:


### PR DESCRIPTION
#### What this PR does / why we need it: 
Enables the use of a StatefulSet with persistent volumes without autoscaling enabled. The autoscaling option isn't possible in our clusters as the autoscaling API it uses is not available. However, we do want buffer persistence and more than one fluentd replica, which wasn't possible before this change.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
