### PR TITLE
[stable/prometheus] Add PodDisruptionBudget support

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 9.5.5
+version: 9.6.0
 appVersion: 2.13.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -117,6 +117,8 @@ Parameter | Description | Default
 `alertmanager.nodeSelector` | node labels for alertmanager pod assignment | `{}`
 `alertmanager.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
 `alertmanager.affinity` | pod affinity | `{}`
+`alertmanager.podDisruptionBudget.enabled` | If true, create a PodDisruptionBudget | `false`
+`alertmanager.podDisruptionBudget.maxUnavailable` | Maximum unavailable instances in PDB | `1`
 `alertmanager.schedulerName` | alertmanager alternate scheduler name | `nil`
 `alertmanager.persistentVolume.enabled` | If true, alertmanager will create a Persistent Volume Claim | `true`
 `alertmanager.persistentVolume.accessModes` | alertmanager data Persistent Volume access modes | `[ReadWriteOnce]`
@@ -173,6 +175,8 @@ Parameter | Description | Default
 `kubeStateMetrics.podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}` |
 `kubeStateMetrics.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
 `kubeStateMetrics.replicaCount` | desired number of kube-state-metrics pods | `1`
+`kubeStateMetrics.podDisruptionBudget.enabled` | If true, create a PodDisruptionBudget | `false`
+`kubeStateMetrics.podDisruptionBudget.maxUnavailable` | Maximum unavailable instances in PDB | `1`
 `kubeStateMetrics.priorityClassName` | kube-state-metrics priorityClassName | `nil`
 `kubeStateMetrics.resources` | kube-state-metrics resource requests and limits (YAML) | `{}`
 `kubeStateMetrics.securityContext` | Custom [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for kube-state-metrics containers | `{}`
@@ -196,6 +200,8 @@ Parameter | Description | Default
 `nodeExporter.nodeSelector` | node labels for node-exporter pod assignment | `{}`
 `nodeExporter.podAnnotations` | annotations to be added to node-exporter pods | `{}`
 `nodeExporter.pod.labels` | labels to be added to node-exporter pods | `{}`
+`nodeExporter.podDisruptionBudget.enabled` | If true, create a PodDisruptionBudget | `false`
+`nodeExporter.podDisruptionBudget.maxUnavailable` | Maximum unavailable instances in PDB | `1`
 `nodeExporter.podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}` |
 `nodeExporter.podSecurityPolicy.enabled` | Specify if a Pod Security Policy for node-exporter must be created | `false`
 `nodeExporter.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
@@ -227,6 +233,8 @@ Parameter | Description | Default
 `pushgateway.podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}` |
 `pushgateway.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
 `pushgateway.replicaCount` | desired number of pushgateway pods | `1`
+`pushgateway.podDisruptionBudget.enabled` | If true, create a PodDisruptionBudget | `false`
+`pushgateway.podDisruptionBudget.maxUnavailable` | Maximum unavailable instances in PDB | `1`
 `pushgateway.schedulerName` | pushgateway alternate scheduler name | `nil`
 `pushgateway.persistentVolume.enabled` | If true, Prometheus pushgateway will create a Persistent Volume Claim | `false`
 `pushgateway.persistentVolume.accessModes` | Prometheus pushgateway data Persistent Volume access modes | `[ReadWriteOnce]`
@@ -278,6 +286,8 @@ Parameter | Description | Default
 `server.nodeSelector` | node labels for Prometheus server pod assignment | `{}`
 `server.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
 `server.affinity` | pod affinity | `{}`
+`server.podDisruptionBudget.enabled` | If true, create a PodDisruptionBudget | `false`
+`server.podDisruptionBudget.maxUnavailable` | Maximum unavailable instances in PDB | `1`
 `server.priorityClassName` | Prometheus server priorityClassName | `nil`
 `server.schedulerName` | Prometheus server alternate scheduler name | `nil`
 `server.persistentVolume.enabled` | If true, Prometheus server will create a Persistent Volume Claim | `true`

--- a/stable/prometheus/templates/alertmanager-pdb.yaml
+++ b/stable/prometheus/templates/alertmanager-pdb.yaml
@@ -4,10 +4,10 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus.alertmanager.fullname" . }}
   labels:
-  {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
+    {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
 spec:
   maxUnavailable: {{ .Values.alertmanager.podDisruptionBudget.maxUnavailable }}
   selector:
     matchLabels:
-    {{- include "prometheus.alertmanager.labels" . | nindent 6 }}
+      {{- include "prometheus.alertmanager.labels" . | nindent 6 }}
 {{- end }}

--- a/stable/prometheus/templates/alertmanager-pdb.yaml
+++ b/stable/prometheus/templates/alertmanager-pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.alertmanager.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "prometheus.alertmanager.fullname" . }}
+  labels:
+  {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
+spec:
+  maxUnavailable: {{ .Values.alertmanager.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+    {{- include "prometheus.alertmanager.labels" . | nindent 6 }}
+{{- end }}

--- a/stable/prometheus/templates/kube-state-metrics-pdb.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.kubeStateMetrics.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "prometheus.kubeStateMetrics.fullname" . }}
+  labels:
+    {{- include "prometheus.kubeStateMetrics.labels" . | nindent 4 }}
+spec:
+  maxUnavailable: {{ .Values.kubeStateMetrics.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "prometheus.kubeStateMetrics.labels" . | nindent 6 }}
+{{- end }}

--- a/stable/prometheus/templates/pushgateway-pdb.yaml
+++ b/stable/prometheus/templates/pushgateway-pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.pushgateway.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "prometheus.pushgateway.fullname" . }}
+  labels:
+    {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
+spec:
+  maxUnavailable: {{ .Values.pushgateway.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "prometheus.pushgateway.labels" . | nindent 6 }}
+{{- end }}

--- a/stable/prometheus/templates/server-pdb.yaml
+++ b/stable/prometheus/templates/server-pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.server.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "prometheus.server.fullname" . }}
+  labels:
+    {{- include "prometheus.server.labels" . | nindent 4 }}
+spec:
+  maxUnavailable: {{ .Values.server.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "prometheus.server.labels" . | nindent 6 }}
+{{- end }}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -153,7 +153,7 @@ alertmanager:
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
   ##
   podDisruptionBudget:
-    enabled: true
+    enabled: false
     maxUnavailable: 1
 
   ## Use an alternate scheduler, e.g. "stork".
@@ -390,7 +390,7 @@ kubeStateMetrics:
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
   ##
   podDisruptionBudget:
-    enabled: true
+    enabled: false
     maxUnavailable: 1
 
   ## kube-state-metrics resource requests and limits
@@ -522,7 +522,7 @@ nodeExporter:
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
   ##
   podDisruptionBudget:
-    enabled: true
+    enabled: false
     maxUnavailable: 1
 
   ## node-exporter resource limits & requests
@@ -736,7 +736,7 @@ server:
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
   ##
   podDisruptionBudget:
-    enabled: true
+    enabled: false
     maxUnavailable: 1
 
   ## Use an alternate scheduler, e.g. "stork".
@@ -995,7 +995,7 @@ pushgateway:
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
   ##
   podDisruptionBudget:
-    enabled: true
+    enabled: false
     maxUnavailable: 1
 
   ## pushgateway resource requests and limits

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -149,6 +149,13 @@ alertmanager:
   ##
   affinity: {}
 
+  ## PodDisruptionBudget settings
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+  ##
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 1
+
   ## Use an alternate scheduler, e.g. "stork".
   ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
   ##
@@ -379,6 +386,13 @@ kubeStateMetrics:
 
   replicaCount: 1
 
+  ## PodDisruptionBudget settings
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+  ##
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 1
+
   ## kube-state-metrics resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
@@ -503,6 +517,13 @@ nodeExporter:
   ##
   pod:
     labels: {}
+
+  ## PodDisruptionBudget settings
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+  ##
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 1
 
   ## node-exporter resource limits & requests
   ## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
@@ -710,6 +731,13 @@ server:
   ## Pod affinity
   ##
   affinity: {}
+
+  ## PodDisruptionBudget settings
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+  ##
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 1
 
   ## Use an alternate scheduler, e.g. "stork".
   ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
@@ -962,6 +990,13 @@ pushgateway:
       # apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'
 
   replicaCount: 1
+
+  ## PodDisruptionBudget settings
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+  ##
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 1
 
   ## pushgateway resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds `podDisruptionBudget` resource support for better upgrades and disruption handling. See [Disruptions in the kubernetes docs](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/).

#### Special notes for your reviewer:
Did not run this in production, but in a quick test it seems to behave as expected.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
