### PR TITLE
[stable/kube-ops-view] Support kubernetes 1.16

### DIFF
--- a/stable/kube-ops-view/Chart.yaml
+++ b/stable/kube-ops-view/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kube-ops-view
-version: 1.1.1
+version: 1.1.2
 appVersion: 19.9.0
 description: Kubernetes Operational View - read-only system dashboard for multiple
   K8s clusters
@@ -15,3 +15,4 @@ sources:
 maintainers:
 - name: hjacobs
   email: henning@jacobs1.de
+engine: gotpl

--- a/stable/kube-ops-view/templates/_helpers.tpl
+++ b/stable/kube-ops-view/templates/_helpers.tpl
@@ -9,12 +9,24 @@ Expand the name of the chart.
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "kube-ops-view.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kube-ops-view.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/stable/kube-ops-view/templates/clusterrole.yaml
+++ b/stable/kube-ops-view/templates/clusterrole.yaml
@@ -3,10 +3,12 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   labels:
-    app: {{ template "kube-ops-view.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ include "kube-ops-view.name" . }}
+    helm.sh/chart: {{ include "kube-ops-view.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
   name: {{ template "kube-ops-view.fullname" . }}
 rules:
 - apiGroups: [""]

--- a/stable/kube-ops-view/templates/clusterrolebinding.yaml
+++ b/stable/kube-ops-view/templates/clusterrolebinding.yaml
@@ -3,10 +3,12 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app: {{ template "kube-ops-view.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ include "kube-ops-view.name" . }}
+    helm.sh/chart: {{ include "kube-ops-view.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
   name: {{ template "kube-ops-view.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/kube-ops-view/templates/deployment.yaml
+++ b/stable/kube-ops-view/templates/deployment.yaml
@@ -1,15 +1,29 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "kube-ops-view.fullname" . }}
+  name: {{ include "kube-ops-view.name" .}}
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/name: {{ include "kube-ops-view.name" . }}
+    helm.sh/chart: {{ include "kube-ops-view.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "kube-ops-view.name" . }}
+      app.kubernetes.io/part-of: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ template "kube-ops-view.fullname" . }}
+        app.kubernetes.io/name: {{ include "kube-ops-view.name" . }}
+        helm.sh/chart: {{ include "kube-ops-view.chart" . }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
+        app.kubernetes.io/part-of: {{ .Release.Name }}
         {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
         {{- end }}

--- a/stable/kube-ops-view/templates/ingress.yaml
+++ b/stable/kube-ops-view/templates/ingress.yaml
@@ -4,10 +4,12 @@ kind: Ingress
 metadata:
   name: {{ template "kube-ops-view.fullname" . }}
   labels:
-    app: {{ template "kube-ops-view.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ include "kube-ops-view.name" . }}
+    helm.sh/chart: {{ include "kube-ops-view.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
 {{- if .Values.ingress.annotations }}
   annotations:
 {{ toYaml .Values.ingress.annotations | indent 4 }}

--- a/stable/kube-ops-view/templates/service.yaml
+++ b/stable/kube-ops-view/templates/service.yaml
@@ -7,7 +7,12 @@ metadata:
 {{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/name: {{ include "kube-ops-view.name" . }}
+    helm.sh/chart: {{ include "kube-ops-view.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}
@@ -18,4 +23,4 @@ spec:
     targetPort: {{ .Values.service.internalPort }}
     protocol: TCP
   selector:
-    app: {{ template "kube-ops-view.fullname" . }}
+    app.kubernetes.io/name: {{ include "kube-ops-view.name" . }}

--- a/stable/kube-ops-view/templates/serviceaccount.yaml
+++ b/stable/kube-ops-view/templates/serviceaccount.yaml
@@ -3,9 +3,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ template "kube-ops-view.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ include "kube-ops-view.name" . }}
+    helm.sh/chart: {{ include "kube-ops-view.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
   name: {{ template "kube-ops-view.fullname" . }}
 {{- end -}}


### PR DESCRIPTION
Signed-off-by: conorfennell <fennell.conor@gmail.com>

@hjacobs 

#### What this PR does / why we need it:
This chart does not work on Kubernetes 1.16 due to:
1.  `extensions/v1beta1` is not supported for the Deployment kind, see https://kubernetes.io/blog/2019/09/18/kubernetes-1-16-release-announcement/

2. The selector attribute is required on the `Deployment` kind

#### Special notes for your reviewer:
As I had to add label selection on the deployment I also brought the helm labels in line with standard helm labels https://helm.sh/docs/topics/chart_best_practices/labels/#standard-labels

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ X] Chart Version bumped
- [ X] Variables are documented in the README.md
- [ X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
