### PR TITLE
[stable/kong] Allow admin_gui_auth_conf to be defined as an external secret

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.29.0
+version: 0.30.0
 appVersion: 1.3

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -320,7 +320,7 @@ always be changed for both configurations.
 
 After creating your secret, set its name in values.yaml, in the
 `.enterprise.rbac.session_conf_secret` and
-`.enterprise.rbac.session_conf_secret` keys.
+`.enterprise.portal.session_conf_secret` keys.
 
 #### Email/SMTP
 

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -408,6 +408,13 @@ You can can learn about kong ingress custom resource definitions [here](https://
 
 ## Changelog
 
+### 0.30.0
+
+#### Breaking changes
+
+- `admin_gui_auth_conf_secret` is now required for Kong Manager authentication methods other than `basic-auth`.
+  Users defining values for `admin_gui_auth_conf` should migrate them to an externally-defined secret with a key of `admin_gui_auth_conf` and reference the secret name in `admin_gui_auth_conf_secret`.
+
 ### 0.29.0
 
 #### New Features

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -132,8 +132,13 @@ spec:
           value: "on"
         - name: KONG_ADMIN_GUI_AUTH
           value: {{ .Values.enterprise.rbac.admin_gui_auth | default "basic-auth" }}
+        {{- if not (eq .Values.enterprise.rbac.admin_gui_auth "basic-auth") }}
         - name: KONG_ADMIN_GUI_AUTH_CONF
-          value: '{{ toJson .Values.enterprise.rbac.admin_gui_auth_conf }}'
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.enterprise.rbac.admin_gui_auth_conf_secret }}
+              key: admin_gui_auth_conf
+        {{- end }}
         - name: KONG_ADMIN_GUI_SESSION_CONF
           valueFrom:
             secretKeyRef:

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -237,8 +237,9 @@ enterprise:
     # If RBAC is enabled, this Secret must contain an admin_gui_session_conf key
     # The key value must be a secret configuration, following the example at https://docs.konghq.com/enterprise/0.35-x/kong-manager/authentication/sessions/
     session_conf_secret: you-must-create-an-rbac-session-conf-secret
-    # Set to the appropriate plugin config JSON if not using basic-auth
-    admin_gui_auth_conf: {}
+    # If admin_gui_auth is not set to basic-auth, provide a secret name which
+    # has an admin_gui_auth_conf key containing the plugin config JSON
+    admin_gui_auth_conf_secret: you-must-create-an-admin-gui-auth-conf-secret
   smtp:
     enabled: false
     portal_emails_from: none@example.com


### PR DESCRIPTION



#### Is this a new chart
No

#### What this PR does / why we need it:

This adds support for providing a secret name rather than the contents of `admin_gui_auth_conf` directly.

For [LDAP authentication](https://docs.konghq.com/enterprise/1.3-x/kong-manager/authentication/ldap/), the `admin_gui_auth_conf` contents include an LDAP password which would be in plaintext in the pod spec's environment variables.

This prevents the LDAP password from being exposed by keeping it in a secret defined outside of the helm chart, similar to other sensitive data.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

Alternatively the chart user could set `enterprise.rbac.enabled: false` and define `KONG_ENFORCE_RBAC`, `KONG_ADMIN_GUI_AUTH`, and `KONG_ADMIN_GUI_AUTH_CONF` themselves in `env:` but this approach seems more intuitive.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
