### PR TITLE
[stable/prometheus-pushgateway] fix default values

### DIFF
--- a/stable/prometheus-pushgateway/Chart.yaml
+++ b/stable/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.2.7
+version: 1.2.8
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/stable/prometheus-pushgateway/values.yaml
+++ b/stable/prometheus-pushgateway/values.yaml
@@ -113,13 +113,13 @@ serviceMonitor:
 
 # The values to set in the PodDisruptionBudget spec (minAvailable/maxUnavailable)
 # If not set then a PodDisruptionBudget will not be created
-podDisruptionBudget:
+podDisruptionBudget: {}
 
 # Configuration for clusters with restrictive network policies in place:
 # - allowAll allows access to the PushGateway from any namespace
 # - customSelector is a list of pod/namespaceSelectors to allow access from
 # These options are mutually exclusive and the latter will take precedence.
-networkPolicy:
+networkPolicy: {}
   # allowAll: true
   # customSelectors:
   #   - namespaceSelector:


### PR DESCRIPTION
 What this PR does / why we need it:

Specify default empty values for `podDisruptionBudget` and `networkPolicy`. This prevents Helm from trying to set this to null every time the chart is upgraded, even when there are no changes. e.g.

```
--- Current prometheus-pushgateway
+++ Desired prometheus-pushgateway
@@ -34,6 +34,7 @@
     },
     "nodeSelector": {},
     "podAnnotations": {},
+    "podDisruptionBudget": null,
     "podLabels": {},
     "replicaCount": 1,
     "resources": {
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
