### PR TITLE
[stable/redis] remove use of `redis.fullname` template for container name

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 10.2.1
+version: 10.2.2
 appVersion: 5.0.7
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/redis-master-statefulset.yaml
+++ b/stable/redis/templates/redis-master-statefulset.yaml
@@ -67,7 +67,7 @@ spec:
       schedulerName: "{{ .Values.master.schedulerName }}"
       {{- end }}
       containers:
-      - name: {{ template "redis.fullname" . }}
+      - name: redis
         image: "{{ template "redis.image" . }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         {{- if .Values.securityContext.enabled }}

--- a/stable/redis/templates/redis-slave-statefulset.yaml
+++ b/stable/redis/templates/redis-slave-statefulset.yaml
@@ -73,7 +73,7 @@ spec:
 {{ tpl (toYaml .) $ | indent 8 }}
     {{- end }}
       containers:
-      - name: {{ template "redis.fullname" . }}
+      - name: redis
         image: {{ template "redis.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         {{- if .Values.securityContext.enabled }}


### PR DESCRIPTION
#### Is this a new chart

NO

#### What this PR does / why we need it:

`redis.fullname` uses the release name in the pod container name which gets a little complicated while looking up containers while testing in our CI.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)