### PR TITLE
[stable/docker-registry] Fix haSharedSecret value documentation

### DIFF
--- a/stable/docker-registry/Chart.yaml
+++ b/stable/docker-registry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Docker Registry
 name: docker-registry
-version: 1.9.2
+version: 1.9.3
 appVersion: 2.7.1
 home: https://hub.docker.com/_/registry/
 icon: https://hub.docker.com/public/images/logos/mini-logo.svg

--- a/stable/docker-registry/README.md
+++ b/stable/docker-registry/README.md
@@ -56,7 +56,7 @@ their default values.
 | `secrets.s3.secretKey`      | Secret Key for S3 configuration                                                            | `nil`           |
 | `secrets.swift.username`    | Username for Swift configuration                                                           | `nil`           |
 | `secrets.swift.password`    | Password for Swift configuration                                                           | `nil`           |
-| `haSharedSecret`            | Shared secret for Registry                                                                 | `nil`           |
+| `secrets.haSharedSecret`    | Shared secret for Registry                                                                 | `nil`           |
 | `configData`                | Configuration hash for docker                                                              | `nil`           |
 | `s3.region`                 | S3 region                                                                                  | `nil`           |
 | `s3.regionEndpoint`         | S3 region endpoint                                                                         | `nil`           |


### PR DESCRIPTION
`haSharedSecret` shoud be `secrets.haSharedSecret`:
https://github.com/helm/charts/blob/b7fe92e77da4254b98eb89c470b3201433d86978/stable/docker-registry/templates/secret.yaml#L16

#### Is this a new chart
no

#### What this PR does / why we need it:
Documentation fix

#### Which issue this PR fixes
Fixes value name (no issue created)

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
