### PR TITLE
[stable/prometheus-operator] Bump grafana and prometheus-node-exporter subcharts

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.3.3
+version: 8.4.0
 appVersion: 0.34.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/requirements.lock
+++ b/stable/prometheus-operator/requirements.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 2.4.1
 - name: prometheus-node-exporter
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.7.3
+  version: 1.8.1
 - name: grafana
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 4.0.2
-digest: sha256:5d90eb0f1ffd7a9af82660bb0eec0e2982b58a86800f5c02613623be5b66189a
-generated: "2019-11-08T16:25:57.127899-05:00"
+  version: 4.0.5
+digest: sha256:ff80ca297120e6a2f024f5cbd43f2cc92acf5c90a9aa29cf1ad780b63fa759cd
+generated: 2019-12-19T16:44:59.127547795Z

--- a/stable/prometheus-operator/requirements.yaml
+++ b/stable/prometheus-operator/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
     condition: kubeStateMetrics.enabled
 
   - name: prometheus-node-exporter
-    version: 1.7.*
+    version: 1.8.*
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: nodeExporter.enabled
 


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
This bumps the prometheus-node-exporter subchart from `1.7.*` to `1.8.*`.
When running `helm dep upgrade` grafana is also updated a patch version.

#### Which issue this PR fixes
* node exporter supports pod annotations and `.Release.Namespace`

#### Special notes for your reviewer:
None

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

#### Diff with default values

Below is a diff of the chart before and after this PR with default values.

```diff
--- before	2019-12-19 17:07:24.000000000 +0000
+++ after	2019-12-19 17:05:52.000000000 +0000
@@ -123,13 +123,14 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
+  name: RELEASE-NAME-prometheus-node-exporter
+  namespace: default
   labels:     
     app: prometheus-node-exporter
     heritage: Helm
     release: RELEASE-NAME
-    chart: prometheus-node-exporter-1.7.3
+    chart: prometheus-node-exporter-1.8.1
     jobLabel: node-exporter
-  name: RELEASE-NAME-prometheus-node-exporter
 spec:
   privileged: false
   # Required to prevent escalations to root.
@@ -34234,12 +34235,13 @@
 kind: ServiceAccount
 metadata:
   name: RELEASE-NAME-prometheus-node-exporter
+  namespace: default
   labels:
     app: prometheus-node-exporter
-    chart: prometheus-node-exporter-1.7.3    
+    chart: prometheus-node-exporter-1.8.1
     release: "RELEASE-NAME"
     heritage: "Helm"
-imagePullSecrets: 
+imagePullSecrets:
   []
 ---
 # Source: prometheus-operator/templates/alertmanager/serviceaccount.yaml
@@ -34450,13 +34452,13 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  name: psp-RELEASE-NAME-prometheus-node-exporter
   labels:     
     app: prometheus-node-exporter
     heritage: Helm
     release: RELEASE-NAME
-    chart: prometheus-node-exporter-1.7.3
+    chart: prometheus-node-exporter-1.8.1
     jobLabel: node-exporter
-  name: psp-RELEASE-NAME-prometheus-node-exporter
 rules:
 - apiGroups: ['extensions']
   resources: ['podsecuritypolicies']
@@ -34696,13 +34698,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  name: psp-RELEASE-NAME-prometheus-node-exporter
   labels:     
     app: prometheus-node-exporter
     heritage: Helm
     release: RELEASE-NAME
-    chart: prometheus-node-exporter-1.7.3
+    chart: prometheus-node-exporter-1.8.1
     jobLabel: node-exporter
-  name: psp-RELEASE-NAME-prometheus-node-exporter
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -34937,13 +34939,14 @@
 kind: Service
 metadata:
   name: RELEASE-NAME-prometheus-node-exporter
+  namespace: default
   annotations:
     prometheus.io/scrape: "true"
   labels:     
     app: prometheus-node-exporter
     heritage: Helm
     release: RELEASE-NAME
-    chart: prometheus-node-exporter-1.7.3
+    chart: prometheus-node-exporter-1.8.1
     jobLabel: node-exporter
 spec:
   type: ClusterIP
@@ -35151,11 +35154,12 @@
 kind: DaemonSet
 metadata:
   name: RELEASE-NAME-prometheus-node-exporter
+  namespace: default
   labels:     
     app: prometheus-node-exporter
     heritage: Helm
     release: RELEASE-NAME
-    chart: prometheus-node-exporter-1.7.3
+    chart: prometheus-node-exporter-1.8.1
     jobLabel: node-exporter
 spec:
   selector:
@@ -35172,7 +35176,7 @@
         app: prometheus-node-exporter
         heritage: Helm
         release: RELEASE-NAME
-        chart: prometheus-node-exporter-1.7.3
+        chart: prometheus-node-exporter-1.8.1
         jobLabel: node-exporter
     spec:
       serviceAccountName: RELEASE-NAME-prometheus-node-exporter
@@ -37820,86 +37824,6 @@
         name: RELEASE-NAME-prometheus-op-operator
         path: /admission-prometheusrules/validate
 ---
-# Source: prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/clusterrolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name:  RELEASE-NAME-prometheus-op-admission
-  namespace: default
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-  labels:
-    app: prometheus-operator-admission    
-    chart: prometheus-operator-8.3.3
-    release: "RELEASE-NAME"
-    heritage: "Helm"
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: RELEASE-NAME-prometheus-op-admission
-subjects:
-  - kind: ServiceAccount
-    name: RELEASE-NAME-prometheus-op-admission
-    namespace: default
----
-# Source: prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name:  RELEASE-NAME-prometheus-op-admission-patch
-  namespace: default
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-  labels:
-    app: prometheus-operator-admission-patch    
-    chart: prometheus-operator-8.3.3
-    release: "RELEASE-NAME"
-    heritage: "Helm"
-spec:
-  template:
-    metadata:
-      name:  RELEASE-NAME-prometheus-op-admission-patch
-      labels:
-        app: prometheus-operator-admission-patch        
-        chart: prometheus-operator-8.3.3
-        release: "RELEASE-NAME"
-        heritage: "Helm"
-    spec:
-      containers:
-        - name: patch
-          image: jettech/kube-webhook-certgen:v1.0.0
-          imagePullPolicy: 
-          args:
-            - patch
-            - --webhook-name=RELEASE-NAME-prometheus-op-admission
-            - --namespace=default
-            - --secret-name=RELEASE-NAME-prometheus-op-admission
-            - --patch-failure-policy=Fail
-          resources:
-            {}
-      restartPolicy: OnFailure
-      serviceAccountName: RELEASE-NAME-prometheus-op-admission
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 2000
----
-# Source: prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name:  RELEASE-NAME-prometheus-op-admission
-  namespace: default
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-  labels:
-    app: prometheus-operator-admission    
-    chart: prometheus-operator-8.3.3
-    release: "RELEASE-NAME"
-    heritage: "Helm"
----
 # Source: prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
 apiVersion: batch/v1
 kind: Job
@@ -37941,11 +37865,12 @@
         runAsNonRoot: true
         runAsUser: 2000
 ---
-# Source: prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/clusterrole.yaml
+# Source: prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name:  RELEASE-NAME-prometheus-op-admission
+  namespace: default
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -37956,18 +37881,12 @@
     heritage: "Helm"
 rules:
   - apiGroups:
-      - admissionregistration.k8s.io
+      - ""
     resources:
-      - validatingwebhookconfigurations
-      - mutatingwebhookconfigurations
+      - secrets
     verbs:
       - get
-      - update
-  - apiGroups: ['extensions']
-    resources: ['podsecuritypolicies']
-    verbs:     ['use']
-    resourceNames:
-    - RELEASE-NAME-prometheus-op-admission
+      - create
 ---
 # Source: prometheus-operator/charts/grafana/templates/tests/test.yaml
 apiVersion: v1
@@ -38015,51 +37934,47 @@
     emptyDir: {}
   restartPolicy: Never
 ---
-# Source: prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/rolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name:  RELEASE-NAME-prometheus-op-admission
-  namespace: default
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-  labels:
-    app: prometheus-operator-admission    
-    chart: prometheus-operator-8.3.3
-    release: "RELEASE-NAME"
-    heritage: "Helm"
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: RELEASE-NAME-prometheus-op-admission
-subjects:
-  - kind: ServiceAccount
-    name: RELEASE-NAME-prometheus-op-admission
-    namespace: default
----
-# Source: prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/role.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+# Source: prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
+apiVersion: batch/v1
+kind: Job
 metadata:
-  name:  RELEASE-NAME-prometheus-op-admission
+  name:  RELEASE-NAME-prometheus-op-admission-patch
   namespace: default
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    app: prometheus-operator-admission    
+    app: prometheus-operator-admission-patch    
     chart: prometheus-operator-8.3.3
     release: "RELEASE-NAME"
     heritage: "Helm"
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - get
-      - create
+spec:
+  template:
+    metadata:
+      name:  RELEASE-NAME-prometheus-op-admission-patch
+      labels:
+        app: prometheus-operator-admission-patch        
+        chart: prometheus-operator-8.3.3
+        release: "RELEASE-NAME"
+        heritage: "Helm"
+    spec:
+      containers:
+        - name: patch
+          image: jettech/kube-webhook-certgen:v1.0.0
+          imagePullPolicy: 
+          args:
+            - patch
+            - --webhook-name=RELEASE-NAME-prometheus-op-admission
+            - --namespace=default
+            - --secret-name=RELEASE-NAME-prometheus-op-admission
+            - --patch-failure-policy=Fail
+          resources:
+            {}
+      restartPolicy: OnFailure
+      serviceAccountName: RELEASE-NAME-prometheus-op-admission
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
 ---
 # Source: prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/psp.yaml
 apiVersion: policy/v1beta1
@@ -38114,3 +38029,92 @@
       - min: 0
         max: 65535
   readOnlyRootFilesystem: false
+---
+# Source: prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name:  RELEASE-NAME-prometheus-op-admission
+  namespace: default
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    app: prometheus-operator-admission    
+    chart: prometheus-operator-8.3.3
+    release: "RELEASE-NAME"
+    heritage: "Helm"
+---
+# Source: prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name:  RELEASE-NAME-prometheus-op-admission
+  namespace: default
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    app: prometheus-operator-admission    
+    chart: prometheus-operator-8.3.3
+    release: "RELEASE-NAME"
+    heritage: "Helm"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: RELEASE-NAME-prometheus-op-admission
+subjects:
+  - kind: ServiceAccount
+    name: RELEASE-NAME-prometheus-op-admission
+    namespace: default
+---
+# Source: prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name:  RELEASE-NAME-prometheus-op-admission
+  namespace: default
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    app: prometheus-operator-admission    
+    chart: prometheus-operator-8.3.3
+    release: "RELEASE-NAME"
+    heritage: "Helm"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: RELEASE-NAME-prometheus-op-admission
+subjects:
+  - kind: ServiceAccount
+    name: RELEASE-NAME-prometheus-op-admission
+    namespace: default
+---
+# Source: prometheus-operator/templates/prometheus-operator/admission-webhooks/job-patch/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name:  RELEASE-NAME-prometheus-op-admission
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    app: prometheus-operator-admission    
+    chart: prometheus-operator-8.3.3
+    release: "RELEASE-NAME"
+    heritage: "Helm"
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - get
+      - update
+  - apiGroups: ['extensions']
+    resources: ['podsecuritypolicies']
+    verbs:     ['use']
+    resourceNames:
+    - RELEASE-NAME-prometheus-op-admission
```
