### PR TITLE
[stable/prometheus-blackbox-exporter] Fix PodDisruptionBudget configuration

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 1.6.1
+version: 2.0.0
 appVersion: 0.15.1
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 1.6.0
+version: 1.6.1
 appVersion: 0.15.1
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/README.md
+++ b/stable/prometheus-blackbox-exporter/README.md
@@ -63,7 +63,7 @@ The following table lists the configurable parameters of the Blackbox-Exporter c
 | `tolerations`                          | node tolerations for pod assignment               | `[]`                          |
 | `affinity`                             | node affinity for pod assignment                  | `{}`                          |
 | `podAnnotations`                       | annotations to add to each pod                    | `{}`                          |
-| `podDisruptionBudget`                  | pod disruption budget                             | `{maxUnavailable: 0}`         |
+| `podDisruptionBudget`                  | pod disruption budget                             | `{}`         |
 | `priorityClassName`                    | priority class name                               | None                          |
 | `resources`                            | pod resource requests & limits                    | `{}`                          |
 | `restartPolicy`                        | container restart policy                          | `Always`                      |
@@ -101,15 +101,10 @@ $ helm install --name my-release -f values.yaml stable/prometheus-blackbox-expor
 
 ### 2.0.0
 
-This version removes `podDisruptionBudget` from chart `values.yaml` file.
+This version removes the `podDisruptionBudget.enabled` parameter and changes the default value of `podDisruptionBudget` to `{}`, in order to fix Helm 3 compatibility.
 
-If you would like to have `podDisruptionBudget` configured for your Release add additional values file with `-f` flag to your `helm` deployment command:
-```bash
-$ helm upgrade --install blackbox-exporter stable/prometheus-blackbox-exporter --version=2.0.0 -f my-values.yaml
-```
-where `my-values.yaml` contains:
-
-```
+In order to upgrade, please remove `podDisruptionBudget.enabled` from your custom values.yaml file and set the content of `podDisruptionBudget`, for example:
+```yaml
 podDisruptionBudget:
   maxUnavailable: 0
 ```

--- a/stable/prometheus-blackbox-exporter/README.md
+++ b/stable/prometheus-blackbox-exporter/README.md
@@ -63,6 +63,7 @@ The following table lists the configurable parameters of the Blackbox-Exporter c
 | `tolerations`                          | node tolerations for pod assignment               | `[]`                          |
 | `affinity`                             | node affinity for pod assignment                  | `{}`                          |
 | `podAnnotations`                       | annotations to add to each pod                    | `{}`                          |
+  | `podDisruptionBudgetEnabled`                  | Enable pod disruption budget                             | `true`         |
 | `podDisruptionBudget`                  | pod disruption budget                             | `{maxUnavailable: 0}`         |
 | `priorityClassName`                    | priority class name                               | None                          |
 | `resources`                            | pod resource requests & limits                    | `{}`                          |

--- a/stable/prometheus-blackbox-exporter/README.md
+++ b/stable/prometheus-blackbox-exporter/README.md
@@ -63,7 +63,6 @@ The following table lists the configurable parameters of the Blackbox-Exporter c
 | `tolerations`                          | node tolerations for pod assignment               | `[]`                          |
 | `affinity`                             | node affinity for pod assignment                  | `{}`                          |
 | `podAnnotations`                       | annotations to add to each pod                    | `{}`                          |
-  | `podDisruptionBudgetEnabled`                  | Enable pod disruption budget                             | `true`         |
 | `podDisruptionBudget`                  | pod disruption budget                             | `{maxUnavailable: 0}`         |
 | `priorityClassName`                    | priority class name                               | None                          |
 | `resources`                            | pod resource requests & limits                    | `{}`                          |
@@ -99,6 +98,21 @@ $ helm install --name my-release -f values.yaml stable/prometheus-blackbox-expor
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
 ## Upgrading an existing Release to a new major version
+
+### 2.0.0
+
+This version removes `podDisruptionBudget` from chart `values.yaml` file.
+
+If you would like to have `podDisruptionBudget` configured for your Release add additional values file with `-f` flag to your `helm` deployment command:
+```bash
+$ helm upgrade --install blackbox-exporter stable/prometheus-blackbox-exporter --version=2.0.0 -f my-values.yaml
+```
+where `my-values.yaml` contains:
+
+```
+podDisruptionBudget:
+  maxUnavailable: 0
+```
 
 ### 1.0.0
 

--- a/stable/prometheus-blackbox-exporter/templates/poddisruptionbudget.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podDisruptionBudget.enabled -}}
+{{- if .Values.global.podDisruptionBudgetEnabled -}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/stable/prometheus-blackbox-exporter/templates/poddisruptionbudget.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.podDisruptionBudgetEnabled -}}
+{{- if .Values.podDisruptionBudget -}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/stable/prometheus-blackbox-exporter/values.yaml
+++ b/stable/prometheus-blackbox-exporter/values.yaml
@@ -1,7 +1,8 @@
 restartPolicy: Always
+global:
+  podDisruptionBudgetEnabled: true
 
 podDisruptionBudget:
-  enabled: true
   maxUnavailable: 0
 
 strategy:

--- a/stable/prometheus-blackbox-exporter/values.yaml
+++ b/stable/prometheus-blackbox-exporter/values.yaml
@@ -1,9 +1,7 @@
 restartPolicy: Always
-global:
-  podDisruptionBudgetEnabled: true
 
-podDisruptionBudget:
-  maxUnavailable: 0
+podDisruptionBudget: {}
+  # maxUnavailable: 0
 
 strategy:
   rollingUpdate:


### PR DESCRIPTION
Signed-off-by: Maxim Valiarovski <maxim.valiarovski@target.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
NO

#### What this PR does / why we need it:
This PR is moving `podDisruptionBudget.enabled` out of the `podDisruptionBudget` yaml. 
Field `enabled` breaks `helm3` deployment:
```
helm upgrade --install blackbox-exporter stable/prometheus-blackbox-exporter --version 1.6.0 --dry-run --debug
history.go:52: [debug] getting history for release blackbox-exporter
upgrade.go:79: [debug] preparing upgrade for blackbox-exporter
upgrade.go:369: [debug] copying values from blackbox-exporter (v1) to new release.
Error: UPGRADE FAILED: error validating "": error validating data: ValidationError(PodDisruptionBudget.spec): unknown field "enabled" in io.k8s.api.policy.v1beta1.PodDisruptionBudgetSpec
helm.go:76: [debug] error validating "": error validating data: ValidationError(PodDisruptionBudget.spec): unknown field "enabled" in io.k8s.api.policy.v1beta1.PodDisruptionBudgetSpec
helm.sh/helm/v3/pkg/kube.scrubValidationError
	/home/circleci/helm.sh/helm/pkg/kube/client.go:525
helm.sh/helm/v3/pkg/kube.(*Client).Build
	/home/circleci/helm.sh/helm/pkg/kube/client.go:137
helm.sh/helm/v3/pkg/action.validateManifest
	/home/circleci/helm.sh/helm/pkg/action/upgrade.go:376
helm.sh/helm/v3/pkg/action.(*Upgrade).prepareUpgrade
	/home/circleci/helm.sh/helm/pkg/action/upgrade.go:188
helm.sh/helm/v3/pkg/action.(*Upgrade).Run
	/home/circleci/helm.sh/helm/pkg/action/upgrade.go:80
main.newUpgradeCmd.func1
	/home/circleci/helm.sh/helm/cmd/helm/upgrade.go:134
github.com/spf13/cobra.(*Command).execute
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:826
github.com/spf13/cobra.(*Command).ExecuteC
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914
github.com/spf13/cobra.(*Command).Execute
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main
	/home/circleci/helm.sh/helm/cmd/helm/helm.go:75
runtime.main
	/usr/local/go/src/runtime/proc.go:203
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1357
UPGRADE FAILED
main.newUpgradeCmd.func1
	/home/circleci/helm.sh/helm/cmd/helm/upgrade.go:136
github.com/spf13/cobra.(*Command).execute
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:826
github.com/spf13/cobra.(*Command).ExecuteC
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914
github.com/spf13/cobra.(*Command).Execute
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main
	/home/circleci/helm.sh/helm/cmd/helm/helm.go:75
runtime.main
	/usr/local/go/src/runtime/proc.go:203
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1357
```  


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
