### PR TITLE
[stable/kong] Added clusterIP as a possible configuration value to service-kong-proxy.yaml

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.30.0
+version: 0.30.1
 appVersion: 1.3

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -90,6 +90,7 @@ and their default values.
 | proxy.tls.hostPort                 | Host port to use for TLS                                                              |                     |
 | proxy.tls.overrideServiceTargetPort| Override service port to use for TLS without touching Kong containerPort              |                     |
 | proxy.type                         | k8s service type. Options: NodePort, ClusterIP, LoadBalancer                          | `NodePort`          |
+| proxy.clusterIP                    | k8s service clusterIP                                                                 |                     |
 | proxy.loadBalancerSourceRanges     | Limit proxy access to CIDRs if set and service type is `LoadBalancer`                 | `[]`                |
 | proxy.loadBalancerIP               | To reuse an existing ingress static IP for the admin service                          |                     |
 | proxy.externalIPs                  | IPs for which nodes in the cluster will also accept traffic for the proxy             | `[]`                |
@@ -407,6 +408,12 @@ You can can learn about kong ingress custom resource definitions [here](https://
 
 
 ## Changelog
+=======
+### 0.30.1
+
+#### New Features
+
+- Add support for specifying Proxy service cluster ip.
 
 ### 0.30.0
 

--- a/stable/kong/templates/service-kong-proxy.yaml
+++ b/stable/kong/templates/service-kong-proxy.yaml
@@ -50,6 +50,9 @@ spec:
   {{- if .Values.proxy.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.proxy.externalTrafficPolicy }}
   {{- end }}
+  {{- if .Values.proxy.clusterIP }}
+  clusterIP: {{ .Values.proxy.clusterIP }}
+  {{- end }}
 
   selector:
     app: {{ template "kong.name" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Allow settings clusterIP: None. This add support for using kong with external-dns services and it's hostPort feature

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
