### PR TITLE
[stable/drone] drone server and restricted pod security policies

### DIFF
--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 2.4.0
+version: 2.4.1
 appVersion: 1.6.1
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 2.4.1
+version: 2.5.0
 appVersion: 1.6.1
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/stable/drone/README.md
+++ b/stable/drone/README.md
@@ -82,6 +82,7 @@ The following table lists the configurable parameters of the drone charts and th
 | `sourceControl.bitbucketServer`               | values to configure bitbucket server (stash)    | see values.yaml       |
 | `server.host`               | Drone **server** hostname (should match callback url in oauth config)              | `(internal hostname)`       |
 | `server.protocol`               | Drone **server** scheme/protocol [http,https]                                                         | `http`       |
+| `server.httpPort`           | Drone **server** http port                                                                    | `80`                        |
 | `server.env`                | Drone **server** environment variables                                                        | `(default values)`          |
 | `server.envSecrets`         | Drone **server** secret environment variables                                                 | `(default values)`          |
 | `server.adminUser`         | Initial user to create and set as admin                                                 | ``          |
@@ -95,6 +96,7 @@ The following table lists the configurable parameters of the drone charts and th
 | `server.affinity`           | Drone **server** scheduling preferences                                                       | `{}`                        |
 | `server.nodeSelector`       | Drone **server** node labels for pod assignment                                               | `{}`                        |
 | `server.tolerations`        | Drone **server** node taints to tolerate                                                      | `[]`                        |
+| `server.securityContext`    | Drone **server** securityContext                                                              | `{}`                        |
 | `server.extraContainers`    | Additional sidecar containers                                                                 | `""`                        |
 | `server.extraVolumes`       | Additional volumes for use in extraContainers                                                 | `""`                        |
 | `agent.env`                 | Drone **agent** environment variables                                                         | `(default values)`          |

--- a/stable/drone/templates/NOTES.txt
+++ b/stable/drone/templates/NOTES.txt
@@ -29,7 +29,7 @@ Get the Drone URL by running:
 Get the Drone URL by running:
   export POD_NAME=$(kubectl get pods -n {{ .Release.Namespace }} -l "component=server,app={{ template "drone.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo http://127.0.0.1:8000/
-  kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME 8000:80
+  kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME 8000:{{ .Values.server.httpPort }}
 {{- end }}
 {{- else -}}
 ##############################################################################

--- a/stable/drone/templates/deployment-server.yaml
+++ b/stable/drone/templates/deployment-server.yaml
@@ -72,6 +72,8 @@ spec:
           {{- else }}
             value: "{{ template "drone.fullname" . }}"
           {{- end }}
+          - name: DRONE_SERVER_PORT
+            value: ":{{ .Values.server.httpPort }}"
           - name: DRONE_RPC_PROTO
             value: "{{ .Values.server.rpcProtocol }}"
           - name: DRONE_RPC_HOST
@@ -103,7 +105,7 @@ spec:
           {{- end }}
         ports:
         - name: http
-          containerPort: 80
+          containerPort: {{ .Values.server.httpPort }}
           protocol: TCP
         - name: https
           containerPort: 443

--- a/stable/drone/templates/deployment-server.yaml
+++ b/stable/drone/templates/deployment-server.yaml
@@ -144,6 +144,10 @@ spec:
       {{- else }}
         emptyDir: {}
       {{- end -}}
+      {{- if .Values.server.securityContext }}
+      securityContext:
+{{ toYaml .Values.server.securityContext | indent 8 }}
+      {{- end }}
 {{- with .Values.server.extraVolumes }}
 {{ tpl . $ | indent 6 }}
 {{- end }}

--- a/stable/drone/templates/service.yaml
+++ b/stable/drone/templates/service.yaml
@@ -19,7 +19,7 @@ spec:
   ports:
   - name: http
     port: {{ .Values.service.httpPort }}
-    targetPort: 80
+    targetPort: {{ .Values.server.httpPort }}
 {{- if hasKey .Values.service "nodePort" }}
     nodePort: {{ .Values.service.nodePort }}
 {{- end }}

--- a/stable/drone/values.yaml
+++ b/stable/drone/values.yaml
@@ -204,6 +204,10 @@ server:
   ##
   tolerations: []
 
+  ## securityContext for drone server
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  securityContext: {}
+
   ## additional siecar containers, e. g. for a database proxy, such as Google's cloudsql-proxy.
   ## ex: https://github.com/kubernetes/charts/tree/master/stable/keycloak
   ##
@@ -212,10 +216,6 @@ server:
   ## additional volumes, e. g. for secrets used in an extraContainers.
   ##
   extraVolumes: |
-
-  ## securityContext for drone server
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-  securityContext: {}
 
 agent:
   ## Drone agent configuration.

--- a/stable/drone/values.yaml
+++ b/stable/drone/values.yaml
@@ -209,6 +209,10 @@ server:
   ##
   extraVolumes: |
 
+  ## securityContext for drone server
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  securityContext: {}
+
 agent:
   ## Drone agent configuration.
   ## Values in here get injected as environment variables.

--- a/stable/drone/values.yaml
+++ b/stable/drone/values.yaml
@@ -118,6 +118,10 @@ server:
   ## protocol should be http or https
   protocol: http
 
+  ## http port
+  ## Set to > 1024 if you want to run the pod as non-root user
+  httpPort: 80
+
   ## rpcProtocol for rpc connection to the server should be http or https
   rpcProtocol: http
 


### PR DESCRIPTION
# What this PR does / why we need it:

Add settings for drone server: 
* `server.httpPort`
* `server.securityContext`

In k8s cluster with restricted pod security policies drone server fails to start because of:
* `Error: container has runAsNonRoot and image will run as root` and
* something like "failed to bind to port 80"

**Solution:** Set `server.httpPort` to > 1024 and `server.securityContext.runAsUser` to > 0.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
