### PR TITLE
[stable/velero] DEPRECATE - Velero

### DIFF
--- a/stable/velero/Chart.yaml
+++ b/stable/velero/Chart.yaml
@@ -2,20 +2,10 @@ apiVersion: v1
 appVersion: 1.2.0
 description: A Helm chart for velero
 name: velero
-version: 2.7.3
+version: 2.7.4
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:
 - https://github.com/vmware-tanzu/velero
-maintainers:
-  - name: domcar
-    email: d-caruso@hotmail.it
-  - name: hectorj2f
-    email: hfernandez@mesosphere.com
-  - name: nrb
-    email: brubakern@vmware.com
-  - name: carlisia
-    email: carlisiac@vmware.com
-  - name: ashish-amarnath
-    email: ashisham@vmware.com
+deprecated: true
 tillerVersion: ">=2.10.0"

--- a/stable/velero/README.md
+++ b/stable/velero/README.md
@@ -1,8 +1,13 @@
-# Velero
+# DEPRECATED - Velero
+
+**This chart has been deprecated and moved to its new home:**
+
+- **GitHub repo:** https://github.com/vmware-tanzu/helm-charts
+- **Charts repo:** https://vmware-tanzu.github.io/helm-charts
 
 Velero is an open source tool to safely backup and restore, perform disaster recovery, and migrate Kubernetes cluster resources and persistent volumes.
 
-Velero has two main components: a CLI, and a server-side Kubernetes deployment. 
+Velero has two main components: a CLI, and a server-side Kubernetes deployment.
 
 ## Installing the Velero CLI
 

--- a/stable/velero/templates/NOTES.txt
+++ b/stable/velero/templates/NOTES.txt
@@ -1,3 +1,11 @@
+***
+Please note that this chart has been deprecated and moved to https://github.com/vmware-tanzu/helm-charts/tree/master/charts/velero.
+Going forward please use the vmware-tanzu helm repo of this chart.
+
+To add the chart repo:
+$ helm repo add vmware-tanzu https://vmware-tanzu.github.io/helm-charts
+***
+
 Check that the velero is up and running:
 
     kubectl get deployment/{{ include "velero.fullname" . }} -n {{ .Release.Namespace }}


### PR DESCRIPTION
#### What this PR does / why we need it:
moving Velero Chart to https://github.com/vmware-tanzu/helm-charts

#### Which issue this PR fixes
  - fixes https://github.com/vmware-tanzu/helm-charts/issues/6

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
