### PR TITLE
[stable/mongodb]: configure update strategy for deployments

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 7.6.1
+version: 7.6.2
 appVersion: 4.0.14
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/templates/deployment-standalone.yaml
+++ b/stable/mongodb/templates/deployment-standalone.yaml
@@ -16,6 +16,11 @@ metadata:
 {{ toYaml . | indent 4 }}
   {{- end }}
 spec:
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
+    {{- if (eq "Recreate" .Values.updateStrategy.type) }}
+    rollingUpdate: null
+    {{- end }}
   selector:
     matchLabels:
       app: {{ template "mongodb.name" . }}


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

The PR makes it possible to configure the `updateStrategy` for a standalone deployment.
This is required so that the `Recreate` updateStrategy can be specified while upgrading a standalone deployment


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)