### PR TITLE
[stable/chartmuseum] Allow adding ServiceAccount annotations

### DIFF
--- a/stable/chartmuseum/Chart.yaml
+++ b/stable/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 2.6.0
+version: 2.6.1
 appVersion: 0.11.0
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/helm/chartmuseum/master/logo2.png

--- a/stable/chartmuseum/README.md
+++ b/stable/chartmuseum/README.md
@@ -17,6 +17,7 @@ Please also see https://github.com/kubernetes-helm/chartmuseum
     - [permissions grant with access keys](#permissions-grant-with-access-keys)
     - [permissions grant with IAM instance profile](#permissions-grant-with-iam-instance-profile)
     - [permissions grant with IAM assumed role](#permissions-grant-with-iam-assumed-role)
+    - [permissions grant with IAM Roles for Service Accounts](#permissions-grant-with-iam-roles-for-service-accounts)
   - [Using with Google Cloud Storage](#using-with-google-cloud-storage)
   - [Using with Google Cloud Storage and a Google Service Account](#using-with-google-cloud-storage-and-a-google-service-account)
   - [Using with Microsoft Azure Blob Storage](#using-with-microsoft-azure-blob-storage)
@@ -31,8 +32,8 @@ Please also see https://github.com/kubernetes-helm/chartmuseum
     - [Bearer/Token auth](#bearertoken-auth)
   - [Ingress](#ingress)
     - [Hosts](#hosts)
-    - [Annotations](#annotations)
     - [Extra Paths](#extra-paths)
+    - [Annotations](#annotations)
     - [Example Ingress configuration](#example-ingress-configuration)
 - [Uninstall](#uninstall)
 
@@ -89,6 +90,7 @@ their default values. See values.yaml for all available options.
 | `resources.requests.memory`             | Container requested memory                                         | `64Mi`                               |
 | `serviceAccount.create`                 | If true, create the service account                                | `false`                              |
 | `serviceAccount.name`                   | Name of the serviceAccount to create or use                        | `{{ chartmuseum.fullname }}`         |
+| `serviceAccount.annotations`            | Additional Service Account annotations                             | `{}`                                 |
 | `securityContext`                       | Map of securityContext for the pod                                 | `{ fsGroup: 1000 }`                  |
 | `nodeSelector`                          | Map of node labels for pod assignment                              | `{}`                                 |
 | `tolerations`                           | List of node taints to tolerate                                    | `[]`                                 |
@@ -273,6 +275,31 @@ env:
 replica:
   annotations:
     iam.amazonaws.com/role: "{assumed role name}"
+```
+
+Run command to install
+
+```shell
+helm install --name my-chartmuseum -f custom.yaml stable/chartmuseum
+```
+
+#### permissions grant with IAM Roles for Service Accounts
+
+For Amazon EKS clusters, access can be provided with a service account using [IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+
+Specify `custom.yaml` with such values
+
+```yaml
+env:
+  open:
+    STORAGE: amazon
+    STORAGE_AMAZON_BUCKET: my-s3-bucket
+    STORAGE_AMAZON_PREFIX:
+    STORAGE_AMAZON_REGION: us-east-1
+serviceAccount:
+  create: true
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::{aws account ID}:role/{assumed role name}"
 ```
 
 Run command to install

--- a/stable/chartmuseum/templates/serviceaccount.yaml
+++ b/stable/chartmuseum/templates/serviceaccount.yaml
@@ -6,4 +6,8 @@ metadata:
   name: {{ include "chartmuseum.fullname" . }}
   labels:
 {{ include "chartmuseum.labels.standard" . | indent 4 }}
+{{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end }}
 {{- end -}}

--- a/stable/chartmuseum/values.yaml
+++ b/stable/chartmuseum/values.yaml
@@ -162,6 +162,8 @@ probes:
 serviceAccount:
   create: false
   # name:
+  ## Annotations for the Service Account
+  annotations: {}
 
 # UID/GID 1000 is the default user "chartmuseum" used in
 # the container image starting in v0.8.0 and above. This


### PR DESCRIPTION
#### Is this a new chart

No.

#### What this PR does / why we need it:

Amazon EKS recently came out with [IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html), which requires annotations on a ServiceAccount.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
