### PR TITLE
[incubator/patroni] allow to use existing secret for credentials

### DIFF
--- a/incubator/patroni/Chart.yaml
+++ b/incubator/patroni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: patroni
 description: 'Highly available elephant herd: HA PostgreSQL cluster.'
-version: 0.15.0
+version: 0.16.0
 appVersion: 1.4-p16
 home: https://github.com/zalando/patroni
 sources:

--- a/incubator/patroni/README.md
+++ b/incubator/patroni/README.md
@@ -68,6 +68,7 @@ The following table lists the configurable parameters of the patroni chart and t
 | `credentials.superuser`           | Password of the superuser                   | `tea`                                               |
 | `credentials.admin`               | Password of the admin                       | `cola`                                              |
 | `credentials.standby`             | Password of the replication user            | `pinacolada`                                        |
+| `credentialsSecret`               | A existing secret to use                    | `nil`                                               |
 | `kubernetes.dcs.enable`           | Using Kubernetes as DCS                     | `true`                                              |
 | `kubernetes.configmaps.enable`    | Using Kubernetes configmaps instead of endpoints | `false`                                        |
 | `etcd.enable`                     | Using etcd as DCS                           | `false`                                             |

--- a/incubator/patroni/templates/_helpers.tpl
+++ b/incubator/patroni/templates/_helpers.tpl
@@ -41,3 +41,14 @@ Create the name of the service account to use.
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the secret for credentials.
+*/}}
+{{- define "patroni.credentialsSecretName" -}}
+{{- if empty .Values.credentialsSecret -}}
+    {{ include "patroni.fullname" . }}
+{{- else -}}
+    {{ .Values.credentialsSecret }}
+{{- end -}}
+{{- end -}}

--- a/incubator/patroni/templates/sec-patroni.yaml
+++ b/incubator/patroni/templates/sec-patroni.yaml
@@ -1,3 +1,4 @@
+{{- if empty .Values.credentialsSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,3 +13,4 @@ data:
   password-superuser: {{ .Values.credentials.superuser | b64enc }}
   password-admin: {{ .Values.credentials.admin | b64enc }}
   password-standby: {{ .Values.credentials.standby | b64enc }}
+{{- end}}

--- a/incubator/patroni/templates/statefulset-patroni.yaml
+++ b/incubator/patroni/templates/statefulset-patroni.yaml
@@ -30,17 +30,17 @@ spec:
         - name: PGPASSWORD_SUPERUSER
           valueFrom:
             secretKeyRef:
-              name: {{ template "patroni.fullname" . }}
+              name: {{ template "patroni.credentialsSecretName" . }}
               key: password-superuser
         - name: PGPASSWORD_ADMIN
           valueFrom:
             secretKeyRef:
-              name: {{ template "patroni.fullname" . }}
+              name: {{ template "patroni.credentialsSecretName" . }}
               key: password-admin
         - name: PGPASSWORD_STANDBY
           valueFrom:
             secretKeyRef:
-              name: {{ template "patroni.fullname" . }}
+              name: {{ template "patroni.credentialsSecretName" . }}
               key: password-standby
         {{- if .Values.kubernetes.dcs.enable }}
         - name: DCS_ENABLE_KUBERNETES_API

--- a/incubator/patroni/values.yaml
+++ b/incubator/patroni/values.yaml
@@ -15,6 +15,10 @@ credentials:
   admin: cola
   standby: pinacolada
 
+# A existing secret for credentials
+# Secret must contain following keys: password-superuser, password-admin, password-standby
+credentialsSecret:
+
 # Distribution Configuration stores
 # Please note that only one of the following stores should be enabled.
 kubernetes:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
no

#### What this PR does / why we need it:
Allows to use a existing secret for PG/Patroni credentials. Useful if you work with flux and kubeseal for example.


#### Which issue this PR fixes
- no issue

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
