### PR TITLE
Bump Consul to 1.6.2

### DIFF
--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -10,6 +10,3 @@ description: DEPRECATED Highly available and distributed service discovery and k
 icon: https://raw.githubusercontent.com/hashicorp/consul/bce3809dfca37b883828c3715b84143dd71c0f85/website/source/assets/images/favicons/android-chrome-512x512.png
 sources:
 - https://github.com/kelseyhightower/consul-on-kubernetes
-maintainers:
-- name: lachie83
-  email: lachlan.evenson@microsoft.com

--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: consul
 home: https://github.com/hashicorp/consul
-version: 3.9.4
-appVersion: 1.5.3
+version: 3.10.0
+appVersion: 1.6.2
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and
   configuration easy.

--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -3,9 +3,10 @@ name: consul
 home: https://github.com/hashicorp/consul
 version: 3.10.0
 appVersion: 1.6.2
-description: Highly available and distributed service discovery and key-value store
+deprecated: true
+description: DEPRECATED Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and
-  configuration easy.
+  configuration easy. See https://github.com/hashicorp/consul-helm for Hashicorp maintained chart.
 icon: https://raw.githubusercontent.com/hashicorp/consul/bce3809dfca37b883828c3715b84143dd71c0f85/website/source/assets/images/favicons/android-chrome-512x512.png
 sources:
 - https://github.com/kelseyhightower/consul-on-kubernetes

--- a/stable/consul/README.md
+++ b/stable/consul/README.md
@@ -30,7 +30,7 @@ The following table lists the configurable parameters of the consul chart and th
 | ----------------------- | ----------------------------------    | ---------------------------------------------------------- |
 | `Name`                  | Consul statefulset name               | `consul`                                                   |
 | `Image`                 | Container image name                  | `consul`                                                   |
-| `ImageTag`              | Container image tag                   | `1.5.2`                                                    |
+| `ImageTag`              | Container image tag                   | `1.6.2`                                                    |
 | `ImagePullPolicy`       | Container pull policy                 | `Always`                                                   |
 | `Replicas`              | k8s statefulset replicas              | `3`                                                        |
 | `Component`             | k8s selector key                      | `consul`                                                   |

--- a/stable/consul/README.md
+++ b/stable/consul/README.md
@@ -1,5 +1,7 @@
 # Consul Helm Chart
 
+This chart is DEPRECATED in favor of Hashicorp maintained version - https://github.com/hashicorp/consul-helm
+
 ## Prerequisites Details
 * Kubernetes 1.10+
 * PV support on underlying infrastructure

--- a/stable/consul/templates/_helpers.tpl
+++ b/stable/consul/templates/_helpers.tpl
@@ -41,3 +41,14 @@ Return the apiVersion of statefulset.
 {{- print "apps/v1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the apiVersion of rbac.
+*/}}
+{{- define "rbac.apiVersion" -}}
+{{- if semverCompare "<1.8-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "rbac.authorization.k8s.io/v1beta1" -}}
+{{- else if semverCompare ">=1.8-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "rbac.authorization.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/consul/templates/consul-statefulset.yaml
+++ b/stable/consul/templates/consul-statefulset.yaml
@@ -112,14 +112,6 @@ spec:
         lifecycle:
 {{ tpl (toYaml .Values.lifecycle) . | indent 10 }}
         {{- end }}
-        livenessProbe:
-          exec:
-            command:
-            - consul
-            - members
-            - -http-addr=http://127.0.0.1:{{ .Values.HttpPort }}
-          initialDelaySeconds: 300
-          timeoutSeconds: 5
         command:
           - "/bin/sh"
           - "-ec"

--- a/stable/consul/templates/consul-test-role.yaml
+++ b/stable/consul/templates/consul-test-role.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.test.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
+apiVersion: {{ template "rbac.apiVersion" . }}
+kind: Role
 metadata:
   labels:
     app: {{ template "consul.name" . }}

--- a/stable/consul/templates/consul-test-rolebinding.yaml
+++ b/stable/consul/templates/consul-test-rolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.test.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
+apiVersion: {{ template "rbac.apiVersion" . }}
+kind: RoleBinding
 metadata:
   labels:
     app: {{ template "consul.name" . }}
@@ -14,6 +14,6 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: {{ template "consul.fullname" . }}-test
 {{- end }}

--- a/stable/consul/templates/consul-test.yaml
+++ b/stable/consul/templates/consul-test.yaml
@@ -24,6 +24,7 @@ spec:
   containers:
     - name: {{ .Release.Name }}-ui-test
       image: {{ .Values.test.image }}:{{ .Values.test.imageTag }}
+      imagePullPolicy: {{ .Values.test.imagePullPolicy }}
       command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
       volumeMounts:
       - mountPath: /tests

--- a/stable/consul/values.yaml
+++ b/stable/consul/values.yaml
@@ -21,7 +21,7 @@ Domain: consul
 Component: "consul"
 Replicas: 3
 Image: "consul"
-ImageTag: "1.5.3"
+ImageTag: "1.6.2"
 ImagePullPolicy: "Always"
 Resources: {}
  # requests:
@@ -141,7 +141,8 @@ acl:
 ## test container details
 test:
   image: lachlanevenson/k8s-kubectl
-  imageTag: v1.4.8-bash
+  imageTag: v1.16.4-bash
+  imagePullPolicy: "Always"
   rbac:
     create: false
     serviceAccountName: ""
@@ -152,11 +153,11 @@ additionalLabels: {}
 podAnnotations: {}
 
 # Lifecycle for StatefulSet
-# lifecycle:
-#   preStop:
-#     exec:
-#       command:
-#       - sh
-#       - -c
-#       - "sleep 60"
+lifecycle:
+  preStop:
+    exec:
+      command:
+      - /bin/sh
+      - -c
+      - consul leave
 forceIpv6: false


### PR DESCRIPTION
This PR includes the following changes:

Deprecate Consul chart in favor of Hashicorp maintained version
Bump Consul to 1.6.2
Bump Chart Version
Update test container image
Add default preStop pod lifecycle hook
Add rbac.apiVersion helper function
Remove somewhat dangerous liveness probe
Convert test rbac to namespace scope
Add imagePullPolicy to test image

Signed-off-by: Lachlan Evenson <lachlan.evenson@microsoft.com>

#### Is this a new chart
No

#### What this PR does / why we need it:
Updates Consul to latest stable minor release and other improvements. Also deprecates chart

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
