### PR TITLE
[stable/jenkins] copy scriptapprovals when overwriteConfig enabled

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.9.12
+
+Scriptapprovals are overwritten when overwriteConfig is enabled
+
 ## 1.9.10
 
 Added documentation for `persistence.storageClass`.

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.9.11
+version: 1.9.12
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -256,7 +256,11 @@ data:
     yes n | cp -i /usr/share/jenkins/ref/plugins/* /var/jenkins_plugins/;
 {{- end }}
 {{- if .Values.master.scriptApproval }}
+  {{- if .Values.Master.OverwriteConfig }}
+    cp /var/jenkins_config/scriptapproval.xml /var/jenkins_home/scriptApproval.xml;
+  {{- else }}
     yes n | cp -i /var/jenkins_config/scriptapproval.xml /var/jenkins_home/scriptApproval.xml;
+  {{- end }}
 {{- end }}
 {{- if .Values.master.initScripts }}
     mkdir -p /var/jenkins_home/init.groovy.d/;


### PR DESCRIPTION
Signed-off-by: Jan Heylen <jan.heylen@nokia.com>

#### Is this a new chart
NO

#### What this PR does / why we need it:
When updating values and configmaps of a helm jenkind deployment, we also want the scriptapprovals to be overwritten when overWriteConfig is enabled

#### Which issue this PR fixes
NA

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
