### PR TITLE
[stable/home-assistant] - probes reconfiguing and bump image version

### DIFF
--- a/stable/home-assistant/Chart.yaml
+++ b/stable/home-assistant/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.101.2
+appVersion: 0.103.3
 description: Home Assistant
 name: home-assistant
-version: 0.9.11
+version: 0.10.0
 keywords:
 - home-assistant
 - hass

--- a/stable/home-assistant/README.md
+++ b/stable/home-assistant/README.md
@@ -36,16 +36,21 @@ The following tables lists the configurable parameters of the Home Assistant cha
 | Parameter                  | Description                         | Default                                                 |
 |----------------------------|-------------------------------------|---------------------------------------------------------|
 | `image.repository`         | Image repository | `homeassistant/home-assistant` |
-| `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/homeassistant/home-assistant/tags/).| `0.101.2`|
+| `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/homeassistant/home-assistant/tags/).| `0.103.3`|
 | `image.pullPolicy`         | Image pull policy | `IfNotPresent` |
 | `image.pullSecrets`        | Secrets to use when pulling the image | `[]` |
 | `strategyType`             | Specifies the strategy used to replace old Pods by new ones | `Recreate` |
+| `probes.liveness.enabled`  | Use the livenessProbe?  | `true` |
 | `probes.liveness.initialDelaySeconds`  | Specify liveness `initialDelaySeconds` parameter for the deployment  | `60` |
 | `probes.liveness.failureThreshold`     | Specify liveness `failureThreshold` parameter for the deployment     | `5`  |
 | `probes.liveness.timeoutSeconds`       | Specify liveness `timeoutSeconds` parameter for the deployment       | `10` |
+| `probes.readiness.enabled`  | Use the readinessProbe?  | `true` |
 | `probes.readiness.initialDelaySeconds` | Specify readiness `initialDelaySeconds` parameter for the deployment | `60` |
 | `probes.readiness.failureThreshold`    | Specify readiness `failureThreshold` parameter for the deployment    | `5`  |
 | `probes.readiness.timeoutSeconds`      | Specify readiness `timeoutSeconds` parameter for the deployment      | `10` |
+| `probes.startup.enabled`  | Use the startupProbe? (new in kubernetes 1.16)  | `false` |
+| `probes.startup.failureThreshold`    | Specify startup `failureThreshold` parameter for the deployment    | `5`  |
+| `probes.startup.periodSeconds`      | Specify startup `periodSeconds` parameter for the deployment      | `10` |
 | `service.type`             | Kubernetes service type for the home-assistant GUI | `ClusterIP` |
 | `service.port`             | Kubernetes port where the home-assistant GUI is exposed| `8123` |
 | `service.annotations`      | Service annotations for the home-assistant GUI | `{}` |

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -73,6 +73,7 @@ spec:
             - name: api
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          {{- if .Values.liveness.enabled }}
           livenessProbe:
             httpGet:
               path: /
@@ -80,6 +81,8 @@ spec:
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
             failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
             timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.readiness.enabled }}
           readinessProbe:
             httpGet:
               path: /
@@ -87,6 +90,15 @@ spec:
             initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
             failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
             timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: /
+              port: api
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+          {{- end }}
           env:
             {{- range $key, $value := .Values.extraEnv }}
             - name: {{ $key }}

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             - name: api
               containerPort: {{ .Values.service.port }}
               protocol: TCP
-          {{- if .Values.liveness.enabled }}
+          {{- if .Values.probes.liveness.enabled }}
           livenessProbe:
             httpGet:
               path: /
@@ -82,7 +82,7 @@ spec:
             failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
             timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
           {{- end }}
-          {{- if .Values.readiness.enabled }}
+          {{- if .Values.probes.readiness.enabled }}
           readinessProbe:
             httpGet:
               path: /
@@ -91,7 +91,7 @@ spec:
             failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
             timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
           {{- end }}
-          {{- if .Values.startup.enabled }}
+          {{- if .Values.probes.startup.enabled }}
           startupProbe:
             httpGet:
               path: /

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: homeassistant/home-assistant
-  tag: 0.101.2
+  tag: 0.103.3
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -14,14 +14,19 @@ strategyType: Recreate
 # Probes configuration
 probes:
   liveness:
+    enabled: true
     initialDelaySeconds: 60
     failureThreshold: 5
     timeoutSeconds: 10
   readiness:
+    enabled: true
     initialDelaySeconds: 60
     failureThreshold: 5
     timeoutSeconds: 10
-
+  startup:
+    enabled: false
+    failureThreshold: 30
+    periodSeconds: 10
 service:
   type: ClusterIP
   port: 8123


### PR DESCRIPTION
#### Is this a new chart

* make all probes optional
* introduce (optional)
[startupProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes) (intoroduced in kubernetes 1.16) which is disabled by default
* bump the home-assistant version to 103.3

#### What this PR does / why we need it:

Home Assistant startup time can vary greatly depending on the configuration and number of integrations, therefore in some situations, relying on probes is problematic and there should be an option to disable probes when it isn't feasible to use them.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
