### PR TITLE
[stable/instana-agent] Chart version 1.0.20

### DIFF
--- a/stable/instana-agent/Chart.yaml
+++ b/stable/instana-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: instana-agent
-version: 1.0.19
+version: 1.0.20
 appVersion: 1.0
 description: Instana Agent for Kubernetes
 home: https://www.instana.com/

--- a/stable/instana-agent/templates/daemonset.yaml
+++ b/stable/instana-agent/templates/daemonset.yaml
@@ -92,6 +92,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           securityContext:
             privileged: true
           volumeMounts:


### PR DESCRIPTION
#### What this PR does / why we need it:

The agent by default binds to loopback addresses and what it perceives to be public IPs as well as docker bridge addresses. In some cases, it will not bind to the pod IP, which will cause the liveness checks to fail.

The agent looks for the `POD_IP` environment variable and will bind to that address instead of trying to detect the public IP address.

This PR adds this environment variable so that the agent can always bind to the right address. This should be more stable in the presence of different network plugins or configurations.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
