### PR TITLE
[stable/postgresql] Fix readiness probe

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 8.1.1
+version: 8.1.2
 appVersion: 11.6.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/_helpers.tpl
+++ b/stable/postgresql/templates/_helpers.tpl
@@ -325,12 +325,12 @@ Get the readiness probe command
 {{- define "postgresql.readinessProbeCommand" -}}
 - |
 {{- if (include "postgresql.database" .) }}
-  pg_isready -U {{ include "postgresql.username" . | quote }} -d {{ (include "postgresql.database" .) | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
+  exec pg_isready -U {{ include "postgresql.username" . | quote }} -d {{ (include "postgresql.database" .) | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
 {{- else }}
-  pg_isready -U {{ include "postgresql.username" . | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
+  exec pg_isready -U {{ include "postgresql.username" . | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
 {{- end }}
 {{- if contains "bitnami/" .Values.image.repository }}
-  [ -f /opt/bitnami/postgresql/tmp/.initialized ]
+  [ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /bitnami/postgresql/.initialized ]
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
In this PR there are two issues fixed:

- **_An issue in the `.initialized` file path after Bash migration:_**

The chart includes as part of the readiness probe the following command:
```bash
[ -f /opt/bitnami/postgresql/tmp/.initialized ]
```
this path is valid for images `>11.2.0-r69`.

In previous images, the `.initialized` the file appeared on another path. As you can see in the [image changelog](https://github.com/bitnami/bitnami-docker-postgresql#9612-r70-9612-ol-7-r72-1070-r69-1070-ol-7-r71-1120-r69-and-1120-ol-7-r71), the image was moved from NodeJS to Bash logic in this version (`11.2.0-r69`).
The refactoring, among other changes, modified the mentioned path.
So the readiness probe is not working as expected with old versions (previous to the new bash logic).

- **_Missing `exec` in the readiness command:_**
Readiness probe doesn't work in some old images because the probe command `/bin/sh -c -e pg_isready ...` didn't contain the `exec` parameter:

```bash
$ kubectl exec -it chart-1577352629-postgresql-0 /bin/bash

I have no name!@chart-1577352629-postgresql-0:/$ /bin/sh -c -e pg_isready -U “postgres” -h 127.0.0.1 -p 5432
/tmp:5432 - no attempt

I have no name!@chart-1577352629-postgresql-0:/$ /bin/sh -c -e exec pg_isready -U “postgres” -h 127.0.0.1 -p 5432

I have no name!@chart-1577352629-postgresql-0:/$ echo $?
0
```

The livenessprobe command contains this parameter and it is working fine. I tested several images and some of them don't work without the `exec`, now all the images (even the old/nami ones) should work.

#### Which issue this PR fixes
  - fixes #19766

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
