### PR TITLE
[stable/docker-registry] Fix incorrect default annotations type (#19739)

### DIFF
--- a/stable/docker-registry/Chart.yaml
+++ b/stable/docker-registry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Docker Registry
 name: docker-registry
-version: 1.9.0
+version: 1.9.1
 appVersion: 2.7.1
 home: https://hub.docker.com/_/registry/
 icon: https://hub.docker.com/public/images/logos/mini-logo.svg

--- a/stable/docker-registry/values.yaml
+++ b/stable/docker-registry/values.yaml
@@ -32,7 +32,7 @@ ingress:
   # Used to create an Ingress record.
   hosts:
     - chart-example.local
-  annotations:
+  annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   labels: {}


### PR DESCRIPTION
The default `annotations type` is an empty array, not an empty map. However, annotations are expected to be a map and this causes a linting error, as well as the release being stuck in the `pending-upgrade` state.

```
helm lint k8s
coalesce.go:199: warning: destination for annotations is a table. Ignoring non-table value <nil>
coalesce.go:199: warning: destination for annotations is a table. Ignoring non-table value <nil>
coalesce.go:199: warning: destination for annotations is a table. Ignoring non-table value <nil>
coalesce.go:199: warning: destination for annotations is a table. Ignoring non-table value <nil>
```

This PR fixes that issue by ensuring that `annotations` is an empty map by default:

```
helm lint k8s
==> Linting k8s
```

#### Is this a new chart
No

#### What this PR does / why we need it:
Fixes a bug in the chart values (see issue below).

#### Which issue this PR fixes
  - fixes #19739 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
