### PR TITLE
[stable/efs-provisioner] Default storage class to aws-efs

### DIFF
--- a/stable/efs-provisioner/Chart.yaml
+++ b/stable/efs-provisioner/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: efs-provisioner
 description: A Helm chart for the AWS EFS external storage provisioner
-version: 0.8.0
+version: 0.9.0
 appVersion: v2.2.0-k8s1.12
 home: https://github.com/kubernetes-incubator/external-storage/tree/master/aws/efs
 sources:

--- a/stable/efs-provisioner/values.yaml
+++ b/stable/efs-provisioner/values.yaml
@@ -40,7 +40,7 @@ efsProvisioner:
   path: /example-pv
   provisionerName: example.com/aws-efs
   storageClass:
-    name: efs
+    name: aws-efs
     isDefault: false
     gidAllocate:
       enabled: true


### PR DESCRIPTION
The current value for the efs-provisioner storage class is efs, which
differs from the default value in
https://github.com/kubernetes-incubator/external-storage/tree/master/aws/efs
and also in the AWS example page at
https://aws.amazon.com/premiumsupport/knowledge-center/eks-pods-efs/
This can be confusing when running examples and (automated) tests, so
I'm changing the value to "aws-efs" in the chart to be consistent with the references
in the storage provider and on the AWS example page.

Signed-off-by: Mariyan Dimitrov <mariyan.dimitrov@gmail.com>

@whereisaaron @mariusv 

#### What this PR does / why we need it:
This PR is for consistent naming of the default storage class.

#### Checklist
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
