### PR TITLE
[stable/mongodb] correct repo link

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 7.6.2
+version: 7.6.3
 appVersion: 4.0.14
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/values-production.yaml
+++ b/stable/mongodb/values-production.yaml
@@ -405,7 +405,7 @@ metrics:
     #   - myRegistryKeySecretName
 
   ## String with extra arguments to the metrics exporter
-  ## ref: https://github.com/dcu/mongodb_exporter/blob/master/mongodb_exporter.go
+  ## ref: https://github.com/percona/mongodb_exporter/blob/master/mongodb_exporter.go
   extraArgs: ""
 
   ## Metrics exporter resource requests and limits

--- a/stable/mongodb/values.yaml
+++ b/stable/mongodb/values.yaml
@@ -407,7 +407,7 @@ metrics:
     #   - myRegistryKeySecretName
 
   ## String with extra arguments to the metrics exporter
-  ## ref: https://github.com/dcu/mongodb_exporter/blob/master/mongodb_exporter.go
+  ## ref: https://github.com/percona/mongodb_exporter/blob/master/mongodb_exporter.go
   extraArgs: ""
 
   ## Metrics exporter resource requests and limits


### PR DESCRIPTION
`dcu/mongodb_exporter` to `percona/mongodb_exporter`