### PR TITLE
[stable/stackdriver-exporter] - Add prometheus rule additionalLabels in servicemonitor.yaml 

### DIFF
--- a/stable/stackdriver-exporter/Chart.yaml
+++ b/stable/stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: stackdriver-exporter
-version: 1.2.1
+version: 1.2.2
 appVersion: 0.6.0
 home: https://www.stackdriver.com/
 sources:

--- a/stable/stackdriver-exporter/README.md
+++ b/stable/stackdriver-exporter/README.md
@@ -87,6 +87,8 @@ Parameter                           | Description                               
 `tolerations`                       | Node taints to tolerate (requires Kubernetes >=1.6) 							  | `[]`
 `serviceMonitor.enabled`            | if `true`, creates a Prometheus Operator ServiceMonitor                         | `false`
 `serviceMonitor.namespace`          | Namespace where you want to create the ServiceMonitor                           | `monitoring`
+`serviceMonitor.additionalLabels`   | Labels used by Prometheus Operator to discover your Service Monitor. Set according to your Prometheus setup | `{}`
+`monitoring`
 `serviceMonitor.interval`           | How frequently to scrape metrics (not set: fall back to Prometheus' default)    |  `nil`
 `serviceMonitor.honorLabels`        | if `true`, label conflicts are resolved by keeping label values from the scraped data | `true`
 

--- a/stable/stackdriver-exporter/templates/servicemonitor.yaml
+++ b/stable/stackdriver-exporter/templates/servicemonitor.yaml
@@ -11,8 +11,8 @@ metadata:
     app: {{ template "stackdriver-exporter.name" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
-{{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    {{- if .Values.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
     {{- end }}
 spec:
   endpoints:

--- a/stable/stackdriver-exporter/templates/servicemonitor.yaml
+++ b/stable/stackdriver-exporter/templates/servicemonitor.yaml
@@ -11,6 +11,9 @@ metadata:
     app: {{ template "stackdriver-exporter.name" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
 spec:
   endpoints:
   - port: http

--- a/stable/stackdriver-exporter/values.yaml
+++ b/stable/stackdriver-exporter/values.yaml
@@ -88,6 +88,8 @@ serviceAccount:
 serviceMonitor:
   enabled: false
   namespace: monitoring
+  # additionalLabels is the set of additional labels to add to the ServiceMonitor
+  additionalLabels: {}
   # fallback to the prometheus default unless specified
   # interval: 10s
   ## Defaults to what's used if you follow CoreOS [Prometheus Install Instructions](https://github.com/helm/charts/tree/master/stable/prometheus-operator#tldr)


### PR DESCRIPTION
Signed-off-by: Ricardo Medeiros ricardo.costa@treasy.com.br

#### What this PR does / why we need it:
We need this rule to prometheus-operator 

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
