### PR TITLE
[stable/kong] Fix: Preserve whitespace when rendering

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.31.1
+version: 0.31.2
 appVersion: 1.4

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -423,6 +423,12 @@ You can can learn about kong ingress custom resource definitions [here](https://
 - Update default version of Ingress Controller to 0.6.2
 - Add support to disable kong-admin service via `admin.enabled` flag.
 
+### 0.31.2
+
+#### Fixes
+
+- Do not remove whitespace between documents when rendering `migrations-pre-upgrade.yaml`
+
 ### 0.30.1
 
 #### New Features

--- a/stable/kong/templates/migrations-pre-upgrade.yaml
+++ b/stable/kong/templates/migrations-pre-upgrade.yaml
@@ -83,7 +83,7 @@ spec:
       {{- include "kong.volumes" . | nindent 6 -}}
 {{- end }}
 
-{{- if or .Values.podSecurityPolicy.enabled (and .Values.ingressController.enabled .Values.ingressController.serviceAccount.create) -}}
+{{ if or .Values.podSecurityPolicy.enabled (and .Values.ingressController.enabled .Values.ingressController.serviceAccount.create) -}}
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION

#### Is this a new chart
No, this is a fix to an existing chart.

#### What this PR does / why we need it:
When running `helm template` with a database enabled, the current templates where not preserving whitespace which causes two files to join together into unparsable yaml.

```shell
helm template --set postgresql.enabled=true,env.database=postgres kong-0.31.1.tgz
```
Created a file `migrations-pre-upgrade.yaml` that contained two joined yamls because of the use of the `{{-` and `-}}` delimiters:

```yaml
          mountPath: /kong
      restartPolicy: OnFailure
      volumes:
      
      - name: custom-nginx-template-volume
        configMap:
          name: RELEASE-NAME-kong-default-custom-server-blocks---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: RELEASE-NAME-kong

```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
