### PR TITLE
[stable/ipfs] Move livenessProbe to container config block

### DIFF
--- a/stable/ipfs/Chart.yaml
+++ b/stable/ipfs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the Interplanetary File System
 name: ipfs
-version: 0.4.0
+version: 0.4.1
 icon: https://raw.githubusercontent.com/ipfs/logo/master/raster-generated/ipfs-logo-128-ice-text.png
 home: https://ipfs.io/
 appVersion: v0.4.22

--- a/stable/ipfs/templates/statefulset.yaml
+++ b/stable/ipfs/templates/statefulset.yaml
@@ -27,21 +27,21 @@ spec:
         # the persistent volume to be able to start.
         fsGroup: 1000
         runAsUser: 1000
-      livenessProbe:
-        httpGet:
-          path: /debug/metrics/prometheus
-          port: api
-        initialDelaySeconds: 15
-        periodSeconds: 3
-      readinessProbe:
-        httpGet:
-          path: /debug/metrics/prometheus
-          port: api
-        initialDelaySeconds: 15
-        periodSeconds: 3
       containers:
       - name: {{ .Chart.Name }}
         image: {{ .Values.image }}
+        livenessProbe:
+          httpGet:
+            path: /debug/metrics/prometheus
+            port: api
+          initialDelaySeconds: 15
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /debug/metrics/prometheus
+            port: api
+          initialDelaySeconds: 15
+          periodSeconds: 3
         ports:
 {{- if .Values.swarm.enabled }}
         - containerPort: 4001


### PR DESCRIPTION
#### What this PR does / why we need it:
Currently, this chart fails with the following error:

```
helm install ipfstest01 stable/ipfs
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: [ValidationError(StatefulSet.spec.template.spec): unknown field "livenessProbe" in io.k8s.api.core.v1.PodSpec, ValidationError(StatefulSet.spec.template.spec): unknown field "readinessProbe" in io.k8s.api.core.v1.PodSpec]
```
This is because the livenessProbe blocks are under the wrong key (it is a property of container, not of security)

Moving these values to the `container` key seem to resolve the issue:

```
kubectl logs ipfstest01-ipfs-0
ipfs version 0.4.22
initializing IPFS node at /data/ipfs
generating 2048-bit RSA keypair...done
peer identity: QmehquKcAmoc1hLE7KJWXWAy8kVZEbBFLCWQicVL3MXkxp
to get started, enter:

	ipfs cat /ipfs/QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv/readme

Initializing daemon...
go-ipfs version: 0.4.22-
Repo version: 7
System version: amd64/linux
Golang version: go1.12.7
Swarm listening on /ip4/127.0.0.1/tcp/4001
Swarm listening on /ip4/192.168.22.44/tcp/4001
Swarm listening on /p2p-circuit
Swarm announcing /ip4/127.0.0.1/tcp/4001
Swarm announcing /ip4/192.168.22.44/tcp/4001
API server listening on /ip4/0.0.0.0/tcp/5001
WebUI: http://0.0.0.0:5001/webui
Gateway (readonly) server listening on /ip4/0.0.0.0/tcp/8080
Daemon is ready
```


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [n/a] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
