### PR TITLE
[stable/sonatype-nexus] Use official sonatype nexus image. Keep default admin123 password.

### DIFF
--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 1.21.2
+version: 1.21.3
 appVersion: 3.20.1-01
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonatype-nexus
 version: 1.21.2
-appVersion: 3.19.1-01
+appVersion: 3.20.1-01
 description: Sonatype Nexus is an open source repository manager
 keywords:
   - artifacts

--- a/stable/sonatype-nexus/values.yaml
+++ b/stable/sonatype-nexus/values.yaml
@@ -9,12 +9,14 @@ deploymentStrategy: {}
   # type: RollingUpdate
 
 nexus:
-  imageName: quay.io/travelaudience/docker-nexus
-  imageTag: 3.19.1
+  imageName: sonatype/nexus3
+  imageTag: 3.20.1
   imagePullPolicy: IfNotPresent
   env:
     - name: install4jAddVmParams
       value: "-Xms1200M -Xmx1200M -XX:MaxDirectMemorySize=2G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+    - name: NEXUS_SECURITY_RANDOMPASSWORD
+      value: "false"
   # nodeSelector:
   #   cloud.google.com/gke-nodepool: default-pool
   resources: {}
@@ -46,8 +48,8 @@ nexus:
   # loadBalancerSourceRanges:
   #   - 192.168.1.10/32
   # labels: {}
-  # securityContext:
-  #   fsGroup: 2000
+  securityContext:
+    fsGroup: 2000
   podAnnotations: {}
   livenessProbe:
     initialDelaySeconds: 30


### PR DESCRIPTION
#### What this PR does / why we need it:
Use official sonatype-nexus docker image which is more up-to-date.

#### Special notes for your reviewer:
* The securityGroup change allows the pvc to be usable (proper permissions) by Nexus.
* NEXUS_SECURITY_RANDOMPASSWORD keeps the default admin password admin123 like the HELM install output says.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)