### PR TITLE
[stable/sonatype-nexus] Allow ingress without proxy container

### DIFF
--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 1.21.3
+version: 1.21.4
 appVersion: 3.20.1-01
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/templates/ingress.yaml
+++ b/stable/sonatype-nexus/templates/ingress.yaml
@@ -11,8 +11,7 @@ metadata:
     {{- end }}
 spec:
   rules:
-{{- if .Values.nexusProxy.enabled -}}  
-  {{- if .Values.nexusProxy.env.nexusHttpHost }}
+{{- if .Values.nexusProxy.env.nexusHttpHost }}
     - host: {{ .Values.nexusProxy.env.nexusHttpHost }}
       http:
         paths:
@@ -22,9 +21,14 @@ spec:
             {{- else }}
               serviceName: {{ template "nexus.fullname" . }}
             {{- end }}
+{{- if .Values.nexusProxy.enabled }}
               servicePort: {{ .Values.nexusProxy.port }}
+{{- else }}
+              servicePort: {{ .Values.nexus.nexusPort }}
+{{- end }}
             path: {{ .Values.ingress.path }}
-  {{- end }}
+{{- end }}
+{{- if .Values.nexusProxy.enabled -}}
   {{- if .Values.nexusProxy.env.nexusDockerHost }}
     - host: {{ .Values.nexusProxy.env.nexusDockerHost }}
       http:
@@ -38,7 +42,7 @@ spec:
               servicePort: {{ .Values.nexusProxy.port }}
             path: {{ .Values.ingress.path }}
   {{- end }}
-{{- end -}}  
+{{- end -}}
 {{- with .Values.ingress.rules  }}
 {{ toYaml . | indent 2 }}
   {{- end -}}

--- a/stable/sonatype-nexus/templates/proxy-svc.yaml
+++ b/stable/sonatype-nexus/templates/proxy-svc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.nexusProxy.enabled }}
+{{- if or .Values.nexusProxy.enabled .Values.ingress.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -21,14 +21,22 @@ metadata:
 {{- end }}
 spec:
   ports:
+{{- if .Values.nexusProxy.enabled }}
     - port: {{ .Values.nexusProxy.port }}
+{{- else }}
+    - port: {{ .Values.nexus.nexusPort }}
+{{- end }}
 {{- if .Values.nexusProxy.svcName }}
       name: {{ .Values.nexusProxy.svcName }}
 {{- else }}
       name: {{ template "nexus.fullname" . }}
 {{- end }}
       protocol: TCP
+{{- if .Values.nexusProxy.enabled }}
       targetPort: {{ .Values.nexusProxy.targetPort }}
+{{- else }}
+      targetPort: {{ .Values.nexus.nexusPort }}
+{{- end }}
   selector:
     app: {{ template "nexus.name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
## What this PR does / why we need it:
Allow using Ingress without the use of the custom proxy container.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
