### PR TITLE
[stable/grafana] - Add allowUiUpdates for Grafana 6.5

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 4.2.2
+version: 4.2.3
 appVersion: 6.5.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -123,6 +123,7 @@ This version requires Helm >= 2.12.0.
 | `sidecar.dashboards.provider.orgid`       | Id of the organisation, to which the dashboards should be added | `1`                                   |
 | `sidecar.dashboards.provider.folder`      | Logical folder in which grafana groups dashboards | `""`                                                |
 | `sidecar.dashboards.provider.disableDelete` | Activate to avoid the deletion of imported dashboards | `false`                                       |
+| `sidecar.dashboards.provider.allowUiUpdates` | Allow updating provisioned dashboards from the UI | `false`                                          |
 | `sidecar.dashboards.provider.type`        | Provider type                                 | `file`                                                  |
 | `sidecar.skipTlsVerify`                   | Set to true to skip tls verification for kube api calls | `nil`       |
 | `sidecar.dashboards.label`                | Label that config maps with dashboards should have to be added | `grafana_dashboard`                                |

--- a/stable/grafana/templates/configmap-dashboard-provider.yaml
+++ b/stable/grafana/templates/configmap-dashboard-provider.yaml
@@ -22,6 +22,7 @@ data:
       folder: '{{ .Values.sidecar.dashboards.provider.folder }}'
       type: {{ .Values.sidecar.dashboards.provider.type }}
       disableDeletion: {{ .Values.sidecar.dashboards.provider.disableDelete }}
+      allowUiUpdates: {{ .Values.sidecar.dashboards.provider.allowUiUpdates }}
       options:
         path: {{ .Values.sidecar.dashboards.folder }}{{- with .Values.sidecar.dashboards.defaultFolderName }}/{{ . }}{{- end }}
 {{- end}}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -465,6 +465,8 @@ sidecar:
       type: file
       # disableDelete to activate a import-only behaviour
       disableDelete: false
+      # allow updating provisioned dashboards from the UI
+      allowUiUpdates: false
   datasources:
     enabled: false
     # label that the configmaps with datasources are marked with


### PR DESCRIPTION
[Starting with Grafana 6.5]((https://grafana.com/docs/grafana/latest/guides/whats-new-in-v6-5/#allow-saving-of-provisioned-dashboards-from-ui)) _`allowUiUpdates`_ option is present for provisioning configuration.
I've added it to the Chart.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
