### PR TITLE
[stable/kube-ops-view] Upgrade redis and also enable when testing

### DIFF
--- a/stable/kube-ops-view/Chart.yaml
+++ b/stable/kube-ops-view/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kube-ops-view
-version: 1.1.2
+version: 1.1.3
 appVersion: 19.9.0
 description: Kubernetes Operational View - read-only system dashboard for multiple
   K8s clusters

--- a/stable/kube-ops-view/ci/redis-enabled-values.yaml
+++ b/stable/kube-ops-view/ci/redis-enabled-values.yaml
@@ -1,0 +1,2 @@
+redis:
+  enabled: true

--- a/stable/kube-ops-view/ci/redis-enabled-values.yaml
+++ b/stable/kube-ops-view/ci/redis-enabled-values.yaml
@@ -1,2 +1,4 @@
 redis:
   enabled: true
+  master:
+    port: 6379

--- a/stable/kube-ops-view/requirements.lock
+++ b/stable/kube-ops-view/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: redis
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 10.3.0
+digest: sha256:b00b2d74e908a28aff8ef770f324c7c4d9bd414f5eaa5a5b6faec7699f387ab6
+generated: "2019-12-30T16:25:17.475036+01:00"

--- a/stable/kube-ops-view/requirements.yaml
+++ b/stable/kube-ops-view/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: redis
-  version: 5.1.0
+  version: 10.3.*
   repository: https://kubernetes-charts.storage.googleapis.com
   condition: redis.enabled


### PR DESCRIPTION
Signed-off-by: David J. M. Karlsen <david@davidkarlsen.com>

#### What this PR does / why we need it:
The optional Redis child-chart was very outdated - update it and also enable test.
Check in the lock file to ensure reproducability.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/helm/charts/19803)
<!-- Reviewable:end -->
