### PR TITLE
[stable/jenkins] Make jenkins-home volume attachable to Azure disks without pvc

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,19 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.9.18
+
+Make `jenkins-home` attachable to Azure Disks without pvc
+
+```
+ volumes:
+  - name: jenkins-home
+    azureDisk:
+      kind: Managed
+      diskName: myAKSDisk
+      diskURI: /subscriptions/<subscriptionID>/resourceGroups/MC_myAKSCluster_myAKSCluster_eastus/providers/Microsoft.Compute/disks/myAKSDisk
+```
+
 ## 1.9.16
 
 Fix PodLabel for NetworkPolicy to work if enabled

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.9.17
+version: 1.9.18
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/home-pvc.yaml
+++ b/stable/jenkins/templates/home-pvc.yaml
@@ -1,3 +1,4 @@
+{{- if not (contains "jenkins-home" (quote .Values.persistence.volumes)) }}
 {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -25,6 +26,7 @@ spec:
   storageClassName: ""
 {{- else }}
   storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -371,12 +371,14 @@ spec:
       - name: plugin-dir
         emptyDir: {}
       {{- end }}
+      {{- if not (contains "jenkins-home" (quote .Values.persistence.volumes)) }}
       - name: jenkins-home
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim | default (include "jenkins.fullname" .) }}
       {{- else }}
         emptyDir: {}
+      {{- end -}}
       {{- end -}}
       {{- if .Values.master.JCasC.enabled }}
       - name: sc-config-volume


### PR DESCRIPTION
Signed-off-by: Marcel Araujo <ceceldada@gmail.com>

#### What this PR does / why we need it:
Azure Disks sometimes don't release static disks properly in time when used though PVC and their recommendation is use static disk attached directly to container.

https://docs.microsoft.com/en-us/azure/aks/azure-disk-volume

#### Special notes for your reviewer:
@lachie83 @viglesiasce  @maorfr 
I think the documentation about release `1.9.11` is missing.

#### Checklist
- [X] [DCO]
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
