### PR TITLE
[stable/metrics-server] Bump appVersion to v0.3.6

### DIFF
--- a/stable/metrics-server/Chart.yaml
+++ b/stable/metrics-server/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.3.5
+appVersion: 0.3.6
 description: Metrics Server is a cluster-wide aggregator of resource usage data.
 name: metrics-server
-version: 2.8.8
+version: 2.8.9
 keywords:
 - metrics-server
 home: https://github.com/kubernetes-incubator/metrics-server

--- a/stable/metrics-server/values.yaml
+++ b/stable/metrics-server/values.yaml
@@ -28,7 +28,7 @@ hostNetwork:
 
 image:
   repository: gcr.io/google_containers/metrics-server-amd64
-  tag: v0.3.5
+  tag: v0.3.6
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
#### What this PR does / why we need it:

Bump metrics-server to v0.3.6. No breaking changes so just a minor chartVersion bump:
https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.3.6

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
