### PR TITLE
[stable/nginx-ingress] Update to stable "rbac.authorization.k8s.io/v1"

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.27.0
+version: 1.27.1
 appVersion: 0.26.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/clusterrole.yaml
+++ b/stable/nginx-ingress/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.rbac.create (not .Values.controller.scope.enabled) -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:

--- a/stable/nginx-ingress/templates/clusterrolebinding.yaml
+++ b/stable/nginx-ingress/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.rbac.create (not .Values.controller.scope.enabled) -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/stable/nginx-ingress/templates/controller-role.yaml
+++ b/stable/nginx-ingress/templates/controller-role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:

--- a/stable/nginx-ingress/templates/controller-rolebinding.yaml
+++ b/stable/nginx-ingress/templates/controller-rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:

--- a/stable/nginx-ingress/templates/default-backend-role.yaml
+++ b/stable/nginx-ingress/templates/default-backend-role.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.rbac.create .Values.podSecurityPolicy.enabled .Values.defaultBackend.enabled -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:

--- a/stable/nginx-ingress/templates/default-backend-rolebinding.yaml
+++ b/stable/nginx-ingress/templates/default-backend-rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.rbac.create .Values.podSecurityPolicy.enabled .Values.defaultBackend.enabled -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:


### PR DESCRIPTION
#### What this PR does / why we need it:
`rbac.authorization.k8s.io/v1beta1` API is promoted to `rbac.authorization.k8s.io/v1` in v1.8.
Ref https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.8.md

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
