### PR TITLE
[stable/nginx-ingress] Add "component" key to deployment selector

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.27.0
+version: 1.27.1
 appVersion: 0.26.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -16,6 +16,7 @@ spec:
     matchLabels:
       app: {{ template "nginx-ingress.name" . }}
       release: {{ .Release.Name }}
+      component: "{{ .Values.controller.name }}"
 {{- if not .Values.controller.autoscaling.enabled }}
   replicas: {{ .Values.controller.replicaCount }}
 {{- end }}

--- a/stable/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/stable/nginx-ingress/templates/default-backend-deployment.yaml
@@ -14,6 +14,7 @@ spec:
     matchLabels:
       app: {{ template "nginx-ingress.name" . }}
       release: {{ .Release.Name }}
+      component: "{{ .Values.defaultBackend.name }}"
   replicas: {{ .Values.defaultBackend.replicaCount }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:


### PR DESCRIPTION
This is needed to ensure that the HPA (or any other component using
deployment to get relevant labels) only targets the correct pods.

Signed-off-by: Aditya Aggarwal <aditya@cybersapien.xyz>


#### Is this a new chart
No

#### What this PR does / why we need it:

##### Issue:
The nginx-ingress chart creates 2 deployments,
1. Ingress controller
2. Default Backend

Both these deployments have a set of common as well as distinct labels. 
The `Deployment` label selectors only have two selectors, `app` and `release`. For almost all components, this works fine, as you add the label selectors to pods directly, for example, in the `Service` manifest, you write,
```
  selector:
    app: {{ template "nginx-ingress.name" . }}
    component: "{{ .Values.controller.name }}" # can be controller name or default backend name
    release: {{ .Release.Name }}
```

However, there are components like the `HPA`, which takes target reference as the `Deployment` itself, and then [extract the labels from their selectors](https://github.com/kubernetes/kubernetes/issues/79365#issuecomment-506128791).

This creates an issue as the HPA meant just for the controller also takes into account the metrics from `default-backend` pods. (and vice-versa). 

Not only the targetAverageUtilization provide incorrect value for this, but this also results in HPA not working at all, if one only specifies the resource requests for just the controller and not the backend. (Of course, it's not ideal to do so).

##### Solution
Adding the relevant `component` label in both the deployment YAML on the backend as well as controller fixes this issue.

#### Which issue this PR fixes
No issue available on this

#### Special notes for your reviewer:
Tested on:
1. kops v1.15.5 on AWS
2. GKE v1.15.4-gke.22

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
