### PR TITLE
[stable/redis] fix runAsUser incompatible types for comparison

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 10.3.0
+version: 10.3.1
 appVersion: 5.0.7
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/redis-master-statefulset.yaml
+++ b/stable/redis/templates/redis-master-statefulset.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/bash
         - -c
         - |
-          {{- if (eq .Values.securityContext.runAsUser 0.0) }}
+          {{- if (eq (.Values.securityContext.runAsUser | int) 0) }}
           useradd redis
           chown -R redis {{ .Values.master.persistence.path }}
           {{- end }}

--- a/stable/redis/templates/redis-slave-statefulset.yaml
+++ b/stable/redis/templates/redis-slave-statefulset.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/bash
         - -c
         - |
-          {{- if (eq .Values.securityContext.runAsUser 0.0) }}
+          {{- if (eq (.Values.securityContext.runAsUser | int) 0) }}
           useradd redis
           chown -R redis {{ .Values.slave.persistence.path }}
           {{- end }}


### PR DESCRIPTION
Signed-off-by: Peter Evers <pevers90@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

#### What this PR does / why we need it:
For Helm 3.0.2 `securityContext.runAsUser` is unmarshalled as float64 for 1001 and to int64 for 0.  Causing `<eq .Values.securityContext.runAsUser 0.0>: error calling eq: incompatible types for comparison`.

It seems that numbers are parsed differently between Helm versions. So instead of guessing the type I'm converting it to int. A UID can be represented as int because the max range is 65533.

#### Which issue this PR fixes
Fixes https://github.com/helm/helm/issues/7023

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
