### PR TITLE
[stable/mediawiki] Add Mediawiki host parameter

### DIFF
--- a/stable/mediawiki/Chart.yaml
+++ b/stable/mediawiki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mediawiki
-version: 9.0.1
+version: 9.1.0
 appVersion: 1.33.1
 description: Extremely powerful, scalable software and a feature-rich wiki implementation that uses PHP to process and display data stored in a database.
 home: http://www.mediawiki.org/

--- a/stable/mediawiki/README.md
+++ b/stable/mediawiki/README.md
@@ -65,6 +65,7 @@ The following table lists the configurable parameters of the MediaWiki chart and
 | `mediawikiPassword`                  | Application password                                        | _random 10 character long alphanumeric string_          |
 | `mediawikiEmail`                     | Admin email                                                 | `user@example.com`                                      |
 | `mediawikiName`                      | Name for the wiki                                           | `My Wiki`                                               |
+| `mediawikiHost`                      | Mediawiki host to create application URLs                   | `nil`                                                   |
 | `allowEmptyPassword`                 | Allow DB blank passwords                                    | `yes`                                                   |
 | `smtpHost`                           | SMTP host                                                   | `nil`                                                   |
 | `smtpPort`                           | SMTP port                                                   | `nil`                                                   |
@@ -127,6 +128,10 @@ The following table lists the configurable parameters of the MediaWiki chart and
 | `metrics.resources`                  | Exporter resource requests/limit                            | {}                                                      |
 
 The above parameters map to the env variables defined in [bitnami/mediawiki](http://github.com/bitnami/bitnami-docker-mediawiki). For more information please refer to the [bitnami/mediawiki](http://github.com/bitnami/bitnami-docker-mediawiki) image documentation.
+
+> **Note**:
+>
+> For Mediawiki to function correctly, you should specify the `mediawikiHost` parameter to specify the FQDN (recommended) or the public IP address of the Mediawiki service.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/mediawiki/templates/NOTES.txt
+++ b/stable/mediawiki/templates/NOTES.txt
@@ -44,6 +44,17 @@ host. To configure Mediawiki with the URL of your service:
 
 {{- else }}
 
+{{- if .Values.ingress.enabled }}
+
+1. Get the Mediawiki URL indicated on the Ingress Rule and associate it to your cluster external IP:
+
+  export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
+  export HOSTNAME=$(kubectl get ingress --namespace {{ .Release.Namespace }} {{ template "mediawiki.fullname" . }} -o jsonpath='{.spec.rules[0].host}')
+  echo "Mediawiki URL: http://$HOSTNAME/"
+  echo "$CLUSTER_IP  $HOSTNAME" | sudo tee -a /etc/hosts
+
+{{- else }}
+
 1. Get the MediaWiki URL by running:
 
 {{- if contains "NodePort" .Values.service.type }}
@@ -67,6 +78,7 @@ host. To configure Mediawiki with the URL of your service:
   echo "Mediawiki URL: http://127.0.0.1:8080/"
   kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "mediawiki.fullname" . }} 8080:{{ .Values.service.port }}
 
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/stable/mediawiki/templates/NOTES.txt
+++ b/stable/mediawiki/templates/NOTES.txt
@@ -1,15 +1,46 @@
 {{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
 
-** Please be patient while the chart is being deployed **
+{{- if empty (include "mediawiki.host" .) -}}
+###############################################################################
+### ERROR: You did not provide an external host in your 'helm install' call ###
+###############################################################################
 
-{{- if .Values.ingress.enabled }}
+This deployment will be incomplete until you configure Mediawiki with a resolvable
+host. To configure Mediawiki with the URL of your service:
 
-1. Get the Mediawiki URL indicated on the Ingress Rule and associate it to your cluster external IP:
+1. Get the Mediawiki URL by running:
 
-   export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
-   export HOSTNAME=$(kubectl get ingress --namespace {{ .Release.Namespace }} {{ template "mediawiki.fullname" . }} -o jsonpath='{.spec.rules[0].host}')
-   echo "Mediawiki URL: http://$HOSTNAME/"
-   echo "$CLUSTER_IP  $HOSTNAME" | sudo tee -a /etc/hosts
+  {{- if contains "NodePort" .Values.service.type }}
+
+  export APP_PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "mediawiki.fullname" . }} -o jsonpath="{.spec.ports[0].nodePort}")
+  export APP_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+
+  {{- else if contains "LoadBalancer" .Values.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "mediawiki.fullname" . }}'
+
+  export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "mediawiki.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+  export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "mediawiki.fullname" . }} -o jsonpath="{.data.mediawiki-password}" | base64 --decode)
+  {{- if .Values.mariadb.mariadbRootPassword }}
+  export DATABASE_ROOT_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "mediawiki.mariadb.fullname" . }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
+  {{- end }}
+  {{- end }}
+  export APP_DATABASE_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "mediawiki.mariadb.fullname" . }} -o jsonpath="{.data.mariadb-password}" | base64 --decode)
+
+2. Complete your Mediawiki deployment by running:
+
+{{- if .Values.mariadb.enabled }}
+
+  helm upgrade {{ .Release.Name }} stable/{{ .Chart.Name }} \
+    --set mediawikiHost=$APP_HOST,mediawikiPassword=$APP_PASSWORD{{ if .Values.mariadb.mariadbRootPassword }},mariadb.mariadbRootPassword=$DATABASE_ROOT_PASSWORD{{ end }},mariadb.db.password=$APP_DATABASE_PASSWORD{{- if .Values.global }}{{- if .Values.global.imagePullSecrets }},global.imagePullSecrets={{ .Values.global.imagePullSecrets }}{{- end }}{{- end }}
+{{- else }}
+
+  ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
+
+  helm upgrade {{ .Release.Name }} stable/{{ .Chart.Name }} \
+    --set mediawikiPassword=$APP_PASSWORD,mediawikiHost=$APP_HOST,service.type={{ .Values.service.type }},mariadb.enabled=false{{- if not (empty .Values.externalDatabase.host) }},externalDatabase.host={{ .Values.externalDatabase.host }}{{- end }}{{- if not (empty .Values.externalDatabase.user) }},externalDatabase.user={{ .Values.externalDatabase.user }}{{- end }}{{- if not (empty .Values.externalDatabase.password) }},externalDatabase.password={{ .Values.externalDatabase.password }}{{- end }}{{- if not (empty .Values.externalDatabase.database) }},externalDatabase.database={{ .Values.externalDatabase.database }}{{- end }}{{- if .Values.global }}{{- if .Values.global.imagePullSecrets }},global.imagePullSecrets={{ .Values.global.imagePullSecrets }}{{- end }}{{- end }}
+{{- end }}
 
 {{- else }}
 

--- a/stable/mediawiki/templates/_helpers.tpl
+++ b/stable/mediawiki/templates/_helpers.tpl
@@ -24,6 +24,27 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Get the user defined LoadBalancerIP for this release.
+Note, returns 127.0.0.1 if using ClusterIP.
+*/}}
+{{- define "mediawiki.serviceIP" -}}
+{{- if eq .Values.service.type "ClusterIP" -}}
+127.0.0.1
+{{- else -}}
+{{- .Values.service.loadBalancerIP | default "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Gets the host to be used for this application.
+If not using ClusterIP, or if a host or LoadBalancerIP is not defined, the value will be empty.
+*/}}
+{{- define "mediawiki.host" -}}
+{{- $host := index .Values (printf "%sHost" .Chart.Name) | default "" -}}
+{{- default (include "mediawiki.serviceIP" .) $host -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "mediawiki.chart" -}}

--- a/stable/mediawiki/templates/deployment.yaml
+++ b/stable/mediawiki/templates/deployment.yaml
@@ -123,7 +123,7 @@ spec:
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: /index.php
+            path: /api.php
             port: http
             httpHeaders:
             - name: Host
@@ -137,7 +137,7 @@ spec:
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: /index.php
+            path: /api.php
             port: http
             httpHeaders:
             - name: Host

--- a/stable/mediawiki/templates/deployment.yaml
+++ b/stable/mediawiki/templates/deployment.yaml
@@ -125,6 +125,9 @@ spec:
           httpGet:
             path: /index.php
             port: http
+            httpHeaders:
+            - name: Host
+              value: {{ include "mediawiki.host" . | quote }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -136,6 +139,9 @@ spec:
           httpGet:
             path: /index.php
             port: http
+            httpHeaders:
+            - name: Host
+              value: {{ include "mediawiki.host" . | quote }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/stable/mediawiki/templates/deployment.yaml
+++ b/stable/mediawiki/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
+{{- if and (include "mediawiki.host" .) (or .Values.mariadb.enabled .Values.externalDatabase.host) -}}
 apiVersion: {{ template "mediawiki.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
@@ -76,6 +76,9 @@ spec:
               name: {{ printf "%s-%s" .Release.Name "externaldb" }}
               key: db-password
             {{- end }}
+        {{- $port:=.Values.service.port | toString }}
+        - name: MEDIAWIKI_HOST
+          value: "{{ include "mediawiki.host" . }}{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}"
         - name: MEDIAWIKI_USERNAME
           value: {{ .Values.mediawikiUser | quote }}
         - name: MEDIAWIKI_PASSWORD

--- a/stable/mediawiki/values.yaml
+++ b/stable/mediawiki/values.yaml
@@ -56,6 +56,11 @@ mediawikiEmail: user@example.com
 ##
 mediawikiName: My Wiki
 
+## Mediawiki host to create application URLs
+## ref: https://github.com/bitnami/bitnami-docker-mediawiki#configuration
+##
+# mediawikiHost:
+
 ## Set to `yes` to allow the container to be started with blank passwords
 ## ref: https://github.com/bitnami/bitnami-docker-mediawiki#environment-variables
 allowEmptyPassword: "yes"


### PR DESCRIPTION
Signed-off-by: David Gomez <dgomezleon@vmware.com>

#### Is this a new chart

No

#### What this PR does / why we need it:

`wgServer` parameter needs to be set from now on (version 1.34). This PR adds a parameter that allows to set it through the chart.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)