### PR TITLE
[stable/sonarqube] upgrades LTS to latest patch

### DIFF
--- a/REVIEW_GUIDELINES.md
+++ b/REVIEW_GUIDELINES.md
@@ -279,7 +279,7 @@ ingress:
 
 ```yaml
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "myapp.fullname" }}

--- a/REVIEW_GUIDELINES.md
+++ b/REVIEW_GUIDELINES.md
@@ -279,7 +279,11 @@ ingress:
 
 ```yaml
 {{- if .Values.ingress.enabled -}}
-apiVersion: networking.k8s.io/v1
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end -}}
 kind: Ingress
 metadata:
   name: {{ include "myapp.fullname" }}

--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: sonarqube
-description: Sonarqube is an open sourced code quality scanning tool
-version: 3.2.8
-appVersion: 7.9.1
+description: SonarQube is an open sourced code quality scanning tool
+version: 3.3.0
+appVersion: 7.9.2
 keywords:
   - coverage
   - security

--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -42,7 +42,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `replicaCount`                              | Number of replicas deployed               | `1`                                        |
 | `deploymentStrategy`                        | Deployment strategy                       | `{}`                                       |
 | `image.repository`                          | image repository                          | `sonarqube`                                |
-| `image.tag`                                 | `sonarqube` image tag.                    | `7.9.1-community`                            |
+| `image.tag`                                 | `sonarqube` image tag.                    | `7.9.2-community`                            |
 | `image.pullPolicy`                          | Image pull policy                         | `IfNotPresent`                             |
 | `image.pullSecret`                          | imagePullSecret to use for private repository      |                                   |
 | `command`                                   | command to run in the container           | `nil` (need to be set prior to 6.7.6, and 7.4)      |

--- a/stable/sonarqube/templates/ingress.yaml
+++ b/stable/sonarqube/templates/ingress.yaml
@@ -1,7 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "sonarqube.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
-apiVersion: networking.k8s.io/v1
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end -}}
 kind: Ingress
 metadata:
   name: {{ template "sonarqube.fullname" . }}

--- a/stable/sonarqube/templates/ingress.yaml
+++ b/stable/sonarqube/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "sonarqube.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "sonarqube.fullname" . }}

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -8,7 +8,7 @@ deploymentStrategy: {}
 
 image:
   repository: sonarqube
-  tag: 7.9.1-community
+  tag: 7.9.2-community
   # If using a private repository, the name of the imagePullSecret to use
   # pullSecret: my-repo-secret
 


### PR DESCRIPTION
Also updates ingress apiVersion, adding support for later k8s versions.
(Modernizes documentaiton accordingly.)

Signed-off-by: Usman Akeju <akeju00+github@gmail.com>

#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

Nope!

#### What this PR does / why we need it:

It upgrades the stable SonarQube chart to refer to the latest patch of its LTS version.
It also makes the chart installable on Kubernetes >= 1.16. (see also #19023)

#### Which issue this PR fixes

  - fixes #19652, fixes #19723, fixes #18999

#### Special notes for your reviewer:

I had to add the `apiVersion` update in order to test it.
As such, this pull request can probably supersede #19023.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
