### PR TITLE
[stable/openebs] Add PodSecurityPolicy (PSP)

### DIFF
--- a/stable/openebs/Chart.yaml
+++ b/stable/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 1.5.0
+version: 1.5.1
 name: openebs
 appVersion: 1.5.0
 description: Containerized Storage for Containers

--- a/stable/openebs/README.md
+++ b/stable/openebs/README.md
@@ -38,6 +38,7 @@ The following table lists the configurable parameters of the OpenEBS chart and t
 | Parameter                               | Description                                   | Default                                   |
 | ----------------------------------------| --------------------------------------------- | ----------------------------------------- |
 | `rbac.create`                           | Enable RBAC Resources                         | `true`                                    |
+| `rbac.pspEnabled`                       | Create pod security policy resources          | `false`                                   |
 | `image.pullPolicy`                      | Container pull policy                         | `IfNotPresent`                            |
 | `apiserver.enabled`                     | Enable API Server                             | `true`                                    |
 | `apiserver.image`                       | Image for API Server                          | `quay.io/openebs/m-apiserver`             |

--- a/stable/openebs/templates/psp-clusterrole.yaml
+++ b/stable/openebs/templates/psp-clusterrole.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.rbac.create .Values.rbac.pspEnabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "openebs.fullname" . }}-psp
+  labels:
+    app: {{ template "openebs.name" . }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "openebs.fullname" . }}-psp
+{{- end }}

--- a/stable/openebs/templates/psp-clusterrolebinding.yaml
+++ b/stable/openebs/templates/psp-clusterrolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.rbac.create .Values.rbac.pspEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "openebs.fullname" . }}-psp
+  labels:
+    app: {{ template "openebs.name" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "openebs.fullname" . }}-psp
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "openebs.serviceAccountName" . }}
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
+

--- a/stable/openebs/templates/psp.yaml
+++ b/stable/openebs/templates/psp.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.rbac.create .Values.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "openebs.fullname" . }}-psp
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: {{ template "openebs.name" . }}
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities: ['*']
+  volumes: ['*']
+  hostNetwork: true
+  hostPorts:
+  - min: 0
+    max: 65535
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+{{- end }}

--- a/stable/openebs/values.yaml
+++ b/stable/openebs/values.yaml
@@ -5,6 +5,7 @@
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
+  pspEnabled: false
 
 serviceAccount:
   create: true


### PR DESCRIPTION
#### What this PR does / why we need it:

In order to run in namespace other than kube-system on cluster with
PSP enabled, we need to allow openebs serviceaccount to launch
privileged containers.

The PSP is taken from [0].

[0] https://docs.openebs.io/v081/docs/next/faq.html#how-to-setup-default-podsecuritypolicy-to-allow-the-openebs-pods-to-work-with-all-permissions

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
