### PR TITLE
[stable/coredns]: Fix incorrect rendering

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: coredns
-version: 1.8.1
+version: 1.8.2
 appVersion: 1.6.6
 description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services
 keywords:

--- a/stable/coredns/templates/podsecuritypolicy.yaml
+++ b/stable/coredns/templates/podsecuritypolicy.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.rbac.pspEnable }}
-{{- if .Capabilities.APIVersions.Has "extensions/v1beta1" -}}
-apiVersion: extensions/v1beta1
-{{- else if .Capabilities.APIVersions.Has "policy/v1beta1" -}}
+{{ if .Capabilities.APIVersions.Has "policy/v1beta1" }}
 apiVersion: policy/v1beta1
-{{- end -}}
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end -}}
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "coredns.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes previous [PR](https://github.com/helm/charts/pull/19795). I messed up and it didn't generate the chart correctly. It failed with the error:
`Error: YAML parse error on coredns/templates/podsecuritypolicy.yaml: error converting YAML to JSON: yaml: mapping values are not allowed in this context
`

This PR fixes it and also defaults to `extensions/v1beta1`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
