### PR TITLE
[stable/redis] Correct master host env value

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 10.3.0
+version: 10.3.1
 appVersion: 5.0.7
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/redis-slave-statefulset.yaml
+++ b/stable/redis/templates/redis-slave-statefulset.yaml
@@ -126,7 +126,7 @@ spec:
         - name: REDIS_REPLICATION_MODE
           value: slave
         - name: REDIS_MASTER_HOST
-          value: {{ template "redis.fullname" . }}-master-0.{{ template "redis.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+          value: {{ template "redis.fullname" . }}-master.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
         - name: REDIS_PORT
           value: {{ .Values.redisPort | quote }}
         - name: REDIS_MASTER_PORT_NUMBER


### PR DESCRIPTION
#### What this PR does / why we need it:
The `REDIS_MASTER_HOST` env variable currently passed to slaves currently points to a non-existing service namely `redis-master-0.redis-headless.default.svc.local`. Which is a mix of pod names and services that is never going to work. So this PR changes that to `redis-master.default.svc.local` targeting the redis master service.

#### Which issue this PR fixes
  - fixes #17245 (possibly, for sure the latest comment, but there is a lot going on in that issue)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
