### PR TITLE
[stable/spark-history-server] Remove duplicate configmap keys

### DIFF
--- a/stable/spark-history-server/Chart.yaml
+++ b/stable/spark-history-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: spark-history-server
-version: 1.1.1
+version: 1.1.2
 appVersion: 2.4.0
 description: A Helm chart for Spark History Server
 home: https://spark.apache.org

--- a/stable/spark-history-server/templates/configmap.yaml
+++ b/stable/spark-history-server/templates/configmap.yaml
@@ -16,19 +16,19 @@ data:
   {{ $key }}: {{ $val | quote }}
   {{- end }}
   {{- if .Values.pvc.enablePVC }}
-  {{- range $key, $val := .Values.pvc }}
+  {{- range $key, $val := omit .Values.pvc "enablePVC" }}
   {{ $key }}: {{ $val | quote }}
   {{- end }}
   {{- else if .Values.gcs.enableGCS }}
-  {{- range $key, $val := .Values.gcs }}
+  {{- range $key, $val := omit .Values.gcs "enableGCS" }}
   {{ $key }}: {{ $val | quote }}
   {{- end }}
   {{- else if .Values.s3.enableS3 }}
-  {{- range $key, $val := .Values.s3 }}
+  {{- range $key, $val := omit .Values.s3 "enableS3" }}
   {{ $key }}: {{ $val | quote }}
   {{- end }}
   {{- else if .Values.wasbs.enableWASBS }}
-  {{- range $key, $val := .Values.wasbs }}
+  {{- range $key, $val := omit .Values.wasbs "enableWASBS" }}
   {{ $key }}: {{ $val | quote }}
   {{- end }}
   {{- else }}


### PR DESCRIPTION
The output of the templated chart breaks other templating tools it
may be used in (like YTT). Removing the duplicate configmap keys cleans
up the output, and makes it easier to use elsewhere.

There are [four hardcoded keys][1] at the top of the chart's configmap, which
are duplicated by the loops below them. This PR omits those hardcoded keys from
the loops, preventing them from being duplicated in the configmap.

Duplicate keys in a map aren't valid Yaml, even though Helm is able to handle
them. See [this section in the Yaml spec][2], specifically:

> JSON's RFC4627 requires that mappings keys merely “SHOULD” be unique, while
> YAML insists they “MUST” be. Technically, YAML therefore complies with the
> JSON spec, choosing to treat duplicates as an error. In practice, since JSON
> is silent on the semantics of such duplicates, the only portable JSON files
> are those with unique keys, which are therefore valid YAML files.

Tools that work on the templated output of the chart may fail because they're
unable to handle duplicate keys in Yaml dictionaries.

[1]: https://github.com/helm/charts/blob/fb1752fd9294cdba0c499a7b7736daea49bb8c35/stable/spark-history-server/templates/configmap.yaml#L11-L14
[2]: https://yaml.org/spec/1.2/spec.html#id2759572

Here's the output of the config map's data from current master (comments mine):
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: spark-history-server
data:
  # Four hardcoded keys
  enablePVC: "true"
  enableGCS: "false"
  enableS3: "false"
  enableWASBS: "false"
  # Generated by loops
  enablePVC: "true"
  eventsDir: "/"
  existingClaimName: "spark-history"
```

And here's the output with this PR applied:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: ddm-spark-history-server
data:
  # Four hardcoded keys
  enablePVC: "true"
  enableGCS: "false"
  enableS3: "false"
  enableWASBS: "false"
  # Generated by loops
  eventsDir: "/"
  existingClaimName: "spark-history"
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
