### PR TITLE
[stable/kong] fix whitespace handling for license

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.33.0
+version: 0.33.1
 appVersion: 1.4

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -450,6 +450,11 @@ value is your SMTP password.
 
 ## Changelog
 
+### 0.33.1
+
+#### Fixed
+
+- Correct an issue with whitespace handling within `final_env` helper.
 
 ### 0.33.0
 

--- a/stable/kong/templates/_helpers.tpl
+++ b/stable/kong/templates/_helpers.tpl
@@ -457,7 +457,7 @@ the template that it itself is using form the above sections.
 - name: KONG_SMTP_MOCK
   value: "on"
 {{- end }}
-{{- include "kong.license" . }}
+{{ include "kong.license" . }}
 {{- end }}
 - name: KONG_NGINX_HTTP_INCLUDE
   value: /kong/servers.conf


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
Do not chomp leading whitespace prior to including kong.license within
the final_env helper. Doing so appends the license block immediately
after the preceding value, generating invalid YAML.

#### Which issue this PR fixes
Fix an issue that generated invalid YAML when Enterprise is enabled. Currently, `final_env` will render something like:
```
        - name: KONG_SMTP_MOCK
          value: "on"- name: KONG_LICENSE_DATA
          valueFrom:
            secretKeyRef:
              name: license
              key: license
```
This change adjusts it to instead render:
```
        - name: KONG_SMTP_MOCK
          value: "on"
        - name: KONG_LICENSE_DATA
          valueFrom:
            secretKeyRef:
              name: license
              key: license
```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
