### PR TITLE
[stable/spotify-docker-gc] Switch away from the deprecated api for daemonset

### DIFF
--- a/stable/spotify-docker-gc/Chart.yaml
+++ b/stable/spotify-docker-gc/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: spotify-docker-gc
 home: https://github.com/spotify/docker-gc
-version: 1.0.0
+version: 1.0.1
 appVersion: latest
 description: A simple Docker container and image garbage collection script.
 sources:

--- a/stable/spotify-docker-gc/templates/daemonset.yaml
+++ b/stable/spotify-docker-gc/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "name" . }}

--- a/stable/spotify-docker-gc/templates/daemonset.yaml
+++ b/stable/spotify-docker-gc/templates/daemonset.yaml
@@ -7,6 +7,9 @@ spec:
   updateStrategy:
     type: RollingUpdate
   {{- end }}
+  selector:
+    matchLabels:
+      daemonset: {{ template "name" . }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
Signed-off-by: Gavin Mogan <git@gavinmogan.com>

@vdice 

#### What this PR does / why we need it:

#### Which issue this PR fixes

Replaces the deprecated apiVersion (see https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/)

#### Special notes for your reviewer:

Will break on older k8s, but i think its a safe upgrade now, people who won't upgrade can pin old version.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
