### PR TITLE
[stable/oauth2-proxy] Fixes to make Google templates work

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 name: oauth2-proxy
-version: 2.1.1
+version: 2.1.2
 apiVersion: v1
-appVersion: 4.0.0
+appVersion: 4.1.0
 home: https://pusher.github.io/oauth2_proxy/
 description: A reverse proxy that provides authentication with Google, Github or other providers
 keywords:

--- a/stable/oauth2-proxy/templates/_helpers.tpl
+++ b/stable/oauth2-proxy/templates/_helpers.tpl
@@ -41,3 +41,14 @@ Get the secret name.
 {{- printf "%s" (include "oauth2-proxy.fullname" .) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Get the secret name.
+*/}}
+{{- define "oauth2-proxy.googleSecretName" -}}
+{{- if .Values.config.google.existingSecret -}}
+{{- printf "%s" .Values.config.google.existingSecret -}}
+{{- else -}}
+{{- printf "%s-google" (include "oauth2-proxy.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/stable/oauth2-proxy/templates/deployment.yaml
+++ b/stable/oauth2-proxy/templates/deployment.yaml
@@ -144,7 +144,7 @@ spec:
 {{- if and .adminEmail (or .serviceAccountJson .existingSecret) }}
       - name: google-secret
         secret:
-          secretName: {{ if .existingSecret }}{{ .existingSecret }}{{ else }} {{ template "oauth2-proxy.secretName" . }}{{ end }}
+          secretName: {{ if .existingSecret }}{{ .existingSecret }}{{ else }} {{ template "oauth2-proxy.googleSecretName" $ }}{{ end }}
 {{- end }}
 {{- end }}
 

--- a/stable/oauth2-proxy/templates/google-secret.yaml
+++ b/stable/oauth2-proxy/templates/google-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.config.google (not .Values.config.google.existingSecret) }}
+{{- if and .Values.config.google .Values.config.google.serviceAccountJson (not .Values.config.google.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
- Also upgrade oauth-proxy to 4.1.0

#### Is this a new chart

No

#### What this PR does / why we need it:

Template isn't valid / doesn't compile if there's a "google" field in the values.yaml data.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
