### PR TITLE
[stable/datadog] fix `useConfigMap` when `useDedicatedContainers=true`

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.39.0
+version: 1.39.1
 appVersion: "7"
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/container-agent.yaml
+++ b/stable/datadog/templates/container-agent.yaml
@@ -121,6 +121,11 @@
   volumeMounts:
     - name: config
       mountPath: /etc/datadog-agent
+    {{- if .Values.daemonset.useConfigMap }}
+    - name: {{ template "datadog.fullname" . }}-datadog-yaml
+      mountPath: /etc/datadog-agent/datadog.yaml
+      subPath: datadog.yaml
+    {{- end }}
     {{- if .Values.datadog.useCriSocketVolume }}
     - name: runtimesocket
       mountPath: {{ default "/var/run/docker.sock" .Values.datadog.criSocketPath | quote }}

--- a/stable/datadog/templates/container-process-agent.yaml
+++ b/stable/datadog/templates/container-process-agent.yaml
@@ -21,6 +21,11 @@
 {{ toYaml .Values.daemonset.containers.processAgent.env | indent 4 }}
 {{- end }}
   volumeMounts:
+    {{- if .Values.daemonset.useConfigMap }}
+    - name: {{ template "datadog.fullname" . }}-datadog-yaml
+      mountPath: /etc/datadog-agent/datadog.yaml
+      subPath: datadog.yaml
+    {{- end }}
     - name: cgroups
       mountPath: /host/sys/fs/cgroup
       readOnly: true

--- a/stable/datadog/templates/container-trace-agent.yaml
+++ b/stable/datadog/templates/container-trace-agent.yaml
@@ -24,6 +24,11 @@
   volumeMounts:
     - name: config
       mountPath: /etc/datadog-agent
+    {{- if .Values.daemonset.useConfigMap }}
+    - name: {{ template "datadog.fullname" . }}-datadog-yaml
+      mountPath: /etc/datadog-agent/datadog.yaml
+      subPath: datadog.yaml
+    {{- end }}
   livenessProbe:
     tcpSocket:
       port: 8126


### PR DESCRIPTION
#### What this PR does / why we need it:

in `stable/datadog` if a user set `useDedicatedContainers=true` the option `useConfigMap` is not used properly.

**reason:** the configmap was not mounted in the different containers used with the option `useDedicatedContainers .
**fix:** add volumeMount confimap entry in each container spec.

#### Which issue this PR fixes

  - fixes #19602

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
