### PR TITLE
[stable/jenkins] fix deprecated config name used

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.9.14
+
+Properly fix case sense in `Values.master.overwriteConfig` in `config.yaml`
+
 ## 1.9.13
 
 Fix case sense in `Values.master.overwriteConfig` in `config.yaml`

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.9.13
+version: 1.9.14
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -256,7 +256,7 @@ data:
     yes n | cp -i /usr/share/jenkins/ref/plugins/* /var/jenkins_plugins/;
 {{- end }}
 {{- if .Values.master.scriptApproval }}
-  {{- if .Values.master.OverwriteConfig }}
+  {{- if .Values.master.overwriteConfig }}
     cp /var/jenkins_config/scriptapproval.xml /var/jenkins_home/scriptApproval.xml;
   {{- else }}
     yes n | cp -i /var/jenkins_config/scriptapproval.xml /var/jenkins_home/scriptApproval.xml;


### PR DESCRIPTION
#### Is this a new chart
NO

#### What this PR does / why we need it:
This fixes the usage of deprecated config value name OverwriteConfig used in templates

#### Which issue this PR fixes
 - fixes #19878

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
