### PR TITLE
[stable/kong] fix Job securityContext indentation

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -11,5 +11,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.34.0
+version: 0.34.1
 appVersion: 1.4

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -450,6 +450,18 @@ value is your SMTP password.
 
 ## Changelog
 
+### 0.34.1
+
+#### Fixed
+
+- Correct indentation for Job securityContexts.
+
+### 0.34.0
+
+#### New features
+
+- Update default version of Ingress Controller to 0.7.0
+
 ### 0.33.1
 
 #### Fixed

--- a/stable/kong/templates/migrations-post-upgrade.yaml
+++ b/stable/kong/templates/migrations-post-upgrade.yaml
@@ -46,7 +46,7 @@ spec:
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
       securityContext:
-      {{- include "kong.podsecuritycontext" . | nindent 6 }}
+      {{- include "kong.podsecuritycontext" . | nindent 8 }}
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}

--- a/stable/kong/templates/migrations-pre-upgrade.yaml
+++ b/stable/kong/templates/migrations-pre-upgrade.yaml
@@ -46,7 +46,7 @@ spec:
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
       securityContext:
-      {{- include "kong.podsecuritycontext" . | nindent 6 }}
+      {{- include "kong.podsecuritycontext" . | nindent 8 }}
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}

--- a/stable/kong/templates/migrations.yaml
+++ b/stable/kong/templates/migrations.yaml
@@ -41,7 +41,7 @@ spec:
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
       securityContext:
-      {{- include "kong.podsecuritycontext" . | nindent 6 }}
+      {{- include "kong.podsecuritycontext" . | nindent 8 }}
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
* Add an additional level of indentation to Job securityContexts. Previously, the context contents would render incorrectly at the same level as the `securityContext` header.
* README/version updates, including a retroactive update for the controller default change in 7315ed65514a2249b76452db249aa3c655e2fd80.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
