### PR TITLE
[stable/minio] fix handling of extraArgs config

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: MinIO is a high performance data infrastructure for machine learning, analytics and application data workloads.
 name: minio
-version: 5.0.3
+version: 5.0.4
 appVersion: master
 keywords:
 - storage

--- a/stable/minio/templates/_helpers.tpl
+++ b/stable/minio/templates/_helpers.tpl
@@ -85,3 +85,12 @@ Determine service account name for deployment or statefulset.
 {{- default "default" .Values.serviceAccount.name -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Properly format optional additional arguments to Minio binary
+*/}}
+{{- define "minio.extraArgs" -}}
+{{- range .Values.extraArgs -}}
+,{{ . | quote }}
+{{- end -}}
+{{- end -}}

--- a/stable/minio/templates/deployment.yaml
+++ b/stable/minio/templates/deployment.yaml
@@ -72,46 +72,49 @@ spec:
           {{- if .Values.s3gateway.enabled }}
           command: [ "/bin/sh",
           "-ce",
-          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway s3 {{ .Values.s3gateway.serviceEndpoint }}" ]
+          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway s3 {{ .Values.s3gateway.serviceEndpoint }}"
+          {{- template "minio.extraArgs" . }} ]
           {{- else }}
           {{- if .Values.azuregateway.enabled }}
           command: [ "/bin/sh",
           "-ce",
-          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway azure" ]
+          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway azure"
+          {{- template "minio.extraArgs" . }} ]
           {{- else }}
           {{- if .Values.gcsgateway.enabled }}
           command: [ "/bin/sh",
           "-ce",
-          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway gcs {{ .Values.gcsgateway.projectId }}" ]
+          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway gcs {{ .Values.gcsgateway.projectId }}"
+          {{- template "minio.extraArgs" . }} ]
           {{- else }}
           {{- if .Values.ossgateway.enabled }}
           command: [ "/bin/sh",
           "-ce",
-          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway oss {{ .Values.ossgateway.endpointURL }}" ]
+          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway oss {{ .Values.ossgateway.endpointURL }}"
+          {{- template "minio.extraArgs" . }} ]
           {{- else }}
           {{- if .Values.nasgateway.enabled }}
           command: [ "/bin/sh",
           "-ce",
-          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway nas {{ $bucketRoot }}" ]
+          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway nas {{ $bucketRoot }}"
+          {{- template "minio.extraArgs" . }} ]
           {{- else }}
           {{- if .Values.b2gateway.enabled }}
           command: [ "/bin/sh",
           "-ce",
-          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway b2" ]
+          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway b2"
+          {{- template "minio.extraArgs" . }} ]
           {{- else }}
           command: [ "/bin/sh",
           "-ce",
-          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} server {{ $bucketRoot }}" ]
+          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} server {{ $bucketRoot }}"
+          {{- template "minio.extraArgs" . }} ]
           {{- end }}
           {{- end }}
           {{- end }}
           {{- end }}
           {{- end }}
           {{- end }}
-          {{- if .Values.extraArgs }}
-          args:
-{{ toYaml .Values.extraArgs | indent 12 }}
-          {{- end  }}
           volumeMounts:
             {{- if and .Values.persistence.enabled (not .Values.gcsgateway.enabled) (not .Values.azuregateway.enabled) (not .Values.s3gateway.enabled) (not .Values.b2gateway.enabled) }}
             - name: export

--- a/stable/minio/templates/statefulset.yaml
+++ b/stable/minio/templates/statefulset.yaml
@@ -82,11 +82,11 @@ spec:
         - name: {{ .Chart.Name }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: [ "/bin/sh", "-ce", "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} server {{- range $i := until $zoneCount }}{{ $factor := mul $i $nodeCount }}{{ $endIndex := add $factor $nodeCount }}{{ $beginIndex := mul $i $nodeCount }}  {{ $scheme }}://{{ template `minio.fullname` $ }}-{{ `{` }}{{ $beginIndex }}...{{ sub $endIndex 1 }}{{ `}`}}.{{ template `minio.fullname` $ }}-svc.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}{{if (gt $drivesPerNode 1)}}{{ $bucketRoot }}-{{ `{` }}0...{{ sub $drivesPerNode 1 }}{{ `}` }}{{else}}{{ $bucketRoot }}{{end}}{{- end}}" ]
-          {{- if .Values.extraArgs }}
-          args:
-{{ toYaml .Values.extraArgs | indent 12 }}
-          {{- end  }}
+
+          command: [ "/bin/sh",
+            "-ce",
+            "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} server {{- range $i := until $zoneCount }}{{ $factor := mul $i $nodeCount }}{{ $endIndex := add $factor $nodeCount }}{{ $beginIndex := mul $i $nodeCount }}  {{ $scheme }}://{{ template `minio.fullname` $ }}-{{ `{` }}{{ $beginIndex }}...{{ sub $endIndex 1 }}{{ `}`}}.{{ template `minio.fullname` $ }}-svc.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}{{if (gt $drivesPerNode 1)}}{{ $bucketRoot }}-{{ `{` }}0...{{ sub $drivesPerNode 1 }}{{ `}` }}{{else}}{{ $bucketRoot }}{{end}}{{- end}}"
+          {{- template "minio.extraArgs" . }} ]
           volumeMounts:
             {{- if $penabled }}
             {{- if (gt $drivesPerNode 1) }}


### PR DESCRIPTION
#### What this PR does / why we need it:  

Starting with v3.0.0 of this Helm Chart, the extraArgs configuration value stopped working,
as it was not passed through the Minio binary.

This fix adds the parameters directly to the Entrypoint command.

#### Which issue this PR fixes

  - fixes #19903

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
