### PR TITLE
[stable/ghost] Provide a way to disable readiness/liveness probes

### DIFF
--- a/stable/ghost/Chart.yaml
+++ b/stable/ghost/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ghost
-version: 9.0.4
+version: 9.1.0
 appVersion: 3.1.1
 description: A simple, powerful publishing platform that allows you to share your stories with the world
 keywords:

--- a/stable/ghost/README.md
+++ b/stable/ghost/README.md
@@ -53,7 +53,7 @@ The following table lists the configurable parameters of the Ghost chart and the
 |-------------------------------------|---------------------------------------------------------------|----------------------------------------------------------|
 | `global.imageRegistry`              | Global Docker image registry                                  | `nil`                                                    |
 | `global.imagePullSecrets`           | Global Docker registry secret names as an array               | `[]` (does not add image pull secrets to deployed pods)  |
-| `global.storageClass`                     | Global storage class for dynamic provisioning                                               | `nil`                                                        |
+| `global.storageClass`               | Global storage class for dynamic provisioning                 | `nil`                                                    |
 | `image.registry`                    | Ghost image registry                                          | `docker.io`                                              |
 | `image.repository`                  | Ghost Image name                                              | `bitnami/ghost`                                          |
 | `image.tag`                         | Ghost Image tag                                               | `{TAG_NAME}`                                             |
@@ -63,7 +63,7 @@ The following table lists the configurable parameters of the Ghost chart and the
 | `fullnameOverride`                  | String to fully override ghost.fullname template with a string                                     | `nil`               |
 | `volumePermissions.image.registry`  | Init container volume-permissions image registry              | `docker.io`                                              |
 | `volumePermissions.image.repository`| Init container volume-permissions image name                  | `bitnami/minideb`                                        |
-| `volumePermissions.image.tag`       | Init container volume-permissions image tag                   | `stretch`                                                 |
+| `volumePermissions.image.tag`       | Init container volume-permissions image tag                   | `stretch`                                                |
 | `volumePermissions.image.pullPolicy`| Init container volume-permissions image pull policy           | `Always`                                                 |
 | `ghostHost`                         | Ghost host to create application URLs                         | `nil`                                                    |
 | `ghostPort`                         | Ghost port to use in application URLs (defaults to `service.port` if `nil`) | `nil`                                      |
@@ -80,6 +80,18 @@ The following table lists the configurable parameters of the Ghost chart and the
 | `smtpFromAddress`                   | SMTP from address                                             | `nil`                                                    |
 | `smtpService`                       | SMTP service                                                  | `nil`                                                    |
 | `allowEmptyPassword`                | Allow DB blank passwords                                      | `yes`                                                    |
+| `livenessProbe.enabled`             | Would you like a livenessProbe to be enabled                  | `true`                                                   |
+| `livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated                      | 120                                                      |
+| `livenessProbe.periodSeconds`       | How often to perform the probe                                | 3                                                        |
+| `livenessProbe.timeoutSeconds`      | When the probe times out                                      | 5                                                        |
+| `livenessProbe.failureThreshold`    | Minimum consecutive failures to be considered failed          | 6                                                        |
+| `livenessProbe.successThreshold`    | Minimum consecutive successes to be considered successful     | 1                                                        |
+| `readinessProbe.enabled`            | Would you like a readinessProbe to be enabled                 | `true`                                                   |
+| `readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated                     | 30                                                       |
+| `readinessProbe.periodSeconds`      | How often to perform the probe                                | 3                                                        |
+| `readinessProbe.timeoutSeconds`     | When the probe times out                                      | 5                                                        |
+| `readinessProbe.failureThreshold`   |  Minimum consecutive failures to be considered failed         | 6                                                        |
+| `readinessProbe.successThreshold`   | Minimum consecutive successes to be considered successful     | 1                                                        |
 | `securityContext.enabled`           | Enable security context                                       | `true`                                                   |
 | `securityContext.fsGroup`           | Group ID for the container                                    | `1001`                                                   |
 | `securityContext.runAsUser`         | User ID for the container                                     | `1001`                                                   |

--- a/stable/ghost/templates/NOTES.txt
+++ b/stable/ghost/templates/NOTES.txt
@@ -36,7 +36,7 @@ host. To configure Ghost with the URL of your service:
 
   echo Blog URL  : http://127.0.0.1:{{ default "80" .Values.service.port }}{{ .Values.ghostPath }}
   echo Admin URL : http://127.0.0.1:{{ default "80" .Values.service.port }}{{ .Values.ghostPath }}ghost
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "ghost.fullname" . }} {{ default "80" .Values.service.port }}:2368
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "ghost.fullname" . }} {{ default "80" .Values.service.port }}:{{ default "80" .Values.service.port }}
 
 {{- else if eq .Values.service.type "NodePort" }}
   export APP_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/stable/ghost/templates/deployment.yaml
+++ b/stable/ghost/templates/deployment.yaml
@@ -131,6 +131,7 @@ spec:
         ports:
         - name: http
           containerPort: 2368
+        {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
             path: {{ .Values.ghostPath }}
@@ -142,9 +143,13 @@ spec:
             - name: X-Forwarded-Proto
               value: https
             {{- end }}
-          initialDelaySeconds: 120
-          timeoutSeconds: 5
-          failureThreshold: 6
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
             path: {{ .Values.ghostPath }}
@@ -156,11 +161,15 @@ spec:
             - name: X-Forwarded-Proto
               value: https
             {{- end }}
-          initialDelaySeconds: 30
-          timeoutSeconds: 3
-          periodSeconds: 5
-        resources:
-{{ toYaml .Values.resources | indent 10 }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.resources }}
+        resources: {{- toYaml .Values.resources | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - name: ghost-data
           mountPath: /bitnami/ghost

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -94,6 +94,24 @@ allowEmptyPassword: "yes"
 # smtpFromAddress
 # smtpService:
 
+## Configure extra options for liveness and readiness probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+##
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 6
+  successThreshold: 1
+
 ##
 ## External database configuration
 ##


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### Is this a new chart

No

#### What this PR does / why we need it:

Currently, there's no way to disable readiness/liveness probes unless you modify the Ghost manifests.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
