### PR TITLE
[stable/prometheus-operator] Add image pull secrets to prometheus operator

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.5.4
+version: 8.5.5
 appVersion: 0.34.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
@@ -115,4 +115,8 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Add imagePullSecrets to prometheus operator deployment to allow pulling images from private repos

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

@vsliouniaev @bismarck @gianrubio