### PR TITLE
[stable/datadog] fix dd_site and dd_dd_url env var

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.39.1
+version: 1.39.2
 appVersion: "7"
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/container-agent.yaml
+++ b/stable/datadog/templates/container-agent.yaml
@@ -21,14 +21,6 @@
     - name: DD_CLUSTER_NAME
       value: {{ .Values.datadog.clusterName | quote }}
     {{- end }}
-    {{- if .Values.datadog.site }}
-    - name: DD_SITE
-      value: {{ .Values.datadog.site | quote }}
-    {{- end }}
-    {{- if .Values.datadog.dd_url }}
-    - name: DD_DD_URL
-      value: {{ .Values.datadog.dd_url | quote }}
-    {{- end }}
     {{- if .Values.datadog.logLevel }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.daemonset.containers.agent.logLevel | default .Values.datadog.logLevel | quote }}

--- a/stable/datadog/templates/containers-common-env.yaml
+++ b/stable/datadog/templates/containers-common-env.yaml
@@ -22,4 +22,12 @@
 {{- end }}
 - name: KUBERNETES
   value: "yes"
+{{- if .Values.datadog.site }}
+- name: DD_SITE
+  value: {{ .Values.datadog.site | quote }}
+{{- end }}
+{{- if .Values.datadog.dd_url }}
+- name: DD_DD_URL
+  value: {{ .Values.datadog.dd_url | quote }}
+{{- end }}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix the usage of the `.Values.datadog.site` and `.Values.datadog.dd_url`
parameters when `.Values.daemonset.useDedicatedContainers` is activated.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
