### PR TITLE
[stable/kong] Improve deployment label selector to not change on chart upgrades

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: harry@konghq.com
 name: kong
 sources:
-version: 0.35.1
+version: 0.36.0
 appVersion: 1.4

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -461,6 +461,19 @@ value is your SMTP password.
 
 ## Changelog
 
+### 0.36.0
+
+#### Upgrade Instructions
+
+- When upgrading from <0.35.0, in-place chart upgrades will fail.
+  It is necessary to delete the helm release with `helm del --purge $RELEASE` and redeploy from scratch.
+  Note that this will cause downtime for the kong proxy. 
+
+#### Improvements 
+
+- Fixed Deployment's label selector that prevented in-place chart upgrades.
+ 
+
 ### 0.35.1
 
 > PR https://github.com/helm/charts/pull/19914

--- a/stable/kong/templates/_helpers.tpl
+++ b/stable/kong/templates/_helpers.tpl
@@ -18,11 +18,17 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "kong.metaLabels" -}}
-apps.kubernetes.io/app: {{ template "kong.name" . }}
+app.kubernetes.io/name: {{ template "kong.name" . }}
 helm.sh/chart: {{ template "kong.chart" . }}
 app.kubernetes.io/instance: "{{ .Release.Name }}"
 app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end -}}
+
+{{- define "kong.selectorLabels" -}}
+app.kubernetes.io/name: {{ template "kong.name" . }}
+app.kubernetes.io/component: app
+app.kubernetes.io/instance: "{{ .Release.Name }}"
 {{- end -}}
 
 {{- define "kong.postgresql.fullname" -}}

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -9,8 +9,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "kong.metaLabels" . | nindent 6 }}
-      app.kubernetes.io/component: app
+      {{- include "kong.selectorLabels" . | nindent 6 }}
   {{- if .Values.updateStrategy }}
   strategy:
 {{ toYaml .Values.updateStrategy | indent 4 }}

--- a/stable/kong/templates/service-kong-admin.yaml
+++ b/stable/kong/templates/service-kong-admin.yaml
@@ -31,6 +31,5 @@ spec:
   {{- end }}
     protocol: TCP
   selector:
-    {{- include "kong.metaLabels" . | nindent 4 }}
-    app.kubernetes.io/component: app
+    {{- include "kong.selectorLabels" . | nindent 4 }}
 {{- end -}}

--- a/stable/kong/templates/service-kong-manager.yaml
+++ b/stable/kong/templates/service-kong-manager.yaml
@@ -46,6 +46,5 @@ spec:
     protocol: TCP
   {{- end }}
   selector:
-    {{- include "kong.metaLabels" . | nindent 4 }}
-    app.kubernetes.io/component: app
+    {{- include "kong.selectorLabels" . | nindent 4 }}
 {{- end -}}

--- a/stable/kong/templates/service-kong-portal-api.yaml
+++ b/stable/kong/templates/service-kong-portal-api.yaml
@@ -46,6 +46,5 @@ spec:
     protocol: TCP
   {{- end }}
   selector:
-    {{- include "kong.metaLabels" . | nindent 4 }}
-    app.kubernetes.io/component: app
+    {{- include "kong.selectorLabels" . | nindent 4 }}
 {{- end -}}

--- a/stable/kong/templates/service-kong-portal.yaml
+++ b/stable/kong/templates/service-kong-portal.yaml
@@ -46,6 +46,5 @@ spec:
     protocol: TCP
   {{- end }}
   selector:
-    {{- include "kong.metaLabels" . | nindent 4 }}
-    app.kubernetes.io/component: app
+    {{- include "kong.selectorLabels" . | nindent 4 }}
 {{- end -}}

--- a/stable/kong/templates/service-kong-proxy.yaml
+++ b/stable/kong/templates/service-kong-proxy.yaml
@@ -51,5 +51,4 @@ spec:
   clusterIP: {{ .Values.proxy.clusterIP }}
   {{- end }}
   selector:
-    {{- include "kong.metaLabels" . | nindent 4 }}
-    app.kubernetes.io/component: app
+    {{- include "kong.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION

#### Is this a new chart
No

#### What this PR does / why we need it:
In 0.35.0, the deployment's label selector changed. This adds a note with upgrade instructions because this field is immutable. It also removed the chart-version-specific labels from the label selector so that future upgrades can be performed in-place as well.

#### Which issue this PR fixes
  - fixes https://github.com/helm/charts/pull/19856#issuecomment-571713247

#### Special notes for your reviewer:

Ideally we could offer an upgrade strategy that doesn't require downtime. I'm not sure how feasible that is though.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
