### PR TITLE
[stable/mongodb-replicaset] Fix metrics issue with unquoted --mongodb.uri connection string

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.11.3
+version: 3.11.4
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/templates/_helpers.tpl
+++ b/stable/mongodb-replicaset/templates/_helpers.tpl
@@ -71,7 +71,7 @@ Create the name for the key secret.
   {{- end -}}
 
   {{- if .Values.tls.enabled }}
-  {{- printf "%s?ssl=true&tlsCertificateKeyFile=/work-dir/mongo.pem&tlsCAFile=/ca/tls.crt" $string -}}
+  {{- printf "%s/?ssl=true&tlsCertificateKeyFile=/work-dir/mongo.pem&tlsCAFile=/ca/tls.crt" $string -}}
   {{- else -}}
   {{- printf $string -}}
   {{- end -}}

--- a/stable/mongodb-replicaset/templates/_helpers.tpl
+++ b/stable/mongodb-replicaset/templates/_helpers.tpl
@@ -71,8 +71,8 @@ Create the name for the key secret.
   {{- end -}}
 
   {{- if .Values.tls.enabled }}
-  {{- printf "%s/?ssl=true&tlsCertificateKeyFile=/work-dir/mongo.pem&tlsCAFile=/ca/tls.crt" $string -}}
+  {{- printf "%s/?ssl=true&tlsCertificateKeyFile=/work-dir/mongo.pem&tlsCAFile=/ca/tls.crt" $string | quote -}}
   {{- else -}}
-  {{- printf $string -}}
+  {{- printf $string | quote -}}
   {{- end -}}
 {{- end -}}

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -241,7 +241,7 @@ spec:
             - -c
             - >-
               /bin/mongodb_exporter
-              --mongodb.uri {{ template "mongodb-replicaset.connection-string" . }}
+              --mongodb.uri "{{ template "mongodb-replicaset.connection-string" . }}"
               --mongodb.socket-timeout={{ .Values.metrics.socketTimeout }}
               --mongodb.sync-timeout={{ .Values.metrics.syncTimeout }}
               --web.telemetry-path={{ .Values.metrics.path }}
@@ -284,7 +284,7 @@ spec:
                 - -c
                 - >-
                   /bin/mongodb_exporter
-                  --mongodb.uri {{ template "mongodb-replicaset.connection-string" . }}
+                  --mongodb.uri "{{ template "mongodb-replicaset.connection-string" . }}"
                   --test
             initialDelaySeconds: 30
             periodSeconds: 10

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -241,7 +241,7 @@ spec:
             - -c
             - >-
               /bin/mongodb_exporter
-              --mongodb.uri "{{ template "mongodb-replicaset.connection-string" . }}"
+              --mongodb.uri {{ template "mongodb-replicaset.connection-string" . }}
               --mongodb.socket-timeout={{ .Values.metrics.socketTimeout }}
               --mongodb.sync-timeout={{ .Values.metrics.syncTimeout }}
               --web.telemetry-path={{ .Values.metrics.path }}
@@ -284,7 +284,7 @@ spec:
                 - -c
                 - >-
                   /bin/mongodb_exporter
-                  --mongodb.uri "{{ template "mongodb-replicaset.connection-string" . }}"
+                  --mongodb.uri {{ template "mongodb-replicaset.connection-string" . }}
                   --test
             initialDelaySeconds: 30
             periodSeconds: 10


### PR DESCRIPTION
#### What this PR does / why we need it:
Bugfix

#### Which issue this PR fixes
Fixes bug introduced in pull request #19495

#### Special notes for your reviewer:
Metrics sidecar crashes for more complicated connection uris:
```
$ k describe po dev-mongodb -n dev
...
metrics:
    Container ID:  docker://18cd6a780f6815c95313c09f0241b682fd398ff452c371d63c7928be647918cb
    Image:         bitnami/mongodb-exporter:0.10.0-debian-9-r71
    Image ID:      docker-pullable://bitnami/mongodb-exporter@sha256:efe55f470c321b7108761bbacbe024549945742e0fcd2af6e003f0062ce61312
    Port:          9216/TCP
    Host Port:     0/TCP
    Command:
      sh
      -c
      /bin/mongodb_exporter --mongodb.uri mongodb://$METRICS_USER:$METRICS_PASSWORD@localhost:27017?ssl=true&tlsCertificateKeyFile=/work-dir/mongo.pem&tlsCAFile=/ca/tls.crt --mongodb.socket-timeout=3s --mongodb.sync-timeout=1m --web.telemetry-path=/metrics --web.listen-address=:9216
    State:          Waiting
      Reason:       CrashLoopBackOff
    Last State:     Terminated
      Reason:       Error


$ k logs dev-mongodb-mongodb-replicaset-0 metrics -n dev
sh: 1: --mongodb.socket-timeout=3s: not found
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)