### PR TITLE
[stable/mongodb-replicaset] Added default values to missing keys in Values.yaml

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.11.2
+version: 3.11.3
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -1,3 +1,7 @@
+# Override the name of the chart, which in turn changes the name of the containers, services etc.
+nameOverride: ""
+fullnameOverride: ""
+
 replicas: 3
 port: 27017
 
@@ -12,14 +16,14 @@ podDisruptionBudget: {}
 
 auth:
   enabled: false
+  existingKeySecret: ""
+  existingAdminSecret: ""
+  existingMetricsSecret: ""
   # adminUser: username
   # adminPassword: password
   # metricsUser: metrics
   # metricsPassword: password
   # key: keycontent
-  # existingKeySecret:
-  # existingAdminSecret:
-  # existingMetricsSecret:
 
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.
@@ -99,7 +103,7 @@ tolerations: []
 
 extraLabels: {}
 
-# priorityClassName: ""
+priorityClassName: ""
 
 persistentVolume:
   enabled: true
@@ -110,7 +114,7 @@ persistentVolume:
   ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
   ##   GKE, AWS & OpenStack)
   ##
-  # storageClass: "-"
+  storageClass: ""
   accessModes:
     - ReadWriteOnce
   size: 10Gi
@@ -144,6 +148,7 @@ configmap: {}
 # initMongodStandalone: |+
 #   db = db.getSiblingDB("mydb")
 #   db.my_users.createIndex({email: 1})
+initMongodStandalone: ""
 
 # Readiness probe
 readinessProbe:


### PR DESCRIPTION
Signed-off-by: Jayadeep KM <kmjayadeep@gmail.com>

#### What this PR does / why we need it:
  - fixes #19923

Running `helm lint --strict` throws errors as some of the variables didn't have default values set in Values.yaml, although they are mentioned in Readme. Added all missing values so that running lint shows 0 errors.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
