### PR TITLE
[stable/gocd] removed server.securityContext.fsGroup default value

### DIFF
--- a/stable/gocd/Chart.yaml
+++ b/stable/gocd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 1.21.0
+version: 1.21.1
 appVersion: 19.12.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/stable/gocd/README.md
+++ b/stable/gocd/README.md
@@ -98,14 +98,14 @@ The following tables list the configurable parameters of the GoCD chart and thei
 | `server.ingress.annotations`               | GoCD ingress annotations.                                                                                     | `{}`                |
 | `server.ingress.tls`                       | GoCD ingress TLS configuration.                                                                               | `[]`                |
 | `server.healthCheck.initialDelaySeconds`   | Initial delays in seconds to start the health checks. **Note**:GoCD server start up time.                     | `90`                |
-| `server.healthCheck.periodSeconds`         | GoCD server health check interval period.                                                                      | `15`                |
+| `server.healthCheck.periodSeconds`         | GoCD server health check interval period.                                                                     | `15`                |
 | `server.healthCheck.failureThreshold`      | Number of unsuccessful attempts made to the GoCD server health check endpoint before restarting.              | `10`                |
 | `server.hostAliases`                       | Aliases for IPs in /etc/hosts                                                                                 | `[]`                |
 | `server.security.ssh.enabled`              | Enable the use of SSH keys for GoCD server                                                                    | `false`             |
 | `server.security.ssh.secretName`           | The name of the secret holding the SSH keys                                                                   | `gocd-server-ssh`   |
 | `server.securityContext.runAsUser`         | The container user for all the GoCD server pods.                                                              | `1000`              |
 | `server.securityContext.runAsGroup`        | The container group for all the GoCD server pods.                                                             | `0`                 |
-| `server.securityContext.fsGroup`           | The container supplementary group for all the GoCD server pods.                                               | `0`                 |
+| `server.securityContext.fsGroup`           | The container supplementary group for all the GoCD server pods.                                               | `nil`               |
 | `server.sidecarContainers`                 | Sidecar containers to run alongside GoCD server.                                                              | `[]`                |
 
 #### Preconfiguring the GoCD Server

--- a/stable/gocd/templates/gocd-server-deployment.yaml
+++ b/stable/gocd/templates/gocd-server-deployment.yaml
@@ -36,7 +36,9 @@ spec:
       securityContext:
         runAsUser: {{ .Values.server.securityContext.runAsUser }}
         runAsGroup: {{ .Values.server.securityContext.runAsGroup }}
+        {{- if .Values.server.securityContext.fsGroup }}
         fsGroup: {{ .Values.server.securityContext.fsGroup }}
+        {{- end }}
       serviceAccountName: {{ template "gocd.serviceAccountName" . }}
       {{- if or .Values.server.shouldPreconfigure (or .Values.server.persistence.enabled (or .Values.server.security.ssh.enabled .Values.server.persistence.extraVolumes)) }}
       volumes:

--- a/stable/gocd/values.yaml
+++ b/stable/gocd/values.yaml
@@ -36,7 +36,7 @@ server:
     # Specify the container group for the GoCD server pod
     runAsGroup: 0
     # Specify the container supplementary group for the GoCD server pod
-    fsGroup: 0
+    # fsGroup: 0
   # server.shouldPreconfigure is used to invoke a script to pre configure the elastic agent profile and the plugin settings in the GoCD server.
   # Note: If this value is set to true, then, the serviceAccount.name is configured for the GoCD server pod. The service account token is mounted as a secret and is used in the lifecycle hook.
   # Note: An attempt to preconfigure the GoCD server is made. There are cases where the pre-configuration can fail and the GoCD server starts with an empty config.


### PR DESCRIPTION
#### Is this a new chart

no

#### What this PR does / why we need it:

This pr removes `server.securityContext.fsGroup` default value form values.yaml so that is should be explicitly set. Helm chart users will have the option to set it or not. If this is set by default, configmap files permissions are being set to `0440`, this will be a problem if we mount ssh-keys that needs to be `0400`

securityContext: 0
```
drwxr-sr-x    2 root     root         100 Jan  8 07:51 .
drwxrwsrwt    3 root     root         140 Jan  8 07:51 ..
-r--r-----    1 root     root        3.2K Jan  8 07:51 id_rsa
-r--r-----    1 root     root         735 Jan  8 07:51 id_rsa.pub
-r--r-----    1 root     root        1.3K Jan  8 07:51 known_hosts
```
securityContext: nil
```
drwxr-sr-x    2 root     root         100 Jan  8 07:51 .
drwxrwsrwt    3 root     root         140 Jan  8 07:51 ..
-r--r-----    1 root     root        3.2K Jan  8 07:51 id_rsa
-r--r-----    1 root     root         735 Jan  8 07:51 id_rsa.pub
-r--r-----    1 root     root        1.3K Jan  8 07:51 known_hosts
```

#### Which issue this PR fixes

none

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
