### PR TITLE
[stable/airflow] git-clone volume without initcontainer

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 5.2.4
+version: 5.2.5
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/templates/deployments-scheduler.yaml
+++ b/stable/airflow/templates/deployments-scheduler.yaml
@@ -251,7 +251,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.logsPersistence.existingClaim | default (printf "%s-logs" (include "airflow.fullname" . | trunc 58 )) }}
         {{- end }}
-        {{- if .Values.dags.initContainer.enabled }}
+        {{- if or .Values.dags.initContainer.enabled .Values.dags.git.gitSync.enabled }}
         - name: git-clone
           configMap:
             name: {{ template "airflow.fullname" . }}-git-clone

--- a/stable/airflow/templates/deployments-web.yaml
+++ b/stable/airflow/templates/deployments-web.yaml
@@ -241,7 +241,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.logsPersistence.existingClaim | default (printf "%s-logs" (include "airflow.fullname" . | trunc 58 )) }}
         {{- end }}
-        {{- if .Values.dags.initContainer.enabled }}
+        {{- if or .Values.dags.initContainer.enabled .Values.dags.git.gitSync.enabled }}
         - name: git-clone
           configMap:
             name: {{ template "airflow.fullname" . }}-git-clone

--- a/stable/airflow/templates/statefulsets-workers.yaml
+++ b/stable/airflow/templates/statefulsets-workers.yaml
@@ -227,7 +227,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.logsPersistence.existingClaim | default (printf "%s-logs" (include "airflow.fullname" . | trunc 58 )) }}
         {{- end }}
-        {{- if .Values.dags.initContainer.enabled }}
+        {{- if or .Values.dags.initContainer.enabled .Values.dags.git.gitSync.enabled }}
         - name: git-clone
           configMap:
             name: {{ template "airflow.fullname" . }}-git-clone


### PR DESCRIPTION
#### What this PR does / why we need it:

When using a side-car git-clone container, but not the init-container,
we still need the git-clone volume with the script.
Without this, the helm installation simply fails with kubernetes failing to validate the deployment due to the missing volume

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
