### PR TITLE
[stable/prometheus-pushgateway] Allow to specify nodePort

### DIFF
--- a/stable/prometheus-pushgateway/Chart.yaml
+++ b/stable/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0.1"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.2.10
+version: 1.2.11
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/stable/prometheus-pushgateway/README.md
+++ b/stable/prometheus-pushgateway/README.md
@@ -54,6 +54,7 @@ The following table lists the configurable parameters of the pushgateway chart a
 | `replicaCount`                    | Number of replicas                                                                                                            | `1`                               |
 | `service.type`                    | Service type                                                                                                                  | `ClusterIP`                       |
 | `service.port`                    | The service port                                                                                                              | `9091`                            |
+| `service.nodePort`                | The optional service node port when `service.type` is `NodePort`                                                              | ``                                |
 | `service.targetPort`              | The target port of the container                                                                                              | `9091`                            |
 | `serviceLabels`                   | Labels for service                                                                                                            | `{}`                              |
 | `serviceAccount.create`           | Specifies whether a service account should be created.                                                                        | `true`                            |

--- a/stable/prometheus-pushgateway/templates/service.yaml
+++ b/stable/prometheus-pushgateway/templates/service.yaml
@@ -9,6 +9,9 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort }}
+      {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
       protocol: TCP
       name: http
   selector:


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR allows to specify a nodePort when the service is `NodePort` type.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)