### PR TITLE
[stable/sentry] Makes changing the secreyKey possible

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 3.1.7
+version: 3.2.0
 appVersion: 9.1.2
 keywords:
   - debugging

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -109,7 +109,8 @@ Parameter                                            | Description              
 `email.password`                                     | SMTP password                                                                                              | `nil`
 `email.use_tls`                                      | SMTP TLS for security                                                                                      | `false`
 `email.enable_replies`                               | Allow email replies                                                                                        | `false`
-`email.existingSecret`                               | SMTP password from an existing secret (key must be `smtp-password`)                                        | `nil`
+`email.existingSecret`                               | SMTP password from an existing secret                                                                      | `nil`
+`email.existingSecretKey`                            | Key to get from the `email.existingSecret` secret                                                          | `smtp-password`
 `service.type`                                       | Kubernetes service type                                                                                    | `LoadBalancer`
 `service.name`                                       | Kubernetes service name                                                                                    | `sentry`
 `service.externalPort`                               | Kubernetes external service port                                                                           | `9000`
@@ -126,7 +127,7 @@ Parameter                                            | Description              
 `postgresql.postgresqlDatabase`                      | Postgres database name                                                                                     | `sentry`
 `postgresql.postgresqlUsername`                      | Postgres username                                                                                          | `postgres`
 `postgresql.postgresqlHost`                          | External postgres host                                                                                     | `nil`
-`postgresql.postgresqlPassword`                      | External/Internal postgres password                                                                                 | `nil`
+`postgresql.postgresqlPassword`                      | External/Internal postgres password                                                                        | `nil`
 `postgresql.postgresqlPort`                          | External postgres port                                                                                     | `5432`
 `redis.enabled`                                      | Deploy redis server (see below)                                                                            | `true`
 `redis.host`                                         | External redis host                                                                                        | `nil`

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -129,6 +129,8 @@ Parameter                                            | Description              
 `postgresql.postgresqlHost`                          | External postgres host                                                                                     | `nil`
 `postgresql.postgresqlPassword`                      | External/Internal postgres password                                                                        | `nil`
 `postgresql.postgresqlPort`                          | External postgres port                                                                                     | `5432`
+`postgresql.existingSecret`                          | Name of existing secret to use for the PostgreSQL password                                                 | `nil`
+`postgresql.existingSecretKey`                       | Key to get from the `postgresql.existingSecret` secret                                                     | `postgresql-password`
 `redis.enabled`                                      | Deploy redis server (see below)                                                                            | `true`
 `redis.host`                                         | External redis host                                                                                        | `nil`
 `redis.password`                                     | External redis password                                                                                    | `nil`

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -135,6 +135,8 @@ Parameter                                            | Description              
 `redis.host`                                         | External redis host                                                                                        | `nil`
 `redis.password`                                     | External redis password                                                                                    | `nil`
 `redis.port`                                         | External redis port                                                                                        | `6379`
+`redis.existingSecret`                               | Name of existing secret to use for the Redis password                                                      | `nil`
+`redis.existingSecretKey`                            | Key to get from the `redis.existingSecret` secret                                                          | `redis-password`
 `filestore.backend`                                  | Backend for Sentry Filestore                                                                               | `filesystem`
 `filestore.filesystem.path`                          | Location to store files for Sentry                                                                         | `/var/lib/sentry/files`
 `filestore.filesystem.persistence.enabled`           | Enable Sentry files persistence using PVC                                                                  | `true`

--- a/stable/sentry/templates/_helpers.tpl
+++ b/stable/sentry/templates/_helpers.tpl
@@ -123,6 +123,17 @@ Set redis secret
 {{- end -}}
 
 {{/*
+Set redis secretKey
+*/}}
+{{- define "sentry.redis.secretKey" -}}
+{{- if .Values.redis.enabled -}}
+"redis-password"
+{{- else -}}
+{{- default "redis-password" .Values.redis.existingSecretKey | quote -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Set redis port
 */}}
 {{- define "sentry.redis.port" -}}

--- a/stable/sentry/templates/_helpers.tpl
+++ b/stable/sentry/templates/_helpers.tpl
@@ -79,6 +79,17 @@ Set postgres secret
 {{- end -}}
 
 {{/*
+Set postgres secretKey
+*/}}
+{{- define "sentry.postgresql.secretKey" -}}
+{{- if .Values.postgresql.enabled -}}
+"postgresql-password"
+{{- else -}}
+{{- default "postgresql-password" .Values.postgresql.existingSecretKey | quote -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Set postgres port
 */}}
 {{- define "sentry.postgresql.port" -}}

--- a/stable/sentry/templates/cron-deployment.yaml
+++ b/stable/sentry/templates/cron-deployment.yaml
@@ -77,7 +77,7 @@ spec:
             {{- else }}
               name: {{ template "sentry.postgresql.secret" . }}
             {{- end }}
-              key: postgresql-password
+              key: {{ template "sentry.postgresql.secretKey" . }}
         - name: SENTRY_POSTGRES_HOST
           value: {{ template "sentry.postgresql.host" . }}
         - name: SENTRY_POSTGRES_PORT

--- a/stable/sentry/templates/cron-deployment.yaml
+++ b/stable/sentry/templates/cron-deployment.yaml
@@ -108,10 +108,11 @@ spec:
             secretKeyRef:
             {{- if .Values.email.existingSecret }}
               name: {{ .Values.email.existingSecret }}
+              key: {{ default "smtp-password" .Values.email.existingSecretKey }}
             {{- else }}
               name: {{ template "sentry.fullname" . }}
-            {{- end }}
               key: smtp-password
+            {{- end }}
         - name: SENTRY_EMAIL_USE_TLS
           value: {{ .Values.email.use_tls | quote }}
         - name: SENTRY_SERVER_EMAIL

--- a/stable/sentry/templates/cron-deployment.yaml
+++ b/stable/sentry/templates/cron-deployment.yaml
@@ -91,7 +91,7 @@ spec:
             {{- else }}
               name: {{ template "sentry.redis.secret" . }}
             {{- end }}
-              key: redis-password
+              key: {{ template "sentry.redis.secretKey" . }}
         {{- end }}
         - name: SENTRY_REDIS_HOST
           value: {{ template "sentry.redis.host" . }}

--- a/stable/sentry/templates/hooks/db-init.job.yaml
+++ b/stable/sentry/templates/hooks/db-init.job.yaml
@@ -58,7 +58,7 @@ spec:
             {{- else }}
               name: {{ template "sentry.postgresql.secret" . }}
             {{- end }}
-              key: postgresql-password
+              key: {{ template "sentry.postgresql.secretKey" . }}
         - name: SENTRY_POSTGRES_HOST
           value: {{ template "sentry.postgresql.host" . }}
         - name: SENTRY_POSTGRES_PORT

--- a/stable/sentry/templates/hooks/db-init.job.yaml
+++ b/stable/sentry/templates/hooks/db-init.job.yaml
@@ -72,7 +72,7 @@ spec:
             {{- else }}
               name: {{ template "sentry.redis.secret" . }}
             {{- end }}
-              key: redis-password
+              key: {{ template "sentry.redis.secretKey" . }}
         {{- end }}
         - name: SENTRY_REDIS_HOST
           value: {{ template "sentry.redis.host" . }}

--- a/stable/sentry/templates/hooks/user-create.job.yaml
+++ b/stable/sentry/templates/hooks/user-create.job.yaml
@@ -58,7 +58,7 @@ spec:
             {{- else }}
               name: {{ template "sentry.postgresql.secret" . }}
             {{- end }}
-              key: postgresql-password
+              key: {{ template "sentry.postgresql.secretKey" . }}
         - name: SENTRY_POSTGRES_HOST
           value: {{ template "sentry.postgresql.host" . }}
         - name: SENTRY_POSTGRES_PORT

--- a/stable/sentry/templates/hooks/user-create.job.yaml
+++ b/stable/sentry/templates/hooks/user-create.job.yaml
@@ -72,7 +72,7 @@ spec:
             {{- else }}
               name: {{ template "sentry.redis.secret" . }}
             {{- end }}
-              key: redis-password
+              key: {{ template "sentry.redis.secretKey" . }}
         {{- end }}
         - name: SENTRY_REDIS_HOST
           value: {{ template "sentry.redis.host" . }}

--- a/stable/sentry/templates/secrets.yaml
+++ b/stable/sentry/templates/secrets.yaml
@@ -25,6 +25,6 @@ data:
   {{ if and (.Values.postgresql.existingSecret) (or (not .Values.postgresql.enabled) (.Values.postgresql.password)) }}
   postgresql-password: {{ .Values.postgresql.postgresqlPassword | default "" | b64enc | quote }}
   {{ end }}
-  {{ if and (not .Values.redis.enabled) (.Values.redis.password) }}
+  {{ if and (.Values.postgresql.existingSecret) (not .Values.redis.enabled) (.Values.redis.password) }}
   redis-password: {{ .Values.redis.password | default "" | b64enc | quote }}
   {{ end }}

--- a/stable/sentry/templates/secrets.yaml
+++ b/stable/sentry/templates/secrets.yaml
@@ -22,7 +22,7 @@ data:
   {{ else }}
   user-password: {{ randAlphaNum 16 | b64enc | quote }}
   {{ end }}
-  {{ if or (not .Values.postgresql.enabled) (.Values.postgresql.password) }}
+  {{ if and (.Values.postgresql.existingSecret) (or (not .Values.postgresql.enabled) (.Values.postgresql.password)) }}
   postgresql-password: {{ .Values.postgresql.postgresqlPassword | default "" | b64enc | quote }}
   {{ end }}
   {{ if and (not .Values.redis.enabled) (.Values.redis.password) }}

--- a/stable/sentry/templates/web-deployment.yaml
+++ b/stable/sentry/templates/web-deployment.yaml
@@ -76,7 +76,7 @@ spec:
             {{- else }}
               name: {{ template "sentry.postgresql.secret" . }}
             {{- end }}
-              key: postgresql-password
+              key: {{ template "sentry.postgresql.secretKey" . }}
         - name: SENTRY_POSTGRES_HOST
           value: {{ template "sentry.postgresql.host" . }}
         - name: SENTRY_POSTGRES_PORT

--- a/stable/sentry/templates/web-deployment.yaml
+++ b/stable/sentry/templates/web-deployment.yaml
@@ -90,7 +90,7 @@ spec:
             {{- else }}
               name: {{ template "sentry.redis.secret" . }}
             {{- end }}
-              key: redis-password
+              key: {{ template "sentry.redis.secretKey" . }}
         {{- end }}
         - name: SENTRY_REDIS_HOST
           value: {{ template "sentry.redis.host" . }}

--- a/stable/sentry/templates/workers-deployment.yaml
+++ b/stable/sentry/templates/workers-deployment.yaml
@@ -100,7 +100,7 @@ spec:
             {{- else }}
               name: {{ template "sentry.redis.secret" . }}
             {{- end }}
-              key: redis-password
+              key: {{ template "sentry.redis.secretKey" . }}
         {{- end }}
         - name: SENTRY_REDIS_HOST
           value: {{ template "sentry.redis.host" . }}

--- a/stable/sentry/templates/workers-deployment.yaml
+++ b/stable/sentry/templates/workers-deployment.yaml
@@ -86,7 +86,7 @@ spec:
             {{- else }}
               name: {{ template "sentry.postgresql.secret" . }}
             {{- end }}
-              key: postgresql-password
+              key: {{ template "sentry.postgresql.secretKey" . }}
         - name: SENTRY_POSTGRES_HOST
           value: {{ template "sentry.postgresql.host" . }}
         - name: SENTRY_POSTGRES_PORT

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -197,10 +197,13 @@ postgresql:
   nameOverride: sentry-postgresql
   postgresqlDatabase: sentry
   postgresqlUsername: postgres
-  # Only used when internal PG is disabled
+  # The following variables are only used when internal PG is disabled
   # postgresqlHost: postgres
   # postgresqlPassword: postgres
   # postgresqlPort: 5432
+  # When defined the `postgresqlPassword` field is ignored
+  # existingSecret: secret-name
+  # existingSecretKey: postgresql-password
 
 redis:
   enabled: true

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -92,6 +92,9 @@ email:
   user:
   password:
   enable_replies: false
+  # When defined the `password` field is ignored
+  # existingSecret: secret-name
+  # existingSecretKey: smtp-password
 
 # Name of the service and what port to expose on the pod
 # Don't change these unless you know what you're doing

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -208,11 +208,14 @@ postgresql:
 redis:
   enabled: true
   nameOverride: sentry-redis
-  # Only used when internal redis is disabled
+  # The following variables are only used when internal PG is disabled
   # host: redis
   # Just omit the password field if your redis cluster doesn't use password
   # password: redis
   # port: 6379
+  # When defined the `password` field is ignored
+  # existingSecret: secret-name
+  # existingSecretKey: redis-password
   master:
     persistence:
       enabled: true


### PR DESCRIPTION
#### What this PR does / why we need it:

* Documents the `existingSecret` variables of email, postgres and redis. These variables where already in the (upstream) chart but undocumented in the README and values.yaml
* Makes it possible to set what key to get from the secrets.

In our we cluster we use a postgres-operator which supplies a credentials secret with the password under the `password` key not the `postgres-password` key. This change allows us to keep using the operator for the database.

#### Special notes for your reviewer:
This should be backward compatible since it defaults to the previous hardcoded values.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
