### PR TITLE
[stable/kong] Add missing watch permissions to custom resources

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: harry@konghq.com
 name: kong
 sources:
-version: 0.36.0
+version: 0.36.1
 appVersion: 1.4

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -461,6 +461,12 @@ value is your SMTP password.
 
 ## Changelog
 
+### 0.36.1
+
+#### Fixed
+
+- Added missing watch permission to custom resources
+
 ### 0.36.0
 
 #### Upgrade Instructions

--- a/stable/kong/templates/controller-rbac-resources.yaml
+++ b/stable/kong/templates/controller-rbac-resources.yaml
@@ -122,6 +122,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding


### PR DESCRIPTION

#### Is this a new chart
No

#### What this PR does / why we need it:

Fixes these reoccurring errors in ingress controller 0.7.0:

```
E0108 16:58:11.838821       1 reflector.go:283] pkg/mod/k8s.io/client-go@v0.0.0-20190819141724-e14f31a72a77/tools/cache/reflector.go:98: Failed to watch *v1.KongCredential: unknown (get kongcredentials.configuration.konghq.com)
E0108 16:58:11.934836       1 reflector.go:283] pkg/mod/k8s.io/client-go@v0.0.0-20190819141724-e14f31a72a77/tools/cache/reflector.go:98: Failed to watch *v1.KongPlugin: unknown (get kongplugins.configuration.konghq.com)
E0108 16:58:11.948711       1 reflector.go:283] pkg/mod/k8s.io/client-go@v0.0.0-20190819141724-e14f31a72a77/tools/cache/reflector.go:98: Failed to watch *v1.KongConsumer: unknown (get kongconsumers.configuration.konghq.com)
E0108 16:58:11.949044       1 reflector.go:283] pkg/mod/k8s.io/client-go@v0.0.0-20190819141724-e14f31a72a77/tools/cache/reflector.go:98: Failed to watch *v1.KongIngress: unknown (get kongingresses.configuration.konghq.com)
```
#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
