### PR TITLE
[promethesus-adapter] use the new tag name

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 1.4.0
+version: 2.0.0
 appVersion: v0.5.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/README.md
+++ b/stable/prometheus-adapter/README.md
@@ -4,7 +4,7 @@ Installs the [Prometheus Adapter](https://github.com/DirectXMan12/k8s-prometheus
 
 ## Prerequisites
 
-Kubernetes 1.11+
+Kubernetes 1.14+
 
 ## Installing the Chart
 
@@ -74,9 +74,9 @@ rules:
             resource: node
           namespace:
             resource: namespace
-          pod_name:
+          pod:
             resource: pod
-      containerLabel: container_name
+      containerLabel: container
     memory:
       containerQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>}) by (<<.GroupBy>>)
       nodeQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>,id='/'}) by (<<.GroupBy>>)
@@ -86,9 +86,9 @@ rules:
             resource: node
           namespace:
             resource: namespace
-          pod_name:
+          pod:
             resource: pod
-      containerLabel: container_name
+      containerLabel: container
     window: 3m
 ```
 

--- a/stable/prometheus-adapter/templates/custom-metrics-configmap.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-configmap.yaml
@@ -12,46 +12,46 @@ data:
   config.yaml: |
     rules:
 {{- if .Values.rules.default }}
-    - seriesQuery: '{__name__=~"^container_.*",container_name!="POD",namespace!="",pod_name!=""}'
+    - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
       seriesFilters: []
       resources:
         overrides:
           namespace:
             resource: namespace
-          pod_name:
+          pod:
             resource: pod
       name:
         matches: ^container_(.*)_seconds_total$
         as: ""
-      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>,container_name!="POD"}[5m]))
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[5m]))
         by (<<.GroupBy>>)
-    - seriesQuery: '{__name__=~"^container_.*",container_name!="POD",namespace!="",pod_name!=""}'
+    - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
       seriesFilters:
       - isNot: ^container_.*_seconds_total$
       resources:
         overrides:
           namespace:
             resource: namespace
-          pod_name:
+          pod:
             resource: pod
       name:
         matches: ^container_(.*)_total$
         as: ""
-      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>,container_name!="POD"}[5m]))
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[5m]))
         by (<<.GroupBy>>)
-    - seriesQuery: '{__name__=~"^container_.*",container_name!="POD",namespace!="",pod_name!=""}'
+    - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
       seriesFilters:
       - isNot: ^container_.*_total$
       resources:
         overrides:
           namespace:
             resource: namespace
-          pod_name:
+          pod:
             resource: pod
       name:
         matches: ^container_(.*)$
         as: ""
-      metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>,container_name!="POD"}) by (<<.GroupBy>>)
+      metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>,container!="POD"}) by (<<.GroupBy>>)
     - seriesQuery: '{namespace!="",__name__!~"^container_.*"}'
       seriesFilters:
       - isNot: .*_total$

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -71,9 +71,9 @@ rules:
 #           resource: node
 #         namespace:
 #           resource: namespace
-#         pod_name:
+#         pod:
 #           resource: pod
-#     containerLabel: container_name
+#     containerLabel: container
 #   memory:
 #     containerQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>}) by (<<.GroupBy>>)
 #     nodeQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>,id='/'}) by (<<.GroupBy>>)
@@ -83,9 +83,9 @@ rules:
 #           resource: node
 #         namespace:
 #           resource: namespace
-#         pod_name:
+#         pod:
 #           resource: pod
-#     containerLabel: container_name
+#     containerLabel: container
 #   window: 3m
 
 service:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No

#### What this PR does / why we need it:

Some metrics labels (namely `pod_name` and `container_name`) have been
removed in Kubernetes 1.16 (deprecated for a few releases). This patch
switch to use the new metrics labels so that metrics can be properly
retrieved and parsed from Prometheus.

See more details about the removal of metrics labels here:
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#removed-metrics

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
