### PR TITLE
[stable/sonarqube] Update Ingress to new API Version

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 3.2.7
+version: 3.2.8
 appVersion: 7.9.1
 keywords:
   - coverage

--- a/stable/sonarqube/templates/ingress.yaml
+++ b/stable/sonarqube/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "sonarqube.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "sonarqube.fullname" . }}

--- a/stable/sonarqube/templates/ingress.yaml
+++ b/stable/sonarqube/templates/ingress.yaml
@@ -1,7 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "sonarqube.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "sonarqube.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR update the Ingress API version from `extensions/v1beta1` to `networking.k8s.io/v1beta1`, because the old extensions API is deprecated.

See: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
