### PR TITLE
[stable/prometheus-operator] AlertManager RBAC: move from ClusterRole to Role

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.5.5
+version: 8.5.6
 appVersion: 0.34.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/templates/alertmanager/psp-clusterrole.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/psp-clusterrole.yaml
@@ -1,8 +1,9 @@
 {{- if and .Values.alertmanager.enabled .Values.global.rbac.create .Values.global.rbac.pspEnabled }}
-kind: ClusterRole
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-alertmanager
+  namespace: {{ $.Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-alertmanager
 {{ include "prometheus-operator.labels" . | indent 4 }}

--- a/stable/prometheus-operator/templates/alertmanager/psp-clusterrolebinding.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/psp-clusterrolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.alertmanager.enabled .Values.global.rbac.create .Values.global.rbac.pspEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-alertmanager
   labels:
@@ -8,7 +8,7 @@ metadata:
 {{ include "prometheus-operator.labels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: {{ template "prometheus-operator.fullname" . }}-alertmanager
 subjects:
   - kind: ServiceAccount


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
ClusterRole for PSP access should not be needed.

#### Special notes for your reviewer:

Note that this is more to trigger a discussion. At least, there should be an option to deploy a Role instead of a ClusterRole (if prometheusOperator.namespaces.additional is none? Manually?)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
