### PR TITLE
[stable/prometheus-snmp-exporter] Fix serviceMonitor params

### DIFF
--- a/stable/prometheus-snmp-exporter/Chart.yaml
+++ b/stable/prometheus-snmp-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
-version: 0.0.4
+version: 0.0.5
 appVersion: 0.14.0
 home: https://github.com/prometheus/snmp_exporter
 sources:

--- a/stable/prometheus-snmp-exporter/README.md
+++ b/stable/prometheus-snmp-exporter/README.md
@@ -70,10 +70,13 @@ The following table lists the configurable parameters of the SNMP-Exporter chart
 | `service.type`                         | type of service to create                       | `ClusterIP`                   |
 | `service.port`                         | port for the snmp http service                  | `9116`                        |
 | `service.externalIPs`                  | list of external ips                            | []                            |
-| `rbac.create` 		                     | Use Role-based Access Control		               | `true`	                       |
-| `serviceAccount.create`	               | Should we create a ServiceAccount	             | `true`                 	     |
-| `serviceAccount.name`		               | Name of the ServiceAccount to use               | `null`		                     |
+| `rbac.create`                          | Use Role-based Access Control                   | `true`                        |
+| `serviceAccount.create`                | Should we create a ServiceAccount               | `true`                        |
+| `serviceAccount.name`                  | Name of the ServiceAccount to use               | `null`                        |
 | `serviceMonitor.enabled`               | Enables ServiceMonitor                          | `false`                       |
+| `serviceMonitor.params.enabled`        | Enables params for serviceMonitor               | `false`                       |
+| `serviceMonitor.params.conf.module`    | Module to use for scrapes                       | `[]`                          |
+| `serviceMonitor.params.conf.target`    | List of target(s) to scrape                     | `[]`                          |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/prometheus-snmp-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-snmp-exporter/templates/servicemonitor.yaml
@@ -22,7 +22,8 @@ spec:
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
     {{- end }}
     {{- if .Values.serviceMonitor.params.enabled }}
-{{ toYaml .Values.conf.params.conf | indent 6 }}
+    params:
+{{ toYaml .Values.serviceMonitor.params.conf | indent 6 }}
     {{- end }}
   selector:
     matchLabels:


### PR DESCRIPTION
The template for prometheus-snmp-exporter's serviceMonitor checks
for `.Values.serviceMonitor.params.enabled` but then tries to insert
`.Values.conf.params.conf` instead.

This change was already part of PR #18389 but that was closed due
to inactivity.

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart

No.

#### What this PR does / why we need it:

Fix this issue: 

```
#> helm diff upgrade prometheus-snmp-exporter stable/prometheus-snmp-exporter -f values.yaml
Error: render error in "prometheus-snmp-exporter/templates/servicemonitor.yaml": template: prometheus-snmp-exporter/templates/servicemonitor.yaml:25:17: executing "prometheus-snmp-exporter/templates/servicemonitor.yaml" at <.Values.conf.params.conf>: nil pointer evaluating interface {}.params
render error in "prometheus-snmp-exporter/templates/servicemonitor.yaml": template: prometheus-snmp-exporter/templates/servicemonitor.yaml:25:17: executing "prometheus-snmp-exporter/templates/servicemonitor.yaml" at <.Values.conf.params.conf>: nil pointer evaluating interface {}.params                                                                                                        Error: plugin "diff" exited with error
```
#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
