### PR TITLE
[stable/prometheus-operator] AlertManager RBAC: move from ClusterRole to Role

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.5.9
+version: 8.5.10
 appVersion: 0.34.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/templates/alertmanager/psp-role.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/psp-role.yaml
@@ -1,17 +1,16 @@
 {{- if and .Values.alertmanager.enabled .Values.global.rbac.create .Values.global.rbac.pspEnabled }}
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-alertmanager
+  namespace: {{ $.Release.Namespace }}
   labels:
     app: {{ template "prometheus-operator.name" . }}-alertmanager
 {{ include "prometheus-operator.labels" . | indent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ template "prometheus-operator.fullname" . }}-alertmanager
-subjects:
-  - kind: ServiceAccount
-    name: {{ template "prometheus-operator.alertmanager.serviceAccountName" . }}
-    namespace: {{ $.Release.Namespace }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "prometheus-operator.fullname" . }}-alertmanager
 {{- end }}

--- a/stable/prometheus-operator/templates/alertmanager/psp-rolebinding.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/psp-rolebinding.yaml
@@ -1,15 +1,17 @@
 {{- if and .Values.alertmanager.enabled .Values.global.rbac.create .Values.global.rbac.pspEnabled }}
-kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-alertmanager
   labels:
     app: {{ template "prometheus-operator.name" . }}-alertmanager
 {{ include "prometheus-operator.labels" . | indent 4 }}
-rules:
-- apiGroups: ['extensions']
-  resources: ['podsecuritypolicies']
-  verbs:     ['use']
-  resourceNames:
-  - {{ template "prometheus-operator.fullname" . }}-alertmanager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "prometheus-operator.fullname" . }}-alertmanager
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "prometheus-operator.alertmanager.serviceAccountName" . }}
+    namespace: {{ $.Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:

ClusterRole for PSP access should not be needed or at least should be deactivatable.

According to doc:
`If a RoleBinding (not a ClusterRoleBinding) is used, it will only grant usage for pods being run in the same namespace as the binding. This can be paired with system groups to grant access to all pods run in the namespace:`

#### Special notes for your reviewer:

Note that this is more to trigger a discussion. At least, there should be an option to deploy a Role instead of a ClusterRole (if prometheusOperator.namespaces.additional is none? Manually?)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
