### PR TITLE
[stable/kong] servicemonitor.yaml: error converting YAML to JSON #19956

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: harry@konghq.com
 name: kong
 sources:
-version: 0.36.2
+version: 0.36.3
 appVersion: 1.4

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -461,6 +461,14 @@ value is your SMTP password.
 
 ## Changelog
 
+### 0.36.3
+
+> PR https://github.com/helm/charts/pull/19992
+
+#### Fixed
+
+- Fix spacing in ServiceMonitor when label is specified in config
+
 ### 0.36.2
 
 > PR https://github.com/helm/charts/pull/19955

--- a/stable/kong/templates/servicemonitor.yaml
+++ b/stable/kong/templates/servicemonitor.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
   {{- if .Values.serviceMonitor.labels }}
-    {{ toYaml .Values.serviceMonitor.labels | indent 4 }}
+    {{ toYaml .Values.serviceMonitor.labels | nindent 4 }}
   {{- end }}
 spec:
   endpoints:


### PR DESCRIPTION
## Which issue this PR fixes
Fixes [stable/kong] #19956

#### Special notes for your reviewer:
Attempting to deploy resulted in "kong/templates/servicemonitor.yaml: error converting YAML to JSON: yaml: line 10: did not find expected key"

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
