### PR TITLE
[stable/nginx-ingress] Revert to appVersion 0.26.1

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.28.2
-appVersion: 0.26.2
+version: 1.28.3
+appVersion: 0.26.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -5,7 +5,7 @@ controller:
   name: controller
   image:
     repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-    tag: "0.26.2"
+    tag: "0.26.1"
     pullPolicy: IfNotPresent
     # www-data -> uid 33
     runAsUser: 33


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Reverts nginx-ingress-controller to version 0.26.1

#### Which issue this PR fixes
  - fixes #20001 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
