### PR TITLE
[stable/graylog] Update mongodb-replicaset dependency version.

### DIFF
--- a/stable/graylog/Chart.yaml
+++ b/stable/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: graylog
 home: https://www.graylog.org
-version: 1.5.0
+version: 1.5.1
 appVersion: 3.1
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:

--- a/stable/graylog/requirements.yaml
+++ b/stable/graylog/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
   tags:
     - install-elasticsearch
 - name: mongodb-replicaset
-  version: 3.8.4
+  version: 3.11.2
   repository: https://kubernetes-charts.storage.googleapis.com/
   tags:
     - install-mongodb


### PR DESCRIPTION
#### What this PR does / why we need it:
`requirements.yaml` pulls reference to outdated mongodb-replicaset chart, which fails to install under k8s 1.16+. This PR updates the dependency version to use a more recent mongodb-replicaset chart.

#### Which issue this PR fixes
Fixes #18997, which causes graylog chart to fail due to deprecated API version used by the old mongodb-replicaset chart.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
