### PR TITLE
[stable/sentry] Fix explicit password setting for postgres and redis

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 3.2.0
+version: 3.2.1
 appVersion: 9.1.2
 keywords:
   - debugging

--- a/stable/sentry/templates/secrets.yaml
+++ b/stable/sentry/templates/secrets.yaml
@@ -22,9 +22,9 @@ data:
   {{ else }}
   user-password: {{ randAlphaNum 16 | b64enc | quote }}
   {{ end }}
-  {{ if and (.Values.postgresql.existingSecret) (or (not .Values.postgresql.enabled) (.Values.postgresql.password)) }}
+  {{ if and (not .Values.postgresql.existingSecret) .Values.postgresql.postgresqlPassword }}
   postgresql-password: {{ .Values.postgresql.postgresqlPassword | default "" | b64enc | quote }}
   {{ end }}
-  {{ if and (.Values.postgresql.existingSecret) (not .Values.redis.enabled) (.Values.redis.password) }}
+  {{ if and (not .Values.redis.existingSecret) .Values.redis.password }}
   redis-password: {{ .Values.redis.password | default "" | b64enc | quote }}
   {{ end }}


### PR DESCRIPTION
The last change (#19938) to the chart broke the possibility to explicitly set password for postgres and redis