### PR TITLE
[stable/node-red] Add values of paths for livenessProbe and readinessProbe

### DIFF
--- a/stable/node-red/Chart.yaml
+++ b/stable/node-red/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.2
 description: Node-RED is low-code programming for event-driven applications
 name: node-red
-version: 1.4.0
+version: 1.4.1
 keywords:
   - nodered
   - node-red

--- a/stable/node-red/README.md
+++ b/stable/node-red/README.md
@@ -41,6 +41,8 @@ The following tables lists the configurable parameters of the Node-RED chart and
 | `image.tag`                        | node-red image tag                                                      | `1.0.2-12-minimal`        |
 | `image.pullPolicy`                 | node-red image pull policy                                              | `IfNotPresent`            |
 | `strategyType`                     | Specifies the strategy used to replace old Pods by new ones             | `Recreate`                |
+| `livenessProbePath`                | Default livenessProbe path                                              | `/`                       |
+| `readinessProbePath`               | Default readinessProbe path                                             | `/`                       |
 | `flows`                            | Default flows configuration                                             | `flows.json`              |
 | `safeMode`                         | Setting to true starts Node-RED in safe (not running) mode              | `false`                   |
 | `enableProjects`                   | setting to true starts Node-RED with the projects feature enabled       | `false`                   |

--- a/stable/node-red/templates/deployment.yaml
+++ b/stable/node-red/templates/deployment.yaml
@@ -37,11 +37,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.livenessProbePath }}
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.readinessProbePath }}
               port: http
           env:
             - name: FLOWS

--- a/stable/node-red/values.yaml
+++ b/stable/node-red/values.yaml
@@ -13,6 +13,9 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
+livenessProbePath: /
+readinessProbePath: /
+
 flows: "flows.json"
 safeMode: "false"
 enableProjects: "false"


### PR DESCRIPTION
Signed-off-by: Takashi Ando <ta.ando@lab.acs-jp.com>

#### Is this a new chart
No

#### What this PR does / why we need it:
Allow to change "httpRoot" of Node-RED from default (/) to any other.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
