### PR TITLE
[stable/sentry] fix: reverts changes to sentry secrets template

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 3.2.0
+version: 3.2.1
 appVersion: 9.1.2
 keywords:
   - debugging

--- a/stable/sentry/templates/secrets.yaml
+++ b/stable/sentry/templates/secrets.yaml
@@ -22,9 +22,9 @@ data:
   {{ else }}
   user-password: {{ randAlphaNum 16 | b64enc | quote }}
   {{ end }}
-  {{ if and (.Values.postgresql.existingSecret) (or (not .Values.postgresql.enabled) (.Values.postgresql.password)) }}
+  {{ if or (not .Values.postgresql.enabled) (.Values.postgresql.password) }}
   postgresql-password: {{ .Values.postgresql.postgresqlPassword | default "" | b64enc | quote }}
   {{ end }}
-  {{ if and (.Values.postgresql.existingSecret) (not .Values.redis.enabled) (.Values.redis.password) }}
+  {{ if and (not .Values.redis.enabled) (.Values.redis.password) }}
   redis-password: {{ .Values.redis.password | default "" | b64enc | quote }}
   {{ end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes regression created in #19938 

This if was leftover from an approach later abandoned in favor of the current. Sorry it got merged in, I looked over it when submitting :neckbeard: 

#### Which issue this PR fixes

https://github.com/helm/charts/pull/19938#discussion_r365110150

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
