### PR TITLE
[stable/openvpn] Allow force setting of ipv4 forward for OpenVPN to fix routing issues

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 3.15.0
+version: 3.15.1
 appVersion: 1.1.0
 maintainers:
 - name: jasongwartz

--- a/stable/openvpn/README.md
+++ b/stable/openvpn/README.md
@@ -112,6 +112,7 @@ Parameter | Description | Default
 `openvpn.istio.enabled`              | Enables istio support for openvpn clients                            | `false`
 `openvpn.istio.proxy.port`           | Istio proxy port                                                     | `15001`
 `openvpn.iptablesExtra`              | Custom iptables rules for clients                                    | `[]`
+`openvpn.forceIpv4Forward`           | Force the init script to set sysctl `net.ipv4.ip_forward` to 1       | `false`
 `nodeSelector`                       | Node labels for pod assignment                                       | `{}`
 `tolerations`                        | Tolerations for node taints                                          | `[]`
 
@@ -152,3 +153,8 @@ And optionally (see openvpn.taKey setting):
  `/etc/openvpn/certs/pki/ta.key`
 
 Note: using mounted secret makes creation of new client certificates impossible inside openvpn pod, since easyrsa needs to write in certs directory, which is read-only.
+
+### IPv4 Forward
+
+Certain clusters (i.e. newer versions of Kubernetes on GKE) will not route traffic from the connected clients into the cluster unless sysctl `net.ipv4.ip_forward` is set to 1 (defaults to 0) inside the container.
+Setting `openvpn.forceIpv4Forward` to true will make sure the init script changes this setting. Doing so requires the container to run in privileged mode, so setting this will also set the securityContext to privileged!

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -163,6 +163,10 @@ data:
       sed 's|NETWORK|'"${NETWORK}"'|' -i /etc/openvpn/openvpn.conf
       sed 's|NETMASK|'"${NETMASK}"'|' -i /etc/openvpn/openvpn.conf
 
+{{ if .Values.openvpn.forceIpv4Forward }}
+      sysctl -w net.ipv4.ip_forward=1
+{{ end }}
+
       # exec openvpn process so it receives lifecycle signals
       exec openvpn --config /etc/openvpn/openvpn.conf
   openvpn.conf: |-

--- a/stable/openvpn/templates/openvpn-deployment.yaml
+++ b/stable/openvpn/templates/openvpn-deployment.yaml
@@ -40,6 +40,9 @@ spec:
           {{- end }}
           name: openvpn
         securityContext:
+          {{- if .Values.openvpn.forceIpv4Forward }}
+          privileged: true
+          {{- end }}
           capabilities:
             add:
               - NET_ADMIN

--- a/stable/openvpn/values.yaml
+++ b/stable/openvpn/values.yaml
@@ -107,6 +107,8 @@ openvpn:
   # - -A FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
   # - -A FORWARD -m conntrack --ctstate NEW -d 10.240.0.0/255.255.0.0 -j ACCEPT
   # - -A FORWARD -j REJECT
+  # Force the init script to set sysctl net.ipv4.ip_forward to 1. Note; requires the container to run in privileged mode!
+  forceIpv4Forward: false
 
 
 nodeSelector: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds a setting to the openvpn deployment to force setting sysctl net.ipv4.ip_forward (optionally) to fix routing issues on certain clusters (i.e.; newer ones on GKE).

#### Which issue this PR fixes
fixes #18530, fixes #10749, fixes #6398, fixes #5572

#### Special notes for your reviewer:
Roughly based on #11852 and #11827, but with a switch and the correct security context to make it work.

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

@jasongwartz, @dippynark