### PR TITLE
[stable/kube-state-metrics] Version bump to 1.9.1

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -6,8 +6,8 @@ keywords:
 - monitoring
 - prometheus
 - kubernetes
-version: 2.6.0
-appVersion: 1.9.0
+version: 2.6.1
+appVersion: 1.9.1
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:
 - https://github.com/kubernetes/kube-state-metrics/

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -15,7 +15,7 @@ $ helm install stable/kube-state-metrics
 | Parameter                                    | Description                                                                           | Default                                    |
 |:---------------------------------------------|:--------------------------------------------------------------------------------------|:-------------------------------------------|
 | `image.repository`                           | The image repository to pull from                                                     | quay.io/coreos/kube-state-metrics          |
-| `image.tag`                                  | The image tag to pull from                                                            | `v1.9.0`                                   |
+| `image.tag`                                  | The image tag to pull from                                                            | `v1.9.1`                                   |
 | `image.pullPolicy`                           | Image pull policy                                                                     | `IfNotPresent`                             |
 | `replicas`                                   | Number of replicas                                                                    | `1`                                        |
 | `service.port`                               | The port of the container                                                             | `8080`                                     |

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -2,7 +2,7 @@
 prometheusScrape: true
 image:
   repository: quay.io/coreos/kube-state-metrics
-  tag: v1.9.0
+  tag: v1.9.1
   pullPolicy: IfNotPresent
 
 replicas: 1


### PR DESCRIPTION
https://github.com/kubernetes/kube-state-metrics/releases/tag/v1.9.1

#### Is this a new chart
No
#### What this PR does / why we need it:
Update to 1.9.1

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
