### PR TITLE
[stable/oauth2-proxy] Add posibility for using environment values ins…

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 2.1.1
+version: 2.2.1
 apiVersion: v1
 appVersion: 4.0.0
 home: https://pusher.github.io/oauth2_proxy/

--- a/stable/oauth2-proxy/README.md
+++ b/stable/oauth2-proxy/README.md
@@ -107,7 +107,7 @@ Parameter | Description | Default
 `tolerations` | list of node taints to tolerate | `[]`
 `securityContext.enabled` | enable Kubernetes security context | `false`
 `securityContext.runAsNonRoot` | make sure that the container runs as a non-root user | `true`
-`useEnvironmentNotSecrets` | use environment values instead of secrets for setting up OAUTH2_PROXY variables. When set, remember to add the variables OAUTH2_PROXY_CLIENT_ID, OAUTH2_PROXY_CLIENT_SECRET, OAUTH2_PROXY_COOKIE_SECRET in extraEnv | `false`
+`proxyVarsAsSecrets` | choose between environment values or secrets for setting up OAUTH2_PROXY variables. When set to false, remember to add the variables OAUTH2_PROXY_CLIENT_ID, OAUTH2_PROXY_CLIENT_SECRET, OAUTH2_PROXY_COOKIE_SECRET in extraEnv | `true`
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/oauth2-proxy/README.md
+++ b/stable/oauth2-proxy/README.md
@@ -107,6 +107,7 @@ Parameter | Description | Default
 `tolerations` | list of node taints to tolerate | `[]`
 `securityContext.enabled` | enable Kubernetes security context | `false`
 `securityContext.runAsNonRoot` | make sure that the container runs as a non-root user | `true`
+`useEnvironmentNotSecrets` | use environment values instead of secrets for setting up OAUTH2_PROXY variables. When set, remember to add the variables OAUTH2_PROXY_CLIENT_ID, OAUTH2_PROXY_CLIENT_SECRET, OAUTH2_PROXY_COOKIE_SECRET in extraEnv | `false`
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/oauth2-proxy/templates/deployment.yaml
+++ b/stable/oauth2-proxy/templates/deployment.yaml
@@ -65,6 +65,7 @@ spec:
         {{- if .Values.htpasswdFile.enabled }}
           - --htpasswd-file=/etc/oauth2_proxy/htpasswd/users.txt
         {{- end }}
+        {{- if not .Values.useEnvironmentNotSecrets }}
         env:
         - name: OAUTH2_PROXY_CLIENT_ID
           valueFrom:
@@ -81,6 +82,7 @@ spec:
             secretKeyRef:
               name:  {{ template "oauth2-proxy.secretName" . }}
               key: cookie-secret
+        {{- end }}
         {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 8 }}
         {{- end }}

--- a/stable/oauth2-proxy/templates/deployment.yaml
+++ b/stable/oauth2-proxy/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
         {{- if .Values.htpasswdFile.enabled }}
           - --htpasswd-file=/etc/oauth2_proxy/htpasswd/users.txt
         {{- end }}
-        {{- if not .Values.useEnvironmentNotSecrets }}
+        {{- if .Values.proxyVarsAsSecrets }}
         env:
         - name: OAUTH2_PROXY_CLIENT_ID
           valueFrom:

--- a/stable/oauth2-proxy/templates/secret.yaml
+++ b/stable/oauth2-proxy/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.config.existingSecret }}
+{{- if and (not .Values.config.existingSecret) (not .Values.useEnvironmentNotSecrets) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/oauth2-proxy/templates/secret.yaml
+++ b/stable/oauth2-proxy/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.config.existingSecret) (not .Values.useEnvironmentNotSecrets) }}
+{{- if and (not .Values.config.existingSecret) (.Values.proxyVarsAsSecrets) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/oauth2-proxy/values.yaml
+++ b/stable/oauth2-proxy/values.yaml
@@ -116,8 +116,8 @@ tolerations: []
 # Ref: https://kubernetes.io/docs/user-guide/node-selection/
 nodeSelector: {}
 
-# Whether to use environment values instead of secrets for setting up OAUTH2_PROXY variables
-useEnvironmentNotSecrets: false
+# Whether to use secrets instead of environment values for setting up OAUTH2_PROXY variables
+proxyVarsAsSecrets: true
 
 # Configure Kubernetes liveness and readiness probes.
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/

--- a/stable/oauth2-proxy/values.yaml
+++ b/stable/oauth2-proxy/values.yaml
@@ -116,6 +116,9 @@ tolerations: []
 # Ref: https://kubernetes.io/docs/user-guide/node-selection/
 nodeSelector: {}
 
+# Whether to use environment values instead of secrets for setting up OAUTH2_PROXY variables
+useEnvironmentNotSecrets: false
+
 # Configure Kubernetes liveness and readiness probes.
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
 # Disable both when deploying with Istio 1.0 mTLS. https://istio.io/help/faq/security/#k8s-health-checks


### PR DESCRIPTION
…tead of secrets

Signed-off-by: Thomas Borup <tbo@trifork.com>

#### What this PR does / why we need it:
We are using hashicorp vault for storing our secrets. So in order to have all secret in vault instead of k8s secrets we need this pull request.

By default this feature is disabled, so that it does not result in a breaking change for any users of the chart.

#### Special notes for your reviewer:
@desaintmartin 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
