### PR TITLE
workaround ELB healthcheck ssl bug

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.8.0
-version: 1.38.1
+version: 1.38.2
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/templates/service.yaml
+++ b/stable/rabbitmq-ha/templates/service.yaml
@@ -33,6 +33,12 @@ spec:
 {{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
 {{- end }}
   ports:
+    {{- if .Values.rabbitmqAmqpsSupport.enabled }}
+    - name: amqps
+      protocol: TCP
+      port: {{ .Values.rabbitmqAmqpsSupport.amqpsNodePort }}
+      targetPort: amqps
+    {{- end }}
     - name: http
       protocol: TCP
       port: {{ .Values.rabbitmqManagerPort }}
@@ -85,12 +91,6 @@ spec:
       protocol: TCP
       port: 15675
       targetPort: mqtt-ws
-    {{- end }}
-    {{- if .Values.rabbitmqAmqpsSupport.enabled }}
-    - name: amqps
-      protocol: TCP
-      port: {{ .Values.rabbitmqAmqpsSupport.amqpsNodePort }}
-      targetPort: amqps
     {{- end }}
     {{ if .Values.prometheus.exporter.enabled }}
     - name: exporter


### PR DESCRIPTION
Due to a bug introduced in version 1.14 of Kubernetes if a user creates a service of type LoadBalancer and the load balancer uses SSL the healthcheck will now be SSL.  This only works when the first port exposed by the service is also an SSL port if not this will fail.

https://github.com/kubernetes/kubernetes/issues/83070

This PR moves the amqps to be the first service.  It will have no backwards incompatibility but will allow users to expose amqps with a load balancer.