### PR TITLE
[stable/drone] adding an option to configure a cloudsql-proxy

### DIFF
--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 2.5.0
+version: 2.5.1
 appVersion: 1.6.1
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/stable/drone/README.md
+++ b/stable/drone/README.md
@@ -130,3 +130,6 @@ The following table lists the configurable parameters of the drone charts and th
 | `rbac.apiVersion`           | RBAC API version                                                                              | `v1`                        |
 | `serviceAccount.create`     | Specifies whether a ServiceAccount should be created.                                         | `true`                      |
 | `serviceAccount.name`       | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template. | `(fullname template)` |
+| `cloudsql.create`       | Specifies whether a CloudSQL-proxy should be created. | `false` |
+
+

--- a/stable/drone/templates/cloudsql-db-credentials.yaml
+++ b/stable/drone/templates/cloudsql-db-credentials.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cloudsql.create }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,3 +7,4 @@ type: Opaque
 data:
   username: {{ .Values.cloudsql.db_credentials.username }}
   password: {{ .Values.cloudsql.db_credentials.password }}
+{{- end }}

--- a/stable/drone/templates/cloudsql-db-credentials.yaml
+++ b/stable/drone/templates/cloudsql-db-credentials.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudsql-db-credentials
+type: Opaque
+data:
+  username: {{ .Values.cloudsql.db_credentials.username }}
+  password: {{ .Values.cloudsql.db_credentials.password }}

--- a/stable/drone/templates/cloudsql-instance-credentials.yaml
+++ b/stable/drone/templates/cloudsql-instance-credentials.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cloudsql.create }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,3 +6,4 @@ metadata:
 type: Opaque
 data:
   credentials.json: {{ .Values.cloudsql.instance_credentials.credentialsjson }}
+{{- end }}

--- a/stable/drone/templates/cloudsql-instance-credentials.yaml
+++ b/stable/drone/templates/cloudsql-instance-credentials.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudsql-instance-credentials
+type: Opaque
+data:
+  credentials.json: {{ .Values.cloudsql.instance_credentials.credentialsjson }}

--- a/stable/drone/templates/deployment-server.yaml
+++ b/stable/drone/templates/deployment-server.yaml
@@ -49,6 +49,29 @@ spec:
 {{- end }}
       serviceAccountName: {{ template "drone.serviceAccountName" . }}
       containers:
+      {{- if .Values.cloudsql.create }}
+      - name: cloudsql-proxy
+        image: "{{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}"
+        command: ["/cloud_sql_proxy",
+                  "-instances={{ .Values.cloudsql.instance.project_id }}:{{ .Values.cloudsql.instance.region }}:{{ .Values.cloudsql.instance.name }}=tcp:5432,{{ .Values.cloudsql.instance.project_id }}:{{ .Values.cloudsql.instance.region }}:{{ .Values.cloudsql.instance.db_name }}=tcp:5433",
+                  "-credential_file=/secrets/cloudsql/credentials.json"]
+        # [START cloudsql_security_context]
+        securityContext:
+         runAsUser: 2  # non-root user
+         allowPrivilegeEscalation: false
+        # [END cloudsql_security_context]
+        volumeMounts:
+         - name: cloudsql-instance-credentials
+           mountPath: /secrets/cloudsql
+           readOnly: true
+        resources:
+          limits:
+            cpu: 200m
+            memory: 128Mi
+          requests:
+            cpu: 50m
+            memory: 64Mi
+      {{- end }}
       - name: server
         image: "{{ .Values.images.server.repository }}:{{ .Values.images.server.tag }}"
         imagePullPolicy: {{ .Values.images.server.pullPolicy }}

--- a/stable/drone/values.yaml
+++ b/stable/drone/values.yaml
@@ -159,6 +159,11 @@ server:
     DRONE_DATABASE_DRIVER: "sqlite3"
     DRONE_DATABASE_DATASOURCE: "/var/lib/drone/drone.sqlite"
 
+  ## If using a Google cloudsql postgres db via a cloudsql-proxy 
+  ## the driver and datasource need to be set like this:
+  #  DRONE_DATABASE_DRIVER: "postgres"
+  #  DRONE_DATABASE_DATASOURCE: "postgres://username:password@127.0.0.1:5432/db_name?sslmode=disable"
+
   ## Secret environment variables are configured in `server.envSecrets`.
   ## Each item in `server.envSecrets` references a Kubernetes Secret.
   ## These Secrets should be created before they are referenced.
@@ -385,3 +390,25 @@ serviceAccount:
   ## The name of the ServiceAccount to use.
   ## If not set and create is true, a name is generated using the fullname template
   name:
+
+cloudsql:
+  ## Set to true to deploy a (Google Cloud) cloudsql-proxy 
+  ## to be able to connect to a cloudsql db in your GCP
+  create: false
+
+  ## If create is true below variables need to be defined.
+
+  # db_credentials:
+  #   username: username-in-base64
+  #   password: password-in-base64
+  # instance_credentials:
+  #   credentialsjson: your-sevice-account-credentials-json-in-base64
+  # image:
+  #   repository: gcr.io/cloudsql-docker/gce-proxy
+  #   tag: 1.11
+  #   pullPolicy: IfNotPresent
+  # instance:
+  #   name: your-cloudsql-instance-name
+  #   project_id: your-GCP-project-name
+  #   region: your-cloudsql-location-region
+  #   db_name: your-db-name

--- a/stable/drone/values.yaml
+++ b/stable/drone/values.yaml
@@ -412,4 +412,3 @@ cloudsql:
   #   project_id: your-GCP-project-name
   #   region: your-cloudsql-location-region
   #   db_name: your-db-name
-  

--- a/stable/drone/values.yaml
+++ b/stable/drone/values.yaml
@@ -159,7 +159,7 @@ server:
     DRONE_DATABASE_DRIVER: "sqlite3"
     DRONE_DATABASE_DATASOURCE: "/var/lib/drone/drone.sqlite"
 
-  ## If using a Google cloudsql postgres db via a cloudsql-proxy 
+  ## If using a Google cloudsql postgres db via a cloudsql-proxy
   ## the driver and datasource need to be set like this:
   #  DRONE_DATABASE_DRIVER: "postgres"
   #  DRONE_DATABASE_DATASOURCE: "postgres://username:password@127.0.0.1:5432/db_name?sslmode=disable"
@@ -392,7 +392,7 @@ serviceAccount:
   name:
 
 cloudsql:
-  ## Set to true to deploy a (Google Cloud) cloudsql-proxy 
+  ## Set to true to deploy a (Google Cloud) cloudsql-proxy
   ## to be able to connect to a cloudsql db in your GCP
   create: false
 
@@ -412,3 +412,4 @@ cloudsql:
   #   project_id: your-GCP-project-name
   #   region: your-cloudsql-location-region
   #   db_name: your-db-name
+  


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR is adding the option to deploy drone.io together with a Google cloudsql-proxy to be able to connect to a cloudsql database in a Google Cloud Project.
At [Humanitec](https://github.com/humanitec) we are running our Drone CI inside a GKE cluster with connection to a postgres db provided by Googles cloudsql service.

I believe that this option can come in handy for others as well.

#### Special notes for your reviewer:
@christian-roggia 
@zakkg3

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
