### PR TITLE
[stable/kong] Add check for config changes

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: harry@konghq.com
 name: kong
 sources:
-version: 0.36.3
+version: 0.36.4
 appVersion: 1.4

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -461,6 +461,15 @@ value is your SMTP password.
 
 ## Changelog
 
+### 0.36.4
+
+> PR https://github.com/helm/charts/pull/20051
+
+#### Fixed
+
+- Issue: [`Ingress Controller errors when chart is redeployed with Admission
+  Webhook enabled`](https://github.com/helm/charts/issues/20050)
+
 ### 0.36.3
 
 > PR https://github.com/helm/charts/pull/19992

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if .Values.ingressController.admissionWebhook.enabled }}
+        checksum/admission-webhook.yaml: {{ include (print $.Template.BasePath "/admission-webhook.yaml") . | sha256sum }}
+        {{- end }}
         {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off" )) }}
         {{- if .Values.dblessConfig.config }}
         checksum/dbless.config: {{ toYaml .Values.dblessConfig.config | sha256sum }}


### PR DESCRIPTION
Add an admission webhook config checksum as an annotation in the
Deployment so that the pods can be redeployed by K8s when the config
changes during redeployments.

#### Is this a new chart
No

#### What this PR does / why we need it:
Bugfix

#### Which issue this PR fixes
- fixes: https://github.com/helm/charts/issues/20050

#### Special notes for your reviewer:
Tested on my local setup. It redeploys the pod containing the kong and ingress-controller containers which then uses the new certificates in the Secret successfully.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
