### PR TITLE
[stable/dex] Add podLabels support

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 2.7.0
+version: 2.8.0
 appVersion: 2.21.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/README.md
+++ b/stable/dex/README.md
@@ -87,6 +87,7 @@ Parameters introduced starting from v2
 | `crd.present` | Whether dex's CRDs are already present (if not cluster role and cluster role binding will be created to enable dex to create them). Depends on `rbac.create` | `false` |
 | `grpc` | Enable dex grpc endpoint | `true` |
 | `https` | Enable TLS termination for the dex http endpoint | `false` |
+| `podLabels` | Custom pod labels | `{}` |
 | `ports.grpc.containerPort` | grpc port listened by the dex | `5000` |
 | `ports.grpc.nodePort` | K8S Service node port for the dex grpc listener | `35000` |
 | `ports.grpc.servicePort` | K8S Service port for the dex grpc listener | `35000` |

--- a/stable/dex/templates/deployment.yaml
+++ b/stable/dex/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
         app.kubernetes.io/name: {{ include "dex.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: dex
+        {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+        {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}

--- a/stable/dex/values.yaml
+++ b/stable/dex/values.yaml
@@ -11,6 +11,8 @@ inMiniKube: false
 
 nodeSelector: {}
 
+podLabels: {}
+
 podAnnotations: {}
 
 initContainers: []


### PR DESCRIPTION
#### What this PR does / why we need it:
Added the ability to set own pod labels to dex deployment template

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
