### PR TITLE
[stable/prometheus-operator] Add information that prometheusOperator.admissionWebhooks.enabled=false workaround requires prometheusOperator.tlsProxy.enabled=false

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.12.10
+version: 8.12.11
 appVersion: 0.37.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -75,7 +75,7 @@ When Google configure the control plane for private clusters, they automatically
 
 You can read more information on how to add firewall rules for the GKE control plane nodes in the [GKE docs](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules)
 
-Alternatively, you can disable the hooks by setting `prometheusOperator.admissionWebhooks.enabled=false`.
+Alternatively, you can disable the hooks by setting `prometheusOperator.admissionWebhooks.enabled=false` and `prometheusOperator.tlsProxy.enabled=false`.
 
 ### Helm fails to create CRDs
 You should upgrade to Helm 2.14 + in order to avoid this issue. However, if you are stuck with an earlier Helm release you should instead use the following approach: Due to a bug in helm, it is possible for the 5 CRDs that are created by this chart to fail to get fully deployed before Helm attempts to create resources that require them. This affects all versions of Helm with a [potential fix pending](https://github.com/helm/helm/pull/5112). In order to work around this issue when installing the chart you will need to make sure all 5 CRDs exist in the cluster first and disable their previsioning by the chart:


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
The instructions to workaround firewall rule on GKE are incomplete.

#### Which issue this PR fixes
./.

#### Special notes for your reviewer:
./.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
