### PR TITLE
[stable/jenkins]

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.9.14
+version: 1.9.15
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -107,6 +107,8 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.csrf.defaultCrumbIssuer.enabled` | Enable the default CSRF Crumb issuer | `true`                             |
 | `master.csrf.defaultCrumbIssuer.proxyCompatability` | Enable proxy compatibility | `true`                            |
 | `master.cli`                      | Enable CLI over remoting             | `false`                                   |
+| `master.slaveListenerServiceType` | Defines how to expose the slaveListener service | `ClusterIP`                    |
+| `master.slaveListenerLoadBalancerIP`  | Static IP for the slaveListener LoadBalancer | Not set                       | 
 | `master.loadBalancerSourceRanges` | Allowed inbound IP addresses         | `0.0.0.0/0`                               |
 | `master.loadBalancerIP`           | Optional fixed external IP           | Not set                                   |
 | `master.jmxPort`                  | Open a port, for JMX stats           | Not set                                   |

--- a/stable/jenkins/templates/jenkins-agent-svc.yaml
+++ b/stable/jenkins/templates/jenkins-agent-svc.yaml
@@ -25,6 +25,8 @@ spec:
     "app.kubernetes.io/component": "{{ .Values.master.componentName }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
   type: {{ .Values.master.slaveListenerServiceType }}
-  {{if eq .Values.master.slaveListenerServiceType "LoadBalancer"}}
-  loadBalancerIP: {{.Values.master.slaveListenerLoadBalancerIP}}
+  {{  if eq .Values.master.slaveListenerServiceType "LoadBalancer"  }}
+  {{  if .Values.master.slaveListenerLoadBalancerIP  }}
+  loadBalancerIP: {{  .Values.master.slaveListenerLoadBalancerIP  }}
+  {{end}}
   {{end}}

--- a/stable/jenkins/templates/jenkins-agent-svc.yaml
+++ b/stable/jenkins/templates/jenkins-agent-svc.yaml
@@ -25,3 +25,6 @@ spec:
     "app.kubernetes.io/component": "{{ .Values.master.componentName }}"
     "app.kubernetes.io/instance": "{{ .Release.Name }}"
   type: {{ .Values.master.slaveListenerServiceType }}
+  {{if eq .Values.master.slaveListenerServiceType "LoadBalancer"}}
+  loadBalancerIP: {{.Values.master.slaveListenerLoadBalancerIP}}
+  {{end}}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -181,6 +181,9 @@ master:
   # this will be an external load balancer and allowing inbound 0.0.0.0/0, a HUGE
   # security risk:  https://github.com/kubernetes/charts/issues/1341
   slaveListenerServiceType: "ClusterIP"
+  # Optionally assign an IP to the LoadBalancer slaveListenerService LoadBalancer
+  # GKE users: only regional static IPs will work for Service Load balancer.
+  # slaveListenerLoadBalancerIP: 1.2.3.4
   slaveListenerServiceAnnotations: {}
   slaveKubernetesNamespace:
 


### PR DESCRIPTION
Signed-off-by: Alberto Geniola <albertogeniola@gmail.com>

@lachie83 
@viglesiasce 
@maorfr 
@torstenwalter 
@mogaal 

#### Is this a new chart
No

#### What this PR does / why we need it:
The current Jenkins chart allows exposing slave agent listener service via external load balancer (secured with annotations), which is convenient for permanent slaves. However, the chart lacked the possibility to set a static IP address to bind the load balancer to, which is really necessary when running Kubernetes on a cloud provider (as GKE).

#### Which issue this PR fixes
None

#### Special notes for your reviewer:
None

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
