### PR TITLE
[stable/metrics-server] Support custom sidecar containers

### DIFF
--- a/stable/metrics-server/Chart.yaml
+++ b/stable/metrics-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.3.6
 description: Metrics Server is a cluster-wide aggregator of resource usage data.
 name: metrics-server
-version: 2.8.9
+version: 2.9.0
 keywords:
 - metrics-server
 home: https://github.com/kubernetes-incubator/metrics-server

--- a/stable/metrics-server/README.md
+++ b/stable/metrics-server/README.md
@@ -35,3 +35,4 @@ Parameter | Description | Default
 `podDisruptionBudget.enabled` | Create a PodDisruptionBudget | `false`
 `podDisruptionBudget.minAvailable` | Minimum available instances; ignored if there is no PodDisruptionBudget |
 `podDisruptionBudget.maxUnavailable` | Maximum unavailable instances; ignored if there is no PodDisruptionBudget |
+`extraContainers`   | Add additional containers  | `[]`

--- a/stable/metrics-server/templates/metrics-server-deployment.yaml
+++ b/stable/metrics-server/templates/metrics-server-deployment.yaml
@@ -39,6 +39,9 @@ spec:
       hostNetwork: true
 {{- end }}
       containers:
+        {{- if .Values.extraContainers }}
+        {{- ( tpl (toYaml .Values.extraContainers) . ) | nindent 8 }}
+        {{- end }}
         - name: metrics-server
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/stable/metrics-server/values.yaml
+++ b/stable/metrics-server/values.yaml
@@ -48,6 +48,8 @@ affinity: {}
 
 replicas: 1
 
+extraContainers: []
+
 podAnnotations: {}
 #  The following annotations guarantee scheduling for critical add-on pods.
 #    See more at: https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/


### PR DESCRIPTION
Signed-off-by: Matteo Ruina <matteo.ruina@skyscanner.net>

#### What this PR does / why we need it:
Allow to run additional containers inside the metrics-server pod. For example, we're using the `addon-resizer` container to automatically resize the metrics-server

#### Special notes for your reviewer:

Looking at other charts, the majority seem to use the `extraContainers` variable, but I'm happy to change it if needed

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
