### PR TITLE
[stable/etcd-operator] Added etcdCluster.repository parameter to the template in order to specify a custom registry

### DIFF
--- a/stable/etcd-operator/Chart.yaml
+++ b/stable/etcd-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: CoreOS etcd-operator Helm chart for Kubernetes
 name: etcd-operator
-version: 0.10.2
+version: 0.10.3
 appVersion: 0.9.4
 home: https://github.com/coreos/etcd-operator
 icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png

--- a/stable/etcd-operator/README.md
+++ b/stable/etcd-operator/README.md
@@ -108,9 +108,7 @@ The following table lists the configurable parameters of the etcd-operator chart
 | `etcdCluster.name`                                | etcd cluster name                                                    | `etcd-cluster`                                 |
 | `etcdCluster.size`                                | etcd cluster size                                                    | `3`                                            |
 | `etcdCluster.version`                             | etcd cluster version                                                 | `3.2.25`                                       |
-| `etcdCluster.image.repository`                    | etcd container image                                                 | `quay.io/coreos/etcd-operator`                 |
-| `etcdCluster.image.tag`                           | etcd container image tag                                             | `v3.2.25`                                      |
-| `etcdCluster.image.pullPolicy`                    | etcd container image pull policy                                     | `Always`                                       |
+| `etcdCluster.repository`                    	    | etcd container image                                                 | `quay.io/coreos/etcd`                          |
 | `etcdCluster.enableTLS`                           | Enable use of TLS                                                    | `false`                                        |
 | `etcdCluster.tls.static.member.peerSecret`        | Kubernetes secret containing TLS peer certs                          | `etcd-peer-tls`                                |
 | `etcdCluster.tls.static.member.serverSecret`      | Kubernetes secret containing TLS server certs                        | `etcd-server-tls`                              |

--- a/stable/etcd-operator/templates/etcd-cluster-crd.yaml
+++ b/stable/etcd-operator/templates/etcd-cluster-crd.yaml
@@ -12,6 +12,7 @@ metadata:
 spec:
   size: {{ .Values.etcdCluster.size }}
   version: "{{ .Values.etcdCluster.version }}"
+  repository: "{{ .Values.etcdCluster.repository }}"
   pod:
 {{ toYaml .Values.etcdCluster.pod | indent 4 }}
   {{- if .Values.etcdCluster.enableTLS }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No, It's an existing chart: **etcd-operator**

#### What this PR does / why we need it:
This PR allows the users to specify a custom registry to pull the etcdCluster image from. It does not work with the documented values. The unused values have been removed from the doc. They were misleading.

#### Which issue this PR fixes
There are no issues related to this PR.   

#### Special notes for your reviewer:
None.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
