### PR TITLE
[stable/etcd-operator] EtcdCluster CRD image override

### DIFF
--- a/stable/etcd-operator/Chart.yaml
+++ b/stable/etcd-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: CoreOS etcd-operator Helm chart for Kubernetes
 name: etcd-operator
-version: 0.10.3
+version: 0.11.0
 appVersion: 0.9.4
 home: https://github.com/coreos/etcd-operator
 icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png

--- a/stable/etcd-operator/templates/etcd-cluster-crd.yaml
+++ b/stable/etcd-operator/templates/etcd-cluster-crd.yaml
@@ -12,6 +12,7 @@ metadata:
 spec:
   size: {{ .Values.etcdCluster.size }}
   version: "{{ .Values.etcdCluster.version }}"
+  repository: "{{ .Values.etcdCluster.image.repository }}"
   pod:
 {{ toYaml .Values.etcdCluster.pod | indent 4 }}
   {{- if .Values.etcdCluster.enableTLS }}

--- a/stable/etcd-operator/values.yaml
+++ b/stable/etcd-operator/values.yaml
@@ -145,6 +145,7 @@ etcdCluster:
   ## etcd cluster pod specific values
   ## Ref: https://github.com/coreos/etcd-operator/blob/master/doc/user/spec_examples.md#three-members-cluster-with-resource-requirement
   pod:
+    busyboxImage: busybox:1.28.0-glibc
     ## Antiaffinity for etcd pod assignment
     ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
     antiAffinity: false


### PR DESCRIPTION
Ability to override image referenced for `EtcdCluster`:

* EtcdImage
* InitContainer busybox image

Use case:

* Secure k8s deployments where external image registries are blocked

