### PR TITLE
[stable/phpmyadmin] Fix an SSL certificates directory conflict

### DIFF
--- a/stable/phpmyadmin/Chart.yaml
+++ b/stable/phpmyadmin/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: phpmyadmin
-version: 4.2.8
+version: 4.2.9
 appVersion: 5.0.1
 description: phpMyAdmin is an mysql administration frontend
 keywords:

--- a/stable/phpmyadmin/templates/deployment.yaml
+++ b/stable/phpmyadmin/templates/deployment.yaml
@@ -76,11 +76,11 @@ spec:
               value: {{ ternary "yes" "no" .Values.db.enableSsl | quote }}
             {{- if .Values.db.enableSsl }}
             - name: DATABASE_SSL_KEY
-              value: "/certs/server_key.pem"
+              value: "/db_certs/server_key.pem"
             - name: DATABASE_SSL_CERT
-              value: "/certs/server_certificate.pem"
+              value: "/db_certs/server_certificate.pem"
             - name: DATABASE_SSL_CA
-              value: "/certs/ca_certificate.pem"
+              value: "/db_certs/ca_certificate.pem"
             {{- if .Values.db.ssl.ciphers }}
             - name: DATABASE_SSL_CIPHERS
               values: {{ .Values.db.ssl.ciphers | quote }}
@@ -111,7 +111,7 @@ spec:
           {{- if .Values.db.enableSsl }}
           volumeMounts:
           - name: ssl-certs
-            mountPath: /certs
+            mountPath: /db_certs
           {{- end }}
 {{- if .Values.metrics.enabled }}
         - name: metrics


### PR DESCRIPTION
Mount the SSL certificates used to connect to the database in  /db_certs instead of /certs, as /certs is already used by the bitnami/phpmyadmin Docker image to configure Apache internally.

Signed-off-by: Nicolas Camus <nicolas@octopulse.io>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

No.

#### What this PR does / why we need it:

When deploying this Chart with `db.sslEnabled` set to `true`, the PHPMyAdmin container failed to start with the following error :

```
E 2020-01-13T10:26:29.810047469Z [0m[38;5;2mINFO Mounting certificates files from /certs...
I 2020-01-13T10:26:32.586060989Z nami    INFO Initializing apache
I 2020-01-13T10:26:32.611706459Z nami    INFO  apache successfully initialized
I 2020-01-13T10:26:35.412699470Z nami    INFO  Initializing php
I 2020-01-13T10:26:35.452136893Z nami    INFO  php successfully initialized
I 2020-01-13T10:26:39.185558014Z nami    INFO  Initializing phpmyadmin
I 2020-01-13T10:26:39.433519635Z phpmyad INFO  Preparing PHP environment...
I 2020-01-13T10:26:39.444187884Z phpmyad INFO  Preparing Apache environment...
I 2020-01-13T10:26:39.444529964Z phpmyad INFO  Configuring App
I 2020-01-13T10:26:39.455265308Z phpmyad INFO  Enabling SSL
I 2020-01-13T10:26:39.463243301Z phpmyad INFO  Generating blowfish_ecret
I 2020-01-13T10:26:39.465742558Z nami    INFO  phpmyadmin successfully initialized
E 2020-01-13T10:26:39.482142037Z [0m[38;5;2mINFO [0m ==> Starting phpmyadmin... 
E 2020-01-13T10:27:13.105445906Z nami    ERROR Unable to start com.bitnami.apache: AH00526: Syntax error on line 6 of /opt/bitnami/apache/conf/vhosts/phpmyadmin-https-vhost.conf:
E 2020-01-13T10:27:13.105479125Z SSLCertificateFile: file '/opt/bitnami/apache/conf/bitnami/certs/server.crt' does not exist or is empty
```

When trying to understand the issue, I found out that when setting `db.sslEnabled` to true, the Chart mounts a _/certs_ directory in the container, in which live the SSL/TLS certificates used to reach the database.

However this directory, when it exists, seems also to be linked by the _bitnami/phpmyadmin_ Docker image's [entrypoint script](https://github.com/bitnami/bitnami-docker-phpmyadmin/blob/master/4/debian-9/rootfs/apache-init.sh) to the Apache configuration.

This is problematic as, in our case, the certificates present in the _/certs_ directory are meant to be used to provide an SSL connection between PHPMyAdmin and the database, not between the user's browser and the web server (Apache).

Therefore the web server init fails, as Apache does not find the right certificates to serve PHPMyAdmin on port 443 even if the image's [entrypoint script](https://github.com/bitnami/bitnami-docker-phpmyadmin/blob/master/4/debian-9/rootfs/apache-init.sh) script has configured it due to the presence of the _/certs_ directory.

Long story short, to fix this I renamed the directory hosting the SSL/TLS certificates for the database to _/db_certs_.

An other option would be to update the Docker image's [entrypoint script](https://github.com/bitnami/bitnami-docker-phpmyadmin/blob/master/4/debian-9/rootfs/apache-init.sh) to find out which certificates are present in the _/certs_ directory instead, but it seems outside this repository's scope.

P.S.: It might be related to [recent changes](https://github.com/bitnami/bitnami-docker-phpmyadmin#485-debian-9-r96-and-485-ol-7-r111) in the underlying Docker image about how the certificates directory location is managed.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

No opened issue is related to this PR to my knowledge.

#### Special notes for your reviewer:

Sorry if my English is bad (I'm not a native speaker), I will gladly try to reword my PR if it's not clear enough.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
