### PR TITLE
[incubator/hoverfly]: Add Openshift Route Creation for Admin & Proxy Interfaces

### DIFF
--- a/incubator/hoverfly/Chart.yaml
+++ b/incubator/hoverfly/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.1.1
 description: Hoverfly is a lightweight, open source API simulation tool. Using Hoverfly, you can create realistic simulations of the APIs your application depends on.
 name: hoverfly
-version: 0.1.1
+version: 0.1.2
 keywords:
   - hoverfly
   - api-simulation

--- a/incubator/hoverfly/README.md
+++ b/incubator/hoverfly/README.md
@@ -52,6 +52,10 @@ The following table lists the configurable parameters of the Hoverfly chart and 
 | `service.externalAdminPort`       | Service Admin port                         | `8888`                                                    |
 | `service.externalProxyPort`       | Service Proxy port                         | `8500`                                                    |
 | `resources`                       | CPU/Memory resource requests/limits        | Memory: `200Mi`, CPU: `0.2`                               |
+| `openshift.route.admin.enabled`   | Create an Openshift route for the Hoverfly Admin Interface | `false` |
+| `openshift.route.admin.hostname`  | Specify the route URL for the Hoverfly Admin Interface     | `""` |
+| `openshift.route.proxy.enabled`   | Create an Openshift route for the Hoverfly Proxy Endpoint  | `false` |
+| `openshift.route.proxy.hostname`  | Specify the route URL for the Hoverfly Proxy Interface     | `""` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/incubator/hoverfly/templates/route.yaml
+++ b/incubator/hoverfly/templates/route.yaml
@@ -1,0 +1,59 @@
+{{ if .Values.openshift.route.admin.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}" 
+  name: "{{ template "fullname" . }}-admin"
+spec:
+  host: "{{ .Values.openshift.route.admin.hostname }}"
+  port:
+    targetPort: admin
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: "{{ template "fullname" . }}" 
+    weight: 100
+status:
+  ingress:
+    - conditions:
+      - lastTransitionTime: "2019-12-06T03:24:58Z"
+        status: ""
+        type: "" 
+      host: ""
+      routerCanonicalHostname: ""
+      routerName: default
+      wildcardPolicy: None
+{{ end }}
+{{ if .Values.openshift.route.proxy.enabled }}
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  name: "{{ template "fullname" . }}-proxy"
+spec:
+  host: "{{ .Values.openshift.route.proxy.hostname }}"
+  port:
+    targetPort: proxy
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: "{{ template "fullname" . }}"
+    weight: 100
+status:
+  ingress:
+    - conditions:
+      - lastTransitionTime: "2019-12-06T03:24:58Z"
+        status: ""
+        type: ""
+      host: ""
+      routerCanonicalHostname: ""
+      routerName: default
+      wildcardPolicy: None
+{{ end }}

--- a/incubator/hoverfly/values.yaml
+++ b/incubator/hoverfly/values.yaml
@@ -23,7 +23,7 @@ hoverflyFlags:
 openshift:
   route:
     admin:
-      enabled: false 
+      enabled: false
       hostname: ""
     proxy:
       enabled: false

--- a/incubator/hoverfly/values.yaml
+++ b/incubator/hoverfly/values.yaml
@@ -20,3 +20,11 @@ hoverflyFlags:
 #   requests:
 #     cpu: 0.1
 #     memory: 100Mi
+openshift:
+  route:
+    admin:
+      enabled: false 
+      hostname: ""
+    proxy:
+      enabled: false
+      hostname: ""


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
This adds the ability to create Openshift routes for the Hoverfly admin and proxy interfaces 

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

cc/ @tommysitu 
