### PR TITLE
[stable/jenkins] Add correct PodLabel for NetworkPolicy

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.9.16
+
+Fix PodLabel for NetworkPolicy to work if enabled
+
 ## 1.9.14
 
 Properly fix case sense in `Values.master.overwriteConfig` in `config.yaml`

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.9.15
+version: 1.9.16
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -147,6 +147,12 @@ data:
           <retentionTimeout>5</retentionTimeout>
           <connectTimeout>0</connectTimeout>
           <readTimeout>0</readTimeout>
+          <podLabels>
+            <org.csanchez.jenkins.plugins.kubernetes.PodLabel>
+              <key>jenkins/{{ .Release.Name }}-{{ .Values.agent.componentName }}</key>
+              <value>true</value>
+            </org.csanchez.jenkins.plugins.kubernetes.PodLabel>
+          </podLabels>
           <podRetention class="org.csanchez.jenkins.plugins.kubernetes.pod.retention.{{ .Values.agent.podRetention }}"/>
         </org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud>
       </clouds>


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds the correct podLabel to the pods so that the NetworkPolicy works as expected.

#### Which issue this PR fixes
  - Fixes #18804 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
