### PR TITLE
[incubator/zookeeper] Add Prometheus Operator PrometheusRule support

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 2.1.3
+version: 2.1.4
 appVersion: 3.5.5
 kubeVersion: "^1.10.0-0"
 description: Centralized service for maintaining configuration information, naming,

--- a/incubator/zookeeper/README.md
+++ b/incubator/zookeeper/README.md
@@ -18,7 +18,8 @@ This chart will do the following:
 * Optionally apply a [Pod Anti-Affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature) to spread the ZooKeeper ensemble across nodes.
 * Optionally start JMX Exporter and Zookeeper Exporter containers inside Zookeeper pods.
 * Optionally create a job which creates Zookeeper chroots (e.g. `/kafka1`).
-* Optionally create a Prometheus ServiceMonitor for each enabled exporter container
+* Optionally create a Prometheus Operator ServiceMonitor resource for each enabled exporter container.
+* Optionally create a Prometheus Operator PrometheusRule resource.
 
 ## Installing the Chart
 You can install the chart with the release name `zookeeper` as below.

--- a/incubator/zookeeper/templates/prometheusrules.yaml
+++ b/incubator/zookeeper/templates/prometheusrules.yaml
@@ -1,0 +1,16 @@
+{{ if and (.Values.prometheus.prometheusRule.enabled) (.Values.prometheus.prometheusRule.rules) }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "zookeeper.fullname" . }}
+  {{- if .Values.prometheus.prometheusRule.namespace }}
+  namespace: {{ .Values.prometheus.prometheusRule.namespace }}
+  {{- end }}
+  labels:
+    {{- toYaml .Values.prometheus.prometheusRule.selector | nindent 4 }}
+spec:
+  groups:
+  - name: {{ include "zookeeper.fullname" . }}
+    rules:
+      {{- toYaml .Values.prometheus.prometheusRule.rules | nindent 6 }}
+{{- end }}

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -239,6 +239,33 @@ prometheus:
     ## [Default Prometheus Operator selector] (https://github.com/helm/charts/blob/f5a751f174263971fafd21eee4e35416d6612a3d/stable/prometheus-operator/templates/prometheus/prometheus.yaml#L74)
     selector: {}
 
+  prometheusRule:
+    ## If true a PrometheusRule resource will be installed
+    enabled: false
+    ## The namespace where the PrometheusRule will be installed
+    # namespace: monitoring
+
+    ## The selector the Prometheus instance is searching for
+    ## [Default Prometheus Operator selector] (https://github.com/helm/charts/blob/f5a751f174263971fafd21eee4e35416d6612a3d/stable/prometheus-operator/templates/prometheus/prometheus.yaml#L102)
+    selector: {}
+
+    ## Some example rules. If you use these it would be a good idea to limit them down to the current release e.g. max(zk_synced_followers{service="my-zookeeper-release"}) < 2
+    rules: []
+    #  - alert: ZookeeperSyncedFollowers
+    #    annotations:
+    #      message: The number of synced followers for the leader node in Zookeeper deployment {{ "{{" }} $labels.service {{ "}}" }} is less than 2. This usually means that some of the Zookeeper nodes aren't communicating properly. If it doesn't resolve itself you can try killing the pods (one by one).
+    #    expr: max(zk_synced_followers) by (service) < 2
+    #    for: 5m
+    #    labels:
+    #      severity: critical
+    #  - alert: ZookeeperOutstandingRequests
+    #    annotations:
+    #      message: The number of outstanding requests for Zookeeper pod {{ "{{" }} $labels.pod {{ "}}" }} is greater than 10. This can indicate a performance issue with the Pod or cluster a whole.
+    #    expr: zk_outstanding_requests > 10
+    #    for: 5m
+    #    labels:
+    #      severity: critical
+
 ## Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
 ##


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds Prometheus Operator PrometheusRule support for deploying of rules/alerts alongside Zookeeper itself.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
