### PR TITLE
[stable/redis] Fix the NOTES label when using NetworkPolicy

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 10.3.3
+version: 10.3.4
 appVersion: 5.0.7
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/NOTES.txt
+++ b/stable/redis/templates/NOTES.txt
@@ -54,7 +54,7 @@ To connect to your Redis server:
 
    kubectl run --namespace {{ .Release.Namespace }} {{ template "redis.fullname" . }}-client --rm --tty -i --restart='Never' \
    {{ if .Values.usePassword }} --env REDIS_PASSWORD=$REDIS_PASSWORD \{{ end }}
-   {{- if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}--labels="{{ template "redis.name" . }}-client=true" \{{- end }}
+   {{- if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}--labels="{{ template "redis.fullname" . }}-client=true" \{{- end }}
    --image {{ template "redis.image" . }} -- bash
 
 2. Connect using the Redis CLI:


### PR DESCRIPTION
#### What this PR does / why we need it:
This fixes an inconsistency in the NOTES file that I discovered while testing the chart with NetworkPolicy enabled. The notes text incorrectly specify the label as {{ template "redis.name" }}-client when the NetworkPolicy that is created specify {{ template "redis.fullname" }}-client

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
