### PR TITLE
[stable/ambassador] Fix service annotation data type

### DIFF
--- a/stable/ambassador/Chart.yaml
+++ b/stable/ambassador/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.86.1
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 5.3.0
+version: 5.3.1
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/stable/ambassador/values.yaml
+++ b/stable/ambassador/values.yaml
@@ -80,6 +80,7 @@ service:
       # nodePort: 30222
 
   annotations:
+    {}
   #############################################################################
   ## Ambassador should be configured using CRD definition. If you want
   ## to use annotations, the following is an example of annotating the


### PR DESCRIPTION
Signed-off-by: Tobias Bohrmann <drawback.grimestat+gitlab@aechelon.net>

#### Is this a new chart
No.

#### What this PR does / why we need it:
This PR sets the data type of the service annotation element in values.yaml from `table` to `map`. Without this PR all added annotations to the service via custom values are ignored.

#### Which issue this PR fixes
No issue created. The bug is the same as [this](https://github.com/helm/charts/issues/18532).

#### Special notes for your reviewer:
None.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)