### PR TITLE
[stable/prometheus-operator] Operator RBAC: move some critical permission to Role

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.5.7
+version: 8.5.8
 appVersion: 0.34.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.5.8
+version: 8.5.9
 appVersion: 0.34.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.5.9
+version: 8.5.12
 appVersion: 0.34.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -230,6 +230,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.tlsProxy.image.pullPolicy` | Image pull policy for the TLS proxy container | `IfNotPresent` |
 | `prometheusOperator.tlsProxy.resources` | Resource requests and limits for the TLS proxy container | `{}` |
 | `prometheusOperator.tolerations` | Tolerations for use with node taints https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ | `[]` |
+| `prometheusOperator.rbac.limitWriteAccessToNamespaces` | Limit risky operations (write, secrets access and similar) to selected namespaces. This is not compatible with `denyNamespaces` | `false` |
 
 
 ### Prometheus

--- a/stable/prometheus-operator/templates/prometheus-operator/clusterrole.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/clusterrole.yaml
@@ -26,12 +26,30 @@ rules:
   - podmonitors
   verbs:
   - '*'
+{{- if not .Values.prometheusOperator.rbac.limitWriteAccessToNamespaces }}
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+{{- end }}
 - apiGroups:
   - ""
   resources:
   - pods
   verbs:
   - list
+{{- if not .Values.prometheusOperator.rbac.limitWriteAccessToNamespaces }}
+  - delete
+{{- end }}
 - apiGroups:
   - ""
   resources:
@@ -40,6 +58,11 @@ rules:
   - endpoints
   verbs:
   - get
+{{- if not .Values.prometheusOperator.rbac.limitWriteAccessToNamespaces }}
+  - create
+  - update
+  - delete
+{{- end }}
 - apiGroups:
   - ""
   resources:

--- a/stable/prometheus-operator/templates/prometheus-operator/role.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/role.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.prometheusOperator.enabled .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-operator
   labels:
@@ -8,22 +8,16 @@ metadata:
 {{ include "prometheus-operator.labels" . | indent 4 }}
 rules:
 - apiGroups:
-  - apiextensions.k8s.io
+  - apps
   resources:
-  - customresourcedefinitions
+  - statefulsets
   verbs:
   - '*'
 - apiGroups:
-  - monitoring.coreos.com
+  - ""
   resources:
-  - alertmanagers
-  - prometheuses
-  - prometheuses/finalizers
-  - alertmanagers/finalizers
-  - servicemonitors
-  - podmonitors
-  - prometheusrules
-  - podmonitors
+  - configmaps
+  - secrets
   verbs:
   - '*'
 - apiGroups:
@@ -32,6 +26,7 @@ rules:
   - pods
   verbs:
   - list
+  - delete
 - apiGroups:
   - ""
   resources:
@@ -40,19 +35,7 @@ rules:
   - endpoints
   verbs:
   - get
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
+  - create
+  - update
+  - delete
 {{- end }}

--- a/stable/prometheus-operator/templates/prometheus-operator/role.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/role.yaml
@@ -1,11 +1,17 @@
-{{- if and .Values.prometheusOperator.enabled .Values.global.rbac.create }}
+{{- if and .Values.prometheusOperator.enabled .Values.global.rbac.create .Values.prometheusOperator.rbac.limitWriteAccessToNamespaces }}
+{{- $ns:= list .Release.Namespace }}
+{{- if .Values.prometheusOperator.namespaces.additonal }}
+{{- $ns = concat $ns .Values.prometheusOperator.namespaces.additonal }}
+{{- end }}
+{{- range $ns }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ template "prometheus-operator.fullname" . }}-operator
+  name: {{ template "prometheus-operator.fullname" $ }}-operator
+  namespace: {{ . }}
   labels:
-    app: {{ template "prometheus-operator.name" . }}-operator
-{{ include "prometheus-operator.labels" . | indent 4 }}
+    app: {{ template "prometheus-operator.name" $ }}-operator
+{{ include "prometheus-operator.labels" $ | indent 4 }}
 rules:
 - apiGroups:
   - apps
@@ -38,4 +44,5 @@ rules:
   - create
   - update
   - delete
+{{- end }}
 {{- end }}

--- a/stable/prometheus-operator/templates/prometheus-operator/rolebinding.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/rolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.prometheusOperator.enabled .Values.global.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "prometheus-operator.fullname" . }}-operator
+  labels:
+    app: {{ template "prometheus-operator.name" . }}-operator
+{{ include "prometheus-operator.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "prometheus-operator.fullname" . }}-operator
+subjects:
+- kind: ServiceAccount
+  name: {{ template "prometheus-operator.operator.serviceAccountName" . }}
+  namespace: {{ $.Release.Namespace }}
+{{- end }}

--- a/stable/prometheus-operator/templates/prometheus-operator/rolebinding.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/rolebinding.yaml
@@ -1,17 +1,24 @@
-{{- if and .Values.prometheusOperator.enabled .Values.global.rbac.create }}
+{{- if and .Values.prometheusOperator.enabled .Values.global.rbac.create .Values.prometheusOperator.rbac.limitWriteAccessToNamespaces }}
+{{- $ns:= list .Release.Namespace }}
+{{- if .Values.prometheusOperator.namespaces.additonal }}
+{{- $ns = concat $ns .Values.prometheusOperator.namespaces.additonal }}
+{{- end }}
+{{- range $ns }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "prometheus-operator.fullname" . }}-operator
+  namespace: {{ . }}
+  name: {{ template "prometheus-operator.fullname" $ }}-operator
   labels:
-    app: {{ template "prometheus-operator.name" . }}-operator
-{{ include "prometheus-operator.labels" . | indent 4 }}
+    app: {{ template "prometheus-operator.name" $ }}-operator
+{{ include "prometheus-operator.labels" $ | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "prometheus-operator.fullname" . }}-operator
+  name: {{ template "prometheus-operator.fullname" $ }}-operator
 subjects:
 - kind: ServiceAccount
-  name: {{ template "prometheus-operator.operator.serviceAccountName" . }}
+  name: {{ template "prometheus-operator.operator.serviceAccountName" $ }}
   namespace: {{ $.Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -1011,6 +1011,12 @@ prometheusOperator:
   ##
   denyNamespaces: []
 
+  rbac:
+    ## Limits write access and secrets/configmap access to selected namespaces only.
+    ## This cannot be used with denyNamespaces option
+    ##
+    limitWriteAccessToNamespaces: false
+
   ## Service account for Alertmanager to use.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
   ##


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
This PR is an idea for moving part of critical permissions from ClusterRole to Role, as I think that it's not very secure to grant monitoring operator such extensive access.

#### Which issue this PR fixes
  - fixes #19953

#### Special notes for your reviewer:
I really needs Your opinion because maybe it's not the best way to fix those permissions, maybe I'm missing something and this access is really needed.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
