### PR TITLE
[stable/prometheus-cloudwatch-exporter] - Add annotations to serviceAccounts for EKS IAM

### DIFF
--- a/stable/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/stable/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.6.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.5.0
+version: 0.6.0
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -15,6 +15,7 @@ This chart bootstraps a [cloudwatch exporter](http://github.com/prometheus/cloud
 ## Prerequisites
 
 - [kube2iam](../../stable/kube2iam) installed to used the **aws.role** config option otherwise configure **aws.aws_access_key_id** and **aws.aws_secret_access_key** or **aws.secret.name**
+- Or an [IAM Role for service account](https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/) attached to a service account with an annotation. However, you cannot run the pod as nobody in `securityContext.runAsUser` as it won't be able to access the mounted secret.
 
 ## Installing the Chart
 
@@ -69,6 +70,7 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | `rbac.create`                     | If true, create & use RBAC resources                                    | `false`                     |
 | `serviceAccount.create`           | Specifies whether a service account should be created.                  | `true`                      |
 | `serviceAccount.name`             | Name of the service account.                                            |                             |
+| `serviceAccount.annotations`      | Custom annotations for service  account.                                | `{}`                        |
 | `tolerations`                     | Add tolerations                                                         | `[]`                        |
 | `nodeSelector`                    | node labels for pod assignment                                          | `{}`                        |
 | `affinity`                        | node/pod affinities                                                     | `{}`                        |

--- a/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -107,8 +107,8 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
     {{- if .Values.serviceAccount.create }}
-      serviceAccount: {{ template "prometheus-cloudwatch-exporter.name" . }}
-      serviceAccountName: {{ template "prometheus-cloudwatch-exporter.name" . }}
+      serviceAccount: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
+      serviceAccountName: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
     {{- end }}
       volumes:
       - configMap:

--- a/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -106,6 +106,10 @@ spec:
       securityContext:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- if .Values.serviceAccount.create }}
+      serviceAccount: {{ template "prometheus-cloudwatch-exporter.name" . }}
+      serviceAccountName: {{ template "prometheus-cloudwatch-exporter.name" . }}
+    {{- end }}
       volumes:
       - configMap:
           defaultMode: 420

--- a/stable/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
@@ -8,8 +8,9 @@ metadata:
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}    
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  {{- if .Values.serviceAccount.annotations }}
+  
   annotations:
+  {{- if .Values.serviceAccount.annotations }}
     {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
   {{- end }}
 {{- end }}

--- a/stable/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "prometheus-cloudwatch-exporter.name" . }}
+  name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
   labels:
     app: {{ template "prometheus-cloudwatch-exporter.name" . }}
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}    

--- a/stable/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
+  name: {{ template "prometheus-cloudwatch-exporter.name" . }}
   labels:
     app: {{ template "prometheus-cloudwatch-exporter.name" . }}
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}    

--- a/stable/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
@@ -8,4 +8,8 @@ metadata:
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}    
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+    {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+  {{- end }}
 {{- end }}

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -64,8 +64,8 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
-  #annotations:
-  # Will add the provided map to the annotations for the crated serviceAccount 
+  # annotations:
+  # Will add the provided map to the annotations for the crated serviceAccount
   # e.g.
   # annotations:
   #   eks.amazonaws.com/role-arn: arn:aws:iam::1234567890:role/prom-cloudwatch-exporter-oidc

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -64,6 +64,11 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+  #annotations:
+  # Will add the provided map to the annotations for the crated serviceAccount 
+  # e.g.
+  # annotations:
+  #   eks.amazonaws.com/role-arn: arn:aws:iam::1234567890:role/prom-cloudwatch-exporter-oidc
 
 rbac:
   # Specifies whether RBAC resources should be created


### PR DESCRIPTION
Add service account annotation and add service account to deployment.

Signed-off-by: Louis Bougeard <lbougeard@and.digital>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This PR allows for annotations to serviceAccounts to allow for IAM roles for service accounts in EKS rather than having to pass in tokens, instead using a web identity token file.

This relates to: https://groups.google.com/forum/#!topic/prometheus-users/mhn1Z3yG-XA

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
