### PR TITLE
Update percona to 5.7.26 and fix manifest to use apps/v1

### DIFF
--- a/stable/percona/Chart.yaml
+++ b/stable/percona/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: percona
-version: 1.2.0
+version: 1.2.1
 appVersion: 5.7.26
 description: free, fully compatible, enhanced, open source drop-in replacement for
   MySQL

--- a/stable/percona/Chart.yaml
+++ b/stable/percona/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: percona
 version: 1.2.0
-appVersion: 5.7.17
+appVersion: 5.7.26
 description: free, fully compatible, enhanced, open source drop-in replacement for
   MySQL
 keywords:

--- a/stable/percona/templates/deployment.yaml
+++ b/stable/percona/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "percona.fullname" . }}
@@ -8,6 +8,9 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "percona.fullname" . }}
   template:
     metadata:
       labels:

--- a/stable/percona/values.yaml
+++ b/stable/percona/values.yaml
@@ -5,7 +5,7 @@ image: "percona"
 ## percona image version
 ## ref: https://hub.docker.com/r/library/percona/tags/
 ##
-imageTag: "5.7.17"
+imageTag: "5.7.26"
 
 ## Specify password for root user
 ##


### PR DESCRIPTION
Current percona chart deployment use extensions/v1beta1 apiVersion which won't work on new versions of kubernetes.

I changed deployment to use apps/v1

Percona image updated from 5.7.17 to 5.7.26 