### PR TITLE
[stable/pgadmin] upgrade to 4.17 and more

### DIFF
--- a/stable/pgadmin/Chart.yaml
+++ b/stable/pgadmin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin is a web based administration tool for PostgreSQL database
 name: pgadmin
-version: 1.0.6
+version: 1.1.0
 appVersion: 4.17.0
 home: https://www.pgadmin.org/
 source: https://github.com/rowanruseler/pgadmin

--- a/stable/pgadmin/Chart.yaml
+++ b/stable/pgadmin/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: pgAdmin is a web based administration tool for PostgreSQL database
 name: pgadmin
-version: 1.0.5
-appVersion: 4.15.0
+version: 1.0.6
+appVersion: 4.17.0
 home: https://www.pgadmin.org/
 source: https://github.com/rowanruseler/pgadmin
 maintainers:

--- a/stable/pgadmin/README.md
+++ b/stable/pgadmin/README.md
@@ -42,7 +42,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | --------- | ----------- | ------- |
 | `replicaCount` | Number of pgadmin replicas | `1` |
 | `image.repository` | Docker image | `dpage/pgadmin4` |
-| `image.tag` | Docker image tag | `4.15` |
+| `image.tag` | Docker image tag | `4.17` |
 | `image.pullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `service.type` | Service type (ClusterIP, NodePort or LoadBalancer) | `ClusterIP` |
 | `service.port` | Service port | `80` |
@@ -53,9 +53,11 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `ingress.path` | Ingress path mapping | `` |
 | `env.username` | pgAdmin default email | `chart@example.local` |
 | `env.password` | pgAdmin default password | `SuperSecret` |
-| `persistence` | Persistent enabled/disabled | `true` |
-| `persistence.accessMode` | Persistent Access Mode | `ReadWriteOnce` |
-| `persistence.size` | Persistent volume size | `10Gi` |
+| `persistentVolume` | Persistent Volume enabled/disabled | `true` |
+| `persistentVolume.accessMode` | Persistent Access Mode | `ReadWriteOnce` |
+| `persistentVolume.size` | Persistent volume size | `10Gi` |
+| `persistentVolume.storageClass` | Persistent Volume Storage Class | `unset` |
+| `securityContext` | Custom [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for pgAdmin containers | `{}` |
 | `resources` | CPU/memory resource requests/limits | `{}` |
 | `nodeSelector` | Node labels for pod assignment | `{}` |
 | `tolerations` | Node tolerations for pod assignment | `[]` |

--- a/stable/pgadmin/templates/deployment.yaml
+++ b/stable/pgadmin/templates/deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: {{ $fullName }}
   labels:
-{{ include "pgadmin.labels" . | indent 4 }}
+    {{- include "pgadmin.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -17,10 +17,6 @@ spec:
         app.kubernetes.io/name: {{ include "pgadmin.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-    {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -29,14 +25,14 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
+        {{- if .Values.livenessProbe }}
           livenessProbe:
-            httpGet:
-              path: /
-              port: http
+            {{- .Values.livenessProbe | toYaml | nindent 12 }}
+        {{- end }}
+        {{- if .Values.readinessProbe }}
           readinessProbe:
-            httpGet:
-              path: /
-              port: http
+            {{- .Values.readinessProbe | toYaml | nindent 12 }}
+        {{- end }}
           env:
             - name: PGADMIN_PORT
               value: "80"
@@ -51,24 +47,32 @@ spec:
             - name: pgadmin-data
               mountPath: /var/lib/pgadmin
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- .Values.resources | toYaml | nindent 12 }}
       volumes:
         - name: pgadmin-data
-        {{- if .Values.persistence.enabled }}
+        {{- if .Values.persistentVolume.enabled }}
           persistentVolumeClaim:
-            claimName: {{ $fullName }}
+            claimName: {{ if .Values.persistentVolume.existingClaim }}{{ .Values.persistentVolume.existingClaim }}{{- else }}{{ $fullName }}{{- end }}
         {{- else }}
           emptyDir: {}
         {{- end }}
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-    {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- .Values.imagePullSecrets | toYaml | nindent 8 }}
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{- .Values.nodeSelector | toYaml | nindent 8 }}
+    {{- end }}
+    {{- if .Values.securityContext }}
+      securityContext:
+        {{- .Values.securityContext | toYaml | nindent 8 }}
+    {{- end }}
+    {{- if .Values.affinity }}
+      affinity:
+        {{- .Values.affinity | toYaml | nindent 8 }}
+    {{- end }}
+    {{- if .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+        {{- .Values.tolerations | toYaml | nindent 8 }}}
     {{- end }}

--- a/stable/pgadmin/templates/ingress.yaml
+++ b/stable/pgadmin/templates/ingress.yaml
@@ -5,10 +5,10 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-{{ include "pgadmin.labels" . | indent 4 }}
+    {{- include "pgadmin.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- .Values.ingress.annotations | toYaml | nindent 4 }}
   {{- end }}
 spec:
 {{- if .Values.ingress.tls }}

--- a/stable/pgadmin/templates/pvc.yaml
+++ b/stable/pgadmin/templates/pvc.yaml
@@ -1,19 +1,26 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+{{- if and .Values.persistentVolume.enabled (not .Values.persistentVolume.existingClaim) }}
 {{- $fullName := include "pgadmin.fullname" . -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ $fullName }}
   labels:
-{{ include "pgadmin.labels" . | indent 4 }}
-  {{- with .Values.persistence.annotations }}
+    {{- include "pgadmin.labels" . | nindent 4 }}
+  {{- with .Values.persistentVolume.annotations }}
   annotations:
-  {{ toYaml . | indent 4 }}
+    {{- .Values.persistentVolume.annotaions | toYaml | nindent 4 }}
   {{- end }}
 spec:
   accessModes:
-    - {{ .Values.persistence.accessMode | quote }}
+    {{- .Values.persistentVolume.accessModes | toYaml | nindent 4 }}
+{{- if .Values.persistentVolume.storageClassName }}
+{{- if (eq "-" .Values.persistentVolume.storageClassName) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistentVolume.storageClassName }}"
+{{- end }}
+{{- end }}
   resources:
     requests:
-      storage: {{ .Values.persistence.size | quote }}
+      storage: {{ .Values.persistentVolume.size }}
 {{- end }}

--- a/stable/pgadmin/templates/secrets.yaml
+++ b/stable/pgadmin/templates/secrets.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: {{ $fullName }}
   labels:
-{{ include "pgadmin.labels" . | indent 4 }}
+    {{- include "pgadmin.labels" . | nindent 4 }}
 type: Opaque
 data:
   password: {{ default "SuperSecret" .Values.env.password | b64enc | quote }}

--- a/stable/pgadmin/templates/service.yaml
+++ b/stable/pgadmin/templates/service.yaml
@@ -1,9 +1,10 @@
+{{- $fullName := include "pgadmin.fullname" . -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "pgadmin.fullname" . }}
+  name: {{ $fullName }}
   labels:
-{{ include "pgadmin.labels" . | indent 4 }}
+    {{- include "pgadmin.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -12,5 +13,5 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: {{ include "pgadmin.name" . }}
+    app.kubernetes.io/name: {{ $fullName }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/pgadmin/values.yaml
+++ b/stable/pgadmin/values.yaml
@@ -2,9 +2,11 @@
 
 replicaCount: 1
 
+## pgAdmin container image
+##
 image:
   repository: dpage/pgadmin4
-  tag: 4.15
+  tag: 4.17
   pullPolicy: IfNotPresent
 
 service:
@@ -12,14 +14,24 @@ service:
   port: 80
 
 ingress:
+  ## If true, pgAdmin Ingress will be created
+  ##
   enabled: false
+
+  ## pgAdmin Ingress annotations
+  ##
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+
+  ## pgAdmin Ingress hostnames with optional path
+  ## Must be provided if Ingress is enabled
   hosts:
     - host: chart-example.local
       paths: []
 
+  ## pgAdmin Ingress TLS configuration
+  ## Secrets must be manually created in the namespace
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
@@ -33,21 +45,42 @@ env:
   email: chart@example.local
   password: SuperSecret
 
-persistence:
+persistentVolume:
+  ## If true, pgAdmin will create/use a Persistent Volume Claim
+  ## If false, use emptyDir
+  ##
   enabled: true
-  annotations: {
-    volume.alpha.kubernetes.io/storage-class: default
-  }
+
+  ## pgAdmin Persistent Volume Claim annotations
+  ##
+  annotations: {}
+
+  ## pgAdmin Persistent Volume access modes
+  ## Must match those of existing PV or dynamic provisioner
+  ## Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  accessModes:
+    - ReadWriteOnce
+
+  ## pgAdmin Persistent Volume Size
+  ##
+  size: 10Gi
+
+  ## pgAdmin Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning
   ## If undefined (the default) or set to null, no storageClassName spec is
   ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
   ##   GKE, AWS & OpenStack)
   ##
-  # storageClass: ""
-  accessMode: ReadWriteOnce
-  size: 10Gi
+  # storageClass: "-"
   # existingClaim: ""
+
+## Security context to be added to pgAdmin pods
+##
+securityContext:
+  runAsUser: 0
+  runAsGroup: 5050
+  fsGroup: 5050
 
 resources: {}
   # limits:
@@ -57,8 +90,37 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+## pgAdmin readiness and liveness probe initial delay and timeout
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+##
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 30
+  timeoutSeconds: 30
+  successThreshold: 1
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 30
+  timeoutSeconds: 30
+  successThreshold: 1
+  failureThreshold: 3
+
+## Node labels for pgAdmin pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
 nodeSelector: {}
 
+## Node tolerations for server scheduling to nodes with taints
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+##
 tolerations: []
 
+## Pod affinity
+##
 affinity: {}


### PR DESCRIPTION
4.17:
  with 4.16 and up `USER: pgadmin` got added to the Dockerfile, this
  caused an ACL issue. securityContext is added to resolve this issue.

also:
  - fixed dynamic PV provisioning
  - livenessProbe
  - readinessProbe
  - commenting
  - updated README.md with new configuration items
  - chart bump version

Signed-off-by: Rowan Ruseler <rowanruseler@gmail.com>
