### PR TITLE
[stable/dex] Add liveness and readiness probes.

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 2.6.2
+version: 2.7.0
 appVersion: 2.21.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/README.md
+++ b/stable/dex/README.md
@@ -95,7 +95,18 @@ Parameters introduced starting from v2
 | `ports.web.servicePort` | K8S Service port for the dex http/https listener | `32000` |
 | `rbac.create` | If `true`, create & use RBAC resources | `true` |
 | `service.loadBalancerIP` | IP override for K8S LoadBalancer Service | `""` |
-
+| `livenessProbe.enabled` | k8s liveness probe enabled (cannot be enabled when `https = true`) | `false` |
+| `livenessProbe.path` |  k8s liveness probe http path | `"/healthz"`  |
+| `livenessProbe.initialDelaySeconds` | Number of seconds after the container has started before liveness probe is initiated.  |  `1` |
+| `livenessProbe.periodSeconds` | How often (in seconds) to perform the probe | `10`  |
+| `livenessProbe.timeoutSeconds` | Number of seconds after which the probe times out | `1`  |
+| `livenessProbe.failureThreshold` | Times to perform probe before restarting the container | `3`  |
+| `readinessProbe.enabled` | k8s readiness probe enabled (cannot be enabled when `https = true`) | `false`  |
+| `readinessProbe.path` |  k8s readiness probe http path | `"/healthz"`  |
+| `readinessProbe.initialDelaySeconds` | Number of seconds after the container has started before readiness probe is initiated.  |  `1` |
+| `readinessProbe.periodSeconds` | How often (in seconds) to perform the probe  |  `10` |
+| `readinessProbe.timeoutSeconds` | Number of seconds after which the probe times out | `1`  |
+| `readinessProbe.failureThreshold` | Times to perform probe before marking the container `Unready` |  `3` |
 
 
 Check [values.yaml](values.yaml) notes together with [dex documentation][dex] and [config examples](https://github.com/dexidp/dex/tree/master/examples) for all the possible configuration options.

--- a/stable/dex/templates/deployment.yaml
+++ b/stable/dex/templates/deployment.yaml
@@ -71,6 +71,26 @@ spec:
           containerPort: {{ .Values.ports.grpc.containerPort }}
           protocol: TCP
         {{- end }}
+{{- if and (not .Values.https) .Values.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.livenessProbe.httpPath }}
+            port: {{ if .Values.https }}https{{ else }}http{{ end }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+{{- end }}
+{{- if and (not .Values.https) .Values.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.readinessProbe.httpPath }}
+            port: {{ if .Values.https }}https{{ else }}http{{ end }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+{{- end }}
         env:
 {{ toYaml .Values.env | indent 10 }}
         volumeMounts:

--- a/stable/dex/values.yaml
+++ b/stable/dex/values.yaml
@@ -52,6 +52,22 @@ ports:
     nodePort: 35000
     servicePort: 35000
 
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 1
+  failureThreshold: 1
+  httpPath: "/healthz"
+  periodSeconds: 10
+  timeoutSeconds: 1
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 1
+  failureThreshold: 1
+  httpPath: "/healthz"
+  periodSeconds: 10
+  timeoutSeconds: 1
+
 service:
   type: ClusterIP
   # Override IP for the Service Type: LoadBalancer.


### PR DESCRIPTION
### What this PR does / why we need it:
Liveness and readiness were missing.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
