### PR TITLE
[stable/owncloud] Set deployment strategy with values

### DIFF
--- a/stable/owncloud/Chart.yaml
+++ b/stable/owncloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: owncloud
-version: 8.0.3
+version: 8.1.0
 appVersion: 10.3.2
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/owncloud/README.md
+++ b/stable/owncloud/README.md
@@ -95,6 +95,7 @@ The following table lists the configurable parameters of the ownCloud chart and 
 | `persistence.owncloud.existingClaim`| An Existing PVC name for ownCloud volume   | `nil` (uses alpha storage class annotation)             |
 | `persistence.owncloud.accessMode`   | PVC Access Mode for ownCloud volume        | `ReadWriteOnce`                                         |
 | `persistence.owncloud.size`         | PVC Storage Request for ownCloud volume    | `8Gi`                                                   |
+| `updateStrategy.type`               | Owncloud deployment strategy               | `RollingUpdate`                                         |
 | `resources`                         | CPU/Memory resource requests/limits        | Memory: `512Mi`, CPU: `300m`                            |
 | `podAnnotations`                    | Pod annotations                            | `{}`                                                    |
 | `affinity`                          | Map of node/pod affinities                 | `{}`                                                    |

--- a/stable/owncloud/templates/deployment.yaml
+++ b/stable/owncloud/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
       app: {{ template "owncloud.fullname" . }}
       release: "{{ .Release.Name }}"
   replicas: 1
+{{- if .Values.updateStrategy }}
+  strategy: {{ toYaml .Values.updateStrategy | nindent 4 }}
+{{- end }}
   template:
     metadata:
       labels:

--- a/stable/owncloud/values.yaml
+++ b/stable/owncloud/values.yaml
@@ -218,6 +218,17 @@ persistence:
     accessMode: ReadWriteOnce
     size: 8Gi
 
+## Set up update strategy for the ownCloud installation.
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+## Example:
+# updateStrategy:
+#  type: RollingUpdate
+#  rollingUpdate:
+#    maxSurge: 25%
+#    maxUnavailable: 25%
+updateStrategy:
+  type: RollingUpdate
+
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##


### PR DESCRIPTION
Signed-off-by: Pavlo Zabudskyi <pavlo.zabudskyi@gmail.com>

#### What this PR does / why we need it:
We need possibility to set `.spec.strategy.type` to `Recreate` for owncloud deployment. When PVC access mode is set to `ReadWriteOnce` and pod is deleted, it can't re-map volume. Default value is set to `RollingUpdate`.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
