### PR TITLE
[stable/rabbitmq] Fix prometheus scrape port

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.16.2
+version: 6.16.3
 appVersion: 3.8.2
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/values-production.yaml
+++ b/stable/rabbitmq/values-production.yaml
@@ -419,7 +419,7 @@ metrics:
   resources: {}
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "9090"
+    prometheus.io/port: "9419"
 
   livenessProbe:
     enabled: true

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -400,7 +400,7 @@ metrics:
   resources: {}
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "9090"
+    prometheus.io/port: "9419"
 
   livenessProbe:
     enabled: true


### PR DESCRIPTION
Signed-off-by: Alejandro Moreno <amoreno@bitnami.com>

#### What this PR does / why we need it:
Specifies the correct port for scraping metrics in RabbitMQ

#### Which issue this PR fixes
  - fixes #20115 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
