### PR TITLE
[stable/prometheus-postgres-exporter] Allow constantLabels argument to be passed

### DIFF
--- a/stable/prometheus-postgres-exporter/Chart.yaml
+++ b/stable/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 1.2.0
+version: 1.3.0
 home: https://github.com/wrouesnel/postgres_exporter
 sources:
 - https://github.com/wrouesnel/postgres_exporter

--- a/stable/prometheus-postgres-exporter/README.md
+++ b/stable/prometheus-postgres-exporter/README.md
@@ -59,6 +59,7 @@ The following table lists the configurable parameters of the postgres Exporter c
 | `config.disableDefaultMetrics`  | Specifies whether to use only metrics from `queries.yaml`| `false` |
 | `config.autoDiscoverDatabases`  | Specifies whether to autodiscover all databases | `false` |
 | `config.excludeDatabases`  | When autodiscover is enabled, list databases to exclude| `[]` |
+| `config.constantLabels`         | Labels to set in all metrics. A list of label=value pairs | `[]` |
 | `rbac.create`                   | Specifies whether RBAC resources should be created.| `true` |
 | `rbac.pspEnabled`               | Specifies whether a PodSecurityPolicy should be created.| `true` |
 | `serviceAccount.create`         | Specifies whether a service account should be created.| `true` |

--- a/stable/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/stable/prometheus-postgres-exporter/templates/deployment.yaml
@@ -48,6 +48,9 @@ spec:
           - {{ .Values.config.excludeDatabases | join "," }}
           {{- end }}
           {{- end }}
+          {{- if .Values.config.constantLabels }}
+          - "--constantLabels={{ .Values.config.constantLabels | join "," }}"
+          {{- end }}
           env:
           - name: DATA_SOURCE_URI
             value: {{ template "prometheus-postgres-exporter.data_source_uri" . }}

--- a/stable/prometheus-postgres-exporter/values.yaml
+++ b/stable/prometheus-postgres-exporter/values.yaml
@@ -78,6 +78,7 @@ config:
   disableSettingsMetrics: false
   autoDiscoverDatabases: false
   excludeDatabases: []
+  constantLabels: []
   # this are the defaults queries that the exporter will run, extracted from: https://github.com/wrouesnel/postgres_exporter/blob/master/queries.yaml
   queries: |-
     pg_replication:


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
The postgres exporter has [a `constantLabels` argument](https://github.com/wrouesnel/postgres_exporter#flags). It's a comma-separated list of `label=value` pairs, so I modeled it after how `excludeDatabases` was implemented.

#### Special notes for your reviewer:
Hey, @gianrubio, thank you for your work on this chart!

I bumped the minor version because that seems consistent with past PRs that have added new values. Let me know if this should be a patch release instead and I can fix it.

I ran this chart against my cluster and it seems to work as expected. It doesn't add the `constantLabels` argument if you don't override it. When you do override, the labels are added as expected to every value on the metrics endpoint.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)