### PR TITLE
[stable/prometheus] fix: alertmanager to use /-/ready as readiness probe

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 10.3.0
+version: 10.3.1
 appVersion: 2.15.2
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/alertmanager-deployment.yaml
+++ b/stable/prometheus/templates/alertmanager-deployment.yaml
@@ -62,7 +62,7 @@ spec:
             - containerPort: 9093
           readinessProbe:
             httpGet:
-              path: {{ .Values.alertmanager.prefixURL }}/#/status
+              path: {{ .Values.alertmanager.prefixURL }}/-/ready
               port: 9093
             initialDelaySeconds: 30
             timeoutSeconds: 30


### PR DESCRIPTION

#### Is this a new chart
No

#### What this PR does / why we need it:
Unifies the readiness probe for prometheus alertmanager. '/#/status' should not be used as its using '#' which is described in RFC https://tools.ietf.org/html/rfc3986#page-113.3 (section 3.3,3.4).
Instead it should use path '/-/ready'

#### Which issue this PR fixes
Already explained higher.

#### Special notes for your reviewer:
This is a really simple change.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
