### PR TITLE
Update jenkins as a code plugin version

### DIFF
--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -253,7 +253,7 @@ master:
   JCasC:
     enabled: false
     defaultConfig: false
-    pluginVersion: "1.32"
+    pluginVersion: "1.35"
     # it's only used when plugin version is <=1.18 for later version the
     # configuration as code support plugin is no longer needed
     supportPluginVersion: "1.18"


### PR DESCRIPTION
Solve issue `Configuration as Code Plugin version 1.32 is older than required. To fix, install version 1.35 or later.`

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

