### PR TITLE
[stable/redis-ha] Fix label selector of haproxy servicemonitor

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 4.4.0
+version: 4.4.1
 appVersion: 5.0.6
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/redis-haproxy-servicemonitor.yaml
+++ b/stable/redis-ha/templates/redis-haproxy-servicemonitor.yaml
@@ -30,5 +30,5 @@ spec:
     matchLabels:
       app: {{ template "redis-ha.name" . }}
       release: {{ .Release.Name }}
-      component: {{ template "redis-ha.name" . }}-haproxy
+      component: {{ template "redis-ha.fullname" . }}-haproxy
 {{- end }}


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
The old servicemonitor did not actually match the deployed service,
because the service uses redis-ha.fullname as a label
(https://github.com/helm/charts/blob/master/stable/redis-ha/templates/redis-haproxy-service.yaml#L9)
but the servicemonitor matches redis-ha.name.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
