### PR TITLE
[stable/rabbitmq] Improvements

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.16.3
+version: 6.16.4
 appVersion: 3.8.2
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -70,6 +70,7 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `rabbitmq.extraPlugins`                      | Extra plugings to enable                         | `nil`                                                   |
 | `rabbitmq.clustering.address_type`           | Switch clustering mode                           | `ip` or `hostname`                                      |
 | `rabbitmq.clustering.k8s_domain`             | Customize internal k8s cluster domain            | `cluster.local`                                         |
+| `rabbitmq.clustering.rebalance`              | Rebalance master for queues in cluster when new replica is created            | `false`                                         |
 | `rabbitmq.logs`                              | Value for the RABBITMQ_LOGS environment variable | `-`                                                     |
 | `rabbitmq.setUlimitNofiles`                  | Specify if max file descriptor limit should be set | `true`                                                |
 | `rabbitmq.ulimitNofiles`                     | Max File Descriptor limit                        | `65536`                                                 |
@@ -164,6 +165,7 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `metrics.serviceMonitor.relabellings`        | Specify Metric Relabellings to add to the scrape endpoint                      | `nil`                     |
 | `metrics.serviceMonitor.honorLabels`         | honorLabels chooses the metric's labels on collisions with target labels.      | `false`                   |
 | `metrics.serviceMonitor.additionalLabels`    | Used to pass Labels that are required by the Installed Prometheus Operator     | `{}`                      |
+| `metrics.serviceMonitor.release`             | Used to pass Labels release that sometimes should be custom for Prometheus Operator     | `nil`                      |
 | `metrics.port        `                       | Prometheus metrics exporter port                 | `9419`                                                  |
 | `metrics.env`                                | Exporter [configuration environment variables](https://github.com/kbudde/rabbitmq_exporter#configuration) | `{}` |
 | `metrics.resources`                          | Exporter resource requests/limit                 | `nil`                                                   |

--- a/stable/rabbitmq/templates/servicemonitor.yaml
+++ b/stable/rabbitmq/templates/servicemonitor.yaml
@@ -10,7 +10,7 @@ metadata:
     app: {{ template "rabbitmq.name" . }}
     chart: {{ template "rabbitmq.chart" .  }}
     heritage: "{{ .Release.Service }}"
-    release:  {{- if .Values.metrics.serviceMonitor.release }}"{{ .Values.metrics.serviceMonitor.release }}"{{ else }}"{{ .Release.Name }}"{{ end }}
+    release: {{ if .Values.metrics.serviceMonitor.release }}"{{ .Values.metrics.serviceMonitor.release }}"{{ else }}"{{ .Release.Name }}"{{ end }}
     {{- if .Values.metrics.serviceMonitor.additionalLabels }}
 {{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
     {{- end }}

--- a/stable/rabbitmq/templates/servicemonitor.yaml
+++ b/stable/rabbitmq/templates/servicemonitor.yaml
@@ -10,7 +10,7 @@ metadata:
     app: {{ template "rabbitmq.name" . }}
     chart: {{ template "rabbitmq.chart" .  }}
     heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
+    release:  {{- if .Values.metrics.serviceMonitor.release }}"{{ .Values.metrics.serviceMonitor.release }}"{{ else }}"{{ .Release.Name }}"{{ end }}
     {{- if .Values.metrics.serviceMonitor.additionalLabels }}
 {{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
     {{- end }}

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -167,6 +167,16 @@ spec:
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
         {{- end }}
+        {{- if and (gt .Values.replicas 1) (.Values.rabbitmq.clustering.rebalance }}
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - until rabbitmqctl cluster_status > /dev/null; do echo waiting for
+                cluster readiness...; sleep 5 ; done; rabbitmq-queues rebalance "all"
+        {{- end }}
         env:
           - name: BITNAMI_DEBUG
             value: {{ ternary "true" "false" .Values.image.debug | quote }}

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -167,14 +167,14 @@ spec:
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
         {{- end }}
-        {{- if and (gt .Values.replicas 1) (.Values.rabbitmq.clustering.rebalance }}
+        {{- if and (gt .Values.replicas 1.0) ( eq .Values.rabbitmq.clustering.rebalance true) }}
         lifecycle:
           postStart:
             exec:
               command:
               - /bin/sh
               - -c
-              - until rabbitmqctl cluster_status > /dev/null; do echo waiting for
+              - until rabbitmqctl cluster_status >/dev/null; do echo Waiting for
                 cluster readiness...; sleep 5 ; done; rabbitmq-queues rebalance "all"
         {{- end }}
         env:

--- a/stable/rabbitmq/values-production.yaml
+++ b/stable/rabbitmq/values-production.yaml
@@ -114,6 +114,9 @@ rabbitmq:
   clustering:
     address_type: hostname
     k8s_domain: cluster.local
+    ## Rebalance master for queues in cluster when new replica is created
+    ## ref: https://www.rabbitmq.com/rabbitmq-queues.8.html#rebalance
+    rebalance: false
 
   loadDefinition:
     enabled: false
@@ -453,6 +456,8 @@ metrics:
     # relabellings:
     ## Specify honorLabels parameter to add the scrape endpoint
     honorLabels: false
+    ## Specify the release for ServiceMonitor. Sometimes it should be custom for prometheus operator to work
+    # release: ""
     ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
     additionalLabels: {}

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -438,7 +438,7 @@ metrics:
     ## Specify honorLabels parameter to add the scrape endpoint
     honorLabels: false
     ## Specify the release for ServiceMonitor. Sometimes it should be custom for prometheus operator to work
-    #release: ""
+    # release: ""
     ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
     additionalLabels: {}

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -114,6 +114,9 @@ rabbitmq:
   clustering:
     address_type: hostname
     k8s_domain: cluster.local
+    ## Rebalance master for queues in cluster when new replica is created
+    ## ref: https://www.rabbitmq.com/rabbitmq-queues.8.html#rebalance
+    rebalance: false
 
   loadDefinition:
     enabled: false
@@ -434,6 +437,8 @@ metrics:
     # relabellings:
     ## Specify honorLabels parameter to add the scrape endpoint
     honorLabels: false
+    ## Specify the release for ServiceMonitor. Sometimes it should be custom for prometheus operator to work
+    #release: ""
     ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
     additionalLabels: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds ability to rebalance master for queues when number of replicas >1
ref: https://www.rabbitmq.com/rabbitmq-queues.8.html#rebalance

Add improvements to ServiceMonitor


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
