### PR TITLE
[stable/graylog] Update elasticsearch dependency version.

### DIFF
--- a/stable/graylog/Chart.yaml
+++ b/stable/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: graylog
 home: https://www.graylog.org
-version: 1.5.1
+version: 1.5.2
 appVersion: 3.1
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:

--- a/stable/graylog/requirements.yaml
+++ b/stable/graylog/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: elasticsearch
-  version: 1.15.0
+  version: 1.32.2
   repository: https://kubernetes-charts.storage.googleapis.com/
   tags:
     - install-elasticsearch


### PR DESCRIPTION
#### What this PR does / why we need it:
`requirements.yaml` pulls reference to outdated elasticsearch chart, which fails to install under k8s 1.16+. This PR updates the dependency version to use a more recent elasticsearch chart.

#### Which issue this PR fixes
Fixes #18997, which causes graylog chart to fail due to deprecated API version used by the old elasticsearch chart.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)