### PR TITLE
[stable/metabase] allow exising secrets to be used for database credentials + add extra pods labels value

### DIFF
--- a/stable/metabase/Chart.yaml
+++ b/stable/metabase/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 0.9.4
+version: 0.10.0
 appVersion: v0.34.0
 maintainers:
 - name: pmint93

--- a/stable/metabase/README.md
+++ b/stable/metabase/README.md
@@ -46,6 +46,7 @@ The following table lists the configurable parameters of the Metabase chart and 
 | -------------------------------  | ----------------------------------------------------------- | ----------------- |
 | replicaCount                     | desired number of controller pods                           | 1                 |
 | podAnnotations                   | controller pods annotations                                 | {}                |
+| podLabels                        | extra pods labels                                           | {}                |
 | image.repository                 | controller container image repository                       | metabase/metabase |
 | image.tag                        | controller container image tag                              | v0.34.0           |
 | image.pullPolicy                 | controller container image pull policy                      | IfNotPresent      |
@@ -63,6 +64,10 @@ The following table lists the configurable parameters of the Metabase chart and 
 | database.dbname                  | Database name                                               | null              |
 | database.username                | Database username                                           | null              |
 | database.password                | Database password                                           | null              |
+| database.existingSecret          | Exising secret for database credentials                     | null              |
+| database.existingSecretUsernameKey | Username key for exising secret                           | null              |
+| database.existingSecretPasswordKey | Password key for exising secret                           | null              |
+| database.existingSecretConnectionURIKey | ConnectionURI key for exising secret                 | null              |
 | password.complexity              | Complexity requirement for Metabase account's password      | normal            |
 | password.length                  | Minimum length required for Metabase account's password     | 6                 |
 | timeZone                         | Service time zone                                           | UTC               |

--- a/stable/metabase/templates/database-secret.yaml
+++ b/stable/metabase/templates/database-secret.yaml
@@ -1,3 +1,4 @@
+{{- if and (ne (.Values.database.type | lower) "h2") (not .Values.database.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,7 +14,6 @@ data:
   {{- if .Values.database.encryptionKey }}
   encryptionKey: {{ .Values.database.encryptionKey | b64enc | quote }}
   {{- end }}
-{{- if ne (.Values.database.type | lower) "h2" }}
   {{- if .Values.database.connectionURI }}
   connectionURI: {{ .Values.database.connectionURI | b64enc | quote }}
   {{- else }}

--- a/stable/metabase/templates/deployment.yaml
+++ b/stable/metabase/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
       labels:
         app: {{ template "metabase.name" . }}
         release: {{ .Release.Name }}
+        {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | trim | indent 8 }}
+        {{- end }}
     spec:
       containers:
         - name: {{ .Chart.Name }}
@@ -59,12 +62,12 @@ spec:
                 key: encryptionKey
           {{- end }}
           {{- if ne (.Values.database.type | lower) "h2" }}
-            {{- if .Values.database.connectionURI }}
+            {{- if or .Values.database.existingSecretConnectionURIKey .Values.database.connectionURI }}
           - name: MB_DB_CONNECTION_URI
             valueFrom:
               secretKeyRef:
-                name: {{ template "metabase.fullname" . }}-database
-                key: connectionURI
+                name: {{ or .Values.database.existingSecret (printf "%s-database" (include "metabase.fullname" .)) }}
+                key: {{ or .Values.database.existingSecretConnectionURIKey "connectionURI" }}
             {{- else }}
           - name: MB_DB_HOST
             value: {{ .Values.database.host | quote }}
@@ -75,13 +78,13 @@ spec:
           - name: MB_DB_USER
             valueFrom:
               secretKeyRef:
-                name: {{ template "metabase.fullname" . }}-database
-                key: username
+                name: {{ or .Values.database.existingSecret (printf "%s-database" (include "metabase.fullname" .)) }}
+                key: {{ or .Values.database.existingSecretUsernameKey "username" }}
           - name: MB_DB_PASS
             valueFrom:
               secretKeyRef:
-                name: {{ template "metabase.fullname" . }}-database
-                key: password
+                name: {{ or .Values.database.existingSecret (printf "%s-database" (include "metabase.fullname" .)) }}
+                key: {{ or .Values.database.existingSecretPasswordKey "password" }}
             {{- end }}
           {{- end }}
           - name: MB_PASSWORD_COMPLEXITY

--- a/stable/metabase/values.yaml
+++ b/stable/metabase/values.yaml
@@ -4,6 +4,7 @@
 # NOTE: Should remain 1
 replicaCount: 1
 podAnnotations: {}
+podLabels: {}
 image:
   repository: metabase/metabase
   tag: v0.34.0
@@ -34,6 +35,11 @@ database:
   # password:
   ## Alternatively, use a connection URI for full configurability. Example for SSL enabled Postgres.
   # connectionURI: postgres://user:password@host:port/database?ssl=true&sslmode=require&sslfactory=org.postgresql.ssl.NonValidatingFactory"
+  ## If a secret with the database credentials already exists, use the following values:
+  # existingSecret:
+  # existingSecretUsernameKey:
+  # existingSecretPasswordKey:
+  # existingSecretConnectionURIKey:
 
 password:
   # Changing Metabase password complexity:


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR allows users to use an existing secret for database credentials. In our case. the database credentials are automatically generated and injected as a secret in the cluster. We don't wish to explicitly write them in the values file. 

Although we don't need it I also added the ability to override the key names for user, password and connectionURI.

This PR also allows users to add extra pod labels. In our case, we need it as we use a network policy for database connections.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)