### PR TITLE
[stable/prometheus] remove namespace to avoid unexpected default ns

### DIFF
--- a/stable/prometheus/templates/alertmanager-clusterrolebinding.yaml
+++ b/stable/prometheus/templates/alertmanager-clusterrolebinding.yaml
@@ -8,7 +8,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "prometheus.serviceAccountName.alertmanager" . }}
-    namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/stable/prometheus/templates/kube-state-metrics-clusterrolebinding.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-clusterrolebinding.yaml
@@ -8,7 +8,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "prometheus.serviceAccountName.kubeStateMetrics" . }}
-    namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/stable/prometheus/templates/node-exporter-role.yaml
+++ b/stable/prometheus/templates/node-exporter-role.yaml
@@ -6,7 +6,6 @@ metadata:
   name: {{ template "prometheus.nodeExporter.fullname" . }}
   labels:
     {{- include "prometheus.nodeExporter.labels" . | nindent 4 }}
-  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups: ['extensions']
   resources: ['podsecuritypolicies']

--- a/stable/prometheus/templates/node-exporter-rolebinding.yaml
+++ b/stable/prometheus/templates/node-exporter-rolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
   name: {{ template "prometheus.nodeExporter.fullname" . }}
   labels:
     {{- include "prometheus.nodeExporter.labels" . | nindent 4 }}
-  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
   name: {{ template "prometheus.nodeExporter.fullname" . }}
@@ -14,6 +13,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "prometheus.serviceAccountName.nodeExporter" . }}
-  namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/stable/prometheus/templates/pushgateway-clusterrolebinding.yaml
+++ b/stable/prometheus/templates/pushgateway-clusterrolebinding.yaml
@@ -8,7 +8,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "prometheus.serviceAccountName.pushgateway" . }}
-    namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/stable/prometheus/templates/server-clusterrolebinding.yaml
+++ b/stable/prometheus/templates/server-clusterrolebinding.yaml
@@ -8,7 +8,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "prometheus.serviceAccountName.server" . }}
-    namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION

namespace: {{ .Release.Namespace }} will cause some time incorrect namespace. All other yaml has already removed this line. 
