### PR TITLE
[stable/redmine] fix: 'servicePort' mismatch between ingress and service

### DIFF
--- a/stable/redmine/Chart.yaml
+++ b/stable/redmine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redmine
-version: 14.1.3
+version: 14.1.4
 appVersion: 4.1.0
 description: A flexible project management web application.
 keywords:

--- a/stable/redmine/templates/ingress.yaml
+++ b/stable/redmine/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
         - path: /
           backend:
             serviceName: "{{ template "redmine.fullname" . }}"
-            servicePort: http
+            servicePort: http-redmine
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
     - host: {{ .name }}
@@ -29,7 +29,7 @@ spec:
         - path: {{ default "/" .path }}
           backend:
             serviceName: "{{ template "redmine.fullname" $ }}"
-            servicePort: http
+            servicePort: http-redmine
     {{- end }}
   {{- if or .Values.ingress.tls .Values.ingress.extraTls .Values.ingress.hosts }}
   tls:


### PR DESCRIPTION
#### What this PR does / why we need it:

There is mismatch between the value of servicePort referenced on the ingress template and the setted on service. (templates/svc.yaml and templates/ingress.yaml).

Nowadays, when the chart is deployed and we access throught the ingress-controller, it returns http error "503 Temporarily Unavailable openresty/1.15.8.2". It is because the ingress references servicePort "http" when it should "http-redmine".

The mistake was introduced on commit Dec 11, 2019: https://github.com/helm/charts/commit/827f27f83830fa2f9d62b08f35d28a1dfda0ff96


<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
