### PR TITLE
[stable/sealed-secrets] Add ability to expose cert.pem via ingress

### DIFF
--- a/stable/sealed-secrets/Chart.yaml
+++ b/stable/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.6.1
+version: 1.7.0
 appVersion: 0.9.6
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/stable/sealed-secrets/templates/ingress.yaml
+++ b/stable/sealed-secrets/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "sealed-secrets.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: 8080
+  {{- end }}
+{{- end }}

--- a/stable/sealed-secrets/values.yaml
+++ b/stable/sealed-secrets/values.yaml
@@ -26,6 +26,19 @@ rbac:
 # secretName: The name of the TLS secret containing the key used to encrypt secrets
 secretName: "sealed-secrets-key"
 
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /v1/cert.pem
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
 crd:
   # crd.create: `true` if the crd resources should be created
   create: true


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
no

#### What this PR does / why we need it:
I want to enable developers to convert the secret to a sealedsecret without access to the kubernetes API (they only have access via a CI/CD pipeline). In the repository from the project itself (https://github.com/bitnami-labs/sealed-secrets) the bitnami guys described how it works:
```bash
kubeseal --cert https://your.intranet.company.com/sealed-secrets/your-cluster.cert
```
With this change, we are now able to expose `/v1/cert.pem` and we can use it like this:
```bash
kubeseal --cert https://chart-example.local/v1/cert.pem
```

#### Which issue this PR fixes
`-`

#### Special notes for your reviewer:
`-`
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
