### PR TITLE
[incubator/kafka] Add ssl-secrets

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.20.7
+version: 0.20.9
 appVersion: 5.0.1
 keywords:
 - kafka

--- a/incubator/kafka/README.md
+++ b/incubator/kafka/README.md
@@ -130,6 +130,21 @@ following configurable parameters:
 | `prometheus.operator.serviceMonitor.releaseNamespace` | Set namespace to release namespace. Default false                                                                           | `false`                                                       |
 | `prometheus.operator.serviceMonitor.selector`         | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install                                                               | `{ prometheus: kube-prometheus }`                                  |
 | `configJob.backoffLimit`                              | Number of retries before considering kafka-config job as failed                                                                                                          | `6`                                                                |
+| `sslSecrets.enable`                                   | If True, installs SSL Secrets
+| `sslSecrets.caBase64`                                 | CA certificate in PEM format encoded in Base64
+| `sslSecrets.broker.truststoreBase64`                  | Broker truststore in JKS format encoded in Base64
+| `sslSecrets.broker.truststorePassword`                | Broker truststore password
+| `sslSecrets.broker.keystoreBase64`                    | Broker keystore in JKS format encoded in Base64
+| `sslSecrets.broker.keystorePassword`                  | Broker keystore password
+| `sslSecrets.broker.keyPassword`                       | Broker key password
+| `sslSecrets.jksClient.truststoreBase64`               | Client truststore in JKS format encoded in Base64
+| `sslSecrets.jksClient.truststorePassword`             | Client truststore password
+| `sslSecrets.jksClient.keystoreBase64`                 | Client keystore in JKS format encoded in Base64
+| `sslSecrets.jksClient.keystorePassword`               | Client keystore password
+| `sslSecrets.jksClient.keyPassword`                    | Client key password
+| `sslSecrets.client.certBase64`                        | Client certificate in PEM format encoded in Base64
+| `sslSecrets.client.keyBase64`                         | Client key in PEM format encoded in Base64
+| `sslSecrets.client.keyPassword`                       | Client key password
 | `topics`                                              | List of topics to create & configure. Can specify name, partitions, replicationFactor, reassignPartitions, config. See values.yaml                                       | `[]` (Empty list)                                                  |
 | `zookeeper.enabled`                                   | If True, installs Zookeeper Chart                                                                                                                                        | `true`                                                             |
 | `zookeeper.resources`                                 | Zookeeper resource requests and limits                                                                                                                                   | `{}`                                                               |

--- a/incubator/kafka/templates/_helpers.tpl
+++ b/incubator/kafka/templates/_helpers.tpl
@@ -25,6 +25,19 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Create a default fully qualified ssl-secrets name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "kafka.sslSecrets.fullname" -}}
+{{- if .Values.sslSecrets.fullnameOverride -}}
+{{- .Values.sslSecrets.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "sslSecrets" .Values.secrets.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified zookeeper name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/incubator/kafka/templates/ssl-secrets.yaml
+++ b/incubator/kafka/templates/ssl-secrets.yaml
@@ -1,0 +1,33 @@
+{{ if .Values.sslSecrets.enable }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include kafka.sslSecrets.fullname . }}
+type: Opaque
+data:
+        {{ with .Values.sslSecrets.broker }}
+        kafka.broker.truststore.jks: {{ required "Truststore is required" .truststoreBase64 }}
+        kafka.broker.truststore.passwd: {{ .truststorePassword | b64enc }}
+
+        kafka.broker.keystore.jks: {{ required "Keystore is required" .keystoreBase64 }}
+        kafka.broker.keystore.passwd: {{ .keystorePassword | b64enc }}
+        kafka.broker.key.passwd: {{ .keyPassword | b64enc }}
+        {{ end }}
+
+        {{ with .Values.sslSecrets.jksClient }}
+        kafka.jksClient.truststore.jks: {{ .truststoreBase64 }}
+        kafka.jksClient.truststore.passwd: {{ .truststorePassword | b64enc }}
+
+        kafka.jksClient.keystore.jks: {{ .keystoreBase64 }}
+        kafka.jksClient.keystore.passwd: {{ .keystorePassword | b64enc }}
+        kafka.jksClient.key.passwd: {{ .keyPassword | b64enc }}
+        {{ end }}
+
+        kafka.ca.crt: {{ required "CA cert is required" .Values.sslSecrets.caBase64 }}
+
+        {{ with .Values.sslSecrets.client }}
+        kafka.client.crt: {{ .certBase64 }}
+        kafka.client.key: {{ .keyBase64 }}
+        kafka.client.key.passwd: {{ .keyPassword | b64enc }}
+        {{ end }}
+{{ end }}

--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -174,6 +174,7 @@ spec:
         - name: KAFKA_JMX_PORT
           value: "{{ .Values.jmx.port }}"
         {{- end }}
+
         {{- range $secret := .Values.secrets }}
           {{- if not $secret.mountPath }}
             {{- range $key := $secret.keys }}
@@ -185,10 +186,33 @@ spec:
             {{- end }}
           {{- end }}
         {{- end }}
+
+        {{- if .Values.sslSecrets.enable }}
+        - name: 'KAFKA_SSL_KEYSTORE_FILENAME'
+          value: 'kafka.broker.keystore.jks'
+        - name: 'KAFKA_SSL_KEYSTORE_FILENAME'
+          value: 'kafka.broker.keystore.jks'
+        - name: 'KAFKA_SSL_KEYSTORE_CREDENTIALS'
+          value: 'keystore-creds'
+        - name: 'KAFKA_SSL_TRUSTSTORE_FILENAME'
+          value: 'kafka.broker.truststore.jks'
+        - name: 'KAFKA_SSL_TRUSTSTORE_CREDENTIALS'
+          value: 'truststore-creds'
+        - name: 'KAFKA_SSL_KEY_CREDENTIALS'
+          value: 'key-creds'
+        - name: 'KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM'
+          value: ''
+        - name: 'KAFKA_SSL_CLIENT_AUTH'
+          value: 'required'
+        - name: 'KAFKA_INTER_BROKER_LISTENER_NAME'
+          value: 'PLAINTEXT'
+        {{- end}}
+
         {{- range $key, $value := .Values.envOverrides }}
         - name: {{ printf "%s" $key | replace "." "_" | upper | quote }}
           value: {{ $value | quote }}
         {{- end }}
+
         # This is required because the Downward API does not yet support identification of
         # pod numbering in statefulsets. Thus, we are required to specify a command which
         # allows us to extract the pod ID for usage as the Kafka Broker ID.
@@ -227,6 +251,12 @@ spec:
             {{- end }}
           {{- end }}
         {{- end }}
+
+        {{- if .Values.sslSecrets.enable }}
+        - name: {{ include "kafka.fullname" $ }}-{{ ssl-secrets }}
+          mountPath: '/etc/kafka/secrets'
+          readOnly: true
+        {{- end }}
       volumes:
       {{- if not .Values.persistence.enabled }}
       - name: datadir
@@ -252,6 +282,13 @@ spec:
           secretName: {{ .name }}
       {{- end }}
       {{- end }}
+
+      {{- if .Values.sslSecrets.enable }}
+      - name: {{ include "kafka.fullname" $ }}-{{ ssl-secrets }}
+        secret:
+          secretName: {{ include "kafka.sslSecrets.fullname" }}
+      {{- end }}
+
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:

--- a/incubator/kafka/values.yaml
+++ b/incubator/kafka/values.yaml
@@ -52,6 +52,31 @@ podManagementPolicy: OrderedReady
 #     - pass
 #   mountPath: /opt/zookeeper/secret
 
+## Pass in SSL secret configurations
+sslSecrets:
+  enable: false
+
+  caBase64: ''
+
+  broker:
+    truststoreBase64: ''
+    truststorePassword: ''
+    keystoreBase64: ''
+    keystorePassword: ''
+    keyPassword: ''
+    
+  jksClient:
+    truststoreBase64: ''
+    truststorePassword: ''
+    keystoreBase64: ''
+    keystorePassword: ''
+    keyPassword: ''
+
+  client:
+    certBase64: ''
+    keyBase64: ''
+    keyPassword: ''
+
 
 ## The subpath within the Kafka container's PV where logs will be stored.
 ## This is combined with `persistence.mountPath`, to create, by default: /opt/kafka/data/logs


### PR DESCRIPTION
#### What this PR does / why we need it:
In a scenario where you need to deploy multiple Kafka clusters into the same Kubernetes cluster dynamically without touching anything in this chart you will need to take special care of the secrets (e.g. certificates, passwords). Since this chart only receives a name pointing to a secret, we cannot automate dynamic deployments without redefining the secrets ref. This PR add the possibility of dynamically deploying a secrets resource among with your Kafka cluster.

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

Signed-off-by: Andre Pontes <andrembpontes@gmail.com>