### PR TITLE
[stable/openvpn] adding boolean property, which allows to skip default route

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 4.0.0
+version: 4.1.0
 appVersion: 1.1.0
 maintainers:
 - name: jasongwartz

--- a/stable/openvpn/README.md
+++ b/stable/openvpn/README.md
@@ -103,6 +103,7 @@ Parameter | Description | Default
 `openvpn.OVPN_K8S_POD_SUBNET`        | Kubernetes pod network subnet (optional)                             | `255.0.0.0`
 `openvpn.OVPN_K8S_SVC_NETWORK`       | Kubernetes service network (optional)                                | `nil`
 `openvpn.OVPN_K8S_SVC_SUBNET`        | Kubernetes service network subnet (optional)                         | `nil`
+`openvpn.DEFAULT_ROUTE_ENABLED`      | Push a route which openvpn sets by default                           | `true`
 `openvpn.dhcpOptionDomain`           | Push a `dhcp-option DOMAIN` config                                   | `true`
 `openvpn.serverConf`                 | Lines appended to the end of the server configuration file (optional)| `nil`
 `openvpn.clientConf`                 | Lines appended into the client configuration file (optional)         | `nil`

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -202,7 +202,9 @@ data:
       user nobody
       group nogroup
 
+{{ if .Values.openvpn.DEFAULT_ROUTE_ENABLED }}
       push "route NETWORK NETMASK"
+{{ end }}
 {{ if (.Values.openvpn.OVPN_K8S_POD_NETWORK) (.Values.openvpn.OVPN_K8S_POD_SUBNET) }}
       push "route {{ .Values.openvpn.OVPN_K8S_POD_NETWORK }} {{ .Values.openvpn.OVPN_K8S_POD_SUBNET }}"
 {{ end }}

--- a/stable/openvpn/values.yaml
+++ b/stable/openvpn/values.yaml
@@ -83,6 +83,8 @@ openvpn:
   # OVPN_K8S_SVC_NETWORK:
   # Kubernetes service network subnet (optional).
   # OVPN_K8S_SVC_SUBNET:
+  # Set default route which openvpn figures basing on network routes inside openvpn pod
+  DEFAULT_ROUTE_ENABLED: true
   # Server certificate data
   # keystoreSecret:
   # secret with openvpn certificates. If specified, certificates are taken from the secret


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
PR adds boolean values to stable/openvpn chart, which allows to skip setting the default route
#### Which issue this PR fixes
fixes #20265 

#### Special notes for your reviewer:
Default route which openvpn chart sets, breaks connectivity in case when pods and nodes are in the same subnet.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
