### PR TITLE
Allow set dnsConfig for prometheus-alertmanager

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 10.3.1
+version: 10.3.2
 appVersion: 2.15.2
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/alertmanager-deployment.yaml
+++ b/stable/prometheus/templates/alertmanager-deployment.yaml
@@ -26,6 +26,10 @@ spec:
         {{ toYaml .Values.alertmanager.podLabels | nindent 8 }}
         {{- end}}
     spec:
+{{- if .Values.alertmanager.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.alertmanager.dnsConfig | indent 8 }}
+{{- end }}
 {{- if .Values.alertmanager.schedulerName }}
       schedulerName: "{{ .Values.alertmanager.schedulerName }}"
 {{- end }}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -89,6 +89,9 @@ alertmanager:
   ##
   configFileName: alertmanager.yml
 
+  # Optionally customize the pod dnsConfig.
+  dnsConfig: {}
+
   ingress:
     ## If true, alertmanager Ingress will be created
     ##


### PR DESCRIPTION
#### What this PR does / why we need it:
Allow set dnsConfig for prometheus-alertmanager
