### PR TITLE
[stable/datadog] Make metricsProvider service port configurable

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.39.3
+version: 1.39.4
 appVersion: "7"
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -345,6 +345,7 @@ helm install --name <RELEASE_NAME> \
 | `clusterAgent.image.pullSecrets`         | Image pull secrets                                                                        | `nil`                                       |
 | `clusterAgent.metricsProvider.enabled`   | Enable Datadog metrics as a source for HPA scaling                                        | `false`                                     |
 | `clusterAgent.metricsProvider.service.type` | The type of service to use for the clusterAgent metrics server                         | `ClusterIP`                                 |
+| `clusterAgent.metricsProvider.service.port` | The port for service to use for the clusterAgent metrics server                         | `443` .                                     |
 | `clusterAgent.clusterChecks.enabled`     | Enable Cluster Checks on both the Cluster Agent and the Agent daemonset                   | `false`                                     |
 | `clusterAgent.confd`                     | Additional check configurations (static and Autodiscovery)                                | `nil`                                       |
 | `clusterAgent.podAnnotations`            | Annotations to add to the Cluster Agent Pod(s)                                            | `nil`                                       |

--- a/stable/datadog/ci/cluster-agent-metrics-server-service-port-values.yaml
+++ b/stable/datadog/ci/cluster-agent-metrics-server-service-port-values.yaml
@@ -6,4 +6,3 @@ clusterAgent:
 
     service:
       port: 4443
-

--- a/stable/datadog/ci/cluster-agent-metrics-server-service-port-values.yaml
+++ b/stable/datadog/ci/cluster-agent-metrics-server-service-port-values.yaml
@@ -1,0 +1,9 @@
+clusterAgent:
+  enabled: true
+
+
+  metricsProvider:
+    enabled: true
+
+    service:
+      port: 4443

--- a/stable/datadog/ci/cluster-agent-metrics-server-service-port-values.yaml
+++ b/stable/datadog/ci/cluster-agent-metrics-server-service-port-values.yaml
@@ -1,9 +1,9 @@
 clusterAgent:
   enabled: true
 
-
   metricsProvider:
     enabled: true
 
     service:
       port: 4443
+

--- a/stable/datadog/templates/agent-services.yaml
+++ b/stable/datadog/templates/agent-services.yaml
@@ -44,7 +44,7 @@ spec:
   selector:
     app: {{ template "datadog.fullname" . }}-cluster-agent
   ports:
-  - port: 443
+  - port: {{ .Values.clusterAgent.metricsProvider.service.port }}
     name: metricsapi
     protocol: TCP
 {{ end }}

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -73,7 +73,7 @@ spec:
           name: agentport
           protocol: TCP
         {{- if .Values.clusterAgent.metricsProvider.enabled }}
-        - containerPort: 443
+        - containerPort: {{ .Values.clusterAgent.metricsProvider.service.port }}
           name: metricsapi
           protocol: TCP
         {{- end }}
@@ -91,6 +91,8 @@ spec:
               secretKeyRef:
                 name: {{ template "datadog.appKeySecretName" . }}
                 key: app-key
+          - name: DD_EXTERNAL_METRICS_PROVIDER_PORT
+            value: {{ .Values.clusterAgent.metricsProvider.service.port | quote }}
           {{- end }}
           {{- if .Values.clusterAgent.clusterChecks.enabled }}
           - name: DD_CLUSTER_CHECKS_ENABLED

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -152,7 +152,7 @@ spec:
 {{- else if .Values.clusterAgent.metricsProvider.enabled }}
         livenessProbe:
           httpGet:
-            port: 443
+            port: {{ .Values.clusterAgent.metricsProvider.service.port }}
             path: /healthz
             scheme: HTTPS
 {{- end }}
@@ -162,7 +162,7 @@ spec:
 {{- else if .Values.clusterAgent.metricsProvider.enabled}}
         readinessProbe:
           httpGet:
-            port: 443
+            port: {{ .Values.clusterAgent.metricsProvider.service.port }}
             path: /healthz
             scheme: HTTPS
 {{- end }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -381,6 +381,9 @@ clusterAgent:
       ##
       #
       type: ClusterIP
+      ## @param port - int - optional
+      ##
+      port: 443
 
   ## @param clusterChecks - object - required
   ## Enable the Cluster Checks feature on both the cluster-agents and the daemonset


### PR DESCRIPTION
#### What this PR does / why we need it:

Allow configuring the container and service port for the external metrics provider, useful when the port has to be different from the default of `443`, e.g. when we cannot bind to low numbered ports (as enforced by `PodSecurityPolicies`, etc.) 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
