### PR TITLE
Fix small issue with documentation 

### DIFF
--- a/stable/pgadmin/Chart.yaml
+++ b/stable/pgadmin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin is a web based administration tool for PostgreSQL database
 name: pgadmin
-version: 1.0.5
+version: 1.0.6
 appVersion: 4.15.0
 home: https://www.pgadmin.org/
 source: https://github.com/rowanruseler/pgadmin

--- a/stable/pgadmin/README.md
+++ b/stable/pgadmin/README.md
@@ -51,7 +51,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `ingress.hosts` | Ingress accepted hostnames | `nil` |
 | `ingress.tls` | Ingress TLS configuration | `[]` |
 | `ingress.path` | Ingress path mapping | `` |
-| `env.username` | pgAdmin default email | `chart@example.local` |
+| `env.email` | pgAdmin default email | `chart@example.local` |
 | `env.password` | pgAdmin default password | `SuperSecret` |
 | `persistence` | Persistent enabled/disabled | `true` |
 | `persistence.accessMode` | Persistent Access Mode | `ReadWriteOnce` |


### PR DESCRIPTION
Change `env.username` to `env.email` in README to match variable usage in template.

Signed-off-by: Jim Robinson <jscrobinson@gmail.com>