### PR TITLE
[stable/sentry] add more options for web deployment probes

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 3.2.4
+version: 4.0.0
 appVersion: 9.1.2
 keywords:
   - debugging

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -77,7 +77,16 @@ Parameter                                            | Description              
 `web.affinity`                                       | Affinity settings for web pod assignment                                                                   | `{}`
 `web.schedulerName`                                  | Name of an alternate scheduler for web pod                                                                 | `nil`
 `web.tolerations`                                    | Toleration labels for web pod assignment                                                                   | `[]`
-`web.probeInitialDelaySeconds`                       | The number of seconds before the probe doing healthcheck                                                   | `50`
+`web.livenessProbe.failureThreshold`                 | The liveness probe failure threshold                                                                       | `5`
+`web.livenessProbe.initialDelaySeconds`              | The liveness probe initial delay seconds                                                                   | `50`
+`web.livenessProbe.periodSeconds`                    | The liveness probe period seconds                                                                          | `10`
+`web.livenessProbe.successThreshold`                 | The liveness probe success threshold                                                                       | `1`
+`web.livenessProbe.timeoutSeconds`                   | The liveness probe timeout seconds                                                                         | `2`
+`web.readinessProbe.failureThreshold`                | The readiness probe failure threshold                                                                      | `10`
+`web.readinessProbe.initialDelaySeconds`             | The readiness probe initial delay seconds                                                                  | `50`
+`web.readinessProbe.periodSeconds`                   | The readiness probe period seconds                                                                         | `10`
+`web.readinessProbe.successThreshold`                | The readiness probe success threshold                                                                      | `1`
+`web.readinessProbe.timeoutSeconds`                  | The readiness probe timeout seconds                                                                        | `2`
 `web.priorityClassName`                              | The priorityClassName on web deployment                                                                    | `nil`
 `web.hpa.enabled`                                    | Boolean to create a HorizontalPodAutoscaler for web deployment                                             | `false`
 `web.hpa.cputhreshold`                               | CPU threshold percent for the web HorizontalPodAutoscaler                                                  | `60`

--- a/stable/sentry/templates/web-deployment.yaml
+++ b/stable/sentry/templates/web-deployment.yaml
@@ -133,25 +133,25 @@ spec:
           mountPath: /var/run/secrets/google
         {{ end }}
         livenessProbe:
-          failureThreshold: 5
+          failureThreshold: {{ .Values.web.livenessProbe.failureThreshold }}
           httpGet:
             path: /_health/
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
-          initialDelaySeconds: {{ .Values.web.probeInitialDelaySeconds }}
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 2
+          initialDelaySeconds: {{ .Values.web.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.web.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.web.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.web.livenessProbe.timeoutSeconds }}
         readinessProbe:
-          failureThreshold: 10
+          failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
           httpGet:
             path: /_health/
             port: {{ .Values.service.internalPort }}
             scheme: HTTP
-          initialDelaySeconds: {{ .Values.web.probeInitialDelaySeconds }}
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 2
+          initialDelaySeconds: {{ .Values.web.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.web.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.web.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.web.readinessProbe.timeoutSeconds }}
         resources:
 {{ toYaml .Values.web.resources | indent 12 }}
       volumes:

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -32,7 +32,18 @@ web:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  probeInitialDelaySeconds: 50
+  livenessProbe:
+    failureThreshold: 5
+    initialDelaySeconds: 50
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 2
+  readinessProbe:
+    failureThreshold: 10
+    initialDelaySeconds: 50
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 2
   # priorityClassName: ""
   ## Use an alternate scheduler, e.g. "stork".
   ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/


### PR DESCRIPTION
#### What this PR does / why we need it:

For some reason at some times some web pods get killed due to probes failing. So here in this PR I am adding options to change every attribute of both probes.

#### Special notes for your reviewer:

I have replaced `web.probeInitialDelaySeconds` with a map under `web.readinessProbe ` and `web.livenessProbe `. I think this is the most elegant solution but it's a breaking change so I've bumped version to `4.0.0`. Let me know if that's a problem or if you want me to do it differently.

#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
