### PR TITLE
[stable/prometheus-blackbox-exporter] Fix multiple target servicemonitor 

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 3.0.0
+version: 3.0.1
 appVersion: 0.15.1
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/servicemonitor.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.serviceMonitor.enabled }}
 {{- range .Values.serviceMonitor.targets }}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -41,3 +42,4 @@ spec:
       - {{ $.Release.Namespace }}
 {{- end }}
 {{- end }}
+


### PR DESCRIPTION
Fix a bug which when using multiple targets, only one service monitor was created.
This PR add the yaml separator `---` in order to separate all the service monitor resources.

Introduced via https://github.com/helm/charts/pull/19620
cc @rsotnychenko