### PR TITLE
[stable/graylog] Fix #20306, hardcode Tiller label for backward compatibility with releases installed with helm2.

### DIFF
--- a/stable/graylog/Chart.yaml
+++ b/stable/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: graylog
 home: https://www.graylog.org
-version: 1.5.2
+version: 1.5.3
 appVersion: 3.1
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:

--- a/stable/graylog/templates/statefulset.yaml
+++ b/stable/graylog/templates/statefulset.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ template "graylog.name" . }}
     helm.sh/chart: {{ template "graylog.chart" . }}
-    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+    app.kubernetes.io/managed-by: "Tiller"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/version: "{{ .Chart.AppVersion }}"
 spec:
@@ -15,7 +15,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ template "graylog.name" . }}
       app.kubernetes.io/instance: "{{ .Release.Name }}"
-      app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+      app.kubernetes.io/managed-by: "Tiller"
   updateStrategy:
     type: {{ .Values.graylog.updateStrategy }}
   template:
@@ -23,7 +23,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "graylog.name" . }}
         helm.sh/chart: {{ template "graylog.chart" . }}
-        app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+        app.kubernetes.io/managed-by: "Tiller"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/version: "{{ .Chart.AppVersion }}"
       annotations:


### PR DESCRIPTION
#### What this PR does / why we need it:

Releases installed from this chart using helm2 cannot be upgraded after migrating to helm3.

Using helm2, the chart renders the label `app.kubernetes.io/managed-by: Tiller` in the Graylog StatefulSet. Meanwhile, using helm3, the chart renders `app.kubernetes.io/managed-by: "Helm"`.

Since Kubernetes considers the field `.spec.template.metadata.label` immutable for StatefulSets, upgrading migrated releases is not  possible and result in the following error message:

```
Error: UPGRADE FAILED: cannot patch "graylog-deploy" with kind StatefulSet: StatefulSet.apps "graylog-deploy" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden
```

This PR hardcodes `app.kubernetes.io/managed-by: Tiller` to allow releases to be upgraded after being migrated to helm3.

#### Which issue this PR fixes
  - fixes #20306

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
