### PR TITLE
[stable/openvpn] Add CCD support to OpenVPN chart

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 4.1.0
+version: 4.2.0
 appVersion: 1.1.0
 maintainers:
 - name: jasongwartz

--- a/stable/openvpn/README.md
+++ b/stable/openvpn/README.md
@@ -114,6 +114,8 @@ Parameter | Description | Default
 `openvpn.istio.enabled`              | Enables istio support for openvpn clients                            | `false`
 `openvpn.istio.proxy.port`           | Istio proxy port                                                     | `15001`
 `openvpn.iptablesExtra`              | Custom iptables rules for clients                                    | `[]`
+`openvpn.ccd.enabled`                | Enable creation and mounting of CCD config                           | `false`
+`openvpn.ccd.config`                 | CCD configuration (see below)                                        | `{}`
 `nodeSelector`                       | Node labels for pod assignment                                       | `{}`
 `tolerations`                        | Tolerations for node taints                                          | `[]`
 `ipForwardInitContainer`             | Add privileged init container to enable IPv4 forwarding              | `false`
@@ -155,6 +157,24 @@ And optionally (see openvpn.taKey setting):
  `/etc/openvpn/certs/pki/ta.key`
 
 Note: using mounted secret makes creation of new client certificates impossible inside openvpn pod, since easyrsa needs to write in certs directory, which is read-only.
+
+### Client specific rules and access policies
+
+You can enable CCD using `openvpn.ccd.enabled` and set the config in `openvpn.ccd.config` to use [OpenVPN client specific rules and access policies](https://openvpn.net/community-resources/configuring-client-specific-rules-and-access-policies/)
+
+For example, if you want to give fixed IP addresses to clients 'johndoe' and 'janedoe':
+
+```
+openvpn:
+  ccd:
+    enabled: true
+    config:
+      johndoe: "ifconfig-push 10.240.100.10 10.240.100.11"
+      janedoe: "ifconfig-push 10.240.100.20 10.240.100.21"
+```
+
+For more options see the OpenVPN documentation. Note that the IPs provided here depend on the type of topology you use.
+
 
 ## Issues
 

--- a/stable/openvpn/templates/config-ccd.yaml
+++ b/stable/openvpn/templates/config-ccd.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.openvpn.ccd.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "openvpn.fullname" . }}-ccd
+  labels:
+    app: {{ template "openvpn.name" . }}
+    chart: {{ template "openvpn.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+{{ toYaml .Values.openvpn.ccd.config | indent 2 }}
+{{- end }}

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -202,6 +202,10 @@ data:
       user nobody
       group nogroup
 
+{{ if .Values.openvpn.ccd.enabled }}
+      client-config-dir /etc/openvpn/ccd
+{{ end }}
+
 {{ if .Values.openvpn.DEFAULT_ROUTE_ENABLED }}
       push "route NETWORK NETMASK"
 {{ end }}

--- a/stable/openvpn/templates/openvpn-deployment.yaml
+++ b/stable/openvpn/templates/openvpn-deployment.yaml
@@ -90,11 +90,21 @@ spec:
             {{- end }}
             name: certs
             readOnly: {{ if .Values.openvpn.keystoreSecret }}true{{ else }}false{{ end }}
+            {{- if .Values.openvpn.ccd.enabled }}
+          - mountPath: /etc/openvpn/ccd
+            name: openvpn-ccd
+            {{- end }}
       volumes:
       - name: openvpn
         configMap:
           name: {{ template "openvpn.fullname" . }}
           defaultMode: 0775
+      {{- if .Values.openvpn.ccd.enabled }}
+      - name: openvpn-ccd
+        configMap:
+          name: {{ template "openvpn.fullname" . }}-ccd
+          defaultMode: 0775
+      {{- end }}
       - name: certs
         {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:

--- a/stable/openvpn/values.yaml
+++ b/stable/openvpn/values.yaml
@@ -126,6 +126,12 @@ openvpn:
   # - -A FORWARD -m conntrack --ctstate NEW -d 10.240.0.0/255.255.0.0 -j ACCEPT
   # - -A FORWARD -j REJECT
 
+  # Enable CCD support
+  ccd:
+    enabled: false
+    config: {}
+    # johndoe: "ifconfig-push 10.240.100.10 10.240.100.11"
+    # janedoe: "ifconfig-push 10.240.100.20 10.240.100.21"
 
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
Signed-off-by: gboor <gerard@tesseract.nl>

#### What this PR does / why we need it:
This adds support for CCD to the OpenVPN chart, allowing client-specific configurations to be pushed.

See https://openvpn.net/community-resources/configuring-client-specific-rules-and-access-policies/

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

@jasongwartz @dippynark 