### PR TITLE
[stable/etcd-operator] Support hostNetwork parameter on deployments

### DIFF
--- a/stable/etcd-operator/Chart.yaml
+++ b/stable/etcd-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: CoreOS etcd-operator Helm chart for Kubernetes
 name: etcd-operator
-version: 0.10.3
+version: 0.10.4
 appVersion: 0.9.4
 home: https://github.com/coreos/etcd-operator
 icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png

--- a/stable/etcd-operator/README.md
+++ b/stable/etcd-operator/README.md
@@ -71,6 +71,7 @@ The following table lists the configurable parameters of the etcd-operator chart
 | `customResources.createRestoreCRD`                | Create an a custom resource: EtcdRestore                             | `false`                                        |
 | `etcdOperator.name`                               | Etcd Operator name                                                   | `etcd-operator`                                |
 | `etcdOperator.replicaCount`                       | Number of operator replicas to create (only 1 is supported)          | `1`                                            |
+| `etcdOperator.hostNetwork`                        | Operator pod host network flag                                       | `false`                                        |
 | `etcdOperator.image.repository`                   | etcd-operator container image                                        | `quay.io/coreos/etcd-operator`                 |
 | `etcdOperator.image.tag`                          | etcd-operator container image tag                                    | `v0.9.3`                                       |
 | `etcdOperator.image.pullpolicy`                   | etcd-operator container image pull policy                            | `Always`                                       |
@@ -83,6 +84,7 @@ The following table lists the configurable parameters of the etcd-operator chart
 | `etcdOperator.priorityClassName`                  | Priority class for the etcd-operator pod(s)                          | `""`                                           |
 | `backupOperator.name`                             | Backup operator name                                                 | `etcd-backup-operator`                         |
 | `backupOperator.replicaCount`                     | Number of operator replicas to create (only 1 is supported)          | `1`                                            |
+| `backupOperator.hostNetwork`                      | Backup operator pod host network flag                                | `false`                                        |
 | `backupOperator.image.repository`                 | Operator container image                                             | `quay.io/coreos/etcd-operator`                 |
 | `backupOperator.image.tag`                        | Operator container image tag                                         | `v0.9.3`                                       |
 | `backupOperator.image.pullpolicy`                 | Operator container image pull policy                                 | `Always`                                       |
@@ -97,6 +99,7 @@ The following table lists the configurable parameters of the etcd-operator chart
 | `backupOperator.priorityClassName`                | Priority class for the etcd-backuop-operator pod(s)                  | `""`                                           |
 | `restoreOperator.name`                            | Restore operator name                                                | `etcd-backup-operator`                         |
 | `restoreOperator.replicaCount`                    | Number of operator replicas to create (only 1 is supported)          | `1`                                            |
+| `restoreOperator.hostNetwork`                     | Restore operator pod host network flag                               | `false`                                        |
 | `restoreOperator.image.repository`                | Operator container image                                             | `quay.io/coreos/etcd-operator`                 |
 | `restoreOperator.image.tag`                       | Operator container image tag                                         | `v0.9.3`                                       |
 | `restoreOperator.image.pullpolicy`                | Operator container image pull policy                                 | `Always`                                       |

--- a/stable/etcd-operator/templates/backup-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/backup-operator-deployment.yaml
@@ -26,6 +26,7 @@ spec:
       priorityClassName: {{ .Values.backupOperator.priorityClassName }}
       {{- end }}
       serviceAccountName: {{ template "etcd-operator.serviceAccountName" . }}
+      hostNetwork: {{ .Values.backupOperator.hostNetwork }}
       containers:
       - name: {{ .Values.backupOperator.name }}
         image: "{{ .Values.backupOperator.image.repository }}:{{ .Values.backupOperator.image.tag }}"

--- a/stable/etcd-operator/templates/operator-deployment.yaml
+++ b/stable/etcd-operator/templates/operator-deployment.yaml
@@ -27,6 +27,7 @@ spec:
       priorityClassName: {{ .Values.etcdOperator.priorityClassName }}
       {{- end }}
       serviceAccountName: {{ template "etcd-operator.serviceAccountName" . }}
+      hostNetwork: {{ .Values.etcdOperator.hostNetwork }}
       containers:
       - name: {{ template "etcd-operator.fullname" . }}
         image: "{{ .Values.etcdOperator.image.repository }}:{{ .Values.etcdOperator.image.tag }}"

--- a/stable/etcd-operator/templates/restore-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/restore-operator-deployment.yaml
@@ -26,6 +26,7 @@ spec:
       priorityClassName: {{ .Values.restoreOperator.priorityClassName }}
       {{- end }}
       serviceAccountName: {{ template "etcd-operator.serviceAccountName" . }}
+      hostNetwork: {{ .Values.restoreOperator.hostNetwork }}
       containers:
       - name: {{ .Values.restoreOperator.name }}
         image: "{{ .Values.restoreOperator.image.repository }}:{{ .Values.restoreOperator.image.tag }}"

--- a/stable/etcd-operator/values.yaml
+++ b/stable/etcd-operator/values.yaml
@@ -41,6 +41,7 @@ etcdOperator:
   priorityClassName: ""
   name: etcd-operator
   replicaCount: 1
+  hostNetwork: false
   image:
     repository: quay.io/coreos/etcd-operator
     tag: v0.9.4
@@ -76,6 +77,7 @@ backupOperator:
   priorityClassName: ""
   name: etcd-backup-operator
   replicaCount: 1
+  hostNetwork: false
   image:
     repository: quay.io/coreos/etcd-operator
     tag: v0.9.4
@@ -102,6 +104,7 @@ restoreOperator:
   priorityClassName: ""
   name: etcd-restore-operator
   replicaCount: 1
+  hostNetwork: false
   image:
     repository: quay.io/coreos/etcd-operator
     tag: v0.9.4


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No, it's not.
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

#### What this PR does / why we need it:
Gives the opportunity to run the deployments with `hostNetwork: true` set via helm values.
This is not enabled by default, but can be useful when using the operator to backup/restore existing etcd clusters running directly on the node.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
It's used on our on-prem kubernetes cluster to backup and restore etcd using cloud storage.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
