### PR TITLE
[stable/datadog] Fixes issue with trace-agent only listening on localhost

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.39.4
+version: 1.39.5
 appVersion: "7"
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/container-trace-agent.yaml
+++ b/stable/datadog/templates/container-trace-agent.yaml
@@ -18,6 +18,12 @@
       value: {{ .Values.datadog.apmEnabled | quote }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.daemonset.containers.traceAgent.logLevel | default .Values.datadog.logLevel | quote }}
+    {{- if .Values.datadog.nonLocalTraffic }}
+    - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
+      value: {{ .Values.datadog.nonLocalTraffic | quote }}
+    - name: DD_APM_NON_LOCAL_TRAFFIC
+      value: {{ .Values.datadog.nonLocalTraffic | quote }}
+    {{- end }}
 {{- if .Values.daemonset.containers.traceAgent.env }}
 {{ toYaml .Values.daemonset.containers.traceAgent.env | indent 4 }}
 {{- end }}


### PR DESCRIPTION
Currently the `trace-agent` only listens on `localhost` regardless whether `nonLocalTraffic` is true or not.

This fixes that by checking if `nonLocalTraffic: true` then we set the correct environment variables in the trace-agent container

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
