### PR TITLE
[stable/stolon] Fix support for clusterName keyword

### DIFF
--- a/stable/stolon/Chart.yaml
+++ b/stable/stolon/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stolon
-version: 1.5.6
+version: 1.5.7
 appVersion: 0.13.0
 description: Stolon - PostgreSQL cloud native High Availability.
 home: https://github.com/sorintlab/stolon

--- a/stable/stolon/templates/NOTES.txt
+++ b/stable/stolon/templates/NOTES.txt
@@ -4,5 +4,5 @@ To get superuser password run
 {{ if not (empty .Values.superuserSecret.name) }}
     PGPASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ .Values.superuserSecret.name }} -o jsonpath="{.data.{{.Values.superuserSecret.passwordKey}}}" | base64 --decode; echo)
 {{ else }}
-    PGPASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "stolon.fullname" . }} -o jsonpath="{.data.pg_su_password}" | base64 --decode; echo)
+    PGPASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "stolon.clusterName" . }} -o jsonpath="{.data.pg_su_password}" | base64 --decode; echo)
 {{ end }}

--- a/stable/stolon/templates/certs.yaml
+++ b/stable/stolon/templates/certs.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "stolon.fullname" . }}-certs
+  name: {{ template "stolon.clusterName" . }}-certs
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}

--- a/stable/stolon/templates/configmap.yaml
+++ b/stable/stolon/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "stolon.fullname" . }}
+  name: {{ template "stolon.clusterName" . }}
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}

--- a/stable/stolon/templates/hooks/create-cluster-job.yaml
+++ b/stable/stolon/templates/hooks/create-cluster-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "stolon.fullname" . }}-create-cluster
+  name: {{ template "stolon.clusterName" . }}-create-cluster
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "stolon.fullname" . }}
+        app: {{ template "stolon.clusterName" . }}
         release: {{ .Release.Name }}
     spec:
       restartPolicy: OnFailure
@@ -28,7 +28,7 @@ spec:
           command: ["sh", "-c", "while ! etcdctl --endpoints {{ .Values.store.endpoints }} cluster-health; do sleep 1 && echo -n .; done"]
   {{- end }}
       containers:
-        - name: {{ template "stolon.fullname" . }}-create-cluster
+        - name: {{ template "stolon.clusterName" . }}-create-cluster
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/usr/local/bin/stolonctl"]

--- a/stable/stolon/templates/hooks/init-db-job.yaml
+++ b/stable/stolon/templates/hooks/init-db-job.yaml
@@ -40,7 +40,7 @@ spec:
           - name: PGPASSWORD
             value: {{ .Values.superuserPassword }}
           - name: HOST
-            value: {{ template "stolon.fullname" . }}-proxy
+            value: {{ template "stolon.clusterName" . }}-proxy
         command: ["/bin/bash", "-e", "/tmp/sql-script/create_script.sh"]
         volumeMounts:
           - mountPath: "/tmp/sql-script"
@@ -54,5 +54,5 @@ spec:
       initContainers:
         - name: wait-for-database
           image: jwilder/dockerize
-          command: ['dockerize', '-timeout', '30s', '-wait', 'tcp://{{ template "stolon.fullname" . }}-proxy:5432']
+          command: ['dockerize', '-timeout', '30s', '-wait', 'tcp://{{ template "stolon.clusterName" . }}-proxy:5432']
 {{- end }}

--- a/stable/stolon/templates/hooks/update-cluster-spec-job.yaml
+++ b/stable/stolon/templates/hooks/update-cluster-spec-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "stolon.fullname" . }}-update-cluster-spec
+  name: {{ template "stolon.clusterName" . }}-update-cluster-spec
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "stolon.fullname" . }}
+        app: {{ template "stolon.clusterName" . }}
         release: {{ .Release.Name }}
     spec:
       restartPolicy: OnFailure
@@ -28,7 +28,7 @@ spec:
           command: ["sh", "-c", "while ! etcdctl --endpoints {{ .Values.store.endpoints }} cluster-health; do sleep 1 && echo -n .; done"]
   {{- end }}
       containers:
-        - name: {{ template "stolon.fullname" . }}-update-cluster-spec
+        - name: {{ template "stolon.clusterName" . }}-update-cluster-spec
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/usr/local/bin/stolonctl"]

--- a/stable/stolon/templates/keeper-headless-service.yaml
+++ b/stable/stolon/templates/keeper-headless-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "stolon.fullname" . }}-keeper-headless
+  name: {{ template "stolon.clusterName" . }}-keeper-headless
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}

--- a/stable/stolon/templates/keeper-pdb.yaml
+++ b/stable/stolon/templates/keeper-pdb.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ template "stolon.fullname" . }}-keeper
+  name: {{ template "stolon.clusterName" . }}-keeper
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}

--- a/stable/stolon/templates/keeper-statefulset.yaml
+++ b/stable/stolon/templates/keeper-statefulset.yaml
@@ -1,14 +1,14 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ template "stolon.fullname" . }}-keeper
+  name: {{ template "stolon.clusterName" . }}-keeper
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  serviceName: {{ template "stolon.fullname" . }}-keeper-headless
+  serviceName: {{ template "stolon.clusterName" . }}-keeper-headless
   replicas: {{ .Values.keeper.replicaCount }}
   selector:
     matchLabels:
@@ -21,7 +21,7 @@ spec:
         app: {{ template "stolon.name" . }}
         release: {{ .Release.Name }}
         component: stolon-keeper
-        stolon-cluster: {{ template "stolon.fullname" . }}
+        stolon-cluster: {{ template "stolon.clusterName" . }}
       annotations:
 {{- with .Values.keeper.annotations }}
 {{ toYaml . | indent 8 }}
@@ -62,7 +62,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: STKEEPER_CLUSTER_NAME
-              value: {{ template "stolon.fullname" . }}
+              value: {{ template "stolon.clusterName" . }}
             - name: STKEEPER_STORE_BACKEND
               value: {{ .Values.store.backend | quote }}
             {{- if eq .Values.store.backend "kubernetes" }}
@@ -177,15 +177,15 @@ spec:
         - name: certs
           secret:
             defaultMode: 0600
-            secretName: {{ if .Values.tls.existingSecret }}{{ .Values.tls.existingSecret }}{{ else }}{{ template "stolon.fullname" . }}-certs{{end}}
+            secretName: {{ if .Values.tls.existingSecret }}{{ .Values.tls.existingSecret }}{{ else }}{{ template "stolon.clusterName" . }}-certs{{end}}
 {{ end }}
         - name: config
           configMap:
-            name: {{ template "stolon.fullname" . }}
+            name: {{ template "stolon.clusterName" . }}
 {{ if or (empty .Values.superuserSecret.name) (empty .Values.replicationSecret.name) }}
         - name: stolon-secrets
           secret:
-            secretName: {{ template "stolon.fullname" . }}
+            secretName: {{ template "stolon.clusterName" . }}
 {{ end }}
 {{ if not (empty .Values.superuserSecret.name) }}
         - name: stolon-secret-{{ .Values.superuserSecret.name }}

--- a/stable/stolon/templates/metrics-service.yaml
+++ b/stable/stolon/templates/metrics-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "stolon.fullname" . }}-metrics
+  name: {{ template "stolon.clusterName" . }}-metrics
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}

--- a/stable/stolon/templates/metrics-servicemonitor.yaml
+++ b/stable/stolon/templates/metrics-servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "stolon.fullname" . }}
+  name: {{ template "stolon.clusterName" . }}
   labels:
   {{- if .Values.serviceMonitor.labels }}
     {{ toYaml .Values.serviceMonitor.labels | nindent 4 }}

--- a/stable/stolon/templates/proxy-deployment.yaml
+++ b/stable/stolon/templates/proxy-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "stolon.fullname" . }}-proxy
+  name: {{ template "stolon.clusterName" . }}-proxy
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}
@@ -20,7 +20,7 @@ spec:
         app: {{ template "stolon.name" . }}
         release: {{ .Release.Name }}
         component: stolon-proxy
-        stolon-cluster: {{ template "stolon.fullname" . }}
+        stolon-cluster: {{ template "stolon.clusterName" . }}
       annotations:
 {{- with .Values.proxy.annotations }}
 {{ toYaml . | indent 8 }}
@@ -49,7 +49,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: STPROXY_CLUSTER_NAME
-              value: {{ template "stolon.fullname" . }}
+              value: {{ template "stolon.clusterName" . }}
             - name: STPROXY_STORE_BACKEND
               value: {{ .Values.store.backend | quote}}
             {{- if eq .Values.store.backend "kubernetes" }}

--- a/stable/stolon/templates/proxy-pdb.yaml
+++ b/stable/stolon/templates/proxy-pdb.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ template "stolon.fullname" . }}-proxy
+  name: {{ template "stolon.clusterName" . }}-proxy
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}

--- a/stable/stolon/templates/proxy-service.yaml
+++ b/stable/stolon/templates/proxy-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "stolon.fullname" . }}-proxy
+  name: {{ template "stolon.clusterName" . }}-proxy
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}

--- a/stable/stolon/templates/role.yaml
+++ b/stable/stolon/templates/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
-  name: {{ template "stolon.fullname" . }}
+  name: {{ template "stolon.clusterName" . }}
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}

--- a/stable/stolon/templates/rolebinding.yaml
+++ b/stable/stolon/templates/rolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  name: {{ template "stolon.fullname" . }}
+  name: {{ template "stolon.clusterName" . }}
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}
@@ -11,7 +11,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "stolon.fullname" . }}
+  name: {{ template "stolon.clusterName" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "stolon.serviceAccountName" . }}

--- a/stable/stolon/templates/secret.yaml
+++ b/stable/stolon/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "stolon.fullname" . }}
+  name: {{ template "stolon.clusterName" . }}
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}

--- a/stable/stolon/templates/sentinel-deployment.yaml
+++ b/stable/stolon/templates/sentinel-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "stolon.fullname" . }}-sentinel
+  name: {{ template "stolon.clusterName" . }}-sentinel
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}
@@ -20,7 +20,7 @@ spec:
         app: {{ template "stolon.name" . }}
         release: {{ .Release.Name }}
         component: stolon-sentinel
-        stolon-cluster: {{ template "stolon.fullname" . }}
+        stolon-cluster: {{ template "stolon.clusterName" . }}
       annotations:
         checksum/config: {{ include (print .Template.BasePath "/hooks/update-cluster-spec-job.yaml") . | sha256sum }}
 {{- with .Values.keeper.annotations }}
@@ -50,7 +50,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: STSENTINEL_CLUSTER_NAME
-              value: {{ template "stolon.fullname" . }}
+              value: {{ template "stolon.clusterName" . }}
             - name: STSENTINEL_STORE_BACKEND
               value: {{ .Values.store.backend | quote}}
             {{- if eq .Values.store.backend "kubernetes" }}

--- a/stable/stolon/templates/sentinel-pdb.yaml
+++ b/stable/stolon/templates/sentinel-pdb.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ template "stolon.fullname" . }}-sentinel
+  name: {{ template "stolon.clusterName" . }}-sentinel
   labels:
     app: {{ template "stolon.name" . }}
     chart: {{ template "stolon.chart" . }}


### PR DESCRIPTION
Signed-off-by: Jerzy Góra <j.gora89@gmail.com>
@rtluckie @lwolf 
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No.

#### What this PR does / why we need it:
Currently the clusterName keyword is ignored during the chart deployment. The logic for clusterName parsing was already implemented in [_helpers.tpl](https://github.com/helm/charts/blob/master/stable/stolon/templates/_helpers.tpl), however it was not used by the templates.

#### Which issue this PR fixes
  - fixes #17056

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
