### PR TITLE
[stable/home-assistant] - Add probe scheme

### DIFF
--- a/stable/home-assistant/Chart.yaml
+++ b/stable/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.103.3
 description: Home Assistant
 name: home-assistant
-version: 0.11.0
+version: 0.12.0
 keywords:
 - home-assistant
 - hass

--- a/stable/home-assistant/README.md
+++ b/stable/home-assistant/README.md
@@ -41,14 +41,17 @@ The following tables lists the configurable parameters of the Home Assistant cha
 | `image.pullSecrets`        | Secrets to use when pulling the image | `[]` |
 | `strategyType`             | Specifies the strategy used to replace old Pods by new ones | `Recreate` |
 | `probes.liveness.enabled`  | Use the livenessProbe?  | `true` |
+| `probes.liveness.scheme `  | Specify liveness `scheme` parameter for the deployment  | `HTTP` |
 | `probes.liveness.initialDelaySeconds`  | Specify liveness `initialDelaySeconds` parameter for the deployment  | `60` |
 | `probes.liveness.failureThreshold`     | Specify liveness `failureThreshold` parameter for the deployment     | `5`  |
 | `probes.liveness.timeoutSeconds`       | Specify liveness `timeoutSeconds` parameter for the deployment       | `10` |
 | `probes.readiness.enabled`  | Use the readinessProbe?  | `true` |
+| `probes.readiness.scheme `  | Specify readiness `scheme` parameter for the deployment  | `HTTP` |
 | `probes.readiness.initialDelaySeconds` | Specify readiness `initialDelaySeconds` parameter for the deployment | `60` |
 | `probes.readiness.failureThreshold`    | Specify readiness `failureThreshold` parameter for the deployment    | `5`  |
 | `probes.readiness.timeoutSeconds`      | Specify readiness `timeoutSeconds` parameter for the deployment      | `10` |
 | `probes.startup.enabled`  | Use the startupProbe? (new in kubernetes 1.16)  | `false` |
+| `probes.startup.scheme `  | Specify startup `scheme` parameter for the deployment  | `HTTP` |
 | `probes.startup.failureThreshold`    | Specify startup `failureThreshold` parameter for the deployment    | `5`  |
 | `probes.startup.periodSeconds`      | Specify startup `periodSeconds` parameter for the deployment      | `10` |
 | `service.type`             | Kubernetes service type for the home-assistant GUI | `ClusterIP` |

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -79,6 +79,7 @@ spec:
             httpGet:
               path: /
               port: api
+              scheme: {{ .Values.probes.liveness.scheme }}
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
             failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
             timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
@@ -88,6 +89,7 @@ spec:
             httpGet:
               path: /
               port: api
+              scheme: {{ .Values.probes.readiness.scheme }}
             initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
             failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
             timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
@@ -97,6 +99,7 @@ spec:
             httpGet:
               path: /
               port: api
+              scheme: {{ .Values.probes.startup.scheme }}
             failureThreshold: {{ .Values.probes.startup.failureThreshold }}
             periodSeconds: {{ .Values.probes.startup.periodSeconds }}
           {{- end }}

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -15,16 +15,19 @@ strategyType: Recreate
 probes:
   liveness:
     enabled: true
+    scheme: HTTP
     initialDelaySeconds: 60
     failureThreshold: 5
     timeoutSeconds: 10
   readiness:
     enabled: true
+    scheme: HTTP
     initialDelaySeconds: 60
     failureThreshold: 5
     timeoutSeconds: 10
   startup:
     enabled: false
+    scheme: HTTP
     failureThreshold: 30
     periodSeconds: 10
 service:


### PR DESCRIPTION
#### What this PR does / why we need it:
* Adds scheme setting to all probes

#### Special notes for your reviewer:
Scheme settings are required for probes to pass when doing TLS in home assistant. 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
