### PR TITLE
[stable/locsut] Adapt locust helm chart to k8s compatibility.

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: locust
 description: A modern load testing framework
-version: 1.1.3
+version: 1.2.0
 appVersion: 0.9.0
 maintainers:
   - name: haugene

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -46,6 +46,7 @@ helm install -n locust-nymph --set master.config.target-host=http://site.example
 | `worker.replicaCount`        | Number of workers to run                | `2`                                                   |
 | `worker.nodeSelector`        | k8s nodeselector                        | `{}`                                                  |
 | `worker.tolerations`         | k8s tolerance                           | `{}`                                                  |
+| `worker.affinities`          | k8s affinities                          | `{}`                                                  |
 
 Specify parameters using `--set key=value[,key=value]` argument to `helm install`
 

--- a/stable/locust/templates/_helpers.tpl
+++ b/stable/locust/templates/_helpers.tpl
@@ -29,3 +29,23 @@ Create fully qualified configmap name.
 {{- printf "%s-%s" .Release.Name "worker" -}}
 {{ end }}
 {{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "locust.labels" -}}
+helm.sh/chart: {{ include "locust.chart" . }}
+{{ include "locust.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "locust.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "locust.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/stable/locust/templates/master-deploy.yaml
+++ b/stable/locust/templates/master-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "locust.master" . }}
@@ -10,6 +10,10 @@ metadata:
     component: master
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      {{- include "locust.selectorLabels" . | nindent 6 }}
+      component: "master"
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -18,8 +22,7 @@ spec:
   template:
     metadata:
       labels:
-        release: {{ .Release.Name | quote }}
-        app: {{ template "locust.fullname" . }}
+        {{- include "locust.selectorLabels" . | nindent 8 }}
         component: "master"
     spec:
     {{- if .Values.image.pullSecrets }}

--- a/stable/locust/templates/master-svc.yaml
+++ b/stable/locust/templates/master-svc.yaml
@@ -34,6 +34,6 @@ spec:
     protocol: TCP
     targetPort: 5558
   selector:
-    app: {{ template "locust.fullname" . }}
+    app.kubernetes.io/name: {{ include "locust.fullname" . }}
     component: "master"
   sessionAffinity: None

--- a/stable/locust/templates/worker-deploy.yaml
+++ b/stable/locust/templates/worker-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "locust.worker" . }}
@@ -10,6 +10,10 @@ metadata:
     component: worker
 spec:
   replicas: {{ default 2 .Values.worker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "locust.selectorLabels" . | nindent 6 }}
+      component: worker
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -18,7 +22,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "locust.fullname" . }}
+        {{- include "locust.selectorLabels" . | nindent 8 }}
         component: worker
     spec:
     {{- if .Values.image.pullSecrets }}
@@ -69,3 +73,6 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
 {{- end }}
+{{- with .Values.worker.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -78,3 +78,12 @@ worker:
   #   operator: "Equal"
   #   value: "api"
   #   effect: "NoSchedule"
+  #
+  #
+  affinity: {}
+  #  podAntiAffinity:
+  #    requiredDuringSchedulingIgnoredDuringExecution:
+  #    - topologyKey: kubernetes.io/hostname
+  #      labelSelector:
+  #        matchLabels:
+  #          component: worker


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

#### What this PR does / why we need it:

This PR changes the objects used in the locust helm charts and makes them k8s 1.16 compatible.

I've try to change as minimum as possible and still make the chart work. If you need/want any further changes, please tell.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
