### PR TITLE
Start a new YAML document for each target

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 3.0.0
+version: 3.0.1
 appVersion: 0.15.1
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/servicemonitor.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.serviceMonitor.enabled }}
 {{- range .Values.serviceMonitor.targets }}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
Otherwise, all targets will be collapsed into a single ServiceMonitor template and only the last target will be created (at least with Helm3)