### PR TITLE
[stable/phpmyadmin] Database SSL settings to be optional

### DIFF
--- a/stable/phpmyadmin/Chart.yaml
+++ b/stable/phpmyadmin/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: phpmyadmin
-version: 4.2.10
+version: 4.2.11
 appVersion: 5.0.1
 description: phpMyAdmin is an mysql administration frontend
 keywords:

--- a/stable/phpmyadmin/templates/NOTES.txt
+++ b/stable/phpmyadmin/templates/NOTES.txt
@@ -50,6 +50,8 @@ $ helm upgrade {{.Release.Name}} stable/phpmyadmin --set db.host=mydb
 
 {{end}}
 
+{{- include "phpmyadmin.validateValues" . -}}
+
 {{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
 
 WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.

--- a/stable/phpmyadmin/templates/_helpers.tpl
+++ b/stable/phpmyadmin/templates/_helpers.tpl
@@ -127,3 +127,28 @@ imagePullSecrets:
 {{- end }}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Compile all warnings into a single message, and call fail.
+*/}}
+{{- define "phpmyadmin.validateValues" -}}
+{{- $messages := list -}}
+{{- $messages := append $messages (include "phpmyadmin.validateValues.db.ssl" .) -}}
+{{- $messages := without $messages "" -}}
+{{- $message := join "\n" $messages -}}
+
+{{- if $message -}}
+{{-   printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Validate values of phpMyAdmin - must provide a valid database ssl configuration */}}
+{{- define "phpmyadmin.validateValues.db.ssl" -}}
+{{- if and .Values.db.enableSsl (empty .Values.db.ssl.clientKey) (empty .Values.db.ssl.clientCertificate) (empty .Values.db.ssl.caCertificate) -}}
+phpMyAdmin: db.ssl
+    Invalid database ssl configuration. You enabled SSL for the connection
+    between phpMyAdmin and the database but no key/certificates were provided
+    (--set db.ssl.clientKey="xxxx", --set db.ssl.clientCertificate="yyyy")
+{{- end -}}
+{{- end -}}

--- a/stable/phpmyadmin/templates/certs.yaml
+++ b/stable/phpmyadmin/templates/certs.yaml
@@ -10,10 +10,13 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
-  server_key.pem:
-    {{ required "A valid .Values.db.ssl.clientKey entry required!" .Values.db.ssl.clientKey | b64enc | quote }}
-  server_certificate.pem:
-    {{ required "A valid .Values.db.ssl.clientCertificate entry required!" .Values.db.ssl.clientCertificate | b64enc | quote }}
-  ca_certificate.pem:
-    {{ required "A valid .Values.db.ssl.caCertificate entry required!" .Values.db.ssl.caCertificate | b64enc | quote }}
+  {{- if not (empty .Values.db.ssl.clientKey) }}
+  server_key.pem: {{ .Values.db.ssl.clientKey | b64enc | quote }}
+  {{- end }}
+  {{- if not (empty .Values.db.ssl.clientCertificate) }}
+  server_certificate.pem: {{ .Values.db.ssl.clientCertificate | b64enc | quote }}
+  {{- end }}
+  {{- if not (empty .Values.db.ssl.caCertificate) }}
+  ca_certificate.pem: {{ .Values.db.ssl.caCertificate | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/stable/phpmyadmin/templates/deployment.yaml
+++ b/stable/phpmyadmin/templates/deployment.yaml
@@ -75,12 +75,18 @@ spec:
             - name: DATABASE_ENABLE_SSL
               value: {{ ternary "yes" "no" .Values.db.enableSsl | quote }}
             {{- if .Values.db.enableSsl }}
+            {{- if not (empty .Values.db.ssl.clientKey) }}
             - name: DATABASE_SSL_KEY
               value: "/db_certs/server_key.pem"
+            {{- end }}
+            {{- if not (empty .Values.db.ssl.clientCertificate) }}
             - name: DATABASE_SSL_CERT
               value: "/db_certs/server_certificate.pem"
+            {{- end }}
+            {{- if not (empty .Values.db.ssl.caCertificate) }}
             - name: DATABASE_SSL_CA
               value: "/db_certs/ca_certificate.pem"
+            {{- end }}
             {{- if .Values.db.ssl.ciphers }}
             - name: DATABASE_SSL_CIPHERS
               values: {{ .Values.db.ssl.ciphers | quote }}
@@ -143,10 +149,16 @@ spec:
           secret:
             secretName: {{ template "phpmyadmin.fullname" . }}-certs
             items:
+              {{- if not (empty .Values.db.ssl.clientKey) }}
               - key: server_key.pem
                 path: server_key.pem
+              {{- end }}
+              {{- if not (empty .Values.db.ssl.clientCertificate) }}
               - key: server_certificate.pem
                 path: server_certificate.pem
+              {{- end }}
+              {{- if not (empty .Values.db.ssl.caCertificate) }}
               - key: ca_certificate.pem
                 path: ca_certificate.pem
+              {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>


#### Is this a new chart

No

#### What this PR does / why we need it:

This PR ensures that database ssl settings (such as `db.ssl.clientKey`, `db.ssl.clientKey` or `db.ssl.clientKey`) are optional when `db.enableSsl` is activated (mandatory to set at least one of them)

#### Which issue this PR fixes

  - fixes #9662 

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
