### PR TITLE
[stable/cluster-autoscaler] Add security context for pod & container

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 6.2.0
+version: 6.3.0
 appVersion: 1.14.6
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/README.md
+++ b/stable/cluster-autoscaler/README.md
@@ -173,6 +173,8 @@ Parameter | Description | Default
 `replicaCount` | desired number of pods | `1`
 `priorityClassName` | priorityClassName | `nil`
 `dnsPolicy` | dnsPolicy | `nil`
+`securityContext` | [Security context for pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `nil`
+`containerSecurityContext` | [Security context for container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) | `nil`
 `resources` | pod resource requests & limits | `{}`
 `service.annotations` | annotations to add to service | none
 `service.externalIPs` | service external IP addresses | `[]`

--- a/stable/cluster-autoscaler/templates/deployment.yaml
+++ b/stable/cluster-autoscaler/templates/deployment.yaml
@@ -169,6 +169,10 @@ spec:
             - containerPort: 8085
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          {{- if .Values.containerSecurityContext }}
+          securityContext:
+            {{ toYaml .Values.containerSecurityContext | nindent 12 | trim }}
+          {{- end }}
           {{- if eq .Values.cloudProvider "gce" }}
           volumeMounts:
             - name: cloudconfig
@@ -186,13 +190,17 @@ spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "cluster-autoscaler.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
+      {{- if .Values.securityContext }}
+      securityContext:
+        {{ toYaml .Values.securityContext | nindent 8 | trim }}
+      {{- end }}
       {{- if eq .Values.cloudProvider "gce" }}
       volumes:
         - name: cloudconfig
           hostPath:
             path: {{ .Values.cloudConfigPath }}
       {{- end }}
-    {{- if .Values.image.pullSecrets }}
+      {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}
         - name: {{ . }}

--- a/stable/cluster-autoscaler/values.yaml
+++ b/stable/cluster-autoscaler/values.yaml
@@ -133,6 +133,20 @@ priorityClassName: ""
 # autoscaler does not depend on cluster DNS, recommended to set this to "Default"
 # dnsPolicy: "Default"
 
+## Security context for pod
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+# securityContext:
+#   runAsNonRoot: true
+#   runAsUser: 1001
+#   runAsGroup: 1001
+
+## Security context for container
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+# containerSecurityContext:
+#   capabilities:
+#     drop:
+#       - all
+
 service:
   annotations: {}
 


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
This change allows specifying security context at pod & container level.

#### Which issue this PR fixes
- fixes #16045

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)