### PR TITLE
[stable/consul] Fix uiIngress typo and fix .Values scoping

### DIFF
--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: consul
 home: https://github.com/hashicorp/consul
-version: 3.9.4
+version: 3.9.5
 appVersion: 1.5.3
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/stable/consul/templates/consul-ingress.yaml
+++ b/stable/consul/templates/consul-ingress.yaml
@@ -27,8 +27,8 @@ spec:
           - backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
-          {{- if .Values.uiIngress.path }}
-            path: {{ .Values.uiIngresspath }}
+          {{- if $.Values.uiIngress.path }}
+            path: {{ $.Values.uiIngress.path }}
           {{- end }}
   {{- end -}}
   {{- if .Values.uiIngress.tls }}


### PR DESCRIPTION
Since we are in a `range` we need to scope back to $.Values, and also fix a typo.

#### What this PR does / why we need it:

Currently this chart is totally broken due to the following error:

`executing "consul/templates/consul-ingress.yaml" at <.Values.uiIngress.path>: can't evaluate field Values in type interface {}`

This is due to the fact that they were using a `.Values` inside a `range` so we need to use `$.Values` to get back to the top-level Values.

#### Which issue this PR fixes

* fixes #20210

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)