### PR TITLE
stable/prometheus-rabbitmq-exporter: Support certs and TLS connection to Rab…

### DIFF
--- a/stable/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/stable/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 0.5.5
+version: 0.5.6
 appVersion: v0.29.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/stable/prometheus-rabbitmq-exporter/README.md
+++ b/stable/prometheus-rabbitmq-exporter/README.md
@@ -42,30 +42,33 @@ The following table lists the configurable parameters and their default values.
 
 | Parameter                | Description                                                            | Default                   |
 | ------------------------ | ---------------------------------------------------------------------- | ------------------------- |
-| `replicaCount`           | desired number of prometheus-rabbitmq-exporter pods                    | `1`                       |
-| `image.repository`       | prometheus-rabbitmq-exporter image repository                          | `kbudde/rabbitmq-exporter`|
-| `image.tag`              | prometheus-rabbitmq-exporter image tag                                 | `v0.29.0`                 |
-| `image.pullPolicy`       | image pull policy                                                      | `IfNotPresent`            |
-| `service.type`           | desired service type                                                   | `ClusterIP`               |
-| `service.internalport`   | service listening port                                                 | `9419`                    |
-| `service.externalPort`   | public service port                                                    | `9419`                    |
-| `resources`              | cpu/memory resource requests/limits                                    | {}                        |
-| `loglevel`               | exporter log level                                                     | {}                        |
-| `rabbitmq.url`           | rabbitmq management url                                                | `http://myrabbit:15672`   |
-| `rabbitmq.user`          | rabbitmq user login                                                    | `guest`                   |
-| `rabbitmq.password`      | rabbitmq password login                                                | `guest`                   |
-| `rabbitmq.existingPasswordSecret` | existing secret name containing password key                  | `~`                       |
-| `rabbitmq.capabilities`  | comma-separated list of capabilities supported by the RabbitMQ server  | `bert,no_sort`            |
-| `rabbitmq.include_queues`| regex queue filter. just matching names are exported                   | `.*`                      |
-| `rabbitmq.skip_queues`   | regex, matching queue names are not exported                           | `^$`                      |
-| `rabbitmq.include_vhost` | regex vhost filter. Only queues in matching vhosts are exported        | `.*`                      |
-| `rabbitmq.skip_vhost`    | regex, matching vhost names are not exported. First performs include_vhost, then skip_vhost | `^$` |
-| `rabbitmq.skip_verify`   | true/0 will ignore certificate errors of the management plugin         | `false`                   |
-| `rabbitmq.exporters`     | List of enabled modules. Just "connections" is not enabled by default  | `exchange,node,overview,queue` |
-| `rabbitmq.output_format` | Log ouput format. TTY and JSON are suported                            | `TTY`                     |
-| `rabbitmq.timeout`       | timeout in seconds for retrieving data from management plugin          | `30`                      |
-| `rabbitmq.max_queues`    | max number of queues before we drop metrics (disabled if set to 0)     | `0`                       |
-| `annotations`            | pod annotations for easier discovery                                   | {}                        |
+| `replicaCount`                    | desired number of prometheus-rabbitmq-exporter pods                    | `1`                       |
+| `image.repository`                | prometheus-rabbitmq-exporter image repository                          | `kbudde/rabbitmq-exporter`|
+| `image.tag`                       | prometheus-rabbitmq-exporter image tag                                 | `v0.29.0`                 |
+| `image.pullPolicy`                | image pull policy                                                      | `IfNotPresent`            |
+| `service.type`                    | desired service type                                                   | `ClusterIP`               |
+| `service.internalport`            | service listening port                                                 | `9419`                    |
+| `service.externalPort`            | public service port                                                    | `9419`                    |
+| `resources`                       | cpu/memory resource requests/limits                                    | {}                        |
+| `loglevel`                        | exporter log level                                                     | {}                        |
+| `rabbitmq.url`                    | rabbitmq management url                                                | `http://myrabbit:15672`   |
+| `rabbitmq.user`                   | rabbitmq user login                                                    | `guest`                   |
+| `rabbitmq.password`               | rabbitmq password login                                                | `guest`                   |
+| `rabbitmq.existingPasswordSecret` | existing secret name containing password key                           | `~`                       |
+| `rabbitmq.caFile`                 | path to root certificate for access management plugin. Just needed if self signed certificate is used. Will be ignored if the file does not exist  | `ca.pem`            |
+| `rabbitmq.certFile`               | path to client certificate used to verify the exporter's authenticity. Will be ignored if the file does not exist  | `client-cert.pem`            |
+| `rabbitmq.keyFile`                | path to private key used with certificate to verify the exporter's authenticity. Will be ignored if the file does not exist  | `client-key.pem`            |
+| `rabbitmq.capabilities`           | comma-separated list of capabilities supported by the RabbitMQ server  | `bert,no_sort`            |
+| `rabbitmq.include_queues`         | regex queue filter. just matching names are exported                   | `.*`                      |
+| `rabbitmq.skip_queues`            | regex, matching queue names are not exported                           | `^$`                      |
+| `rabbitmq.include_vhost`          | regex vhost filter. Only queues in matching vhosts are exported        | `.*`                      |
+| `rabbitmq.skip_vhost`             | regex, matching vhost names are not exported. First performs include_vhost, then skip_vhost | `^$` |
+| `rabbitmq.skip_verify`            | true/0 will ignore certificate errors of the management plugin         | `false`                   |
+| `rabbitmq.exporters`              | List of enabled modules. Just "connections" is not enabled by default  | `exchange,node,overview,queue` |
+| `rabbitmq.output_format`          | Log ouput format. TTY and JSON are suported                            | `TTY`                     |
+| `rabbitmq.timeout`                | timeout in seconds for retrieving data from management plugin          | `30`                      |
+| `rabbitmq.max_queues`             | max number of queues before we drop metrics (disabled if set to 0)     | `0`                       |
+| `annotations`                     | pod annotations for easier discovery                                   | {}                        |
 | `prometheus.monitor.enabled` | Set this to `true` to create ServiceMonitor for Prometheus operator | `false` |
 | `prometheus.monitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | {} |
 | `prometheus.monitor.interval` | Interval at which Prometheus Operator scrapes exporter | `15s` |

--- a/stable/prometheus-rabbitmq-exporter/templates/deployment.yaml
+++ b/stable/prometheus-rabbitmq-exporter/templates/deployment.yaml
@@ -42,6 +42,12 @@ spec:
             {{- end }}
             - name: PUBLISH_PORT
               value: "{{ .Values.service.internalPort }}"
+            - name: CAFILE
+              value: "{{ .Values.rabbitmq.caFile }}"
+            - name: CERTFILE
+              value: "{{ .Values.rabbitmq.certFile }}"
+            - name: KEYFILE
+              value: "{{ .Values.rabbitmq.keyFile }}"
             - name: LOG_LEVEL
               value: "{{ .Values.loglevel }}"
             - name: RABBIT_CAPABILITIES

--- a/stable/prometheus-rabbitmq-exporter/values.yaml
+++ b/stable/prometheus-rabbitmq-exporter/values.yaml
@@ -35,6 +35,9 @@ rabbitmq:
   password: guest
   # If existingPasswordSecret is set then password is ignored
   existingPasswordSecret: ~
+  caFile: "ca.pem"
+  certFile: "client-cert.pem"
+  keyFile: "client-key.pem"
   capabilities: bert,no_sort
   include_queues: ".*"
   include_vhost: ".*"


### PR DESCRIPTION
…bitMQ Mgmt API

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

#### What this PR does / why we need it:
In order to connect to managed RabbitMQ instances behind IBM Cloud, the connection must be made over TLS with a certificate.  This pull request supports these extra fields.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
These are direct values taken from here:
https://github.com/kbudde/rabbitmq_exporter/blob/master/README.md

Latest chart version users will be able to direct upgrade with no change.  If values are not provided or are invalid, they will be ignored.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
