### PR TITLE
[stable/sonarqube] Upgrade postgresql chart version

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 3.3.3
+version: 3.4.0
 appVersion: 7.9.2
 keywords:
   - coverage

--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -79,11 +79,11 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `sonarProperties`                           | Custom `sonar.properties` file            | `{}`                                       |
 | `database.type`                             | Set to "mysql" to use mysql database       | `postgresql`|
 | `postgresql.enabled`                        | Set to `false` to use external server / mysql database     | `true`                                     |
-| `postgresql.postgresServer`                 | Hostname of the external Postgresql server| `null`                                     |
-| `postgresql.postgresPasswordSecret`         | Secret containing the password of the external Postgresql server | `null`              |
-| `postgresql.postgresUser`                   | Postgresql database user                  | `sonarUser`                                |
-| `postgresql.postgresPassword`               | Postgresql database password              | `sonarPass`                                |
-| `postgresql.postgresDatabase`               | Postgresql database name                  | `sonarDB`                                  |
+| `postgresql.postgresqlServer`               | Hostname of the external Postgresql server| `null`                                     |
+| `postgresql.postgresqlPasswordSecret`       | Secret containing the password of the external Postgresql server | `null`              |
+| `postgresql.postgresqlUsername`             | Postgresql database user                  | `sonarUser`                                |
+| `postgresql.postgresqlPassword`             | Postgresql database password              | `sonarPass`                                |
+| `postgresql.postgresqlDatabase`             | Postgresql database name                  | `sonarDB`                                  |
 | `postgresql.service.port`                   | Postgresql port                           | `5432`                                     |
 | `mysql.enabled`                             | Set to `false` to use external server / postgresql database        | `false`                                     |
 | `mysql.mysqlServer`                         | Hostname of the external Mysql server     | `null`                                     |

--- a/stable/sonarqube/requirements.lock
+++ b/stable/sonarqube/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.8.3
+  version: 8.2.0
 - name: mysql
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.6.0
-digest: sha256:2e9888ddfac13a780385a8c40f720b7248914986f4afbe0dce143ba7fecb9313
-generated: 2018-05-28T12:47:06.012847582+02:00
+digest: sha256:e7f6d50c8a679e5b674212d8ef83781aa29df89d0490670f9f222b3f71e85b30
+generated: "2020-01-29T11:02:00.270992632+01:00"

--- a/stable/sonarqube/requirements.yaml
+++ b/stable/sonarqube/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: postgresql
-    version: 0.8.3
+    version: 8.2.0
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: postgresql.enabled
   - name: mysql

--- a/stable/sonarqube/templates/_helpers.tpl
+++ b/stable/sonarqube/templates/_helpers.tpl
@@ -34,7 +34,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- if .Values.postgresql.enabled -}}
 {{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s" .Values.postgresql.postgresServer -}}
+{{- printf "%s" .Values.postgresql.postgresqlServer -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stable/sonarqube/templates/deployment.yaml
+++ b/stable/sonarqube/templates/deployment.yaml
@@ -163,7 +163,7 @@ spec:
             {{- end }}
             - name: SONARQUBE_JDBC_USERNAME
               {{- if eq .Values.database.type "postgresql" }}
-              value: {{ .Values.postgresql.postgresUser | quote }}
+              value: {{ .Values.postgresql.postgresqlUsername | quote }}
               {{- else if eq .Values.database.type "mysql" }}
               value: {{ .Values.mysql.mysqlUser | quote }}
               {{- end }}
@@ -171,15 +171,15 @@ spec:
               valueFrom:
                 secretKeyRef:
                   {{- if eq .Values.database.type "postgresql" }}
-                  name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else if .Values.postgresql.postgresPasswordSecret }} {{ .Values.postgresql.postgresPasswordSecret }} {{- else }} {{ template "sonarqube.fullname" . }} {{- end }}
-                  key: postgres-password
+                  name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else if .Values.postgresql.postgresqlPasswordSecret }} {{ .Values.postgresql.postgresqlPasswordSecret }} {{- else }} {{ template "sonarqube.fullname" . }} {{- end }}
+                  key: postgresql-password
                   {{- else if eq .Values.database.type "mysql" }}
                   name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else if .Values.mysql.mysqlPasswordSecret }} {{ .Values.mysql.mysqlPasswordSecret }} {{- else }} {{ template "sonarqube.fullname" . }} {{- end }}
                   key: mysql-password
                   {{- end }}
             - name: SONARQUBE_JDBC_URL
               {{- if eq .Values.database.type "postgresql" }}
-              value: "jdbc:postgresql://{{ template "postgresql.hostname" . }}:{{- .Values.postgresql.service.port -}}/{{- .Values.postgresql.postgresDatabase -}}"
+              value: "jdbc:postgresql://{{ template "postgresql.hostname" . }}:{{- .Values.postgresql.service.port -}}/{{- .Values.postgresql.postgresqlDatabase -}}"
               {{- else if eq .Values.database.type "mysql" }}
               value: "jdbc:mysql://{{ template "mysql.hostname" . }}:{{ .Values.mysql.service.port }}/{{ .Values.mysql.mysqlDatabase }}?useUnicode=true&characterEncoding=utf8&rewriteBatchedStatements=true{{- range $key, $value := .Values.mysql.mysqlParams }}&{{ $key }}={{ $value }}{{- end }}"
               {{- end }}

--- a/stable/sonarqube/templates/secret.yaml
+++ b/stable/sonarqube/templates/secret.yaml
@@ -1,6 +1,6 @@
 {{- if eq .Values.database.type "postgresql" -}}
 {{- if eq .Values.postgresql.enabled false -}}
-{{- if not .Values.postgresql.postgresPasswordSecret -}}
+{{- if not .Values.postgresql.postgresqlPasswordSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,7 +12,7 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
-  postgres-password: {{ .Values.postgresql.postgresPassword | b64enc | quote }}
+  postgresql-password: {{ .Values.postgresql.postgresqlPassword | b64enc | quote }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -184,14 +184,14 @@ postgresql:
   enabled: true
   # To use an external PostgreSQL instance, set enabled to false and uncomment
   # the line below:
-  # postgresServer: ""
+  # postgresqlServer: ""
   # To use an external secret for the password for an external PostgreSQL
   # instance, set enabled to false and provide the name of the secret on the
   # line below:
-  # postgresPasswordSecret: ""
-  postgresUser: "sonarUser"
-  postgresPassword: "sonarPass"
-  postgresDatabase: "sonarDB"
+  # postgresqlPasswordSecret: ""
+  postgresqlUsername: "sonarUser"
+  postgresqlPassword: "sonarPass"
+  postgresqlDatabase: "sonarDB"
   # Specify the TCP port that PostgreSQL should use
   service:
     port: 5432


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Sonarqube uses a very old version of Postgresql Chart. We miss some features provided by new versions such as being able to add annotations.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #20414 (partial fix)

#### Special notes for your reviewer:

Postgresql chart values attribute name have change. I had to update them.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
