### PR TITLE
[stable/external-dns] Add support to retrieve credentials from existing secrets

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.15.3
+version: 2.16.0
 appVersion: 0.5.18
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/templates/_helpers.tpl
+++ b/stable/external-dns/templates/_helpers.tpl
@@ -110,6 +110,49 @@ imagePullSecrets:
 {{- end -}}
 {{- end -}}
 
+{{/*
+Return true if a secret object should be created
+*/}}
+{{- define "external-dns.createSecret" -}}
+{{- if and (eq .Values.provider "aws") .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey (not .Values.aws.credentials.secretName) }}
+    {{- true -}}
+{{- else if and (eq .Values.provider "azure") (or (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId .Values.azure.aadClientId .Values.azure.aadClientSecret (not .Values.azure.useManagedIdentityExtension)) (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId .Values.azure.useManagedIdentityExtension)) (not .Values.azure.secretName) -}}
+    {{- true -}}
+{{- else if and (eq .Values.provider "cloudflare") (or .Values.cloudflare.apiToken .Values.cloudflare.apiKey) (not .Values.cloudflare.secretName) -}}
+    {{- true -}}
+{{- else if and (eq .Values.provider "digitalocean") .Values.digitalocean.apiToken (not .Values.digitalocean.secretName) -}}
+    {{- true -}}
+{{- else if and (eq .Values.provider "google") .Values.google.serviceAccountKey (not .Values.google.serviceAccountSecret) -}}
+    {{- true -}}
+{{- else if and (eq .Values.provider "infoblox") (and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword) -}}
+    {{- true -}}
+{{- else if and (eq .Values.provider "rfc2136") .Values.rfc2136.tsigSecret -}}
+    {{- true -}}
+{{- else if and (eq .Values.provider "pdns") .Values.pdns.apiKey -}}
+    {{- true -}}
+{{- else -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the name of the Secret used to store the passwords
+*/}}
+{{- define "external-dns.secretName" -}}
+{{- if and (eq .Values.provider "aws") .Values.aws.credentials.secretName }}
+{{- .Values.aws.credentials.secretName }}
+{{- else if and (eq .Values.provider "azure") .Values.azure.secretName }}
+{{- .Values.azure.secretName }}
+{{- else if and (eq .Values.provider "cloudflare") .Values.cloudflare.secretName }}
+{{- .Values.cloudflare.secretName }}
+{{- else if and (eq .Values.provider "digitalocean") .Values.digitalocean.secretName }}
+{{- .Values.digitalocean.secretName }}
+{{- else if and (eq .Values.provider "google") .Values.google.serviceAccountSecret }}
+{{- .Values.google.serviceAccountSecret }}
+{{- else -}}
+{{- template "external-dns.fullname" . }}
+{{- end -}}
+{{- end -}}
+
 {{- define "external-dns.aws-credentials" }}
 [default]
 aws_access_key_id = {{ .Values.aws.credentials.accessKey }}

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -334,7 +334,7 @@ spec:
         {{- end }}
         volumeMounts:
         # AWS mountPath(s)
-        {{- if and (eq .Values.provider "aws") (or .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey .Values.aws.credentials.secretName) }}
+        {{- if and (eq .Values.provider "aws") (or (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey) .Values.aws.credentials.secretName) }}
         - name: aws-credentials
           mountPath: {{ .Values.aws.credentials.mountPath }}
           readOnly: true
@@ -356,7 +356,7 @@ spec:
           readOnly: true
         {{- end }}
         # Google mountPath(s)
-        {{- if eq .Values.provider "google" (or .Values.google.serviceAccountKey .Values.google.serviceAccountSecret) }}
+        {{- if and (eq .Values.provider "google") (or .Values.google.serviceAccountKey .Values.google.serviceAccountSecret) }}
         - name: google-service-account
           mountPath: /etc/secrets/service-account/
         {{- end }}
@@ -393,7 +393,7 @@ spec:
           defaultMode: 400
       {{- end }}
       # Google volume(s)
-      {{- if eq .Values.provider "google" (or .Values.google.serviceAccountKey .Values.google.serviceAccountSecret) }}
+      {{- if and (eq .Values.provider "google") (or .Values.google.serviceAccountKey .Values.google.serviceAccountSecret) }}
       - name: google-service-account
         secret:
           secretName: {{ template "external-dns.secretName" . }}

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
         {{- if or .Values.podAnnotations .Values.metrics.enabled }}
         {{ include "external-dns.podAnnotations" . | nindent 8 }}
         {{- end }}
-        {{- if or (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey) (or .Values.cloudflare.apiToken .Values.cloudflare.apiKey) .Values.digitalocean.apiToken (and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword) .Values.rfc2136.tsigSecret .Values.extraEnv .Values.google.serviceAccountKey }}
+        {{- if (include "external-dns.createSecret" .) }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
         {{- if and (eq .Values.provider "designate") .Values.designate.customCA.enabled }}
@@ -230,17 +230,17 @@ spec:
         {{- end }}
         # Cloudflare environment variables
         {{- if eq .Values.provider "cloudflare" }}
-        {{- if .Values.cloudflare.apiToken }}
+        {{- if or .Values.cloudflare.apiToken .Values.cloudflare.secretName }}
         - name: CF_API_TOKEN
           valueFrom:
             secretKeyRef:
-              name: {{ template "external-dns.fullname" . }}
+              name: {{ template "external-dns.secretName" . }}
               key: cloudflare_api_token
-        {{- else }}
+        {{- else if or .Values.cloudflare.apiKey .Values.cloudflare.secretName }}
         - name: CF_API_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ template "external-dns.fullname" . }}
+              name: {{ template "external-dns.secretName" . }}
               key: cloudflare_api_key
         - name: CF_API_EMAIL
           value: {{ required "cloudflare.email is required if cloudflare.apiToken is not provided" .Values.cloudflare.email | quote }}
@@ -260,14 +260,12 @@ spec:
         {{- end }}
         {{- end }}
         # DigitalOcean environment variables
-        {{- if eq .Values.provider "digitalocean" }}
-        {{- if .Values.digitalocean.apiToken }}
+        {{- if and (eq .Values.provider "digitalocean") (or .Values.digitalocean.apiToken .Values.digitalocean.secretName) }}
         - name: DO_TOKEN
           valueFrom:
             secretKeyRef:
-              name: {{ template "external-dns.fullname" . }}
+              name: {{ template "external-dns.secretName" . }}
               key: digitalocean_api_token
-        {{- end }}
         {{- end }}
         # Google environment variables
         {{- if eq .Values.provider "google" }}
@@ -290,12 +288,12 @@ spec:
         - name: EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME
           valueFrom:
             secretKeyRef:
-              name: {{ template "external-dns.fullname" . }}
+              name: {{ template "external-dns.secretName" . }}
               key: infoblox_wapi_username
         - name: EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "external-dns.fullname" . }}
+              name: {{ template "external-dns.secretName" . }}
               key: infoblox_wapi_password
         {{- end }}
         {{- end }}
@@ -304,7 +302,7 @@ spec:
         - name: EXTERNAL_DNS_RFC2136_TSIG_SECRET
           valueFrom:
             secretKeyRef:
-              name: {{ template "external-dns.fullname" . }}
+              name: {{ template "external-dns.secretName" . }}
               key: rfc2136_tsig_secret
         {{- end }}
         {{- if and (eq .Values.provider "designate") .Values.designate.customCA.enabled }}
@@ -316,7 +314,7 @@ spec:
         - name: PDNS_API_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ template "external-dns.fullname" . }}
+              name: {{ template "external-dns.secretName" . }}
               key: pdns_api_key
         {{- end }}
         # Extra environment variables
@@ -336,7 +334,7 @@ spec:
         {{- end }}
         volumeMounts:
         # AWS mountPath(s)
-        {{- if and (eq .Values.provider "aws") (or .Values.aws.assumeRoleArn (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey)) }}
+        {{- if and (eq .Values.provider "aws") (or .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey .Values.aws.credentials.secretName) }}
         - name: aws-credentials
           mountPath: {{ .Values.aws.credentials.mountPath }}
           readOnly: true
@@ -358,11 +356,9 @@ spec:
           readOnly: true
         {{- end }}
         # Google mountPath(s)
-        {{- if eq .Values.provider "google" }}
-        {{- if or .Values.google.serviceAccountSecret .Values.google.serviceAccountKey }}
+        {{- if eq .Values.provider "google" (or .Values.google.serviceAccountKey .Values.google.serviceAccountSecret) }}
         - name: google-service-account
           mountPath: /etc/secrets/service-account/
-        {{- end }}
         {{- end }}
         # Designate mountPath(s)
         {{- if and (eq .Values.provider "designate") .Values.designate.customCA.enabled }}
@@ -372,20 +368,17 @@ spec:
         {{- end }}
       volumes:
       # AWS volume(s)
-      {{- if and (eq .Values.provider "aws") (or .Values.aws.assumeRoleArn (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey)) }}
+      {{- if and (eq .Values.provider "aws") (or (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey) .Values.aws.credentials.secretName) }}
       - name: aws-credentials
         secret:
-          secretName: {{ template "external-dns.fullname" . }}
+          secretName: {{ template "external-dns.secretName" . }}
       {{- end }}
       # Azure volume(s)
       {{- if eq .Values.provider "azure" }}
       - name: azure-config-file
-        {{- if .Values.azure.secretName }}
+        {{- if or .Values.azure.secretName (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId) }}
         secret:
-          secretName: {{ .Values.azure.secretName }}
-        {{- else if (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId) }}
-        secret:
-          secretName: {{ template "external-dns.fullname" . }}
+          secretName: {{ template "external-dns.secretName" . }}
         {{- else if not .Values.azure.useManagedIdentityExtension }}
         hostPath:
           path: /etc/kubernetes/azure.json
@@ -400,21 +393,15 @@ spec:
           defaultMode: 400
       {{- end }}
       # Google volume(s)
-      {{- if eq .Values.provider "google" }}
-      {{- if .Values.google.serviceAccountSecret }}
+      {{- if eq .Values.provider "google" (or .Values.google.serviceAccountKey .Values.google.serviceAccountSecret) }}
       - name: google-service-account
         secret:
-          secretName: {{ .Values.google.serviceAccountSecret | quote }}
-          {{- if .Values.google.serviceAccountSecretKey }}
+          secretName: {{ template "external-dns.secretName" . }}
+          {{- if and .Values.google.serviceAccountSecret .Values.google.serviceAccountSecretKey }}
           items:
           - key: {{ .Values.google.serviceAccountSecretKey | quote }}
             path: credentials.json
           {{- end }}
-      {{- else if .Values.google.serviceAccountKey }}
-      - name: google-service-account
-        secret:
-          secretName: {{ template "external-dns.fullname" . }}
-      {{- end}}
       {{- end }}
       # Designate volume(s)
       {{- if and (eq .Values.provider "designate") .Values.designate.customCA.enabled }}

--- a/stable/external-dns/templates/secret.yaml
+++ b/stable/external-dns/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.aws.assumeRoleArn (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey) (or .Values.cloudflare.apiToken .Values.cloudflare.apiKey) .Values.digitalocean.apiToken .Values.google.serviceAccountKey (and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword) .Values.rfc2136.tsigSecret .Values.pdns.apiKey (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId .Values.azure.aadClientId .Values.azure.aadClientSecret (not .Values.azure.useManagedIdentityExtension)) (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId .Values.azure.useManagedIdentityExtension) }}
+{{- if (include "external-dns.createSecret" .) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,14 +7,15 @@ metadata:
 type: Opaque
 data:
   {{- if eq .Values.provider "aws" }}
-  {{- if and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey }}
   credentials: {{ include "external-dns.aws-credentials" . | b64enc | quote }}
-  {{- end }}
   {{- if .Values.aws.region }}
   config: {{ include "external-dns.aws-config" . | b64enc | quote }}
   {{- end }}
   {{- end }}
-  {{- if and (eq .Values.provider "google") .Values.google.serviceAccountKey }}
+  {{- if eq .Values.provider "azure" }}
+  azure.json: {{ include "external-dns.azure-credentials" . | b64enc | quote }}
+  {{- end }}
+  {{- if eq .Values.provider "google" }}
   credentials.json: {{ .Values.google.serviceAccountKey | b64enc | quote }}
   {{- end }}
   {{- if eq .Values.provider "cloudflare" }}
@@ -24,20 +25,17 @@ data:
   cloudflare_api_key: {{ required "cloudflare.apiKey is required if cloudflare.apiToken is not provided" .Values.cloudflare.apiKey | b64enc | quote }}
   {{- end }}
   {{- end }}
-  {{- if .Values.digitalocean.apiToken }}
+  {{- if eq .Values.provider "digitalocean" }}
   digitalocean_api_token: {{ .Values.digitalocean.apiToken | b64enc | quote }}
   {{- end }}
-  {{- if and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword }}
+  {{- if eq .Values.provider "infoblox" }}
   infoblox_wapi_username: {{ .Values.infoblox.wapiUsername | b64enc | quote }}
   infoblox_wapi_password: {{ .Values.infoblox.wapiPassword | b64enc | quote }}
   {{- end }}
-  {{- if .Values.rfc2136.tsigSecret }}
-  rfc2136_tsig_secret: {{ .Values.rfc2136.tsigSecret | b64enc | quote }}
-  {{- end }}
-  {{- if .Values.pdns.apiKey }}
+  {{- if eq .Values.provider "pdns" }}
   pdns_api_key: {{ .Values.pdns.apiKey | b64enc | quote }}
   {{- end }}
-  {{- if eq .Values.provider "azure" }}
-  azure.json: {{ (include "external-dns.azure-credentials" .) | b64enc | quote }}
+  {{- if eq .Values.provider "rfc2136" }}
+  rfc2136_tsig_secret: {{ .Values.rfc2136.tsigSecret | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/stable/external-dns/values-production.yaml
+++ b/stable/external-dns/values-production.yaml
@@ -80,6 +80,11 @@ aws:
     ## pre external-dns 0.5.9 home dir should be `/root/.aws`
     ##
     mountPath: "/.aws"
+    ## Use an existing secret with key "credentials" defined.
+    ## This ignores aws.credentials.secretKey, and aws.credentials.accessKey
+    ##
+    # secretName:
+
   ## AWS region
   ##
   region: "us-east-1"
@@ -142,6 +147,10 @@ cloudflare:
   ## `CF_API_KEY` to set in the environment
   ##
   apiKey: ""
+  ## Use an existing secret with keys "cloudflare_api_token" or "cloudflare_api_key" defined.
+  ## This ignores cloudflare.apiToken, and cloudflare.apiKey
+  ##
+  # secretName:
   ## `CF_API_EMAIL` to set in the environment
   ##
   email: ""
@@ -208,6 +217,10 @@ digitalocean:
   ## `DO_TOKEN` to set in the environment
   ##
   apiToken: ""
+  ## Use an existing secret with key "digitalocean_api_token" defined.
+  ## This ignores digitalocean.apiToken
+  ##
+  # secretName:
 
 ## Google configuration to be set via arguments/env. variables
 ##

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -80,6 +80,11 @@ aws:
     ## pre external-dns 0.5.9 home dir should be `/root/.aws`
     ##
     mountPath: "/.aws"
+    ## Use an existing secret with key "credentials" defined.
+    ## This ignores aws.credentials.secretKey, and aws.credentials.accessKey
+    ##
+    # secretName:
+
   ## AWS region
   ##
   region: "us-east-1"
@@ -141,6 +146,10 @@ cloudflare:
   ## `CF_API_KEY` to set in the environment
   ##
   apiKey: ""
+  ## Use an existing secret with keys "cloudflare_api_token" or "cloudflare_api_key" defined.
+  ## This ignores cloudflare.apiToken, and cloudflare.apiKey
+  ##
+  # secretName:
   ## `CF_API_EMAIL` to set in the environment
   ##
   email: ""
@@ -207,6 +216,10 @@ digitalocean:
   ## `DO_TOKEN` to set in the environment
   ##
   apiToken: ""
+  ## Use an existing secret with key "digitalocean_api_token" defined.
+  ## This ignores digitalocean.apiToken
+  ##
+  # secretName:
 
 ## Google configuration to be set via arguments/env. variables
 ##


### PR DESCRIPTION
## Is this a new chart

No

#### What this PR does / why we need it:

This PRs add support to retrieve credentials from existing secrets to some providers such as AWS, Google, and Cloudflare.

#### Which issue this PR fixes

  - fixes https://github.com/helm/charts/issues/20394

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
