### PR TITLE
[stable/rabbitmq] Add 'extraConfiguration' to values.schema

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.17.3
+version: 6.17.4
 appVersion: 3.8.2
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/values.schema.json
+++ b/stable/rabbitmq/values.schema.json
@@ -15,6 +15,13 @@
           "title": "RabbitMQ password",
           "form": true,
           "description": "Defaults to a random 10-character alphanumeric string if not set"
+        },
+        "extraConfiguration": {
+          "type": "string",
+          "title": "Extra RabbitMQ Configuration",
+          "form": true,
+          "render": "textArea",
+          "description": "Extra configuration to be appended to RabbitMQ Configuration"
         }
       }
     },


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### Is this a new chart

No

#### What this PR does / why we need it:

This PRs adds a new parameter (`rabbitmq.extraConfiguration`) in the JSON schema for RabbitMQ so it's validated by Helm3 and rendered by Kubeapps in the Deployment form (see https://github.com/kubeapps/kubeapps/blob/master/docs/developer/basic-form-support.md for more information).


#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
