### PR TITLE
[stable/datadog] Resouces on init containers

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.39.6
+version: 1.39.7
 appVersion: "7"
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -320,6 +320,10 @@ helm install --name <RELEASE_NAME> \
 | `daemonset.containers.systemProbe.resources.requests.cpu`         | CPU resource requests for the system-probe container                                    | `100m`                                        |
 | `daemonset.containers.systemProbe.resources.limits.memory`        | Memory resource limits for the system-probe container                                   | `200Mi`                                       |
 | `daemonset.containers.systemProbe.resources.requests.memory`      | Memory resource requests for the system-probe container                                 | `200Mi`                                       |
+| `daemonset.containers.initContainers.resources.limits.cpu`         | CPU resource limits for the init containers                                            | `200m`                                        |
+| `daemonset.containers.initContainers.resources.requests.cpu`       | CPU resource requests for the init containers                                          | `200m`                                        |
+| `daemonset.containers.initContainers.resources.limits.memory`      | Memory resource limits for the init containers                                         | `256Mi`                                       |
+| `daemonset.containers.initContainers.resources.requests.memory`    | Memory resource requests for the init containers                                       | `256Mi`                                       |
 | `daemonset.priorityClassName`            | Which Priority Class to associate with the daemonset                                      | `nil`                                       |
 | `daemonset.useConfigMap`                 | Configures a configmap to provide the agent configuration                                 | `false`                                     |
 | `daemonset.customAgentConfig`            | Specify custom contents for the datadog agent config (datadog.yaml).                      | `{}`                                        |

--- a/stable/datadog/requirements.lock
+++ b/stable/datadog/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 2.2.3
-digest: sha256:28fd41002af09316b9f614d320ea4171db39a144b595c68f616c546dd5292709
-generated: "2019-08-13T09:53:34.977562+02:00"
+digest: sha256:ce13be2cc7678a902f976b7ae164bfce9cd50e92cf961ae4272d812b61bce63e
+generated: "2020-01-30T22:05:57.682739182-05:00"

--- a/stable/datadog/requirements.lock
+++ b/stable/datadog/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 2.2.3
-digest: sha256:ce13be2cc7678a902f976b7ae164bfce9cd50e92cf961ae4272d812b61bce63e
-generated: "2020-01-30T22:05:57.682739182-05:00"
+digest: sha256:28fd41002af09316b9f614d320ea4171db39a144b595c68f616c546dd5292709
+generated: "2019-08-13T09:53:34.977562+02:00"

--- a/stable/datadog/templates/containers-init.yaml
+++ b/stable/datadog/templates/containers-init.yaml
@@ -4,10 +4,8 @@
   command: ["bash", "-c"]
   args:
     - cp -r /etc/datadog-agent /opt
-{{- if .Values.daemonset.containers.initContainers.resources }}
   resources:
 {{ toYaml .Values.daemonset.containers.initContainers.resources | indent 4 }}
-{{- end }}
   volumeMounts:
     - name: config
       mountPath: /opt/datadog-agent
@@ -16,10 +14,8 @@
   command: ["bash", "-c"]
   args:
     - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
-{{- if .Values.daemonset.containers.initContainers.resources }}
   resources:
 {{ toYaml .Values.daemonset.containers.initContainers.resources | indent 4 }}
-{{- end }}
   volumeMounts:
     - name: config
       mountPath: /etc/datadog-agent

--- a/stable/datadog/templates/containers-init.yaml
+++ b/stable/datadog/templates/containers-init.yaml
@@ -4,6 +4,10 @@
   command: ["bash", "-c"]
   args:
     - cp -r /etc/datadog-agent /opt
+{{- if .Values.daemonset.containers.initContainers.resources }}
+  resources:
+{{ toYaml .Values.daemonset.containers.initContainers.resources | indent 4 }}
+{{- end }}
   volumeMounts:
     - name: config
       mountPath: /opt/datadog-agent
@@ -12,6 +16,10 @@
   command: ["bash", "-c"]
   args:
     - for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done
+{{- if .Values.daemonset.containers.initContainers.resources }}
+  resources:
+{{ toYaml .Values.daemonset.containers.initContainers.resources | indent 4 }}
+{{- end }}
   volumeMounts:
     - name: config
       mountPath: /etc/datadog-agent

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -653,6 +653,20 @@ daemonset:
       #    cpu: 100m
       #    memory: 200Mi
 
+    initContainers:
+      ## @param resources - object - required
+      ## Resource requests and limits for the init containers.
+      #
+      resources: {}
+      #  requests:
+      #    cpu: 100m
+      #    memory: 200Mi
+      #  limits:
+      #    cpu: 100m
+      #    memory: 200Mi
+
+
+
   ## @param useHostNetwork - boolean - optional
   ## Bind ports on the hostNetwork. Useful for CNI networking where hostPort might
   ## not be supported. The ports need to be available on all hosts. It Can be

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -666,7 +666,6 @@ daemonset:
       #    memory: 200Mi
 
 
-
   ## @param useHostNetwork - boolean - optional
   ## Bind ports on the hostNetwork. Useful for CNI networking where hostPort might
   ## not be supported. The ports need to be available on all hosts. It Can be


### PR DESCRIPTION
@hkaj @irabinovitch @charlyf @mfpierre @clamoriniere @xlucas @L3n41c @celenechang 

#### What this PR does / why we need it:
I currently cannot provide resources to init containers, and therefore the resources for those containers gets defaulted to an empty map. This is not permitted on my cluster, thus I am not able to use dedicated containers.

#### Which issue this PR fixes
  - fixes #20035 

#### Special notes for your reviewer:
I tested this by simply setting `daemonset.useDedicatedContainers=true` and verifying that no resources are created, just as before my changes. I then set the values `daemonset.useDedicatedContainers=true,daemonset.containers.initContainers.resources.limits.cpu=200m,daemonset.containers.initContainers.resources.requests.cpu=200m,daemonset.containers.initContainers.resources.limits.memory=256Mi,daemonset.containers.initContainers.resources.requests.memory=256Mi` and verified that the resources block was created.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
