### PR TITLE
[stable/graylog] Add helm2Compatibility flag to values.yaml that preserves specific labels installed by helm2 for backward compatibility

### DIFF
--- a/stable/graylog/Chart.yaml
+++ b/stable/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: graylog
 home: https://www.graylog.org
-version: 1.5.2
+version: 1.5.3
 appVersion: 3.1
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:

--- a/stable/graylog/templates/statefulset.yaml
+++ b/stable/graylog/templates/statefulset.yaml
@@ -15,7 +15,11 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ template "graylog.name" . }}
       app.kubernetes.io/instance: "{{ .Release.Name }}"
+      {{- if .Values.helm2Compatibility }}
+      app.kubernetes.io/managed-by: "Tiller"
+      {{- else }}
       app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+      {{- end }}
   updateStrategy:
     type: {{ .Values.graylog.updateStrategy }}
   template:
@@ -23,7 +27,11 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "graylog.name" . }}
         helm.sh/chart: {{ template "graylog.chart" . }}
+        {{- if .Values.helm2Compatibility }}
+        app.kubernetes.io/managed-by: "Tiller"
+        {{- else }}
         app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+        {{- end }}
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/version: "{{ .Chart.AppVersion }}"
       annotations:

--- a/stable/graylog/values.yaml
+++ b/stable/graylog/values.yaml
@@ -22,6 +22,16 @@ tags:
   # If true, this chart will install MongoDB replicaset from requirement dependencies
   install-mongodb: true
 
+## Enable only if your current release was migrated from helm2 (using 2to3 plugin).
+##
+## Because Kubernetes considers some StatefulSets fields/labels immutable,
+## this flag preserves the values rendered by helm2. This allows helm3
+## to upgrade the current release without a complete purge/reinstall.
+##
+## Further details: https://github.com/helm/charts/issues/20306
+##
+# helm2Compatibility: true
+
 graylog:
   ## Graylog image version
   ## Ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
#### What this PR does / why we need it:

Releases installed from this chart using helm2 cannot be upgraded after migrating to helm3.

Using helm2, the chart renders the label `app.kubernetes.io/managed-by: Tiller` in the Graylog StatefulSet. Meanwhile, using helm3, the chart renders `app.kubernetes.io/managed-by: "Helm"`.

Since Kubernetes considers the field `.spec.template.metadata.label` immutable for StatefulSets, upgrading migrated releases is not possible without a complete purge/reinstall.

The attempt to upgrade results in the following error message:

```
Error: UPGRADE FAILED: cannot patch "graylog-deploy" with kind StatefulSet: StatefulSet.apps "graylog-deploy" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden
```

This PR adds the flag `helm2Compatibility` to values.yaml, giving users the choice to preserve related label fields. This allows upgrades to continue without a complete purge/reinstall of the current release.

#### Which issue this PR fixes
  - fixes #20306

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
