### PR TITLE
[stable/nfs-server-provisioner] Upgrade nfs-provisioner to v2.3.0

### DIFF
--- a/stable/nfs-server-provisioner/Chart.yaml
+++ b/stable/nfs-server-provisioner/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 2.2.2
+appVersion: 2.3.0
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 0.4.0
+version: 0.5.0
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/stable/nfs-server-provisioner/values.yaml
+++ b/stable/nfs-server-provisioner/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 
 image:
   repository: quay.io/kubernetes_incubator/nfs-provisioner
-  tag: v2.2.2
+  tag: v2.3.0
   pullPolicy: IfNotPresent
 
 # For a list of available arguments


### PR DESCRIPTION
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

No
#### What this PR does / why we need it:
 
It upgrades the version of nfs-provisioner from v2.2.2 to v2.3.0. **v2.3.0** contains valuable features including one that fixes the *'stale file handle'* issue on certain environment dealing with persistent disks. 

* https://github.com/kubernetes-incubator/external-storage/issues/1212
* https://github.com/kubernetes-incubator/external-storage/pull/1214

#### Which issue this PR fixes
There are no open issue in this repo related to this PR.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
