### PR TITLE
[stable/gocd] Quote ingress host

### DIFF
--- a/stable/gocd/CHANGELOG.md
+++ b/stable/gocd/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.22.1
+* [b856007](https://github.com/kubernetes/charts/commit/b856007): Ingress version api change
+* [e2f27a9](https://github.com/kubernetes/charts/commit/e2f27a9): Quote ingress host
+
 ### 1.22.0
 * [bcd9825](https://github.com/kubernetes/charts/commit/bcd9825): Bump up GoCD Version to 20.1.0
 ### 1.21.0

--- a/stable/gocd/Chart.yaml
+++ b/stable/gocd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gocd
 home: https://www.gocd.org/
-version: 1.22.0
+version: 1.22.1
 appVersion: 20.1.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/stable/gocd/templates/ingress.yaml
+++ b/stable/gocd/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.server.enabled }}
 {{- if .Values.server.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "gocd.fullname" . }}-server

--- a/stable/gocd/templates/ingress.yaml
+++ b/stable/gocd/templates/ingress.yaml
@@ -19,7 +19,7 @@ spec:
   {{ $dot := .}}
   rules:
     {{- range $host := .Values.server.ingress.hosts }}
-    - host: {{ $host }}
+    - host: {{ $host | quote }}
       http:
         paths:
         - backend:


### PR DESCRIPTION
When using a wildcard DNS name for host, such as *.example.com, Helm
fails with a yaml parsing error. 

Signed-off-by: Austin Orth <aorth@niche.com>

#### What this PR does / why we need it:
Added quote function to allow use of wildcard DNS names in the ingress template. Without this PR, Helm will error when trying to set up the ingress when users try a wildcard DNS name.

#### Which issue this PR fixes
When setting `hosts` in values file to `["*.example.com"]`
```bash
$ helm install gocd ./ -f ~/gocd/values.aws.yaml
coalesce.go:199: warning: destination for annotations is a table. Ignoring non-table value <nil>
Error: YAML parse error on gocd/templates/ingress.yaml: error converting YAML to JSON: yaml: line 16: did not find expected alphabetic or numeric character
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

**cc:** @arvindsv @ganeshspatil @varshavaradarajan