### PR TITLE
[stable/datadog] Replace hard coded ports with variables

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.39.6
+version: 1.39.7
 appVersion: "7"
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -272,6 +272,7 @@ helm install --name <RELEASE_NAME> \
 | `datadog.useCriSocketVolume`             | Enable mounting the container runtime socket in Agent containers                          | `True`                                      |
 | `datadog.dogstatsdOriginDetection`       | Enable origin detection for container tagging                                             | `False`                                     |
 | `datadog.dogStatsDPort`                  | Used to override the default agent DogStatsD Port                                         | `8125`                                      |
+| `datadog.tracePort`                      | Used to override the default agent Trace Port                                             | `8126`                                      |
 | `datadog.useDogStatsDSocketVolume`       | Enable dogstatsd over Unix Domain Socket                                                  | `False`                                     |
 | `datadog.dogStatsDSocketPath`            | Custom path to the socket, has to be located in the `/var/run/datadog` folder path        | `/var/run/datadog/dsd.socket`               |
 | `datadog.volumes`                        | Additional volumes for the daemonset or deployment                                        | `nil`                                       |
@@ -285,6 +286,7 @@ helm install --name <RELEASE_NAME> \
 | `datadog.resources.limits.memory`        | Memory resource limits                                                                    | `256Mi`                                     |
 | `datadog.securityContext`                | Allows you to overwrite the default securityContext applied to the container              | `nil`                                       |
 | `datadog.livenessProbe`                  | Overrides the default liveness probe                                                      | http port 5555                              |
+| `datadog.healthPort`                     | Used to override the default agent health Port                                            | `5555`                                      |
 | `datadog.hostname`                       | Set the hostname (write it in datadog.conf)                                               | `nil`                                       |
 | `datadog.acInclude`                      | Include containers based on image name                                                    | `nil`                                       |
 | `datadog.acExclude`                      | Exclude containers based on image name                                                    | `nil`                                       |

--- a/stable/datadog/templates/container-agent.yaml
+++ b/stable/datadog/templates/container-agent.yaml
@@ -97,7 +97,7 @@
     {{- end }}
     {{- if not .Values.datadog.livenessProbe }}
     - name: DD_HEALTH_PORT
-      value: "5555"
+      value: {{ default 5555 .Values.datadog.healthPort | quote }}
     {{- end }}
     {{- if .Values.datadog.useDogStatsDSocketVolume }}
     - name: DD_DOGSTATSD_SOCKET
@@ -155,7 +155,7 @@
   livenessProbe:
     httpGet:
       path: /health
-      port: 5555
+      port: {{ default 5555 .Values.datadog.healthPort }}
     initialDelaySeconds: 15
     periodSeconds: 15
     timeoutSeconds: 5

--- a/stable/datadog/templates/container-agents.yaml
+++ b/stable/datadog/templates/container-agents.yaml
@@ -12,9 +12,9 @@
     name: dogstatsdport
     protocol: UDP
   {{- if .Values.datadog.apmEnabled }}
-  - containerPort: 8126
+  - containerPort: {{ default 8126 .Values.datadog.tracePort }}
     {{- if .Values.daemonset.useHostPort }}
-    hostPort: 8126
+    hostPort: {{ default 8126 .Values.datadog.tracePort }}
     {{- end }}
     name: traceport
     protocol: TCP
@@ -47,6 +47,10 @@
     {{- if .Values.datadog.dogStatsDPort }}
     - name: DD_DOGSTATD_PORT
       value: {{ .Values.datadog.dogStatsDPort | quote }}
+    {{- end }}
+    {{- if and .Values.datadog.apmEnabled .Values.datadog.tracePort }}
+    - name: DD_TRACE_AGENT_PORT
+      value: {{ .Values.datadog.tracePort | quote }}
     {{- end }}
     {{- if .Values.datadog.nonLocalTraffic }}
     - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
@@ -140,7 +144,7 @@
     {{- end }}
     {{- if not .Values.datadog.livenessProbe }}
     - name: DD_HEALTH_PORT
-      value: "5555"
+      value: {{ default 5555 .Values.datadog.healthPort | quote }}
     {{- end }}
     {{- if .Values.datadog.useDogStatsDSocketVolume }}
     - name: DD_DOGSTATSD_SOCKET
@@ -213,7 +217,7 @@
   livenessProbe:
     httpGet:
       path: /health
-      port: 5555
+      port: {{ default 5555 .Values.datadog.healthPort }}
     initialDelaySeconds: 15
     periodSeconds: 15
     timeoutSeconds: 5

--- a/stable/datadog/templates/container-trace-agent.yaml
+++ b/stable/datadog/templates/container-trace-agent.yaml
@@ -6,9 +6,9 @@
   resources:
 {{ toYaml .Values.daemonset.containers.traceAgent.resources | indent 4 }}
   ports:
-  - containerPort: 8126
+  - containerPort: {{ default 8126 .Values.datadog.tracePort }}
     {{- if .Values.daemonset.useHostPort }}
-    hostPort: 8126
+    hostPort: {{ default 8126 .Values.datadog.tracePort }}
     {{- end }}
     name: traceport
     protocol: TCP
@@ -18,6 +18,10 @@
       value: {{ .Values.datadog.apmEnabled | quote }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.daemonset.containers.traceAgent.logLevel | default .Values.datadog.logLevel | quote }}
+    {{- if .Values.datadog.tracePort }}
+    - name: DD_TRACE_AGENT_PORT
+      value: {{ .Values.datadog.tracePort | quote }}
+    {{- end }}
     {{- if .Values.datadog.nonLocalTraffic }}
     - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
       value: {{ .Values.datadog.nonLocalTraffic | quote }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -164,7 +164,7 @@ datadog:
   #  # Override the Agent trace port.
   #  # Note: Make sure your client is sending to the same TCP port.
   #
-  # traceDPort:
+  # tracePort:
 
   ## @param nonLocalTraffic - boolean - optional - default: false
   ## Enable this to make each node accept non-local statsd traffic.
@@ -291,6 +291,11 @@ datadog:
   # livenessProbe:
   #   exec:
   #     command: ["/bin/true"]
+
+  #  # healthPort - integer - optional - default: 5555
+  #  # Override the Agent health port.
+  #
+  # healthPort:
 
   ## @param resources - object -required
   ## datadog-agent resource requests and limits

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -160,6 +160,12 @@ datadog:
   #
   # dogStatsDPort:
 
+  #  # tracePort - integer - optional - default: 8126
+  #  # Override the Agent trace port.
+  #  # Note: Make sure your client is sending to the same TCP port.
+  #
+  # traceDPort:
+
   ## @param nonLocalTraffic - boolean - optional - default: false
   ## Enable this to make each node accept non-local statsd traffic.
   ## ref: https://github.com/DataDog/docker-dd-agent#environment-variables


### PR DESCRIPTION
@hkaj @irabinovitch @CharlyF @mfpierre @clamoriniere @xlucas @L3n41c @celenechang

#### What this PR does / why we need it:
This gives the ability for a user to set the `tracePort` and `healthPort` to the port of their choosing. This is useful for when using the host network or host ports and those ports are already in use on the host.

#### Which issue this PR fixes
  - fixes #20485

#### Special notes for your reviewer:
Tested by setting `datadog.apmEnabled=true` to verify that the `traceport` port was set to 8126 and the livenes check's port was set to 5555 and DD_HEALTH_PORT was also set to 5555

I then set `datadog.tracePort=9999` and `datadog.healthPort=8888` and verified that the `traceport` port was set to 9999 and the environment variable DD_TRACE_AGENT_PORT was set to 9999. Likewise the port for the liveness check was set to 8888 and DD_HEALTH_PORT was also set to 8888

Finally I set `daemonset.useDedicatedContainers=true` and verified both cases above we still true in their respective contatiners.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
