### PR TITLE
[stable/etcd-operator] [#20508] Allows the override of the etcd-cluster docker image created by the etcdcluster crd

### DIFF
--- a/stable/etcd-operator/Chart.yaml
+++ b/stable/etcd-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: CoreOS etcd-operator Helm chart for Kubernetes
 name: etcd-operator
-version: 0.10.2
+version: 0.10.3
 appVersion: 0.9.4
 home: https://github.com/coreos/etcd-operator
 icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png

--- a/stable/etcd-operator/README.md
+++ b/stable/etcd-operator/README.md
@@ -108,9 +108,7 @@ The following table lists the configurable parameters of the etcd-operator chart
 | `etcdCluster.name`                                | etcd cluster name                                                    | `etcd-cluster`                                 |
 | `etcdCluster.size`                                | etcd cluster size                                                    | `3`                                            |
 | `etcdCluster.version`                             | etcd cluster version                                                 | `3.2.25`                                       |
-| `etcdCluster.image.repository`                    | etcd container image                                                 | `quay.io/coreos/etcd-operator`                 |
-| `etcdCluster.image.tag`                           | etcd container image tag                                             | `v3.2.25`                                      |
-| `etcdCluster.image.pullPolicy`                    | etcd container image pull policy                                     | `Always`                                       |
+| `etcdCluster.repository`    | etcd container image                                                 | `quay.io/coreos/etcd-operator`                 |
 | `etcdCluster.enableTLS`                           | Enable use of TLS                                                    | `false`                                        |
 | `etcdCluster.tls.static.member.peerSecret`        | Kubernetes secret containing TLS peer certs                          | `etcd-peer-tls`                                |
 | `etcdCluster.tls.static.member.serverSecret`      | Kubernetes secret containing TLS server certs                        | `etcd-server-tls`                              |

--- a/stable/etcd-operator/templates/etcd-cluster-crd.yaml
+++ b/stable/etcd-operator/templates/etcd-cluster-crd.yaml
@@ -11,6 +11,9 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   size: {{ .Values.etcdCluster.size }}
+  {{- if .Values.etcdCluster.repository }}
+  repository: "{{ .Values.etcdCluster.repository }}"
+  {{- end }}
   version: "{{ .Values.etcdCluster.version }}"
   pod:
 {{ toYaml .Values.etcdCluster.pod | indent 4 }}

--- a/stable/etcd-operator/templates/restore-etcd-crd.yaml
+++ b/stable/etcd-operator/templates/restore-etcd-crd.yaml
@@ -16,8 +16,8 @@ metadata:
 spec:
   clusterSpec:
     size: {{ .Values.etcdCluster.size }}
-    baseImage: "{{ .Values.etcdCluster.image.repository }}"
-    version: {{ .Values.etcdCluster.image.tag }}
+    repository: "{{ .Values.etcdCluster.repository }}"
+    version: "{{ .Values.etcdCluster.version }}"
     pod:
 {{ toYaml .Values.etcdCluster.pod | indent 6 }}
     {{- if .Values.etcdCluster.enableTLS }}

--- a/stable/etcd-operator/values.yaml
+++ b/stable/etcd-operator/values.yaml
@@ -127,10 +127,9 @@ etcdCluster:
   name: etcd-cluster
   size: 3
   version: 3.2.25
-  image:
-    repository: quay.io/coreos/etcd
-    tag: v3.2.25
-    pullPolicy: Always
+  # the repository used for the etcd docker images, defaults to quay.io/coreos/etcd in the etcd-operator
+  # https://github.com/coreos/etcd-operator/blob/master/pkg/apis/etcd/v1beta2/cluster.go#L26
+  repository:
   enableTLS: false
   # TLS configs
   tls:
@@ -142,6 +141,9 @@ etcdCluster:
   ## etcd cluster pod specific values
   ## Ref: https://github.com/coreos/etcd-operator/blob/master/doc/user/spec_examples.md#three-members-cluster-with-resource-requirement
   pod:
+    # busyboxImage used for the init-container, defaults to busybox:1.28.0-glibc in the etcd-operator
+    # https://github.com/coreos/etcd-operator/blob/master/pkg/util/k8sutil/k8sutil.go#L65
+    busyboxImage:
     ## Antiaffinity for etcd pod assignment
     ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
     antiAffinity: false


### PR DESCRIPTION
… etcd-operator to populate the repository used by the etcd cluster.

#### What this PR does / why we need it:
I need to use locally hosted docker images due to a corporate requirement that images are configuration managed and vulnerability scanned for use on our aws cluster. I attempted to set the .Values.etcdCluster.image.repository to localdockerregistry.internal.example.com/coreos/etcd

#### Which issue this PR fixes
  - fixes #20508

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
