### PR TITLE
[incubator/cassandra] Change configOverrides to use an initContainer

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cassandra
-version: 0.13.4
+version: 0.14.0
 appVersion: 3.11.5
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/templates/statefulset.yaml
+++ b/incubator/cassandra/templates/statefulset.yaml
@@ -50,6 +50,20 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- end }}
+{{- if .Values.configOverrides }}
+      initContainers:
+      - name: config-copier
+        image: busybox
+        command: [ 'sh', '-c', 'cp /configmap-files/* /cassandra-configs/ && chown 999:999 /cassandra-configs/*']
+        volumeMounts:
+{{- range $key, $value := .Values.configOverrides }}
+        - name: cassandra-config-{{ $key | replace "." "-" | replace "_" "--" }}
+          mountPath: /configmap-files/{{ $key }}
+          subPath: {{ $key }}
+{{- end }}
+        - name: cassandra-configs
+          mountPath: /cassandra-configs/
+{{- end }}
       containers:
 {{- if .Values.exporter.enabled }}
       - name: cassandra-exporter
@@ -153,11 +167,10 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /var/lib/cassandra
-{{- range $key, $value := .Values.configOverrides }}
-        - name: cassandra-config-{{ $key | replace "." "-" }}
-          mountPath: /etc/cassandra/{{ $key }}
-          subPath: {{ $key }}
-{{- end }}
+        {{- if .Values.configOverrides }}
+        - name: cassandra-configs
+          mountPath: /etc/cassandra
+        {{- end }}
         {{- if not .Values.persistence.enabled }}
         lifecycle:
           preStop:
@@ -175,7 +188,11 @@ spec:
 {{- range $key, $value := .Values.configOverrides }}
       - configMap:
           name: cassandra
-        name: cassandra-config-{{ $key | replace "." "-" }}
+        name: cassandra-config-{{ $key | replace "." "-" | replace "_" "--" }}
+{{- end }}
+{{- if .Values.configOverrides }}
+      - name: cassandra-configs
+        emptyDir: {}
 {{- end }}
 {{- if not .Values.persistence.enabled }}
       - name: data


### PR DESCRIPTION
This allows the filesystem of the configs to be r/w.

Signed-off-by: Matthew Walker <matthew.walker@prolucid.ca>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No.

#### What this PR does / why we need it:
Currently the `configOverrides` option in `values.yaml` cannot work properly, due to changes in k8s 1.9 on how configmaps are mounted (specifically that they are mounted read-only).  This PR fixes that and allows you to override the config files in `/etc/cassandra` without changing the interface in `values.yaml`.

The method is that instead of mounting the configmap files directly onto `/etc/cassandra` (which renders them r/o and so doesn't allow the startup script in the image to `sed` them in-place), we copy them to an `emptyDir` volume using an `initContainer`, and then `chown` them to `cassandra`'s numeric user id.

#### Which issue this PR fixes
  - fixes #14098
    (already closed but never resolved)

#### Special notes for your reviewer:
It remains impossible to change the files in the `triggers` directory under `/etc/cassandra`, and this directory is removed when using `configOverrides`.  This behavior is identical to how it works before this PR, however.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
