### PR TITLE
[stable/anchore-engine] added default admin password helper

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: anchore-engine
-version: 1.4.2
+version: 1.4.3
 appVersion: 0.6.1
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/_helpers.tpl
+++ b/stable/anchore-engine/templates/_helpers.tpl
@@ -128,3 +128,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "redis.fullname" -}}
 {{- printf "%s-%s" .Release.Name "anchore-ui-redis" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Return Anchore Engine default admin password
+*/}}
+{{- define "anchore-engine.defaultAdminPassword" -}}
+{{- if .Values.anchoreGlobal.defaultAdminPassword }}
+    {{- .Values.anchoreGlobal.defaultAdminPassword -}}
+{{- else -}}
+    {{- randAlphaNum 32 -}}
+{{- end -}}
+{{- end -}}

--- a/stable/anchore-engine/templates/api_deployment.yaml
+++ b/stable/anchore-engine/templates/api_deployment.yaml
@@ -81,6 +81,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ANCHORE_CLI_PASS
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "anchore-engine.fullname" . }}
+              key: ANCHORE_ADMIN_PASSWORD
         ports:
         - containerPort: {{ .Values.anchoreApi.service.port }}
           name: external-api

--- a/stable/anchore-engine/templates/secrets.yaml
+++ b/stable/anchore-engine/templates/secrets.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- end }}
 type: Opaque
 stringData:
-  ANCHORE_ADMIN_PASSWORD: {{ .Values.anchoreGlobal.defaultAdminPassword | quote }}
+  ANCHORE_ADMIN_PASSWORD: {{ include "anchore-engine.defaultAdminPassword" . | quote }}
   ANCHORE_DB_PASSWORD: {{ index .Values "postgresql" "postgresPassword" | quote }}
   {{- if and .Values.anchoreEnterpriseGlobal.enabled .Values.anchoreEnterpriseFeeds.enabled }}
   .feedsDbPassword: {{ index .Values "anchore-feeds-db" "postgresPassword" | quote }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a helper to generate a random 32 character alphanumeric password if `anchoreGlobal.defaultAdminPassword` is unset and overwrites the `ANCHORE_CLI_PASS` environment variable from the [image](https://github.com/anchore/anchore-engine/blob/master/Dockerfile)'s with the secret's `ANCHORE_ADMIN_PASSWORD` value.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
