### PR TITLE
[stable/sonarqube] Remove privileged securityContext from chmod-volume-mounts init container

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 3.4.0
+version: 3.4.1
 appVersion: 7.9.2
 keywords:
   - coverage

--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -149,8 +149,8 @@ Since SonarQube comes bundled with an Elasticsearch instance, some [bootstrap ch
 
 This chart offers the option to use an initContainer in privilaged mode to automatically set certain kernel settings on the kube worker.  While this can ensure proper functionality of Elasticsearch, modifying the underlying kernel settings on the Kubernetes node can impact other users.  It may be best to work with your cluster administrator to either provide specific nodes with the proper kernel settings, or ensure they are set cluster wide.
 
-To enable auto-configuration of the kube worker node, set `elasticsearch.configureNode` to `true`
+To enable auto-configuration of the kube worker node, set `elasticsearch.configureNode` to `true`.  This is the default behavior, so you do not need to explicitly set this.
 
 This will run `sysctl -w vm.max_map_count=262144` on the worker where the sonarqube pod(s) get scheduled.  This needs to be set to `262144` but normally defaults to `65530`.  Other kernel settings are recommended by the [docker image](https://hub.docker.com/_/sonarqube/#requirements), but the defaults work fine in most cases.
 
-Note that if node configuration is not enabled, then you will likely need to disable the Elasticsearch bootstrap checks.  These can be explicitly enabled by setting `elasticsearch.bootstrapChecks` to `false`.
+To disable worker node configuration, set `elasticsearch.configureNode` to `false`.  Note that if node configuration is not enabled, then you will likely need to also disable the Elasticsearch bootstrap checks.  These can be explicitly disabled by setting `elasticsearch.bootstrapChecks` to `false`.

--- a/stable/sonarqube/templates/deployment.yaml
+++ b/stable/sonarqube/templates/deployment.yaml
@@ -43,8 +43,6 @@ spec:
                chown 999:999 -R $(printf "/opt/sonarqube/${1-%s\n}" temp logs data extensions/downloads extensions/plugins/tmp extensions/plugins)'
           image: busybox:1.31
           imagePullPolicy: IfNotPresent
-          securityContext:
-            privileged: true
           volumeMounts:
           - mountPath: /opt/sonarqube/temp
             name: sonarqube


### PR DESCRIPTION
#### What this PR does / why we need it:

Recently this chart has begun to fail to install on our managed cluster, where running containers with a privileged securityContext is not allowed.  

This PR deletes that securityContext privilege escalation from the `chmod-volume-mounts` init container, which does not seem to have any adverse effects when starting the chart with default values.  I'm not seeing any reason why this may be needed, as the point of this container seems to be to just initialize some directories inside the sonarqube volume to ensure they have the correct permissions.  This fix resolves the issue that is preventing our users from running the latest version of this chart.

I also added some tweaks to the Elasticsearch section of the README.  I had added that section and the `elasticsearch` section to `values.yaml` for a similar reason in PR #17634.  I can move this commit to a separate PR if so requested.  

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)