### PR TITLE
[stable/seq] use deployment strategy `Recreate`

### DIFF
--- a/stable/seq/Chart.yaml
+++ b/stable/seq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: seq
-version: 1.0.4
+version: 1.0.5
 appVersion: 5
 description: Seq is the easiest way for development teams to capture, search and visualize structured log events! This page will walk you through the very quick setup process.
 keywords:

--- a/stable/seq/templates/deployment.yaml
+++ b/stable/seq/templates/deployment.yaml
@@ -12,6 +12,8 @@ spec:
     matchLabels:
       app: {{ template "seq.name" . }}
       release: {{ .Release.Name }}
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Signed-off-by: Adam Chester <adamchester@gmail.com>

#### What this PR does / why we need it:
This fixes #17737 by using the [Recreate Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#recreate-deployment) instead of a [Rolling Update Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment). Before this change, when a rolling update was the default, Kubernetes spins up a new pod before the old one is destroyed, and the new Pod will never gain the required exclusive locks on the files it needs. 

#### Which issue this PR fixes
  - fixes #17737

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
