### PR TITLE
[stable/testlink] add service annotations

### DIFF
--- a/stable/testlink/Chart.yaml
+++ b/stable/testlink/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: testlink
-version: 7.0.3
+version: 7.0.4
 appVersion: 1.9.19
 description: Web-based test management system that facilitates software quality assurance.
 icon: https://bitnami.com/assets/stacks/testlink/img/testlink-stack-220x234.png

--- a/stable/testlink/Chart.yaml
+++ b/stable/testlink/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: testlink
-version: 7.0.4
+version: 7.1.0
 appVersion: 1.9.19
 description: Web-based test management system that facilitates software quality assurance.
 icon: https://bitnami.com/assets/stacks/testlink/img/testlink-stack-220x234.png

--- a/stable/testlink/README.md
+++ b/stable/testlink/README.md
@@ -49,71 +49,72 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the TestLink chart and their default values.
 
-|              Parameter              |               Description               |                         Default                         |
-|-------------------------------------|-----------------------------------------|---------------------------------------------------------|
-| `global.imageRegistry`              | Global Docker image registry            | `nil`                                                   |
-| `global.imagePullSecrets`           | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
-| `global.storageClass`                     | Global storage class for dynamic provisioning                                               | `nil`                                                        |
-| `image.registry`                    | TestLink image registry                 | `docker.io`                                             |
-| `image.repository`                  | TestLink image name                     | `bitnami/testlink`                                      |
-| `image.tag`                         | TestLink image tag                      | `{TAG_NAME}`                                            |
-| `image.pullPolicy`                  | Image pull policy                       | `IfNotPresent`                                          |
-| `image.pullSecrets`                 | Specify docker-registry secret names as an array  | `[]` (does not add image pull secrets to deployed pods) |
-| `nameOverride`                      | String to partially override testlink.fullname template with a string (will prepend the release name) | `nil` |
-| `fullnameOverride`                  | String to fully override testlink.fullname template with a string                                     | `nil` |
-| `testlinkUsername`                  | Admin username                          | `user`                                                  |
-| `testlinkPassword`                  | Admin user password                     | _random 10 character long alphanumeric string_          |
-| `testlinkEmail`                     | Admin user email                        | `user@example.com`                                      |
-| `smtpEnable`                        | Enable SMTP                             | `false`                                                 |
-| `smtpHost`                          | SMTP host                               | `nil`                                                   |
-| `smtpPort`                          | SMTP port                               | `nil`                                                   |
-| `smtpUser`                          | SMTP user                               | `nil`                                                   |
-| `smtpPassword`                      | SMTP password                           | `nil`                                                   |
-| `smtpConnectionMode`                | SMTP connection mode [`ssl`, `tls`]     | `nil`                                                   |
-| `allowEmptyPassword`                | Allow DB blank passwords                | `yes`                                                   |
-| `ingress.enabled`                   | Enable ingress controller resource                            | `false`                                                  |
-| `ingress.annotations`               | Ingress annotations                                           | `[]`                                                     |
-| `ingress.certManager`               | Add annotations for cert-manager                              | `false`                                                  |
-| `ingress.hosts[0].name`             | Hostname to your testlink installation                           | `testlink.local`                                            |
-| `ingress.hosts[0].path`             | Path within the url structure                                 | `/`                                                      |
-| `ingress.hosts[0].tls`              | Utilize TLS backend in ingress                                | `false`                                                  |
-| `ingress.hosts[0].tlsHosts`         | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`)                               | `nil`                                                  |
-| `ingress.hosts[0].tlsSecret`        | TLS Secret (certificates)                                     | `testlink.local-tls-secret`                                 |
-| `ingress.secrets[0].name`           | TLS Secret Name                                               | `nil`                                                    |
-| `ingress.secrets[0].certificate`    | TLS Secret Certificate                                        | `nil`                                                    |
-| `ingress.secrets[0].key`            | TLS Secret Key                                                | `nil`                                                    |
-| `externalDatabase.host`             | Host of the external database           | `nil`                                                   |
-| `externalDatabase.port`             | Port of the external database           | `3306`                                                  |
-| `externalDatabase.user`             | Existing username in the external db    | `bn_testlink`                                           |
-| `externalDatabase.password`         | Password for the above username         | `nil`                                                   |
-| `externalDatabase.database`         | Name of the existing database           | `bitnami_testlink`                                      |
-| `mariadb.enabled`                   | Whether to use the MariaDB chart        | `true`                                                  |
-| `mariadb.db.name`                   | Database name to create                 | `bitnami_testlink`                                      |
-| `mariadb.db.user`                   | Database user to create                 | `bn_testlink`                                           |
-| `mariadb.db.password`               | Password for the database               | `nil`                                                   |
-| `mariadb.rootUser.password`         | MariaDB admin password                  | `nil`                                                   |
-| `service.type`                    | Kubernetes Service type                    | `LoadBalancer`                                          |
-| `service.port`                    | Service HTTP port                  | `80`                                          |
-| `service.httpsPort`                    | Service HTTPS port                   | `443`                                          |
-| `service.nodePorts.http`                 | Kubernetes http node port                  | `""`                                                    |
-| `service.nodePorts.https`                | Kubernetes https node port                 | `""`                                                    |
-| `service.externalTrafficPolicy`   | Enable client source IP preservation       | `Cluster`                                               |
-| `service.loadBalancerIP`   | LoadBalancer service IP address       | `""`                                               |
-| `persistence.enabled`               | Enable persistence using PVC            | `true`                                                  |
-| `persistence.testlink.storageClass` | PVC Storage Class for TestLink volume   | `nil` (uses alpha storage class annotation)             |
-| `persistence.testlink.accessMode`   | PVC Access Mode for TestLink volume     | `ReadWriteOnce`                                         |
-| `persistence.testlink.size`         | PVC Storage Request for TestLink volume | `8Gi`                                                   |
-| `resources`                         | CPU/Memory resource requests/limits     | Memory: `512Mi`, CPU: `300m`                            |
-| `podAnnotations`                | Pod annotations                                   | `{}`                                                       |
-| `affinity`                          | Map of node/pod affinities                                    | `{}`                                                     |
-| `metrics.enabled`                          | Start a side-car prometheus exporter                        | `false`                                              |
-| `metrics.image.registry`                   | Apache exporter image registry                              | `docker.io`                                          |
-| `metrics.image.repository`                 | Apache exporter image name                                  | `bitnami/apache-exporter`                            |
-| `metrics.image.tag`                        | Apache exporter image tag                                   | `{TAG_NAME}`                                         |
-| `metrics.image.pullPolicy`                 | Image pull policy                                           | `IfNotPresent`                                       |
-| `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array            | `[]` (does not add image pull secrets to deployed pods)  |
-| `metrics.podAnnotations`                   | Additional annotations for Metrics exporter pod             | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}`                                                   |
-| `metrics.resources`                        | Exporter resource requests/limit                            | {}                        |
+| Parameter                           | Description                                                                                           | Default                                                      |
+|-------------------------------------|-------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `global.imageRegistry`              | Global Docker image registry                                                                          | `nil`                                                        |
+| `global.imagePullSecrets`           | Global Docker registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods)      |
+| `global.storageClass`               | Global storage class for dynamic provisioning                                                         | `nil`                                                        |
+| `image.registry`                    | TestLink image registry                                                                               | `docker.io`                                                  |
+| `image.repository`                  | TestLink image name                                                                                   | `bitnami/testlink`                                           |
+| `image.tag`                         | TestLink image tag                                                                                    | `{TAG_NAME}`                                                 |
+| `image.pullPolicy`                  | Image pull policy                                                                                     | `IfNotPresent`                                               |
+| `image.pullSecrets`                 | Specify docker-registry secret names as an array                                                      | `[]` (does not add image pull secrets to deployed pods)      |
+| `nameOverride`                      | String to partially override testlink.fullname template with a string (will prepend the release name) | `nil`                                                        |
+| `fullnameOverride`                  | String to fully override testlink.fullname template with a string                                     | `nil`                                                        |
+| `testlinkUsername`                  | Admin username                                                                                        | `user`                                                       |
+| `testlinkPassword`                  | Admin user password                                                                                   | _random 10 character long alphanumeric string_               |
+| `testlinkEmail`                     | Admin user email                                                                                      | `user@example.com`                                           |
+| `smtpEnable`                        | Enable SMTP                                                                                           | `false`                                                      |
+| `smtpHost`                          | SMTP host                                                                                             | `nil`                                                        |
+| `smtpPort`                          | SMTP port                                                                                             | `nil`                                                        |
+| `smtpUser`                          | SMTP user                                                                                             | `nil`                                                        |
+| `smtpPassword`                      | SMTP password                                                                                         | `nil`                                                        |
+| `smtpConnectionMode`                | SMTP connection mode [`ssl`, `tls`]                                                                   | `nil`                                                        |
+| `allowEmptyPassword`                | Allow DB blank passwords                                                                              | `yes`                                                        |
+| `ingress.enabled`                   | Enable ingress controller resource                                                                    | `false`                                                      |
+| `ingress.annotations`               | Ingress annotations                                                                                   | `[]`                                                         |
+| `ingress.certManager`               | Add annotations for cert-manager                                                                      | `false`                                                      |
+| `ingress.hosts[0].name`             | Hostname to your testlink installation                                                                | `testlink.local`                                             |
+| `ingress.hosts[0].path`             | Path within the url structure                                                                         | `/`                                                          |
+| `ingress.hosts[0].tls`              | Utilize TLS backend in ingress                                                                        | `false`                                                      |
+| `ingress.hosts[0].tlsHosts`         | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`)                  | `nil`                                                        |
+| `ingress.hosts[0].tlsSecret`        | TLS Secret (certificates)                                                                             | `testlink.local-tls-secret`                                  |
+| `ingress.secrets[0].name`           | TLS Secret Name                                                                                       | `nil`                                                        |
+| `ingress.secrets[0].certificate`    | TLS Secret Certificate                                                                                | `nil`                                                        |
+| `ingress.secrets[0].key`            | TLS Secret Key                                                                                        | `nil`                                                        |
+| `externalDatabase.host`             | Host of the external database                                                                         | `nil`                                                        |
+| `externalDatabase.port`             | Port of the external database                                                                         | `3306`                                                       |
+| `externalDatabase.user`             | Existing username in the external db                                                                  | `bn_testlink`                                                |
+| `externalDatabase.password`         | Password for the above username                                                                       | `nil`                                                        |
+| `externalDatabase.database`         | Name of the existing database                                                                         | `bitnami_testlink`                                           |
+| `mariadb.enabled`                   | Whether to use the MariaDB chart                                                                      | `true`                                                       |
+| `mariadb.db.name`                   | Database name to create                                                                               | `bitnami_testlink`                                           |
+| `mariadb.db.user`                   | Database user to create                                                                               | `bn_testlink`                                                |
+| `mariadb.db.password`               | Password for the database                                                                             | `nil`                                                        |
+| `mariadb.rootUser.password`         | MariaDB admin password                                                                                | `nil`                                                        |
+| `service.type`                      | Kubernetes Service type                                                                               | `LoadBalancer`                                               |
+| `service.port`                      | Service HTTP port                                                                                     | `80`                                                         |
+| `service.httpsPort`                 | Service HTTPS port                                                                                    | `443`                                                        |
+| `service.nodePorts.http`            | Kubernetes http node port                                                                             | `""`                                                         |
+| `service.nodePorts.https`           | Kubernetes https node port                                                                            | `""`                                                         |
+| `service.externalTrafficPolicy`     | Enable client source IP preservation                                                                  | `Cluster`                                                    |
+| `service.loadBalancerIP`            | LoadBalancer service IP address                                                                       | `""`                                                         |
+| `service.annotations`               | Service annotations                                                                                   | `{}`                                                         |
+| `persistence.enabled`               | Enable persistence using PVC                                                                          | `true`                                                       |
+| `persistence.testlink.storageClass` | PVC Storage Class for TestLink volume                                                                 | `nil` (uses alpha storage class annotation)                  |
+| `persistence.testlink.accessMode`   | PVC Access Mode for TestLink volume                                                                   | `ReadWriteOnce`                                              |
+| `persistence.testlink.size`         | PVC Storage Request for TestLink volume                                                               | `8Gi`                                                        |
+| `resources`                         | CPU/Memory resource requests/limits                                                                   | Memory: `512Mi`, CPU: `300m`                                 |
+| `podAnnotations`                    | Pod annotations                                                                                       | `{}`                                                         |
+| `affinity`                          | Map of node/pod affinities                                                                            | `{}`                                                         |
+| `metrics.enabled`                   | Start a side-car prometheus exporter                                                                  | `false`                                                      |
+| `metrics.image.registry`            | Apache exporter image registry                                                                        | `docker.io`                                                  |
+| `metrics.image.repository`          | Apache exporter image name                                                                            | `bitnami/apache-exporter`                                    |
+| `metrics.image.tag`                 | Apache exporter image tag                                                                             | `{TAG_NAME}`                                                 |
+| `metrics.image.pullPolicy`          | Image pull policy                                                                                     | `IfNotPresent`                                               |
+| `metrics.image.pullSecrets`         | Specify docker-registry secret names as an array                                                      | `[]` (does not add image pull secrets to deployed pods)      |
+| `metrics.podAnnotations`            | Additional annotations for Metrics exporter pod                                                       | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
+| `metrics.resources`                 | Exporter resource requests/limit                                                                      | {}                                                           |
 
 The above parameters map to the env variables defined in [bitnami/testlink](http://github.com/bitnami/bitnami-docker-testlink). For more information please refer to the [bitnami/testlink](http://github.com/bitnami/bitnami-docker-testlink) image documentation.
 

--- a/stable/testlink/README.md
+++ b/stable/testlink/README.md
@@ -99,7 +99,7 @@ The following table lists the configurable parameters of the TestLink chart and 
 | `service.nodePorts.https`           | Kubernetes https node port                                                                            | `""`                                                         |
 | `service.externalTrafficPolicy`     | Enable client source IP preservation                                                                  | `Cluster`                                                    |
 | `service.loadBalancerIP`            | LoadBalancer service IP address                                                                       | `""`                                                         |
-| `service.annotations`               | Service annotations                                                                                   | `{}`                                                         |
+| `service.annotations`               | Kubernetes service annotations, evaluated as a template                                               | `{}`                                                         |
 | `persistence.enabled`               | Enable persistence using PVC                                                                          | `true`                                                       |
 | `persistence.testlink.storageClass` | PVC Storage Class for TestLink volume                                                                 | `nil` (uses alpha storage class annotation)                  |
 | `persistence.testlink.accessMode`   | PVC Access Mode for TestLink volume                                                                   | `ReadWriteOnce`                                              |

--- a/stable/testlink/requirements.lock
+++ b/stable/testlink/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 7.3.7
-digest: sha256:8d1ee7cc4c880337a8efd3ecb86ae84700533aa231d9b6a9ccbfd6c77179b4c9
-generated: "2020-02-04T09:06:55.497018467Z"
+  version: 7.3.3
+digest: sha256:cd64413a4a697ccf85c0091e9c55cdc5876938ddced84c05d37c57ff9abc5864
+generated: 2020-01-14T20:59:22.425819807Z

--- a/stable/testlink/requirements.lock
+++ b/stable/testlink/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 7.3.3
-digest: sha256:cd64413a4a697ccf85c0091e9c55cdc5876938ddced84c05d37c57ff9abc5864
-generated: 2020-01-14T20:59:22.425819807Z
+  version: 7.3.7
+digest: sha256:8d1ee7cc4c880337a8efd3ecb86ae84700533aa231d9b6a9ccbfd6c77179b4c9
+generated: "2020-02-04T09:06:55.497018467Z"

--- a/stable/testlink/templates/_helpers.tpl
+++ b/stable/testlink/templates/_helpers.tpl
@@ -164,3 +164,16 @@ Return the appropriate apiVersion for deployment.
 {{- print "apps/v1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "testlink.tplValue" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "testlink.tplValue" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/stable/testlink/templates/svc.yaml
+++ b/stable/testlink/templates/svc.yaml
@@ -7,9 +7,8 @@ metadata:
     chart: "{{ template "testlink.chart" . }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Name | quote }}
-  annotations:
 {{- if .Values.service.annotations }}
-{{ toYaml .Values.service.annotations | indent 4 }}
+  annotations: {{ include "testlink.tplValue" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
 {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/stable/testlink/templates/svc.yaml
+++ b/stable/testlink/templates/svc.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: "{{ template "testlink.chart" . }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Name | quote }}
+  annotations:
+{{- if .Values.service.annotations }}
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}

--- a/stable/testlink/values.yaml
+++ b/stable/testlink/values.yaml
@@ -162,8 +162,7 @@ service:
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   ##
   externalTrafficPolicy: Cluster
-  
-  ## Provide any additional annotations which may be required. 
+  ## Provide any additional annotations which may be required.
   ## Evaluated as a template
   ##
   annotations: {}

--- a/stable/testlink/values.yaml
+++ b/stable/testlink/values.yaml
@@ -162,6 +162,10 @@ service:
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   ##
   externalTrafficPolicy: Cluster
+  
+  ## Provide any additional annotations which may be required. 
+  ## Evaluated as a template
+  ##
   annotations: {}
 
 ## Enable persistence using Persistent Volume Claims

--- a/stable/testlink/values.yaml
+++ b/stable/testlink/values.yaml
@@ -162,6 +162,7 @@ service:
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   ##
   externalTrafficPolicy: Cluster
+  annotations: {}
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@bitnami.com>

#### What this PR does / why we need it:

This PR adds the possibility of passing annotations to the service so that we can configure better the service, e.g: internal load balancers. 

#### Which issue this PR fixes
  - fixes https://github.com/bitnami/charts/issues/1879

#### Special notes for your reviewer:

N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
