### PR TITLE
[stable/collabora-code] add option to specify a path for readiness and  liveness probes

### DIFF
--- a/stable/collabora-code/Chart.yaml
+++ b/stable/collabora-code/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "4.0.3.1"
 description: A Helm chart for Collabora Office - CODE-Edition
 name: collabora-code
-version: 1.0.5
+version: 1.0.6
 icon: https://avatars0.githubusercontent.com/u/22418908?s=200&v=4
 sources:
 - https://github.com/CollaboraOnline/Docker-CODE

--- a/stable/collabora-code/README.md
+++ b/stable/collabora-code/README.md
@@ -75,12 +75,13 @@ The following tables lists the configurable parameters of this chart and their d
 | `ingress.hosts`                                   |                                                               | `[]`                                                        |
 | `ingress.tls`                                     |                                                               | `[]`                                                        |
 | `livenessProbe.enabled`                           | Turn on and off liveness probe                                | `true`                                                      |
-| `livenessProbe.initialDelaySeconds`               | Delay before liveness probe is initiated                      | `30`                                                       |
+| `livenessProbe.initialDelaySeconds`               | Delay before liveness probe is initiated                      | `30`                                                        |
 | `livenessProbe.periodSeconds`                     | How often to perform the probe                                | `10`                                                        |
 | `livenessProbe.timeoutSeconds`                    | When the probe times out                                      | `2`                                                         |
 | `livenessProbe.successThreshold`                  | Minimum consecutive successes for the probe                   | `1`                                                         |
 | `livenessProbe.failureThreshold`                  | Minimum consecutive failures for the probe                    | `3`                                                         |
 | `livenessProbe.scheme`                            | Scheme for the probe                                          | `HTTP`                                                      |
+| `livenessProbe.path`                              | Path for the probe                                            | `/`                                                         |
 | `readinessProbe.enabled`                          | Turn on and off readiness probe                               | `true`                                                      |
 | `readinessProbe.initialDelaySeconds`              | Delay before readiness probe is initiated                     | `30`                                                        |
 | `readinessProbe.periodSeconds`                    | How often to perform the probe                                | `10`                                                        |
@@ -88,6 +89,7 @@ The following tables lists the configurable parameters of this chart and their d
 | `readinessProbe.successThreshold`                 | Minimum consecutive successes for the probe                   | `1`                                                         |
 | `readinessProbe.failureThreshold`                 | Minimum consecutive failures for the probe                    | `3`                                                         |
 | `readinessProbe.scheme`                           | Scheme for the probe                                          | `HTTP`                                                      |
+| `readinessProbe.path`                             | Path for the probe                                            | `/`                                                         |
 | `securityContext.allowPrivilegeEscalation`        | Create & use Pod Security Policy resources                    | `true`                                                      |
 | `securitycontext.capabilities.add`                | Collabora needs to run with MKNOD as capabibility             | `[MKNOD]`                                                   |
 | `resources`                                       | Resources required (e.g. CPU, memory)                         | `{}`                                                        |

--- a/stable/collabora-code/templates/deployment.yaml
+++ b/stable/collabora-code/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
           livenessProbe:
             failureThreshold: 3
             httpGet:
-              path: /
+              path: {{ .Values.livenessProbe.path }}
               port: http
               scheme: {{ .Values.livenessProbe.scheme }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
@@ -78,7 +78,7 @@ spec:
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /
+              path: {{ .Values.readinessProbe.path }}
               port: http
               scheme: {{ .Values.readinessProbe.scheme }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}

--- a/stable/collabora-code/values.yaml
+++ b/stable/collabora-code/values.yaml
@@ -62,6 +62,7 @@ livenessProbe:
   successThreshold: 1
   failureThreshold: 3
   scheme: HTTP
+  path: /
 
 readinessProbe:
   enabled: true
@@ -71,3 +72,5 @@ readinessProbe:
   successThreshold: 1
   failureThreshold: 3
   scheme: HTTP
+  path: /
+

--- a/stable/collabora-code/values.yaml
+++ b/stable/collabora-code/values.yaml
@@ -73,4 +73,3 @@ readinessProbe:
   failureThreshold: 3
   scheme: HTTP
   path: /
-


### PR DESCRIPTION
#### What this PR does / why we need it:
The readiness/liveness probes do not work if loolwsd is bootstraped with a custom base path using `--o:net.service_root="/libreoffice"`. The probe would request `/` which results in a HTTP 400.
By using the new readinessProbe.path and livenessProbe.path it is possible to change that behaviour.

Note, given the /libreoffice example I had to specify `/libreoffice/` with a trailing slash as probe path since loolwsd still replied with a 400 using `/libreoffice` which is probably a bug in loolwsd and should not be handled in the chart. 

Workaround without this pr is to disable the probes.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)