### PR TITLE
[stable/jenkins] Add hostname for resources URL in ingress

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.9.16
+version: 1.9.17
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -121,6 +121,8 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.ingress.labels`           | Ingress labels                       | `{}`                                      |
 | `master.ingress.path`             | Ingress path                         | Not set                                   |
 | `master.ingress.tls`              | Ingress TLS configuration            | `[]`                                      |
+| `master.ingress.hostNameResources`| Ingress host name for resources root | Not set                                   |
+| `master.ingress.pathResources`    | Ingress path for resources root      | Not set                                   |
 | `master.backendconfig.enabled`     | Enables backendconfig     | `false`              |
 | `master.backendconfig.apiVersion`  | backendconfig API version | `extensions/v1beta1` |
 | `master.backendconfig.name`        | backendconfig name        | Not set              |

--- a/stable/jenkins/templates/jenkins-master-ingress.yaml
+++ b/stable/jenkins/templates/jenkins-master-ingress.yaml
@@ -30,6 +30,17 @@ spec:
 {{- if .Values.master.ingress.hostName }}
     host: {{ .Values.master.ingress.hostName | quote }}
 {{- end }}
+{{- if .Values.master.ingress.hostNameResources }}
+  - http:
+      paths:
+      - backend:
+          serviceName: {{ template "jenkins.fullname" . }}
+          servicePort: {{ .Values.master.servicePort }}
+{{- if .Values.master.ingress.pathResources }}
+        path: {{ .Values.master.ingress.pathResources }}
+{{- end -}}
+    host: {{ .Values.master.ingress.hostNameResources | quote }}
+{{- end }}
 {{- if .Values.master.ingress.tls }}
   tls:
 {{ toYaml .Values.master.ingress.tls | indent 4 }}


### PR DESCRIPTION
Since Jenkins 2.200, it is possible to define a Resource Root URL
in the Jenkins system configuration as an alternative
to relaxing the Content Security Policy rules.

This commit allows user to define a new ingress hostname pointing the same
service (aka the same Jenkins instance) to serve artifacts using the
resources root endpoint.

See https://wiki.jenkins.io/display/JENKINS/Configuring+Content+Security+Policy
and https://issues.jenkins-ci.org/browse/JENKINS-41891

NOTE: I am not sure that's the right way to do this. Maybe we have to change the ingress to allow user to define as many as they want rules (using toYaml of a value in ingress), let me know what do you think about it and I can make modifications.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
