### PR TITLE
[stable/fluentd] Use correct strategy for StatefulSets

### DIFF
--- a/stable/fluentd/Chart.yaml
+++ b/stable/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Fluentd Elasticsearch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd
-version: 2.3.2
+version: 2.4.0
 appVersion: v2.4.0
 home: https://www.fluentd.org/
 sources:

--- a/stable/fluentd/templates/deployment.yaml
+++ b/stable/fluentd/templates/deployment.yaml
@@ -20,8 +20,13 @@ spec:
       app: {{ template "fluentd.name" . }}
       release: {{ .Release.Name }}
   {{- if .Values.persistence.enabled }}
+  {{- if .Values.autoscaling.enabled }}
+  updateStrategy:
+    type: RollingUpdate
+  {{- else }}
   strategy:
     type: Recreate
+  {{- end }}
   {{- end }}
   template:
     metadata:


### PR DESCRIPTION
#### What this PR does / why we need it:
`Deployment` object [uses `spec.strategy` field](https://v1-13.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#deploymentstrategy-v1-apps) to configure what happens when Pod template is updated. `StatefulSet`, however, [uses `spec.updateStrategy`](https://v1-13.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#statefulsetupdatestrategy-v1-apps) for the same purpose.

At the moment, if both `.Values.autoscaling.enabled` and `.Values.persistence.enabled` are true, the rendered manifest fails with

```
  Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: [ValidationError(StatefulSet.spec): unknown field "strategy" in io.k8s.api.apps.v1.StatefulSet
```

This affects Helm 3. Helm 2 seems to rewrite `strategy` to `updateStrategy`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
