### PR TITLE
[stable/fluentd] Fix manifest errors when using autoscaling + persistence

### DIFF
--- a/stable/fluentd/Chart.yaml
+++ b/stable/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Fluentd Elasticsearch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd
-version: 2.3.2
+version: 2.3.3
 appVersion: v2.4.0
 home: https://www.fluentd.org/
 sources:

--- a/stable/fluentd/templates/deployment.yaml
+++ b/stable/fluentd/templates/deployment.yaml
@@ -14,7 +14,8 @@ metadata:
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
-{{- else}}
+{{- end }}
+{{- if .Values.autoscaling.enabled }}
   serviceName: {{ template "fluentd.name" . }}
 {{- end }}
   selector:

--- a/stable/fluentd/templates/deployment.yaml
+++ b/stable/fluentd/templates/deployment.yaml
@@ -14,12 +14,14 @@ metadata:
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+{{- else}}
+  serviceName: {{ template "fluentd.name" . }}
 {{- end }}
   selector:
     matchLabels:
       app: {{ template "fluentd.name" . }}
       release: {{ .Release.Name }}
-  {{- if .Values.persistence.enabled }}
+  {{- if and .Values.persistence.enabled (not .Values.autoscaling.enabled) }}
   strategy:
     type: Recreate
   {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
When both values `autoscaling.enabled` and `persistence.enabled` are set to `true`, the resulting StatefulSet manifest is invalid. This PR adjusts the corresponding conditionals and adds required fields for StatefulSet.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
