### PR TITLE
[stable/cluster-autoscaler ]Added DaemonSet and UpdateStrategy

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 6.4.0
+version: 6.4.1
 appVersion: 1.14.6
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/README.md
+++ b/stable/cluster-autoscaler/README.md
@@ -170,6 +170,8 @@ Parameter | Description | Default
 `rbac.serviceAccountName` | existing ServiceAccount to use (ignored if rbac.create=true) | `default`
 `rbac.serviceAccountAnnotations` | Additional Service Account annotations	| `{}`
 `rbac.pspEnabled` | Must be used with `rbac.create` true. If true, creates & uses RBAC resources required in the cluster with [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) enabled. | `false`
+`kind` | install as Deployment, DaemonSet or Both | `Deployment`
+`updateStrategy` | allows setting of RollingUpdate strategy | `{}`
 `replicaCount` | desired number of pods | `1`
 `priorityClassName` | priorityClassName | `nil`
 `dnsPolicy` | dnsPolicy | `nil`

--- a/stable/cluster-autoscaler/templates/daemonset.yaml
+++ b/stable/cluster-autoscaler/templates/daemonset.yaml
@@ -1,21 +1,20 @@
-{{- if or (eq .Values.kind "Deployment") (eq .Values.kind "Both") }}
+{{- if or (eq .Values.kind "DaemonSet") (eq .Values.kind "Both") }}
 {{- if or .Values.autoDiscovery.clusterName .Values.autoscalingGroups }}
 {{/* one of the above is required */}}
 apiVersion: {{ template "deployment.apiVersion" . }}
-kind: Deployment
+kind: DaemonSet
 metadata:
   labels:
 {{ include "cluster-autoscaler.labels" . | indent 4 }}
   name: {{ template "cluster-autoscaler.fullname" . }}
 spec:
-  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
 {{ include "cluster-autoscaler.instance-name" . | indent 6 }}
     {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 6 }}
     {{- end }}
-  strategy:
+  updateStrategy:
 {{ toYaml .Values.updateStrategy | indent 4 }}
   template:
     metadata:

--- a/stable/cluster-autoscaler/values.yaml
+++ b/stable/cluster-autoscaler/values.yaml
@@ -68,6 +68,15 @@ tolerations: []
 ## Extra ENV passed to the container
 extraEnv: {}
 
+## DaemonSet or Deployment
+##
+kind: Deployment
+
+updateStrategy: {}
+  #  rollingUpdate:
+  #    maxUnavailable: 1
+  #  type: RollingUpdate
+
 extraArgs:
   v: 4
   stderrthreshold: info


### PR DESCRIPTION
/cc @mgoodness
/cc @yurrriq

#### Is this a new chart
no

#### What this PR does / why we need it:
For having the cluster-autoscaler properly running on all master nodes we needed DaemonSets.
A DaemonSet needs the UpdateStrategy for being easily upgraded.
Our use case is that the only autoscaling group is allowed to be zero-sized. 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)