### PR TITLE
[stable/signalsciences] updated for new signalsciences version and best practices

### DIFF
--- a/stable/signalsciences/Chart.yaml
+++ b/stable/signalsciences/Chart.yaml
@@ -3,7 +3,7 @@ name: signalsciences
 home: https://signalsciences.com
 icon: https://dashboard.signalsciences.net/static/images/logo-icon-color.svg
 version: 2.0.0
-appVersion: 4.4.1
+appVersion: 4.5.0
 description: SignalSciences is a web application firewall. This chart is the installable agent.
 keywords:
 - signalsciences

--- a/stable/signalsciences/Chart.yaml
+++ b/stable/signalsciences/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 name: signalsciences
 home: https://signalsciences.com
 icon: https://dashboard.signalsciences.net/static/images/logo-icon-color.svg
-version: 1.0.0
-appVersion: 3.12.1
+version: 2.0.0
+appVersion: 4.4.1
 description: SignalSciences is a web application firewall. This chart is the installable agent.
 keywords:
 - signalsciences
@@ -13,7 +13,7 @@ keywords:
 - firewall
 - waf
 sources:
-- https://github.com/marccampbell/docker-sigsci
+- https://github.com/helm/charts/tree/master/stable/signalsciences
 maintainers:
 - name: cpanato
   email: ctadeu@gmail.com

--- a/stable/signalsciences/Chart.yaml
+++ b/stable/signalsciences/Chart.yaml
@@ -13,7 +13,7 @@ keywords:
 - firewall
 - waf
 sources:
-- https://github.com/helm/charts/tree/master/stable/signalsciences
+- https://github.com/signalsciences
 maintainers:
 - name: cpanato
   email: ctadeu@gmail.com

--- a/stable/signalsciences/README.md
+++ b/stable/signalsciences/README.md
@@ -46,7 +46,7 @@ The following table lists the configurable parameters of the SignalSciences char
 | `signalsciences.secretAccessKey`               | Your SignalSciences secretAccessKey                                       | `Nil` You must provide your own secretAccessKey |
 | `signalsciences.secretAccessKeyExistingSecret` | If set, use the secret with a provided name instead of creating a new one | `nil`                                           |
 | `image.repository`                             | The image repository to pull from                                         | `signalsciences/sigsci-agent`                             |
-| `image.tag`                                    | The image tag to pull                                                     | `4.4.1`                                        |
+| `image.tag`                                    | The image tag to pull                                                     | `4.5.0`                                        |
 | `image.pullPolicy`                             | Image pull policy                                                         | `IfNotPresent`                                  |
 | `signalsciences.agentTempVolume`       | Temporary volume to mount the socket and a writeable dir                                                    | `/sigsci/tmp`                                        |
 | `signalsciences.resources.requests.cpu`        | CPU resource requests                                                     | `200m`                                          |

--- a/stable/signalsciences/README.md
+++ b/stable/signalsciences/README.md
@@ -45,13 +45,15 @@ The following table lists the configurable parameters of the SignalSciences char
 | `signalsciences.accessKeyIdExistingSecret`     | If set, use the secret with a provided name instead of creating a new one | `nil`                                           |
 | `signalsciences.secretAccessKey`               | Your SignalSciences secretAccessKey                                       | `Nil` You must provide your own secretAccessKey |
 | `signalsciences.secretAccessKeyExistingSecret` | If set, use the secret with a provided name instead of creating a new one | `nil`                                           |
-| `image.repository`                             | The image repository to pull from                                         | `marc/sigsci-agent`                             |
-| `image.tag`                                    | The image tag to pull                                                     | `3.12.1`                                        |
+| `image.repository`                             | The image repository to pull from                                         | `signalsciences/sigsci-agent`                             |
+| `image.tag`                                    | The image tag to pull                                                     | `4.4.1`                                        |
 | `image.pullPolicy`                             | Image pull policy                                                         | `IfNotPresent`                                  |
+| `signalsciences.agentTempVolume`       | Temporary volume to mount the socket and a writeable dir                                                    | `/sigsci/tmp`                                        |
 | `signalsciences.resources.requests.cpu`        | CPU resource requests                                                     | `200m`                                          |
 | `signalsciences.resources.limits.cpu`          | CPU resource limits                                                       | `200m`                                          |
 | `signalsciences.resources.requests.memory`     | Memory resource requests                                                  | `256Mi`                                         |
 | `signalsciences.resources.limits.memory`       | Memory resource limits                                                    | `256Mi`                                         |
+| `signalsciences.socketAddress`       | If set, allows you to change the default socket location                                                    | `nil`                                         |
 | `daemonset.podAnnotations`                     | Annotations to add to the DaemonSet's Pods                                | `nil`                                           |
 | `daemonset.tolerations`                        | List of node taints to tolerate (requires Kubernetes >= 1.6)              | `nil`                                           |
 | `daemonset.nodeSelector`                       | Node selectors                                                            | `nil`                                           |

--- a/stable/signalsciences/README.md
+++ b/stable/signalsciences/README.md
@@ -46,7 +46,7 @@ The following table lists the configurable parameters of the SignalSciences char
 | `signalsciences.secretAccessKey`               | Your SignalSciences secretAccessKey                                       | `Nil` You must provide your own secretAccessKey |
 | `signalsciences.secretAccessKeyExistingSecret` | If set, use the secret with a provided name instead of creating a new one | `nil`                                           |
 | `image.repository`                             | The image repository to pull from                                         | `signalsciences/sigsci-agent`                             |
-| `image.tag`                                    | The image tag to pull                                                     | `4.5.0`                                        |
+| `image.tag`                                    | The image tag to pull                                                     | `4.6.0`                                        |
 | `image.pullPolicy`                             | Image pull policy                                                         | `IfNotPresent`                                  |
 | `signalsciences.agentTempVolume`       | Temporary volume to mount the socket and a writeable dir                                                    | `/sigsci/tmp`                                        |
 | `signalsciences.resources.requests.cpu`        | CPU resource requests                                                     | `200m`                                          |

--- a/stable/signalsciences/README.md
+++ b/stable/signalsciences/README.md
@@ -46,7 +46,7 @@ The following table lists the configurable parameters of the SignalSciences char
 | `signalsciences.secretAccessKey`               | Your SignalSciences secretAccessKey                                       | `Nil` You must provide your own secretAccessKey |
 | `signalsciences.secretAccessKeyExistingSecret` | If set, use the secret with a provided name instead of creating a new one | `nil`                                           |
 | `image.repository`                             | The image repository to pull from                                         | `signalsciences/sigsci-agent`                             |
-| `image.tag`                                    | The image tag to pull                                                     | `4.6.0`                                        |
+| `image.tag`                                    | The image tag to pull                                                     | `4.5.0`                                        |
 | `image.pullPolicy`                             | Image pull policy                                                         | `IfNotPresent`                                  |
 | `signalsciences.agentTempVolume`       | Temporary volume to mount the socket and a writeable dir                                                    | `/sigsci/tmp`                                        |
 | `signalsciences.resources.requests.cpu`        | CPU resource requests                                                     | `200m`                                          |

--- a/stable/signalsciences/templates/daemonset.yaml
+++ b/stable/signalsciences/templates/daemonset.yaml
@@ -44,7 +44,7 @@ spec:
                 name: sigsci-tmp
                 readOnly: false
           env:
-      {{- if ..Values.signalsciences.socketAddress }}
+      {{- if .Values.signalsciences.socketAddress }}
             - name: SIGSCI_RPC_ADDRESS
               value: unix:{{ .Values.signalsciences.socketAddress }}
       {{- end }}

--- a/stable/signalsciences/templates/daemonset.yaml
+++ b/stable/signalsciences/templates/daemonset.yaml
@@ -32,20 +32,22 @@ spec:
 {{ toYaml .Values.daemonset.nodeSelector | indent 8 }}
       {{- end }}
       volumes:
-        - name: var-run
+        - name: sigsci-tmp
           hostPath:
-            path: {{ .Values.signalsciences.socketDir }}
+            path: {{ .Values.signalsciences.agentTempVolume}}
       containers:
         - name: sigsci-agent
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
-              - mountPath: {{ .Values.signalsciences.socketDir }}
-                name: var-run
+              - mountPath: {{ .Values.signalsciences.agentTempVolume }}
+                name: sigsci-tmp
                 readOnly: false
           env:
+      {{- if ..Values.signalsciences.socketAddress }}
             - name: SIGSCI_RPC_ADDRESS
-              value: unix:{{ .Values.signalsciences.socketDir }}/{{ .Values.signalsciences.socketFile }}
+              value: unix:{{ .Values.signalsciences.socketAddress }}
+      {{- end }}
             - name: SIGSCI_HOSTNAME
               valueFrom:
                 fieldRef:
@@ -60,6 +62,9 @@ spec:
                 secretKeyRef:
                   name: {{ template "signalsciences.accessKeyIdSecretName" . }}
                   key: accessKeyId
+          securityContext:
+            # The sigsci-agent container should run with its root filesystem read only
+            readOnlyRootFilesystem: true
           resources:
 {{ toYaml .Values.signalsciences.resources | indent 12 }}
   updateStrategy:

--- a/stable/signalsciences/values.yaml
+++ b/stable/signalsciences/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: signalsciences/sigsci-agent
-  tag: 4.4.1
+  tag: 4.5.0
   pullPolicy: IfNotPresent
 
 daemonset: {}

--- a/stable/signalsciences/values.yaml
+++ b/stable/signalsciences/values.yaml
@@ -5,8 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: marc/sigsci-agent
-  tag: 3.12.1
+  repository: signalsciences/sigsci-agent
+  tag: 4.4.1
   pullPolicy: IfNotPresent
 
 daemonset: {}
@@ -45,12 +45,13 @@ signalsciences:
   ## Use existing Secret which stores the secretAccessKey instead of creating a new one
   # secretAccessKeyExistingSecret:
 
-  ## Directory to mount and create the shared unix socket file for mdule installation
-  socketDir: /var/run/sigsci
-
-  ## Filename of the shared socket file
-  socketFile: sigsci.sock
-
+  ## For added security, it is recommended that the sigsci-agent container be executed
+  ## with the root filesystem mounted read only. The agent, however, still needs to write
+  ## some temporary files such as the socket file for RPC communication and some periodically
+  ## updated files such as GeoIP data
+  agentTempVolume: /sigsci/tmp
+# If required (default is /sigsci/tmp/sigsci.sock for the container)
+# socketAddress: /sigsci/tmp/sigsci.sock
   resources:
     requests:
       cpu: 200m

--- a/stable/signalsciences/values.yaml
+++ b/stable/signalsciences/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: signalsciences/sigsci-agent
-  tag: 4.5.0
+  tag: 4.6.0
   pullPolicy: IfNotPresent
 
 daemonset: {}

--- a/stable/signalsciences/values.yaml
+++ b/stable/signalsciences/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: signalsciences/sigsci-agent
-  tag: 4.6.0
+  tag: 4.5.0
   pullPolicy: IfNotPresent
 
 daemonset: {}


### PR DESCRIPTION
@cpanato 
#### What this PR does / why we need it:
Brings this chart in line with official documentation from SignalSciences, as well as bumping to the official container.
https://docs.signalsciences.net/install-guides/kubernetes/kubernetes-agent-module/

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
