### PR TITLE
[stable/sonarqube] allow overriding app fullname

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 3.4.0
+version: 3.4.1
 appVersion: 7.9.2
 keywords:
   - coverage

--- a/stable/sonarqube/templates/_helpers.tpl
+++ b/stable/sonarqube/templates/_helpers.tpl
@@ -11,8 +11,11 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "sonarqube.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.fullnameOverride -}}
+{{- printf "%s" .Values.fullnameOverride | trunc 63 -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "sonarqube.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/sonarqube/templates/_helpers.tpl
+++ b/stable/sonarqube/templates/_helpers.tpl
@@ -12,7 +12,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "sonarqube.fullname" -}}
 {{- if .Values.fullnameOverride -}}
-{{- printf "%s" .Values.fullnameOverride | trunc 63 -}}
+{{- .Values.fullnameOverride | trunc 63 -}}
 {{- else -}}
 {{- printf "%s-%s" .Release.Name (include "sonarqube.name" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}


### PR DESCRIPTION
#### Is this a new chart

No.

#### What this PR does / why we need it:

Allows to override the `fullname` used in various places. Today, a helper template function determines the format of the name, and it can't be overridden. This is inconvenient and unwanted in many cases (e.g. when tooling maps the app name to a hostname—I want `sonarqube.example.org`, but today I can only get `sonarqube-sonarqube.example.org`). It's generally better to allow the fullname to be explicitly overridden if so desired.

#### Special notes for your reviewer:

This has a similar, but subtly different effect as adding the `nameOverride` value. I hesitated to instead implement behavior that would reuse `name` as the `fullname` (e.g. introduce a `useNameAsFullname` boolean value), but I decided on an approach that allows these values to be overridden independently.

Also, since the `nameOverride` is already undocumented (I assume intentionally?), I likewise opted to leave this new value undocumented.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] ~Variables are documented in the README.md~
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
