### PR TITLE
[stable/newrelic-infrastructure] Add missing cluster role permissions for secrets

### DIFF
--- a/stable/newrelic-infrastructure/Chart.yaml
+++ b/stable/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 0.13.19
+version: 0.13.20
 appVersion: 1.13.2
 home: https://hub.docker.com/r/newrelic/infrastructure-k8s/
 source:

--- a/stable/newrelic-infrastructure/templates/clusterrole.yaml
+++ b/stable/newrelic-infrastructure/templates/clusterrole.yaml
@@ -13,6 +13,7 @@ rules:
       - "nodes/proxy"
       - "pods"
       - "services"
+      - "secrets"
     verbs: ["get", "list"]
 {{- if .Values.rbac.pspEnabled }}
   - apiGroups:


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:

It adds cluster role permissions for listing and getting secrets. These are required for the control plane monitoring feature.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
