### PR TITLE
[stable/fluentd] Upgrade syntax in templates to latest kubernetes version.

### DIFF
--- a/stable/fluentd/Chart.yaml
+++ b/stable/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Fluentd Elasticsearch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd
-version: 2.3.2
+version: 2.3.3
 appVersion: v2.4.0
 home: https://www.fluentd.org/
 sources:

--- a/stable/fluentd/README.md
+++ b/stable/fluentd/README.md
@@ -56,6 +56,7 @@ Parameter | Description | Default
 `image.repository` | Image repository | `gcr.io/google-containers/fluentd-elasticsearch`
 `image.tag` | Image tag | `v2.4.0`
 `imagePullSecrets` | Specify image pull secrets | `nil` (does not add image pull secrets to deployed pods)
+`updateStrategy.type`   | Specify updateeStrategy | `Recreate` See [values.yaml](values.yaml)
 `extraEnvVars` | Adds additional environment variables to the deployment (in yaml syntax) | `{}` See [values.yaml](values.yaml)
 `extraVolumeMounts` | Mount extra volumes (in yaml syntax) | `` See [values.yaml](values.yaml)
 `extraVolumes` | Extra volumes (in yaml syntax) | `` See [values.yaml](values.yaml)

--- a/stable/fluentd/README.md
+++ b/stable/fluentd/README.md
@@ -56,7 +56,7 @@ Parameter | Description | Default
 `image.repository` | Image repository | `gcr.io/google-containers/fluentd-elasticsearch`
 `image.tag` | Image tag | `v2.4.0`
 `imagePullSecrets` | Specify image pull secrets | `nil` (does not add image pull secrets to deployed pods)
-`updateStrategy.type`   | Specify updateeStrategy | `Recreate` See [values.yaml](values.yaml)
+`updateStrategy.type`   | Specify updateStrategy | `Recreate` See [values.yaml](values.yaml)
 `extraEnvVars` | Adds additional environment variables to the deployment (in yaml syntax) | `{}` See [values.yaml](values.yaml)
 `extraVolumeMounts` | Mount extra volumes (in yaml syntax) | `` See [values.yaml](values.yaml)
 `extraVolumes` | Extra volumes (in yaml syntax) | `` See [values.yaml](values.yaml)

--- a/stable/fluentd/templates/deployment.yaml
+++ b/stable/fluentd/templates/deployment.yaml
@@ -22,10 +22,11 @@ spec:
     matchLabels:
       app: {{ template "fluentd.name" . }}
       release: {{ .Release.Name }}
-{{- if .Values.persistence.enabled }}
   updateStrategy:
-    type: RollingUpdate
-{{- end }}
+    type: {{ .Values.updateStrategy.type }}
+    {{- if (eq "Recreate" .Values.updateStrategy.type) }}
+    rollingUpdate: null
+    {{- end }}
   template:
     metadata:
       labels:

--- a/stable/fluentd/templates/deployment.yaml
+++ b/stable/fluentd/templates/deployment.yaml
@@ -13,7 +13,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
 {{- if .Values.autoscaling.enabled}}
-  serviceName: {{ template "fluentd.fullname" . }}
+  serviceName: {{ template "fluentd.fullname" . }}-headless
 {{- end}}
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/stable/fluentd/templates/deployment.yaml
+++ b/stable/fluentd/templates/deployment.yaml
@@ -12,6 +12,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+{{- if .Values.autoscaling.enabled}}
+  serviceName: {{ template "fluentd.fullname" . }}
+{{- end}}
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
 {{- end }}
@@ -19,10 +22,10 @@ spec:
     matchLabels:
       app: {{ template "fluentd.name" . }}
       release: {{ .Release.Name }}
-  {{- if .Values.persistence.enabled }}
-  strategy:
-    type: Recreate
-  {{- end }}
+{{- if .Values.persistence.enabled }}
+  updateStrategy:
+    type: RollingUpdate
+{{- end }}
   template:
     metadata:
       labels:

--- a/stable/fluentd/templates/headless-service.yaml
+++ b/stable/fluentd/templates/headless-service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.autoscaling.enabled}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fluentd.fullname" . }}-headless
+  labels:
+    app: {{ template "fluentd.name" . }}
+    chart: {{ template "fluentd.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  {{- range $port := .Values.service.ports }}
+    - name: {{ $port.name }}
+      port: {{ $port.containerPort }}
+  {{- end }}
+  selector:
+    app: {{ template "fluentd.name" . }}
+    release: {{ .Release.Name }}
+{{- end}}

--- a/stable/fluentd/templates/headless-service.yaml
+++ b/stable/fluentd/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  spec:
   type: ClusterIP
   clusterIP: None
   ports:

--- a/stable/fluentd/values.yaml
+++ b/stable/fluentd/values.yaml
@@ -19,6 +19,12 @@ output:
 
 env: {}
 
+## Update Strategy for the StatefulSet or Deployment
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#updating-a-deployment
+updateStrategy:
+  type: Recreate
+
 # Extra Environment Values - allows yaml definitions
 extraEnvVars:
 #  - name: VALUE_FROM_SECRET


### PR DESCRIPTION
#### What this PR does / why we need it:
Change syntax to latest kubernetes version.

https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/

Right now provisioning fails with:
`Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: [ValidationError(StatefulSet.spec): unknown field "strategy" in io.k8s.api.apps.v1.StatefulSetSpec, ValidationError(StatefulSet.spec): missing required field "serviceName" in io.k8s.api.apps.v1.StatefulSetSpec]`

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped