### PR TITLE
[stable/fluent-bit] Add tag to kubernetes-audit in fluent-bit chart.

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluent-bit
-version: 2.8.7
+version: 2.8.8
 appVersion: 1.3.5
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -93,6 +93,7 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `audit.enable`                     | Enable collection of audit logs                         | `false`                             |
 | `audit.input.memBufLimit`          | Specify Mem_Buf_Limit in tail input                     | `35mb`                              |
 | `audit.input.parser`               | Specify Parser in tail input                            | `docker`                            |
+| `audit.input.tag`                  | Specify Tag in tail input                               | `audit.*`                           |
 | `audit.input.path`                 | Specify log file(s) through the use of common wildcards | `/var/log/kube-apiserver-audit.log` |
 | `audit.input.bufferChunkSize`      | Specify Buffer_Chunk_Size in tail                       | `2MB`                               |
 | `audit.input.bufferMaxSize`        | Specify Buffer_Max_Size in tail                         | `10MB`                              |

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -59,7 +59,7 @@ data:
         Path              {{ .Values.audit.input.path }}
         Parser            {{ .Values.audit.input.parser }}
         DB                /var/log/audit.db
-        Tag               audit.*
+        Tag               {{ .Values.audit.input.tag }}
         Refresh_Interval  5
         Mem_Buf_Limit     {{ .Values.audit.input.memBufLimit }}
         Buffer_Chunk_Size {{ .Values.audit.input.bufferChunkSize }}

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -244,6 +244,7 @@ audit:
   input:
     memBufLimit: 35MB
     parser: docker
+    tag: audit.*
     path: /var/log/kube-apiserver-audit.log
     bufferChunkSize: 2MB
     bufferMaxSize: 10MB


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds tag variable to kubernetes-audit logs input. It's becomes easier to manage audit logs from kubernetes if tag used for filtering on a central log-sink.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/fluent-bit]`)
