### PR TITLE
[stable/elasticsearch-exporter] Feature flap the flag es.uri

### DIFF
--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 2.2.0
+version: 2.3.0
 kubeVersion: ">=1.10.0-0"
 appVersion: 1.1.0
 home: https://github.com/justwatchcom/elasticsearch_exporter

--- a/stable/elasticsearch-exporter/templates/deployment.yaml
+++ b/stable/elasticsearch-exporter/templates/deployment.yaml
@@ -63,7 +63,9 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["elasticsearch_exporter",
+                    {{- if .Values.es.uri }}                    
                     "--es.uri={{ .Values.es.uri }}",
+                    {{- end }}
                     {{- if .Values.es.all }}
                     "--es.all",
                     {{- end }}


### PR DESCRIPTION
Signed-off-by: Maxime Fouilleul <maxime.fouilleul@gmail.com>

#### What this PR does / why we need it:
* It make optional the flag es.uri (but still used by defaut as the value is set in the values.yaml)
* This allows to fallback the the env var ES_URI, allowing to use a secret for this string

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped 
- [x] Variables are documented in the README.md (no need as we don't change default values)
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
