### PR TITLE
[stable/drone] add back support for ingress in k8s < 1.14

### DIFF
--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 2.6.0
+version: 2.6.1
 appVersion: 1.6.1
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/stable/drone/templates/_helpers.tpl
+++ b/stable/drone/templates/_helpers.tpl
@@ -69,3 +69,14 @@ Create the name of the secret for an enterprise license key
   {{ printf "%s-%s" (include "drone.fullname" .) "license-key" | trunc 63 }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "drone.ingress.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "^1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/drone/templates/ingress.yaml
+++ b/stable/drone/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "drone.fullname" . }}
 {{- $httpPort := .Values.service.httpPort }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ template "drone.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   annotations:


### PR DESCRIPTION
Commit https://github.com/helm/charts/commit/767bbf51247da1cfc26f4cad0bf883f6debdc741#diff-7fce3b1f19f6b2e10c38fa1ad5dc8f4eR4 broke compatibility with k8s < 1.14. https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/ shows ingress api extensions/v1beta1 is supported until 1.20. Removing it from the chart was premature. I've added it back with logic.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
