### PR TITLE
[incubator/aws-alb-ingress-controller] add pod security policy and se…

### DIFF
--- a/incubator/aws-alb-ingress-controller/Chart.yaml
+++ b/incubator/aws-alb-ingress-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-alb-ingress-controller
 description: A Helm chart for AWS ALB Ingress Controller
-version: 0.1.13
+version: 0.1.14
 appVersion: "v1.1.5"
 engine: gotpl
 home: https://github.com/kubernetes-sigs/aws-alb-ingress-controller

--- a/incubator/aws-alb-ingress-controller/README.md
+++ b/incubator/aws-alb-ingress-controller/README.md
@@ -66,6 +66,7 @@ The following tables lists the configurable parameters of the alb-ingress-contro
 | `tolerations`             | controller pod toleration for taints                                                                           | `{}`                                                                      |
 | `podAnnotations`          | annotations to be added to controller pod                                                                      | `{}`                                                                      |
 | `podLabels`               | labels to be added to controller pod                                                                           | `{}`                                                                      |
+| `podSecurityPolicy.create` | creates Pod Security Policy to attach to the controller pod                                                   | `false`                                                                   |
 | `priorityClassName`       | set to ensure your pods survive resource shortages                                                             | `""`                                                                      |
 | `resources`               | controller pod resource requests & limits                                                                      | `{}`                                                                      |
 | `rbac.create`             | If true, create & use RBAC resources                                                                           | `true`                                                                    |
@@ -74,6 +75,9 @@ The following tables lists the configurable parameters of the alb-ingress-contro
 | `scope.ingressClass`      | If provided, the ALB ingress controller will only act on Ingress resources annotated with this class           | `alb`                                                                     |
 | `scope.singleNamespace`   | If true, the ALB ingress controller will only act on Ingress resources in a single namespace                   | `false` (watch all namespaces)                                            |
 | `scope.watchNamespace`    | If scope.singleNamespace=true, the ALB ingress controller will only act on Ingress resources in this namespace | `""` (namespace of the ALB ingress controller)                            |
+| `securityContext.enabled` | enables the Security Context for the controller deployment and container                                       | `false`                                                                   |
+| `securityContext.fsGroup` | set fsGroup for the controller deployment                                                                      | `1001`                                                                    |
+| `securityContext.runAsUser` | set user ID for the controller container                                                                     | `1001`                                                                    |
 
 ```bash
 helm install incubator/aws-alb-ingress-controller --set clusterName=MyClusterName --set autoDiscoverAwsRegion=true --set autoDiscoverAwsVpcID=true --name my-release --namespace kube-system

--- a/incubator/aws-alb-ingress-controller/templates/clusterrole.yaml
+++ b/incubator/aws-alb-ingress-controller/templates/clusterrole.yaml
@@ -9,6 +9,16 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 rules:
+{{- if .Values.podSecurityPolicy.create }}
+  - apiGroups:
+      - policy/v1beta1
+    resources: 
+      - podsecuritypolicies
+    verbs:
+      - use
+    resourceNames:
+      - {{ include "aws-alb-ingress-controller.fullname" . }}
+{{- end }}
   - apiGroups:
       - ""
       - extensions

--- a/incubator/aws-alb-ingress-controller/templates/deployment.yaml
+++ b/incubator/aws-alb-ingress-controller/templates/deployment.yaml
@@ -29,10 +29,18 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.securityContext.enabled }}
+          securityContext:
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+          {{- end }}
           args:
             - --cluster-name={{ required "specify clusterName via --set clusterName=YourClusterName" .Values.clusterName }}
           {{- if .Values.scope.ingressClass }}

--- a/incubator/aws-alb-ingress-controller/templates/psp.yaml
+++ b/incubator/aws-alb-ingress-controller/templates/psp.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.podSecurityPolicy.create }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "aws-alb-ingress-controller.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "aws-alb-ingress-controller.name" . }}
+    helm.sh/chart: {{ include "aws-alb-ingress-controller.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: {{ .Values.securityContext.fsGroup }}
+        max: {{ .Values.securityContext.fsGroup }}
+  hostIPC: false
+  hostNetwork: false
+  hostPID: false
+  privileged: false
+  readOnlyRootFilesystem: false
+  requiredDropCapabilities:
+    - ALL
+  runAsUser:
+    rule: 'MustRunAs'
+    ranges:
+      - min: {{ .Values.securityContext.runAsUser }}
+        max: {{ .Values.securityContext.runAsUser }}
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: {{ .Values.securityContext.runAsUser }}
+        max: {{ .Values.securityContext.runAsUser }}
+  volumes:
+    - 'configMap'
+    - 'secret'
+    - 'emptyDir'
+{{- end }}

--- a/incubator/aws-alb-ingress-controller/values.yaml
+++ b/incubator/aws-alb-ingress-controller/values.yaml
@@ -74,6 +74,15 @@ rbac:
   ## Annotations for the Service Account
   serviceAccountAnnotations: {}
 
+podSecurityPolicy:
+  create: false
+
+## Security Context
+securityContext:
+  enabled: false
+  fsGroup: 1001
+  runAsUser: 1001
+
 image:
   repository: docker.io/amazon/aws-alb-ingress-controller
   tag: "v1.1.5"


### PR DESCRIPTION
…curity context

Signed-off-by: Shaun Rasmusen <shaunrasmusen@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No.

#### What this PR does / why we need it:
Adds a Pod Security Policy and related security context to the chart so that it can be deployed in a kubernetes cluster with the PodSecurityPolicy Admission Controller enabled.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - n/a

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
