### PR TITLE
[stable/grafana] Update Grafana to v6.6.1

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: grafana
-version: 4.6.3
-appVersion: 6.6.0
+version: 4.6.4
+appVersion: 6.6.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -50,7 +50,7 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 6.6.0
+  tag: 6.6.1
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
What this PR does / why we need it:
Upgrades Grafana to v6.6.1, it fixed several critical bugs. https://github.com/grafana/grafana/releases/tag/v6.6.1

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ x] Chart Version bumped
- [x ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
