### PR TITLE
fix typo , in service of type nodePort Results in error.

### DIFF
--- a/stable/logstash/values.yaml
+++ b/stable/logstash/values.yaml
@@ -18,8 +18,8 @@ image:
 
 service:
   type: ClusterIP
-  # clusterIP: None
-  # nodePort:
+  # ClusterIP: None
+  # NodePort:
   # Set this to local, to preserve client source ip.  Default stripes out the source ip
   # externalTrafficPolicy: Local
   annotations: {}


### PR DESCRIPTION
Fix the error:

`# helm install --name logstash -f charts/stable/logstash/values.yaml stable/logstash 
Error: release logstash failed: Service "logstash" is invalid: spec.type: Unsupported value: "nodePort": supported values: "ClusterIP", "ExternalName", "LoadBalancer", "NodePort"
`