### PR TITLE
[stable/pgadmin] version 4.17 to 4.18

### DIFF
--- a/stable/pgadmin/Chart.yaml
+++ b/stable/pgadmin/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: pgAdmin is a web based administration tool for PostgreSQL database
 name: pgadmin
-version: 1.1.3
-appVersion: 4.17.0
+version: 1.1.4
+appVersion: 4.18.0
 home: https://www.pgadmin.org/
 source: https://github.com/rowanruseler/pgadmin
 maintainers:

--- a/stable/pgadmin/README.md
+++ b/stable/pgadmin/README.md
@@ -42,7 +42,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | --------- | ----------- | ------- |
 | `replicaCount` | Number of pgadmin replicas | `1` |
 | `image.repository` | Docker image | `dpage/pgadmin4` |
-| `image.tag` | Docker image tag | `4.17` |
+| `image.tag` | Docker image tag | `4.18` |
 | `image.pullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `service.type` | Service type (ClusterIP, NodePort or LoadBalancer) | `ClusterIP` |
 | `service.port` | Service port | `80` |

--- a/stable/pgadmin/values.yaml
+++ b/stable/pgadmin/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 ##
 image:
   repository: dpage/pgadmin4
-  tag: 4.17
+  tag: 4.18
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
This version ensures Postfix starts in the container:

```
sudo /usr/sbin/postfix start
```

Version 4.18 release notes can be found here:
https://www.pgadmin.org/docs/pgadmin4/development/release_notes_4_18.html

Signed-off-by: Rowan Ruseler <rowanruseler@gmail.com>