### PR TITLE
[stable/pgadmin] Server Definitions implementation

### DIFF
--- a/stable/pgadmin/Chart.yaml
+++ b/stable/pgadmin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin is a web based administration tool for PostgreSQL database
 name: pgadmin
-version: 1.1.4
+version: 1.1.5
 appVersion: 4.18.0
 home: https://www.pgadmin.org/
 source: https://github.com/rowanruseler/pgadmin

--- a/stable/pgadmin/README.md
+++ b/stable/pgadmin/README.md
@@ -47,6 +47,8 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `service.type` | Service type (ClusterIP, NodePort or LoadBalancer) | `ClusterIP` |
 | `service.port` | Service port | `80` |
 | `strategy` | Specifies the strategy used to replace old Pods by new ones | `{}` |
+| `serverDefinitions.enabled` | Enables Server Definitions | `false` |
+| `serverDefinitions.servers` | Pre-configured server parameters | `` |
 | `ingress.enabled` | Enables Ingress | `false` |
 | `ingress.annotations` | Ingress annotations | `{}` |
 | `ingress.hosts` | Ingress accepted hostnames | `nil` |

--- a/stable/pgadmin/templates/_helpers.tpl
+++ b/stable/pgadmin/templates/_helpers.tpl
@@ -43,3 +43,21 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Generate chart secret name
+*/}}
+{{- define "pgadmin.secretName" -}}
+{{ default (include "pgadmin.fullname" .) .Values.existingSecret }}
+{{- end -}}
+
+{{/*
+Defines a JSON file containing server definitions. This allows connection information to be pre-loaded into the instance of pgAdmin in the container. Note that server definitions are only loaded on first launch, i.e. when the configuration database is created, and not on subsequent launches using the same configuration database.
+*/}}
+{{- define "pgadmin.serverDefinitions" -}}
+{
+  "Servers": {
+{{ .Values.serverDefinitions.servers | indent 4 }}
+  }
+}
+{{- end -}}

--- a/stable/pgadmin/templates/deployment.yaml
+++ b/stable/pgadmin/templates/deployment.yaml
@@ -64,6 +64,11 @@ spec:
           volumeMounts:
             - name: pgadmin-data
               mountPath: /var/lib/pgadmin
+          {{- if .Values.serverDefinitions.enabled }}
+            - name: definitions
+              mountPath: /pgadmin4/servers.json
+              subPath: servers.json
+          {{- end }}
           resources:
             {{- .Values.resources | toYaml | nindent 12 }}
       volumes:
@@ -74,6 +79,14 @@ spec:
         {{- else }}
           emptyDir: {}
         {{- end }}
+      {{- if .Values.serverDefinitions.enabled }}
+        - name: definitions
+          secret:
+            secretName: {{ template "pgadmin.secretName" . }}
+            items:
+            - key: servers.json
+              path: servers.json
+      {{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- .Values.iamgePullSecrets | toYaml | nindent 8 }}

--- a/stable/pgadmin/templates/secrets.yaml
+++ b/stable/pgadmin/templates/secrets.yaml
@@ -8,3 +8,6 @@ metadata:
 type: Opaque
 data:
   password: {{ default "SuperSecret" .Values.env.password | b64enc | quote }}
+{{- if .Values.serverDefinitions.enabled }}
+  servers.json: {{ include "pgadmin.serverDefinitions" . | b64enc | quote }}
+{{- end }}

--- a/stable/pgadmin/values.yaml
+++ b/stable/pgadmin/values.yaml
@@ -22,6 +22,26 @@ strategy: {}
   #   maxSurge: 0
   #   maxUnavailable: 1
 
+## Server definitions will be loaded at launch time. This allows connection
+## information to be pre-loaded into the instance of pgAdmin in the container.
+## Ref: https://www.pgadmin.org/docs/pgadmin4/4.13/import_export_servers.html
+##
+serverDefinitions:
+  ## If true, server definitions will be created
+  ##
+  enabled: false
+
+  servers: |-
+  #  "1": {
+  #    "Name": "Minimally Defined Server",
+  #    "Group": "Servers",
+  #    "Port": 5432,
+  #    "Username": "postgres",
+  #    "Host": "localhost",
+  #    "SSLMode": "prefer",
+  #    "MaintenanceDB": "postgres"
+  #  }
+
 ingress:
   ## If true, pgAdmin Ingress will be created
   ##


### PR DESCRIPTION
Server definitions will be loaded at launch time. This allows connection
information to be pre-loaded into the instance of pgAdmin in the container.

Signed-off-by: Rowan Ruseler <rowanruseler@gmail.com>