### PR TITLE
[stable/vsphere-cpi] Improved Security for vSphere CPI

### DIFF
--- a/stable/vsphere-cpi/Chart.yaml
+++ b/stable/vsphere-cpi/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.0.0
+appVersion: 1.1.0
 description: A Helm chart for vSphere Cloud Provider Interface Manager (CPI)
 name: vsphere-cpi
-version: 0.1.2
+version: 0.1.3
 keywords:
   - vsphere
   - vmware

--- a/stable/vsphere-cpi/README.md
+++ b/stable/vsphere-cpi/README.md
@@ -23,15 +23,15 @@ $ helm repo update
 Then to install this chart and by providing vCenter information/credentials, run the following command:
 
 ```bash
-$ helm install vsphere-cpi stable/vsphere-cpi --set config.enabled=true --set config.vcenter=<vCenter IP> --set config.username=<vCenter Username> --set config.password=<vCenter Password> --set config.datacenter=<vCenter Datacenter>
+$ helm install vsphere-cpi stable/vsphere-cpi --namespace kube-system --set config.enabled=true --set config.vcenter=<vCenter IP> --set config.username=<vCenter Username> --set config.password=<vCenter Password> --set config.datacenter=<vCenter Datacenter>
 ```
 
 > **Tip**: List all releases using `helm list --all`
 
-If you want to provide your own `vsphere.conf` and Kubernetes secret `vsphere-cpi` in the `kube-system` namespace (for example, to handle multple datacenters/vCenters or for using zones), you can learn more about the `vsphere.conf` and `vsphere-cpi` secret by reading the following [documentation](https://github.com/kubernetes/cloud-provider-vsphere/blob/master/docs/book/tutorials/kubernetes-on-vsphere-with-kubeadm.md) and then running the following command:
+If you want to provide your own `vsphere.conf` and Kubernetes secret `vsphere-cpi` (for example, to handle multple datacenters/vCenters or for using zones), you can learn more about the `vsphere.conf` and `vsphere-cpi` secret by reading the following [documentation](https://cloud-provider-vsphere.sigs.k8s.io/tutorials/kubernetes-on-vsphere-with-kubeadm.html) and then running the following command:
 
 ```bash
-$ helm install vsphere-cpi stable/vsphere-cpi
+$ helm install vsphere-cpi stable/vsphere-cpi --namespace kube-system
 ```
 
 ## Installing the Chart using Helm 2.X
@@ -39,13 +39,13 @@ $ helm install vsphere-cpi stable/vsphere-cpi
 To install this chart with the release name `vsphere-cpi` and by providing a vCenter information/credentials, run the following command:
 
 ```bash
-$ helm install stable/vsphere-cpi --name vsphere-cpi --set config.enabled=true --set config.vcenter=<vCenter IP> --set config.username=<vCenter Username> --set config.password=<vCenter Password> --set config.datacenter=<vCenter Datacenter>
+$ helm install stable/vsphere-cpi --name vsphere-cpi --namespace kube-system --set config.enabled=true --set config.vcenter=<vCenter IP> --set config.username=<vCenter Username> --set config.password=<vCenter Password> --set config.datacenter=<vCenter Datacenter>
 ```
 
-If you provide your own `vsphere.conf` and Kubernetes secret `vsphere-cpi` in the `kube-system` namespace, then deploy the chart running the following command:
+If you provide your own `vsphere.conf` and Kubernetes secret `vsphere-cpi`, then deploy the chart running the following command:
 
 ```bash
-$ helm install stable/vsphere-cpi --name vsphere-cpi
+$ helm install stable/vsphere-cpi --name vsphere-cpi --namespace kube-system
 ```
 
 ## Uninstalling the Chart
@@ -53,12 +53,12 @@ $ helm install stable/vsphere-cpi --name vsphere-cpi
 To uninstall/delete the `vsphere-cpi` deployment:
 
 ```bash
-$ helm delete vsphere-cpi
+$ helm delete vsphere-cpi --namespace kube-system
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
-> **Tip**: To permanently remove the release using Helm v2.X, run `helm delete --purge vsphere-cpi`
+> **Tip**: To permanently remove the release using Helm v2.X, run `helm delete --purge vsphere-cpi --namespace kube-system`
 
 ## Configuration
 
@@ -66,6 +66,13 @@ The following table lists the configurable parameters of the vSphere CPI chart a
 
 |             Parameter                    |            Description              |                  Default               |
 |------------------------------------------|-------------------------------------|----------------------------------------|
+| `podSecurityPolicy.enabled`              | Enable pod sec policy (k8s > 1.17)  |  false                                 |
+| `podSecurityPolicy.annotations`          | Annotations for pd sec policy       |  nil                                   |
+| `securityContext.enabled`                | Enable sec context for container    |  false                                 |
+| `securityContext.runAsUser`              | RunAsUser. Default is `nobody` in   |  65534                                 |
+|                                          |    distroless image                 |                                        |
+| `securityContext.fsGroup`                | FsGroup. Default is `nobody` in     |  65534                                 |
+|                                          |    distroless image                 |                                        |
 | `config.enabled`                         | Create a simple single VC config    |  false                                 |
 | `config.vcenter`                         | FQDN or IP of vCenter               |  vcenter.local                         |
 | `config.username`                        | vCenter username                    |  user                                  |
@@ -87,6 +94,8 @@ The following table lists the configurable parameters of the vSphere CPI chart a
 | `daemonset.resources`                    | Node resources                      | `[]`                                   |
 | `daemonset.podAnnotations`               | Annotations for CPI pod             |  nil                                   |
 | `daemonset.podLabels`                    | Labels for CPI pod                  |  nil                                   |
+| `daemonset.nodeSelector`                 | User-defined node selectors         |  nil                                   |
+| `daemonset.tolerations`                  | User-defined tolerations            |  nil                                   |
 | `service.enabled`                        | Enabled the CPI API endpoint        |  false                                 |
 | `service.annotations`                    | Annotations for API service         |  nil                                   |
 | `service.type`                           | Service type                        |  ClusterIP                             |

--- a/stable/vsphere-cpi/templates/common.yaml
+++ b/stable/vsphere-cpi/templates/common.yaml
@@ -9,6 +9,6 @@ metadata:
     component: cloud-controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
 data:
   api.binding: "{{ template "api.binding" . }}"

--- a/stable/vsphere-cpi/templates/configmap.yaml
+++ b/stable/vsphere-cpi/templates/configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     component: cloud-controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
 data:
   vsphere.conf: |
     [Global]
@@ -19,7 +19,7 @@ data:
     insecure-flag = "1" #set to 1 if the vCenter uses a self-signed cert
     # settings for using k8s secret
     secret-name = "vsphere-cpi"
-    secret-namespace = "kube-system"
+    secret-namespace = "{{ .Release.Namespace }}"
 
     [VirtualCenter "{{ .Values.config.vcenter }}"]
     datacenters = "{{ .Values.config.datacenter }}"

--- a/stable/vsphere-cpi/templates/daemonset.yaml
+++ b/stable/vsphere-cpi/templates/daemonset.yaml
@@ -9,7 +9,7 @@ metadata:
     component: cloud-controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
 {{- if .Values.daemonset.annotations }}
   annotations:
 {{ toYaml .Values.daemonset.annotations | indent 4 }}
@@ -36,15 +36,28 @@ spec:
 {{- end }}
     spec:
       nodeSelector:
+{{- if .Values.daemonset.nodeSelector }}
+{{ toYaml .Values.daemonset.nodeSelector | indent 8 }}
+{{- else }}
         node-role.kubernetes.io/master: ""
+{{- end }}
       securityContext:
         runAsUser: 0
       tolerations:
+{{- if .Values.daemonset.tolerations }}
+{{ toYaml .Values.daemonset.tolerations | indent 8 }}
+{{- else }}
       - key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"
         effect: NoSchedule
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+ {{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+      {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- if .Values.daemonset.useHostNetwork }}
       hostNetwork: true

--- a/stable/vsphere-cpi/templates/ingress.yaml
+++ b/stable/vsphere-cpi/templates/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     component: cloud-controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.ingress.annotations }}
   annotations:
 {{ toYaml .Values.ingress.annotations | indent 4 }}

--- a/stable/vsphere-cpi/templates/podsecuritypolicy.yaml
+++ b/stable/vsphere-cpi/templates/podsecuritypolicy.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.podSecurityPolicy.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "cpi.name" . }}
+  labels:
+    app: {{ template "cpi.name" . }}
+    component: cloud-controller
+    release: {{ .Release.Name }}
+    vsphere-cpi-infra: pod-security-policy
+{{- if .Values.podSecurityPolicy.annotations }}
+  annotations:
+{{ toYaml .Values.podSecurityPolicy.annotations | indent 4 }}
+{{- end }}
+spec:
+  allowPrivilegeEscalation: false
+  privileged: false
+  volumes:
+    - 'configMap'
+    - 'secret'
+    - 'emptyDir'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAs'
+    ranges:
+      - min: {{ .Values.securityContext.runAsUser }}
+        max: {{ .Values.securityContext.runAsUser }}
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: {{ .Values.securityContext.runAsUser }}
+        max: {{ .Values.securityContext.runAsUser }}
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+    - ALL
+{{- end }}

--- a/stable/vsphere-cpi/templates/role-binding.yaml
+++ b/stable/vsphere-cpi/templates/role-binding.yaml
@@ -14,7 +14,7 @@ items:
       component: cloud-controller
       heritage: {{ .Release.Service }}
       release: {{ .Release.Name }}
-    namespace: kube-system
+    namespace: {{ .Release.Namespace }}
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: Role
@@ -23,7 +23,7 @@ items:
   - apiGroup: ""
     kind: ServiceAccount
     name: {{ .Values.serviceAccount.name }}
-    namespace: kube-system
+    namespace: {{ .Release.Namespace }}
   - apiGroup: ""
     kind: User
     name: {{ .Values.serviceAccount.name }}
@@ -45,7 +45,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name }}
-    namespace: kube-system
+    namespace: {{ .Release.Namespace }}
   - kind: User
     name: {{ .Values.serviceAccount.name }}
 {{- end -}}

--- a/stable/vsphere-cpi/templates/secret.yaml
+++ b/stable/vsphere-cpi/templates/secret.yaml
@@ -10,7 +10,7 @@ metadata:
     component: cloud-controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
 data:
   {{ .Values.config.vcenter }}.username: {{ .Values.config.username | b64enc }}
   {{ .Values.config.vcenter }}.password: {{ .Values.config.password | b64enc }}

--- a/stable/vsphere-cpi/templates/service-account.yaml
+++ b/stable/vsphere-cpi/templates/service-account.yaml
@@ -10,5 +10,5 @@ metadata:
     component: cloud-controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/stable/vsphere-cpi/templates/service.yaml
+++ b/stable/vsphere-cpi/templates/service.yaml
@@ -10,7 +10,7 @@ metadata:
     component: cloud-controller
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/stable/vsphere-cpi/values.yaml
+++ b/stable/vsphere-cpi/values.yaml
@@ -9,6 +9,26 @@ config:
   password: "pass"
   datacenter: "dc"
 
+## Specify if a Pod Security Policy for kube-state-metrics must be created
+## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+podSecurityPolicy:
+  enabled: false
+  annotations: {}
+    # Specify pod annotations
+    # Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
+    # Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
+    # Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#sysctl
+    #
+    # seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    # seccomp.security.alpha.kubernetes.io/defaultProfileName: 'docker/default'
+    # apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'
+
+# Run containers to have security context. Default is 'nobody' (65534/65534) in distroless
+securityContext:
+  enabled: false
+  runAsUser: 65534
+  fsGroup: 65534
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
@@ -22,7 +42,7 @@ serviceAccount:
 daemonset:
   annotations: {}
   image: gcr.io/cloud-provider-vsphere/cpi/release/manager
-  tag: v1.0.0
+  tag: v1.1.0
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdline:
@@ -44,6 +64,10 @@ daemonset:
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
+  ## Allows for the default selector to be replaced with user-defined ones
+  nodeSelector: {}
+  ## Allows for the default tolerations to be replaced with user-defined ones
+  tolerations: []
 
 service:
   enabled: false


### PR DESCRIPTION
## What this PR does / why we need it:
Improvements made:
- No longers runs the container as root. Default: `nobody` as defined by the distroless image
- Introduces override for `runAsUser` and `fsGroup`. Default: `65534/65534` which represents `nobody` as delcared above.
- Introduces PodSecurityContext for k8s 1.17+. Default: disabled for greater compatibility
- Configurable namespace. Default: kube-system
- Allows overriding the default daemonset `nodeSelector`
- Allows overriding the default daemonset `tolerations`
- Bumps the chart to GA version v1.1.0

#### Which issue this PR fixes
  - fixes https://github.com/helm/charts/issues/19807

#### Special notes for your reviewer:
Tested on vSphere 6.7u3 with:
- run as user nobody
- enabling pod security context

Depends on the following PR:
https://github.com/kubernetes/cloud-provider-vsphere/pull/297

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
