### PR TITLE
[stable/nginx-ingress] Fix typo in description of "sessionAffinity"

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.30.0
+version: 1.30.1
 appVersion: 0.28.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -254,7 +254,7 @@ controller:
     ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
     externalTrafficPolicy: ""
 
-    # Must be either "None" or "ClusterIP" if set. Kubernetes will default to "None".
+    # Must be either "None" or "ClientIP" if set. Kubernetes will default to "None".
     # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
     sessionAffinity: ""
 


### PR DESCRIPTION
Kubernetes only supports "ClientIP" and "None" as a value for "sessionAffinity"

    spec.sessionAffinity: Unsupported value: "ClusterIP": supported values: "ClientIP", "None"