### PR TITLE
[stable/home-assistant] feat: Make service port name configurable

### DIFF
--- a/stable/home-assistant/Chart.yaml
+++ b/stable/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.103.3
 description: Home Assistant
 name: home-assistant
-version: 0.12.0
+version: 0.12.1
 keywords:
 - home-assistant
 - hass

--- a/stable/home-assistant/README.md
+++ b/stable/home-assistant/README.md
@@ -56,6 +56,7 @@ The following tables lists the configurable parameters of the Home Assistant cha
 | `probes.startup.periodSeconds`      | Specify startup `periodSeconds` parameter for the deployment      | `10` |
 | `service.type`             | Kubernetes service type for the home-assistant GUI | `ClusterIP` |
 | `service.port`             | Kubernetes port where the home-assistant GUI is exposed| `8123` |
+| `service.portName`         | Kubernetes port name where the home-assistant GUI is exposed | `api` |
 | `service.annotations`      | Service annotations for the home-assistant GUI | `{}` |
 | `service.clusterIP`   | Cluster IP for the home-assistant GUI | `` |
 | `service.externalIPs`   | External IPs for the home-assistant GUI | `[]` |

--- a/stable/home-assistant/templates/service.yaml
+++ b/stable/home-assistant/templates/service.yaml
@@ -37,7 +37,7 @@ spec:
 {{ toYaml .Values.service.externalIPs | indent 4 }}
 {{- end }}
   ports:
-    - name: api
+    - name: {{ .Values.service.portName }}
       port: {{ .Values.service.port }}
       protocol: TCP
       targetPort: 8123

--- a/stable/home-assistant/templates/servicemonitor.yaml
+++ b/stable/home-assistant/templates/servicemonitor.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 spec:
   endpoints:
-  - targetPort: api
+  - targetPort: {{ .Values.service.portName }}
     path: /api/prometheus
 {{- if .Values.monitoring.serviceMonitor.interval }}
     interval: {{ .Values.monitoring.serviceMonitor.interval }}

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -33,6 +33,7 @@ probes:
 service:
   type: ClusterIP
   port: 8123
+  portName: api
   annotations: {}
   labels: {}
   clusterIP: ""


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This allows for compatibility with istio-enabled setups, which need the port name to start with `http`

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
