### PR TITLE
[stable/jenkins] Make chart compatible with Helm 3

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 home: https://jenkins.io/
-version: 1.11.3
+version: 1.11.4
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -132,6 +132,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `master.route.enabled`            | Enables openshift route              | `false`                                   |
 | `master.route.annotations`        | Route annotations                    | `{}`                                      |
 | `master.route.labels`             | Route labels                         | `{}`                                      |
+| `master.route.host`               | Route host                           | Not set                                   |
 | `master.route.path`               | Route path                           | Not set                                   |
 | `master.jenkinsUrlProtocol`       | Set protocol for JenkinsLocationConfiguration.xml | Set to `https` if `Master.ingress.tls`, `http` otherwise |
 | `master.JCasC.enabled`            | Wheter Jenkins Configuration as Code is enabled or not | `false`                 |

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -192,3 +192,12 @@ Create the name of the service account for Jenkins agents to use
     {{ default "default" .Values.serviceAccountAgent.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Workaround for OpenShift Route spec bug
+https://github.com/openshift/origin/issues/24060
+*/}}
+{{- define "chart.helmRouteFix" -}}
+status:
+  ingress: []
+{{- end -}}

--- a/stable/jenkins/templates/jenkins-master-route.yaml
+++ b/stable/jenkins/templates/jenkins-master-route.yaml
@@ -18,7 +18,8 @@ metadata:
 {{- end }}
   name: {{ template "jenkins.fullname" . }}
 spec:
-  host: {{ .Values.master.route.path }}
+  host: "{{ .Values.master.route.host }}"
+  path: {{ .Values.master.route.path }}
   port:
     targetPort: http
   tls:
@@ -29,4 +30,5 @@ spec:
     name: {{ template "jenkins.fullname" . }}
     weight: 100
   wildcardPolicy: None
+{{ include "chart.helmRouteFix" $ }}
 {{- end }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -365,6 +365,7 @@ master:
     enabled: false
     labels: {}
     annotations: {}
+    # host:
     # path: "/jenkins"
 
   additionalConfig: {}


### PR DESCRIPTION
Signed-off-by: Helder Pereira <helfper@gmail.com>

#### What this PR does / why we need it:

Trying to install Jenkins chart with route enabled using Helm 3 fails because of https://github.com/openshift/origin/issues/24060:

    $ helm install jenkins . --set master.route.enabled=true
    Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: [ValidationError(Route.spec): missing required field "host" in com.github.openshift.api.route.v1.RouteSpec, ValidationError(Route): missing required field "status" in com.github.openshift.api.route.v1.Route]

This PR adds the missing fields required by the Route v1 spec. Additionally, it also fixes the confusing binding from a value called `master.route.path` to the Route's `host` field.

#### Checklist

- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
