### PR TITLE
[stable/opa] Add affinity settings to OPA deployment

### DIFF
--- a/stable/opa/Chart.yaml
+++ b/stable/opa/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - opa
 - admission control
 - policy
-version: 1.13.3
+version: 1.13.4
 home: https://www.openpolicyagent.org
 icon: https://raw.githubusercontent.com/open-policy-agent/opa/master/logo/logo.png
 sources:

--- a/stable/opa/README.md
+++ b/stable/opa/README.md
@@ -75,6 +75,7 @@ Reference](https://www.openpolicyagent.org/docs/configuration.html).
 | `logLevel` | Log level that OPA outputs at, (`debug`, `info` or `error`) | `info` |
 | `logFormat` | Log format that OPA produces (`text` or `json`) | `text` |
 | `replicas` | Number of admission controller replicas to deploy. | `1` |
+| `affinity` | Pod/Node affinity and anti-affinity | `{}` |
 | `tolerations` | List of node taint tolerations. | `[]` |
 | `nodeSelector` | Node labels for pod assignment. | `{}` |
 | `resources` | CPU and memory limits for OPA container. | `{}` |

--- a/stable/opa/templates/deployment.yaml
+++ b/stable/opa/templates/deployment.yaml
@@ -188,6 +188,8 @@ spec:
         - name: bootstrap
           emptyDir: {}
 {{- end }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
       tolerations:

--- a/stable/opa/values.yaml
+++ b/stable/opa/values.yaml
@@ -146,11 +146,27 @@ logFormat: text
 # or more replicas.
 replicas: 1
 
-# To control how the OPA is scheduled on the cluster, set the tolerations and
-# nodeSelector values below. For example, to deploy OPA onto the master nodes:
+# To control how the OPA is scheduled on the cluster, set the affinity,
+# tolerations and nodeSelector values below. For example, to deploy OPA onto
+# the master nodes, 1 replica per node:
 #
-# tolerations: [{key: "node-role.kubernetes.io/master", effect: NoSchedule, operator: Exists}]
-# nodeSelector: {"kubernetes.io/role": "master"}
+# affinity:
+#   podAntiAffinity:
+#     requiredDuringSchedulingIgnoredDuringExecution:
+#     - labelSelector:
+#         matchExpressions:
+#         - key: "app"
+#           operator: In
+#           values:
+#           - opa
+#       topologyKey: "kubernetes.io/hostname"
+# tolerations:
+# - key: "node-role.kubernetes.io/master"
+#   effect: NoSchedule
+#   operator: Exists
+# nodeSelector:
+#   kubernetes.io/role: "master"
+affinity: {}
 tolerations: []
 nodeSelector: {}
 


### PR DESCRIPTION
Signed-off-by: Igor Belikov <mail@igorbelikov.com>

#### Is this a new chart
NO

#### What this PR does / why we need it:
Add the option to specify affinity/anti-affinity settings for OPA deployment, allowing more sophisticated scheduling scenarios. One of the examples is given in values.yaml comments -  scheduling OPA on master nodes, 1 replica per node.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
