### PR TITLE
[stable/elasticsearch] Update to 6.8.6 + Fix plugin install initcontainer which would fail if plugin already exists.

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.32.2
+version: 1.32.3
 appVersion: 6.8.2
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
 version: 1.32.3
-appVersion: 6.8.2
+appVersion: 6.8.6
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg

--- a/stable/elasticsearch/templates/_helpers.tpl
+++ b/stable/elasticsearch/templates/_helpers.tpl
@@ -97,7 +97,13 @@ plugin installer template
     - "-c"
     - |
       {{- range .Values.cluster.plugins }}
-      /usr/share/elasticsearch/bin/elasticsearch-plugin install -b {{ . }}
+      PLUGIN_NAME="{{ . }}"
+      echo "Installing $PLUGIN_NAME..."
+      if /usr/share/elasticsearch/bin/elasticsearch-plugin list | grep "$PLUGIN_NAME" > /dev/null; then
+        echo "Plugin $PLUGIN_NAME already exists, skipping."
+      else
+        /usr/share/elasticsearch/bin/elasticsearch-plugin install -b $PLUGIN_NAME
+      fi
       {{- end }}
   volumeMounts:
   - mountPath: /usr/share/elasticsearch/plugins/

--- a/stable/elasticsearch/values.yaml
+++ b/stable/elasticsearch/values.yaml
@@ -1,7 +1,7 @@
 # Default values for elasticsearch.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-appVersion: "6.8.2"
+appVersion: "6.8.6"
 
 ## Define serviceAccount names for components. Defaults to component's fully qualified name.
 ##
@@ -42,7 +42,7 @@ securityContext:
 
 image:
   repository: "docker.elastic.co/elasticsearch/elasticsearch-oss"
-  tag: "6.8.2"
+  tag: "6.8.6"
   pullPolicy: "IfNotPresent"
   # If specified, use these secrets to access the image
   # pullSecrets:


### PR DESCRIPTION
- Update to 6.8.6.
- Fix plugin install initcontainer which would fail if plugin already exists. Fix plugin install initcontainer which would fail if plugin already exists.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
