### PR TITLE
[stable/mariadb] Replace stretch by buster in minideb secondary containers

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb
-version: 7.3.7
+version: 7.3.8
 appVersion: 10.3.22
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -64,7 +64,7 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `volumePermissions.enabled`                 | Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work) | `false`             |
 | `volumePermissions.image.registry`          | Init container volume-permissions image registry    | `docker.io`                                                       |
 | `volumePermissions.image.repository`        | Init container volume-permissions image name        | `bitnami/minideb`                                                 |
-| `volumePermissions.image.tag`               | Init container volume-permissions image tag         | `stretch`                                                         |
+| `volumePermissions.image.tag`               | Init container volume-permissions image tag         | `buster`                                                          |
 | `volumePermissions.image.pullPolicy`        | Init container volume-permissions image pull policy | `Always`                                                          |
 | `volumePermissions.resources`               | Init container resource requests/limit              | `nil`                                                             |
 | `service.type`                              | Kubernetes service type                             | `ClusterIP`                                                       |

--- a/stable/mariadb/values-production.yaml
+++ b/stable/mariadb/values-production.yaml
@@ -53,7 +53,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/minideb
-    tag: stretch
+    tag: buster
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -53,7 +53,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/minideb
-    tag: stretch
+    tag: buster
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Replace stretch by buster in minideb secondary containers

Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
