### PR TITLE
[stable/rabbitmq] Replace stretch by buster in minideb secondary containers

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.17.0
+version: 6.17.1
 appVersion: 3.8.2
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -178,7 +178,7 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `volumePermissions.enabled`                  | Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work) | `false |
 | `volumePermissions.image.registry`           | Init container volume-permissions image registry     | `docker.io`                                         |
 | `volumePermissions.image.repository`         | Init container volume-permissions image name         | `bitnami/minideb`                                   |
-| `volumePermissions.image.tag`                | Init container volume-permissions image tag          | `stretch`                                           |
+| `volumePermissions.image.tag`                | Init container volume-permissions image tag          | `buster`                                            |
 | `volumePermissions.image.pullPolicy`         | Init container volume-permissions image pull policy  | `Always`                                            |
 | `volumePermissions.resources`                | Init container resource requests/limit               | `nil`                                               |
 | `forceBoot.enabled`                          | Executes 'rabbitmqctl force_boot' to force boot cluster shut down unexpectedly in an unknown order. Use it only if you prefer availability over integrity. | `false` |

--- a/stable/rabbitmq/values-production.yaml
+++ b/stable/rabbitmq/values-production.yaml
@@ -542,7 +542,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/minideb
-    tag: stretch
+    tag: buster
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -523,7 +523,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/minideb
-    tag: stretch
+    tag: buster
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Replace stretch by buster in minideb secondary containers

Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
