### PR TITLE
[AIRFLOW] Adding extraConfigmapMounts to Flower

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 6.0.2
+version: 6.1.0
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -391,6 +391,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `airflow.extraVolumes`                   | additional volumes for the scheduler, worker & web pods | `[]`                      |
 | `airflow.initdb`                         | run `airflow initdb` when starting the scheduler        | `true`                    |
 | `flower.enabled`                         | enable flow                                             | `true`                    |
+| `flower.extraConfigmapMounts`            | Additional configMap volume mounts on the flower pod.   | `[]`                      |
 | `flower.urlPrefix`                       | path of the flower ui                                   | ""                        |
 | `flower.resources`                       | custom resource configuration for flower pod            | `{}`                      |
 | `flower.labels`                          | labels for the flower deployment                        | `{}`                      |

--- a/stable/airflow/templates/deployments-flower.yaml
+++ b/stable/airflow/templates/deployments-flower.yaml
@@ -68,6 +68,10 @@ spec:
             - name: flower
               containerPort: 5555
               protocol: TCP
+          {{- if .Values.flower.extraConfigmapMounts }}
+          volumeMounts:
+{{ toYaml .Values.flower.extraConfigmapMounts | indent 12 }}
+          {{- end }}
           args: ["flower"]
           livenessProbe:
             httpGet:

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -231,6 +231,13 @@ flower:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+  extraConfigmapMounts: []
+  # Use-case example: adding a public certificate used for connection to a remote TLS endpoint
+  # - name: extra-cert
+  #   mountPath: /etc/ssl/certs/extra-cert.pem
+  #   configMap: extra-certificates
+  #   readOnly: true
+  #   subPath: extra-cert.pem
 
 web:
   ##


### PR DESCRIPTION
When configuring Airflow extra configs can be passed using the Helm values to the web, scheduler and workers. But that's not the case for the flower pod. A use-case when you want to do it is when you want to add a public certificate used for connection to a remote TLS endpoint. This PR fixes that issue by adding a similar extraConfigmapMounts to flower.
