### PR TITLE
Use tpl for annotations and labels

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.8.0
-version: 1.39.0
+version: 1.40.0
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -94,6 +94,7 @@ and their default values.
 | `nodeSelector`                                 | Node labels for pod assignment                                                                                                                                                                        | `{}`                                                       |
 | `persistentVolume.accessMode`                  | Persistent volume access modes                                                                                                                                                                        | `[ReadWriteOnce]`                                          |
 | `persistentVolume.annotations`                 | Persistent volume annotations                                                                                                                                                                         | `{}`                                                       |
+| `persistentVolume.labels`                      | Persistent volume labels                                                                                                                                                                              | `{}`                                                       |
 | `persistentVolume.enabled`                     | If `true`, persistent volume claims are created                                                                                                                                                       | `false`                                                    |
 | `persistentVolume.name`                        | Persistent volume name                                                                                                                                                                                | `data`                                                     |
 | `persistentVolume.size`                        | Persistent volume size                                                                                                                                                                                | `8Gi`                                                      |
@@ -279,3 +280,6 @@ The `tpl` function allows us to pass values from `values.yaml` through the templ
 
 * `extraContainers`
 * `extraInitContainers`
+* `persistentVolume.annotations`
+* `persistentVolume.labels`
+* `service.annotations`

--- a/stable/rabbitmq-ha/templates/service.yaml
+++ b/stable/rabbitmq-ha/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
 {{- if .Values.service.annotations }}
   annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
+{{ tpl (toYaml .Values.service.annotations) . | indent 4 }}
 {{- end }}
   name: {{ template "rabbitmq-ha.fullname" . }}
   namespace: {{ .Release.Namespace }}

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -322,9 +322,9 @@ spec:
     - metadata:
         name: {{ .Values.persistentVolume.name }}
         annotations:
-        {{- range $key, $value := .Values.persistentVolume.annotations }}
-          {{ $key }}: {{ $value }}
-        {{- end }}
+{{ tpl (toYaml .Values.persistentVolume.annotations) . | indent 10 }}
+        labels:
+{{ tpl (toYaml .Values.persistentVolume.labels) . | indent 10 }}
       spec:
         accessModes:
         {{- range .Values.persistentVolume.accessModes }}

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -395,6 +395,7 @@ persistentVolume:
     - ReadWriteOnce
   size: 8Gi
   annotations: {}
+  labels: {}
 
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector


### PR DESCRIPTION
~This PR provides the ability to add labels to the `persistentVolume` template (with `tpl` interpolation).~
Updated to leverage existing method of templating yaml blocks. Extended for key areas.
- Adds labels for persistentVolumes