### PR TITLE
[stable/lamp] Add support for new deployment and ingress APIs in Kubernetes 1.16+

### DIFF
--- a/stable/lamp/Chart.yaml
+++ b/stable/lamp/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Modular and transparent LAMP stack chart supporting PHP-FPM, Release Cloning, LoadBalancer, Ingress, SSL and lots more!
 name: lamp
-version: 1.1.2
+version: 1.1.3
 appVersion: 7
 home: https://github.com/lead4good/helm-lamp-stack
 maintainers:

--- a/stable/lamp/templates/deployment.yaml
+++ b/stable/lamp/templates/deployment.yaml
@@ -1,4 +1,8 @@
+{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: apps/v1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Deployment
 metadata:
   name: {{ template "lamp.fullname" . }}
@@ -9,6 +13,11 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+  selector:
+    matchLabels:
+      app: {{ template "lamp.name" . }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/stable/lamp/templates/deployment.yaml
+++ b/stable/lamp/templates/deployment.yaml
@@ -13,7 +13,7 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
-  {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+  {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion}}
   selector:
     matchLabels:
       app: {{ template "lamp.name" . }}

--- a/stable/lamp/templates/ingress-services.yaml
+++ b/stable/lamp/templates/ingress-services.yaml
@@ -1,5 +1,9 @@
 {{- if and .Values.ingress.enabled (or .Values.phpmyadmin.enabled .Values.webdav.enabled) }}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "lamp.fullname" . }}-service

--- a/stable/lamp/templates/ingress-www.yaml
+++ b/stable/lamp/templates/ingress-www.yaml
@@ -1,5 +1,9 @@
 {{- if and .Values.ingress.enabled .Values.ingress.subdomainWWW }}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "lamp.fullname" . }}-www

--- a/stable/lamp/templates/ingress.yaml
+++ b/stable/lamp/templates/ingress.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.ingress.enabled }}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "lamp.fullname" . }}-app


### PR DESCRIPTION
Signed-off-by: Andy Mardell <andy@mardell.me>

#### What this PR does / why we need it:
- Adds support for the `apps/v1` deployment API version in Kubernetes 1.16
- Adds support for the `networking.k8s.io/v1beta1` ingress API version in Kubernetes 1.14

#### Which issue this PR fixes
- fixes #18875 [stable/lamp] Not working in Kubernetes 1.16

#### Special notes for your reviewer:
@lead4good Tested in 1.14, 1.15, 1.16 and all seems okay 👍 

I used the same checks used by the template chart generated by `helm create newChart`:
`{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}` so seems like the normal way to check.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
