### PR TITLE
[stable/moodle] Adapt docs to Helm 3

### DIFF
--- a/stable/moodle/Chart.yaml
+++ b/stable/moodle/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: moodle
-version: 7.1.0
+version: 7.1.1
 appVersion: 3.8.1
 description: Moodle is a learning platform designed to provide educators, administrators and learners with a single robust, secure and integrated system to create personalised learning environments
 keywords:

--- a/stable/moodle/README.md
+++ b/stable/moodle/README.md
@@ -5,7 +5,7 @@
 ## TL;DR;
 
 ```console
-$ helm install stable/moodle
+$ helm install my-release stable/moodle
 ```
 
 ## Introduction
@@ -28,7 +28,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install --name my-release stable/moodle
+$ helm install my-release stable/moodle
 ```
 
 The command deploys Moodle on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
@@ -138,7 +138,7 @@ The above parameters map to the env variables defined in [bitnami/moodle](http:/
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-$ helm install --name my-release \
+$ helm install my-release \
   --set moodleUsername=admin,moodlePassword=password,mariadb.mariadbRootPassword=secretpassword \
     stable/moodle
 ```
@@ -148,7 +148,7 @@ The above command sets the Moodle administrator account username and password to
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-$ helm install --name my-release -f values.yaml stable/moodle
+$ helm install my-release -f values.yaml stable/moodle
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)


### PR DESCRIPTION
#### What this PR does / why we need it:
There are some commands (like `helm install`) whose syntax had been changing and there is not a compatible command that works in both cases:

Helm 2:
```
▶ helm2 install bitnami/fluentd
▶ helm2 install --name myChart bitnami/fluentd
```
Helm 3:
```
▶ helm3 install --generated-name bitnami/fluentd
▶ helm3 install myChart bitnami/fluentd
```
The first one uses a random name and the second one myChart but the syntax is different in both versions.

To unify everything and update the doc to use Helm 3, this PR uses the `helm install my-release bitnami/fluentd` way.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
