### PR TITLE
[stable/phabricator] Adapt docs to Helm 3

### DIFF
--- a/stable/phabricator/Chart.yaml
+++ b/stable/phabricator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: phabricator
-version: 9.0.7
+version: 9.0.8
 appVersion: 2019.50.0
 description: Collection of open source web applications that help software companies build better software.
 keywords:

--- a/stable/phabricator/README.md
+++ b/stable/phabricator/README.md
@@ -129,8 +129,9 @@ The above parameters map to the env variables defined in [bitnami/phabricator](h
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-$ helm install my-release stable/phabricator --name my-release \
+$ helm install my-release \
   --set phabricatorUsername=admin,phabricatorPassword=password,mariadb.mariadbRootPassword=secretpassword \
+  stable/phabricator
 ```
 
 The above command sets the Phabricator administrator account username and password to `admin` and `password` respectively. Additionally, it sets the MariaDB `root` user password to `secretpassword`.

--- a/stable/phabricator/README.md
+++ b/stable/phabricator/README.md
@@ -5,7 +5,7 @@
 ## TL;DR;
 
 ```console
-$ helm install stable/phabricator
+$ helm install my-release stable/phabricator
 ```
 
 ## Introduction
@@ -28,7 +28,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install --name my-release stable/phabricator
+$ helm install my-release stable/phabricator
 ```
 
 The command deploys Phabricator on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
@@ -129,7 +129,7 @@ The above parameters map to the env variables defined in [bitnami/phabricator](h
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-$ helm install stable/phabricator --name my-release \
+$ helm install my-release stable/phabricator --name my-release \
   --set phabricatorUsername=admin,phabricatorPassword=password,mariadb.mariadbRootPassword=secretpassword \
 ```
 
@@ -138,7 +138,7 @@ The above command sets the Phabricator administrator account username and passwo
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-$ helm install --name my-release -f values.yaml stable/phabricator
+$ helm install my-release -f values.yaml stable/phabricator
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)


### PR DESCRIPTION
#### What this PR does / why we need it:
There are some commands (like `helm install`) whose syntax had been changing and there is not a compatible command that works in both cases:

Helm 2:
```
▶ helm2 install bitnami/fluentd
▶ helm2 install --name myChart bitnami/fluentd
```
Helm 3:
```
▶ helm3 install --generated-name bitnami/fluentd
▶ helm3 install myChart bitnami/fluentd
```
The first one uses a random name and the second one myChart but the syntax is different in both versions.

To unify everything and update the doc to use Helm 3, this PR uses the `helm install my-release bitnami/fluentd` way.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
