### PR TITLE
[stable/phpbb] Adapt docs to Helm 3

### DIFF
--- a/stable/phpbb/Chart.yaml
+++ b/stable/phpbb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: phpbb
-version: 7.0.4
+version: 7.0.5
 appVersion: 3.3.0
 description: Community forum that supports the notion of users and groups, file attachments, full-text search, notifications and more.
 keywords:

--- a/stable/phpbb/README.md
+++ b/stable/phpbb/README.md
@@ -5,7 +5,7 @@
 ## TL;DR;
 
 ```console
-$ helm install stable/phpbb
+$ helm install my-release stable/phpbb
 ```
 
 ## Introduction
@@ -26,7 +26,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install --name my-release stable/phpbb
+$ helm install my-release stable/phpbb
 ```
 
 The command deploys phpBB on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
@@ -116,7 +116,7 @@ The above parameters map to the env variables defined in [bitnami/phpbb](http://
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-$ helm install --name my-release \
+$ helm install my-release \
   --set phpbbUser=admin,phpbbPassword=password,mariadb.mariadbRootPassword=secretpassword \
     stable/phpbb
 ```
@@ -126,7 +126,7 @@ The above command sets the phpBB administrator account username and password to 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-$ helm install --name my-release -f values.yaml stable/phpbb
+$ helm install my-release -f values.yaml stable/phpbb
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)


### PR DESCRIPTION
#### What this PR does / why we need it:
There are some commands (like `helm install`) whose syntax had been changing and there is not a compatible command that works in both cases:

Helm 2:
```
▶ helm2 install bitnami/fluentd
▶ helm2 install --name myChart bitnami/fluentd
```
Helm 3:
```
▶ helm3 install --generated-name bitnami/fluentd
▶ helm3 install myChart bitnami/fluentd
```
The first one uses a random name and the second one myChart but the syntax is different in both versions.

To unify everything and update the doc to use Helm 3, this PR uses the `helm install my-release bitnami/fluentd` way.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
