### PR TITLE
[stable/rabbitmq] Adapt docs to Helm 3

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.17.1
+version: 6.17.2
 appVersion: 3.8.2
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -5,7 +5,7 @@
 ## TL;DR;
 
 ```bash
-$ helm install stable/rabbitmq
+$ helm install my-release stable/rabbitmq
 ```
 
 ## Introduction
@@ -25,7 +25,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 To install the chart with the release name `my-release`:
 
 ```bash
-$ helm install --name my-release stable/rabbitmq
+$ helm install my-release stable/rabbitmq
 ```
 
 The command deploys RabbitMQ on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
@@ -189,7 +189,7 @@ The above parameters map to the env variables defined in [bitnami/rabbitmq](http
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```bash
-$ helm install --name my-release \
+$ helm install my-release \
   --set rabbitmq.username=admin,rabbitmq.password=secretpassword,rabbitmq.erlangCookie=secretcookie \
     stable/rabbitmq
 ```
@@ -199,7 +199,7 @@ The above command sets the RabbitMQ admin username and password to `admin` and `
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml stable/rabbitmq
+$ helm install my-release -f values.yaml stable/rabbitmq
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
@@ -385,7 +385,7 @@ The chart mounts a [Persistent Volume](http://kubernetes.io/docs/user-guide/pers
 1. Install the chart
 
 ```bash
-$ helm install --set persistence.existingClaim=PVC_NAME rabbitmq
+$ helm install my-release --set persistence.existingClaim=PVC_NAME stable/rabbitmq
 ```
 
 ### Adjust permissions of the persistence volume mountpoint

--- a/stable/rabbitmq/templates/_helpers.tpl
+++ b/stable/rabbitmq/templates/_helpers.tpl
@@ -235,7 +235,7 @@ rabbitmq: LDAP
     Invalid LDAP configuration. When enabling LDAP support, the parameters "ldap.server",
     "ldap.port", and "ldap. user_dn_pattern" are mandatory. Please provide them:
 
-    $ helm install --name {{ .Release.Name }} stable/rabbitmq \
+    $ helm install {{ .Release.Name }} stable/rabbitmq \
       --set ldap.enabled=true \
       --set ldap.server="lmy-ldap-server" \
       --set ldap.port="389" \


### PR DESCRIPTION
#### What this PR does / why we need it:
There are some commands (like `helm install`) whose syntax had been changing and there is not a compatible command that works in both cases:

Helm 2:
```
▶ helm2 install bitnami/fluentd
▶ helm2 install --name myChart bitnami/fluentd
```
Helm 3:
```
▶ helm3 install --generated-name bitnami/fluentd
▶ helm3 install myChart bitnami/fluentd
```
The first one uses a random name and the second one myChart but the syntax is different in both versions.

To unify everything and update the doc to use Helm 3, this PR uses the `helm install my-release bitnami/fluentd` way.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
