### PR TITLE
[stable/redis] Adapt docs to Helm 3

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 10.4.3
+version: 10.4.4
 appVersion: 5.0.7
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/README.md
+++ b/stable/redis/README.md
@@ -7,12 +7,12 @@
 
 ```bash
 # Testing configuration
-$ helm install stable/redis
+$ helm install my-release stable/redis
 ```
 
 ```bash
 # Production configuration
-$ helm install stable/redis --values values-production.yaml
+$ helm install my-release stable/redis --values values-production.yaml
 ```
 
 ## Introduction
@@ -32,7 +32,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 To install the chart with the release name `my-release`:
 
 ```bash
-$ helm install --name my-release stable/redis
+$ helm install my-release stable/redis
 ```
 
 The command deploys Redis on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
@@ -246,7 +246,7 @@ The following table lists the configurable parameters of the Redis chart and the
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```bash
-$ helm install --name my-release \
+$ helm install my-release \
   --set password=secretpassword \
     stable/redis
 ```
@@ -256,7 +256,7 @@ The above command sets the Redis server password to `secretpassword`.
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml stable/redis
+$ helm install my-release -f values.yaml stable/redis
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
@@ -376,7 +376,7 @@ By default, the chart mounts a [Persistent Volume](http://kubernetes.io/docs/use
 3. Install the chart
 
 ```bash
-$ helm install --set persistence.existingClaim=PVC_NAME stable/redis
+$ helm install my-release --set persistence.existingClaim=PVC_NAME stable/redis
 ```
 
 ## NetworkPolicy
@@ -429,14 +429,14 @@ This version causes a change in the Redis Master StatefulSet definition, so the 
   - Recommended: Create a clone of the Redis Master PVC (for example, using projects like [this one](https://github.com/edseymour/pvc-transfer)). Then launch a fresh release reusing this cloned PVC.
 
    ```
-   helm install stable/redis --set persistence.existingClaim=<NEW PVC>
+   helm install my-release stable/redis --set persistence.existingClaim=<NEW PVC>
    ```
 
   - Alternative (not recommended, do at your own risk): `helm delete --purge` does not remove the PVC assigned to the Redis Master StatefulSet. As a consequence, the following commands can be done to upgrade the release
 
    ```
    helm delete --purge <RELEASE>
-   helm install stable/redis --name <RELEASE>
+   helm install my-release stable/redis --name <RELEASE>
    ```
 
 Previous versions of the chart were not using persistence in the slaves, so this upgrade would add it to them. Another important change is that no values are inherited from master to slaves. For example, in 6.0.0 `slaves.readinessProbe.periodSeconds`, if empty, would be set to `master.readinessProbe.periodSeconds`. This approach lacked transparency and was difficult to maintain. From now on, all the slave parameters must be configured just as it is done with the masters.

--- a/stable/redis/README.md
+++ b/stable/redis/README.md
@@ -436,7 +436,7 @@ This version causes a change in the Redis Master StatefulSet definition, so the 
 
    ```
    helm delete --purge <RELEASE>
-   helm install my-release stable/redis --name <RELEASE>
+   helm install <RELEASE> stable/redis
    ```
 
 Previous versions of the chart were not using persistence in the slaves, so this upgrade would add it to them. Another important change is that no values are inherited from master to slaves. For example, in 6.0.0 `slaves.readinessProbe.periodSeconds`, if empty, would be set to `master.readinessProbe.periodSeconds`. This approach lacked transparency and was difficult to maintain. From now on, all the slave parameters must be configured just as it is done with the masters.


### PR DESCRIPTION
#### What this PR does / why we need it:
There are some commands (like `helm install`) whose syntax had been changing and there is not a compatible command that works in both cases:

Helm 2:
```
▶ helm2 install bitnami/fluentd
▶ helm2 install --name myChart bitnami/fluentd
```
Helm 3:
```
▶ helm3 install --generated-name bitnami/fluentd
▶ helm3 install myChart bitnami/fluentd
```
The first one uses a random name and the second one myChart but the syntax is different in both versions.

To unify everything and update the doc to use Helm 3, this PR uses the `helm install my-release bitnami/fluentd` way.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
