### PR TITLE
[stable/wordpress] Adapt docs to Helm 3

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 8.1.2
+version: 8.1.3
 appVersion: 5.3.2
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -5,7 +5,7 @@
 ## TL;DR;
 
 ```console
-$ helm install stable/wordpress
+$ helm install my-release stable/wordpress
 ```
 
 ## Introduction
@@ -28,7 +28,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install --name my-release stable/wordpress
+$ helm install my-release stable/wordpress
 ```
 
 The command deploys WordPress on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
@@ -164,7 +164,7 @@ The above parameters map to the env variables defined in [bitnami/wordpress](htt
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-$ helm install --name my-release \
+$ helm install my-release \
   --set wordpressUsername=admin,wordpressPassword=password,mariadb.mariadbRootPassword=secretpassword \
     stable/wordpress
 ```
@@ -174,7 +174,7 @@ The above command sets the WordPress administrator account username and password
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-$ helm install --name my-release -f values.yaml stable/wordpress
+$ helm install my-release -f values.yaml stable/wordpress
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
@@ -216,7 +216,7 @@ This chart includes a `values-production.yaml` file where you can find some para
 + ## To use the /admin portal and to ensure you can scale wordpress you need to provide a
 + ## ReadWriteMany PVC, if you dont have a provisioner for this type of storage
 + ## We recommend that you install the nfs provisioner and map it to a RWO volume
-+ ## helm install stable/nfs-server-provisioner --set persistence.enabled=true,persistence.size=10Gi
++ ## helm install nfs-server stable/nfs-server-provisioner --set persistence.enabled=true,persistence.size=10Gi
 + persistence.accessMode: ReadWriteMany
 ```
 

--- a/stable/wordpress/values-production.yaml
+++ b/stable/wordpress/values-production.yaml
@@ -344,7 +344,7 @@ persistence:
   ## To use the /admin portal and to ensure you can scale wordpress you need to provide a
   ## ReadWriteMany PVC, if you dont have a provisioner for this type of storage
   ## We recommend that you install the nfs provisioner and map it to a RWO volume
-  ## helm install stable/nfs-server-provisioner --set persistence.enabled=true,persistence.size=10Gi
+  ## helm install nfs-server stable/nfs-server-provisioner --set persistence.enabled=true,persistence.size=10Gi
   accessMode: ReadWriteMany
   size: 10Gi
 


### PR DESCRIPTION
#### What this PR does / why we need it:
There are some commands (like `helm install`) whose syntax had been changing and there is not a compatible command that works in both cases:

Helm 2:
```
▶ helm2 install bitnami/fluentd
▶ helm2 install --name myChart bitnami/fluentd
```
Helm 3:
```
▶ helm3 install --generated-name bitnami/fluentd
▶ helm3 install myChart bitnami/fluentd
```
The first one uses a random name and the second one myChart but the syntax is different in both versions.

To unify everything and update the doc to use Helm 3, this PR uses the `helm install my-release bitnami/fluentd` way.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
