### PR TITLE
[stable/drupal] Adapt docs to Helm 3

### DIFF
--- a/stable/drupal/Chart.yaml
+++ b/stable/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 6.2.4
+version: 6.2.5
 appVersion: 8.8.2
 description: One of the most versatile open source content management systems.
 keywords:

--- a/stable/drupal/README.md
+++ b/stable/drupal/README.md
@@ -5,7 +5,7 @@
 ## TL;DR;
 
 ```console
-$ helm install stable/drupal
+$ helm install my-release stable/drupal
 ```
 
 ## Introduction
@@ -28,7 +28,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install --name my-release stable/drupal
+$ helm install my-release stable/drupal
 ```
 
 The command deploys Drupal on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
@@ -116,7 +116,7 @@ The above parameters map to the env variables defined in [bitnami/drupal](http:/
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-$ helm install --name my-release \
+$ helm install my-release \
   --set drupalUsername=admin,drupalPassword=password,mariadb.mariadbRootPassword=secretpassword \
     stable/drupal
 ```
@@ -126,7 +126,7 @@ The above command sets the Drupal administrator account username and password to
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-$ helm install --name my-release -f values.yaml stable/drupal
+$ helm install my-release -f values.yaml stable/drupal
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
@@ -171,7 +171,7 @@ See the [Parameters](#parameters) section to configure the PVC or to disable per
 1. Install the chart
 
 ```bash
-$ helm install --name my-release --set persistence.drupal.existingClaim=PVC_NAME stable/drupal
+$ helm install my-release --set persistence.drupal.existingClaim=PVC_NAME stable/drupal
 ```
 
 ### Host path
@@ -187,7 +187,7 @@ $ helm install --name my-release --set persistence.drupal.existingClaim=PVC_NAME
 1. Install the chart
 
     ```bash
-    $ helm install --name my-release --set persistence.drupal.hostPath=/PATH/TO/HOST/MOUNT stable/drupal
+    $ helm install my-release --set persistence.drupal.hostPath=/PATH/TO/HOST/MOUNT stable/drupal
     ```
 
     This will mount the `drupal-data` volume into the `hostPath` directory. The site data will be persisted if the mount path contains valid data, else the site data will be initialized at first launch.


### PR DESCRIPTION
#### What this PR does / why we need it:
There are some commands (like `helm install`) whose syntax had been changing and there is not a compatible command that works in both cases:

Helm 2:
```
▶ helm2 install bitnami/fluentd
▶ helm2 install --name myChart bitnami/fluentd
```
Helm 3:
```
▶ helm3 install --generated-name bitnami/fluentd
▶ helm3 install myChart bitnami/fluentd
```
The first one uses a random name and the second one myChart but the syntax is different in both versions.

To unify everything and update the doc to use Helm 3, this PR uses the `helm install my-release bitnami/fluentd` way.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
