### PR TITLE
[stable/kubewatch] Adapt docs to Helm 3

### DIFF
--- a/stable/kubewatch/Chart.yaml
+++ b/stable/kubewatch/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubewatch
-version: 1.0.4
+version: 1.0.5
 apiVersion: v1
 appVersion: 0.0.4
 home: https://github.com/bitnami-labs/kubewatch

--- a/stable/kubewatch/README.md
+++ b/stable/kubewatch/README.md
@@ -6,7 +6,7 @@
 ## TL;DR;
 
 ```console
-$ helm install stable/kubewatch
+$ helm install my-release stable/kubewatch
 ```
 
 ## Introduction
@@ -23,7 +23,7 @@ This chart bootstraps a kubewatch deployment on a [Kubernetes](http://kubernetes
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install stable/kubewatch --name my-release
+$ helm install my-release stable/kubewatch --name my-release
 ```
 
 The command deploys kubewatch on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
@@ -91,14 +91,14 @@ The following table lists the configurable parameters of the kubewatch chart and
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-$ helm install stable/kubewatch --name my-release \
+$ helm install my-release stable/kubewatch --name my-release \
   --set=slack.channel="#bots",slack.token="XXXX-XXXX-XXXX"
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-$ helm install stable/kubewatch --name my-release -f values.yaml
+$ helm install my-release stable/kubewatch --name my-release -f values.yaml
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/kubewatch/README.md
+++ b/stable/kubewatch/README.md
@@ -23,7 +23,7 @@ This chart bootstraps a kubewatch deployment on a [Kubernetes](http://kubernetes
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install my-release stable/kubewatch --name my-release
+$ helm install my-release stable/kubewatch
 ```
 
 The command deploys kubewatch on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
@@ -91,14 +91,14 @@ The following table lists the configurable parameters of the kubewatch chart and
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-$ helm install my-release stable/kubewatch --name my-release \
+$ helm install my-release stable/kubewatch \
   --set=slack.channel="#bots",slack.token="XXXX-XXXX-XXXX"
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-$ helm install my-release stable/kubewatch --name my-release -f values.yaml
+$ helm install my-release -f values.yaml stable/kubewatch
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)


### PR DESCRIPTION
#### What this PR does / why we need it:
There are some commands (like `helm install`) whose syntax had been changing and there is not a compatible command that works in both cases:

Helm 2:
```
▶ helm2 install bitnami/fluentd
▶ helm2 install --name myChart bitnami/fluentd
```
Helm 3:
```
▶ helm3 install --generated-name bitnami/fluentd
▶ helm3 install myChart bitnami/fluentd
```
The first one uses a random name and the second one myChart but the syntax is different in both versions.

To unify everything and update the doc to use Helm 3, this PR uses the `helm install my-release bitnami/fluentd` way.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
