### PR TITLE
[stable/sealed-secrets] Add priorityClassName to sealed-secrets

### DIFF
--- a/stable/sealed-secrets/Chart.yaml
+++ b/stable/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.7.4
+version: 1.7.5
 appVersion: 0.9.7
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/stable/sealed-secrets/README.md
+++ b/stable/sealed-secrets/README.md
@@ -66,6 +66,7 @@ Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-la
 | **ingress.hosts**             | Ingress accepted hostnames                                                 | `["chart-example.local"]`                   |
 | **ingress.tls**               | Ingress TLS configuration                                                  | `[]`                                        |
 | **podAnnotations**            | Annotations to annotate pods with.                                         | `{}`                                        |
+| **priorityClassName**         | Optional class to specify priority for pods                                | `""`                                        |
 
 
 - In the case that **serviceAccount.create** is `false` and **rbac.create** is `true` it is expected for a service account with the name **serviceAccount.name** to exist _in the same namespace as this chart_ before installation.

--- a/stable/sealed-secrets/templates/deployment.yaml
+++ b/stable/sealed-secrets/templates/deployment.yaml
@@ -25,6 +25,9 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ template "sealed-secrets.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
       containers:
         - name: {{ template "sealed-secrets.fullname" . }}
           command:

--- a/stable/sealed-secrets/values.yaml
+++ b/stable/sealed-secrets/values.yaml
@@ -52,3 +52,5 @@ securityContext:
   runAsUser: 1001
 
 podAnnotations: {}
+
+priorityClassName: ""


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Adds `priorityClassName` to [Sealed Secrets chart](https://github.com/helm/charts/tree/master/stable/sealed-secrets)

#### Which issue this PR fixes
None

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)