### PR TITLE
[stable/external-dns] Add support for the TransIP provider

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.16.3
+version: 2.17.0
 appVersion: 0.6.0
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -123,6 +123,8 @@ The following table lists the configurable parameters of the external-dns chart 
 | `pdns.apiUrl`                       | When using the PowerDNS provider, specify the API URL of the server.                                     | `""`                                                        |
 | `pdns.apiPort`                      | When using the PowerDNS provider, specify the API port of the server.                                    | `8081`                                                      |
 | `pdns.apiKey`                       | When using the PowerDNS provider, specify the API key of the server.                                     | `""`                                                        |
+| `transip.account`                   | When using the TransIP provider, specify the account name.                                               | `""`                                                        |
+| `transip.apiKey`                    | When using the TransIP provider, specify the API key to use.                                             | `""`                                                        |
 | `annotationFilter`                  | Filter sources managed by external-dns via annotation using label selector (optional)                    | `""`                                                        |
 | `domainFilters`                     | Limit possible target zones by domain suffixes (optional)                                                | `[]`                                                        |
 | `zoneIdFilters`                     | Limit possible target zones by zone id (optional)                                                        | `[]`                                                        |

--- a/stable/external-dns/templates/_helpers.tpl
+++ b/stable/external-dns/templates/_helpers.tpl
@@ -130,6 +130,8 @@ Return true if a secret object should be created
     {{- true -}}
 {{- else if and (eq .Values.provider "pdns") .Values.pdns.apiKey -}}
     {{- true -}}
+{{- else if and (eq .Values.provider "transip") .Values.transip.apiKey -}}
+    {{- true -}}
 {{- else -}}
 {{- end -}}
 {{- end -}}
@@ -201,6 +203,8 @@ Compile all warnings into a single message, and call fail.
 {{- $messages := append $messages (include "external-dns.validateValues.azure.useManagedIdentityExtensionAadClientSecret" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.azure.aadClientId" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.azure.aadClientSecret" .) -}}
+{{- $messages := append $messages (include "external-dns.validateValues.transip.account" .) -}}
+{{- $messages := append $messages (include "external-dns.validateValues.transip.apiKey" .) -}}
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 
@@ -396,5 +400,29 @@ Validate values of Azure DNS:
 external-dns: azure.seManagedIdentityExtension
     You must provide the Azure AAD Client Secret when provider="azure" and useManagedIdentityExtension is not set.
     Please set set the aadClientSecret parameter (--set azure.aadClientSecret="xxxx")
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of TransIP DNS:
+- must provide the account name when provider is "transip"
+*/}}
+{{- define "external-dns.validateValues.transip.account" -}}
+{{- if and (eq .Values.provider "transip") (not .Values.transip.account) -}}
+external-dns: transip.account
+    You must provide the TransIP account name when provider="transip".
+    Please set the account parameter (--set transip.account="xxxx")
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of TransIP DNS:
+- must provide the API key when provider is "transip"
+*/}}
+{{- define "external-dns.validateValues.transip.apiKey" -}}
+{{- if and (eq .Values.provider "transip") (not .Values.transip.apiKey) -}}
+external-dns: transip.apiKey
+    You must provide the TransIP API key when provider="transip".
+    Please set the apiKey parameter (--set transip.apiKey="xxxx")
 {{- end -}}
 {{- end -}}

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -189,6 +189,11 @@ spec:
         - --pdns-server={{ .Values.pdns.apiUrl }}:{{ .Values.pdns.apiPort }}
         - --pdns-api-key=$(PDNS_API_KEY)
         {{- end }}
+        # TransIP arguments
+        {{- if eq .Values.provider "transip" }}
+        - --transip-account={{ .Values.transip.account }}
+        - --transip-keyfile=/transip/transip-api-key
+        {{- end }}
         # Extra arguments
         {{- range $key, $value := .Values.extraArgs }}
           {{- if $value }}
@@ -366,6 +371,12 @@ spec:
           mountPath: {{ .Values.designate.customCA.mountPath }}
           readOnly: true
         {{- end }}
+        # TransIP mountPath(s)
+        {{- if (eq .Values.provider "transip") }}
+        - name: transip-api-key
+          mountPath: /transip
+          readOnly: true
+        {{- end }}
       volumes:
       # AWS volume(s)
       {{- if and (eq .Values.provider "aws") (or (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey) .Values.aws.credentials.secretName) }}
@@ -411,4 +422,10 @@ spec:
           items:
           - key: {{ .Values.designate.customCA.filename }}
             path: {{ .Values.designate.customCA.filename }}
+      {{- end }}
+      # TransIP volume(s)
+      {{- if (eq .Values.provider "transip") }}
+      - name: transip-api-key
+        secret:
+          name: {{ template "external-dns.fullname" . }}
       {{- end }}

--- a/stable/external-dns/templates/secret.yaml
+++ b/stable/external-dns/templates/secret.yaml
@@ -38,4 +38,7 @@ data:
   {{- if eq .Values.provider "rfc2136" }}
   rfc2136_tsig_secret: {{ .Values.rfc2136.tsigSecret | b64enc | quote }}
   {{- end }}
+  {{- if eq .Values.provider "transip" }}
+  transip-api-key: {{ .Values.transip.apiKey | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/stable/external-dns/values-production.yaml
+++ b/stable/external-dns/values-production.yaml
@@ -40,7 +40,7 @@ sources:
 # - crd
 
 ## DNS provider where the DNS records will be created. Available providers are:
-## - aws, azure, cloudflare, coredns, designate, digitalocoean, google, infoblox, rfc2136
+## - aws, azure, cloudflare, coredns, designate, digitalocoean, google, infoblox, rfc2136, transip
 ##
 provider: aws
 
@@ -267,6 +267,16 @@ rfc2136:
 pdns:
   apiUrl: ""
   apiPort: "8081"
+  apiKey: ""
+
+## TransIP configuration to be set via arguments/env. variables
+##
+transip:
+  ## Account name to be used
+  ##
+  account: ""
+  ##
+  ## API key that is authorised for the account
   apiKey: ""
 
 ## Limit possible target zones by domain suffixes (optional)

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -40,7 +40,7 @@ sources:
 # - crd
 
 ## DNS provider where the DNS records will be created. Available providers are:
-## - aws, azure, azure-private-dns, cloudflare, coredns, designate, digitalocean, google, infoblox, rfc2136
+## - aws, azure, azure-private-dns, cloudflare, coredns, designate, digitalocean, google, infoblox, rfc2136, transip
 ##
 provider: aws
 
@@ -266,6 +266,16 @@ rfc2136:
 pdns:
   apiUrl: ""
   apiPort: "8081"
+  apiKey: ""
+
+## TransIP configuration to be set via arguments/env. variables
+##
+transip:
+  ## Account name to be used
+  ##
+  account: ""
+  ##
+  ## API key that is authorised for the account
   apiKey: ""
 
 ## Limit possible target zones by domain suffixes (optional)


### PR DESCRIPTION
As described here: https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/transip.md

#### What this PR does / why we need it:
This adds support for the TransIP provider. As this basically adds a new "feature", I thought it warranted a minor version bump.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
