### PR TITLE
[stable/docker-registry] #20711 addition of new values so we can add arbitrary environment values to the registry container, which allows us to selectively override values from the config file

### DIFF
--- a/stable/docker-registry/Chart.yaml
+++ b/stable/docker-registry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Docker Registry
 name: docker-registry
-version: 1.9.1
+version: 1.9.2
 appVersion: 2.7.1
 home: https://hub.docker.com/_/registry/
 icon: https://hub.docker.com/public/images/logos/mini-logo.svg

--- a/stable/docker-registry/README.md
+++ b/stable/docker-registry/README.md
@@ -75,6 +75,7 @@ their default values.
 | `ingress.tls`               | Ingress TLS configuration (YAML)                                                           | `[]`            |
 | `extraVolumeMounts`         | Additional volumeMounts to the registry container                                          | `[]`            |
 | `extraVolumes`              | Additional volumes to the pod                                                              | `[]`            |
+| `extraEnv`                  | Additional environment variables to the registry container                                 | `[]`            |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.

--- a/stable/docker-registry/templates/deployment.yaml
+++ b/stable/docker-registry/templates/deployment.yaml
@@ -71,6 +71,9 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           env:
+{{- if .Values.extraEnv }}
+{{- toYaml .Values.extraEnv | nindent 12 }}
+{{- end }}
 {{- if .Values.secrets.htpasswd }}
             - name: REGISTRY_AUTH
               value: "htpasswd"
@@ -157,6 +160,9 @@ spec:
 {{- if .Values.persistence.deleteEnabled }}
             - name: REGISTRY_STORAGE_DELETE_ENABLED
               value: "true"
+{{- end }}
+{{- if .Values.extraEnv }}
+{{- toYaml .Values.extraEnv | nindent 12 }}
 {{- end }}
           volumeMounts:
 {{- if .Values.secrets.htpasswd }}

--- a/stable/docker-registry/values.yaml
+++ b/stable/docker-registry/values.yaml
@@ -141,3 +141,11 @@ extraVolumes: []
 #        - key: cloudfront.pem
 #          path: cloudfront.pem
 #          mode: 511
+
+extraEnv: []
+## Additional environment variables to the registry container.
+#  - name: "REGISTRY_PROXY_PASSWORD"
+#    valueFrom:
+#      secretKeyRef:
+#        key: password
+#        name: docker-registry-proxy-credentials


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
* #20711 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
