### PR TITLE
[stable/redis] allow all pods from chart to talk to eachother

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 10.5.0
+version: 10.5.1
 appVersion: 5.0.7
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/networkpolicy.yaml
+++ b/stable/redis/templates/networkpolicy.yaml
@@ -46,20 +46,10 @@ spec:
       - podSelector:
           matchLabels:
             {{ template "redis.fullname" . }}-client: "true"
-      {{- if .Values.metrics.enabled }}
       - podSelector:
           matchLabels:
             app: {{ template "redis.name" . }}
             release: {{ .Release.Name }}
-            role: metrics
-      {{- end }}
-      {{- if .Values.cluster.enabled }}
-      - podSelector:
-          matchLabels:
-            app: {{ template "redis.name" . }}
-            release: {{ .Release.Name }}
-            role: slave
-      {{- end }}
       {{- if .Values.networkPolicy.ingressNSMatchLabels }}
       - namespaceSelector:
           matchLabels:


### PR DESCRIPTION
#### What this PR does / why we need it:

As it was only `metrics`, `slave` components can talk to the other pods. We needed to add `master` component to be able to talk to pods (e.g. sentinel, when master dies and restarts as a replica and asks the peer pods for list of sentinel nodes).

Instead of adding yet another item to the from list, I simply removed the component label. Let all pods from the chart talk to eachother.


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
