### PR TITLE
[stable/nginx-ingress] Apply default backend service command line argument if one is configured

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.30.1
+version: 1.30.2
 appVersion: 0.28.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -67,7 +67,9 @@ spec:
           {{- if .Values.defaultBackend.enabled }}
             - --default-backend-service={{ .Release.Namespace }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}
           {{- else }}
-            {{- if and (semverCompare "<0.21.0" .Values.controller.image.tag) }}
+            {{- if (semverCompare "<0.21.0" .Values.controller.image.tag) }}
+            - --default-backend-service={{ required ".Values.controller.defaultBackendService is required if .Values.defaultBackend.enabled=false and .Values.controller.image.tag < 0.21.0" .Values.controller.defaultBackendService }}
+            {{- else if .Values.controller.defaultBackendService }}
             - --default-backend-service={{ .Values.controller.defaultBackendService }}
             {{- end }}
           {{- end }}

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -68,7 +68,9 @@ spec:
           {{- if .Values.defaultBackend.enabled }}
             - --default-backend-service={{ .Release.Namespace }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}
           {{- else }}
-            {{- if and (semverCompare "<0.21.0" .Values.controller.image.tag) }}
+            {{- if (semverCompare "<0.21.0" .Values.controller.image.tag) }}
+            - --default-backend-service={{ required ".Values.controller.defaultBackendService is required if .Values.defaultBackend.enabled=false and .Values.controller.image.tag < 0.21.0" .Values.controller.defaultBackendService }}
+            {{- else if .Values.controller.defaultBackendService }}
             - --default-backend-service={{ .Values.controller.defaultBackendService }}
             {{- end }}
           {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
PR #20297 changed the deployment behaviour of the chart if it is configured with: 

* `.Values.defaultBackend.enabled=false`
* `.Values.controller.defaultBackendService=my-namespace/my-default-backend-server`

As a result, the controller no longer uses the default backend that is configured with the values mentioned above but the default 404 error page of nginx.

That configuration combination is useful if you want to deploy your own default backend independently of this chart and you don't want to configure the `default-backend-service` command line argument through `.Values.controller.extraArgs`

This PR restores the previous deployment behaviour while keeping the intent of PR #20297 intact.

#### Which issue this PR fixes
None

#### Special notes for your reviewer:
None

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
