### PR TITLE
[stable/airflow] Fix postgres parameters

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 6.0.0
+version: 6.0.1
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/templates/_helpers.tpl
+++ b/stable/airflow/templates/_helpers.tpl
@@ -98,7 +98,7 @@ The key names for postgres and redis are fixed, which is consistent with the sub
 */}}
 {{- define "airflow.mapenvsecrets" }}
   - name: POSTGRES_USER
-    value: {{ default "postgres" .Values.postgresql.postgresUser | quote }}
+    value: {{ default "postgres" .Values.postgresql.postgresqlUsername | quote }}
   {{- if or .Values.postgresql.existingSecret .Values.postgresql.enabled }}
   - name: POSTGRES_PASSWORD
     valueFrom:

--- a/stable/airflow/templates/configmap-env.yaml
+++ b/stable/airflow/templates/configmap-env.yaml
@@ -13,7 +13,7 @@ data:
   ## Postgres DB configuration
   POSTGRES_HOST: "{{ template "airflow.postgresql.fullname" . }}"
   POSTGRES_PORT: "{{ .Values.postgresql.service.port }}"
-  POSTGRES_DB: "{{ .Values.postgresql.postgresDatabase }}"
+  POSTGRES_DB: "{{ .Values.postgresql.postgresqlDatabase }}"
   {{- if eq .Values.airflow.executor "Celery" }}
   ## Redis DB configuration
   REDIS_HOST: "{{ template "airflow.redis.host" . }}"

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -604,7 +604,9 @@ postgresql:
 
   ##
   ## If you are bringing your own PostgreSQL, you should set postgresHost and
-  ## also probably service.port, postgresUser, postgresPassword, and postgresDatabase
+  ## also probably service.port, postgresqlUsername, postgresqlPassword, and
+  ## postgresqlDatabase.
+  ##
   ## postgresHost:
   ##
   ## PostgreSQL port


### PR DESCRIPTION
#### Is this a new chart
No, it is not.

#### What this PR does / why we need it:
The postgres related parameters are not passed correctly, eg.  in version 6.0.0 postgresDatabase changed to postgresqlDatabase.

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
