### PR TITLE
[stable/docker-registry] Set default type for updateStrategy

### DIFF
--- a/stable/docker-registry/Chart.yaml
+++ b/stable/docker-registry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Docker Registry
 name: docker-registry
-version: 1.9.1
+version: 1.9.2
 appVersion: 2.7.1
 home: https://hub.docker.com/_/registry/
 icon: https://hub.docker.com/public/images/logos/mini-logo.svg

--- a/stable/docker-registry/values.yaml
+++ b/stable/docker-registry/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 replicaCount: 1
 
-updateStrategy:
+updateStrategy: {}
   # type: RollingUpdate
   # rollingUpdate:
   #   maxSurge: 1


### PR DESCRIPTION
#### What this PR does / why we need it:
Resolving warning due helm upgrade/install/template
```
coalesce.go:165: warning: skipped value for updateStrategy: Not a table.
````
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
