### PR TITLE
[mssql/linux] Allow setting tolerations, affinity, and securityContext

### DIFF
--- a/stable/mssql-linux/Chart.yaml
+++ b/stable/mssql-linux/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: SQL Server 2017 Linux Helm Chart
 name: mssql-linux
-version: 0.11.0
+version: 0.11.1
 appVersion: 14.0.3023.8
 home: https://hub.docker.com/r/microsoft/mssql-server-linux/
 icon: https://img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE1I4Dx

--- a/stable/mssql-linux/README.md
+++ b/stable/mssql-linux/README.md
@@ -87,48 +87,51 @@ Express Edition (64-bit) on Linux (Ubuntu 16.04.3 LTS)
 
 The configuration parameters in this section control the resources requested and utilized by the SQL Server instance.
 
-| Parameter        | Description                                                                                    | Default                          |
-| ---------------- | ---------------------------------------------------------------------------------------------- | -------------------------------- |
-| acceptEula.value | EULA that needs to be accepted.  It will need to be changed via commandline or values.yaml.    | `n`                              |
-| edition.value    | The edition of SQL Server to install.  See section [Editions](#sql-server-for-linux-editions). | `Express`                        |
-| sapassword       | Password for sa login                                                                          | `Random (20-AlphNum)`<sup>1<sup> |
-| existingSecret   | Name of an existing secret containing the sa password                                          | `Empty String`                   |
-| existingSecretKey| Name of key of the password in existing secret                                                 | `sapassword`                     |
-| image.repository | The docker hub repo for SQL Server                                                             | `microsoft/mssql-server-linux`   |
-| image.tag        | The tag for the image                                                                          | `2017-CU5`                       |
-| image.pullPolicy | The pull policy for the deployment                                                             | `IfNotPresent`                   |
-| image.pullSecrets   | Specify an image pull secret if needed  | `Commented Out`  |
-| nodeSelector     | Node labels for pod assignment                                                                 | `{}`                             |
-| service.headless   | Allows you to setup a headless service  | `false`  |
-| service.type     | Service Type                                                                                   | `ClusterIP`                      |
-| service.loadBalancerIP     | Loadbalancer IP                                                                                   | `nil`                      |
-| service.port     | Service Port                                                                                   | `1433`                           |
-| service.nodePort | Optional NodePort to use when `service.type` is `NodePort`                                     | None                             |
-| service.annotations | Kubernetes service annotations                                                              | `{}`                             |
-| service.labels   | Kubernetes service labels                                                                      | `{}`                             |
-| deployment.annotations | Kubernetes deployment annotations                                                        | `{}`                             |
-| deployment.labels | Kubernetes deployment labels                                                                  | `{}`                             |
-| pod.annotations   | Kubernetes pod annotations                                                                    | `{}`                             |
-| pod.labels        | Kubernetes pod labels                                                                         | `{}`                             |
-| collation        | Default collation for SQL Server                                                               | `SQL_Latin1_General_CP1_CI_AS`   |
-| lcid             | Default languages for SQL Server                                                               | `1033`                           |
-| hadr             | Enable Availability Group                                                                      | `0`                              |
-| agent.enabled    | Enable Agent                                                                                   | `false`                          |
-| schedulerName    | Name of the k8s scheduler (other than default)                                                 | `nil`                            |
-| persistence.enabled | Persist the Data and Log files for SQL Server                                               | `true`                          |
-| persistence.existingDataClaim | Identify an existing Claim to be used for the Data Directory                      | `Commented Out`                  |
-| persistence.existingTransactionLogClaim  | Identify an existing Claim to be used for the Log Directory            | `Commented Out`                  |
-| persistence.existingBackupClaim | Identify an existing Claim to be used for the SQL Database Backups              | `Commented Out`                  |
-| persistence.existingMasterClaim | Identify an existing Claim to be used for the Master Database log & file        | `Commented Out`                  |
-| persistence.storageClass      | Storage Class to be used                                                          | `Commented Out`                  |
-| persistence.dataAccessMode    | Data Access Mode to be used for the Data Directory                                | `ReadWriteOnce`                  |
-| persistence.dataSize          | PVC Size for Data Directory                                                       | `1Gi`                            |
-| persistence.logAccessMode     | Data Access Mode to be used for the Log Directory                                 | `ReadWriteOnce`                  |
-| persistence.logSize           | PVC Size for Log Directory                                                        | `1Gi`                            |
-| persistence.backupAccessMode  | Data Access Mode to be used for the Backup Directory                              | `ReadWriteOnce`                  |
-| persistence.backupSize        | PVC Size for Backup Directory                                                     | `1Gi`                            |
-| persistence.masterAccessMode  | Data Access Mode to be used for the Master Database                               | `ReadWriteOnce`                  |
-| persistence.masterSize        | PVC Size for Master Database                                                      | `1Gi`                            |
+| Parameter                               | Description                                                                                    | Default                          |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------- | -------------------------------- |
+| acceptEula.value                        | EULA that needs to be accepted.  It will need to be changed via commandline or values.yaml.    | `n`                              |
+| edition.value                           | The edition of SQL Server to install.  See section [Editions](#sql-server-for-linux-editions). | `Express`                        |
+| sapassword                              | Password for sa login                                                                          | `Random (20-AlphNum)`<sup>1<sup> |
+| existingSecret                          | Name of an existing secret containing the sa password                                          | `Empty String`                   |
+| existingSecretKey                       | Name of key of the password in existing secret                                                 | `sapassword`                     |
+| image.repository                        | The docker hub repo for SQL Server                                                             | `microsoft/mssql-server-linux`   |
+| image.tag                               | The tag for the image                                                                          | `2017-CU5`                       |
+| image.pullPolicy                        | The pull policy for the deployment                                                             | `IfNotPresent`                   |
+| image.pullSecrets                       | Specify an image pull secret if needed                                                         | `Commented Out`                  |
+| nodeSelector                            | Node labels for pod assignment                                                                 | `{}`                             |
+| service.headless                        | Allows you to setup a headless service                                                         | `false`                          |
+| service.type                            | Service Type                                                                                   | `ClusterIP`                      |
+| service.loadBalancerIP                  | Loadbalancer IP                                                                                | `nil`                            |
+| service.port                            | Service Port                                                                                   | `1433`                           |
+| service.nodePort                        | Optional NodePort to use when `service.type` is `NodePort`                                     | None                             |
+| service.annotations                     | Kubernetes service annotations                                                                 | `{}`                             |
+| service.labels                          | Kubernetes service labels                                                                      | `{}`                             |
+| deployment.annotations                  | Kubernetes deployment annotations                                                              | `{}`                             |
+| deployment.labels                       | Kubernetes deployment labels                                                                   | `{}`                             |
+| pod.annotations                         | Kubernetes pod annotations                                                                     | `{}`                             |
+| pod.labels                              | Kubernetes pod labels                                                                          | `{}`                             |
+| collation                               | Default collation for SQL Server                                                               | `SQL_Latin1_General_CP1_CI_AS`   |
+| lcid                                    | Default languages for SQL Server                                                               | `1033`                           |
+| hadr                                    | Enable Availability Group                                                                      | `0`                              |
+| agent.enabled                           | Enable Agent                                                                                   | `false`                          |
+| schedulerName                           | Name of the k8s scheduler (other than default)                                                 | `nil`                            |
+| persistence.enabled                     | Persist the Data and Log files for SQL Server                                                  | `true`                           |
+| persistence.existingDataClaim           | Identify an existing Claim to be used for the Data Directory                                   | `Commented Out`                  |
+| persistence.existingTransactionLogClaim | Identify an existing Claim to be used for the Log Directory                                    | `Commented Out`                  |
+| persistence.existingBackupClaim         | Identify an existing Claim to be used for the SQL Database Backups                             | `Commented Out`                  |
+| persistence.existingMasterClaim         | Identify an existing Claim to be used for the Master Database log & file                       | `Commented Out`                  |
+| persistence.storageClass                | Storage Class to be used                                                                       | `Commented Out`                  |
+| persistence.dataAccessMode              | Data Access Mode to be used for the Data Directory                                             | `ReadWriteOnce`                  |
+| persistence.dataSize                    | PVC Size for Data Directory                                                                    | `1Gi`                            |
+| persistence.logAccessMode               | Data Access Mode to be used for the Log Directory                                              | `ReadWriteOnce`                  |
+| persistence.logSize                     | PVC Size for Log Directory                                                                     | `1Gi`                            |
+| persistence.backupAccessMode            | Data Access Mode to be used for the Backup Directory                                           | `ReadWriteOnce`                  |
+| persistence.backupSize                  | PVC Size for Backup Directory                                                                  | `1Gi`                            |
+| persistence.masterAccessMode            | Data Access Mode to be used for the Master Database                                            | `ReadWriteOnce`                  |
+| persistence.masterSize                  | PVC Size for Master Database                                                                   | `1Gi`                            |
+| tolerations                             | List of node taints to tolerate                                                                | `[]`                             |
+| affinity                                | Map of node/pod affinities                                                                     | `{}`                             |
+| securityContext                         | SecurityContext to apply to the pod                                                            | `{}`                             |
 
 > 1 - [Please read password requirements](https://docs.microsoft.com/en-us/sql/relational-databases/security/password-policy)
 
@@ -145,10 +148,10 @@ The SQL Server instance has liveness and readiness checks specified. These param
 
 ### Readiness Probes
 
-| Parameter                           | Description                                                                          | Default |
-| ----------------------------------- | ------------------------------------------------------------------------------------ | ------- |
-| readinessprobe.initialDelaySeconds  | Tells the kubelet that it should wait XX second(s) before performing the first probe | 5       |
-| readinessprobe.periodSeconds        | Field specifies that the kubelet should perform a liveness probe every XX second(s)  | 10      |
+| Parameter                          | Description                                                                          | Default |
+| ---------------------------------- | ------------------------------------------------------------------------------------ | ------- |
+| readinessprobe.initialDelaySeconds | Tells the kubelet that it should wait XX second(s) before performing the first probe | 5       |
+| readinessprobe.periodSeconds       | Field specifies that the kubelet should perform a liveness probe every XX second(s)  | 10      |
 
 ## Resources
 

--- a/stable/mssql-linux/templates/deployment.yaml
+++ b/stable/mssql-linux/templates/deployment.yaml
@@ -109,6 +109,18 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
+    {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}
+    {{- if .Values.securityContext }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+    {{- end }}
       volumes:
       - name: data
       {{- if .Values.persistence.enabled }}

--- a/stable/mssql-linux/values.yaml
+++ b/stable/mssql-linux/values.yaml
@@ -70,3 +70,10 @@ resources:
   #  memory: 2Gi
 nodeSelector: {}
   # kubernetes.io/hostname: minikube
+
+tolerations: []
+
+affinity: {}
+
+securityContext: {}
+  # runAsUser: 1000


### PR DESCRIPTION
## Is this a new chart
No

#### What this PR does / why we need it:
Tolerations and affinity allow better node scheduling. Security Context is required to comply with cluster PodSecurityPolicies (SQL Server 2019 runs as non-root).

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
