### PR TITLE
[stable/etcd-operator] Allow for setting priority classes.

### DIFF
--- a/stable/etcd-operator/Chart.yaml
+++ b/stable/etcd-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: CoreOS etcd-operator Helm chart for Kubernetes
 name: etcd-operator
-version: 0.10.2
+version: 0.10.3
 appVersion: 0.9.4
 home: https://github.com/coreos/etcd-operator
 icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png

--- a/stable/etcd-operator/README.md
+++ b/stable/etcd-operator/README.md
@@ -80,6 +80,7 @@ The following table lists the configurable parameters of the etcd-operator chart
 | `etcdOperator.nodeSelector`                       | Node labels for etcd operator pod assignment                         | `{}`                                           |
 | `etcdOperator.podAnnotations`                     | Annotations for the etcd operator pod                                | `{}`                                           |
 | `etcdOperator.commandArgs`                        | Additional command arguments                                         | `{}`                                           |
+| `etcdOperator.priorityClassName`                  | Priority class for the etcd-operator pod(s)                          | `""`                                           |
 | `backupOperator.name`                             | Backup operator name                                                 | `etcd-backup-operator`                         |
 | `backupOperator.replicaCount`                     | Number of operator replicas to create (only 1 is supported)          | `1`                                            |
 | `backupOperator.image.repository`                 | Operator container image                                             | `quay.io/coreos/etcd-operator`                 |
@@ -93,6 +94,7 @@ The following table lists the configurable parameters of the etcd-operator chart
 | `backupOperator.spec.s3.awsSecret`                | Name of kubernetes secret containing aws credentials                 |                                                |
 | `backupOperator.nodeSelector`                     | Node labels for etcd operator pod assignment                         | `{}`                                           |
 | `backupOperator.commandArgs`                      | Additional command arguments                                         | `{}`                                           |
+| `backupOperator.priorityClassName`                | Priority class for the etcd-backuop-operator pod(s)                  | `""`                                           |
 | `restoreOperator.name`                            | Restore operator name                                                | `etcd-backup-operator`                         |
 | `restoreOperator.replicaCount`                    | Number of operator replicas to create (only 1 is supported)          | `1`                                            |
 | `restoreOperator.image.repository`                | Operator container image                                             | `quay.io/coreos/etcd-operator`                 |
@@ -105,6 +107,7 @@ The following table lists the configurable parameters of the etcd-operator chart
 | `restoreOperator.spec.s3.awsSecret`               | Name of kubernetes secret containing aws credentials                 |                                                |
 | `restoreOperator.nodeSelector`                    | Node labels for etcd operator pod assignment                         | `{}`                                           |
 | `restoreOperator.commandArgs`                     | Additional command arguments                                         | `{}`                                           |
+| `restoreOperator.priorityClassName`               | Priority class for the etcd-restore-operator pod(s)                  | `""`                                           |
 | `etcdCluster.name`                                | etcd cluster name                                                    | `etcd-cluster`                                 |
 | `etcdCluster.size`                                | etcd cluster size                                                    | `3`                                            |
 | `etcdCluster.version`                             | etcd cluster version                                                 | `3.2.25`                                       |

--- a/stable/etcd-operator/templates/backup-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/backup-operator-deployment.yaml
@@ -22,6 +22,9 @@ spec:
         app: {{ template "etcd-backup-operator.fullname" . }}
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.backupOperator.priorityClassName }}
+      priorityClassName: {{ .Values.backupOperator.priorityClassName }}
+      {{- end }}
       serviceAccountName: {{ template "etcd-operator.serviceAccountName" . }}
       containers:
       - name: {{ .Values.backupOperator.name }}

--- a/stable/etcd-operator/templates/operator-deployment.yaml
+++ b/stable/etcd-operator/templates/operator-deployment.yaml
@@ -23,6 +23,9 @@ spec:
         release: {{ .Release.Name }}
       annotations: {{ toYaml .Values.etcdOperator.podAnnotations | nindent 8}}
     spec:
+      {{- if .Values.etcdOperator.priorityClassName }}
+      priorityClassName: {{ .Values.etcdOperator.priorityClassName }}
+      {{- end }}
       serviceAccountName: {{ template "etcd-operator.serviceAccountName" . }}
       containers:
       - name: {{ template "etcd-operator.fullname" . }}

--- a/stable/etcd-operator/templates/restore-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/restore-operator-deployment.yaml
@@ -22,6 +22,9 @@ spec:
         app: {{ template "etcd-restore-operator.name" . }}
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.restoreOperator.priorityClassName }}
+      priorityClassName: {{ .Values.restoreOperator.priorityClassName }}
+      {{- end }}
       serviceAccountName: {{ template "etcd-operator.serviceAccountName" . }}
       containers:
       - name: {{ .Values.restoreOperator.name }}

--- a/stable/etcd-operator/values.yaml
+++ b/stable/etcd-operator/values.yaml
@@ -38,6 +38,7 @@ customResources:
 
 # etcdOperator
 etcdOperator:
+  priorityClassName: ""
   name: etcd-operator
   replicaCount: 1
   image:
@@ -72,6 +73,7 @@ etcdOperator:
 
 # backup spec
 backupOperator:
+  priorityClassName: ""
   name: etcd-backup-operator
   replicaCount: 1
   image:
@@ -97,6 +99,7 @@ backupOperator:
 
 # restore spec
 restoreOperator:
+  priorityClassName: ""
   name: etcd-restore-operator
   replicaCount: 1
   image:


### PR DESCRIPTION
#### Is this a new chart

No.

#### What this PR does / why we need it:

Allows for setting priority classes for the `etcd-operator`, `etcd-backup-operator` and `etcd-restore-operator` pods.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

N/A

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)