### PR TITLE
[stable/influxdb] labels, serviceaccount and remove clusterIP specificity

### DIFF
--- a/stable/influxdb/Chart.yaml
+++ b/stable/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 3.2.1
+version: 4.0.0
 appVersion: 1.7.6
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/stable/influxdb/README.md
+++ b/stable/influxdb/README.md
@@ -78,7 +78,7 @@ To enable InfluxDB Enterprise, set the following keys and values in a values fil
 | `service.ClusterIP` | Use a headless service for StatefulSets | `"None"` |
 | `env.name[_HOSTNAME]` | Used to provide a unique `name.service` for InfluxDB. See [values.yaml]() for an example | `valueFrom.fieldRef.fieldPath: metadata.name` |
 | `enterprise.enabled` | Create StatefulSets for use with `influx-data` and `influx-meta` images | `true` |
-| `enterprise.licensekey` | License for InfluxDB Enterprise |  | 
+| `enterprise.licensekey` | License for InfluxDB Enterprise |  |
 | `enterprise.clusterSize` | Replicas for `influx` StatefulSet | Dependent on license |
 | `enterprise.meta.image.tag` | Set to an `meta` image. See https://hub.docker.com/_/influxdb for details | `meta` |
 | `enterprise.meta.clusterSize` | Replicas for `influxdb-meta` StatefulSet. | `3` |
@@ -114,7 +114,7 @@ To handle this setup on startup, a job can be enabled in `values.yaml` by settin
 
 Make sure to uncomment or configure the job settings after enabling it. If a password is not set, a random password will be generated.
 
-Alternatively, if `.Values.setDefaultUser.user.existingSecret` is set the user and password are obtained from an existing Secret, the expected keys are `influxdb-user` and `influxdb-password`. Use this variable  if you need to check in the `values.yaml` in a repository to avoid exposing your secrets. 
+Alternatively, if `.Values.setDefaultUser.user.existingSecret` is set the user and password are obtained from an existing Secret, the expected keys are `influxdb-user` and `influxdb-password`. Use this variable  if you need to check in the `values.yaml` in a repository to avoid exposing your secrets.
 
 ## Upgrading
 
@@ -129,3 +129,9 @@ The Kubernetes API change to support 1.160 may not be backwards compatible and m
 ### From < 3.0.0 to >= 3.0.0
 
 Since version 3.0.0 this chart uses a StatefulSet instead of a Deployment. As part of this update the existing persistent volume (and all data) is deleted and a new one is created. Make sure to backup and restore the data manually.
+
+### From < 4.0.0 to >= 4.0.0
+
+Labels are changed to those in accordance with [kubernetes recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/\#labels). This change also removes the ability to configure clusterIP value as to avoid `Error: UPGRADE FAILED: failed to replace object: Service "my-influxdb" is invalid: spec.clusterIP: Invalid value: "": field is immutable` type errors. For more info on this error and why it should be avoided at all costs, please see [this github issue](https://github.com/helm/helm/issues/6378#issuecomment-582764215).
+
+Due to the significance of the changes. The recommended approach is to uninstall and reinstall the chart (the PVC *should* not be deleted during this process, but it is highly recommended to backup your data before).

--- a/stable/influxdb/templates/_helpers.tpl
+++ b/stable/influxdb/templates/_helpers.tpl
@@ -30,3 +30,34 @@ Create chart name and version as used by the chart label.
 {{- define "influxdb.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "influxdb.labels" -}}
+helm.sh/chart: {{ include "influxdb.chart" . }}
+{{ include "influxdb.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "influxdb.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "influxdb.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "influxdb.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "influxdb.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/influxdb/templates/backup-cronjob.yaml
+++ b/stable/influxdb/templates/backup-cronjob.yaml
@@ -2,12 +2,10 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: "{{ template "influxdb.fullname" . }}-backup"
+  name: {{ include "influxdb.fullname" . }}-backup
   labels:
-    app: "{{ template "influxdb.fullname" . }}"
-    chart: "{{ template "influxdb.chart" . }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "influxdb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
   annotations:
     {{- toYaml .Values.backup.annotations | nindent 4 }}
 spec:
@@ -30,6 +28,7 @@ spec:
             secret:
               secretName: {{ .Values.backup.gcs.serviceAccountSecret | quote }}
           {{- end }}
+          serviceAccountName: {{ include "influxdb.serviceAccountName" . }}
           initContainers:
           - name: influxdb-backup
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/influxdb/templates/config.yaml
+++ b/stable/influxdb/templates/config.yaml
@@ -1,12 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ template "influxdb.fullname" . }}"
+  name: {{ include "influxdb.fullname" . }}
   labels:
-    app: "{{ template "influxdb.fullname" . }}"
-    chart: "{{ template "influxdb.chart" . }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "influxdb.labels" . | nindent 4 }}
 data:
   influxdb.conf: |+
     reporting-disabled = {{ .Values.config.reporting_disabled | default false }}
@@ -96,9 +93,9 @@ data:
       realm = "{{ .Values.config.http.realm }}"
       unix-socket-enabled = {{ .Values.config.http.unix_socket_enabled }}
       bind-socket = "{{ .Values.config.http.bind_socket }}"
-    
+
     # TODO: allow multiple graphite listeners
-    
+
     [[graphite]]
       enabled = {{ .Values.config.graphite.enabled }}
       bind-address = ":{{ .Values.config.graphite.bind_address }}"
@@ -118,7 +115,7 @@ data:
         {{- end }}
       ]
       {{- end }}
-    
+
     # TODO: allow multiple collectd listeners with templates
 
     [[collectd]]
@@ -133,7 +130,7 @@ data:
       typesdb = "{{ .Values.config.collectd.typesdb }}"
       security-level = "{{ .Values.config.collectd.security_level }}"
       auth-file = "{{ .Values.config.collectd.auth_file }}"
-    
+
     # TODO: allow multiple opentsdb listeners with templates
 
     [[opentsdb]]
@@ -148,7 +145,7 @@ data:
       batch-pending = {{ .Values.config.opentsdb.batch_pending | int64 }}
       batch-timeout = "{{ .Values.config.opentsdb.batch_timeout }}"
       log-point-errors = {{ .Values.config.opentsdb.log_point_errors }}
-    
+
     # TODO: allow multiple udp listeners with templates
 
     [[udp]]

--- a/stable/influxdb/templates/ingress.yaml
+++ b/stable/influxdb/templates/ingress.yaml
@@ -2,12 +2,9 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: "{{ template "influxdb.fullname" . }}"
+  name: {{ include "influxdb.fullname" . }}
   labels:
-    app: "{{ template "influxdb.fullname" . }}"
-    chart: "{{ template "influxdb.chart" . }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "influxdb.labels" . | nindent 4 }}
   annotations:
 {{ toYaml .Values.ingress.annotations | indent 4 }}
 spec:

--- a/stable/influxdb/templates/init-config.yaml
+++ b/stable/influxdb/templates/init-config.yaml
@@ -2,12 +2,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ template "influxdb.fullname" . }}-init"
+  name: {{ include "influxdb.fullname" . }}-init
   labels:
-    app: "{{ template "influxdb.fullname" . }}"
-    chart: "{{ template "influxdb.chart" . }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "influxdb.labels" . | nindent 4 }}
 data:
 {{ toYaml .Values.initScripts.scripts | indent 2 }}
 {{- end -}}

--- a/stable/influxdb/templates/meta-config.yaml
+++ b/stable/influxdb/templates/meta-config.yaml
@@ -2,12 +2,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ template "influxdb.fullname" . }}-meta"
+  name: {{ include "influxdb.fullname" . }}-meta
   labels:
-    app: "{{ template "influxdb.fullname" . }}-meta"
-    chart: "{{ template "influxdb.chart" . }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "influxdb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: meta
 data:
   influxdb-meta.conf: |+
     reporting-disabled = {{ .Values.config.reporting_disabled | default false }}

--- a/stable/influxdb/templates/meta-service.yaml
+++ b/stable/influxdb/templates/meta-service.yaml
@@ -6,12 +6,10 @@ metadata:
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}
-  name: "{{ template "influxdb.fullname" . }}-meta"
+  name: {{ include "influxdb.fullname" . }}-meta
   labels:
-    app: "{{ template "influxdb.fullname" . }}-meta"
-    chart: "{{ template "influxdb.chart" . }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "influxdb.labels" . | nindent 4 }}
+    app.kubernets.io/component: meta
 spec:
   type: ClusterIP
   clusterIP: None
@@ -22,5 +20,6 @@ spec:
       port: {{ .Values.config.meta.bind_address }}
       targetPort: {{ .Values.config.meta.bind_address }}
   selector:
-    app: "{{ template "influxdb.fullname" . }}-meta"
+    {{- include "influxdb.selectorLabels" . | nindent 4 }}
+    app.kubernets.io/component: meta
 {{- end }}

--- a/stable/influxdb/templates/meta-statefulset.yaml
+++ b/stable/influxdb/templates/meta-statefulset.yaml
@@ -2,23 +2,22 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: "{{ template "influxdb.fullname" . }}-meta"
+  name: {{ include "influxdb.fullname" . }}-meta
   labels:
-    app: "{{ template "influxdb.fullname" . }}-meta"
-    chart: "{{ template "influxdb.chart" . }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "influxdb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: meta
 spec:
   replicas: {{ .Values.enterprise.meta.clusterSize }}
   selector:
     matchLabels:
-      app: "{{ template "influxdb.fullname" . }}-meta"
-  serviceName: "{{ template "influxdb.fullname" . }}-meta"
+      {{- include "influxdb.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: meta
+  serviceName: "{{ include "influxdb.fullname" . }}-meta"
   template:
     metadata:
       labels:
-        app: "{{ template "influxdb.fullname" . }}-meta"
-        release: "{{ .Release.Name }}"
+        {{- include "influxdb.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: meta
       {{- if .Values.podAnnotations }}
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
@@ -31,7 +30,7 @@ spec:
       {{- end}}
       {{- end }}
       containers:
-      - name: "{{ template "influxdb.fullname" . }}-meta"
+      - name: "{{ include "influxdb.fullname" . }}-meta"
         image: "{{ .Values.image.repository }}:{{ .Values.enterprise.meta.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         resources:
@@ -48,7 +47,7 @@ spec:
 {{ toYaml .Values.env | indent 10 }}
           # Values.env's HOSTNAME isn't fundamentally different from $HOSTNAME, but this way we get a distinguished name for InfluxDB at runtime.
           - name: INFLUXDB_HOSTNAME
-            value: "$(_HOSTNAME).{{ template "influxdb.fullname" . }}-meta"
+            value: "$(_HOSTNAME).{{ include "influxdb.fullname" . }}-meta"
         {{- end }}
         livenessProbe:
           httpGet:
@@ -71,7 +70,7 @@ spec:
           periodSeconds: {{ .Values.startupProbe.periodSeconds | default 5 }}
         {{- end }}
         volumeMounts:
-        - name: {{ template "influxdb.fullname" . }}-meta
+        - name: {{ include "influxdb.fullname" . }}-meta
           mountPath: {{ .Values.config.storage_directory }}
         - name: config
           mountPath: /etc/influxdb
@@ -82,14 +81,14 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: {{ template "influxdb.fullname" . }}-meta
+          name: {{ include "influxdb.fullname" . }}-meta
       {{- if .Values.initScripts.enabled }}
       - name: init
         configMap:
-          name: {{ template "influxdb.fullname" . }}-init
+          name: {{ include "influxdb.fullname" . }}-init
       {{- end }}
       {{- if (not .Values.persistence.enabled ) }}
-      - name: {{ template "influxdb.fullname" . }}-meta
+      - name: {{ include "influxdb.fullname" . }}-meta
         emptyDir: {}
       {{- end }}
     {{- if .Values.schedulerName }}
@@ -110,7 +109,7 @@ spec:
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
-        name: {{ template "influxdb.fullname" . }}-meta
+        name: {{ include "influxdb.fullname" . }}-meta
         annotations:
         {{- range $key, $value := .Values.persistence.annotations }}
           {{ $key }}: "{{ $value }}"

--- a/stable/influxdb/templates/post-install-set-auth.yaml
+++ b/stable/influxdb/templates/post-install-set-auth.yaml
@@ -2,12 +2,9 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+  name: {{ include "caca.fullname" . }}-set-auth
   labels:
-    app: "{{ template "influxdb.fullname" . }}"
-    chart: "{{ template "influxdb.chart" . }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
-  name: {{ template "influxdb.fullname" . }}-set-auth
+    {{- include "caca.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/stable/influxdb/templates/secret.yaml
+++ b/stable/influxdb/templates/secret.yaml
@@ -3,12 +3,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  name: {{ include "influxdb.fullname" . }}-auth
   labels:
-    app: "{{ template "influxdb.fullname" . }}"
-    chart: "{{ template "influxdb.chart" . }}"
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
-  name: {{ template "influxdb.fullname" . }}-auth
+    {{- include "influxdb.labels" . | nindent 4 }}
 data:
   {{- if .Values.setDefaultUser.user.password }}
   influxdb-password:  {{ .Values.setDefaultUser.user.password | b64enc | quote }}

--- a/stable/influxdb/templates/service.yaml
+++ b/stable/influxdb/templates/service.yaml
@@ -5,12 +5,9 @@ metadata:
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}
-  name: "{{ template "influxdb.fullname" . }}"
+  name: {{ include "influxdb.fullname" . }}
   labels:
-    app: "{{ template "influxdb.fullname" . }}"
-    chart: "{{ template "influxdb.chart" . }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "influxdb.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   {{- if .Values.service.clusterIP }}

--- a/stable/influxdb/templates/service.yaml
+++ b/stable/influxdb/templates/service.yaml
@@ -10,20 +10,6 @@ metadata:
     {{- include "influxdb.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
-  {{- if .Values.service.clusterIP }}
-  clusterIP: {{ .Values.service.clusterIP }}
-  {{- end }}
-  {{- if .Values.service.externalIPs }}
-  externalIPs:
-  {{ toYaml .Values.service.externalIPs | indent 4 }}
-  {{- end }}
-  {{- if .Values.service.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
-  {{- end }}
-  {{- with .Values.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
   ports:
   {{- if .Values.config.http.enabled }}
   - name: api

--- a/stable/influxdb/templates/serviceaccount.yaml
+++ b/stable/influxdb/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  name: {{ template "influxdb.serviceAccountName" . }}
+  labels:
+{{ include "influxdb.labels" . | indent 4 }}
+{{- end -}}

--- a/stable/influxdb/templates/statefulset.yaml
+++ b/stable/influxdb/templates/statefulset.yaml
@@ -1,12 +1,9 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: "{{ template "influxdb.fullname" . }}"
+  name: {{ include "influxdb.fullname" . }}
   labels:
-    app: "{{ template "influxdb.fullname" . }}"
-    chart: "{{ template "influxdb.chart" . }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "influxdb.labels" . | nindent 4 }}
 spec:
   {{- if .Values.enterprise.enabled }}
   replicas: {{ .Values.enterprise.clusterSize }}
@@ -15,15 +12,12 @@ spec:
   {{- end}}
   selector:
     matchLabels:
-      app: {{ template "influxdb.fullname" . }}
-      release: "{{ .Release.Name }}"
-  serviceName: "{{ template "influxdb.fullname" . }}"
+      {{- include "influxdb.selectorLabels" . | nindent 6 }}
+  serviceName: "{{ include "influxdb.fullname" . }}"
   template:
     metadata:
       labels:
-        app: {{ template "influxdb.fullname" . }}
-        release: "{{ .Release.Name }}"
-        chart: "{{ template "influxdb.chart" . }}"
+        {{- include "influxdb.selectorLabels" . | nindent 8 }}
       {{- if .Values.podAnnotations }}
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
@@ -50,8 +44,9 @@ spec:
         - name: {{ . }}
       {{- end}}
       {{- end }}
+      serviceAccountName: {{ include "influxdb.serviceAccountName" . }}
       containers:
-      - name: {{ template "influxdb.fullname" . }}
+      - name: {{ include "influxdb.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         resources:
@@ -90,7 +85,7 @@ spec:
 {{ toYaml .Values.env | indent 10 }}
         {{- if .Values.enterprise.enabled }}
           - name: INFLUXDB_HOSTNAME # Values.env's HOSTNAME isn't fundamentally different from $HOSTNAME, but this way weg get a distinguished name at runtime.
-            value: "$(_HOSTNAME).{{ template "influxdb.fullname" . }}"
+            value: "$(_HOSTNAME).{{ include "influxdb.fullname" . }}"
         {{- end }}
         {{- end }}
         livenessProbe:
@@ -114,7 +109,7 @@ spec:
           periodSeconds: {{ .Values.startupProbe.periodSeconds | default 5 }}
         {{- end }}
         volumeMounts:
-        - name: {{ template "influxdb.fullname" . }}-data
+        - name: {{ include "influxdb.fullname" . }}-data
           mountPath: {{ .Values.config.storage_directory }}
         - name: config
           mountPath: /etc/influxdb
@@ -125,20 +120,20 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: {{ template "influxdb.fullname" . }}
+          name: {{ include "influxdb.fullname" . }}
       {{- if .Values.initScripts.enabled }}
       - name: init
         configMap:
-          name: {{ template "influxdb.fullname" . }}-init
+          name: {{ include "influxdb.fullname" . }}-init
       {{- end }}
       {{- if (not .Values.persistence.enabled ) }}
-      - name: {{ template "influxdb.fullname" . }}-data
+      - name: {{ include "influxdb.fullname" . }}-data
         emptyDir: {}
       {{- end }}
 {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
-        name: {{ template "influxdb.fullname" . }}-data
+        name: {{ include "influxdb.fullname" . }}-data
         annotations:
         {{- range $key, $value := .Values.persistence.annotations }}
           {{ $key }}: "{{ $value }}"

--- a/stable/influxdb/values.yaml
+++ b/stable/influxdb/values.yaml
@@ -8,6 +8,12 @@ image:
   # pullSecrets:
   #   - registry-secret
 
+
+serviceAccount:
+  create: true
+  name:
+  annotations: {}
+
 ## Customize livenessProbe and readinessProbe
 ## ref: https://docs.influxdata.com/influxdb/v1.7/tools/api/#ping-http-endpoint
 ##

--- a/stable/influxdb/values.yaml
+++ b/stable/influxdb/values.yaml
@@ -37,14 +37,6 @@ service:
   ## Add annotations to service
   # annotations: {}
   type: ClusterIP
-  ## Add IP Cluster
-  # clusterIP: ""
-  ## Add external IPs that route to one or more cluster nodes
-  # externalIPs: []
-  ## Specify LoadBalancer IP (only allow on some cloud provider)
-  # loadBalancerIP: ""
-  ## Allow source IPs to access on service (if empty, any access allow)
-  # loadBalancerSourceRanges: []
 
 ## Persist data to a persistent volume
 ##


### PR DESCRIPTION
#### What this PR does / why we need it:

In accordance with https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/\#labels, this PR uses recommended labels and creates the required helpers to keep teplates more DRY. This PR also adds a serviceaccount, a first step in allowing GCP users to use workload identity for storage access.

This change also removes the ability to configure clusterIP value as to avoid `Error: UPGRADE FAILED: failed to replace object: Service "my-influxdb" is invalid: spec.clusterIP: Invalid value: "": field is immutable` type errors. For more info on this error and why it should be avoided at all costs, please see [this github issue](https://github.com/helm/helm/issues/6378#issuecomment-582764215).

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

This is a major change and requires chart uninstall + reinstall. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
