### PR TITLE
[stable/kafka-manager] Add LDAP authentication configurable features

### DIFF
--- a/stable/kafka-manager/Chart.yaml
+++ b/stable/kafka-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka-manager
-version: 2.2.1
+version: 2.3.0
 appVersion: 1.3.3.22
 kubeVersion: "^1.8.0-0"
 description: A tool for managing Apache Kafka.

--- a/stable/kafka-manager/README.md
+++ b/stable/kafka-manager/README.md
@@ -53,6 +53,15 @@ Parameter | Description | Default
 `basicAuth.enabled` | If true, enable basic authentication | `false`
 `basicAuth.username` | Username for basic auth | `admin`
 `basicAuth.password` | Password for basic auth | `""`
+`basicAuth.ldap.enabled` | If true, enable LDAP authentication | `false`
+`basicAuth.ldap.server` | FQDN of the LDAP server | `""`
+`basicAuth.ldap.port` | Port used for LDAP | `""`
+`basicAuth.ldap.username` | Optional LDAP DN to bind for query | `""`
+`basicAuth.ldap.pasword`  | Optional LDAP password for the DN | `""`
+`basicAuth.ldap.searchBaseDn` | LDAP search base | `""`
+`basicAuth.ldap.searchFilter` | LDAP search filter for a valid account | `""`
+`basicAuth.ldap.connectionPoolSize` | LDAP connection pool size | `10`
+`basicAuth.ldap.ssl` | Enable LDAPS (not StartTLS) | `false`
 `javaOptions` | Java runtime options | `""`
 `service.type` | Kafka-manager service type | `ClusterIP`
 `service.port` | Kafka-manager service port | `9000`

--- a/stable/kafka-manager/templates/deployment.yaml
+++ b/stable/kafka-manager/templates/deployment.yaml
@@ -51,6 +51,30 @@ spec:
                 secretKeyRef:
                   name: {{ template "kafka-manager.fullname" . }}
                   key: basicAuthPassword
+            - name: KAFKA_MANAGER_LDAP_ENABLED
+              value: {{ .Values.basicAuth.ldap.enabled | quote }}
+            - name: KAFKA_MANAGER_LDAP_SERVER
+              value: {{ .Values.basicAuth.ldap.server | quote }}
+            - name: KAFKA_MANAGER_LDAP_PORT
+              value: {{ .Values.basicAuth.ldap.port | quote }}
+            - name: KAFKA_MANAGER_LDAP_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "kafka-manager.fullname" . }}
+                  key: basicAuthLDAPUsername
+            - name: KAFKA_MANAGER_LDAP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "kafka-manager.fullname" . }}
+                  key: basicAuthLDAPPssword
+            - name: KAFKA_MANAGER_LDAP_SEARCH_BASE_DN
+              value: {{ .Values.basicAuth.ldap.searchBaseDn | quote }}
+            - name: KAFKA_MANAGER_LDAP_SEARCH_FILTER
+              value: {{ .Values.basicAuth.ldap.searchFilter | quote }}
+            - name: KAFKA_MANAGER_LDAP_CONNECTION_POOL_SIZE
+              value: {{ .Values.basicAuth.ldap.connectionPoolSize | quote }}
+            - name: KAFKA_MANAGER_LDAP_SSL
+              value: {{ .Values.basicAuth.ldap.ssl | quote }}
           livenessProbe:
 {{ toYaml .Values.livenessProbe | indent 12 }}
           readinessProbe:

--- a/stable/kafka-manager/templates/deployment.yaml
+++ b/stable/kafka-manager/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ template "kafka-manager.fullname" . }}
-                  key: basicAuthLDAPPssword
+                  key: basicAuthLDAPPassword
             - name: KAFKA_MANAGER_LDAP_SEARCH_BASE_DN
               value: {{ .Values.basicAuth.ldap.searchBaseDn | quote }}
             - name: KAFKA_MANAGER_LDAP_SEARCH_FILTER

--- a/stable/kafka-manager/templates/secrets.yaml
+++ b/stable/kafka-manager/templates/secrets.yaml
@@ -23,7 +23,7 @@ data:
   {{ end }}
   basicAuthLDAPUsername: {{ .Values.basicAuth.ldap.username | b64enc | quote }}
   {{ if .Values.basicAuth.ldap.password }}
-  basicAuthLDAPPssword: {{ .Values.basicAuth.ldap.password | b64enc | quote }}
+  basicAuthLDAPPassword: {{ .Values.basicAuth.ldap.password | b64enc | quote }}
   {{ else }}
   basicAuthLDAPPassword: {{ randAlphaNum 10 | b64enc | quote }}
   {{ end }}

--- a/stable/kafka-manager/templates/secrets.yaml
+++ b/stable/kafka-manager/templates/secrets.yaml
@@ -21,3 +21,9 @@ data:
   {{ else }}
   basicAuthPassword: {{ randAlphaNum 10 | b64enc | quote }}
   {{ end }}
+  basicAuthLDAPUsername: {{ .Values.basicAuth.ldap.username | b64enc | quote }}
+  {{ if .Values.basicAuth.ldap.password }}
+  basicAuthLDAPPssword: {{ .Values.basicAuth.ldap.password | b64enc | quote }}
+  {{ else }}
+  basicAuthLDAPPassword: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ end }}

--- a/stable/kafka-manager/values.yaml
+++ b/stable/kafka-manager/values.yaml
@@ -99,6 +99,19 @@ basicAuth:
   ## Defaults to a random 10-character alphanumeric string if not set
   ##
   password: ""
+  ## LDAP Authentication
+  ## Ref : https://github.com/yahoo/CMAK#authenticating-a-user-with-ldap
+  ##
+  ldap:
+    enabled: false
+    server: ""
+    port: 389
+    username: ""
+    password: ""
+    searchBaseDn: ""
+    searchFilter: "(uid=$capturedLogin$)"
+    connectionPoolSize: 10
+    ssl: false
 
 ## Java runtime options. Passed through the JAVA_OPTS environmental variable
 ##


### PR DESCRIPTION
Signed-off-by: Parth Kolekar <parthkolekar@indeed.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No. 

#### What this PR does / why we need it:
This PR adds LDAP authentication features to the kafka-manager chart that are configurable in CMAK (pka kafka-manager), but not configurable via the values.yaml

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
There is an additional `KAFKA_MANAGER_LDAP_GROUP_FILTER` feature that is present in a newer version of CMAK (pka kafka-manager), that I am not including in this chart, since the chart configures application version `1.3.3.23`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
