### PR TITLE
[stable/graylog]: use correct object path for existing root secret

### DIFF
--- a/stable/graylog/Chart.yaml
+++ b/stable/graylog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: graylog
 home: https://www.graylog.org
-version: 1.5.6
+version: 1.5.7
 appVersion: 3.1
 description: Graylog is the centralized log management solution built to open standards for capturing, storing, and enabling real-time analysis of terabytes of machine data.
 keywords:

--- a/stable/graylog/templates/job.yaml
+++ b/stable/graylog/templates/job.yaml
@@ -27,7 +27,7 @@ spec:
           - name: GRAYLOG_PASSWORD_SECRET
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.existingRootSecret | default (include "graylog.fullname" .) }}
+                name: {{ .Values.graylog.existingRootSecret | default (include "graylog.fullname" .) }}
 
                 key: graylog-password-secret
         volumeMounts:

--- a/stable/graylog/templates/statefulset.yaml
+++ b/stable/graylog/templates/statefulset.yaml
@@ -95,12 +95,12 @@ spec:
             - name: GRAYLOG_PASSWORD_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.existingRootSecret | default (include "graylog.fullname" .) }}
+                  name: {{ .Values.graylog.existingRootSecret | default (include "graylog.fullname" .) }}
                   key: graylog-password-secret
             - name: GRAYLOG_ROOT_PASSWORD_SHA2
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.existingRootSecret | default (include "graylog.fullname" .) }}
+                  name: {{ .Values.graylog.existingRootSecret | default (include "graylog.fullname" .) }}
                   key: graylog-password-sha2
             {{- range $key, $value := .Values.graylog.env }}
             - name: {{ $key }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Changes `existingRootSecret` references from `.Values.existingRootSecret` to `.Values.graylog.existingRootSecret` as documentation states that the existing root secret should be set in `graylog` object. 

When `graylog.existingRootSecret` is provided, Statefulset pods will not start due to a `CreateContainerConfigError`. The chart secret is correctly not created when `Values.graylog.existingRootSecret` is provided however, env attempts to load the secret by referencing the invalid `.Values.existingRootSecret` key or defaulting to the `graylog.fullname` template value.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
