### PR TITLE
[stable/telegraf] Add nodeSelector support

### DIFF
--- a/stable/telegraf/Chart.yaml
+++ b/stable/telegraf/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: telegraf
-version: 1.5.0
+version: 1.6.0
 appVersion: 1.12
 deprecated: false
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/stable/telegraf/templates/deployment.yaml
+++ b/stable/telegraf/templates/deployment.yaml
@@ -58,6 +58,10 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
       - name: config
         configMap:

--- a/stable/telegraf/values.yaml
+++ b/stable/telegraf/values.yaml
@@ -27,6 +27,10 @@ resources: {}
   #   memory: 128Mi
   #   cpu: 100m
 
+## Node labels for pod assignment
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
 service:
   enabled: true
   type: ClusterIP


### PR DESCRIPTION
#### What this PR does / why we need it:
This adds nodeSelector support to the stable/telegraf chart.
#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in ~~the README.md~~ values.yaml
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
