### PR TITLE
[stable/minecraft] Add failure/successThreshold and timeoutSeconds conf

### DIFF
--- a/stable/minecraft/Chart.yaml
+++ b/stable/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minecraft
-version: 1.1.6
+version: 1.1.7
 appVersion: 1.14.4
 home: https://minecraft.net/
 description: Minecraft server

--- a/stable/minecraft/templates/deployment.yaml
+++ b/stable/minecraft/templates/deployment.yaml
@@ -38,12 +38,18 @@ spec:
 {{ toYaml .Values.readinessProbe.command | indent 14 }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
         livenessProbe:
           exec:
             command:
 {{ toYaml .Values.livenessProbe.command | indent 14 }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
         env:
         - name: EULA
           value: {{ .Values.minecraftServer.eula | quote }}

--- a/stable/minecraft/values.yaml
+++ b/stable/minecraft/values.yaml
@@ -29,6 +29,9 @@ livenessProbe:
     - status
   initialDelaySeconds: 30
   periodSeconds: 5
+  failureThreshold: 10
+  successThreshold: 1
+  timeoutSeconds: 1
 readinessProbe:
   command:
     - mcstatus
@@ -36,6 +39,9 @@ readinessProbe:
     - status
   initialDelaySeconds: 30
   periodSeconds: 5
+  failureThreshold: 10
+  successThreshold: 1
+  timeoutSeconds: 1
 minecraftServer:
   # This must be overridden, since we can't accept this for the user.
   eula: "FALSE"


### PR DESCRIPTION
Signed-off-by: Julien DOCHE <julien.doche@gmail.com>

#### What this PR does / why we need it:
This PR adds configuration of failureThreshold, successThreshold and timeoutSeconds for liveness and readiness probes

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
