### PR TITLE
[stable/pgadmin] README incorrect example

### DIFF
--- a/stable/pgadmin/Chart.yaml
+++ b/stable/pgadmin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin is a web based administration tool for PostgreSQL database
 name: pgadmin
-version: 1.2.0
+version: 1.2.1
 appVersion: 4.18.0
 home: https://www.pgadmin.org/
 source: https://github.com/rowanruseler/pgadmin

--- a/stable/pgadmin/README.md
+++ b/stable/pgadmin/README.md
@@ -54,7 +54,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `ingress.hosts` | Ingress accepted hostnames | `nil` |
 | `ingress.tls` | Ingress TLS configuration | `[]` |
 | `ingress.path` | Ingress path mapping | `` |
-| `env.username` | pgAdmin default email | `chart@example.local` |
+| `env.email` | pgAdmin default email | `chart@example.local` |
 | `env.password` | pgAdmin default password | `SuperSecret` |
 | `persistentVolume.enabled` | If true, pgAdmin will create a Persistent Volume Claim | `true` |
 | `persistentVolume.accessMode` | Persistent Volume access Mode | `ReadWriteOnce` |


### PR DESCRIPTION
Within the README file there was an incorrect example where env.username
was given rather then env.email.

Pointed out in issue: https://github.com/helm/charts/issues/20789

Signed-off-by: Rowan Ruseler <rowanruseler@gmail.com>