### PR TITLE
[stable/prometheus-postgres-exporter] set targetLabels and podTargetLabels for the SeriviceMonitor

### DIFF
--- a/stable/prometheus-postgres-exporter/Chart.yaml
+++ b/stable/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 1.2.0
+version: 1.3.0
 home: https://github.com/wrouesnel/postgres_exporter
 sources:
 - https://github.com/wrouesnel/postgres_exporter

--- a/stable/prometheus-postgres-exporter/Chart.yaml
+++ b/stable/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 1.3.0
+version: 1.4.0
 home: https://github.com/wrouesnel/postgres_exporter
 sources:
 - https://github.com/wrouesnel/postgres_exporter

--- a/stable/prometheus-postgres-exporter/README.md
+++ b/stable/prometheus-postgres-exporter/README.md
@@ -52,6 +52,8 @@ The following table lists the configurable parameters of the postgres Exporter c
 | `serviceMonitor.interval`         | How frequently Prometheus should scrape                                 |                             |
 | `serviceMonitor.telemetryPath`    | path to cloudwatch-exporter telemtery-path                              |                             |
 | `serviceMonitor.labels`           | labels for the ServiceMonitor passed to Prometheus Operator             | `{}`                        |
+| `serviceMonitor.podTargetLabels`  | podTargetLabels for the ServiceMonitor passed to Prometheus Operator    | `[]`                        |
+| `serviceMonitor.targetLabels`     | targetLabels for the ServiceMonitor passed to Prometheus Operator       | `[]`                        |
 | `serviceMonitor.timeout`          | Timeout after which the scrape is ended                                 |                             |
 | `resources`          |                                  |                    `{}`                                  |
 | `config.datasource`                 | Postgresql datasource configuration                      |  see [values.yaml](values.yaml)              |

--- a/stable/prometheus-postgres-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-postgres-exporter/templates/servicemonitor.yaml
@@ -23,6 +23,14 @@ spec:
     scrapeTimeout: {{ .Values.serviceMonitor.timeout }}
 {{- end }}
   jobLabel: {{ template "prometheus-postgres-exporter.fullname" . }}
+{{- if .Values.serviceMonitor.targetLabels }}
+  targetLabels:
+{{ toYaml .Values.serviceMonitor.targetLabels | indent 4 -}}
+{{- end }}
+{{- if .Values.serviceMonitor.podTargetLabels }}
+  podTargetLabels:
+{{ toYaml .Values.serviceMonitor.podTargetLabels | indent 4 -}}
+{{- end }}
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/stable/prometheus-postgres-exporter/values.yaml
+++ b/stable/prometheus-postgres-exporter/values.yaml
@@ -28,6 +28,10 @@ serviceMonitor:
   # telemetryPath: /metrics
   # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
   # labels:
+  # Set targetLabels for the SeriviceMonitor, use this to define your scrape podTargetLabels for Prometheus Operator
+  # targetLabels: []
+  # Set podTargetLabels for the SeriviceMonitor, use this to define your scrape podTargetLabels for Prometheus Operator
+  # podTargetLabels: []
   # Set timeout for scrape
   # timeout: 10s
 


### PR DESCRIPTION
#### What this PR does / why we need it:
set targetLabels and podTargetLabels for the SeriviceMonitor

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
