### PR TITLE
[stable/metabase] Add {} after annotations tag to remove annotations warning

### DIFF
--- a/stable/metabase/Chart.yaml
+++ b/stable/metabase/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 0.10.3
+version: 0.10.4
 appVersion: v0.34.0
 maintainers:
 - name: pmint93

--- a/stable/metabase/README.md
+++ b/stable/metabase/README.md
@@ -90,7 +90,7 @@ The following table lists the configurable parameters of the Metabase chart and 
 | ingress.hosts                    | Ingress resource hostnames                                  | null              |
 | ingress.path                     | Ingress path                                                | /                 |
 | ingress.labels                   | Ingress labels configuration                                | null              |
-| ingress.annotations              | Ingress annotations configuration                           | null              |
+| ingress.annotations              | Ingress annotations configuration                           | {}                |
 | ingress.tls                      | Ingress TLS configuration                                   | null              |
 | log4jProperties                  | Custom `log4j.properties` file                              | null              |
 | resources                        | Server resource requests and limits                         | {}                |

--- a/stable/metabase/values.yaml
+++ b/stable/metabase/values.yaml
@@ -78,7 +78,7 @@ service:
   type: ClusterIP
   externalPort: 80
   internalPort: 3000
-  annotations:
+  annotations: {}
     # Used to add custom annotations to the Service.
     # service.beta.kubernetes.io/aws-load-balancer-internal: "0.0.0.0/0"
 ingress:
@@ -92,7 +92,7 @@ ingress:
     # Used to add custom labels to the Ingress
     # Useful if for example you have multiple Ingress controllers and want your Ingress controllers to bind to specific Ingresses
     # traffic: internal
-  annotations:
+  annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   tls:


### PR DESCRIPTION
cc @pmint93 

#### What this PR does / why we need it:
Removes warning "Add {} after annotations in values.yaml to avoid "warning: destination for annotations is a table. Ignoring non-table value <nil>" when the chart is used as a dependency of another chart and installed with helm3, which also causes CI/CD pipelines to fail.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #20833 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
