### PR TITLE
[incubator/cassandra] Fixes cassandra backup pod affinity syntax and cain container name

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cassandra
-version: 0.14.1
+version: 0.14.2
 appVersion: 3.11.5
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cassandra
-version: 0.14.0
+version: 0.14.1
 appVersion: 3.11.5
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/templates/backup/cronjob.yaml
+++ b/incubator/cassandra/templates/backup/cronjob.yaml
@@ -36,6 +36,8 @@ spec:
             - {{ $release.Namespace }}
             - --selector
             - release={{ $release.Name }},app={{ template "cassandra.name" $ }}
+            - --container
+            - {{ template "cassandra.fullname" $ }}
             - --keyspace
             - {{ $schedule.keyspace }}
             - --dst
@@ -66,22 +68,24 @@ spec:
             secret:
               secretName: {{ $backup.google.serviceAccountSecret | quote }}
 {{- end }}
-        affinity:
-          podAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - {{ template "cassandra.fullname" $ }}
-                - key: release
-                  operator: In
-                  values:
-                  - {{ $release.Name }}
-              topologyKey: "kubernetes.io/hostname"
-      {{- with $values.tolerations }}
-        tolerations:
+          affinity:
+            podAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                      - {{ template "cassandra.fullname" $ }}
+                    - key: release
+                      operator: In
+                      values:
+                      - {{ $release.Name }}
+                  topologyKey: "kubernetes.io/hostname"
+        {{- with $values.tolerations }}
+          tolerations:
 {{ toYaml . | indent 10 }}
       {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Toni Röyhy <toni@montel.fi>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Enabling backup in cassandra chart failed as cronjob template was not valid ( at least not for Kubernetes v1.15.5)
```
Error: UPGRADE FAILED: error validating "": error validating data: ValidationError(CronJob.spec.jobTemplate.spec.template): unknown field "affinity" in io.k8s.api.core.v1.PodTemplateSpec
```
Cain backup defaulted to `cassandra` as target container name and failed because real name of container is `{{ template "cassandra.fullname" $ }}`

#### Special notes for your reviewer:
My first contribution, sorry if this PR is not  100%  as instructed.
#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
