### PR TITLE
[stable/phabricator] Release 9.0.9 (using Helm 2)

### DIFF
--- a/stable/phabricator/Chart.yaml
+++ b/stable/phabricator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: phabricator
-version: 9.0.8
-appVersion: 2019.50.0
+version: 9.0.9
+appVersion: 2020.7.0
 description: Collection of open source web applications that help software companies build better software.
 keywords:
 - phabricator

--- a/stable/phabricator/requirements.lock
+++ b/stable/phabricator/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 7.3.6
+  version: 7.3.9
 digest: sha256:22662ca4b6b22e2476dbffb98118b0369277a68918a0129d17bf34bd66100653
-generated: 2020-01-24T13:07:16.998235444Z
+generated: "2020-02-18T10:48:36.47906334Z"

--- a/stable/phabricator/values.yaml
+++ b/stable/phabricator/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/phabricator
-  tag: 2019.50.0-debian-10-r0
+  tag: 2020.7.0-debian-10-r3
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -228,7 +228,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.7.0-debian-10-r0
+    tag: 0.7.0-debian-10-r20
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
This is a manual Pull Request updating (all or part of):

- App version: `2020.7.0`.
- Chart version: `9.0.9`.
- Immutable tags inside the values files:
  - `"docker.io/bitnami/phabricator:2020.7.0-debian-10-r3"`
  - `"docker.io/bitnami/apache-exporter:0.7.0-debian-10-r20"`
- Requirements.

Replace https://github.com/helm/charts/pull/20835 that fails because of https://github.com/helm/charts/issues/20809