### PR TITLE
[stable/kured] Fix bad bitnami kubectl version #20433

### DIFF
--- a/stable/kured/Chart.yaml
+++ b/stable/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.2.0"
 description: A Helm chart for kured
 name: kured
-version: 1.4.2
+version: 1.4.3
 home: https://github.com/weaveworks/kured
 maintainers:
   - name: plumdog

--- a/stable/kured/values.yaml
+++ b/stable/kured/values.yaml
@@ -20,7 +20,7 @@ autolock:
   enabled: false
   image:
     repository: docker.io/bitnami/kubectl
-    tag: 1.15.4
+    tag: 1.15.3
   scheduleUnlock: 0 4 * * *
   schedulelock: 0 6 * * *
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Current default version (1.15.4) of bitnami kubectl does not exist, 1.15.3 exists https://hub.docker.com/r/bitnami/kubectl/tags?page=1&name=1.15.3

#### Which issue this PR fixes

  - fixes #20433

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
