### PR TITLE
[stable/datadog] Fix DD_TAGS parsing

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 1.39.9
+version: 1.39.10
 appVersion: "7"
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/container-agents.yaml
+++ b/stable/datadog/templates/container-agents.yaml
@@ -60,7 +60,7 @@
     {{- end }}
     {{- if .Values.datadog.tags }}
     - name: DD_TAGS
-      value: {{ .Values.datadog.tags | quote }}
+      value: {{ .Values.datadog.tags | quote | replace "map[" "" | replace "[" "" | replace "]" "" }}
     {{- end }}
     {{- if .Values.datadog.apmEnabled }}
     - name: DD_APM_ENABLED

--- a/stable/datadog/templates/containers-common-env.yaml
+++ b/stable/datadog/templates/containers-common-env.yaml
@@ -18,7 +18,7 @@
 {{- end }}
 {{- if .Values.datadog.tags }}
 - name: DD_TAGS
-  value: {{ .Values.datadog.tags | quote }}
+  value: {{ .Values.datadog.tags | quote | replace "map[" "" | replace "[" "" | replace "]" "" }}
 {{- end }}
 - name: KUBERNETES
   value: "yes"

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -93,7 +93,7 @@ spec:
           {{- end }}
           {{- if .Values.datadog.tags }}
           - name: DD_TAGS
-            value: {{ .Values.datadog.tags | quote }}
+            value: {{ .Values.datadog.tags | quote | replace "map[" "" | replace "[" "" | replace "]" "" }}
           {{- end }}
           {{- if .Values.datadog.apmEnabled }}
           - name: DD_APM_ENABLED


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes the way the chart is parsing DD_TAGS environment variables. Currently, it will append `map_` to each tag due to the way the parsing is done. My fix removes that `map_` so when you add a tag like this:
```yaml
tags:
  - foo: bar
  - wobble: wubble
```
Datadog receives the tag as `foo: bar` and `wobble: wubble`, not `map_foo: bar` and `map_wobble: wubble`

#### Which issue this PR fixes

  - fixes #20842 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
