### PR TITLE
[incubator/zookeeper]JMX disable java option should be added as Quoru…

### DIFF
--- a/incubator/zookeeper/templates/config-script.yaml
+++ b/incubator/zookeeper/templates/config-script.yaml
@@ -101,7 +101,7 @@ data:
 
       if [ -n "$JMXDISABLE" ]
       then
-          MAIN=org.apache.zookeeper.server.quorum.QuorumPeerMain
+          MAIN="-Dzookeeper.jmx.disable=true org.apache.zookeeper.server.quorum.QuorumPeerMain"
       else
           MAIN="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=$JMXPORT -Dcom.sun.management.jmxremote.authenticate=$JMXAUTH -Dcom.sun.management.jmxremote.ssl=$JMXSSL -Dzookeeper.jmx.log4j.disable=$JMXLOG4J org.apache.zookeeper.server.quorum.QuorumPeerMain"
       fi


### PR DESCRIPTION
…mPeerMain will start JMX inside

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
NOT a new chart, just a quick fix
#### What this PR does / why we need it:

#### Which issue this PR fixes
As zookeeper says,
```
The class org.apache.zookeeper.server.quorum.QuorumPeerMain will start a JMX manageable ZooKeeper server. This class registers the proper MBeans during initalization to support JMX monitoring and management of the instance. See bin/zkServer.sh for one example of starting ZooKeeper using QuorumPeerMain.
```
Actually in practice it will start JMX inside QuorumPeerMain indeed, we need jmx disable java option in launch command to avoid it, like what have been done in zkServer.sh:
```
	else
		echo "JMX disabled by user request" >&2
		ZOOMAIN="-Dzookeeper.jmx.disable=true org.apache.zookeeper.server.quorum.QuorumPeerMain"
	fi
```
#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
