### PR TITLE
[stable/prometheus-node-exporter] Add updateStrategy to template

### DIFF
--- a/stable/prometheus-node-exporter/Chart.yaml
+++ b/stable/prometheus-node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.18.1
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 1.8.1
+version: 1.8.2
 home: https://github.com/prometheus/node_exporter/
 sources:
 - https://github.com/prometheus/node_exporter/

--- a/stable/prometheus-node-exporter/README.md
+++ b/stable/prometheus-node-exporter/README.md
@@ -36,39 +36,40 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Node Exporter chart and their default values.
 
-|             Parameter             |                                                          Description                                                          |                 Default                 |     |
-| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | --- |
-| `image.repository`                | Image repository                                                                                                              | `quay.io/prometheus/node-exporter`      |     |
-| `image.tag`                       | Image tag                                                                                                                     | `v0.18.1`                               |     |
-| `image.pullPolicy`                | Image pull policy                                                                                                             | `IfNotPresent`                          |     |
-| `extraArgs`                       | Additional container arguments                                                                                                | `[]`                                    |     |
-| `extraHostVolumeMounts`           | Additional host volume mounts                                                                                                 | `[]`                                    |     |
-| `podAnnotations`                  | Annotations to be added to node exporter pods                                                                                 | `{}`                                    |     |
-| `podLabels`                       | Additional labels to be added to pods                                                                                         | `{}`                                    |     |
-| `rbac.create`                     | If true, create & use RBAC resources                                                                                          | `true`                                  |     |
-| `rbac.pspEnabled`                 | Specifies whether a PodSecurityPolicy should be created.                                                                      | `true`                                  |     |
-| `resources`                       | CPU/Memory resource requests/limits                                                                                           | `{}`                                    |     |
-| `service.type`                    | Service type                                                                                                                  | `ClusterIP`                             |     |
-| `service.port`                    | The service port                                                                                                              | `9100`                                  |     |
-| `service.targetPort`              | The target port of the container                                                                                              | `9100`                                  |     |
-| `service.nodePort`                | The node port of the service                                                                                                  |                                         |     |
-| `service.annotations`             | Kubernetes service annotations                                                                                                | `{prometheus.io/scrape: "true"}`        |     |
-| `serviceAccount.create`           | Specifies whether a service account should be created.                                                                        | `true`                                  |     |
-| `serviceAccount.name`             | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |                                         |     |
-| `serviceAccount.imagePullSecrets` | Specify image pull secrets                                                                                                    | `[]`                                    |     |
-| `securityContext`                 | SecurityContext                                                                                                               | `{"runAsNonRoot": true, "runAsUser": 65534}` |     |
-| `affinity`                        | A group of affinity scheduling rules for pod assignment                                                                       | `{}`                                    |     |
-| `nodeSelector`                    | Node labels for pod assignment                                                                                                | `{}`                                    |     |
-| `tolerations`                     | List of node taints to tolerate                                                                                               | `- effect: NoSchedule operator: Exists` |     |
-| `priorityClassName`               | Name of Priority Class to assign pods                                                                                         | `nil`                                   |     |
-| `endpoints`            | list of addresses that have node exporter deployed outside of the cluster                                                                | `[]`                                    |     |
-| `hostNetwork`                     | Whether to expose the service to the host network                                                                             | `true`                                  |     |
-| `prometheus.monitor.enabled` | Set this to `true` to create ServiceMonitor for Prometheus operator | `false` | |
-| `prometheus.monitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}` | |
-| `prometheus.monitor.namespace` | namespace where servicemonitor resource should be created | `the same namespace as prometheus node exporter` | |
-| `prometheus.monitor.scrapeTimeout` | Timeout after which the scrape is ended | `10s` | |
-| `configmaps`                      | Allow mounting additional configmaps.                                                                                         | `[]`                                    |     |
-| `namespaceOverride`               | Override the deployment namespace     | `""` (`Release.Namespace`)             |  |
+|             Parameter                 |                                                          Description                                                          |                 Default                          |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `image.repository`                    | Image repository                                                                                                              | `quay.io/prometheus/node-exporter`               |
+| `image.tag`                           | Image tag                                                                                                                     | `v0.18.1`                                        |
+| `image.pullPolicy`                    | Image pull policy                                                                                                             | `IfNotPresent`                                   |
+| `extraArgs`                           | Additional container arguments                                                                                                | `[]`                                             |
+| `extraHostVolumeMounts`               | Additional host volume mounts                                                                                                 | `[]`                                             |
+| `podAnnotations`                      | Annotations to be added to node exporter pods                                                                                 | `{}`                                             |
+| `podLabels`                           | Additional labels to be added to pods                                                                                         | `{}`                                             |
+| `rbac.create`                         | If true, create & use RBAC resources                                                                                          | `true`                                           |
+| `rbac.pspEnabled`                     | Specifies whether a PodSecurityPolicy should be created.                                                                      | `true`                                           |
+| `resources`                           | CPU/Memory resource requests/limits                                                                                           | `{}`                                             |
+| `service.type`                        | Service type                                                                                                                  | `ClusterIP`                                      |
+| `service.port`                        | The service port                                                                                                              | `9100`                                           |
+| `service.targetPort`                  | The target port of the container                                                                                              | `9100`                                           |
+| `service.nodePort`                    | The node port of the service                                                                                                  |                                                  |
+| `service.annotations`                 | Kubernetes service annotations                                                                                                | `{prometheus.io/scrape: "true"}`                 |
+| `serviceAccount.create`               | Specifies whether a service account should be created.                                                                        | `true`                                           |
+| `serviceAccount.name`                 | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |                                                  |
+| `serviceAccount.imagePullSecrets`     | Specify image pull secrets                                                                                                    | `[]`                                             |
+| `securityContext`                     | SecurityContext                                                                                                               | `{"runAsNonRoot": true, "runAsUser": 65534}`     |
+| `affinity`                            | A group of affinity scheduling rules for pod assignment                                                                       | `{}`                                             |
+| `nodeSelector`                        | Node labels for pod assignment                                                                                                | `{}`                                             |
+| `tolerations`                         | List of node taints to tolerate                                                                                               | `- effect: NoSchedule operator: Exists`          |
+| `priorityClassName`                   | Name of Priority Class to assign pods                                                                                         | `nil`                                            |
+| `endpoints`                           | list of addresses that have node exporter deployed outside of the cluster                                                     | `[]`                                             |
+| `hostNetwork`                         | Whether to expose the service to the host network                                                                             | `true`                                           |
+| `prometheus.monitor.enabled`          | Set this to `true` to create ServiceMonitor for Prometheus operator                                                           | `false`                                          |
+| `prometheus.monitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus                                         | `{}`                                             |
+| `prometheus.monitor.namespace`        | namespace where servicemonitor resource should be created                                                                     | `the same namespace as prometheus node exporter` |
+| `prometheus.monitor.scrapeTimeout`    | Timeout after which the scrape is ended                                                                                       | `10s`                                            |
+| `configmaps`                          | Allow mounting additional configmaps.                                                                                         | `[]`                                             |
+| `namespaceOverride`                   | Override the deployment namespace                                                                                             | `""` (`Release.Namespace`)                       |
+| `updateStrategy`                      | Configure a custom update strategy for the daemonset                                                                          | `Rolling update with 1 max unavailable`          |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-node-exporter/templates/daemonset.yaml
+++ b/stable/prometheus-node-exporter/templates/daemonset.yaml
@@ -9,10 +9,10 @@ spec:
     matchLabels:
       app: {{ template "prometheus-node-exporter.name" . }}
       release: {{ .Release.Name }}
+  {{- if .Values.updateStrategy }}
   updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
+{{ toYaml .Values.updateStrategy | indent 4 }}
+  {{- end }}
   template:
     metadata:
       labels: {{ include "prometheus-node-exporter.labels" . | indent 8 }}

--- a/stable/prometheus-node-exporter/values.yaml
+++ b/stable/prometheus-node-exporter/values.yaml
@@ -22,6 +22,12 @@ prometheus:
 
     scrapeTimeout: 10s
 
+## Customize the updateStrategy if set
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
This PR adds configuration value `updateStrategy` which allows the user of the chart to specify an update strategy that works for their environment.

It can be desirable to have faster rolling updates for large clusters, or to disable rolling updates all together for maximum stability and control. It makes sense to leave this up to the user of the chart, as requirements vary.

The default value in `values.yaml` matches the previous hard-coded configuration of a rolling update with 1 max unavailable pod. This will hopefully avoid unexpected surprises when a user updates the chart and does not set `updateStrategy`.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
This is my first PR for a helm/charts, hopefully I covered all the bases!

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
