### PR TITLE
[stable/elasticsearch-curator] load envs from secrets first

### DIFF
--- a/stable/elasticsearch-curator/Chart.yaml
+++ b/stable/elasticsearch-curator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "5.7.6"
 description: A Helm chart for Elasticsearch Curator
 name: elasticsearch-curator
-version: 2.1.4
+version: 2.1.5
 home: https://github.com/elastic/curator
 keywords:
 - curator

--- a/stable/elasticsearch-curator/templates/cronjob.yaml
+++ b/stable/elasticsearch-curator/templates/cronjob.yaml
@@ -89,12 +89,6 @@ spec:
               args: [ "--config", "/etc/es-curator/config.yml", "/etc/es-curator/action_file.yml" ]
 {{- end }}
               env:
-{{- if .Values.env }}
-{{- range $key,$value := .Values.env }}
-              - name: {{ $key | upper | quote}}
-                value: {{ $value | quote}}
-{{- end }}
-{{- end }}
 {{- if .Values.envFromSecrets }}
 {{- range $key,$value := .Values.envFromSecrets }}
               - name: {{ $key | upper | quote}}
@@ -102,6 +96,12 @@ spec:
                   secretKeyRef:
                     name: {{ $value.from.secret | quote}}
                     key: {{ $value.from.key | quote}}
+{{- end }}
+{{- end }}
+{{- if .Values.env }}
+{{- range $key,$value := .Values.env }}
+              - name: {{ $key | upper | quote}}
+                value: {{ $value | quote}}
 {{- end }}
 {{- end }}
               resources:


### PR DESCRIPTION


<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
no

#### What this PR does / why we need it:
allows using environment variable composition with env variables that are loaded from secrets (e.g. for loading a HTTP password and then compositing it into a full basic auth env variable). The referenced environment variable needs to be loaded first, and therefore env variables from secrets need to be loaded first to enable composition. Please see #20872 for details.

This will allow using this snippet:

```yaml
[...]
env:
  ELASTIC_HOST: elastic-es-http
  ELASTIC_CREDENTIALS: "elastic:$(ELASTIC_PASSWORD)"
envFromSecrets:
  ELASTIC_PASSWORD:
    from:
      secret: elastic-es-elastic-user
      key: elastic
configMaps:
  config_yml: |-
    ---
    client:
      hosts:
        - ${ELASTIC_HOST}
      port: 9200
      use_ssl: True
      certificate: /certs/elastic/ca.crt
      ssl_no_validate: False
      http_auth: ${ELASTIC_CREDENTIALS}
[...]
```

Right now, Kubernetes will not expand `$(ELASTIC_PASSWORD)`.

#### Which issue this PR fixes
  - fixes #20872

#### Special notes for your reviewer:
none

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
