### PR TITLE
Add missing template rendering (Fixup #20644)

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.8.0
-version: 1.40.0
+version: 1.40.1
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/templates/service-discovery.yaml
+++ b/stable/rabbitmq-ha/templates/service-discovery.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
 {{- if .Values.service.annotations }}
   annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
+{{ tpl (toYaml .Values.service.annotations) . | indent 4 }}
 {{- end }}
   name: {{ printf "%s-discovery" (include "rabbitmq-ha.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
The templating provided in #20644 missed a usage of `service.annotations` which results in un-templated annotations for the `service-discovery` Service. This PR seeks to correct this issue.