### PR TITLE
[stable/prometheus-adapter]: do not create apiservice when not needed

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 2.1.1
+version: 2.1.2
 appVersion: v0.6.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/templates/custom-metrics-apiservice.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-apiservice.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.rules.default .Values.rules.custom }}
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
 metadata:
@@ -19,3 +20,4 @@ spec:
   insecureSkipTLSVerify: {{ if .Values.tls.enable }}false{{ else }}true{{ end }}
   groupPriorityMinimum: 100
   versionPriority: 100
+{{- end }}


### PR DESCRIPTION

#### What this PR does / why we need it:

without it, having no custom rules (e.g. only external rules) would make the api service still be created, but it woulnd't work, and would cause errors suchs as:

```
unable to retrieve the complete list of server APIs: custom.metrics.k8s.io/v1beta1: the server is currently unable to handle the request
```

#### Which issue this PR fixes


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
