### PR TITLE
[stable/drone] Downgrade drone-agent to the latest published image tag

### DIFF
--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 2.7.0
+version: 2.7.1
 appVersion: 1.6.5
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/stable/drone/values.yaml
+++ b/stable/drone/values.yaml
@@ -12,7 +12,7 @@ images:
   ##
   agent:
     repository: "docker.io/drone/agent"
-    tag: 1.6.5
+    tag: 1.6.2
     pullPolicy: IfNotPresent
 
   ## The official docker (dind) image, change tag to use a different version.


### PR DESCRIPTION
Fix regression from c89126cc9189e8eb5b02c157092853e26fe3fe6b.
The latest published drone/agent image tag as of today is 1.6.2, see https://hub.docker.com/r/drone/agent/tags.

#### What this PR does / why we need it:
Fixes docker-agent.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
