### PR TITLE
[stable/cluster-autoscaler]: fix default psp

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 6.6.0
+version: 6.6.1
 appVersion: 1.14.6
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/templates/podsecuritypolicy.yaml
+++ b/stable/cluster-autoscaler/templates/podsecuritypolicy.yaml
@@ -16,6 +16,9 @@ spec:
     - 'configMap'
     - 'secret'
     - 'hostPath'
+    - 'emptyDir'
+    - 'projected'
+    - 'downwardAPI'
 {{- if eq .Values.cloudProvider "gce" }}
   allowedHostPaths:
     - pathPrefix: {{ .Values.cloudConfigPath }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Use a more sensible default, pods fails because it needs projected
volumes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)