### PR TITLE
[incubator/kube-registry-proxy] Update DaemonSet apiVersion to 'apps/v1' - Mandatory for K8s 1.16

### DIFF
--- a/incubator/kube-registry-proxy/Chart.yaml
+++ b/incubator/kube-registry-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kube-registry-proxy
 home: https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/registry
-version: 0.3.1
+version: 0.3.2
 appVersion: 0.4
 description: Installs the kubernetes-registry-proxy cluster addon.
 maintainers:

--- a/incubator/kube-registry-proxy/templates/daemon.yaml
+++ b/incubator/kube-registry-proxy/templates/daemon.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "kube-registry-proxy.fullname" . }}

--- a/incubator/kube-registry-proxy/templates/daemon.yaml
+++ b/incubator/kube-registry-proxy/templates/daemon.yaml
@@ -7,6 +7,9 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "kube-registry-proxy.fullname" . }}
   template:
     metadata:
       name: {{ template "kube-registry-proxy.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

There are several deprecations in the API introduced in K8s 1.16 (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#deprecations-and-removals) which affect our manifests. 

- This PR changes [incubator/kube-registry-proxy] DaemonSet apiVersion to `apps/v1`.
- Also, as of Kubernetes 1.8, you must specify a pod selector that matches the labels of the .spec.template([see here](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#pod-selector)).
This PR also adds proper selector value to [incubator/kube-registry-proxy] DaemonSet.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
