### PR TITLE
[incubator/mysqlha] Update statefulset api version to apps/v1

### DIFF
--- a/incubator/mysqlha/Chart.yaml
+++ b/incubator/mysqlha/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mysqlha
-version: 1.0.0
+version: 1.0.1
 appVersion: 5.7.13
 description: MySQL cluster with a single master and zero or more slave replicas
 keywords:

--- a/incubator/mysqlha/README.md
+++ b/incubator/mysqlha/README.md
@@ -8,7 +8,7 @@ This chart bootstraps a single master and multiple slave MySQL deployment on a [
 
 ## Prerequisites
 
-- Kubernetes 1.6+
+- Kubernetes 1.10+ with Beta APIs enabled
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/incubator/mysqlha/templates/statefulset.yaml
+++ b/incubator/mysqlha/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "fullname" . }}
@@ -8,12 +8,17 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+      release: {{ .Release.Name }}
   serviceName: {{ template "fullname" . }}
   replicas: {{ .Values.mysqlha.replicaCount }}
   template:
     metadata:
       labels:
         app: {{ template "fullname" . }}
+        release: {{ .Release.Name }}
       {{- if .Values.mysqlha.podAnnotations }}
       annotations:
 {{ toYaml .Values.mysqlha.podAnnotations | indent 8 }}

--- a/incubator/mysqlha/values.yaml
+++ b/incubator/mysqlha/values.yaml
@@ -1,7 +1,7 @@
 ## mysql image version
 ## ref: https://hub.docker.com/r/library/mysql/tags/
 ##
-mysqlImage: mysql:5.7.13
+mysqlImage: mysql:5.7.29
 xtraBackupImage: gcr.io/google-samples/xtrabackup:1.0
 
 ## Specify an imagePullPolicy (Required)


### PR DESCRIPTION
Signed-off-by: Ciprian Hacman <ciprian.hacman@sematext.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:

The `apps/v1beta1` api version was removed in Kubernetes 1.16. To install the chart, `apps/v1` is required.
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

#### Special notes for your reviewer:

`apps/v1` is available since Kubernetes 1.9:
https://github.com/kubernetes/api/tree/release-1.9/apps/v1

Already done for [stable/mysql]:
https://github.com/helm/charts/pull/17642

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
