### PR TITLE
[stable/minio] fix serviceMonitor authentication

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: MinIO is a high performance data infrastructure for machine learning, analytics and application data workloads.
 name: minio
-version: 5.0.18
+version: 5.0.19
 appVersion: master
 keywords:
 - storage

--- a/stable/minio/templates/post-install-prometheus-metrics-job.yaml
+++ b/stable/minio/templates/post-install-prometheus-metrics-job.yaml
@@ -1,0 +1,110 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+{{- $fullName := include "minio.fullname" . -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $fullName }}-update-prometheus-secret
+  labels:
+    app: {{ template "minio.name" . }}-update-prometheus-secret
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+  {{ toYaml .Values.updatePrometheusJob.annotations | indent 4 }}
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "minio.name" . }}-update-prometheus-secret
+        release: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+    spec:
+{{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ $fullName }}-update-prometheus-secret
+{{- end }}
+      restartPolicy: OnFailure
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+      volumes:
+        - name: workdir
+          emptyDir: {}
+      initContainers:
+        - name: minio-mc
+          image: "{{ .Values.mcImage.repository }}:{{ .Values.mcImage.tag }}"
+          imagePullPolicy: {{ .Values.mcImage.pullPolicy }}
+          command:
+            - /bin/sh
+            - "-c"
+            - mc admin prometheus generate target --json --no-color -q > /workdir/mc.json
+          env:
+            # mc admin prometheus generate don't really connect to remote server, TLS cert isn't required
+            - name: MC_HOST_target
+              value: http{{ if .Values.tls.enabled }}s{{ end }}://{{ .Values.accessKey }}:{{ .Values.secretKey }}@{{ $fullName }}:{{ .Values.service.port }}
+          volumeMounts:
+            - name: workdir
+              mountPath: /workdir
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+        # extract bearerToken from mc admin output
+        - name: jq
+          image: "{{ .Values.helmKubectlJqImage.repository }}:{{ .Values.helmKubectlJqImage.tag }}"
+          imagePullPolicy: {{ .Values.helmKubectlJqImage.pullPolicy }}
+          command:
+            - /bin/sh
+            - "-c"
+            - jq -e -c -j -r .bearerToken < /workdir/mc.json > /workdir/token
+          volumeMounts:
+            - name: workdir
+              mountPath: /workdir
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+        - name: kubectl-create
+          image: "{{ .Values.helmKubectlJqImage.repository }}:{{ .Values.helmKubectlJqImage.tag }}"
+          imagePullPolicy: {{ .Values.helmKubectlJqImage.pullPolicy }}
+          command:
+            - /bin/sh
+            - "-c"
+            # The following script does:
+            # - get the servicemonitor that need this secret and copy some metadata and create the ownerreference for the secret file
+            # - create the secret
+            # - merge both json
+            - >
+              kubectl -n {{ .Release.Namespace }} get servicemonitor {{ $fullName }} -o json |
+                jq -c '{metadata: {name: "{{ $fullName }}-prometheus", namespace: .metadata.namespace, labels: {app: .metadata.labels.app, release: .metadata.labels.release}, ownerReferences: [{apiVersion: .apiVersion, kind: .kind, blockOwnerDeletion: true, controller: true, uid: .metadata.uid, name: .metadata.name}]}}' > /workdir/metadata.json &&
+              kubectl create secret generic {{ $fullName }}-prometheus --from-file=token=/workdir/token --dry-run -o json > /workdir/secret.json &&
+              cat /workdir/secret.json /workdir/metadata.json | jq -s add > /workdir/object.json
+          volumeMounts:
+            - name: workdir
+              mountPath: /workdir
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+      containers:
+        - name: kubectl-apply
+          image: "{{ .Values.helmKubectlJqImage.repository }}:{{ .Values.helmKubectlJqImage.tag }}"
+          imagePullPolicy: {{ .Values.helmKubectlJqImage.pullPolicy }}
+          command:
+            - kubectl
+            - apply
+            - "-f"
+            - /workdir/object.json
+          volumeMounts:
+            - name: workdir
+              mountPath: /workdir
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+{{- end }}

--- a/stable/minio/templates/post-install-prometheus-metrics-role.yaml
+++ b/stable/minio/templates/post-install-prometheus-metrics-role.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.serviceAccount.create -}}
+{{- $fullName := include "minio.fullname" . -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $fullName }}-update-prometheus-secret
+  labels:
+    app: {{ template "minio.name" . }}-update-prometheus-secret
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+      - update
+      - patch
+    resourceNames:
+      - {{ $fullName }}-prometheus
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+    resourceNames:
+      - {{ $fullName }}
+{{- end -}}

--- a/stable/minio/templates/post-install-prometheus-metrics-rolebinding.yaml
+++ b/stable/minio/templates/post-install-prometheus-metrics-rolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.serviceAccount.create -}}
+{{- $fullName := include "minio.fullname" . -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullName }}-update-prometheus-secret
+  labels:
+    app: {{ template "minio.name" . }}-update-prometheus-secret
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $fullName }}-update-prometheus-secret
+subjects:
+  - kind: ServiceAccount
+    name: {{ $fullName }}-update-prometheus-secret
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/stable/minio/templates/post-install-prometheus-metrics-serviceaccount.yaml
+++ b/stable/minio/templates/post-install-prometheus-metrics-serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+{{- $fullName := include "minio.fullname" . -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $fullName }}-update-prometheus-secret
+  labels:
+    app: {{ template "minio.name" . }}-update-prometheus-secret
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end -}}

--- a/stable/minio/templates/servicemonitor.yaml
+++ b/stable/minio/templates/servicemonitor.yaml
@@ -28,6 +28,9 @@ spec:
       {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
       {{- end }}
+      bearerTokenSecret:
+        name: {{ template "minio.fullname" . }}-prometheus
+        key: token
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/stable/minio/values.yaml
+++ b/stable/minio/values.yaml
@@ -25,6 +25,14 @@ mcImage:
   tag: RELEASE.2020-03-14T01-23-37Z
   pullPolicy: IfNotPresent
 
+## Set default image, imageTag, and imagePullPolicy for the `jq` (the JSON
+## process used to create secret for prometheus ServiceMonitor).
+##
+helmKubectlJqImage:
+  repository: bskim45/helm-kubectl-jq
+  tag: 3.1.0
+  pullPolicy: IfNotPresent
+
 ## minio server mode, i.e. standalone or distributed.
 ## Distributed Minio ref: https://docs.minio.io/docs/distributed-minio-quickstart-guide
 ##
@@ -224,6 +232,10 @@ buckets: []
 
 ## Additional Annotations for the Kubernetes Batch (make-bucket-job)
 makeBucketJob:
+  annotations:
+
+## Additional Annotations for the Kubernetes Batch (update-prometheus-secret)
+updatePrometheusJob:
   annotations:
 
 s3gateway:


### PR DESCRIPTION
#### What this PR does / why we need it:

Prometheus can't scrape metrics anymore, it get a 403. I think this change had been introduced [in this release](https://github.com/minio/minio/tree/RELEASE.2019-10-11T00-38-09Z).

Basically, the metrics URL now requires authentication. [Minio doc regarding this](https://docs.min.io/docs/how-to-monitor-minio-using-prometheus.html).

This PR add a job that:

- use `minio/mc` to generate a token. this step don't connect to backend, it just createa JWT using access/secret key [code reference](https://github.com/minio/mc/blob/9663319/cmd/admin-prometheus-generate.go#L157). This token is good for [~100 years](https://github.com/minio/mc/blob/9663319/cmd/admin-prometheus-generate.go#L114)
- change `ServiceMonitor` to use token in a secret
- Run a job that create/update that token and set the `ServiceMonitor` as it's owner & controller

The token can be updated at every execution.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
