### PR TITLE
[stable/cluster-autoscaler] fix deployment strategy location

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 6.5.0
+version: 6.6.0
 appVersion: 1.14.6
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/templates/deployment.yaml
+++ b/stable/cluster-autoscaler/templates/deployment.yaml
@@ -14,6 +14,10 @@ spec:
     {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 6 }}
     {{- end }}
+{{- if .Values.updateStrategy }}
+  strategy:
+    {{ toYaml .Values.updateStrategy | nindent 4 | trim }}
+{{- end }}
   template:
     metadata:
     {{- if .Values.podAnnotations }}
@@ -193,10 +197,6 @@ spec:
       {{- if .Values.securityContext }}
       securityContext:
         {{ toYaml .Values.securityContext | nindent 8 | trim }}
-      {{- end }}
-      {{- if .Values.updateStrategy }}
-      strategy:
-        {{ toYaml .Values.updateStrategy | nindent 8 | trim }}
       {{- end }}
       {{- if eq .Values.cloudProvider "gce" }}
       volumes:


### PR DESCRIPTION

#### Is this a new chart
NO

#### What this PR does / why we need it:
While introducing `updateStrategy` in https://github.com/helm/charts/pull/20801 I've made a mistake with field placement.

#### Which issue this PR fixes
  - fixes #20897

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
