### PR TITLE
[stable/prometheus-adapter] Do not create custom metrics rbac

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 2.1.2
+version: 2.1.3
 appVersion: v0.6.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/templates/custom-metrics-cluster-role.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-cluster-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if and .Values.rbac.create (or .Values.rules.default .Values.rules.custom) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
#### What this PR does / why we need it:

[stable/prometheus-adapter] Do not create custom metrics rbac
    
Commit b7afaf9d8875f6aa1cfed4c0422cb28e51d823a3 ("do not create
apiservice when not needed") from PR #20883 disabled the custom API
Service when no custom rules are used. However, we also need to not
deploy the cluster role as it has no use.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ x] Chart Version bumped
- [x ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
