### PR TITLE
[stable/rabbitmq] Changed RabbitMQ TLS secret type to kubernetes.io/tls.

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.18.0
+version: 6.18.1
 appVersion: 3.8.2
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -342,7 +342,7 @@ You must include in your values.yaml the caCertificate, serverCertificate and se
     -----END RSA PRIVATE KEY-----
 ```
 
-This will be generate a secret with the certs, but is possible specify an existing secret using `existingSecret: name-of-existing-secret-to-rabbitmq`
+This will be generate a secret with the certs, but is possible specify an existing secret using `existingSecret: name-of-existing-secret-to-rabbitmq`. The secret is of type `kubernetes.io/tls`.
 
 Disabling [failIfNoPeerCert](https://www.rabbitmq.com/ssl.html#peer-verification-configuration) allows a TLS connection if client fails to provide a certificate
 

--- a/stable/rabbitmq/templates/certs.yaml
+++ b/stable/rabbitmq/templates/certs.yaml
@@ -8,12 +8,12 @@ metadata:
     chart: {{ template "rabbitmq.chart" .  }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-type: Opaque
+type: kubernetes.io/tls
 data:
-  ca_certificate.pem:
+  ca.crt:
     {{ required "A valid .Values.rabbitmq.tls.caCertificate entry required!" .Values.rabbitmq.tls.caCertificate | b64enc | quote }}
-  server_certificate.pem:
+  tls.crt:
     {{ required "A valid .Values.rabbitmq.tls.serverCertificate entry required!" .Values.rabbitmq.tls.serverCertificate| b64enc | quote }}
-  server_key.pem:
+  tls.key:
     {{ required "A valid .Values.rabbitmq.tls.serverKey entry required!" .Values.rabbitmq.tls.serverKey | b64enc | quote }}
 {{- end }}

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -311,11 +311,11 @@ spec:
           secret:
             secretName: {{ if .Values.rabbitmq.tls.existingSecret }}{{ .Values.rabbitmq.tls.existingSecret }}{{- else }}{{ template "rabbitmq.fullname" . }}-certs{{- end }}
             items:
-            - key: ca_certificate.pem
+            - key: ca.crt
               path: ca_certificate.pem
-            - key: server_certificate.pem
+            - key: tls.crt
               path: server_certificate.pem
-            - key: server_key.pem
+            - key: tls.key
               path: server_key.pem
         {{- end }}
         - name: config-volume


### PR DESCRIPTION
Changed RabbitMQ TLS secret type to kubernetes.io/tls. Can use cert-manager created secrets with this chart now.

Signed-off-by: Charalampos Kaidos <ckaidos@intracom-telecom.com>

#### Is this a new chart
No.

#### What this PR does / why we need it:
It changes the type of the secret holding the TLS certificates from `Opaque` to `kubernetes.io/tls`. This allows to use externally created certificates (e.g. from cert-manager) using the Kubernetes secret type defined for this purpose.

#### Which issue this PR fixes
None (afaik)

#### Special notes for your reviewer:
The actual filenames the pod looks for have not been changed. The keys of the TLS secret are mounted to the existing paths.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
