### PR TITLE
[stable/chaoskube] Support adding pod labels.

### DIFF
--- a/stable/chaoskube/Chart.yaml
+++ b/stable/chaoskube/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: chaoskube
-version: 3.1.3
+version: 3.1.4
 appVersion: 0.14.0
 description: Chaoskube periodically kills random pods in your Kubernetes cluster.
 icon: https://raw.githubusercontent.com/linki/chaoskube/master/chaoskube.png

--- a/stable/chaoskube/README.md
+++ b/stable/chaoskube/README.md
@@ -63,6 +63,7 @@ $ helm install stable/chaoskube --set dryRun=false
 | `affinity`                                | Affinity settings for pod assignment                                                  | `{}`                             |
 | `minimumAge`                              | Set minimum pod age to filter pod by                                                  | `0s`                             |
 | `podAnnotations`                          | Annotations for the chaoskube pod                                                     | `{}`                             |
+| `podLabels`                               | Labels for the chaoskube pod                                                          | `{}`                             |
 | `gracePeriod`                             | grace period to give pods when terminating them                                       | `-1s` (pod decides)              |
 | `metrics.enabled`                         | Enable metrics handler                                                                | `false`                          |
 | `metrics.port`                            | Listening port for metrics handler                                                    | `8080`                           |

--- a/stable/chaoskube/templates/deployment.yaml
+++ b/stable/chaoskube/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
     metadata:
       labels:
 {{ include "labels.standard" . | indent 8 }}
+    {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+    {{- end }}
     {{- if .Values.podAnnotations }}
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}

--- a/stable/chaoskube/values.yaml
+++ b/stable/chaoskube/values.yaml
@@ -115,3 +115,9 @@ podAnnotations: {}
   #  podAnnotations:
   #    prometheus.io/scrape: "true"
   #    prometheus.io/port: "8080"
+
+podLabels: {}
+  ## Labels for the chaoskube pod.
+  #  podLabels:
+  #    my.first.label: "value"
+  #    my.other.label: "other-value"


### PR DESCRIPTION
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

No

#### What this PR does / why we need it:

This PR allows for additional labels to be added to `chaoskube` pods.

It is useful in environments where network policies exists and access to k8s api-server is controlled by specific labels on the pod.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
