### PR TITLE
feature: add extra volumes and mounts for nextcloud container

### DIFF
--- a/stable/nextcloud/Chart.yaml
+++ b/stable/nextcloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nextcloud
-version: 1.9.1
+version: 1.9.2
 appVersion: 17.0.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/nextcloud/README.md
+++ b/stable/nextcloud/README.md
@@ -137,6 +137,8 @@ The following table lists the configurable parameters of the nextcloud chart and
 | `readinessProbe.successThreshold`                            | Minimum consecutive successes for the probe             | `1`                                                     |
 | `deploymentAnnotations`                                      | Annotations to be added at 'deployment' level           | not set                                                 |
 | `podAnnotations`                                             | Annotations to be added at 'pod' level                  | not set                                                 |
+| `extraVolumes`                                             | List of extra volumes to be defined                  | not set                                                 |
+| `extraVolumeMounts`                                             | List of extra volume mounts to nextcloud container                  | not set                                                 |
 
 > **Note**:
 >

--- a/stable/nextcloud/templates/deployment.yaml
+++ b/stable/nextcloud/templates/deployment.yaml
@@ -201,6 +201,7 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
+        {{- if .Values.extraVolumeMounts }}{{ toYaml .Values.extraVolumeMounts | trim | nindent 8 }}{{ end }}
         - name: nextcloud-data
           mountPath: /var/www/
           subPath: root
@@ -318,6 +319,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       volumes:
+      {{- if .Values.extraVolumes  }}{{ toYaml .Values.extraVolumes | trim | nindent 6 }}{{ end }}  
       - name: nextcloud-data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:

--- a/stable/nextcloud/values.yaml
+++ b/stable/nextcloud/values.yaml
@@ -309,3 +309,15 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Any extra volumes to define for the pod
+extraVolumes: []
+  # - name: example-name
+  #   hostPath:
+  #     path: /path/on/host
+  #     type: DirectoryOrCreate
+
+# Any extra volume mounts to define for the nextcloud container
+extraVolumeMounts: []
+#   - name: example-name
+#     mountPath: /path/in/container


### PR DESCRIPTION
In most of the case the nextcloud will be hosted in a single node cluster (e.g., k3s) for personal private cloud. To use the 'local' external storage feature, mounting an existing local folder to nextcloud container is a simple and useful option.
@billimek 
@chrisingenhaag

#### Is this a new chart
No. This is a minor enhancement for an existing chart (nextcloud)

#### What this PR does / why we need it:
To enable user to mount a local path/folder to nextcloud container so that 'local' external storage could be setup easily.

#### Which issue this PR fixes
none.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/nextcloud]`)
