### PR TITLE
[stable/drone] add component labels for ServiceMonitor

### DIFF
--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 2.7.1
+version: 2.7.2
 appVersion: 1.6.5
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/stable/drone/templates/service-secrets.yaml
+++ b/stable/drone/templates/service-secrets.yaml
@@ -14,6 +14,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    component: secrets
 spec:
   type: ClusterIP
   ports:

--- a/stable/drone/templates/service.yaml
+++ b/stable/drone/templates/service.yaml
@@ -11,6 +11,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    component: server
 spec:
   type: {{ .Values.service.type }}
   {{- if and (hasKey .Values.service "loadBalancerIP") (eq .Values.service.type "LoadBalancer") }}


### PR DESCRIPTION
### What this PR does / why we need it:

Drone Servers support prometheus metrics. Drone Kubernetes Secrets don't.
Prometheus `ServiceMonitor` use only `metadata.labels` to match the service to monitor.
As those 2 services have exactly same labels there is no ways to filter a `ServiceMonitor` to only pick the server and not secrets, which cause the following:

![Screenshot from 2020-02-21 23-41-54](https://user-images.githubusercontent.com/474302/75048670-d977ee80-5503-11ea-830c-4f809325257a.png)

This PR create a label `component` that can be used to enforce ServiceMonitor to focus on server and ignore secrets.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
