### PR TITLE
[stable/airflow] FIX CoreOS ServiceMonitor spec.groups is an array

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 6.2.1
+version: 6.2.2
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -716,7 +716,7 @@ prometheusRule:
   ## Define individual alerting rules as required
   ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#rulegroup
   ##      https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
-  groups: {}
+  groups: []
 
   ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Prometheus Rules to work with
   ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec


### PR DESCRIPTION
This fixes a little syntax error in the default values for the Chart.

`For ServiceMonitor: spec.groups in body must be of type array: "object"`