### PR TITLE
[incubator/cassandra] Fix affinity for backup cronjob

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cassandra
-version: 0.14.1
+version: 0.14.2
 appVersion: 3.11.5
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/templates/backup/cronjob.yaml
+++ b/incubator/cassandra/templates/backup/cronjob.yaml
@@ -66,23 +66,25 @@ spec:
             secret:
               secretName: {{ $backup.google.serviceAccountSecret | quote }}
 {{- end }}
-        affinity:
-          podAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - {{ template "cassandra.fullname" $ }}
-                - key: release
-                  operator: In
-                  values:
-                  - {{ $release.Name }}
-              topologyKey: "kubernetes.io/hostname"
-      {{- with $values.tolerations }}
-        tolerations:
-{{ toYaml . | indent 10 }}
-      {{- end }}
+          affinity:
+            podAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                      - {{ template "cassandra.fullname" $ }}
+                    - key: release
+                      operator: In
+                      values:
+                      - {{ $release.Name }}
+                  topologyKey: "kubernetes.io/hostname"
+          {{- with $values.tolerations }}
+          tolerations:
+{{ toYaml . | indent 12 }}
+          {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Simon Hardy <sha@taktik.com>

#### What this PR does / why we need it:
The affinity section of the backup part of incubator/cassandra is and has always been broken, this PR fixes it. The problem comes from both wrong indentation, and wrong syntax (actually I think the syntax of the affinity section changed over time, which would explain why it is currently wrong). 

Example: 
simon@sha cassandra % helm upgrade cassandra incubator/cassandra -f cassandra-values.yaml 
coalesce.go:199: warning: destination for env is a table. Ignoring non-table value [map[name:AWS_REGION value:us-east-1]]
Error: UPGRADE FAILED: error validating "": error validating data: ValidationError(CronJob.spec.jobTemplate.spec.template): unknown field "affinity" in io.k8s.api.core.v1.PodTemplateSpec

Previously the chart was installable so people never really noticed it, but now with Helm 3 the chart is not installable anymore. The reason is the following: 
"Helm 3 validates all of your rendered templates against the Kubernetes OpenAPI schema. This was enabled in v3.0.0. Prior to this, Helm would render your templates and send them to the Kubernetes API and leave it up to the API to determine what was valid."

#### Special notes for your reviewer:
I never really used the affinity feature so please make sure to cross-check it, but what I can assure is that this fixed chart is installable/upgradable with Helm 3. 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
