### PR TITLE
[stable/dex] Update dex example URLs

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: dex
 version: 2.8.1
 appVersion: 2.21.0
-description: CoreOS Dex
+description: OpenID Connect Identity (OIDC) and OAuth 2.0 Provider with Pluggable Connectors
 keywords:
 - dex
 - oidc

--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dex
-version: 2.8.0
+version: 2.8.1
 appVersion: 2.21.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/values.yaml
+++ b/stable/dex/values.yaml
@@ -108,7 +108,7 @@ certs:
     caDays: 10000
     certDays: 10000
     altNames:
-      - dex.io
+      - dex.example.com
     altIPs: {}
     secret:
       tlsName: dex-web-server-tls
@@ -120,7 +120,7 @@ certs:
     create: true
     activeDeadlineSeconds: 300
     altNames:
-      - dex.io
+      - dex.example.com
     altIPs: {}
     secret:
       serverTlsName: dex-grpc-server-tls
@@ -162,7 +162,7 @@ podDisruptionBudget: {}
   # maxUnavailable: 1
 
 config:
-  issuer: http://dex.io:8080
+  issuer: http://dex.example.com:8080
   storage:
     type: kubernetes
     config:


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:

The example URL used in the default configuration points to an existing website. If someone does not update the default values, they might end up sending information to that site. At the very least, it's confusing. That example URL (dex.io) is not affiliated with Dex itself.

#### Which issue this PR fixes
  - fixes dexidp/dex#1587

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
