### PR TITLE
[stable/mongodb-replicaset] Fix test race condition

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.11.5
+version: 3.11.6
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/tests/mongodb-up-test.sh
+++ b/stable/mongodb-replicaset/tests/mongodb-up-test.sh
@@ -73,7 +73,7 @@ setup() {
     until [[ "$ready" -eq $(replicas) ]]; do
         echo "Waiting for application to become ready" >&2
         sleep 1
-
+        ready=0
         for ((i = 0; i < $(replicas); ++i)); do
             response=$(mongo $MONGOARGS "--host=$(pod_name "$i")" "--eval=rs.status().ok" || true)
             if [[ "$response" -eq 1 ]]; then


### PR DESCRIPTION
Signed-off-by: Tuan Anh Nguyen <tuananh.nguyen-ext@commercetools.de>

#### Is this a new chart
No

#### What this PR does / why we need it:
The current test of mongodb-replicaset has an error in the logic since the ready flag doesn't reset after each loop. When `helm test` is run immediately after `helm upgrade` and the replicaset is being upgraded (for example, having `response = 1` for 2 out of 3 replicas for a while), this can cause the flag value to jump over the number of replicas, making the loop to run indefinitely.

#### Which issue this PR fixes
  - fixes #20553

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
