### PR TITLE
[stable/sematext-agent] Limit permissions required for Logagent only setups

### DIFF
--- a/stable/sematext-agent/Chart.yaml
+++ b/stable/sematext-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.0"
-version: 1.0.21
+version: 1.0.22
 description: Helm chart for deploying Sematext Agent to Kubernetes
 keywords:
   - sematext

--- a/stable/sematext-agent/templates/clusterrole.yaml
+++ b/stable/sematext-agent/templates/clusterrole.yaml
@@ -14,6 +14,14 @@ rules:
   resources:
   - events
   - pods
+  verbs:
+  - list
+  - get
+  - watch
+{{- if or (.Values.containerToken) (.Values.infraToken) }}
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   - nodes
   - secrets
@@ -52,4 +60,5 @@ rules:
   - get
   - watch
   - list
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Ciprian Hacman <ciprian.hacman@sematext.com>

#### What this PR does / why we need it:
The chart can provision both metrics and logs agents. If only the logs agent is provisioned, it will require very few permissions compared to the metrics agent. This PR limits the required in this case.

#### Which issue this PR fixes
n/a

#### Special notes for your reviewer:
n/a

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
