### PR TITLE
[stable/zeppelin] Use official Docker image, add Spark UI ingress

### DIFF
--- a/stable/zeppelin/Chart.yaml
+++ b/stable/zeppelin/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Web-based notebook that enables data-driven, interactive data analytics and collaborative documents with SQL, Scala and more.
 name: zeppelin
-version: 1.1.0
-appVersion: 0.7.2
+version: 1.2.0
+appVersion: 0.8.2
 home: https://zeppelin.apache.org/
 sources:
 - https://github.com/apache/zeppelin
@@ -10,3 +10,5 @@ icon: https://zeppelin.apache.org/assets/themes/zeppelin/img/zeppelin_classic_lo
 maintainers:
 - name: danisla
   email: disla@google.com
+- name: ebuildy
+  email: ebuildy@gmail.com

--- a/stable/zeppelin/README.md
+++ b/stable/zeppelin/README.md
@@ -31,6 +31,11 @@ The following table lists the configurable parameters of the Zeppelin chart and 
 | `ingress.hosts`                      | Ingress Hostnames                                                 | `["zeppelin.local"]`                                       |
 | `ingress.path`                       | Path within the URL structure                                     | `/`                                                        |
 | `ingress.tls`                        | Ingress TLS configuration                                         | `[]`                                                       |
+| `spark.ui.ingress.enabled`           | Enable Spark UI ingress                                                    | `false`                                                    |
+| `spark.ui.ingress.annotations`       | Spark UI Ingress annotations                                               | `{}`                                                       |
+| `spark.ui.ingress.hosts`             | Spark UI Ingress Hostnames                                                 | `["zeppelin-spark.local"]`                                       |
+| `spark.ui.ingress.path`              | Spark UI Path within the URL structure                                     | `/`                                                        |
+| `spark.ui.ingress.tls`               | Spark UI Ingress TLS configuration                                         | `[]`                                                       |
 | `nodeSelecor`                        | Node selector for the Zeppelin deployment                         | `{}`                                                       |
 
 ## Related charts

--- a/stable/zeppelin/templates/deployment.yaml
+++ b/stable/zeppelin/templates/deployment.yaml
@@ -25,7 +25,11 @@ spec:
           ports:
             - containerPort: 8080
               name: web
+            - containerPort: 4040
+              name: spark
           env:
+            - name: ZEPPELIN_ADDR
+              value: "0.0.0.0"
             - name: ZEPPELIN_PORT
               value: "8080"
             - name: ZEPPELIN_JAVA_OPTS
@@ -51,7 +55,7 @@ spec:
             httpGet:
               path: /
               port: 8080
-            initialDelaySeconds: 20
+            initialDelaySeconds: 40
             timeoutSeconds: 1
 {{- if .Values.hadoop.useConfigMap }}
       volumes:

--- a/stable/zeppelin/templates/spark_ui_ingress.yaml
+++ b/stable/zeppelin/templates/spark_ui_ingress.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.spark.ui.ingress.enabled }}
+{{- $ingress := .Values.spark.ui.ingress -}}
+{{- $ingressPath := $ingress.path -}}
+{{- $fullName := printf "%s-zeppelin-spark" .Release.Name -}}
+{{- $service := printf "%s-zeppelin" .Release.Name -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "zeppelin.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with $ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  rules:
+  {{- range $ingress.hosts }}
+  - host: {{ . | quote }}
+    http:
+      paths:
+        - path: {{ $ingressPath }}
+          backend:
+            serviceName: {{ $service }}
+            servicePort: 4040
+  {{- end }}
+{{- if $ingress.tls }}
+  tls:
+  {{- range $ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/stable/zeppelin/templates/svc.yaml
+++ b/stable/zeppelin/templates/svc.yaml
@@ -12,6 +12,8 @@ spec:
   ports:
   - port: 8080
     name: web
+  - port: 4040
+    name: spark
   selector:
     app: {{ template "zeppelin.name" . }}
     release: {{ .Release.Name }}

--- a/stable/zeppelin/values.yaml
+++ b/stable/zeppelin/values.yaml
@@ -1,5 +1,5 @@
 zeppelin:
-  image: dylanmei/zeppelin:0.7.2
+  image: apache/zeppelin:0.8.2
   resources:
     limits:
       memory: "4096Mi"
@@ -14,6 +14,19 @@ spark:
   driverMemory: 1g
   executorMemory: 1g
   numExecutors: 2
+  ui:
+    ingress:
+      enabled: false
+      annotations:
+        # kubernetes.io/ingress.class: nginx
+        # kubernetes.io/tls-acme: "true"
+        # nginx.ingress.kubernetes.io/auth-secret: zeppelin-tls-secret
+      path: / #spark(/|$)(.*)
+      hosts:
+        - zeppelin-spark.local
+      tls: []
+        # - secretName: zeppelin-tls-secret
+        #   hosts: zeppelin.local
 
 ingress:
   enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:

Last stable version use an old Docker image (version 0.7.2), I propose to use the official Docker image (version 0.8.2).

Also, since Zeppelin provides a local Spark, it's interesting to access to Spark web UI (port 4040).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
