### PR TITLE
[stable/grafana] Add Traefik's 2 IngressRoute support

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.0.1
+version: 5.0.2
 appVersion: 6.6.1
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -73,6 +73,12 @@ You have to add --force to your helm upgrade command as the labels of the chart 
 | `ingress.hosts`                           | Ingress accepted hostnames                    | `[]`                                                    |
 | `ingress.extraPaths`                      | Ingress extra paths to prepend to every host configuration. Useful when configuring [custom actions with AWS ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/#actions). | `[]`                                                    |
 | `ingress.tls`                             | Ingress TLS configuration                     | `[]`                                                    |
+| `ingressRoute.enabled`                    | Enables IngressRoute for [traefik2](https://docs.traefik.io/routing/providers/kubernetes-crd/#kind-ingressroute)| `false` |
+| `ingressRoute.labels`                     | Custom labels                                 | `{}`                                                    |
+| `ingressRoute.entryPoints`                | Traefik 2 entry points accepted               | `{}`                                                    |
+| `ingressRoute.hosts`                      | Traefik 2 IngressRoute accepted hostnames     | `[]`                                                    |
+| `ingressRoute.path`                       | Traefik 2 IngressRoute accepted path          | `/`                                                     |
+| `ingressRoute.tls`                        | Traefik 2 IngressRoute TLS configuration      | `{}`                                                    |
 | `resources`                               | CPU/Memory resource requests/limits           | `{}`                                                    |
 | `nodeSelector`                            | Node labels for pod assignment                | `{}`                                                    |
 | `tolerations`                             | Toleration labels for pod assignment          | `[]`                                                    |

--- a/stable/grafana/templates/ingressRoute.yaml
+++ b/stable/grafana/templates/ingressRoute.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.ingressRoute.enabled }}
+{{- $fullName := include "grafana.fullname" . -}}
+{{- $namespace := include "grafana.namespace" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $ingressPath := .Values.ingressRoute.path -}}
+{{- $stripPrefix := (and .Values.ingressRoute.path (ne .Values.ingressRoute.path "/")) -}}
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ template "grafana.namespace" . }}
+  labels:
+    {{- include "grafana.labels" . | nindent 4 }}
+{{- if .Values.ingressRoute.labels }}
+{{ toYaml .Values.ingressRoute.labels | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingressRoute.entryPoints }}
+  entryPoints:
+  {{- range .Values.ingressRoute.entryPoints }}
+    - {{ . }}
+  {{- end }}
+{{- end }}
+{{- if .Values.ingressRoute.tls }}
+  tls:
+{{ toYaml .Values.ingressRoute.tls | indent 4 }}
+{{- end }}
+  routes:
+  {{- if .Values.ingressRoute.hosts }}
+    {{- range $host := .Values.ingressRoute.hosts }}
+    - match: Host(`{{ tpl $host $ }}`) && PathPrefix(`{{ $ingressPath }}`)
+      kind: Rule
+      services:
+        - name: {{ $fullName }}
+          kind: Service
+          port: {{ $servicePort }}
+      {{- if $stripPrefix }}
+      middlewares:
+        - name: {{ $namespace }}-{{ $fullName }}-stripprefix@kubernetescrd
+      {{- end }}
+    {{- end }}
+  {{- else }}
+    - match: PathPrefix(`{{ $ingressPath }}`)
+      kind: Rule
+      services:
+        - name: {{ $fullName }}
+          kind: Service
+          port: {{ $servicePort }}
+      {{- if $stripPrefix }}
+      middlewares:
+        - name: {{ $namespace }}-{{ $fullName }}-stripprefix@kubernetescrd
+      {{- end }}
+  {{- end }}
+  
+{{- if $stripPrefix }}
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $fullName }}-stripprefix
+  namespace: {{ template "grafana.namespace" . }}
+  labels:
+    {{- include "grafana.labels" . | nindent 4 }}
+spec:
+  stripPrefix:
+    prefixes:
+      - {{ $ingressPath }}
+{{- end }}
+  
+{{- end }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -139,6 +139,23 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+ingressRoute:
+  ## More info: https://docs.traefik.io/routing/routers/
+  enabled: false
+
+  labels: {}
+
+  entryPoints: []
+  #  - websecure
+
+  hosts: []
+  #  - chart-example.local
+
+  path: /
+
+  tls: {}
+  #  certResolver: exampleResolver
+
 resources: {}
 #  limits:
 #    cpu: 100m


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR added to grafana chart Traefik's 2 IngressRoute support

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
