### PR TITLE
[stable/chartmuseum] Allow using initContainer to set volume permissions

### DIFF
--- a/incubator/chartmuseum/templates/deployment.yaml
+++ b/incubator/chartmuseum/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
         args:
         - --port=8080
 {{- if eq .Values.env.open.STORAGE "local" }}
-        - --storage-local-rootdir={{ .Values.persistence.path }}
+        - --storage-local-rootdir=/storage
 {{- end }}
         ports:
         - name: http
@@ -61,7 +61,7 @@ spec:
 {{ toYaml .Values.probes.readiness | indent 10 }}
 {{- if eq .Values.env.open.STORAGE "local" }}
         volumeMounts:
-        - mountPath: {{ .Values.persistence.path }}
+        - mountPath: /storage
           name: storage-volume
 {{- end }}
       {{- with .Values.resources }}

--- a/incubator/chartmuseum/templates/deployment.yaml
+++ b/incubator/chartmuseum/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
         args:
         - --port=8080
 {{- if eq .Values.env.open.STORAGE "local" }}
-        - --storage-local-rootdir=/storage
+        - --storage-local-rootdir={{ .Values.persistence.path }}
 {{- end }}
         ports:
         - name: http
@@ -61,7 +61,7 @@ spec:
 {{ toYaml .Values.probes.readiness | indent 10 }}
 {{- if eq .Values.env.open.STORAGE "local" }}
         volumeMounts:
-        - mountPath: /storage
+        - mountPath: {{ .Values.persistence.path }}
           name: storage-volume
 {{- end }}
       {{- with .Values.resources }}

--- a/stable/chartmuseum/Chart.yaml
+++ b/stable/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 2.7.1
+version: 2.8.0
 appVersion: 0.11.0
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/helm/chartmuseum/master/logo2.png

--- a/stable/chartmuseum/README.md
+++ b/stable/chartmuseum/README.md
@@ -76,6 +76,7 @@ their default values. See values.yaml for all available options.
 | `image.tag`                             | Container image tag to deploy                                               | `v0.8.0`                             |
 | `persistence.accessMode`                | Access mode to use for PVC                                                  | `ReadWriteOnce`                      |
 | `persistence.enabled`                   | Whether to use a PVC for persistent storage                                 | `false`                              |
+| `persistence.path`                      | PV mount path                                                               | `/storage`                              |
 | `persistence.size`                      | Amount of space to claim for PVC                                            | `8Gi`                                |
 | `persistence.labels`                    | Additional labels for PVC                                                   | `{}`                                 |
 | `persistence.storageClass`              | Storage Class to use for PVC                                                | `-`                                  |

--- a/stable/chartmuseum/README.md
+++ b/stable/chartmuseum/README.md
@@ -593,7 +593,7 @@ helm install --name my-chartmuseum -f custom.yaml stable/chartmuseum
 
 ### Setting local storage permissions with initContainers
 
-Some clusters do not allow using securityContext to set permissions for persistent volumes. Instead, an initContainer can be created to run `chown` on the mounted volume. To enable it, set `volumePermissions.enabled` to `true`.
+Some clusters do not allow using securityContext to set permissions for persistent volumes. Instead, an initContainer can be created to run `chown` on the mounted volume. To enable it, set `securityContext.enabled` to `false`.
 
 
 #### Example storage class

--- a/stable/chartmuseum/README.md
+++ b/stable/chartmuseum/README.md
@@ -10,32 +10,35 @@ Please also see https://github.com/kubernetes-helm/chartmuseum
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 
-- [Prerequisites](#prerequisites)
-- [Configuration](#configuration)
-- [Installation](#installation)
-  - [Using with Amazon S3](#using-with-amazon-s3)
-    - [permissions grant with access keys](#permissions-grant-with-access-keys)
-    - [permissions grant with IAM instance profile](#permissions-grant-with-iam-instance-profile)
-    - [permissions grant with IAM assumed role](#permissions-grant-with-iam-assumed-role)
-    - [permissions grant with IAM Roles for Service Accounts](#permissions-grant-with-iam-roles-for-service-accounts)
-  - [Using with Google Cloud Storage](#using-with-google-cloud-storage)
-  - [Using with Google Cloud Storage and a Google Service Account](#using-with-google-cloud-storage-and-a-google-service-account)
-  - [Using with Microsoft Azure Blob Storage](#using-with-microsoft-azure-blob-storage)
-  - [Using with Alibaba Cloud OSS Storage](#using-with-alibaba-cloud-oss-storage)
-  - [Using with Openstack Object Storage](#using-with-openstack-object-storage)
-  - [Using with Oracle Object Storage](#using-with-oracle-object-storage)
-  - [Using an existing secret](#using-an-existing-secret)
-  - [Using with local filesystem storage](#using-with-local-filesystem-storage)
-    - [Example storage class](#example-storage-class)
-  - [Authentication](#authentication)
-    - [Basic Authentication](#basic-authentication)
-    - [Bearer/Token auth](#bearertoken-auth)
-  - [Ingress](#ingress)
-    - [Hosts](#hosts)
-    - [Extra Paths](#extra-paths)
-    - [Annotations](#annotations)
-    - [Example Ingress configuration](#example-ingress-configuration)
-- [Uninstall](#uninstall)
+- [ChartMuseum Helm Chart](#chartmuseum-helm-chart)
+  - [Table of Content](#table-of-content)
+  - [Prerequisites](#prerequisites)
+  - [Configuration](#configuration)
+  - [Installation](#installation)
+    - [Using with Amazon S3](#using-with-amazon-s3)
+      - [permissions grant with access keys](#permissions-grant-with-access-keys)
+      - [permissions grant with IAM instance profile](#permissions-grant-with-iam-instance-profile)
+      - [permissions grant with IAM assumed role](#permissions-grant-with-iam-assumed-role)
+      - [permissions grant with IAM Roles for Service Accounts](#permissions-grant-with-iam-roles-for-service-accounts)
+    - [Using with Google Cloud Storage](#using-with-google-cloud-storage)
+    - [Using with Google Cloud Storage and a Google Service Account](#using-with-google-cloud-storage-and-a-google-service-account)
+    - [Using with Microsoft Azure Blob Storage](#using-with-microsoft-azure-blob-storage)
+    - [Using with Alibaba Cloud OSS Storage](#using-with-alibaba-cloud-oss-storage)
+    - [Using with Openstack Object Storage](#using-with-openstack-object-storage)
+    - [Using with Oracle Object Storage](#using-with-oracle-object-storage)
+    - [Using an existing secret](#using-an-existing-secret)
+    - [Using with local filesystem storage](#using-with-local-filesystem-storage)
+    - [Setting local storage permissions with initContainers](#setting-local-storage-permissions-with-initcontainers)
+      - [Example storage class](#example-storage-class)
+    - [Authentication](#authentication)
+      - [Basic Authentication](#basic-authentication)
+      - [Bearer/Token auth](#bearertoken-auth)
+    - [Ingress](#ingress)
+      - [Hosts](#hosts)
+      - [Extra Paths](#extra-paths)
+      - [Annotations](#annotations)
+      - [Example Ingress configuration](#example-ingress-configuration)
+  - [Uninstall](#uninstall)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -83,6 +86,10 @@ their default values. See values.yaml for all available options.
 | `persistence.pv.nfs.server`             | NFS server for PV                                                           | ``                                   |
 | `persistence.pv.nfs.path`               | Storage Path                                                                | ``                                   |
 | `persistence.pv.pvname`                 | Custom name for private volume                                              | ``                                   |
+| `volumePermissions.image.registry`      | Init container volume-permissions image registry                            | `docker.io`                          |
+| `volumePermissions.image.repository`    | Init container volume-permissions image name                                | `bitnami/minideb`                    |
+| `volumePermissions.image.tag`           | Init container volume-permissions image tag                                 | `buster`                             |
+| `volumePermissions.image.pullPolicy`    | Init container volume-permissions image pull policy                         | `Always`                             |
 | `replicaCount`                          | k8s replicas                                                                | `1`                                  |
 | `resources.limits.cpu`                  | Container maximum CPU                                                       | `100m`                               |
 | `resources.limits.memory`               | Container maximum memory                                                    | `128Mi`                              |
@@ -91,7 +98,8 @@ their default values. See values.yaml for all available options.
 | `serviceAccount.create`                 | If true, create the service account                                         | `false`                              |
 | `serviceAccount.name`                   | Name of the serviceAccount to create or use                                 | `{{ chartmuseum.fullname }}`         |
 | `serviceAccount.annotations`            | Additional Service Account annotations                                      | `{}`                                 |
-| `securityContext`                       | Map of securityContext for the pod                                          | `{ fsGroup: 1000 }`                  |
+| `securityContext.enabled`               | Enable securityContext                                                      | `true`                               |
+| `securityContext.fsGroup`               | Group ID for the container                                                  | `1000`                               |
 | `nodeSelector`                          | Map of node labels for pod assignment                                       | `{}`                                 |
 | `tolerations`                           | List of node taints to tolerate                                             | `[]`                                 |
 | `affinity`                              | Map of node/pod affinities                                                  | `{}`                                 |
@@ -581,6 +589,11 @@ Run command to install
 ```shell
 helm install --name my-chartmuseum -f custom.yaml stable/chartmuseum
 ```
+
+### Setting local storage permissions with initContainers
+
+Some clusters do not allow using securityContext to set permissions for persistent volumes. Instead, an initContainer can be created to run `chown` on the mounted volume. To enable it, set `volumePermissions.enabled` to `true`.
+
 
 #### Example storage class
 

--- a/stable/chartmuseum/templates/deployment.yaml
+++ b/stable/chartmuseum/templates/deployment.yaml
@@ -105,7 +105,7 @@ spec:
         args:
         - --port=8080
 {{- if eq .Values.env.open.STORAGE "local" }}
-        - --storage-local-rootdir=/storage
+        - --storage-local-rootdir={{ .Values.persistence.path }}
 {{- end }}
         ports:
         - name: http
@@ -122,7 +122,7 @@ spec:
 {{ toYaml .Values.probes.readiness | indent 10 }}
         volumeMounts:
 {{- if eq .Values.env.open.STORAGE "local" }}
-        - mountPath: /storage
+        - mountPath: {{ .Values.persistence.path }}
           name: storage-volume
 {{- end }}
 {{- if  .Values.gcp.secret.enabled }}

--- a/stable/chartmuseum/templates/deployment.yaml
+++ b/stable/chartmuseum/templates/deployment.yaml
@@ -38,6 +38,20 @@ spec:
 {{ toYaml .Values.deployment.labels | indent 8 }}
 {{- end }}
     spec:
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- else if .Values.persistence.enabled }}
+      initContainers:
+      - name: volume-permissions
+        image: {{ template "chartmuseum.volumePermissions.image" . }}
+        imagePullPolicy: "{{ .Values.volumePermissions.image.pullPolicy }}"
+        command: ['sh', '-c', 'chown -R {{ .Values.securityContext.fsGroup }}:{{ .Values.securityContext.fsGroup }} {{ .Values.persistence.path }}']
+        volumeMounts:
+        - mountPath: {{ .Values.persistence.path }}
+          name: storage-volume
+      {{- end }}
+{{- include "chartmuseum.imagePullSecrets" . | indent 6 }}
       containers:
       - name: {{ .Chart.Name }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -144,10 +158,6 @@ spec:
       serviceAccountName: {{ include "chartmuseum.fullname" . }}
     {{- else if .Values.serviceAccount.name }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
-    {{- end }}
-    {{- with .Values.securityContext }}
-      securityContext:
-{{ toYaml . | indent 8 }}
     {{- end }}
       volumes:
       - name: storage-volume

--- a/stable/chartmuseum/values.yaml
+++ b/stable/chartmuseum/values.yaml
@@ -170,9 +170,10 @@ serviceAccount:
 
 # UID/GID 1000 is the default user "chartmuseum" used in
 # the container image starting in v0.8.0 and above. This
-# is required for local persistant storage. If your cluster
+# is required for local persistent storage. If your cluster
 # does not allow this, try setting securityContext: {}
 securityContext:
+  enabled: true
   fsGroup: 1000
 
 nodeSelector: {}
@@ -210,6 +211,22 @@ persistence:
     nfs:
       server:
       path:
+
+## Init containers parameters:
+## volumePermissions: Change the owner of the persistent volume mountpoint to RunAsUser:fsGroup
+##
+volumePermissions:
+  image:
+    registry: docker.io
+    repository: bitnami/minideb
+    tag: buster
+    pullPolicy: Always
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
 
 ## Ingress for load balancer
 ingress:

--- a/stable/chartmuseum/values.yaml
+++ b/stable/chartmuseum/values.yaml
@@ -187,6 +187,7 @@ persistence:
   accessMode: ReadWriteOnce
   size: 8Gi
   labels: {}
+  path: /storage
   #   name: value
   ## A manually managed Persistent Volume and Claim
   ## Requires persistence.enabled: true


### PR DESCRIPTION
#### What this PR does / why we need it:

Some cloud providers, such as IBM cloud, require permissions to be set explicitly on persistent volumes. Using an `initContainer` that runs `chown` on the mounted volume is a common practice to do it.

Additional changes:
- Use `persistence.path` variable instead of hard-coded `/storage` mount path

#### Special notes for your reviewer:
- The `initContainer` configuration has been taken from `stable/ghost` chart.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
