### PR TITLE
[stable/airflow]Add optional security context to airflow deployments.

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 6.1.1
+version: 6.1.2
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/templates/deployments-flower.yaml
+++ b/stable/airflow/templates/deployments-flower.yaml
@@ -55,6 +55,10 @@ spec:
       tolerations:
 {{ toYaml .Values.flower.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.flower.securityContext }}
+      securityContext:
+{{ toYaml .Values.flower.securityContext | indent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-flower
           image: {{ .Values.airflow.image.repository }}:{{ .Values.airflow.image.tag }}

--- a/stable/airflow/templates/deployments-scheduler.yaml
+++ b/stable/airflow/templates/deployments-scheduler.yaml
@@ -68,6 +68,10 @@ spec:
       tolerations:
 {{ toYaml .Values.scheduler.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.scheduler.securityContext }}
+      securityContext:
+{{ toYaml .Values.scheduler.securityContext | indent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "airflow.serviceAccountName" . }}
       {{- if .Values.dags.initContainer.enabled }}
       initContainers:

--- a/stable/airflow/templates/deployments-web.yaml
+++ b/stable/airflow/templates/deployments-web.yaml
@@ -66,6 +66,10 @@ spec:
       tolerations:
 {{ toYaml .Values.web.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.web.securityContext }}
+      securityContext:
+{{ toYaml .Values.web.securityContext | indent 8 }}
+      {{- end }}
       {{- if .Values.dags.initContainer.enabled }}
       initContainers:
         - name: git-clone

--- a/stable/airflow/templates/statefulsets-workers.yaml
+++ b/stable/airflow/templates/statefulsets-workers.yaml
@@ -69,7 +69,10 @@ spec:
       tolerations:
 {{ toYaml .Values.workers.tolerations | indent 8 }}
       {{- end }}
-
+      {{- if .Values.workers.securityContext }}
+      securityContext:
+{{ toYaml .Values.workers.securityContext | indent 8 }}
+      {{- end }}
       {{- if .Values.dags.initContainer.enabled }}
       initContainers:
         - name: git-clone


### PR DESCRIPTION
Signed-off-by: Ziyang Liu <zliu@chanzuckerberg.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:
Adds the ability to add security context to pods created by the Airflow chart. This allows work around for things like using AWS IAM Roles for Service Accounts (IRSA) giving the service account the ability to access AWS resources, as documented in https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
