### PR TITLE
[stable/openldap]Parameterize init image for openldap chart

### DIFF
--- a/stable/openldap/Chart.yaml
+++ b/stable/openldap/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: openldap
 home: https://www.openldap.org
-version: 1.2.3
+version: 1.2.4
 appVersion: 2.4.48
 description: Community developed LDAP software
 icon: http://www.openldap.org/images/headers/LDAPworm.gif

--- a/stable/openldap/README.md
+++ b/stable/openldap/README.md
@@ -30,6 +30,7 @@ The following table lists the configurable parameters of the openldap chart and 
 | `image.repository`                 | Container image repository                                                                                                                | `osixia/openldap`   |
 | `image.tag`                        | Container image tag                                                                                                                       | `1.1.10`            |
 | `image.pullPolicy`                 | Container pull policy                                                                                                                     | `IfNotPresent`      |
+| `init.image`                       | Init Container image                                                                                                                      | `busybox`           |
 | `extraLabels`                      | Labels to add to the Resources                                                                                                            | `{}`                |
 | `podAnnotations`                   | Annotations to add to the pod                                                                                                             | `{}`                |
 | `existingSecret`                   | Use an existing secret for admin and config user passwords                                                                                | `""`                |

--- a/stable/openldap/templates/deployment.yaml
+++ b/stable/openldap/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
       {{- end }}
       {{- if .Values.customLdifFiles }}
       - name: {{ .Chart.Name }}-init-ldif
-        image: busybox
+        image: {{ .Values.init.image }}
         command: ['sh', '-c', 'cp /customldif/* /ldifworkingdir']
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
@@ -52,7 +52,7 @@ spec:
       {{- end }}
       {{- if .Values.tls.enabled }}
       - name: {{ .Chart.Name }}-init-tls
-        image: busybox
+        image: {{ .Values.init.image }}
         command: ['sh', '-c', 'cp /tls/* /certs']
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
@@ -64,7 +64,7 @@ spec:
 {{ toYaml .Values.initResources | indent 10 }}
       {{- if .Values.tls.CA.enabled }}
       - name: {{ .Chart.Name }}-init-catls
-        image: busybox
+        image: {{ .Values.init.image }}
         command: ['sh', '-c', 'cp /catls/ca.crt /certs']
         volumeMounts:
           - name: catls

--- a/stable/openldap/values.yaml
+++ b/stable/openldap/values.yaml
@@ -22,6 +22,9 @@ image:
   tag: 1.2.4
   pullPolicy: IfNotPresent
 
+init:
+  image: busybox
+
 # Spcifies an existing secret to be used for admin and config user passwords
 existingSecret: ""
 


### PR DESCRIPTION
Signed-off-by: Yuiko Mori <yuiko-mori@nec.com>

#### Is this a new chart
NO

#### What this PR does / why we need it:

Provide values for init container image to allow alternate registries to be used when this chart is used on a Kubernetes cluster that cannot pull from docker hub.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
