### PR TITLE
[stable/elasticsearch] Adds imagePullSecrets to test image

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.32.3
+version: 1.32.4
 appVersion: 6.8.6
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/stable/elasticsearch/templates/tests/test.yaml
+++ b/stable/elasticsearch/templates/tests/test.yaml
@@ -10,6 +10,12 @@ metadata:
   annotations:
     "helm.sh/hook": test-success
 spec:
+{{- if .Values.image.pullSecrets }}
+  imagePullSecrets:
+  {{- range $pullSecret := .Values.image.pullSecrets }}
+    - name: {{ $pullSecret }}
+  {{- end }}
+{{- end }}
   initContainers:
     - name: test-framework
       image: "{{ .Values.testFramework.image}}:{{ .Values.testFramework.tag }}"


### PR DESCRIPTION
#### What this PR does / why we need it:
In private environments where we replicate all the images, the test image cannot be pulled due it misses imagePullSecrets.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
