### PR TITLE
[stable/kube-state-metrics] Add missing permission for volumeattachment collector

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - monitoring
 - prometheus
 - kubernetes
-version: 2.7.1
+version: 2.7.2
 appVersion: 1.9.5
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/templates/clusterrole.yaml
+++ b/stable/kube-state-metrics/templates/clusterrole.yaml
@@ -166,9 +166,9 @@ rules:
   verbs: ["list", "watch"]
 {{ end -}}
 {{ if .Values.collectors.volumeattachments }}
-- apiGroups: ["storageclasses.k8s.io"]
+- apiGroups: ["storage.k8s.io"]
   resources:
-    - storageclasses
+    - volumeattachments
   verbs: ["list", "watch"]
 {{ end -}}
 {{ if .Values.collectors.verticalpodautoscalers }}


### PR DESCRIPTION
When enabling the volumeattachments collector, the following error is
logged without this permission:

Failed to list *v1.VolumeAttachment: volumeattachments.storage.k8s.io is forbidden: User "XXXXX:kube-state-metrics" cannot list resource "volumeattachments" in API group "storage.k8s.io" at the cluster scope
