### PR TITLE
[stable/prometheus-nats-exporter]: add prometheus-operator servicemonitor support

### DIFF
--- a/stable/prometheus-nats-exporter/Chart.yaml
+++ b/stable/prometheus-nats-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.6.0"
 description: A Helm chart for prometheus-nats-exporter
 name: prometheus-nats-exporter
-version: 2.3.0
+version: 2.4.0
 home: https://github.com/nats-io/prometheus-nats-exporter
 sources:
   - https://github.com/nats-io/prometheus-nats-exporter

--- a/stable/prometheus-nats-exporter/README.md
+++ b/stable/prometheus-nats-exporter/README.md
@@ -36,30 +36,34 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the postgres Exporter chart and their default values.
 
-| Parameter                       | Description                                   | Default                                                    |
-| ------------------------------- | --------------------------------------------- | ---------------------------------------------------------- |
-| `image`                         | Image                                         | `synadia/prometheus-nats-exporter`                         |
-| `imageTag`                      | Image tag                                     | `0.6.0`                                                    |
-| `imagePullPolicy`               | Image pull policy                             | `IfNotPresent`                                             |
-| `service.type`                  | Service type                                  | `ClusterIP`                                                |
-| `service.port`                  | The service port                              | `80`                                                       |
-| `service.targetPort`            | The target port of the container              | `7777`                                                     |
-| `resources`                     |                                               | `{}`                                                       |
-| `config.nats.service`            | NATS monitoring [service name][svc-name]      | `nats-nats-monitoring`                                     |
-| `config.nats.namespace`          | Namespace in which NATS deployed              | `default`                                                  |
-| `config.nats.port`               | NATS monitoring service port                  | `8222`                                                     |
-| `config.metrics.varz`            | NATS varz metrics                             | `true`                                                     |
-| `config.metrics.channelz`        | NATS channelz metrics                         | `true`                                                     |
-| `config.metrics.connz`           | NATS connz metrics                            | `true`                                                     |
-| `config.metrics.routez`          | NATS routez metrics                           | `true`                                                     |
-| `config.metrics.serverz`         | NATS serverz metrics                          | `true`                                                     |
-| `config.metrics.subz`            | NATS subz metrics                             | `true`                                                     |
-| `tolerations`                   | Add tolerations                               | `[]`                                                       |
-| `nodeSelector`                  | node labels for pod assignment                | `{}`                                                       |
-| `affinity`                       | node/pod affinities                            | `{}`                                                       |
-| `annotations`                   | Deployment annotations                        | `{}`                                                       |
-| `extraContainers`               | Additional sidecar containers                 | `""`                                                       |
-| `extraVolumes`                  | Additional volumes for use in extraContainers | `""`                                                       |
+| Parameter                         | Description                                             | Default                                          |
+| --------------------------------- | ------------------------------------------------------- | ------------------------------------------------ |
+| `image`                           | Image                                                   | `synadia/prometheus-nats-exporter`               |
+| `imageTag`                        | Image tag                                               | `0.6.0`                                          |
+| `imagePullPolicy`                 | Image pull policy                                       | `IfNotPresent`                                   |
+| `service.type`                    | Service type                                            | `ClusterIP`                                      |
+| `service.port`                    | The service port                                        | `80`                                             |
+| `service.targetPort`              | The target port of the container                        | `7777`                                           |
+| `serviceMonitor.enabled`          | Set to true if using the Prometheus Operator            | `false`                                          |
+| `serviceMonitor.interval`         | Interval at which metrics should be scraped             | ``                                               |
+| `serviceMonitor.namespace`        | The namespace where the Prometheus Operator is deployed | ``                                               |
+| `serviceMonitor.additionalLabels` | Additional labels to add to the ServiceMonitor          | `{}`                                             |
+| `resources`                       |                                                         | `{}`                                             |
+| `config.nats.service`             | NATS monitoring [service name][svc-name]                | `nats-nats-monitoring`                           |
+| `config.nats.namespace`           | Namespace in which NATS deployed                        | `default`                                        |
+| `config.nats.port`                | NATS monitoring service port                            | `8222`                                           |
+| `config.metrics.varz`             | NATS varz metrics                                       | `true`                                           |
+| `config.metrics.channelz`         | NATS channelz metrics                                   | `true`                                           |
+| `config.metrics.connz`            | NATS connz metrics                                      | `true`                                           |
+| `config.metrics.routez`           | NATS routez metrics                                     | `true`                                           |
+| `config.metrics.serverz`          | NATS serverz metrics                                    | `true`                                           |
+| `config.metrics.subz`             | NATS subz metrics                                       | `true`                                           |
+| `tolerations`                     | Add tolerations                                         | `[]`                                             |
+| `nodeSelector`                    | node labels for pod assignment                          | `{}`                                             |
+| `affinity`                        | node/pod affinities                                     | `{}`                                             |
+| `annotations`                     | Deployment annotations                                  | `{}`                                             |
+| `extraContainers`                 | Additional sidecar containers                           | `""`                                             |
+| `extraVolumes`                    | Additional volumes for use in extraContainers           | `""`                                             |
 
 [svc-name]: https://github.com/helm/charts/blob/master/stable/nats/templates/monitoring-svc.yaml
 

--- a/stable/prometheus-nats-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-nats-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "prometheus-nats-exporter.fullname" . }}
+  {{- with .Values.serviceMonitor.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-nats-exporter.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "prometheus-nats-exporter.chart" . }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+{{ toYaml . | indent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: http
+      honorLabels: true
+      {{- with .Values.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "prometheus-nats-exporter.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+

--- a/stable/prometheus-nats-exporter/values.yaml
+++ b/stable/prometheus-nats-exporter/values.yaml
@@ -14,6 +14,13 @@ service:
   port: 80
   targetPort: 7777
 
+serviceMonitor:
+  enabled: false
+  additionalLabels: {}
+  namespace:
+  interval:
+  scrapeTimeout:
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
#### What this PR does / why we need it:
Adding servicemonitor crd support from prometheus-operator.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
