### PR TITLE
[incubator/zookeeper] Allows to configure podManagementPolicy option.

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 2.1.3
+version: 2.1.4
 appVersion: 3.5.5
 kubeVersion: "^1.10.0-0"
 description: Centralized service for maintaining configuration information, naming,

--- a/incubator/zookeeper/templates/statefulset.yaml
+++ b/incubator/zookeeper/templates/statefulset.yaml
@@ -18,6 +18,7 @@ spec:
       component: server
   updateStrategy:
 {{ toYaml .Values.updateStrategy | indent 4 }}
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
   template:
     metadata:
       labels:

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -13,6 +13,11 @@ updateStrategy:
   type: RollingUpdate
 
 ## refs:
+## - https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
+## - https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#parallel-pod-management
+podManagementPolicy: Parallel
+
+## refs:
 ## - https://github.com/kubernetes/contrib/tree/master/statefulsets/zookeeper
 ## - https://github.com/kubernetes/contrib/blob/master/statefulsets/zookeeper/Makefile#L1
 image:


### PR DESCRIPTION
Signed-off-by: daniel kaczmarek <daniel.kaczmarek.it@gmail.com>

#### What this PR does / why we need it:
This PR introduce possibility to configure podManagementPolicy option. There are two valid pod management policies: OrderedReady and Parallel. I set the default value to Parallel. This option tells the StatefulSet controller to launch or terminate all Pods in parallel, and not to wait for Pods to become Running and Ready or completely terminated prior to launching or terminating another Pod.

Ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
