### PR TITLE
[stable/wordpress] Move WP to non-root

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,21 +1,21 @@
 apiVersion: v1
 name: wordpress
-version: 8.1.6
+version: 9.0.0
 appVersion: 5.3.2
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png
 keywords:
-- wordpress
-- cms
-- blog
-- http
-- web
-- application
-- php
+  - wordpress
+  - cms
+  - blog
+  - http
+  - web
+  - application
+  - php
 home: http://www.wordpress.com/
 sources:
-- https://github.com/bitnami/bitnami-docker-wordpress
+  - https://github.com/bitnami/bitnami-docker-wordpress
 maintainers:
-- name: Bitnami
-  email: containers@bitnami.com
+  - name: Bitnami
+    email: containers@bitnami.com
 engine: gotpl

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -117,7 +117,7 @@ The following table lists the configurable parameters of the WordPress chart and
 | `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe                                    | `6`                                                     |
 | `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe                                   | `1`                                                     |
 | `livenessProbeHeaders`               | Headers to use for livenessProbe                                              | `{}`                                                    |
-| `readiness.enabled`                  | Enable/disable readinessProbe                                                 | `true`                                                  |
+| `readinessProbe.enabled`             | Enable/disable readinessProbe                                                 | `true`                                                  |
 | `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                     | `30`                                                    |
 | `readinessProbe.periodSeconds`       | How often to perform the probe                                                | `10`                                                    |
 | `readinessProbe.timeoutSeconds`      | When the probe times out                                                      | `5`                                                     |
@@ -160,18 +160,22 @@ The following table lists the configurable parameters of the WordPress chart and
 
 ### Database parameters
 
-| Parameter                    | Description                             | Default                                        |
-|------------------------------|-----------------------------------------|------------------------------------------------|
-| `mariadb.enabled`            | Deploy MariaDB container(s)             | `true`                                         |
-| `mariadb.rootUser.password`  | MariaDB admin password                  | `nil`                                          |
-| `mariadb.db.name`            | Database name to create                 | `bitnami_wordpress`                            |
-| `mariadb.db.user`            | Database user to create                 | `bn_wordpress`                                 |
-| `mariadb.db.password`        | Password for the database               | _random 10 character long alphanumeric string_ |
-| `externalDatabase.host`      | Host of the external database           | `localhost`                                    |
-| `externalDatabase.user`      | Existing username in the external db    | `bn_wordpress`                                 |
-| `externalDatabase.password`  | Password for the above username         | `nil`                                          |
-| `externalDatabase.database`  | Name of the existing database           | `bitnami_wordpress`                            |
-| `externalDatabase.port`      | Database port number                    | `3306`                                         |
+| Parameter                                | Description                             | Default                                        |
+|------------------------------------------|-----------------------------------------|------------------------------------------------|
+| `mariadb.enabled`                        | Deploy MariaDB container(s)             | `true`                                         |
+| `mariadb.rootUser.password`              | MariaDB admin password                  | `nil`                                          |
+| `mariadb.db.name`                        | Database name to create                 | `bitnami_wordpress`                            |
+| `mariadb.db.user`                        | Database user to create                 | `bn_wordpress`                                 |
+| `mariadb.db.password`                    | Password for the database               | _random 10 character long alphanumeric string_ |
+| `mariadb.replication.enabled`            | MariaDB replication enabled             | `false`                                        |
+| `mariadb.master.persistence.enabled`     | Enable database persistence using PVC   | `true`                                         |
+| `mariadb.master.persistence.accessModes` | Database Persistent Volume Access Modes | `[ReadWriteOnce]`                              |
+| `mariadb.master.persistence.size`        | Database Persistent Volume Size         | `8Gi`                                          |
+| `externalDatabase.host`                  | Host of the external database           | `localhost`                                    |
+| `externalDatabase.user`                  | Existing username in the external db    | `bn_wordpress`                                 |
+| `externalDatabase.password`              | Password for the above username         | `nil`                                          |
+| `externalDatabase.database`              | Name of the existing database           | `bitnami_wordpress`                            |
+| `externalDatabase.port`                  | Database port number                    | `3306`                                         |
 
 ### Metrics parameters
 
@@ -325,7 +329,7 @@ To enable ingress integration, please set `ingress.enabled` to `true`
 
 ### Hosts
 
-Most likely you will only want to have one hostname that maps to this WordPress installation. If that's your case, the property `ingress.hostname` will set it. However, it is possible to have more than one host. To facilitate this, the `ingress.extraHosts` object is can be specified as an array. You can also use `ingress.extraTLS` to add the TLS configuration for extra hosts. 
+Most likely you will only want to have one hostname that maps to this WordPress installation. If that's your case, the property `ingress.hostname` will set it. However, it is possible to have more than one host. To facilitate this, the `ingress.extraHosts` object is can be specified as an array. You can also use `ingress.extraTLS` to add the TLS configuration for extra hosts.
 
 For each host indicated at `ingress.extraHosts`, please indicate a `name`, `path`, and any `annotations` that you may want the ingress controller to know about.
 

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -5,7 +5,7 @@
 ## TL;DR;
 
 ```console
-$ helm install my-release stable/wordpress
+helm install my-release stable/wordpress
 ```
 
 ## Introduction
@@ -28,7 +28,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install my-release stable/wordpress
+helm install my-release stable/wordpress
 ```
 
 The command deploys WordPress on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
@@ -40,132 +40,169 @@ The command deploys WordPress on the Kubernetes cluster in the default configura
 To uninstall/delete the `my-release` deployment:
 
 ```console
-$ helm delete my-release
+helm delete my-release
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
 ## Parameters
 
-The following table lists the configurable parameters of the WordPress chart and their default values.
+The following table lists the configurable parameters of the WordPress chart and their default values per section/component:
 
-|                 Parameter                 |                                              Description                                               |                           Default                            |
-|-------------------------------------------|--------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `global.imageRegistry`                    | Global Docker image registry                                                                           | `nil`                                                        |
-| `global.imagePullSecrets`                 | Global Docker registry secret names as an array                                                        | `[]` (does not add image pull secrets to deployed pods)      |
-| `global.storageClass`                     | Global storage class for dynamic provisioning                                                          | `nil`                                                        |
-| `image.registry`                          | WordPress image registry                                                                               | `docker.io`                                                  |
-| `image.repository`                        | WordPress image name                                                                                   | `bitnami/wordpress`                                          |
-| `image.tag`                               | WordPress image tag                                                                                    | `{TAG_NAME}`                                                 |
-| `image.pullPolicy`                        | Image pull policy                                                                                      | `IfNotPresent`                                               |
-| `image.pullSecrets`                       | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods)      |
-| `nameOverride`                            | String to partially override wordpress.fullname template with a string (will prepend the release name) | `nil`                                                        |
-| `fullnameOverride`                        | String to fully override wordpress.fullname template with a string                                     | `nil`                                                        |
-| `wordpressSkipInstall`                    | Skip wizard installation                                                                               | `false`                                                      |
-| `wordpressUsername`                       | User of the application                                                                                | `user`                                                       |
-| `wordpressPassword`                       | Application password                                                                                   | _random 10 character long alphanumeric string_               |
-| `wordpressEmail`                          | Admin email                                                                                            | `user@example.com`                                           |
-| `wordpressFirstName`                      | First name                                                                                             | `FirstName`                                                  |
-| `wordpressLastName`                       | Last name                                                                                              | `LastName`                                                   |
-| `wordpressBlogName`                       | Blog name                                                                                              | `User's Blog!`                                               |
-| `wordpressTablePrefix`                    | Table prefix                                                                                           | `wp_`                                                        |
-| `wordpressScheme`                         | Scheme to generate application URLs [`http`, `https`]                                                  | `http`                                                       |
-| `allowEmptyPassword`                      | Allow DB blank passwords                                                                               | `true`                                                       |
-| `allowOverrideNone`                       | Set Apache AllowOverride directive to None                                                             | `false`                                                      |
-| `customHTAccessCM`                        | Configmap with custom wordpress-htaccess.conf directives                                               | `nil`                                                        |
-| `smtpHost`                                | SMTP host                                                                                              | `nil`                                                        |
-| `smtpPort`                                | SMTP port                                                                                              | `nil`                                                        |
-| `smtpUser`                                | SMTP user                                                                                              | `nil`                                                        |
-| `smtpPassword`                            | SMTP password                                                                                          | `nil`                                                        |
-| `smtpUsername`                            | User name for SMTP emails                                                                              | `nil`                                                        |
-| `smtpProtocol`                            | SMTP protocol [`tls`, `ssl`, `none`]                                                                   | `nil`                                                        |
-| `replicaCount`                            | Number of WordPress Pods to run                                                                        | `1`                                                          |
-| `extraEnv`                                | Additional container environment variables                                                             | `[]`                                                         |
-| `extraVolumeMounts`                       | Additional volume mounts                                                                               | `[]`                                                         |
-| `extraVolumes`                            | Additional volumes                                                                                     | `[]`                                                         |
-| `mariadb.enabled`                         | Deploy MariaDB container(s)                                                                            | `true`                                                       |
-| `mariadb.rootUser.password`               | MariaDB admin password                                                                                 | `nil`                                                        |
-| `mariadb.db.name`                         | Database name to create                                                                                | `bitnami_wordpress`                                          |
-| `mariadb.db.user`                         | Database user to create                                                                                | `bn_wordpress`                                               |
-| `mariadb.db.password`                     | Password for the database                                                                              | _random 10 character long alphanumeric string_               |
-| `externalDatabase.host`                   | Host of the external database                                                                          | `localhost`                                                  |
-| `externalDatabase.user`                   | Existing username in the external db                                                                   | `bn_wordpress`                                               |
-| `externalDatabase.password`               | Password for the above username                                                                        | `nil`                                                        |
-| `externalDatabase.database`               | Name of the existing database                                                                          | `bitnami_wordpress`                                          |
-| `externalDatabase.port`                   | Database port number                                                                                   | `3306`                                                       |
-| `service.annotations`                     | Service annotations                                                                                    | `{}`                                                         |
-| `service.type`                            | Kubernetes Service type                                                                                | `LoadBalancer`                                               |
-| `service.port`                            | Service HTTP port                                                                                      | `80`                                                         |
-| `service.httpsPort`                       | Service HTTPS port                                                                                     | `443`                                                        |
-| `service.httpsTargetPort`                 | Service Target HTTPS port                                                                              | `https`                                                      |
-| `service.loadBalancerSourceRanges`        | Restricts access for LoadBalancer (only with `service.type: LoadBalancer`)                             | `[]`                                                         |
-| `service.metricsPort`                     | Service Metrics port                                                                                   | `9117`                                                       |
-| `service.externalTrafficPolicy`           | Enable client source IP preservation                                                                   | `Cluster`                                                    |
-| `service.nodePorts.http`                  | Kubernetes http node port                                                                              | `""`                                                         |
-| `service.nodePorts.https`                 | Kubernetes https node port                                                                             | `""`                                                         |
-| `service.nodePorts.metrics`               | Kubernetes metrics node port                                                                           | `""`                                                         |
-| `service.extraPorts`                      | Extra ports to expose in the service (normally used with the `sidecar` value)                          | `nil`                                                        |
-| `healthcheckHttps`                        | Use https for liveliness and readiness                                                                 | `false`                                                      |
-| `livenessProbe.enabled`                   | Enable/disable livenessProbe                                                                          | `true`                                                       |
-| `livenessProbe.initialDelaySeconds`       | Delay before liveness probe is initiated                                                               | `120`                                                        |
-| `livenessProbe.periodSeconds`             | How often to perform the probe                                                                         | `10`                                                         |
-| `livenessProbe.timeoutSeconds`            | When the probe times out                                                                               | `5`                                                          |
-| `livenessProbe.failureThreshold`          | Minimum consecutive failures for the probe                                                             | `6`                                                          |
-| `livenessProbe.successThreshold`          | Minimum consecutive successes for the probe                                                            | `1`                                                          |
-| `livenessProbeHeaders`                    | Headers to use for livenessProbe                                                                       | `nil`                                                        |
-| `readiness.enabled`                       | Enable/disable readinessProbe                                                                          | `true`                                                       |
-| `readinessProbe.initialDelaySeconds`      | Delay before readiness probe is initiated                                                              | `30`                                                         |
-| `readinessProbe.periodSeconds`            | How often to perform the probe                                                                         | `10`                                                         |
-| `readinessProbe.timeoutSeconds`           | When the probe times out                                                                               | `5`                                                          |
-| `readinessProbe.failureThreshold`         | Minimum consecutive failures for the probe                                                             | `6`                                                          |
-| `readinessProbe.successThreshold`         | Minimum consecutive successes for the probe                                                            | `1`                                                          |
-| `readinessProbeHeaders`                   | Headers to use for readinessProbe                                                                      | `nil`                                                        |
-| `ingress.enabled`                         | Enable ingress controller resource                                                                     | `false`                                                      |
-| `ingress.certManager`                     | Add annotations for cert-manager                                                                       | `false`                                                      |
-| `ingress.hostname`                        | Default host for the ingress resource                                                                  | `wordpress.local`                                            |
-| `ingress.annotations`                     | Ingress annotations                                                                                    | `[]`                                                         |
-| `ingress.hosts[0].name`                   | Hostname to your Wordpress installation                                                                | `wordpress.local`                                            |
-| `ingress.hosts[0].path`                   | Path within the url structure                                                                          | `/`                                                          |
-| `ingress.tls[0].hosts[0]`                 | TLS hosts                                                                                              | `wordpress.local`                                            |
-| `ingress.tls[0].secretName`               | TLS Secret (certificates)                                                                              | `wordpress.local-tls`                                        |
-| `ingress.secrets[0].name`                 | TLS Secret Name                                                                                        | `nil`                                                        |
-| `ingress.secrets[0].certificate`          | TLS Secret Certificate                                                                                 | `nil`                                                        |
-| `ingress.secrets[0].key`                  | TLS Secret Key                                                                                         | `nil`                                                        |
-| `schedulerName`                           | Name of the alternate scheduler                                                                        | `nil`                                                        |
-| `persistence.enabled`                     | Enable persistence using PVC                                                                           | `true`                                                       |
-| `persistence.existingClaim`               | Enable persistence using an existing PVC                                                               | `nil`                                                        |
-| `persistence.storageClass`                | PVC Storage Class                                                                                      | `nil` (uses alpha storage class annotation)                  |
-| `persistence.accessMode`                  | PVC Access Mode                                                                                        | `ReadWriteOnce`                                              |
-| `persistence.size`                        | PVC Storage Request                                                                                    | `10Gi`                                                       |
-| `nodeSelector`                            | Node labels for pod assignment                                                                         | `{}`                                                         |
-| `tolerations`                             | List of node taints to tolerate                                                                        | `[]`                                                         |
-| `affinity`                                | Map of node/pod affinities                                                                             | `{}`                                                         |
-| `podAnnotations`                          | Pod annotations                                                                                        | `{}`                                                         |
-| `metrics.enabled`                         | Start a side-car prometheus exporter                                                                   | `false`                                                      |
-| `metrics.image.registry`                  | Apache exporter image registry                                                                         | `docker.io`                                                  |
-| `metrics.image.repository`                | Apache exporter image name                                                                             | `bitnami/apache-exporter`                                    |
-| `metrics.image.tag`                       | Apache exporter image tag                                                                              | `{TAG_NAME}`                                                 |
-| `metrics.image.pullPolicy`                | Image pull policy                                                                                      | `IfNotPresent`                                               |
-| `metrics.image.pullSecrets`               | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods)      |
-| `metrics.podAnnotations`                  | Additional annotations for Metrics exporter pod                                                        | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
-| `metrics.resources`                       | Exporter resource requests/limit                                                                       | `{}`                                                         |
-| `metrics.serviceMonitor.enabled`          | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                           | `false`                                                      |
-| `metrics.serviceMonitor.namespace`        | Namespace where servicemonitor resource should be created                                              | `nil`                                                        |
-| `metrics.serviceMonitor.interval`         | Specify the interval at which metrics should be scraped                                                | `30s`                                                        |
-| `metrics.serviceMonitor.scrapeTimeout`    | Specify the timeout after which the scrape is ended                                                    | `nil`                                                        |
-| `metrics.serviceMonitor.relabellings`     | Specify Metric Relabellings to add to the scrape endpoint                                              | `nil`                                                        |
-| `metrics.serviceMonitor.honorLabels`      | honorLabels chooses the metric's labels on collisions with target labels.                              | `false`                                                      |
-| `metrics.serviceMonitor.additionalLabels` | Used to pass Labels that are required by the Installed Prometheus Operator                             | `{}`                                                         |
-| `sidecars`                                | Attach additional containers to the pod                                                                | `nil`                                                        |
-| `updateStrategy`                          | Set up update strategy                                                                                 | `RollingUpdate`                                              |
+### Global parameters
+
+| Parameter                 | Description                                     | Default                                                 |
+|---------------------------|-------------------------------------------------|---------------------------------------------------------|
+| `global.imageRegistry`    | Global Docker image registry                    | `nil`                                                   |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
+| `global.storageClass`     | Global storage class for dynamic provisioning   | `nil`                                                   |
+
+### Common parameters
+
+| Parameter                 | Description                                     | Default                                                 |
+|---------------------------|-------------------------------------------------|---------------------------------------------------------|
+| `nameOverride`            | String to partially override wordpress.fullname | `nil`                                                   |
+| `fullnameOverride`        | String to fully override wordpress.fullname     | `nil`                                                   |
+| `clusterDomain`           | Default Kubernetes cluster domain               | `cluster.local`                                         |
+
+### WordPress parameters
+
+| Parameter                            | Description                                                                   | Default                                                 |
+|--------------------------------------|-------------------------------------------------------------------------------|---------------------------------------------------------|
+| `image.registry`                     | WordPress image registry                                                      | `docker.io`                                             |
+| `image.repository`                   | WordPress image name                                                          | `bitnami/wordpress`                                     |
+| `image.tag`                          | WordPress image tag                                                           | `{TAG_NAME}`                                            |
+| `image.pullPolicy`                   | WordPress image pull policy                                                   | `IfNotPresent`                                          |
+| `image.pullSecrets`                  | Specify docker-registry secret names as an array                              | `[]` (does not add image pull secrets to deployed pods) |
+| `image.debug`                        | Specify if debug logs should be enabled                                       | `false`                                                 |
+| `wordpressSkipInstall`               | Skip wizard installation                                                      | `false`                                                 |
+| `wordpressUsername`                  | User of the application                                                       | `user`                                                  |
+| `wordpressPassword`                  | Application password                                                          | _random 10 character long alphanumeric string_          |
+| `wordpressEmail`                     | Admin email                                                                   | `user@example.com`                                      |
+| `wordpressFirstName`                 | First name                                                                    | `FirstName`                                             |
+| `wordpressLastName`                  | Last name                                                                     | `LastName`                                              |
+| `wordpressBlogName`                  | Blog name                                                                     | `User's Blog!`                                          |
+| `wordpressTablePrefix`               | Table prefix                                                                  | `wp_`                                                   |
+| `wordpressScheme`                    | Scheme to generate application URLs [`http`, `https`]                         | `http`                                                  |
+| `allowEmptyPassword`                 | Allow DB blank passwords                                                      | `true`                                                  |
+| `allowOverrideNone`                  | Set Apache AllowOverride directive to None                                    | `false`                                                 |
+| `customHTAccessCM`                   | Configmap with custom wordpress-htaccess.conf directives                      | `nil`                                                   |
+| `smtpHost`                           | SMTP host                                                                     | `nil`                                                   |
+| `smtpPort`                           | SMTP port                                                                     | `nil`                                                   |
+| `smtpUser`                           | SMTP user                                                                     | `nil`                                                   |
+| `smtpPassword`                       | SMTP password                                                                 | `nil`                                                   |
+| `smtpUsername`                       | User name for SMTP emails                                                     | `nil`                                                   |
+| `smtpProtocol`                       | SMTP protocol [`tls`, `ssl`, `none`]                                          | `nil`                                                   |
+| `extraEnv`                           | Additional container environment variables                                    | `[]`                                                    |
+| `extraVolumeMounts`                  | Additional volume mounts                                                      | `[]`                                                    |
+| `extraVolumes`                       | Additional volumes                                                            | `[]`                                                    |
+| `sidecars`                           | Attach additional sidecar containers to the pod                               | `nil`                                                   |
+| `replicaCount`                       | Number of WordPress Pods to run                                               | `1`                                                     |
+| `updateStrategy`                     | Set up update strategy                                                        | `RollingUpdate`                                         |
+| `schedulerName`                      | Name of the alternate scheduler                                               | `nil`                                                   |
+| `securityContext.enabled`            | Enable security context for WordPress pods                                    | `true`                                                  |
+| `securityContext.fsGroup`            | Group ID for the WordPress filesystem                                         | `1001`                                                  |
+| `securityContext.runAsUser`          | User ID for the WordPress container                                           | `1001`                                                  |
+| `resources.limits`                   | The resources limits for the WordPress container                              | `{}`                                                    |
+| `resources.requests`                 | The requested resources for the WordPress container                           | `{"memory": "512Mi", "cpu": "300m"}`                    |
+| `nodeSelector`                       | Node labels for pod assignment                                                | `{}` (evaluated as a template)                          |
+| `tolerations`                        | Tolerations for pod assignment                                                | `[]` (evaluated as a template)                          |
+| `affinity`                           | Affinity for pod assignment                                                   | `{}` (evaluated as a template)                          |
+| `podAnnotations`                     | Pod annotations                                                               | `{}` (evaluated as a template)                          |
+| `healthcheckHttps`                   | Use https for liveliness and readiness                                        | `false`                                                 |
+| `livenessProbe.enabled`              | Enable/disable livenessProbe                                                  | `true`                                                  |
+| `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                      | `120`                                                   |
+| `livenessProbe.periodSeconds`        | How often to perform the probe                                                | `10`                                                    |
+| `livenessProbe.timeoutSeconds`       | When the probe times out                                                      | `5`                                                     |
+| `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe                                    | `6`                                                     |
+| `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe                                   | `1`                                                     |
+| `livenessProbeHeaders`               | Headers to use for livenessProbe                                              | `{}`                                                    |
+| `readiness.enabled`                  | Enable/disable readinessProbe                                                 | `true`                                                  |
+| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                     | `30`                                                    |
+| `readinessProbe.periodSeconds`       | How often to perform the probe                                                | `10`                                                    |
+| `readinessProbe.timeoutSeconds`      | When the probe times out                                                      | `5`                                                     |
+| `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe                                    | `6`                                                     |
+| `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe                                   | `1`                                                     |
+| `readinessProbeHeaders`              | Headers to use for readinessProbe                                             | `{}`                                                    |
+| `service.annotations`                | Service annotations                                                           | `{}` (evaluated as a template)                          |
+| `service.type`                       | Kubernetes Service type                                                       | `LoadBalancer`                                          |
+| `service.port`                       | Service HTTP port                                                             | `80`                                                    |
+| `service.httpsPort`                  | Service HTTPS port                                                            | `443`                                                   |
+| `service.httpsTargetPort`            | Service Target HTTPS port                                                     | `https`                                                 |
+| `service.loadBalancerSourceRanges`   | Restricts access for LoadBalancer (only with `service.type: LoadBalancer`)    | `[]`                                                    |
+| `service.metricsPort`                | Service Metrics port                                                          | `9117`                                                  |
+| `service.externalTrafficPolicy`      | Enable client source IP preservation                                          | `Cluster`                                               |
+| `service.nodePorts.http`             | Kubernetes http node port                                                     | `""`                                                    |
+| `service.nodePorts.https`            | Kubernetes https node port                                                    | `""`                                                    |
+| `service.nodePorts.metrics`          | Kubernetes metrics node port                                                  | `""`                                                    |
+| `service.extraPorts`                 | Extra ports to expose in the service (normally used with the `sidecar` value) | `nil`                                                   |
+| `persistence.enabled`                | Enable persistence using PVC                                                  | `true`                                                  |
+| `persistence.existingClaim`          | Enable persistence using an existing PVC                                      | `nil`                                                   |
+| `persistence.storageClass`           | PVC Storage Class                                                             | `nil` (uses alpha storage class annotation)             |
+| `persistence.accessMode`             | PVC Access Mode                                                               | `ReadWriteOnce`                                         |
+| `persistence.size`                   | PVC Storage Request                                                           | `10Gi`                                                  |
+
+### Ingress parameters
+
+| Parameter                         | Description                                              | Default                        |
+|-----------------------------------|----------------------------------------------------------|--------------------------------|
+| `ingress.enabled`                 | Enable ingress controller resource                       | `false`                        |
+| `ingress.certManager`             | Add annotations for cert-manager                         | `false`                        |
+| `ingress.hostname`                | Default host for the ingress resource                    | `wordpress.local`              |
+| `ingress.annotations`             | Ingress annotations                                      | `[]` (evaluated as a template) |
+| `ingress.extraHosts[0].name`      | Additional hostnames to be covered                       | `nil`                          |
+| `ingress.extraHosts[0].path`      | Additional hostnames to be covered                       | `nil`                          |
+| `ingress.extraTls[0].hosts[0]`    | TLS configuration for additional hostnames to be covered | `nil`                          |
+| `ingress.extraTls[0].secretName`  | TLS configuration for additional hostnames to be covered | `nil`                          |
+| `ingress.secrets[0].name`         | TLS Secret Name                                          | `nil`                          |
+| `ingress.secrets[0].certificate`  | TLS Secret Certificate                                   | `nil`                          |
+| `ingress.secrets[0].key`          | TLS Secret Key                                           | `nil`                          |
+
+### Database parameters
+
+| Parameter                    | Description                             | Default                                        |
+|------------------------------|-----------------------------------------|------------------------------------------------|
+| `mariadb.enabled`            | Deploy MariaDB container(s)             | `true`                                         |
+| `mariadb.rootUser.password`  | MariaDB admin password                  | `nil`                                          |
+| `mariadb.db.name`            | Database name to create                 | `bitnami_wordpress`                            |
+| `mariadb.db.user`            | Database user to create                 | `bn_wordpress`                                 |
+| `mariadb.db.password`        | Password for the database               | _random 10 character long alphanumeric string_ |
+| `externalDatabase.host`      | Host of the external database           | `localhost`                                    |
+| `externalDatabase.user`      | Existing username in the external db    | `bn_wordpress`                                 |
+| `externalDatabase.password`  | Password for the above username         | `nil`                                          |
+| `externalDatabase.database`  | Name of the existing database           | `bitnami_wordpress`                            |
+| `externalDatabase.port`      | Database port number                    | `3306`                                         |
+
+### Metrics parameters
+
+| Parameter                                 | Description                                                                  | Default                                                      |
+|-------------------------------------------|------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `metrics.enabled`                         | Start a side-car prometheus exporter                                         | `false`                                                      |
+| `metrics.image.registry`                  | Apache exporter image registry                                               | `docker.io`                                                  |
+| `metrics.image.repository`                | Apache exporter image name                                                   | `bitnami/apache-exporter`                                    |
+| `metrics.image.tag`                       | Apache exporter image tag                                                    | `{TAG_NAME}`                                                 |
+| `metrics.image.pullPolicy`                | Image pull policy                                                            | `IfNotPresent`                                               |
+| `metrics.image.pullSecrets`               | Specify docker-registry secret names as an array                             | `[]` (does not add image pull secrets to deployed pods)      |
+| `metrics.podAnnotations`                  | Additional annotations for Metrics exporter pod                              | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
+| `metrics.resources.limits`                | The resources limits for the metrics exporter container                      | `{}`                                                         |
+| `metrics.resources.requests`              | The requested resources for the metrics exporter container                   | `{}`                                                         |
+| `metrics.serviceMonitor.enabled`          | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator | `false`                                                      |
+| `metrics.serviceMonitor.namespace`        | Namespace where servicemonitor resource should be created                    | `nil`                                                        |
+| `metrics.serviceMonitor.interval`         | Specify the interval at which metrics should be scraped                      | `30s`                                                        |
+| `metrics.serviceMonitor.scrapeTimeout`    | Specify the timeout after which the scrape is ended                          | `nil`                                                        |
+| `metrics.serviceMonitor.relabellings`     | Specify Metric Relabellings to add to the scrape endpoint                    | `nil`                                                        |
+| `metrics.serviceMonitor.honorLabels`      | honorLabels chooses the metric's labels on collisions with target labels.    | `false`                                                      |
+| `metrics.serviceMonitor.additionalLabels` | Used to pass Labels that are required by the Installed Prometheus Operator   | `{}`                                                         |
 
 The above parameters map to the env variables defined in [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress). For more information please refer to the [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-$ helm install my-release \
-  --set wordpressUsername=admin,wordpressPassword=password,mariadb.mariadbRootPassword=secretpassword \
+helm install my-release \
+  --set wordpressUsername=admin \
+  --set wordpressPassword=password \
+  --set mariadb.mariadbRootPassword=secretpassword \
     stable/wordpress
 ```
 
@@ -174,7 +211,7 @@ The above command sets the WordPress administrator account username and password
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-$ helm install my-release -f values.yaml stable/wordpress
+helm install my-release -f values.yaml stable/wordpress
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
@@ -192,43 +229,49 @@ Bitnami will release a new chart updating its containers if a new version of the
 This chart includes a `values-production.yaml` file where you can find some parameters oriented to production configuration in comparison to the regular `values.yaml`. You can use this file instead of the default one.
 
 - Set Apache AllowOverride directive to None:
+
 ```diff
 - allowOverrideNone: false
 + allowOverrideNone: true
 ```
 
-- Number of WordPress Pods to run
+- Number of WordPress Pods to run:
+
 ```diff
 - replicaCount: 1
 + replicaCount: 3
 ```
 
 - Enable client source IP preservation:
+
 ```diff
 - service.externalTrafficPolicy: Cluster
 + service.externalTrafficPolicy: Local
 ```
 
 - PVC Access Mode:
+
 ```diff
 - persistence.accessMode: ReadWriteOnce
-+ ##
 + ## To use the /admin portal and to ensure you can scale wordpress you need to provide a
 + ## ReadWriteMany PVC, if you dont have a provisioner for this type of storage
 + ## We recommend that you install the nfs provisioner and map it to a RWO volume
 + ## helm install nfs-server stable/nfs-server-provisioner --set persistence.enabled=true,persistence.size=10Gi
++ ##
 + persistence.accessMode: ReadWriteMany
 ```
 
 - Start a side-car prometheus exporter:
+
 ```diff
 - metrics.enabled: false
 + metrics.enabled: true
 ```
 
-Note that [values-production.yaml](values-production.yaml) includes a replicaCount of 3, so there will be 3 WordPress pods. As a result, to use the /admin portal and to ensure you can scale wordpress you need to provide a ReadWriteMany PVC, if you don't have a provisioner for this type of storage, we recommend that you install the nfs provisioner (with the correct parameters, such as `persistence.enabled=true` and `persistence.size=10Gi`) and map it to a RWO volume.
+Note that [values-production.yaml](values-production.yaml) includes a replicaCount of 3, so there will be 3 WordPress pods. As a result, to use the "/admin" portal and to ensure you can scale wordpress you need to provide a ReadWriteMany PVC, if you don't have a provisioner for this type of storage, we recommend that you install the NFS provisioner chart (with the correct parameters, such as `persistence.enabled=true` and `persistence.size=10Gi`) and map it to a RWO volume.
 
 Then you can deploy WordPress chart using the proper parameters:
+
 ```console
 persistence.storageClass=nfs
 mariadb.master.persistence.storageClass=nfs
@@ -246,6 +289,7 @@ sidecars:
   ports:
   - name: portname
    containerPort: 1234
+```
 
 If these sidecars export extra ports, you can add extra port definitions using the `service.extraPorts` value:
 
@@ -281,36 +325,37 @@ To enable ingress integration, please set `ingress.enabled` to `true`
 
 ### Hosts
 
-Most likely you will only want to have one hostname that maps to this WordPress installation. If that's your case, the property `ingress.hostname` will set it. However, it is possible to have more than one host. To facilitate this, the `ingress.hosts` object is can be specified as an array.
+Most likely you will only want to have one hostname that maps to this WordPress installation. If that's your case, the property `ingress.hostname` will set it. However, it is possible to have more than one host. To facilitate this, the `ingress.extraHosts` object is can be specified as an array. You can also use `ingress.extraTLS` to add the TLS configuration for extra hosts. 
 
-For each item, please indicate a `name`, `tls`, `tlsSecret`, and any `annotations` that you may want the ingress controller to know about.
+For each host indicated at `ingress.extraHosts`, please indicate a `name`, `path`, and any `annotations` that you may want the ingress controller to know about.
 
-Indicating TLS will cause WordPress to generate HTTPS URLs, and WordPress will be connected to at port 443.  The actual secret that `tlsSecret` references do not have to be generated by this chart. However, please note that if TLS is enabled, the ingress record will not work until this secret exists.
+Indicating TLS will cause WordPress to generate HTTPS URLs, and WordPress will be connected to at port 443. The actual TLS secret do not have to be generated by this chart. However, please note that if TLS is enabled, the ingress record will not work until this secret exists.
 
-For annotations, please see [this document](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md).
-Not all annotations are supported by all ingress controllers, but this document does a good job of indicating which annotation is supported by many popular ingress controllers.
+For annotations, please see [this document](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md). Not all annotations are supported by all ingress controllers, but this document does a good job of indicating which annotation is supported by many popular ingress controllers.
 
 ### TLS Secrets
 
 This chart will facilitate the creation of TLS secrets for use with the ingress controller, however, this is not required.  There are three common use cases:
 
-* helm generates/manages certificate secrets
-* user generates/manages certificates separately
-* an additional tool (like [kube-lego](https://kubeapps.com/charts/stable/kube-lego)) manages the secrets for the application
+- Helm generates/manages certificate secrets
+- User generates/manages certificates separately
+- An additional tool (like [kube-lego](https://kubeapps.com/charts/stable/kube-lego)) manages the secrets for the application
 
 In the first two cases, one will need a certificate and a key.  We would expect them to look like this:
 
-* certificate files should look like (and there can be more than one certificate if there is a certificate chain)
+- certificate files should look like (and there can be more than one certificate if there is a certificate chain)
 
-```
+```console
 -----BEGIN CERTIFICATE-----
 MIID6TCCAtGgAwIBAgIJAIaCwivkeB5EMA0GCSqGSIb3DQEBCwUAMFYxCzAJBgNV
 ...
 jScrvkiBO65F46KioCL9h5tDvomdU1aqpI/CBzhvZn1c0ZTf87tGQR8NK7v7
 -----END CERTIFICATE-----
 ```
-* keys should look like:
-```
+
+- keys should look like:
+
+```console
 -----BEGIN RSA PRIVATE KEY-----
 MIIEogIBAAKCAQEAvLYcyu8f3skuRyUgeeNpeDvYBCDcgq+LsWap6zbX5f8oLqp4
 ...
@@ -330,11 +375,11 @@ In cases where HTTPS/TLS is terminated on the ingress, you may run into an issue
 
 ```yaml
 livenessProbeHeaders:
-- name: X-Forwarded-Proto
-  value: https
+  - name: X-Forwarded-Proto
+    value: https
 readinessProbeHeaders:
-- name: X-Forwarded-Proto
-  value: https
+  - name: X-Forwarded-Proto
+    value: https
 ```
 
 Any number of name/value pairs may be specified; they are all copied into the liveness or readiness probe definition.
@@ -359,6 +404,19 @@ See the [Parameters](#parameters) section to configure the PVC or to disable per
 
 ## Upgrading
 
+### To 9.0.0
+
+The [Bitnami WordPress](https://github.com/bitnami/bitnami-docker-wordpress) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. You can revert this behavior by setting the parameters `securityContext.runAsUser`, and `securityContext.fsGroup` to `root`.
+Chart labels and Ingress configuration were also adapted to follow the Helm charts best practices.
+
+Consequences:
+
+- The HTTP/HTTPS ports exposed by the container are now `8080/8443` instead of `80/443`.
+- No writing permissions will be granted on `wp-config.php` by default.
+- Backwards compatibility is not guaranteed.
+
+To upgrade to `9.0.0`, install a new WordPress chart, and migrate your WordPress site using backup/restore tools such as [VaultPress](https://vaultpress.com/) or [All-in-One WP Migration](https://wordpress.org/plugins/all-in-one-wp-migration/).
+
 ### To 8.0.0
 
 Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.
@@ -373,6 +431,6 @@ Backwards compatibility is not guaranteed unless you modify the labels used on t
 Use the workaround below to upgrade from versions previous to `3.0.0`. The following example assumes that the release name is `wordpress`:
 
 ```console
-$ kubectl patch deployment wordpress-wordpress --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
-$ kubectl delete statefulset wordpress-mariadb --cascade=false
+kubectl patch deployment wordpress-wordpress --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
+kubectl delete statefulset wordpress-mariadb --cascade=false
 ```

--- a/stable/wordpress/requirements.lock
+++ b/stable/wordpress/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 7.3.12
-digest: sha256:3f28d5788a5de6ea45ab46583381147505fea1b5be41d58897e4b8b17184e291
-generated: "2020-02-28T10:29:38.518239833Z"
+digest: sha256:0a5be71f27bb4258b63df284f5006ab452666b4c3125a1c15b8753e71ec8c118
+generated: "2020-02-28T13:36:51.88416+01:00"

--- a/stable/wordpress/requirements.lock
+++ b/stable/wordpress/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 7.3.10
+  version: 7.3.11
 digest: sha256:0a5be71f27bb4258b63df284f5006ab452666b4c3125a1c15b8753e71ec8c118
-generated: "2020-02-26T08:45:16.922661067Z"
+generated: "2020-02-26T19:12:33.661503+01:00"

--- a/stable/wordpress/requirements.lock
+++ b/stable/wordpress/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 7.3.11
-digest: sha256:0a5be71f27bb4258b63df284f5006ab452666b4c3125a1c15b8753e71ec8c118
-generated: "2020-02-26T19:12:33.661503+01:00"
+  version: 7.3.12
+digest: sha256:3f28d5788a5de6ea45ab46583381147505fea1b5be41d58897e4b8b17184e291
+generated: "2020-02-28T10:29:38.518239833Z"

--- a/stable/wordpress/requirements.yaml
+++ b/stable/wordpress/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
-- name: mariadb
-  version: 7.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  condition: mariadb.enabled
-  tags:
-    - wordpress-database
+  - name: mariadb
+    version: 7.x.x
+    repository: https://kubernetes-charts.storage.googleapis.com/
+    condition: mariadb.enabled
+    tags:
+      - wordpress-database

--- a/stable/wordpress/templates/NOTES.txt
+++ b/stable/wordpress/templates/NOTES.txt
@@ -1,46 +1,63 @@
-1. Get the WordPress URL:
+** Please be patient while the chart is being deployed **
+
+To access your WordPress site from outside the cluster follow the steps below:
 
 {{- if .Values.ingress.enabled }}
 
-  You should be able to access your new WordPress installation through
+1. Get the WordPress URL and associate WordPress hostname to your cluster external IP:
 
-  {{- range .Values.ingress.hosts }}
-  {{ if .tls }}https{{ else }}http{{ end }}://{{ .name }}/admin
-  {{- end }}
+   export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
+   echo "WordPress URL: http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.hostname }}/"
+   echo "$CLUSTER_IP  {{ .Values.ingress.hostname }}" | sudo tee -a /etc/hosts
+
+{{- else }}
+{{- $port := .Values.service.port | toString }}
+
+1. Get the WordPress URL by running these commands:
+
+{{- if contains "NodePort" .Values.service.type }}
+
+   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "wordpress.fullname" . }})
+   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+   echo "WordPress URL: http://$NODE_IP:$NODE_PORT/"
+   echo "WordPress Admin URL: http://$NODE_IP:$NODE_PORT/admin"
 
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "wordpress.fullname" . }}'
 
-{{- $port:=.Values.service.port | toString }}
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "wordpress.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo "WordPress URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/"
-  echo "WordPress Admin URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/admin"
+   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "wordpress.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+   echo "WordPress URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/"
+   echo "WordPress Admin URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/admin"
 
 {{- else if contains "ClusterIP"  .Values.service.type }}
 
-  echo "WordPress URL: http://127.0.0.1:8080/"
-  echo "WordPress Admin URL: http://127.0.0.1:8080/admin"
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "wordpress.fullname" . }} 8080:{{ .Values.service.port }}
-
-{{- else if contains "NodePort" .Values.service.type }}
-
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "wordpress.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo "WordPress URL: http://$NODE_IP:$NODE_PORT/"
-  echo "WordPress Admin URL: http://$NODE_IP:$NODE_PORT/admin"
+   kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "wordpress.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }} &
+   echo "WordPress URL: http://127.0.0.1{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}//"
+   echo "WordPress Admin URL: http://127.0.0.1{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}//admin"
 
 {{- end }}
+{{- end }}
 
-2. Login with the following credentials to see your blog
+2. Open a browser and access WordPress using the obtained URL.
+
+3. Login with the following credentials below to see your blog:
 
   echo Username: {{ .Values.wordpressUsername }}
   echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "wordpress.fullname" . }} -o jsonpath="{.data.wordpress-password}" | base64 --decode)
 
-{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
+{{- if .Values.metrics.enabled }}
 
-WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
-+info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
+You can access Apache Prometheus metrics following the steps below:
+
+1. Get the Apache Prometheus metrics URL by running:
+
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "wordpress.fullname" . }} {{ .Values.service.metricsPort }}:{{ .Values.service.metricsPort }} &
+    echo "Apache Prometheus metrics URL: http://127.0.0.1:{{ .Values.service.metricsPort }}/metrics"
+
+2. Open a browser and access Apache Prometheus metrics using the obtained URL.
 
 {{- end }}
+
+{{- include "wordpress.checkRollingTags" . }}

--- a/stable/wordpress/templates/_helpers.tpl
+++ b/stable/wordpress/templates/_helpers.tpl
@@ -22,6 +22,32 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "wordpress.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "wordpress.labels" -}}
+app.kubernetes.io/name: {{ include "wordpress.name" . }}
+helm.sh/chart: {{ include "wordpress.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Labels to use on {deploy|sts}.spec.selector.matchLabels and svc.spec.selector
+*/}}
+{{- define "wordpress.matchLabels" -}}
+app.kubernetes.io/name: {{ include "wordpress.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
@@ -51,13 +77,6 @@ Also, we can't use a single if because lazy evaluation is not an option
 {{- else -}}
     {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
-{{- end -}}
-
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "wordpress.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -180,4 +199,82 @@ Return the appropriate apiVersion for deployment.
 {{- else -}}
 {{- print "apps/v1" -}}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "wordpress.tplValue" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "wordpress.tplValue" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}
+
+{{/*
+Return the MariaDB Hostname
+*/}}
+{{- define "wordpress.databaseHost" -}}
+{{- if .Values.mariadb.enabled }}
+    {{- printf "%s" (include "mariadb.fullname" .) -}}
+{{- else -}}
+    {{- printf "%s" .Values.externalDatabase.host -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the MariaDB Port
+*/}}
+{{- define "wordpress.databasePort" -}}
+{{- if .Values.mariadb.enabled }}
+    {{- printf "3306" -}}
+{{- else -}}
+    {{- printf "%s" .Values.externalDatabase.port -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the MariaDB Database Name
+*/}}
+{{- define "wordpress.databaseName" -}}
+{{- if .Values.mariadb.enabled }}
+    {{- printf "%s" .Values.mariadb.db.name -}}
+{{- else -}}
+    {{- printf "%s" .Values.externalDatabase.database -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the MariaDB User
+*/}}
+{{- define "wordpress.databaseUser" -}}
+{{- if .Values.mariadb.enabled }}
+    {{- printf "%s" .Values.mariadb.db.user -}}
+{{- else -}}
+    {{- printf "%s" .Values.externalDatabase.user -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the MariaDB User
+*/}}
+{{- define "wordpress.databaseSecretName" -}}
+{{- if .Values.mariadb.enabled }}
+    {{- printf "%s" (include "mariadb.fullname" .) -}}
+{{- else -}}
+    {{- printf "%s-%s" .Release.Name "externaldb" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Check if there are rolling tags in the images
+*/}}
+{{- define "wordpress.checkRollingTags" -}}
+{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
+WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
++info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
+{{- end }}
 {{- end -}}

--- a/stable/wordpress/templates/deployment.yaml
+++ b/stable/wordpress/templates/deployment.yaml
@@ -2,246 +2,225 @@ apiVersion: {{ template "wordpress.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "wordpress.fullname" . }}
-  labels:
-    app: "{{ template "wordpress.fullname" . }}"
-    chart: "{{ template "wordpress.chart" . }}"
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  labels: {{- include "wordpress.labels" . | nindent 4 }}
 spec:
   selector:
-    matchLabels:
-      app: "{{ template "wordpress.fullname" . }}"
-      release: {{ .Release.Name | quote }}
+    matchLabels: {{- include "wordpress.matchLabels" . | nindent 6 }}
   {{- if .Values.updateStrategy }}
   strategy: {{ toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
-      labels:
-        app: "{{ template "wordpress.fullname" . }}"
-        chart: "{{ template "wordpress.chart" . }}"
-        release: {{ .Release.Name | quote }}
-{{- if or .Values.podAnnotations .Values.metrics.enabled }}
+      labels: {{- include "wordpress.labels" . | nindent 8 }}
+      {{- if or .Values.podAnnotations .Values.metrics.enabled }}
       annotations:
-{{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.metrics.podAnnotations }}
-{{ toYaml .Values.metrics.podAnnotations | indent 8 }}
-{{- end }}
-{{- end }}
+        {{- if .Values.podAnnotations }}
+        {{- include "wordpress.tplValue" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.metrics.podAnnotations }}
+        {{- include "wordpress.tplValue" (dict "value" .Values.metrics.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
+      {{- end }}
     spec:
-      {{- if .Values.schedulerName }}
-      schedulerName: "{{ .Values.schedulerName }}"
-      {{- end }}
 {{- include "wordpress.imagePullSecrets" . | indent 6 }}
+      {{- if .Values.schedulerName }}
+      schedulerName: {{ .Values.schedulerName | quote }}
+      {{- end }}
       hostAliases:
-      - ip: "127.0.0.1"
-        hostnames:
-        - "status.localhost"
+        - ip: "127.0.0.1"
+          hostnames:
+            - "status.localhost"
+      {{- if .Values.affinity }}
+      affinity: {{- include "wordpress.tplValue" (dict "value" .Values.affinity "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{- include "wordpress.tplValue" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{- include "wordpress.tplValue" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- end }}
       containers:
-      - name: wordpress
-        image: {{ template "wordpress.image" . }}
-        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-        env:
-        - name: ALLOW_EMPTY_PASSWORD
-          value: {{ ternary "yes" "no" .Values.allowEmptyPassword | quote }}
-        - name: MARIADB_HOST
-        {{- if .Values.mariadb.enabled }}
-          value: {{ template "mariadb.fullname" . }}
-        {{- else }}
-          value: {{ .Values.externalDatabase.host | quote }}
-        {{- end }}
-        - name: MARIADB_PORT_NUMBER
-        {{- if .Values.mariadb.enabled }}
-          value: "3306"
-        {{- else }}
-          value: {{ .Values.externalDatabase.port | quote }}
-        {{- end }}
-        - name: WORDPRESS_DATABASE_NAME
-        {{- if .Values.mariadb.enabled }}
-          value: {{ .Values.mariadb.db.name | quote }}
-        {{- else }}
-          value: {{ .Values.externalDatabase.database | quote }}
-        {{- end }}
-        - name: WORDPRESS_DATABASE_USER
-        {{- if .Values.mariadb.enabled }}
-          value: {{ .Values.mariadb.db.user | quote }}
-        {{- else }}
-          value: {{ .Values.externalDatabase.user | quote }}
-        {{- end }}
-        - name: WORDPRESS_DATABASE_PASSWORD
-          valueFrom:
-            secretKeyRef:
-            {{- if .Values.mariadb.enabled }}
-              name: {{ template "mariadb.fullname" . }}
-              key: mariadb-password
-            {{- else }}
-              name: {{ printf "%s-%s" .Release.Name "externaldb" }}
-              key: db-password
+        - name: wordpress
+          image: {{ template "wordpress.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          env:
+            {{- if .Values.image.debug }}
+            - name: NAMI_DEBUG
+              value: "--log-level trace"
             {{- end }}
-        - name: WORDPRESS_USERNAME
-          value: {{ .Values.wordpressUsername | quote }}
-        - name: WORDPRESS_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "wordpress.fullname" . }}
-              key: wordpress-password
-        - name: WORDPRESS_EMAIL
-          value: {{ .Values.wordpressEmail | quote }}
-        - name: WORDPRESS_FIRST_NAME
-          value: {{ .Values.wordpressFirstName | quote }}
-        - name: WORDPRESS_LAST_NAME
-          value: {{ .Values.wordpressLastName | quote }}
-        - name: WORDPRESS_HTACCESS_OVERRIDE_NONE
-          value: {{ ternary "yes" "no" .Values.allowOverrideNone | quote }}
-        - name: WORDPRESS_BLOG_NAME
-          value: {{ .Values.wordpressBlogName | quote }}
-        - name: WORDPRESS_SKIP_INSTALL
-          value: {{ ternary "yes" "no" .Values.wordpressSkipInstall | quote }}
-        - name: WORDPRESS_TABLE_PREFIX
-          value: {{ .Values.wordpressTablePrefix | quote }}
-        - name: WORDPRESS_SCHEME
-          value: {{ .Values.wordpressScheme | quote }}
-        {{- if .Values.smtpHost }}
-        - name: SMTP_HOST
-          value: {{ .Values.smtpHost | quote }}
-        {{- end }}
-        {{- if .Values.smtpPort }}
-        - name: SMTP_PORT
-          value: {{ .Values.smtpPort | quote }}
-        {{- end }}
-        {{- if .Values.smtpUser }}
-        - name: SMTP_USER
-          value: {{ .Values.smtpUser | quote }}
-        {{- end }}
-        {{- if .Values.smtpPassword }}
-        - name: SMTP_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "wordpress.fullname" . }}
-              key: smtp-password
-        {{- end }}
-        {{- if .Values.smtpUsername }}
-        - name: SMTP_USERNAME
-          value: {{ .Values.smtpUsername | quote }}
-        {{- end }}
-        {{- if .Values.smtpProtocol }}
-        - name: SMTP_PROTOCOL
-          value: {{ .Values.smtpProtocol | quote }}
-        {{- end }}
-        {{- with .Values.extraEnv }}
-{{ toYaml . | indent 8 }}
-        {{- end }}
-        ports:
-        - name: http
-          containerPort: 80
-        - name: https
-          containerPort: 443
-        {{- if .Values.livenessProbe.enabled }}
-        livenessProbe:
-          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.livenessProbe.successThreshold }}
-          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
-          httpGet:
-            path: /wp-login.php
-            port: {{ ternary "https" "http" .Values.healthcheckHttps }}
-            {{- if .Values.healthcheckHttps }}
-            scheme: HTTPS
+            - name: ALLOW_EMPTY_PASSWORD
+              value: {{ ternary "yes" "no" .Values.allowEmptyPassword | quote }}
+            - name: MARIADB_HOST
+              value: {{ include "wordpress.databaseHost" . | quote }}
+            - name: MARIADB_PORT_NUMBER
+              value: {{ include "wordpress.databasePort" . | quote }}
+            - name: WORDPRESS_DATABASE_NAME
+              value: {{ include "wordpress.databaseName" . | quote }}
+            - name: WORDPRESS_DATABASE_USER
+              value: {{ include "wordpress.databaseUser" . | quote }}
+            - name: WORDPRESS_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wordpress.databaseSecretName" . }}
+                  key: mariadb-password
+            - name: WORDPRESS_USERNAME
+              value: {{ .Values.wordpressUsername | quote }}
+            - name: WORDPRESS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wordpress.fullname" . }}
+                  key: wordpress-password
+            - name: WORDPRESS_EMAIL
+              value: {{ .Values.wordpressEmail | quote }}
+            - name: WORDPRESS_FIRST_NAME
+              value: {{ .Values.wordpressFirstName | quote }}
+            - name: WORDPRESS_LAST_NAME
+              value: {{ .Values.wordpressLastName | quote }}
+            - name: WORDPRESS_HTACCESS_OVERRIDE_NONE
+              value: {{ ternary "yes" "no" .Values.allowOverrideNone | quote }}
+            - name: WORDPRESS_BLOG_NAME
+              value: {{ .Values.wordpressBlogName | quote }}
+            - name: WORDPRESS_SKIP_INSTALL
+              value: {{ ternary "yes" "no" .Values.wordpressSkipInstall | quote }}
+            - name: WORDPRESS_TABLE_PREFIX
+              value: {{ .Values.wordpressTablePrefix | quote }}
+            - name: WORDPRESS_SCHEME
+              value: {{ .Values.wordpressScheme | quote }}
+            {{- if .Values.smtpHost }}
+            - name: SMTP_HOST
+              value: {{ .Values.smtpHost | quote }}
             {{- end }}
-          {{- if .Values.livenessProbeHeaders }}
-            httpHeaders:
-{{ toYaml .Values.livenessProbeHeaders | indent 14 }}
+            {{- if .Values.smtpPort }}
+            - name: SMTP_PORT
+              value: {{ .Values.smtpPort | quote }}
+            {{- end }}
+            {{- if .Values.smtpUser }}
+            - name: SMTP_USER
+              value: {{ .Values.smtpUser | quote }}
+            {{- end }}
+            {{- if .Values.smtpPassword }}
+            - name: SMTP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "wordpress.fullname" . }}
+                  key: smtp-password
+            {{- end }}
+            {{- if .Values.smtpUsername }}
+            - name: SMTP_USERNAME
+              value: {{ .Values.smtpUsername | quote }}
+            {{- end }}
+            {{- if .Values.smtpProtocol }}
+            - name: SMTP_PROTOCOL
+              value: {{ .Values.smtpProtocol | quote }}
+            {{- end }}
+            {{- if .Values.extraEnv }}
+            {{- include "wordpress.tplValue" (dict "value" .Values.extraEnv "context" $) | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: https
+              containerPort: 8443
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            httpGet:
+              path: /wp-login.php
+              port: {{ ternary "https" "http" .Values.healthcheckHttps }}
+              {{- if .Values.healthcheckHttps }}
+              scheme: HTTPS
+              {{- end }}
+              {{- if .Values.livenessProbeHeaders }}
+              httpHeaders: {{- toYaml .Values.livenessProbeHeaders | nindent 16 }}
+              {{- end }}
           {{- end }}
-        {{- end }}
-        {{- if .Values.readinessProbe.enabled }}
-        readinessProbe:
-          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.readinessProbe.successThreshold }}
-          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
-          httpGet:
-            path: /wp-login.php
-            port: {{ ternary "https" "http" .Values.healthcheckHttps }}
-            {{- if .Values.healthcheckHttps }}
-            scheme: HTTPS
-            {{- end }}
-          {{- if .Values.readinessProbeHeaders }}
-            httpHeaders:
-{{ toYaml .Values.readinessProbeHeaders | indent 14 }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            httpGet:
+              path: /wp-login.php
+              port: {{ ternary "https" "http" .Values.healthcheckHttps }}
+              {{- if .Values.healthcheckHttps }}
+              scheme: HTTPS
+              {{- end }}
+              {{- if .Values.readinessProbeHeaders }}
+              httpHeaders: {{- toYaml .Values.readinessProbeHeaders | nindent 16 }}
+              {{- end }}
           {{- end }}
-        {{- end }}
-        volumeMounts:
-        - mountPath: /bitnami/wordpress
-          name: wordpress-data
-          subPath: wordpress
-        {{- if and .Values.allowOverrideNone .Values.customHTAccessCM }}
-        - mountPath: /htaccess
-          name: custom-htaccess
-        {{- end }}
-        {{- with .Values.extraVolumeMounts }}
-{{ toYaml . | indent 8 }}
-        {{- end }}
-        resources:
-{{ toYaml .Values.resources | indent 10 }}
-{{- if .Values.metrics.enabled }}
-      - name: metrics
-        image: {{ template "wordpress.metrics.image" . }}
-        imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
-        command: [ '/bin/apache_exporter', '-scrape_uri', 'http://status.localhost:80/server-status/?auto']
-        ports:
+          volumeMounts:
+            - mountPath: /bitnami/wordpress
+              name: wordpress-data
+              subPath: wordpress
+            {{- if and .Values.allowOverrideNone .Values.customHTAccessCM }}
+            - mountPath: /htaccess
+              name: custom-htaccess
+            {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "wordpress.tplValue" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+        {{- if .Values.metrics.enabled }}
         - name: metrics
-          containerPort: 9117
-        livenessProbe:
-          httpGet:
-            path: /metrics
-            port: metrics
-          initialDelaySeconds: 15
-          timeoutSeconds: 5
-        readinessProbe:
-          httpGet:
-            path: /metrics
-            port: metrics
-          initialDelaySeconds: 5
-          timeoutSeconds: 1
-        resources:
-{{ toYaml .Values.metrics.resources | indent 10 }}
-{{- end }}
-{{- if .Values.sidecars }}
-{{ toYaml .Values.sidecars | indent 6 }}
-{{- end }}
+          image: {{ template "wordpress.metrics.image" . }}
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
+          command:
+            - /bin/apache_exporter
+            - -scrape_uri
+            - http://status.localhost:8080/server-status/?auto
+          ports:
+            - name: metrics
+              containerPort: 9117
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 15
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          {{- if .Values.metrics.resources }}
+          resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.sidecars }}
+        {{- include "wordpress.tplValue" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
+        {{- end }}
       volumes:
-      {{- if and .Values.allowOverrideNone .Values.customHTAccessCM }}
-      - name: custom-htaccess
-        configMap:
-          name: {{ template "wordpress.customHTAccessCM" . }}
-          items:
-            - key: wordpress-htaccess.conf
-              path: wordpress-htaccess.conf
-      {{- end }}
-      - name: wordpress-data
-      {{- if .Values.persistence.enabled }}
-        persistentVolumeClaim:
-          claimName: {{ .Values.persistence.existingClaim | default (include "wordpress.fullname" .) }}
-      {{- else }}
-        emptyDir: {}
-      {{ end }}
-      {{- with .Values.extraVolumes }}
-{{ toYaml . | indent 6 }}
-      {{- end }}
-    {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-      {{- end -}}
-    {{- with .Values.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+        {{- if and .Values.allowOverrideNone .Values.customHTAccessCM }}
+        - name: custom-htaccess
+          configMap:
+            name: {{ template "wordpress.customHTAccessCM" . }}
+            items:
+              - key: wordpress-htaccess.conf
+                path: wordpress-htaccess.conf
+        {{- end }}
+        - name: wordpress-data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "wordpress.fullname" .) }}
+          {{- else }}
+          emptyDir: {}
+          {{ end }}
+        {{- if .Values.extraVolumes }}
+        {{- include "wordpress.tplValue" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}

--- a/stable/wordpress/templates/externaldb-secrets.yaml
+++ b/stable/wordpress/templates/externaldb-secrets.yaml
@@ -3,12 +3,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
-  labels:
-    app: {{ printf "%s-%s" .Release.Name "externaldb"  }}
-    chart: "{{ template "wordpress.chart" . }}"
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  labels: {{- include "wordpress.labels" . | nindent 4 }}
 type: Opaque
 data:
-  db-password: {{ .Values.externalDatabase.password | b64enc | quote }}
+  mariadb-password: {{ .Values.externalDatabase.password | b64enc | quote }}
 {{- end }}

--- a/stable/wordpress/templates/ingress.yaml
+++ b/stable/wordpress/templates/ingress.yaml
@@ -3,40 +3,43 @@ apiVersion: {{ template "wordpress.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "wordpress.fullname" . }}
-  labels:
-    app: "{{ template "wordpress.fullname" . }}"
-    chart: "{{ template "wordpress.chart" . }}"
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  labels: {{- include "wordpress.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"
     {{- end }}
-    {{- range $key, $value := .Values.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
+    {{- if .Values.ingress.annotations }}
+    {{- include "wordpress.tplValue" (dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:
   rules:
-  {{- if .Values.ingress.hostname }}
-  - host: {{ .Values.ingress.hostname }}
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: "{{ template "wordpress.fullname" $ }}"
-          servicePort: http
-  {{- end }}
-  {{- range .Values.ingress.hosts }}
-  - host: {{ .name }}
-    http:
-      paths:
-      - path: {{ default "/" .path }}
-        backend:
-          serviceName: "{{ template "wordpress.fullname" $ }}"
-          servicePort: http
-  {{- end }}
-  {{- if .Values.ingress.tls }}
+    {{- if .Values.ingress.hostname }}
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ template "wordpress.fullname" . }}
+              servicePort: http
+    {{- end }}
+    {{- range .Values.ingress.extraHosts }}
+    - host: {{ .name }}
+      http:
+        paths:
+          - path: {{ default "/" .path }}
+            backend:
+              serviceName: {{ template "wordpress.fullname" $ }}
+              servicePort: http
+    {{- end }}
+  {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
   tls:
-{{ toYaml .Values.ingress.tls | indent 4 }}
+    {{- if .Values.ingress.tls }}
+    - hosts:
+        - {{ .Values.ingress.hostname }}
+      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+    {{- end }}
+    {{- if .Values.ingress.extraTls }}
+    {{- toYaml .Values.ingress.extraTls | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/stable/wordpress/templates/pvc.yaml
+++ b/stable/wordpress/templates/pvc.yaml
@@ -3,11 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "wordpress.fullname" . }}
-  labels:
-    app: "{{ template "wordpress.fullname" . }}"
-    chart: "{{ template "wordpress.chart" . }}"
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  labels: {{- include "wordpress.labels" . | nindent 4 }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}
@@ -15,4 +11,4 @@ spec:
     requests:
       storage: {{ .Values.persistence.size | quote }}
   {{ include "wordpress.storageClass" . }}
-{{- end -}}
+{{- end }}

--- a/stable/wordpress/templates/secrets.yaml
+++ b/stable/wordpress/templates/secrets.yaml
@@ -2,15 +2,11 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "wordpress.fullname" . }}
-  labels:
-    app: "{{ template "wordpress.fullname" . }}"
-    chart: "{{ template "wordpress.chart" . }}"
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  labels: {{- include "wordpress.labels" . | nindent 4 }}
 type: Opaque
 data:
   {{- if .Values.wordpressPassword }}
-  wordpress-password: {{ default "" .Values.wordpressPassword | b64enc | quote }}
+  wordpress-password: {{ .Values.wordpressPassword | b64enc | quote }}
   {{- else }}
   wordpress-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}

--- a/stable/wordpress/templates/servicemonitor.yaml
+++ b/stable/wordpress/templates/servicemonitor.yaml
@@ -6,31 +6,24 @@ metadata:
   {{- if .Values.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.metrics.serviceMonitor.namespace }}
   {{- end }}
-  labels:
-    app: "{{ template "wordpress.fullname" . }}"
-    chart: {{ template "wordpress.chart" .  }}
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
+  labels: {{- include "wordpress.labels" . | nindent 4 }}
     {{- if .Values.metrics.serviceMonitor.additionalLabels }}
-{{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    {{- include "wordpress.tplValue" (dict "value" .Values.metrics.serviceMonitor.additionalLabels "context" $) | nindent 4 }}
     {{- end }}
 spec:
   endpoints:
-  - port: metrics
-    interval: {{ .Values.metrics.serviceMonitor.interval }}
-    {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
-    scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
-    {{- end }}
-    honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
-    {{- if .Values.metrics.serviceMonitor.relabellings }}
-    metricRelabelings:
-{{ toYaml .Values.metrics.serviceMonitor.relabellings | indent 6 }}
-    {{- end }}
+    - port: metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
+      {{- if .Values.metrics.serviceMonitor.relabellings }}
+      metricRelabelings: {{- toYaml .Values.metrics.serviceMonitor.relabellings | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
   selector:
-    matchLabels:
-      app: "{{ template "wordpress.fullname" . }}"
-      release: "{{ .Release.Name }}"
+    matchLabels: {{- include "wordpress.matchLabels" . | nindent 6 }}
 {{- end }}

--- a/stable/wordpress/templates/svc.yaml
+++ b/stable/wordpress/templates/svc.yaml
@@ -2,15 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "wordpress.fullname" . }}
-  labels:
-    app: "{{ template "wordpress.fullname" . }}"
-    chart: "{{ template "wordpress.chart" . }}"
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
-  annotations:
-{{- if .Values.service.annotations }}
-{{ toYaml .Values.service.annotations | indent 4 }}
-{{- end }}
+  labels: {{- include "wordpress.labels" . | nindent 4 }}
+  {{- if .Values.service.annotations }}
+  annotations: {{- include "wordpress.tplValue" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
@@ -26,7 +21,7 @@ spec:
     - name: http
       port: {{ .Values.service.port }}
       targetPort: http
-      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePorts.http)))}}
+      {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.http))) }}
       nodePort: {{ .Values.service.nodePorts.http }}
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
@@ -34,7 +29,7 @@ spec:
     - name: https
       port: {{ .Values.service.httpsPort }}
       targetPort: {{ .Values.service.httpsTargetPort }}
-      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePorts.https)))}}
+      {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.https))) }}
       nodePort: {{ .Values.service.nodePorts.https }}
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
@@ -43,14 +38,13 @@ spec:
     - name: metrics
       port: {{ .Values.service.metricsPort }}
       targetPort: metrics
-      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePorts.metrics)))}}
+      {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.metrics))) }}
       nodePort: {{ .Values.service.nodePorts.metrics }}
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
       {{- end }}
-{{- if .Values.service.extraPorts }}
-{{ toYaml .Values.service.extraPorts | indent 4 }}
-{{- end }}      
-  selector:
-    app: "{{ template "wordpress.fullname" . }}"
+    {{- if .Values.service.extraPorts }}
+    {{- include "wordpress.tplValue" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
+  selector: {{- include "wordpress.matchLabels" . | nindent 4 }}

--- a/stable/wordpress/templates/tests/test-mariadb-connection.yaml
+++ b/stable/wordpress/templates/tests/test-mariadb-connection.yaml
@@ -13,7 +13,6 @@ spec:
       {{- if .Values.securityContext.enabled }}
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
-        fsGroup: {{ .Values.securityContext.fsGroup }}
       {{- end }}
       env:
         - name: MARIADB_HOST

--- a/stable/wordpress/templates/tests/test-mariadb-connection.yaml
+++ b/stable/wordpress/templates/tests/test-mariadb-connection.yaml
@@ -7,23 +7,32 @@ metadata:
     "helm.sh/hook": test-success
 spec:
   containers:
-  - name: {{ .Release.Name }}-credentials-test
-    image: {{ template "wordpress.image" . }}
-    imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-    env:
-      - name: MARIADB_HOST
-        value: {{ template "mariadb.fullname" . }}
-      - name: MARIADB_PORT
-        value: "3306"
-      - name: WORDPRESS_DATABASE_NAME
-        value: {{ default "" .Values.mariadb.db.name | quote }}
-      - name: WORDPRESS_DATABASE_USER
-        value: {{ default "" .Values.mariadb.db.user | quote }}
-      - name: WORDPRESS_DATABASE_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: {{ template "mariadb.fullname" . }}
-            key: mariadb-password
-    command: ["sh", "-c", "mysql --host=$MARIADB_HOST --port=$MARIADB_PORT --user=$WORDPRESS_DATABASE_USER --password=$WORDPRESS_DATABASE_PASSWORD"]
+    - name: {{ .Release.Name }}-credentials-test
+      image: {{ template "wordpress.image" . }}
+      imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- end }}
+      env:
+        - name: MARIADB_HOST
+          value: {{ template "mariadb.fullname" . }}
+        - name: MARIADB_PORT
+          value: "3306"
+        - name: WORDPRESS_DATABASE_NAME
+          value: {{ default "" .Values.mariadb.db.name | quote }}
+        - name: WORDPRESS_DATABASE_USER
+          value: {{ default "" .Values.mariadb.db.user | quote }}
+        - name: WORDPRESS_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "mariadb.fullname" . }}
+              key: mariadb-password
+      command:
+        - /bin/bash
+        - -ec
+        - |
+          mysql --host=$MARIADB_HOST --port=$MARIADB_PORT --user=$WORDPRESS_DATABASE_USER --password=$WORDPRESS_DATABASE_PASSWORD
   restartPolicy: Never
 {{- end }}

--- a/stable/wordpress/templates/tls-secrets.yaml
+++ b/stable/wordpress/templates/tls-secrets.yaml
@@ -4,11 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}
-  labels:
-    app: "{{ template "wordpress.fullname" $ }}"
-    chart: "{{ template "wordpress.chart" $ }}"
-    release: {{ $.Release.Name | quote }}
-    heritage: {{ $.Release.Service | quote }}
+  labels: {{- include "wordpress.labels" . | nindent 4 }}
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .certificate | b64enc }}

--- a/stable/wordpress/values-production.yaml
+++ b/stable/wordpress/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/wordpress
-  tag: 5.3.2-debian-10-r29
+  tag: 5.3.2-debian-10-r32
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -418,7 +418,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.7.0-debian-10-r29
+    tag: 0.7.0-debian-10-r32
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/stable/wordpress/values-production.yaml
+++ b/stable/wordpress/values-production.yaml
@@ -26,6 +26,9 @@ image:
   ##
   # pullSecrets:
   #   - myRegistryKeySecretName
+  ## Set to true if you would like to see extra information on logs
+  ##
+  debug: false
 
 ## String to partially override wordpress.fullname template (will maintain the release name)
 ##
@@ -122,45 +125,220 @@ customHTAccessCM:
 
 replicaCount: 3
 
-# Additional container environment variables
+## Additional container environment variables
+## Example: Configure SSL for database
+## extraEnv:
+##   - name: WORDPRESS_DATABASE_SSL_CA_FILE
+##     value: /path/to/ca_cert
+##
 extraEnv: []
-  ## Example: Configure SSL for database
-  # - name: WORDPRESS_DATABASE_SSL_CA_FILE
-  #   value: /path/to/ca_cert
 
-# Additional volume mounts
+## Additional volume mounts
+## Example: Mount CA file
+## extraVolumeMounts
+##   - name: ca-cert
+##     subPath: ca_cert
+##     mountPath: /path/to/ca_cert
 extraVolumeMounts: []
-  ## Example: Mount CA file
-  # - name: ca-cert
-  #   subPath: ca_cert
-  #   mountPath: /path/to/ca_cert
 
-# Additional volumes
+## Additional volumes
+## Example: Add secret volume
+## extraVolumes:
+##  - name: ca-cert
+##    secret:
+##      secretName: ca-cert
+##      items:
+##        - key: ca-cert
+##          path: ca_cert
 extraVolumes: []
-  ## Example: Add secret volume
-  # - name: ca-cert
-  #   secret:
-  #     secretName: ca-cert
-  #     items:
-  #     - key: ca-cert
-  #       path: ca_cert
 
-externalDatabase:
-## All of these values are only used when mariadb.enabled is set to false
-  ## Database host
-  host: localhost
+## WordPress containers' resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  limits: {}
+  requests:
+    memory: 512Mi
+    cpu: 300m
 
-  ## non-root Username for Wordpress Database
-  user: bn_wordpress
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}
 
-  ## Database password
-  password: ""
+## Node labels for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
 
-  ## Database name
-  database: bitnami_wordpress
+## Tolerations for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: {}
 
-  ## Database port number
-  port: 3306
+## Pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+
+## K8s Security Context for WordPress pods
+## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+##
+securityContext:
+  enabled: true
+  fsGroup: 1001
+  runAsUser: 1001
+
+## Allow health checks to be pointed at the https port
+healthcheckHttps: false
+
+## WordPress pod extra options for liveness and readiness probes
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+## If using an HTTPS-terminating load-balancer, the probes may need to behave
+## like the balancer to prevent HTTP 302 responses. According to the Kubernetes
+## docs, 302 should be considered "successful", but this issue on GitHub
+## (https://github.com/kubernetes/kubernetes/issues/47893) shows that it isn't.
+##
+# livenessProbeHeaders:
+# - name: X-Forwarded-Proto
+#   value: https
+# readinessProbeHeaders:
+# - name: X-Forwarded-Proto
+#   value: https
+livenessProbeHeaders: {}
+readinessProbeHeaders: {}
+
+## Kubernetes configuration
+## For minikube, set this to NodePort, elsewhere use LoadBalancer or ClusterIP
+##
+service:
+  type: LoadBalancer
+  ## HTTP Port
+  ##
+  port: 80
+  ## HTTPS Port
+  ##
+  httpsPort: 443
+  ## HTTPS Target Port
+  ## defaults to https unless overridden to the specified port.
+  ## if you want the target port to be "http" or "80" you can specify that here.
+  ##
+  httpsTargetPort: https
+  ## Metrics Port
+  ##
+  metricsPort: 9117
+  ## Node Ports to expose
+  ## nodePorts:
+  ##   http: <to set explicitly, choose port between 30000-32767>
+  ##   https: <to set explicitly, choose port between 30000-32767>
+  ##   metrics: <to set explicitly, choose port between 30000-32767>
+  nodePorts:
+    http: ""
+    https: ""
+    metrics: ""
+  ## Enable client source IP preservation
+  ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  ##
+  externalTrafficPolicy: Local
+  annotations: {}
+  ## Limits which cidr blocks can connect to service's load balancer
+  ## Only valid if service.type: LoadBalancer
+  loadBalancerSourceRanges: []
+  ## Extra ports to expose (normally used with the `sidecar` value)
+  # extraPorts:
+
+## Configure the ingress resource that allows you to access the
+## WordPress installation. Set up the URL
+## ref: http://kubernetes.io/docs/user-guide/ingress/
+##
+ingress:
+  ## Set to true to enable ingress record generation
+  ##
+  enabled: false
+
+  ## Set this to true in order to add the corresponding annotations for cert-manager
+  ##
+  certManager: false
+
+  ## When the ingress is enabled, a host pointing to this will be created
+  ##
+  hostname: wordpress.local
+
+  ## Ingress annotations done as key:value pairs
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ##
+  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+  ##
+  annotations: {}
+
+  ## The list of additional hostnames to be covered with this ingress record.
+  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+  ## extraHosts:
+  ## - name: wordpress.local
+  ##   path: /
+
+  ## The tls configuration for additional hostnames to be covered with this ingress record.
+  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## extraTls:
+  ## - hosts:
+  ##     - wordpress.local
+  ##   secretName: wordpress.local-tls
+
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
+  ##
+  ## name should line up with a tlsSecret set further up
+  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+  ##
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  ##
+  secrets: []
+  ## - name: wordpress.local-tls
+  ##   key:
+  ##   certificate:
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  enabled: true
+  ## wordpress data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  ##
+  ## If you want to reuse an existing claim, you can pass the name of the PVC using
+  ## the existingClaim variable
+  # existingClaim: your-claim
+  ##
+  ## To use the /admin portal and to ensure you can scale wordpress you need to provide a
+  ## ReadWriteMany PVC, if you dont have a provisioner for this type of storage
+  ## We recommend that you install the nfs provisioner and map it to a RWO volume
+  ## helm install nfs-server stable/nfs-server-provisioner --set persistence.enabled=true,persistence.size=10Gi
+  accessMode: ReadWriteMany
+  size: 10Gi
 
 ##
 ## MariaDB chart configuration
@@ -207,174 +385,32 @@ mariadb:
       accessMode: ReadWriteOnce
       size: 8Gi
 
-## Kubernetes configuration
-## For minikube, set this to NodePort, elsewhere use LoadBalancer or ClusterIP
 ##
-service:
-  type: LoadBalancer
-  # HTTP Port
-  port: 80
-  # HTTPS Port
-  httpsPort: 443
-  # HTTPS Target Port
-  # defaults to https unless overridden to the specified port.
-  # if you want the target port to be "http" or "80" you can specify that here.
-  httpsTargetPort: https
-  # metrics Port
-  metricsPort: 9117
-  ##
-  ## nodePorts:
-  ##   http: <to set explicitly, choose port between 30000-32767>
-  ##   https: <to set explicitly, choose port between 30000-32767>
-    ##   metrics: <to set explicitly, choose port between 30000-32767>
-  nodePorts:
-    http: ""
-    https: ""
-    metrics: ""
-  ## Enable client source IP preservation
-  ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
-  ##
-  externalTrafficPolicy: Local
-  annotations: {}
-  ## Limits which cidr blocks can connect to service's load balancer
-  ## Only valid if service.type: LoadBalancer
-  loadBalancerSourceRanges: []
-  ## Extra ports to expose (normally used with the `sidecar` value)
-  # extraPorts:
-
-## Allow health checks to be pointed at the https port
-healthcheckHttps: false
-
-## Configure extra options for liveness and readiness probes
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
-livenessProbe:
-  enabled: true
-  initialDelaySeconds: 120
-  periodSeconds: 10
-  timeoutSeconds: 5
-  failureThreshold: 6
-  successThreshold: 1
-
-readinessProbe:
-  enabled: true
-  initialDelaySeconds: 30
-  periodSeconds: 10
-  timeoutSeconds: 5
-  failureThreshold: 6
-  successThreshold: 1
-## If using an HTTPS-terminating load-balancer, the probes may need to behave
-## like the balancer to prevent HTTP 302 responses.  According to the Kubernetes
-## docs, 302 should be considered "successful", but this issue on GitHub
-## (https://github.com/kubernetes/kubernetes/issues/47893) shows that it isn't.
-# livenessProbeHeaders:
-# - name: X-Forwarded-Proto
-#   value: https
-# readinessProbeHeaders:
-# - name: X-Forwarded-Proto
-#   value: https
-
-## Configure the ingress resource that allows you to access the
-## WordPress installation. Set up the URL
-## ref: http://kubernetes.io/docs/user-guide/ingress/
+## External Database Configuration
 ##
-ingress:
-  ## Set to true to enable ingress record generation
-  enabled: false
-
-  ## Set this to true in order to add the corresponding annotations for cert-manager
-  certManager: false
-
-  ## When the ingress is enabled, a host pointing to this will be created
-  hostname: wordpress.local
-
-  ## Ingress annotations done as key:value pairs
-  ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
-  ##
-  ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
-  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
-  annotations: {}
-  #  kubernetes.io/ingress.class: nginx
-
-  ## The list of additional hostnames to be covered with this ingress record.
-  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
-  ## hosts:
-  ## - name: wordpress.local
-  ##   path: /
-
-  ## The tls configuration for the ingress
-  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-  ## tls:
-  ## - hosts:
-  ##     - wordpress.local
-  ##   secretName: wordpress.local-tls
-
-  secrets:
-  ## If you're providing your own certificates, please use this to add the certificates as secrets
-  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
-  ## -----BEGIN RSA PRIVATE KEY-----
-  ##
-  ## name should line up with a tlsSecret set further up
-  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
-  ##
-  ## It is also possible to create and manage the certificates outside of this helm chart
-  ## Please see README.md for more information
-  # - name: wordpress.local-tls
-  #   key:
-  #   certificate:
-
-## Enable persistence using Persistent Volume Claims
-## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+## All of these values are only used when mariadb.enabled is set to false
 ##
-persistence:
-  enabled: true
-  ## wordpress data Persistent Volume Storage Class
-  ## If defined, storageClassName: <storageClass>
-  ## If set to "-", storageClassName: "", which disables dynamic provisioning
-  ## If undefined (the default) or set to null, no storageClassName spec is
-  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-  ##   GKE, AWS & OpenStack)
+externalDatabase:  
+  ## Database host
   ##
-  # storageClass: "-"
+  host: localhost
+
+  ## non-root Username for Wordpress Database
   ##
-  ## If you want to reuse an existing claim, you can pass the name of the PVC using
-  ## the existingClaim variable
-  # existingClaim: your-claim
+  user: bn_wordpress
+
+  ## Database password
   ##
-  ## To use the /admin portal and to ensure you can scale wordpress you need to provide a
-  ## ReadWriteMany PVC, if you dont have a provisioner for this type of storage
-  ## We recommend that you install the nfs provisioner and map it to a RWO volume
-  ## helm install nfs-server stable/nfs-server-provisioner --set persistence.enabled=true,persistence.size=10Gi
-  accessMode: ReadWriteMany
-  size: 10Gi
+  password: ""
 
-## Configure resource requests and limits
-## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-##
-resources:
-  requests:
-    memory: 512Mi
-    cpu: 300m
+  ## Database name
+  ##
+  database: bitnami_wordpress
 
-## Node labels for pod assignment
-## Ref: https://kubernetes.io/docs/user-guide/node-selection/
-##
-nodeSelector: {}
+  ## Database port number
+  ##
+  port: 3306
 
-## Tolerations for pod assignment
-## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-##
-tolerations: []
-
-## Affinity for pod assignment
-## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-##
-affinity: {}
-
-## Pod annotations
-## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-##
-podAnnotations: {}
 ## Prometheus Exporter / Metrics
 ##
 metrics:
@@ -394,10 +430,13 @@ metrics:
   podAnnotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9117"
-  ## Metrics exporter resource requests and limits
+
+  ## Metrics exporter containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
-  # resources: {}
+  resources:
+    limits: {}
+    requests: {}
 
   ## Prometheus Service Monitor
   ## ref: https://github.com/coreos/prometheus-operator
@@ -419,12 +458,14 @@ metrics:
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
     additionalLabels: {}
 
-sidecars:
 ## Add sidecars to the pod.
-## e.g.
-# - name: your-image-name
-  # image: your-image
-  # imagePullPolicy: Always
-  # ports:
-  # - name: portname
-  #   containerPort: 1234
+## Example:
+## sidecars:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+sidecars: {}

--- a/stable/wordpress/values-production.yaml
+++ b/stable/wordpress/values-production.yaml
@@ -382,7 +382,8 @@ mariadb:
       ##   GKE, AWS & OpenStack)
       ##
       # storageClass: "-"
-      accessMode: ReadWriteOnce
+      accessModes:
+        - ReadWriteOnce
       size: 8Gi
 
 ##
@@ -390,7 +391,7 @@ mariadb:
 ##
 ## All of these values are only used when mariadb.enabled is set to false
 ##
-externalDatabase:  
+externalDatabase:
   ## Database host
   ##
   host: localhost

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/wordpress
-  tag: 5.3.2-debian-10-r29
+  tag: 5.3.2-debian-10-r32
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -413,7 +413,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.7.0-debian-10-r29
+    tag: 0.7.0-debian-10-r32
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -377,7 +377,8 @@ mariadb:
       ##   GKE, AWS & OpenStack)
       ##
       # storageClass: "-"
-      accessMode: ReadWriteOnce
+      accessModes:
+        - ReadWriteOnce
       size: 8Gi
 
 ##
@@ -385,7 +386,7 @@ mariadb:
 ##
 ## All of these values are only used when mariadb.enabled is set to false
 ##
-externalDatabase:  
+externalDatabase:
   ## Database host
   ##
   host: localhost

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -26,6 +26,9 @@ image:
   ##
   # pullSecrets:
   #   - myRegistryKeySecretName
+  ## Set to true if you would like to see extra information on logs
+  ##
+  debug: false
 
 ## String to partially override wordpress.fullname template (will maintain the release name)
 ##
@@ -122,45 +125,215 @@ customHTAccessCM:
 
 replicaCount: 1
 
-# Additional container environment variables
+## Additional container environment variables
+## Example: Configure SSL for database
+## extraEnv:
+##   - name: WORDPRESS_DATABASE_SSL_CA_FILE
+##     value: /path/to/ca_cert
+##
 extraEnv: []
-  ## Example: Configure SSL for database
-  # - name: WORDPRESS_DATABASE_SSL_CA_FILE
-  #   value: /path/to/ca_cert
 
-# Additional volume mounts
+## Additional volume mounts
+## Example: Mount CA file
+## extraVolumeMounts
+##   - name: ca-cert
+##     subPath: ca_cert
+##     mountPath: /path/to/ca_cert
 extraVolumeMounts: []
-  ## Example: Mount CA file
-  # - name: ca-cert
-  #   subPath: ca_cert
-  #   mountPath: /path/to/ca_cert
 
-# Additional volumes
+## Additional volumes
+## Example: Add secret volume
+## extraVolumes:
+##  - name: ca-cert
+##    secret:
+##      secretName: ca-cert
+##      items:
+##        - key: ca-cert
+##          path: ca_cert
 extraVolumes: []
-  ## Example: Add secret volume
-  # - name: ca-cert
-  #   secret:
-  #     secretName: ca-cert
-  #     items:
-  #     - key: ca-cert
-  #       path: ca_cert
 
-externalDatabase:
-## All of these values are only used when mariadb.enabled is set to false
-  ## Database host
-  host: localhost
+## WordPress containers' resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  limits: {}
+  requests:
+    memory: 512Mi
+    cpu: 300m
 
-  ## non-root Username for Wordpress Database
-  user: bn_wordpress
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}
 
-  ## Database password
-  password: ""
+## Node labels for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
 
-  ## Database name
-  database: bitnami_wordpress
+## Tolerations for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: {}
 
-  ## Database port number
-  port: 3306
+## Pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+
+## K8s Security Context for WordPress pods
+## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+##
+securityContext:
+  enabled: true
+  fsGroup: 1001
+  runAsUser: 1001
+
+## Allow health checks to be pointed at the https port
+healthcheckHttps: false
+
+## WordPress pod extra options for liveness and readiness probes
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+## If using an HTTPS-terminating load-balancer, the probes may need to behave
+## like the balancer to prevent HTTP 302 responses. According to the Kubernetes
+## docs, 302 should be considered "successful", but this issue on GitHub
+## (https://github.com/kubernetes/kubernetes/issues/47893) shows that it isn't.
+##
+# livenessProbeHeaders:
+# - name: X-Forwarded-Proto
+#   value: https
+# readinessProbeHeaders:
+# - name: X-Forwarded-Proto
+#   value: https
+livenessProbeHeaders: {}
+readinessProbeHeaders: {}
+
+## Kubernetes configuration
+## For minikube, set this to NodePort, elsewhere use LoadBalancer or ClusterIP
+##
+service:
+  type: LoadBalancer
+  ## HTTP Port
+  ##
+  port: 80
+  ## HTTPS Port
+  ##
+  httpsPort: 443
+  ## HTTPS Target Port
+  ## defaults to https unless overridden to the specified port.
+  ## if you want the target port to be "http" or "80" you can specify that here.
+  ##
+  httpsTargetPort: https
+  ## Metrics Port
+  ##
+  metricsPort: 9117
+  ## Node Ports to expose
+  ## nodePorts:
+  ##   http: <to set explicitly, choose port between 30000-32767>
+  ##   https: <to set explicitly, choose port between 30000-32767>
+  ##   metrics: <to set explicitly, choose port between 30000-32767>
+  nodePorts:
+    http: ""
+    https: ""
+    metrics: ""
+  ## Enable client source IP preservation
+  ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  ##
+  externalTrafficPolicy: Cluster
+  annotations: {}
+  ## Limits which cidr blocks can connect to service's load balancer
+  ## Only valid if service.type: LoadBalancer
+  loadBalancerSourceRanges: []
+  ## Extra ports to expose (normally used with the `sidecar` value)
+  # extraPorts:
+
+## Configure the ingress resource that allows you to access the
+## WordPress installation. Set up the URL
+## ref: http://kubernetes.io/docs/user-guide/ingress/
+##
+ingress:
+  ## Set to true to enable ingress record generation
+  ##
+  enabled: false
+
+  ## Set this to true in order to add the corresponding annotations for cert-manager
+  ##
+  certManager: false
+
+  ## When the ingress is enabled, a host pointing to this will be created
+  ##
+  hostname: wordpress.local
+
+  ## Ingress annotations done as key:value pairs
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ##
+  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+  ##
+  annotations: {}
+
+  ## The list of additional hostnames to be covered with this ingress record.
+  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+  ## extraHosts:
+  ## - name: wordpress.local
+  ##   path: /
+
+  ## The tls configuration for additional hostnames to be covered with this ingress record.
+  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## extraTls:
+  ## - hosts:
+  ##     - wordpress.local
+  ##   secretName: wordpress.local-tls
+
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
+  ##
+  ## name should line up with a tlsSecret set further up
+  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+  ##
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  ##
+  secrets: []
+  ## - name: wordpress.local-tls
+  ##   key:
+  ##   certificate:
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  enabled: true
+  ## wordpress data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  ##
+  ## If you want to reuse an existing claim, you can pass the name of the PVC using
+  ## the existingClaim variable
+  # existingClaim: your-claim
+  accessMode: ReadWriteOnce
+  size: 10Gi
 
 ##
 ## MariaDB chart configuration
@@ -207,169 +380,32 @@ mariadb:
       accessMode: ReadWriteOnce
       size: 8Gi
 
-## Kubernetes configuration
-## For minikube, set this to NodePort, elsewhere use LoadBalancer or ClusterIP
 ##
-service:
-  type: LoadBalancer
-  # HTTP Port
-  port: 80
-  # HTTPS Port
-  httpsPort: 443
-  # HTTPS Target Port
-  # defaults to https unless overridden to the specified port.
-  # if you want the target port to be "http" or "80" you can specify that here.
-  httpsTargetPort: https
-  # metrics Port
-  metricsPort: 9117
+## External Database Configuration
+##
+## All of these values are only used when mariadb.enabled is set to false
+##
+externalDatabase:  
+  ## Database host
   ##
-  ## nodePorts:
-  ##   http: <to set explicitly, choose port between 30000-32767>
-  ##   https: <to set explicitly, choose port between 30000-32767>
-  ##   metrics: <to set explicitly, choose port between 30000-32767>
-  nodePorts:
-    http: ""
-    https: ""
-    metrics: ""
-  ## Enable client source IP preservation
-  ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  host: localhost
+
+  ## non-root Username for Wordpress Database
   ##
-  externalTrafficPolicy: Cluster
-  annotations: {}
-  ## Limits which cidr blocks can connect to service's load balancer
-  ## Only valid if service.type: LoadBalancer
-  loadBalancerSourceRanges: []
-  ## Extra ports to expose (normally used with the `sidecar` value)
-  # extraPorts:
+  user: bn_wordpress
 
-## Allow health checks to be pointed at the https port
-healthcheckHttps: false
-
-## Configure extra options for liveness and readiness probes
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
-livenessProbe:
-  enabled: true
-  initialDelaySeconds: 120
-  periodSeconds: 10
-  timeoutSeconds: 5
-  failureThreshold: 6
-  successThreshold: 1
-
-readinessProbe:
-  enabled: true
-  initialDelaySeconds: 30
-  periodSeconds: 10
-  timeoutSeconds: 5
-  failureThreshold: 6
-  successThreshold: 1
-## If using an HTTPS-terminating load-balancer, the probes may need to behave
-## like the balancer to prevent HTTP 302 responses.  According to the Kubernetes
-## docs, 302 should be considered "successful", but this issue on GitHub
-## (https://github.com/kubernetes/kubernetes/issues/47893) shows that it isn't.
-# livenessProbeHeaders:
-# - name: X-Forwarded-Proto
-#   value: https
-# readinessProbeHeaders:
-# - name: X-Forwarded-Proto
-#   value: https
-
-## Configure the ingress resource that allows you to access the
-## WordPress installation. Set up the URL
-## ref: http://kubernetes.io/docs/user-guide/ingress/
-##
-ingress:
-  ## Set to true to enable ingress record generation
-  enabled: false
-
-  ## Set this to true in order to add the corresponding annotations for cert-manager
-  certManager: false
-
-  ## When the ingress is enabled, a host pointing to this will be created
-  hostname: wordpress.local
-
-  ## Ingress annotations done as key:value pairs
-  ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ## Database password
   ##
-  ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
-  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
-  annotations: {}
-  #  kubernetes.io/ingress.class: nginx
+  password: ""
 
-  ## The list of additional hostnames to be covered with this ingress record.
-  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
-  ## hosts:
-  ## - name: wordpress.local
-  ##   path: /
-
-  ## The tls configuration for the ingress
-  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-  ## tls:
-  ## - hosts:
-  ##     - wordpress.local
-  ##   secretName: wordpress.local-tls
-
-  secrets:
-  ## If you're providing your own certificates, please use this to add the certificates as secrets
-  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
-  ## -----BEGIN RSA PRIVATE KEY-----
+  ## Database name
   ##
-  ## name should line up with a tlsSecret set further up
-  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+  database: bitnami_wordpress
+
+  ## Database port number
   ##
-  ## It is also possible to create and manage the certificates outside of this helm chart
-  ## Please see README.md for more information
-  # - name: wordpress.local-tls
-  #   key:
-  #   certificate:
+  port: 3306
 
-## Enable persistence using Persistent Volume Claims
-## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-##
-persistence:
-  enabled: true
-  ## wordpress data Persistent Volume Storage Class
-  ## If defined, storageClassName: <storageClass>
-  ## If set to "-", storageClassName: "", which disables dynamic provisioning
-  ## If undefined (the default) or set to null, no storageClassName spec is
-  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-  ##   GKE, AWS & OpenStack)
-  ##
-  # storageClass: "-"
-  ##
-  ## If you want to reuse an existing claim, you can pass the name of the PVC using
-  ## the existingClaim variable
-  # existingClaim: your-claim
-  accessMode: ReadWriteOnce
-  size: 10Gi
-
-## Configure resource requests and limits
-## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-##
-resources:
-  requests:
-    memory: 512Mi
-    cpu: 300m
-
-## Node labels for pod assignment
-## Ref: https://kubernetes.io/docs/user-guide/node-selection/
-##
-nodeSelector: {}
-
-## Tolerations for pod assignment
-## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-##
-tolerations: []
-
-## Affinity for pod assignment
-## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-##
-affinity: {}
-
-## Pod annotations
-## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-##
-podAnnotations: {}
 ## Prometheus Exporter / Metrics
 ##
 metrics:
@@ -389,10 +425,13 @@ metrics:
   podAnnotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9117"
-  ## Metrics exporter resource requests and limits
+
+  ## Metrics exporter containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
-  # resources: {}
+  resources:
+    limits: {}
+    requests: {}
 
   ## Prometheus Service Monitor
   ## ref: https://github.com/coreos/prometheus-operator
@@ -414,12 +453,14 @@ metrics:
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
     additionalLabels: {}
 
-sidecars:
 ## Add sidecars to the pod.
-## e.g.
-# - name: your-image-name
-  # image: your-image
-  # imagePullPolicy: Always
-  # ports:
-  # - name: portname
-  #   containerPort: 1234
+## Example:
+## sidecars:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+sidecars: {}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>


#### Is this a new chart

No

#### What this PR does / why we need it:

This PR transforms the WP chart into a "non-root" chart by default. This practice is very extended on K8s and, indeed, it is mandatory for some K8s distributions such as **OpenShift** or **VMware Tanzu Kubernetes Grid.**

This **PR breaks backwards compatibility** and a migration will be required to upgrade to the latest version.

#### Which issue this PR fixes

  - fixes #21098

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
