### PR TITLE
[stable/sysdig] fix setting env

### DIFF
--- a/stable/sysdig/CHANGELOG.md
+++ b/stable/sysdig/CHANGELOG.md
@@ -3,6 +3,12 @@
 This file documents all notable changes to Sysdig Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.7.3
+
+### Minor changes
+
+* Removed dependency on ebpf.enabled to set environment variables
+
 ## v1.7.2
 
 ### Minor changes

--- a/stable/sysdig/Chart.yaml
+++ b/stable/sysdig/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sysdig
-version: 1.7.2
+version: 1.7.3
 appVersion: 9.5.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/stable/sysdig/templates/daemonset.yaml
+++ b/stable/sysdig/templates/daemonset.yaml
@@ -71,31 +71,31 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
           securityContext:
             privileged: true
-          {{- if .Values.ebpf.enabled }}
           env:
+            {{- if .Values.ebpf.enabled }}
             - name: SYSDIG_BPF_PROBE
               value:
-          {{- end }}
-          {{- if .Values.proxy.httpProxy }}
+            {{- end }}
+            {{- if .Values.proxy.httpProxy }}
             - name: http_proxy
               value: {{ .Values.proxy.httpProxy }}
-          {{- end }}
-          {{- if .Values.proxy.httpsProxy }}
+            {{- end }}
+            {{- if .Values.proxy.httpsProxy }}
             - name: https_proxy
               value: {{ .Values.proxy.httpsProxy }}
-          {{- end }}
-          {{- if .Values.proxy.noProxy }}
+            {{- end }}
+            {{- if .Values.proxy.noProxy }}
             - name: no_proxy
               value: {{ .Values.proxy.noProxy }}
-          {{- end }}
-          {{- if .Values.timezone }}
+            {{- end }}
+            {{- if .Values.timezone }}
             - name: TZ
               value: {{ .Values.timezone }}
-          {{- end }}
-          {{- range $key, $value := .Values.daemonset.env }}
+            {{- end }}
+            {{- range $key, $value := .Values.daemonset.env }}
             - name: "{{ $key }}"
               value: "{{ $value }}"
-          {{- end }}
+            {{- end }}
           readinessProbe:
             exec:
               command: [ "test", "-e", "/opt/draios/logs/running" ]

--- a/stable/sysdig/values.yaml
+++ b/stable/sysdig/values.yaml
@@ -92,7 +92,7 @@ sysdig:
   # Required: You need your Sysdig Monitor access key before running agents.
   accessKey: ""
 
-  settings:
+  settings: {}
     ### Agent tags
     # tags: linux:ubuntu,dept:dev,local:nyc
     #### Sysdig Software related config ####


### PR DESCRIPTION
#### Is this a new chart
no

#### What this PR does / why we need it:
allows setting env vars without having to use ebpf

#### Which issue this PR fixes
fixes #21105 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
