### PR TITLE
[stable/airflow] Allow users to specify a secret containing the git url

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 6.1.1
+version: 6.2.0
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -474,6 +474,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `dags.git.secret`                        | name of a secret containing an ssh deploy key           | nil                       |
 | `dags.git.privateKeyName`                | name of private key mounted in secret(only needed if using ssh to connect to git)   | ''                        |
 | `dags.git.repoHost`                      | Host of git repo you are establish an ssh connection to ex. github.com (only needed if using ssh to connect to git)            | ''                        |
+| `dags.git.repoSecret`                    | The name of an existing secret with a key named `DAG_GIT_REPO` to use as the repo URL for git sync and git clone | ''                   |
 | `dags.git.gitSync.enabled`               | Enables a sidecar container that syncs dags             | `false`                   |
 | `dags.git.gitSync.image.repository`      | Image of the sidecar container that syncs dags          | `alpine/git`                  |
 | `dags.git.gitSync.image.tag`             | Image tag of sidecar container that syncs dags          | `1.0.4`                  |

--- a/stable/airflow/templates/deployments-scheduler.yaml
+++ b/stable/airflow/templates/deployments-scheduler.yaml
@@ -77,12 +77,20 @@ spec:
           envFrom:
           - configMapRef:
               name: "{{ template "airflow.fullname" . }}-env"
+          {{- if .Values.dags.git.repoSecret }}
+          - secretRef:
+              name: {{ .Values.dags.git.repoSecret }}
+          {{- end }}
           env:
           {{- include "airflow.mapenvsecrets" . | indent 10 }}
           command:
             - /usr/local/git/git-clone.sh
           args:
+            {{- if .Values.dags.git.repoSecret }}
+            - "$(DAG_GIT_REPO)"
+            {{- else }}
             - "{{ .Values.dags.git.url }}"
+            {{- end }}
             - "{{ .Values.dags.git.ref }}"
             - "/dags"
             - "{{ .Values.dags.git.repoHost}}"
@@ -111,12 +119,20 @@ spec:
           envFrom:
           - configMapRef:
               name: "{{ template "airflow.fullname" . }}-env"
+          {{- if .Values.dags.git.repoSecret }}
+          - secretRef:
+              name: {{ .Values.dags.git.repoSecret }}
+          {{- end }}
           env:
           {{- include "airflow.mapenvsecrets" . | indent 10 }}
           command:
             - /usr/local/git/git-sync.sh
           args:
+            {{- if .Values.dags.git.repoSecret }}
+            - "$(DAG_GIT_REPO)"
+            {{- else }}
             - "{{ .Values.dags.git.url }}"
+            {{- end }}
             - "{{ .Values.dags.git.ref }}"
             - "/dags"
             - "{{ .Values.dags.git.repoHost}}"

--- a/stable/airflow/templates/deployments-web.yaml
+++ b/stable/airflow/templates/deployments-web.yaml
@@ -74,12 +74,20 @@ spec:
           envFrom:
           - configMapRef:
               name: "{{ template "airflow.fullname" . }}-env"
+          {{- if .Values.dags.git.repoSecret }}
+          - secretRef:
+              name: {{ .Values.dags.git.repoSecret }}
+          {{- end }}
           env:
           {{- include "airflow.mapenvsecrets" . | indent 10 }}
           command:
             - /usr/local/git/git-clone.sh
           args:
+            {{- if .Values.dags.git.repoSecret }}
+            - "$(DAG_GIT_REPO)"
+            {{- else }}
             - "{{ .Values.dags.git.url }}"
+            {{- end }}
             - "{{ .Values.dags.git.ref }}"
             - "/dags"
             - "{{ .Values.dags.git.repoHost}}"
@@ -102,12 +110,20 @@ spec:
           envFrom:
           - configMapRef:
               name: "{{ template "airflow.fullname" . }}-env"
+          {{- if .Values.dags.git.repoSecret }}
+          - secretRef:
+              name: {{ .Values.dags.git.repoSecret }}
+          {{- end }}
           env:
           {{- include "airflow.mapenvsecrets" . | indent 10 }}
           command:
             - /usr/local/git/git-sync.sh
           args:
+            {{- if .Values.dags.git.repoSecret }}
+            - "$(DAG_GIT_REPO)"
+            {{- else }}
             - "{{ .Values.dags.git.url }}"
+            {{- end }}
             - "{{ .Values.dags.git.ref }}"
             - "/dags"
             - "{{ .Values.dags.git.repoHost}}"

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -541,6 +541,9 @@ dags:
     repoHost: ""
     ## The name of the private key in your git sync secret (Only need if using ssh not https git sync)
     privateKeyName: ""
+    ## The name of the pre-created secret containing the key DAG_GIT_REPO with the git repo url.
+    ## Use this secret if your url contains sensitive information such as a token.
+    repoSecret: ""
     gitSync:
       ## Turns on the side car container
       enabled: false


### PR DESCRIPTION
Signed-off-by: Edward Young <edward.young.net@gmail.com>

#### What this PR does / why we need it:

Allow users to specify a secret containing the git url used for git sync and git clone.  This is useful if the git url contains sensitive information such as a token.

If `dags.git.repoSecret` is defined, the key-value pairs will be added to the git-sync and git-clone containers as environment variables.  The secret must contain a key named DAG_GIT_REPO with the git url as its value.

If both `dags.git.repoSecret` and `dags.git.url` are provided, the url in the `dags.git.repoSecret` will be used.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
