### PR TITLE
WIP: Add mutating webhook

### DIFF
--- a/stable/datadog/requirements.lock
+++ b/stable/datadog/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 2.2.3
-digest: sha256:28fd41002af09316b9f614d320ea4171db39a144b595c68f616c546dd5292709
-generated: "2019-08-13T09:53:34.977562+02:00"
+digest: sha256:ce13be2cc7678a902f976b7ae164bfce9cd50e92cf961ae4272d812b61bce63e
+generated: "2020-02-24T15:39:31.124307-05:00"

--- a/stable/datadog/templates/_helpers.tpl
+++ b/stable/datadog/templates/_helpers.tpl
@@ -69,3 +69,29 @@ Return the appropriate apiVersion for RBAC APIs.
 "rbac.authorization.k8s.io/v1beta1"
 {{- end -}}
 {{- end -}}
+
+{{/*
+Define standard labels for frequently used metadata.
+*/}}
+{{- define "datadog.labels.standard" -}}
+app: {{ template "datadog.fullname" . }}
+chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+release: "{{ .Release.Name }}"
+heritage: "{{ .Release.Service }}"
+{{- end -}}
+
+{{- define "datadog.selfSignedIssuer" -}}
+{{ printf "%s-selfsign" (include "datadog.fullname" .) }}
+{{- end -}}
+
+{{- define "datadog.rootCAIssuer" -}}
+{{ printf "%s-ca" (include "datadog.fullname" .) }}
+{{- end -}}
+
+{{- define "datadog.rootCACertificate" -}}
+{{ printf "%s-ca" (include "datadog.fullname" .) }}
+{{- end -}}
+
+{{- define "datadog.servingCertificate" -}}
+{{ printf "%s-webhook-tls" (include "datadog.fullname" .) }}
+{{- end -}}

--- a/stable/datadog/templates/agent-services.yaml
+++ b/stable/datadog/templates/agent-services.yaml
@@ -18,9 +18,12 @@ spec:
   selector:
     app: {{ template "datadog.fullname" . }}-cluster-agent
   ports:
-  - port: 5005
-    name: agentport
+  - port: 5005 # Cluster Agent commands: has to be the same as the one exposed in the DCA.
     protocol: TCP
+    name: agentport
+  - port: 5004 # K8S Admission Webhooks: has to be the same as the one exposed in the DCA.
+    protocol: TCP
+    name: webhook
 {{ end }}
 
 {{- if and .Values.clusterAgent.enabled .Values.clusterAgent.metricsProvider.enabled -}}

--- a/stable/datadog/templates/cluster-agent-admission-controller-post-install-job.yaml
+++ b/stable/datadog/templates/cluster-agent-admission-controller-post-install-job.yaml
@@ -1,0 +1,92 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  creationTimestamp: null
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: {{ template "datadog.fullname" . }}-admission-controller-hook
+rules:
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: "{{ template "datadog.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+  name: {{ template "datadog.fullname" . }}-admission-controller-hook
+---
+apiVersion: {{ template "rbac.apiVersion" . }}
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: "{{ template "datadog.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app.kubernetes.io/name: "{{ template "datadog.fullname" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+  name: {{ template "datadog.fullname" . }}-admission-controller-hook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "datadog.fullname" . }}-admission-controller-hook
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "datadog.fullname" . }}
+    namespace: {{ template "datadog.fullname" . }}-admission-controller-hook
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-post-install-job"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install
+#    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-post-install-job"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      serviceAccountName: {{ template "datadog.fullname" . }}-admission-controller-hook
+      restartPolicy: Never
+      containers:
+#        - name: post-install-job
+#          image: "alpine:3.3"
+#          command: ["/bin/sleep","10"]
+        - name: create-webhook-certificate
+          image: "newrelic/k8s-webhook-cert-manager"
+          command: ["./generate_certificate.sh", "--service", {{ template "datadog.fullname" . }}-cluster-agent, "--webhook", {{ template "datadog.fullname" . }}-cluster-agent-mutating-webhook, "--secret", {{ template "datadog.fullname" . }}-admission-cert, "--namespace", {{ .Release.Namespace }} ]

--- a/stable/datadog/templates/cluster-agent-admission-controller.yaml
+++ b/stable/datadog/templates/cluster-agent-admission-controller.yaml
@@ -1,0 +1,126 @@
+{{- if .Values.clusterAgent.enabled }}
+
+{{- $cn := printf "%s-cluster-agent.%s.svc" ( include "datadog.fullname" . ) .Release.Namespace }}
+{{- $ca := genCA "datadog-admission-ca" 3650 -}}
+{{- $cert := genSignedCert $cn nil nil 3650 $ca -}}
+
+kind: MutatingWebhookConfiguration
+apiVersion: admissionregistration.k8s.io/v1beta1
+metadata:
+  name: {{ template "datadog.fullname" . }}-cluster-agent-mutating-webhook
+  annotations:
+{{- if .Values.clusterAgent.certManager.enabled }}
+    certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s" .Release.Namespace (include "datadog.rootCACertificate" .) | quote }}
+{{- end }}
+  labels:
+{{ include "datadog.labels.standard" . | indent 4 }}
+webhooks:
+  - name: {{ template "datadog.fullname" . }}.cluster-agent-mutating-webhook.local
+{{- with .Values.clusterAgent.admissionControllerNamespaceSelector }}
+    namespaceSelector:
+{{ toYaml . | indent 6 }}
+{{ end }}
+    failurePolicy: {{ .Values.clusterAgent.admissionControllerFailurePolicy }}
+    rules:
+{{ toYaml .Values.clusterAgent.admissionControllerRules | indent 6 }}
+    clientConfig:
+{{ if not .Values.clusterAgent.certManager.enabled }}
+{{ if .Values.clusterAgent.generateAdmissionControllerCerts }}
+      caBundle: {{ b64enc $ca.Cert }}
+{{ else }}
+      caBundle: {{ b64enc .Values.clusterAgent.admissionControllerCA }}
+{{ end }}
+{{ end }}
+      service:
+        name: {{ template "datadog.fullname" . }}-cluster-agent
+        namespace: {{ .Release.Namespace }}
+        path: /api/v1/application-mutating-webhook
+        port: 5004
+    sideEffects: {{ .Values.clusterAgent.admissionControllerSideEffect }}
+{{ if .Values.clusterAgent.timeoutSeconds }}
+    timeoutSeconds: {{ .Values.clusterAgent.timeoutSeconds }}
+{{ end }}
+
+{{ if .Values.clusterAgent.certManager.enabled }}
+---
+# Create a selfsigned Issuer, in order to create a root CA certificate for
+# signing webhook serving certificates
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Issuer
+metadata:
+  name: {{ include "datadog.selfSignedIssuer" . }}
+  labels:
+{{ include "datadog.labels.standard" . | indent 4 }}
+spec:
+  selfSigned: {}
+
+---
+# Generate a CA Certificate used to sign certificates for the webhook
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: {{ include "datadog.rootCACertificate" . }}
+  labels:
+{{ include "datadog.labels.standard" . | indent 4 }}
+spec:
+  secretName: {{ include "datadog.rootCACertificate" . }}
+  duration: 43800h # 5y
+  issuerRef:
+    name: {{ include "datadog.selfSignedIssuer" . }}
+  commonName: "ca.webhook.datadog"
+  isCA: true
+
+---
+# Create an Issuer that uses the above generated CA certificate to issue certs
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Issuer
+metadata:
+  name: {{ include "datadog.rootCAIssuer" . }}
+  labels:
+{{ include "datadog.labels.standard" . | indent 4 }}
+spec:
+  ca:
+    secretName: {{ include "datadog.rootCACertificate" . }}
+
+---
+
+# Finally, generate a serving certificate for the webhook to use
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: {{ include "datadog.servingCertificate" . }}
+  labels:
+{{ include "datadog.labels.standard" . | indent 4 }}
+spec:
+  secretName: {{ template "datadog.fullname" . }}-admission-cert
+  duration: 8760h # 1y
+  issuerRef:
+    name: {{ include "datadog.rootCAIssuer" . }}
+  dnsNames:
+  - {{ include "datadog.fullname" . }}
+  - {{ include "datadog.fullname" . }}.{{ .Release.Namespace }}
+  - {{ include "datadog.fullname" . }}.{{ .Release.Namespace }}.svc
+{{ end }}
+{{- if not .Values.clusterAgent.certManager.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "datadog.fullname" . }}-admission-cert
+  labels:
+    app: {{ template "datadog.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+{{ if .Values.clusterAgent.generateAdmissionControllerCerts }}
+  tls.crt: {{ b64enc $cert.Cert }}
+  tls.key: {{ b64enc $cert.Key }}
+{{ else }}
+  tls.crt: {{ b64enc .Values.clusterAgent.admissionControllerCert }}
+  tls.key: {{ b64enc .Values.clusterAgent.admissionControllerKey }}
+{{ end }}
+{{ end }}
+
+{{- end -}}

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -72,6 +72,9 @@ spec:
         - containerPort: 5005
           name: agentport
           protocol: TCP
+        - containerPort: 5004
+          name: webhook
+          protocol: TCP
         {{- if .Values.clusterAgent.metricsProvider.enabled }}
         - containerPort: {{ .Values.clusterAgent.metricsProvider.service.port }}
           name: metricsapi
@@ -172,6 +175,11 @@ spec:
             mountPath: /conf.d
             readOnly: true
 {{- end }}
+{{- if .Values.clusterAgent.admissionController.enabled }}
+          - name: certs
+            readOnly: true
+            mountPath: /certs
+{{- end }}
 {{- if .Values.clusterAgent.volumeMounts }}
 {{ toYaml .Values.clusterAgent.volumeMounts | indent 10 }}
 {{- end }}
@@ -180,6 +188,11 @@ spec:
         - name: confd
           configMap:
             name: {{ template "datadog.fullname" . }}-cluster-agent-confd
+{{- end }}
+{{- if .Values.clusterAgent.admissionController.enabled }}
+        - name: certs
+          secret:
+            secretName: {{ template "datadog.fullname" . }}-admission-cert
 {{- end }}
 {{- if .Values.clusterAgent.volumes }}
 {{ toYaml .Values.clusterAgent.volumes | indent 10 }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -355,9 +355,9 @@ clusterAgent:
 
   containerName: cluster-agent
   image:
-    repository: datadog/cluster-agent
-    tag: 1.4.0
-    pullPolicy: IfNotPresent
+    repository: marcotc/cluster-agent # TODO revert me
+    tag: latest
+    pullPolicy: Always # TODO revert me
 
   ## @param token - string - required
   ## This needs to be at least 32 characters a-zA-z
@@ -485,6 +485,44 @@ clusterAgent:
   #   - name: <VOLUME_NAME>
   #     mountPath: <CONTAINER_PATH>
   #     readOnly: true
+
+  admissionController:
+    enabled: true
+
+  # To _fail closed_ on failures, change to Fail. During initial testing, we
+  # recommend leaving the failure policy as Ignore.
+  admissionControllerFailurePolicy: Ignore # TODO revert me
+#  admissionControllerFailurePolicy: Fail
+
+  admissionControllerRules:
+#    - operations: [ "CREATE" ]
+#      apiGroups: ["*"]
+#      apiVersions: ["*"]
+#      resources: ["pods"]
+    - operations: [ "CREATE" ]
+      apiGroups: ["apps", ""]
+      apiVersions: ["v1"]
+      resources: ["deployments","services","pods"]
+
+  # Setup the webhook using cert-manager
+  certManager:
+    enabled: false
+
+  # The helm Chart will automatically generate a CA and server certificate for
+  # the webhook. If you want to supply your own certificates, set the field below to
+  # false and add the PEM encoded CA certificate and server key pair below.
+  #
+  # WARNING: The common name name in the server certificate MUST match the
+  # hostname of the service that exposes the OPA to the apiserver. For example.
+  # if the service name is created in the "default" namespace with name "datadog"
+  # the common name MUST be set to "opa.default.svc".
+  #
+  # If the common name is not set correctly, the apiserver will refuse to
+  # communicate with the OPA.
+  generateAdmissionControllerCerts: true
+  admissionControllerCA: ""
+  admissionControllerCert: ""
+  admissionControllerKey: ""
 
 rbac:
 


### PR DESCRIPTION
#### Is this a new chart
Existing `stable/datadog` chart.

#### What this PR does / why we need it:
Adding a mutating admission webhook to facilitate onboarding for Datadog users.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
