### PR TITLE
[stable/drone] Add deprecation note in favor of official Charts

### DIFF
--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -3,7 +3,7 @@ name: drone
 deprecated: true
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 2.7.1
+version: 2.7.2
 appVersion: 1.6.5
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -1,5 +1,6 @@
 apiVersion: v1
 name: drone
+deprecated: true
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
 version: 2.7.1

--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -16,10 +16,3 @@ keywords:
 - go
 sources:
 - https://github.com/drone/drone
-maintainers:
-- name: christian-roggia
-  email: christian.roggia@gmail.com
-- name: paulczar
-  email: username.taken@gmail.com
-- name: zakkg3
-  email: zakkg3@gmail.com

--- a/stable/drone/README.md
+++ b/stable/drone/README.md
@@ -1,5 +1,7 @@
 # Drone.io
 
+> This chart is deprecated in favor of the [official Drone chart](https://github.com/drone/charts).
+
 [Drone](http://readme.drone.io/) v1 is a Continuous Integration platform built on container technology with native Kubernetes support.
 
 > It is not recommended to upgrade from earlier (0.8.x) versions of Drone due to the large amount of breaking changes both in the product and in the helm charts.

--- a/stable/drone/templates/NOTES.txt
+++ b/stable/drone/templates/NOTES.txt
@@ -1,3 +1,8 @@
+##############################################################################
+This chart has been deprecated in favor of the official Drone chart:
+https://github.com/drone/charts
+##############################################################################
+
 {{- if eq (include "drone.providerOK" .) "true" }}
 *********************************************************************************
 ***        PLEASE BE PATIENT: drone may take a few minutes to install         ***


### PR DESCRIPTION
Drone provides a set of [official charts](https://github.com/drone/charts) that are being actively developed and maintained. We would kindly ask the Drone chart in stable be deprecated and users be directed to our official charts. I attempted to use the same conventions as https://github.com/helm/charts/pull/1876 which deprecated gitlab. Thanks!