### PR TITLE
[stable/minio] annotation fix

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: MinIO is a high performance data infrastructure for machine learning, analytics and application data workloads.
 name: minio
-version: 5.0.11
+version: 5.0.12
 appVersion: master
 keywords:
 - storage

--- a/stable/minio/templates/post-install-create-bucket-job.yaml
+++ b/stable/minio/templates/post-install-create-bucket-job.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
-  {{ toYaml .Values.makeBucketJob.annotations | indent 4 }}
+    {{- "\n"}}{{ toYaml .Values.makeBucketJob.annotations | indent 4 }}
 spec:
   template:
     metadata:

--- a/stable/minio/templates/post-install-create-bucket-job.yaml
+++ b/stable/minio/templates/post-install-create-bucket-job.yaml
@@ -11,7 +11,9 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
-    {{- "\n"}}{{ toYaml .Values.makeBucketJob.annotations | indent 4 }}
+    {{- with .Values.makeBucketJob.annotations }}
+    {{ toYaml . | indent 4 }}
+    {{- end }}
 spec:
   template:
     metadata:


### PR DESCRIPTION
#### Is this a new chart

No :)

#### What this PR does / why we need it:

currently filling `.Values.makeBucketJob.annotations` doesn't work properly (results in extra spaces at the first line of the added annotations). This PR fixes it

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/minio]`)
