### PR TITLE
[stable/mongodb-replicaset] Namespace override

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.10.2
+version: 3.10.3
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -106,6 +106,7 @@ The following table lists the configurable parameters of the mongodb chart and t
 | `readinessProbe.timeoutSeconds`     | Readiness probe timeout seconds                                           | `1`                                                 |
 | `extraVars`                         | Set environment variables for the main container                          | `{}`                                                |
 | `extraLabels`                       | Additional labels to add to resources                                     | `{}`                                                |
+| `global.namespaceOverride`          | Override the deployment namespace                                         | Not set (`Release.Namespace`)                       |
 
 *MongoDB config file*
 

--- a/stable/mongodb-replicaset/templates/NOTES.txt
+++ b/stable/mongodb-replicaset/templates/NOTES.txt
@@ -1,14 +1,14 @@
 1. After the statefulset is created completely, one can check which instance is primary by running:
 
-    $ for ((i = 0; i < {{ .Values.replicas }}; ++i)); do kubectl exec --namespace {{ .Release.Namespace }} {{ template "mongodb-replicaset.fullname" . }}-$i -- sh -c 'mongo --eval="printjson(rs.isMaster())"'; done
+    $ for ((i = 0; i < {{ .Values.replicas }}; ++i)); do kubectl exec --namespace {{ template "mongodb-replicaset.namespace" . }} {{ template "mongodb-replicaset.fullname" . }}-$i -- sh -c 'mongo --eval="printjson(rs.isMaster())"'; done
 
 2. One can insert a key into the primary instance of the mongodb replica set by running the following:
     MASTER_POD_NAME must be replaced with the name of the master found from the previous step.
 
-    $ kubectl exec --namespace {{ .Release.Namespace }} MASTER_POD_NAME -- mongo --eval="printjson(db.test.insert({key1: 'value1'}))"
+    $ kubectl exec --namespace {{ template "mongodb-replicaset.namespace" . }} MASTER_POD_NAME -- mongo --eval="printjson(db.test.insert({key1: 'value1'}))"
 
 3. One can fetch the keys stored in the primary or any of the slave nodes in the following manner.
     POD_NAME must be replaced by the name of the pod being queried.
 
-    $ kubectl exec --namespace {{ .Release.Namespace }} POD_NAME -- mongo --eval="rs.slaveOk(); db.test.find().forEach(printjson)"
+    $ kubectl exec --namespace {{ template "mongodb-replicaset.namespace" . }} POD_NAME -- mongo --eval="rs.slaveOk(); db.test.find().forEach(printjson)"
 

--- a/stable/mongodb-replicaset/templates/_helpers.tpl
+++ b/stable/mongodb-replicaset/templates/_helpers.tpl
@@ -61,3 +61,14 @@ Create the name for the key secret.
         {{- template "mongodb-replicaset.fullname" . -}}-keyfile
     {{- end -}}
 {{- end -}}
+
+{{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts.
+*/}}
+{{- define "mongodb-replicaset.namespace" -}}
+  {{- if and ((hasKey .Values "global") .Values.global.namespaceOverride) -}}
+    {{- .Values.global.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}

--- a/stable/mongodb-replicaset/templates/mongodb-admin-secret.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-admin-secret.yaml
@@ -11,6 +11,7 @@ metadata:
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
   name: {{ template "mongodb-replicaset.adminSecret" . }}
+  namespace: {{ template "mongodb-replicaset.namespace" . }}
 type: Opaque
 data:
   user: {{ .Values.auth.adminUser | b64enc }}

--- a/stable/mongodb-replicaset/templates/mongodb-ca-secret.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-ca-secret.yaml
@@ -12,6 +12,7 @@ metadata:
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
   name: {{ template "mongodb-replicaset.fullname" . }}-ca
+  namespace: {{ template "mongodb-replicaset.namespace" . }}
 data:
   tls.key: {{ .Values.tls.cakey }}
   tls.crt: {{ .Values.tls.cacert }}

--- a/stable/mongodb-replicaset/templates/mongodb-init-configmap.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-init-configmap.yaml
@@ -10,6 +10,7 @@ metadata:
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
   name: {{ template "mongodb-replicaset.fullname" . }}-init
+  namespace: {{ template "mongodb-replicaset.namespace" . }}
 data:
   on-start.sh: |
 {{ .Files.Get "init/on-start.sh" | indent 4 }}

--- a/stable/mongodb-replicaset/templates/mongodb-keyfile-secret.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-keyfile-secret.yaml
@@ -11,6 +11,7 @@ metadata:
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
   name: {{ template "mongodb-replicaset.keySecret" . }}
+  namespace: {{ template "mongodb-replicaset.namespace" . }}
 type: Opaque
 data:
   key.txt: {{ .Values.auth.key | b64enc }}

--- a/stable/mongodb-replicaset/templates/mongodb-metrics-secret.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-metrics-secret.yaml
@@ -11,6 +11,7 @@ metadata:
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
   name: {{ template "mongodb-replicaset.metricsSecret" . }}
+  namespace: {{ template "mongodb-replicaset.namespace" . }}
 type: Opaque
 data:
   user: {{ .Values.auth.metricsUser | b64enc }}

--- a/stable/mongodb-replicaset/templates/mongodb-mongodb-configmap.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-mongodb-configmap.yaml
@@ -10,6 +10,7 @@ metadata:
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
   name: {{ template "mongodb-replicaset.fullname" . }}-mongodb
+  namespace: {{ template "mongodb-replicaset.namespace" . }}
 data:
   mongod.conf: |
 {{ toYaml .Values.configmap | indent 4 }}

--- a/stable/mongodb-replicaset/templates/mongodb-poddisruptionbudget.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-poddisruptionbudget.yaml
@@ -11,6 +11,7 @@ metadata:
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
   name: {{ template "mongodb-replicaset.fullname" . }}
+  namespace: {{ template "mongodb-replicaset.namespace" . }}
 spec:
   selector:
     matchLabels:

--- a/stable/mongodb-replicaset/templates/mongodb-service-client.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-service-client.yaml
@@ -15,6 +15,7 @@ metadata:
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
   name: {{ template "mongodb-replicaset.fullname" . }}-client
+  namespace: {{ template "mongodb-replicaset.namespace" . }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/stable/mongodb-replicaset/templates/mongodb-service.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-service.yaml
@@ -13,6 +13,7 @@ metadata:
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
   name: {{ template "mongodb-replicaset.fullname" . }}
+  namespace: {{ template "mongodb-replicaset.namespace" . }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -10,6 +10,7 @@ metadata:
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
   name: {{ template "mongodb-replicaset.fullname" . }}
+  namespace: {{ template "mongodb-replicaset.namespace" . }}
 spec:
   selector:
     matchLabels:

--- a/stable/mongodb-replicaset/templates/tests/mongodb-up-test-configmap.yaml
+++ b/stable/mongodb-replicaset/templates/tests/mongodb-up-test-configmap.yaml
@@ -7,6 +7,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "mongodb-replicaset.fullname" . }}-tests
+  namespace: {{ template "mongodb-replicaset.namespace" . }}
 data:
   mongodb-up-test.sh: |
 {{ .Files.Get "tests/mongodb-up-test.sh" | indent 4 }}

--- a/stable/mongodb-replicaset/templates/tests/mongodb-up-test-pod.yaml
+++ b/stable/mongodb-replicaset/templates/tests/mongodb-up-test-pod.yaml
@@ -9,6 +9,7 @@ metadata:
   name: {{ template "mongodb-replicaset.fullname" . }}-test
   annotations:
     "helm.sh/hook": test-success
+  namespace: {{ template "mongodb-replicaset.namespace" . }}
 spec:
   initContainers:
     - name: test-framework

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -156,3 +156,7 @@ livenessProbe:
   failureThreshold: 3
   periodSeconds: 10
   successThreshold: 1
+
+# Override the deployment namespace
+# global:
+#   namespaceOverride: ""


### PR DESCRIPTION
#### What this PR does / why we need it:
It adds a `global.namespaceOverride` parameter, which allows this chart to be used in an umbrella helm chart with multiple namespaces. 

Similar changes has been merged before: #15202 and #18986

There is no change in the default behavior.

@unguiculus @steven-sheehy

#### Which issue this PR fixes
  - fixes #21162

#### Special notes for your reviewer:
`global` variable is being used here to help with the cascading scenario, so namespace can be overridden in multiple level.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
