### PR TITLE
[stable/wordpress] Fix issue with port number when using external dbs

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 9.0.0
+version: 9.0.1
 appVersion: 5.3.2
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/templates/_helpers.tpl
+++ b/stable/wordpress/templates/_helpers.tpl
@@ -232,7 +232,7 @@ Return the MariaDB Port
 {{- if .Values.mariadb.enabled }}
     {{- printf "3306" -}}
 {{- else -}}
-    {{- printf "%s" .Values.externalDatabase.port -}}
+    {{- printf "%d" (.Values.externalDatabase.port | int ) -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### Is this a new chart

No

#### What this PR does / why we need it:

This PRs fixes an issue since we need to force "integer" type for the port number.

#### Which issue this PR fixes

  - fixes https://github.com/helm/charts/issues/21142

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
