### PR TITLE
[stable/grafana] Use selectorLabels helper in headless service

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.0.4
+version: 5.0.5
 appVersion: 6.6.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/headless-service.yaml
+++ b/stable/grafana/templates/headless-service.yaml
@@ -13,7 +13,6 @@ metadata:
 spec:
   clusterIP: None
   selector:
-    app: {{ template "grafana.name" . }}
-    release: {{ .Release.Name }}
+    {{- include "grafana.selectorLabels" . | nindent 4 }}
   type: ClusterIP
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Use the `grafana.selectorLabels` helper for selectors in the `grafana-headless` service

#### Which issue this PR fixes
  - fixes #21195 

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
