### PR TITLE
[stable/couchbase-cluster] Add Chart to deploy Couchbase Cluster

### DIFF
--- a/stable/couchbase-cluster/.helmignore
+++ b/stable/couchbase-cluster/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+# OWNERS file for Kubernetes
+OWNERS

--- a/stable/couchbase-cluster/Chart.yaml
+++ b/stable/couchbase-cluster/Chart.yaml
@@ -16,4 +16,3 @@ sources:
 maintainers:
 - name: tahmmee
   email: tahmmee@gmail.com
-

--- a/stable/couchbase-cluster/Chart.yaml
+++ b/stable/couchbase-cluster/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+name: couchbase-cluster
+description: Couchbase Server is a NoSQL document database with a distributed architecture for performance, scalability, and availability. It enables developers to build applications easier and faster by leveraging the power of SQL with the flexibility of JSON.
+version: 1.2.2
+appVersion: 1.2.2
+keywords:
+- couchbase
+- database
+- nosql
+- cluster
+- replication
+home: https://www.couchbase.com
+icon: https://couchbase-partners.github.io/helm-charts/assets/img/CB_Logomark_220.png
+sources:
+- https://github.com/couchbase/docker/tree/master/enterprise/couchbase-server
+maintainers:
+- name: tahmmee
+  email: tahmmee@gmail.com
+

--- a/stable/couchbase-cluster/OWNERS
+++ b/stable/couchbase-cluster/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- tahmmee
+- spjmurray
+- danielma82
+reviewers:
+- tahmmee
+- spjmurray
+- danielma82

--- a/stable/couchbase-cluster/crds/couchbaseclusters.couchbase.com.yaml
+++ b/stable/couchbase-cluster/crds/couchbaseclusters.couchbase.com.yaml
@@ -1,0 +1,371 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: couchbaseclusters.couchbase.com
+spec:
+  group: couchbase.com
+  names:
+    kind: CouchbaseCluster
+    plural: couchbaseclusters
+    shortNames:
+    - couchbase
+    - cbc
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            adminConsoleServiceType:
+              enum:
+              - NodePort
+              - LoadBalancer
+              type: string
+            adminConsoleServices:
+              items:
+                enum:
+                - data
+                - index
+                - query
+                - search
+                - eventing
+                - analytics
+                type: string
+              type: array
+            antiAffinity:
+              type: boolean
+            authSecret:
+              minLength: 1
+              type: string
+            baseImage:
+              type: string
+            buckets:
+              items:
+                properties:
+                  compressionMode:
+                    enum:
+                    - "off"
+                    - passive
+                    - active
+                    type: string
+                  conflictResolution:
+                    enum:
+                    - seqno
+                    - lww
+                    type: string
+                  enableFlush:
+                    type: boolean
+                  enableIndexReplica:
+                    type: boolean
+                  evictionPolicy:
+                    enum:
+                    - valueOnly
+                    - fullEviction
+                    - noEviction
+                    - nruEviction
+                    type: string
+                  ioPriority:
+                    enum:
+                    - high
+                    - low
+                    type: string
+                  memoryQuota:
+                    minimum: 100
+                    type: integer
+                  name:
+                    pattern: ^[a-zA-Z0-9._\-%]*$
+                    type: string
+                  replicas:
+                    maximum: 3
+                    minimum: 0
+                    type: integer
+                  type:
+                    enum:
+                    - couchbase
+                    - ephemeral
+                    - memcached
+                    type: string
+                required:
+                - name
+                - type
+                - memoryQuota
+                type: object
+              type: array
+            cluster:
+              properties:
+                analyticsServiceMemoryQuota:
+                  minimum: 1024
+                  type: integer
+                autoFailoverMaxCount:
+                  maximum: 3
+                  minimum: 1
+                  type: integer
+                autoFailoverOnDataDiskIssues:
+                  type: boolean
+                autoFailoverOnDataDiskIssuesTimePeriod:
+                  maximum: 3600
+                  minimum: 5
+                  type: integer
+                autoFailoverServerGroup:
+                  type: boolean
+                autoFailoverTimeout:
+                  maximum: 3600
+                  minimum: 5
+                  type: integer
+                clusterName:
+                  type: string
+                dataServiceMemoryQuota:
+                  minimum: 256
+                  type: integer
+                eventingServiceMemoryQuota:
+                  minimum: 256
+                  type: integer
+                indexServiceMemoryQuota:
+                  minimum: 256
+                  type: integer
+                indexStorageSetting:
+                  enum:
+                  - plasma
+                  - memory_optimized
+                  type: string
+                searchServiceMemoryQuota:
+                  minimum: 256
+                  type: integer
+              required:
+              - dataServiceMemoryQuota
+              - indexServiceMemoryQuota
+              - searchServiceMemoryQuota
+              - eventingServiceMemoryQuota
+              - analyticsServiceMemoryQuota
+              - indexStorageSetting
+              - autoFailoverTimeout
+              - autoFailoverMaxCount
+              type: object
+            disableBucketManagement:
+              type: boolean
+            dns:
+              properties:
+                domain:
+                  type: string
+              required:
+              - domain
+              type: object
+            exposeAdminConsole:
+              type: boolean
+            exposedFeatureServiceType:
+              enum:
+              - NodePort
+              - LoadBalancer
+              type: string
+            exposedFeatureTrafficPolicy:
+              enum:
+              - Local
+              - Cluster
+              type: string
+            exposedFeatures:
+              items:
+                enum:
+                - admin
+                - xdcr
+                - client
+                type: string
+              type: array
+            logRetentionCount:
+              minimum: 0
+              type: integer
+            logRetentionTime:
+              pattern: ^\d+(ns|us|ms|s|m|h)$
+              type: string
+            paused:
+              type: boolean
+            platform:
+              enum:
+              - aws
+              - gce
+              - azure
+              type: string
+            serverGroups:
+              items:
+                type: string
+              type: array
+            servers:
+              items:
+                properties:
+                  name:
+                    minLength: 1
+                    pattern: ^[-_a-zA-Z0-9]+$
+                    type: string
+                  pod:
+                    properties:
+                      automountServiceAccountToken:
+                        type: boolean
+                      couchbaseEnv:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      labels:
+                        type: object
+                      nodeSelector:
+                        type: object
+                      resources:
+                        properties:
+                          limits:
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
+                              storage:
+                                type: string
+                            type: object
+                          requests:
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
+                              storage:
+                                type: string
+                            type: object
+                        type: object
+                      tolerations:
+                        items:
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              type: integer
+                            value:
+                              type: string
+                          required:
+                          - key
+                          - operator
+                          - value
+                          - effect
+                          type: object
+                        type: array
+                      volumeMounts:
+                        properties:
+                          analytics:
+                            items:
+                              type: string
+                            type: array
+                          data:
+                            type: string
+                          default:
+                            type: string
+                          index:
+                            type: string
+                          logs:
+                            type: string
+                        type: object
+                    type: object
+                  serverGroups:
+                    items:
+                      type: string
+                    type: array
+                  services:
+                    items:
+                      enum:
+                      - data
+                      - index
+                      - query
+                      - search
+                      - eventing
+                      - analytics
+                      type: string
+                    minLength: 1
+                    type: array
+                  size:
+                    minimum: 1
+                    type: integer
+                required:
+                - size
+                - name
+                - services
+                type: object
+              minLength: 1
+              type: array
+            serviceAnnotations:
+              type: object
+            softwareUpdateNotifications:
+              type: boolean
+            tls:
+              properties:
+                static:
+                  properties:
+                    member:
+                      properties:
+                        serverSecret:
+                          type: string
+                      required:
+                      - serverSecret
+                      type: object
+                    operatorSecret:
+                      type: string
+                  required:
+                  - member
+                  - operatorSecret
+                  type: object
+              required:
+              - static
+              type: object
+            version:
+              pattern: ^([\w\d]+-)?\d+\.\d+.\d+(-[\w\d]+)?$
+              type: string
+            volumeClaimTemplates:
+              items:
+                properties:
+                  metadata:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  spec:
+                    properties:
+                      resources:
+                        properties:
+                          limits:
+                            properties:
+                              storage:
+                                type: string
+                            required:
+                            - storage
+                            type: object
+                          requests:
+                            properties:
+                              storage:
+                                type: string
+                            required:
+                            - storage
+                            type: object
+                        type: object
+                      storageClassName:
+                        type: string
+                    required:
+                    - resources
+                    type: object
+                required:
+                - metadata
+                - spec
+                type: object
+              type: array
+          required:
+          - baseImage
+          - version
+          - authSecret
+          - cluster
+          - servers
+          type: object
+  version: v1

--- a/stable/couchbase-cluster/templates/NOTES.txt
+++ b/stable/couchbase-cluster/templates/NOTES.txt
@@ -1,0 +1,6 @@
+1. Get couchbase cluster status
+  kubectl describe --namespace {{ .Release.Namespace }} couchbasecluster {{ (include "couchbase-cluster.clustername" .) }}
+
+2. Connect to Admin console
+  kubectl port-forward --namespace {{ .Release.Namespace }} {{ printf "%s-0000" (include "couchbase-cluster.clustername" .) }} 8091:8091
+  # open http://localhost:8091

--- a/stable/couchbase-cluster/templates/_helpers.tpl
+++ b/stable/couchbase-cluster/templates/_helpers.tpl
@@ -1,0 +1,115 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "couchbase-cluster.name" -}}
+{{- default .Chart.Name .Values.couchbaseCluster.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "couchbase-cluster.fullname" -}}
+{{- printf "%s-%s" .Release.Name (include "couchbase-cluster.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "couchbase-cluster.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the username of the Admin user.
+TODO: Auto generate when there is a better mechanism for upgrading secrets
+      https://github.com/pulumi/pulumi-kubernetes/issues/205
+*/}}
+{{- define "couchbase-cluster.username" -}}
+  {{ .Values.couchbaseCluster.username | b64enc | quote }}
+{{- end -}}
+
+{{/*
+Create the password of the Admin user.
+TODO: Auto generate when there is a better mechanism for upgrading secrets
+      https://github.com/pulumi/pulumi-kubernetes/issues/205
+*/}}
+{{- define "couchbase-cluster.password" -}}
+  {{ .Values.couchbaseCluster.password | b64enc | quote }}
+{{- end -}}
+
+
+{{/*
+Create secret for couchbase cluster.
+*/}}
+{{- define "couchbase-cluster.secret.name" -}}
+{{- default (include "couchbase-cluster.fullname" .) .Values.couchbaseCluster.authSecretOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Generate cluster name from chart name or use user value
+*/}}
+{{- define "couchbase-cluster.clustername" -}}
+  {{ default (include "couchbase-cluster.fullname" .) .Values.couchbaseCluster.name }}
+{{- end -}}
+
+{{/*
+Name of tls operator secret
+*/}}
+{{- define  "couchbase-cluster.secret.tls-operator" -}}
+{{- $fullname := printf "%s-operator-tls" (include "couchbase-cluster.fullname" .) -}}
+{{- default $fullname .Values.couchbaseTLS.ServerSecret | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Name of tls server secret
+*/}}
+{{- define  "couchbase-cluster.secret.tls-server" -}}
+{{- $fullname := printf "%s-server-tls" (include "couchbase-cluster.fullname" .) -}}
+{{- default $fullname .Values.couchbaseTLS.ServerSecret | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Generate certificates for couchbase-cluster
+*/}}
+{{- define "couchbase-cluster.gen-certs" -}}
+{{- $expiration := (.Values.couchbaseTLS.expiration | int) -}}
+{{- if (or (empty .Values.couchbaseTLS.cert) (empty .Values.couchbaseTLS.key)) -}}
+{{- $ca :=  genCA "couchbase-cluster-ca" $expiration -}}
+{{- template "couchbase-cluster.gen-client-tls" (dict "RootScope" . "CA" $ca) -}}
+{{- else -}}
+{{- $ca :=  buildCustomCert (.Values.couchbaseTLS.cert | b64enc) (.Values.couchbaseTLS.key | b64enc) -}}
+{{- template "couchbase-cluster.gen-client-tls" (dict "RootScope" . "CA" $ca) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate client key and cert from CA
+*/}}
+{{- define "couchbase-cluster.gen-client-tls" -}}
+{{- $clustername := (include "couchbase-cluster.clustername" .RootScope) -}}
+{{- $altNames :=  list (printf "*.%s.%s.svc" $clustername .RootScope.Release.Namespace) -}}
+{{- if .RootScope.Values.couchbaseCluster.dns -}}
+{{- $extendedAltNames := append $altNames (printf "*.%s.%s" $clustername .RootScope.Values.couchbaseCluster.dns.domain) -}}
+{{- template "couchbase-cluster.internal.gen-client-tls" (dict "RootScope" .RootScope "CA" .CA "AltNames" $extendedAltNames) -}}
+{{- else -}}
+{{- template "couchbase-cluster.internal.gen-client-tls" (dict "RootScope" .RootScope "CA" .CA "AltNames" $altNames) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate client key and cert from CA and altNames
+*/}}
+{{- define "couchbase-cluster.internal.gen-client-tls" -}}
+{{- $expiration := (.RootScope.Values.couchbaseTLS.expiration | int) -}}
+{{- $cert := genSignedCert ( include "couchbase-cluster.fullname" .RootScope) nil .AltNames $expiration .CA -}}
+{{- $clientCert := default $cert.Cert .RootScope.Values.couchbaseTLS.operatorSecret.cert | b64enc -}}
+{{- $clientKey := default $cert.Key .RootScope.Values.couchbaseTLS.operatorSecret.key | b64enc -}}
+caCert: {{ .CA.Cert | b64enc }}
+clientCert: {{ $clientCert }}
+clientKey: {{ $clientKey }}
+{{- end -}}

--- a/stable/couchbase-cluster/templates/couchbase-admin-secret.yaml
+++ b/stable/couchbase-cluster/templates/couchbase-admin-secret.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "couchbase-cluster.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "couchbase-cluster.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "couchbase-cluster.chart" . }}
+type: Opaque
+data:
+  username: {{ template "couchbase-cluster.username" . }}
+  password: {{ template "couchbase-cluster.password" . }}

--- a/stable/couchbase-cluster/templates/couchbase-cluster-secret.yaml
+++ b/stable/couchbase-cluster/templates/couchbase-cluster-secret.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.couchbaseTLS.create }}
+{{ $tls := fromYaml ( include "couchbase-cluster.gen-certs" . ) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "couchbase-cluster.secret.tls-operator" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "couchbase-cluster.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "couchbase-cluster.chart" . }}
+data:
+  ca.crt: {{ $tls.caCert }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "couchbase-cluster.secret.tls-server" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "couchbase-cluster.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "couchbase-cluster.chart" . }}
+data:
+  chain.pem: {{ $tls.clientCert }}
+  pkey.key: {{ $tls.clientKey }}
+{{- end -}}

--- a/stable/couchbase-cluster/templates/couchbase-cluster.yaml
+++ b/stable/couchbase-cluster/templates/couchbase-cluster.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: "couchbase.com/v1"
+kind: "CouchbaseCluster"
+metadata:
+  name: {{ template "couchbase-cluster.clustername" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "couchbase-cluster.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "couchbase-cluster.chart" . }}
+spec:
+  baseImage: {{ .Values.couchbaseCluster.baseImage }}
+  version: {{ .Values.couchbaseCluster.version }}
+  authSecret: {{ template "couchbase-cluster.secret.name" . }}
+  exposeAdminConsole: {{ .Values.couchbaseCluster.exposeAdminConsole }}
+  adminConsoleServices: {{ .Values.couchbaseCluster.adminConsoleServices }}
+  exposedFeatures: {{ .Values.couchbaseCluster.exposedFeatures }}
+  adminConsoleServiceType: {{ .Values.couchbaseCluster.adminConsoleServiceType }}
+  exposedFeatureServiceType: {{ .Values.couchbaseCluster.exposedFeatureServiceType }}
+  logRetentionTime: {{ .Values.couchbaseCluster.logRetentionTime }}
+  logRetentionCount: {{ .Values.couchbaseCluster.logRetentionCount }}
+{{- if .Values.couchbaseCluster.dns }}
+  dns:
+    domain: {{ .Values.couchbaseCluster.dns.domain }}
+{{- end }}
+{{- if .Values.couchbaseCluster.platform }}
+  platform: {{ .Values.couchbaseCluster.platform }}
+{{- end }}
+  cluster:
+{{ toYaml .Values.couchbaseCluster.cluster | indent 4 }}
+  buckets:
+  {{- range $bucket, $config := .Values.couchbaseCluster.buckets }}
+  {{- if typeIs "map[string]interface {}" $config}}
+  -
+{{ toYaml $config | indent 4 }}
+  {{- end }}
+  {{- end }}
+  servers:
+  {{- range $server, $config := .Values.couchbaseCluster.servers }}
+  - name: {{ $server }}
+{{ toYaml $config | indent 4 }}
+  {{- end }}
+{{- if .Values.couchbaseTLS.create }}
+  tls:
+    static:
+      member:
+        serverSecret: {{ template "couchbase-cluster.secret.tls-server" . }}
+      operatorSecret: {{ template "couchbase-cluster.secret.tls-operator" . }}
+{{- end }}
+  securityContext:
+{{ toYaml .Values.couchbaseCluster.securityContext | indent 4 }}
+  volumeClaimTemplates:
+{{ toYaml .Values.couchbaseCluster.volumeClaimTemplates | indent 4 }}

--- a/stable/couchbase-cluster/values.yaml
+++ b/stable/couchbase-cluster/values.yaml
@@ -41,7 +41,7 @@ couchbaseCluster:
   # The maximum number of log volumes that can be kept after their associated pods have been deleted.
   logRetentionCount: 20
   # Uncomment these 2 lines for specifying the dynamic DNS configuration to use when exposing services
-  #dns:
+  # dns:
   # domain:  example.domain.com
   # Indicates which underlying cloud platform the Kubernetes cluster is running.
   # The Value must be one of aws, gce or azure

--- a/stable/couchbase-cluster/values.yaml
+++ b/stable/couchbase-cluster/values.yaml
@@ -1,0 +1,141 @@
+# Default values for couchbase-cluster.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# couchbaseCluster config
+couchbaseCluster:
+  # create flag to deploy couchbase cluster
+  create: true
+  # name of the cluster. defaults to name of chart release
+  name: ""
+  # username of the cluster admin.
+  username: "Administrator"
+  # password of the cluster admin.
+  password: "password"
+  # authSecretOverride is name of secret to use instead of using
+  # the default secret with username and password specified above
+  authSecretOverride: ""
+  # BaseImage is the base couchbase image name that will be used to launch
+  # couchbase clusters. This is useful for private registries, etc.
+  baseImage: "couchbase/server"
+  # Version is the expected version of the couchbase cluster
+  version: "enterprise-6.0.3"
+  # Option to expose admin console
+  exposeAdminConsole: true
+  # Option to expose admin console
+  adminConsoleServices:
+    - data
+  # Specific services to use when exposing ui
+  exposedFeatures:
+    - xdcr
+  # Defines how the admin console service is exposed.
+  # Allowed values are NodePort and LoadBalancer.
+  # If this field is LoadBalancer then you must also define a spec.dns.domain.
+  adminConsoleServiceType: NodePort
+  # Defines how the per Couchbase node ports are exposed.
+  # Allowed values are NodePort and LoadBalancer.
+  # If this field is LoadBalancer then you must also define a spec.dns.domain.
+  exposedFeatureServiceType: NodePort
+  # The retention period that log volumes are kept for after their associated pods have been deleted.
+  logRetentionTime: 604800s
+  # The maximum number of log volumes that can be kept after their associated pods have been deleted.
+  logRetentionCount: 20
+  # Uncomment these 2 lines for specifying the dynamic DNS configuration to use when exposing services
+  #dns:
+  # domain:  example.domain.com
+  # Indicates which underlying cloud platform the Kubernetes cluster is running.
+  # The Value must be one of aws, gce or azure
+  platform:
+  # Cluster wide settings for nodes and services
+  cluster:
+    # The amount of memory that should be allocated to the data service
+    dataServiceMemoryQuota: 256
+    # The amount of memory that should be allocated to the index service
+    indexServiceMemoryQuota: 256
+    # The amount of memory that should be allocated to the search service
+    searchServiceMemoryQuota: 256
+    # The amount of memory that should be allocated to the eventing service
+    eventingServiceMemoryQuota: 256
+    # The amount of memory that should be allocated to the analytics service
+    analyticsServiceMemoryQuota: 1024
+    # The index storage mode to use for secondary indexing
+    indexStorageSetting: memory_optimized
+    # Timeout that expires to trigger the auto failover.
+    autoFailoverTimeout: 120
+    # The number of failover events we can tolerate
+    autoFailoverMaxCount: 3
+    # Whether to auto failover if disk issues are detected
+    autoFailoverOnDataDiskIssues: true
+    # How long to wait for transient errors before failing over a faulty disk
+    autoFailoverOnDataDiskIssuesTimePeriod: 120
+    # Whether to enable failing over a server group
+    autoFailoverServerGroup: false
+
+  # cluster buckets
+  buckets:
+    # The default bucket
+    default:
+      # Name of the bucket
+      name: default
+      # The type of bucket to use
+      type: couchbase
+      # The amount of memory that should be allocated to the bucket
+      memoryQuota: 128
+      # The number of bucket replicates
+      replicas: 1
+      # The priority when compared to other buckets
+      ioPriority: high
+      # The bucket eviction policy which determines behavior during expire and high mem usage
+      evictionPolicy: fullEviction
+      # The bucket's conflict resolution mechanism; which is to be used if a conflict occurs during Cross Data-Center Replication (XDCR). Sequence-based and timestamp-based mechanisms are supported.
+      conflictResolution: seqno
+      # The enable flush option denotes wether the data in the bucket can be flushed
+      enableFlush: true
+      # Enable Index replica specifies whether or not to enable view index replicas for this bucket.
+      enableIndexReplica: false
+      # data compression mode for the bucket to run in [off, passive, active]
+      compressionMode: "passive"
+  servers:
+    # Name for the server configuration. It must be unique.
+    all_services:
+      # Size of the couchbase cluster.
+      size: 3
+      # The services to run on nodes
+      services:
+        - data
+        - index
+        - query
+        - search
+        - eventing
+        - analytics
+      # ServerGroups define the set of availability zones we want to distribute pods over.
+      serverGroups: []
+      # Pod defines the policy to create pod for the couchbase pod.
+      pod: {}
+  # Security Context for all pods
+  securityContext: {}
+  # VolumeClaimTemplates define the desired characteristics of a volume
+  # that can be requested and claimed by a pod.
+  volumeClaimTemplates: []
+
+# couchbaseTLS can be used to override the Certs that will be used
+# to sign the keys used by the nodes.
+couchbaseTLS:
+  # disable if manually creating certs
+  # provide cert and key via --set-file
+  create: false
+  # A base64 encoded PEM format certificate for the CA
+  cert:
+  # A base64 encoded PEM format private key for the CA
+  key:
+  # Expiry time of CA in days for generated certs
+  expiration: 365
+  # OperatorSecret is the secret containing TLS certs used by operator
+  operatorSecret:
+    name: ""
+    # PEM format certificate for operator (auto-generated)
+    # override via --set-file
+    cert:
+    # PEM format private key for operator (auto-generated)
+    # override via --set-file
+    key:


### PR DESCRIPTION
Installs couchbase cluster CRD along with
cluster resource.

Signed-off-by: Tommie McAfee <tommie@couchbase.com>


#### What this PR does / why we need it:
The Chart helps Kubernetes administrators to deploy Couchbase Cluster and Bucket resources.
This chart is very helpful when deploying secure clusters since it is able to generate certificates to encrypt communication between operator and cluster.



#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Variables are documented in the README.md => https://docs.couchbase.com/operator/current/helm-cluster-config.html
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
