### PR TITLE
[stable/cluster-autoscaler] reuse existing service account

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 6.6.2
+version: 7.0.0
 appVersion: 1.14.6
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 6.6.1
+version: 6.6.2
 appVersion: 1.14.6
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/README.md
+++ b/stable/cluster-autoscaler/README.md
@@ -167,8 +167,8 @@ Parameter | Description | Default
 `nodeSelector` | node labels for pod assignment | `{}`
 `podAnnotations` | annotations to add to each pod | `{}`
 `rbac.create` | If true, create & use RBAC resources | `false`
-`rbac.skipServiceAccountCreation` | If true (and rbac.create is true), no service account will be created  | `false`
-`rbac.serviceAccountName` | existing ServiceAccount to use (ignored if rbac.create=true and rbac.skipServiceAccountCreation=false) | `default`
+`rbac.serviceAccount.create` | If true and rbac.create is also true, a service account will be created | `true`
+`rbac.serviceAccount.name` | existing ServiceAccount to use (ignored if rbac.create=true and rbac.serviceAccount.create=true) | `default`
 `rbac.serviceAccountAnnotations` | Additional Service Account annotations	| `{}`
 `rbac.pspEnabled` | Must be used with `rbac.create` true. If true, creates & uses RBAC resources required in the cluster with [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) enabled. | `false`
 `replicaCount` | desired number of pods | `1`

--- a/stable/cluster-autoscaler/README.md
+++ b/stable/cluster-autoscaler/README.md
@@ -167,7 +167,8 @@ Parameter | Description | Default
 `nodeSelector` | node labels for pod assignment | `{}`
 `podAnnotations` | annotations to add to each pod | `{}`
 `rbac.create` | If true, create & use RBAC resources | `false`
-`rbac.serviceAccountName` | existing ServiceAccount to use (ignored if rbac.create=true) | `default`
+`rbac.skipServiceAccountCreation` | If true (and rbac.create is true), no service account will be created  | `false`
+`rbac.serviceAccountName` | existing ServiceAccount to use (ignored if rbac.create=true and rbac.skipServiceAccountCreation=false) | `default`
 `rbac.serviceAccountAnnotations` | Additional Service Account annotations	| `{}`
 `rbac.pspEnabled` | Must be used with `rbac.create` true. If true, creates & uses RBAC resources required in the cluster with [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) enabled. | `false`
 `replicaCount` | desired number of pods | `1`

--- a/stable/cluster-autoscaler/templates/_helpers.tpl
+++ b/stable/cluster-autoscaler/templates/_helpers.tpl
@@ -71,3 +71,14 @@ Return the appropriate apiVersion for podsecuritypolicy.
 {{- print "policy/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the service account name.
+*/}}
+{{- define "serviceaccount.name" -}}
+{{- if .Values.rbac.skipServiceAccountCreation -}}
+{{ .Values.rbac.serviceAccountName }}
+{{- else -}}
+{{ include "cluster-autoscaler.fullname" . }}
+{{- end -}}
+{{- end -}}

--- a/stable/cluster-autoscaler/templates/_helpers.tpl
+++ b/stable/cluster-autoscaler/templates/_helpers.tpl
@@ -73,12 +73,12 @@ Return the appropriate apiVersion for podsecuritypolicy.
 {{- end -}}
 
 {{/*
-Return the service account name.
+Return the service account name used by the pod.
 */}}
 {{- define "serviceaccount.name" -}}
-{{- if .Values.rbac.skipServiceAccountCreation -}}
-{{ .Values.rbac.serviceAccountName }}
-{{- else -}}
+{{- if and .Values.rbac.create .Values.rbac.serviceAccount.create -}}
 {{ include "cluster-autoscaler.fullname" . }}
+{{- else -}}
+{{ .Values.rbac.serviceAccount.name }}
 {{- end -}}
 {{- end -}}

--- a/stable/cluster-autoscaler/templates/clusterrolebinding.yaml
+++ b/stable/cluster-autoscaler/templates/clusterrolebinding.yaml
@@ -11,6 +11,6 @@ roleRef:
   name: {{ template "cluster-autoscaler.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "cluster-autoscaler.fullname" . }}
+    name: {{ template "serviceaccount.name" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/stable/cluster-autoscaler/templates/deployment.yaml
+++ b/stable/cluster-autoscaler/templates/deployment.yaml
@@ -191,7 +191,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
-      serviceAccountName: {{ if .Values.rbac.create }}{{ template "cluster-autoscaler.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      serviceAccountName: {{ template "serviceaccount.name" . }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- if .Values.securityContext }}

--- a/stable/cluster-autoscaler/templates/rolebinding.yaml
+++ b/stable/cluster-autoscaler/templates/rolebinding.yaml
@@ -11,6 +11,6 @@ roleRef:
   name: {{ template "cluster-autoscaler.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "cluster-autoscaler.fullname" . }}
+    name: {{ template "serviceaccount.name" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/stable/cluster-autoscaler/templates/serviceaccount.yaml
+++ b/stable/cluster-autoscaler/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create (not .Values.rbac.skipServiceAccountCreation) -}}
+{{- if and .Values.rbac.create .Values.rbac.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/stable/cluster-autoscaler/templates/serviceaccount.yaml
+++ b/stable/cluster-autoscaler/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if and .Values.rbac.create (not .Values.rbac.skipServiceAccountCreation) -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/stable/cluster-autoscaler/values.yaml
+++ b/stable/cluster-autoscaler/values.yaml
@@ -108,14 +108,14 @@ rbac:
   ## If true, create & use RBAC resources
   ##
   create: false
-  ## If true, the service account won't be created, this allows to reuse an existing one
-  skipServiceAccountCreation: false
   ## If true, create & use Pod Security Policy resources
   ## https://kubernetes.io/docs/concepts/policy/pod-security-policy/
   pspEnabled: false
-  ## Ignored if rbac.create is true and skipServiceAccountCreation is false
-  ##
-  serviceAccountName: default
+  ## if rbac.create is false or (if rbac.create is true and rbac.serviceAccount.create is false)
+  ## the service account rbac.serviceAccount.name will be used instead
+  serviceAccount:
+    create: true
+    name: default
   ## Annotations for the Service Account
   ##
   serviceAccountAnnotations: {}

--- a/stable/cluster-autoscaler/values.yaml
+++ b/stable/cluster-autoscaler/values.yaml
@@ -108,10 +108,12 @@ rbac:
   ## If true, create & use RBAC resources
   ##
   create: false
+  ## If true, the service account won't be created, this allows to reuse an existing one
+  skipServiceAccountCreation: false
   ## If true, create & use Pod Security Policy resources
   ## https://kubernetes.io/docs/concepts/policy/pod-security-policy/
   pspEnabled: false
-  ## Ignored if rbac.create is true
+  ## Ignored if rbac.create is true and skipServiceAccountCreation is false
   ##
   serviceAccountName: default
   ## Annotations for the Service Account


### PR DESCRIPTION
Signed-off-by: Nicolas Degory <nicolas.degory@gmail.com>

#### Is this a new chart

No

#### What this PR does / why we need it:

This PR allows to reuse an existing service accounts (for instance created with eksctl with its related IAM role) and still manage the role and cluster role bindings with the chart.
An IAM role created by eksctl has a condition on the service account name it also creates, so we cannot just use the serviceAccountAnnotations value to do the mapping, unless we modify the role.

#### Special notes for your reviewer:

@yurrriq

I've tested the MR, with the default value it behaves as before. The new feature is present only when both rbac.create and skipServiceAccountCreation is true.

Tested with Helm 2.16.1.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
