### PR TITLE
[stable/airflow] FIX PR# 20640 add volumes declaration

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 6.2.1
+version: 6.2.2
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -391,7 +391,6 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `airflow.extraVolumes`                   | additional volumes for the scheduler, worker & web pods | `[]`                      |
 | `airflow.initdb`                         | run `airflow initdb` when starting the scheduler        | `true`                    |
 | `flower.enabled`                         | enable flow                                             | `true`                    |
-| `flower.extraConfigmapMounts`            | Additional configMap volume mounts on the flower pod.   | `[]`                      |
 | `flower.urlPrefix`                       | path of the flower ui                                   | ""                        |
 | `flower.resources`                       | custom resource configuration for flower pod            | `{}`                      |
 | `flower.labels`                          | labels for the flower deployment                        | `{}`                      |

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -391,6 +391,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `airflow.extraVolumes`                   | additional volumes for the scheduler, worker & web pods | `[]`                      |
 | `airflow.initdb`                         | run `airflow initdb` when starting the scheduler        | `true`                    |
 | `flower.enabled`                         | enable flow                                             | `true`                    |
+| `flower.extraEnv`                        | specify additional environment variables to mount       | `{}`                      |
 | `flower.urlPrefix`                       | path of the flower ui                                   | ""                        |
 | `flower.resources`                       | custom resource configuration for flower pod            | `{}`                      |
 | `flower.labels`                          | labels for the flower deployment                        | `{}`                      |

--- a/stable/airflow/templates/deployments-flower.yaml
+++ b/stable/airflow/templates/deployments-flower.yaml
@@ -64,6 +64,9 @@ spec:
                 name: "{{ template "airflow.fullname" . }}-env"
           env:
           {{- include "airflow.mapenvsecrets" . | indent 10 }}
+          {{- if .Values.flower.extraEnv }}
+{{ toYaml .Values.flower.extraEnv | indent 12 }}
+          {{- end }}
           ports:
             - name: flower
               containerPort: 5555

--- a/stable/airflow/templates/deployments-flower.yaml
+++ b/stable/airflow/templates/deployments-flower.yaml
@@ -68,9 +68,19 @@ spec:
             - name: flower
               containerPort: 5555
               protocol: TCP
-          {{- if .Values.flower.extraConfigmapMounts }}
+          {{- if or .Values.airflow.extraVolumeMounts .Values.airflow.extraConfigmapMounts }}
           volumeMounts:
-{{ toYaml .Values.flower.extraConfigmapMounts | indent 12 }}
+          {{- if .Values.airflow.extraVolumeMounts }}
+{{ toYaml .Values.airflow.extraVolumeMounts | indent 12 }}
+          {{- end }}
+          {{- range .Values.airflow.extraConfigmapMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              readOnly: {{ .readOnly }}
+              {{ if .subPath }}
+              subPath: {{ .subPath }}
+              {{ end }}
+          {{- end }}
           {{- end }}
           args: ["flower"]
           livenessProbe:
@@ -84,4 +94,15 @@ spec:
             failureThreshold: 5
           resources:
 {{ toYaml .Values.flower.resources | indent 12 }}
+      {{- if or .Values.airflow.extraVolumes .Values.airflow.extraConfigmapMounts }}
+      volumes:
+        {{- if .Values.airflow.extraVolumes }}
+{{ toYaml .Values.airflow.extraVolumes | indent 8 }}
+        {{- end }}
+        {{- range .Values.airflow.extraConfigmapMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
+        {{- end }}
+      {{- end }}
 {{- end }}

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -232,6 +232,19 @@ flower:
   affinity: {}
   tolerations: []
 
+  ## Extra environment variables to mount in the Flower pod
+  # NOTE: this is especially useful if you use a Redis broker with TLS-enabled, as
+  # Flower does handle the TLS configuration using the `rediss://` procotol while
+  # Airflow does not handle that protocol. Using the following configuration you can
+  # override the AIRFLOW__CELERY__BROKER_URL or AIRFLOW__CELERY__BROKER_URL_CMD variable
+  # in order to provide Flower with its separate configuration.
+  extraEnv:
+  #  - name: AIRFLOW__CELERY__BROKER_URL
+  #    valueFrom:
+  #      secretKeyRef:
+  #        name: airflow
+  #        key: flower_broker_url
+
 web:
   ##
   ## Set AIRFLOW__WEBSERVER__BASE_URL

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -231,13 +231,6 @@ flower:
   nodeSelector: {}
   affinity: {}
   tolerations: []
-  extraConfigmapMounts: []
-  # Use-case example: adding a public certificate used for connection to a remote TLS endpoint
-  # - name: extra-cert
-  #   mountPath: /etc/ssl/certs/extra-cert.pem
-  #   configMap: extra-certificates
-  #   readOnly: true
-  #   subPath: extra-cert.pem
 
 web:
   ##


### PR DESCRIPTION
Fixes PR #20640 (feature was broken but non-blocking and not impacting existing configs)

EDIT :

As a matter of fact Airflow's flower pod is so tightly coupled with other Airflow configuration that the only way to make this work is to consider Flower the same way as other Airflow pods and provide it with the same extraVolumes and extraVolumeMounts as them.

Scenario: using a variable `AIRFLOW__CELERY__RESULT_BACKEND_CMD` to set a config value using a command that itself reads a secret. It works very well for every other components, but it does render Flower unusable (the pod does not even start). 

Even configurations that are not related with Flower can break the Flower pod... So there is no way, for the moment, to treat Flower separately (unless disabling it totally).

This PR makes it possible to use Flower as-is, until someone decouples it a little better in the Airflow project.