### PR TITLE
[stable/postgresql] Use tpl for extraEnvVarsCM

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 8.5.0
+version: 8.5.1
 appVersion: 11.7.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -251,7 +251,7 @@ spec:
           {{- if .Values.extraEnvVarsCM }}
           envFrom:
             - configMapRef:
-                name: {{ .Values.extraEnvVarsCM }}
+                name: {{ tpl .Values.extraEnvVarsCM . }}
           {{- end }}
           ports:
             - name: tcp-postgresql


### PR DESCRIPTION
#### What this PR does / why we need it:
Use tpl for extraEnvVarsCM in statefulset.yml so that the ConfigMap name can be expanded when used as a subchart like:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) Signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
