### PR TITLE
[stable/ifps] Fix serviceName when Ingress enabled

### DIFF
--- a/stable/ipfs/Chart.yaml
+++ b/stable/ipfs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the Interplanetary File System
 name: ipfs
-version: 0.4.1
+version: 0.4.2
 icon: https://raw.githubusercontent.com/ipfs/logo/master/raster-generated/ipfs-logo-128-ice-text.png
 home: https://ipfs.io/
 appVersion: v0.4.22

--- a/stable/ipfs/templates/ingress-api.yaml
+++ b/stable/ipfs/templates/ingress-api.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.ingressApi.enabled -}}
+{{- $serviceName := include "ipfs.fullname" . }}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -21,7 +22,7 @@ spec:
         paths:
           - path: /{{ rest $url | join "/" }}
             backend:
-              serviceName: {{ include "ipfs.fullname" . }}
+              serviceName: {{ $serviceName }}
               servicePort: 5001
         {{- end -}}
         {{- if .Values.ingressApi.tls }}

--- a/stable/ipfs/templates/ingress-gateway.yaml
+++ b/stable/ipfs/templates/ingress-gateway.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.ingressGateway.enabled -}}
+{{- $serviceName := include "ipfs.fullname" . }}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -21,7 +22,7 @@ spec:
         paths:
           - path: /{{ rest $url | join "/" }}
             backend:
-              serviceName: {{ include "ipfs.fullname" . }}
+              serviceName: {{ $serviceName }}
               servicePort: 8080
         {{- end -}}
         {{- if .Values.ingressGateway.tls }}


### PR DESCRIPTION
#### What this PR does / why we need it:

When `--set ingressApi.enabled=true` Helm gives the following error:
```
template: ipfs/templates/ingress-api.yaml:24:30: executing "ipfs/templates/ingress-api.yaml" at <include "ipfs.fullname" .>: error calling include: template: ipfs/templates/_helpers.tpl:14:27: executing "ipfs.fullname" at <.Chart.Name>: can't evaluate field Chart in type string
```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
