### PR TITLE
[stable/bookstack] allowed config of livenessProbe and readinessProbe

### DIFF
--- a/stable/bookstack/Chart.yaml
+++ b/stable/bookstack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.27.5
 description: BookStack is a simple, self-hosted, easy-to-use platform for organising and storing information.
 name: bookstack
-version: 1.2.1
+version: 1.2.2
 home: https://www.bookstackapp.com/
 icon: https://github.com/BookStackApp/website/blob/master/static/images/logo.png
 sources:

--- a/stable/bookstack/README.md
+++ b/stable/bookstack/README.md
@@ -95,6 +95,19 @@ The following table lists the configurable parameters of the Redmine chart and t
 | `ldap.pass`                    | Password of user performing search queries.  | `nil` |
 | `ldap.userFilter`                    | A filter to use when searching for users | `nil` |
 | `ldap.version`                    | Set the LDAP version to use when connecting to the server. Required especially when using AD. | `nil` |
+| `livenessProbe.enabled`                    | Enable/disable the Liveness probe | `true` |
+| `livenessProbe.failureThreshold`                    | Minimum consecutive failures for the liveness probe to be considered failed after having succeeded | `3` |
+| `livenessProbe.initialDelaySeconds`                    | Delay before liveness probe is initiated | `30` |
+| `livenessProbe.periodSeconds`                    | How often to perform the liveness probe | `10` |
+| `livenessProbe.successThreshold`                    | Minimum consecutive successes for the liveness probe to be considered successful after having failed | `1` |
+| `livenessProbe.timeoutSeconds`                    | When the liveness probe times out  | `1` |
+| `readinessProbe.enabled`                    | Enable/disable the Readiness probe | `true` |
+| `readinessProbe.failureThreshold`                    | Minimum consecutive failures for the readiness probe to be considered failed after having succeeded | `3` |
+| `readinessProbe.initialDelaySeconds`                    | Delay before readiness probe is initiated   | `30` |
+| `readinessProbe.periodSeconds`                    | How often to perform the readiness probe  | `10` |
+| `readinessProbe.successThreshold`                    | Minimum consecutive successes for the readiness probe to be considered successful after having failed | `1` |
+| `readinessProbe.timeoutSeconds`                    | When the readiness probe times out   | `1` |
+
 
 The above parameters map to the env variables defined in the [Bookstack image](https://hub.docker.com/r/solidnerd/bookstack/) and the MariaDB/MySQL database settings. For more information please refer to the [Bookstack](https://hub.docker.com/r/solidnerd/bookstack/) image documentation.
 

--- a/stable/bookstack/templates/deployment.yaml
+++ b/stable/bookstack/templates/deployment.yaml
@@ -28,14 +28,28 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /
               port: http
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /
               port: http
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          {{- end }}
           env:
           {{- if .Values.ldap.enabled }}
             - name: AUTH_METHOD

--- a/stable/bookstack/values.yaml
+++ b/stable/bookstack/values.yaml
@@ -172,3 +172,20 @@ ldap:
   pass:
   userFilter:
   version:
+
+## Configure liveness and readiness probe values
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+livenessProbe:
+  enabled: true
+  failureThreshold: 3
+  initialDelaySeconds: 30 # very conservative value, to give enough time for database migrations
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+readinessProbe:
+  enabled: true
+  failureThreshold: 3
+  initialDelaySeconds: 30 # very conservative value, to give enough time for database migrations
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1


### PR DESCRIPTION
Signed-off-by: Nicolas Mehlei <nicolas.mehlei@gmail.com>

#### What this PR does / why we need it:
This change allows for configuration of livenessProbe and readinessProbe. This is important because it fixes a problem in which bookstack containers are prematurely interrupted during database migrations and can become unusable because the database is left in a somewhat inconsistent state.

#### Which issue this PR fixes
no issues of this project, only from bookstack directly

#### Special notes for your reviewer:
The changes are very similar than aspects are already in the seq chart

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
