### PR TITLE
[stable/kube-state-metrics] Enable all collectors by default

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - monitoring
 - prometheus
 - kubernetes
-version: 2.7.2
+version: 2.8.0
 appVersion: 1.9.5
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -49,8 +49,9 @@ $ helm install stable/kube-state-metrics
 | `collectors.ingresses`                       | Enable the ingresses collector.                                                       | `true`                                     |
 | `collectors.jobs`                            | Enable the jobs collector.                                                            | `true`                                     |
 | `collectors.limitranges`                     | Enable the limitranges collector.                                                     | `true`                                     |
-| `collectors.mutatingwebhookconfigurations`   | Enable the mutatingwebhookconfigurations collector.                                   | `false`                                    | 
+| `collectors.mutatingwebhookconfigurations`   | Enable the mutatingwebhookconfigurations collector.                                   | `true`                                     |
 | `collectors.namespaces`                      | Enable the namespaces collector.                                                      | `true`                                     |
+| `collectors.networkpolicies`                 | Enable the networkpolicies collector.                                                 | `true`                                     |
 | `collectors.nodes`                           | Enable the nodes collector.                                                           | `true`                                     |
 | `collectors.persistentvolumeclaims`          | Enable the persistentvolumeclaims collector.                                          | `true`                                     |
 | `collectors.persistentvolumes`               | Enable the persistentvolumes collector.                                               | `true`                                     |
@@ -63,9 +64,9 @@ $ helm install stable/kube-state-metrics
 | `collectors.services`                        | Enable the services collector.                                                        | `true`                                     |
 | `collectors.statefulsets`                    | Enable the statefulsets collector.                                                    | `true`                                     |
 | `collectors.storageclasses`                  | Enable the storageclasses collector.                                                  | `true`                                     |
-| `collectors.validatingwebhookconfigurations` | Enable the validatingwebhookconfigurations collector.                                 | `false`                                    |
-| `collectors.verticalpodautoscalers`          | Enable the verticalpodautoscalers collector.                                          | `false`                                    |
-| `collectors.volumeattachments`               | Enable the volumeattachments collector.                                               | `false`                                    |
+| `collectors.validatingwebhookconfigurations` | Enable the validatingwebhookconfigurations collector.                                 | `true`                                     |
+| `collectors.verticalpodautoscalers`          | Enable the verticalpodautoscalers collector.                                          | `true`                                     |
+| `collectors.volumeattachments`               | Enable the volumeattachments collector.                                               | `true`                                     |
 | `prometheus.monitor.enabled`                 | Set this to `true` to create ServiceMonitor for Prometheus operator                   | `false`                                    |
 | `prometheus.monitor.additionalLabels`        | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`                                       |
 | `prometheus.monitor.namespace`               | Namespace where servicemonitor resource should be created                             | `the same namespace as kube-state-metrics` |

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -99,9 +99,9 @@ collectors:
   ingresses: true
   jobs: true
   limitranges: true
-  mutatingwebhookconfigurations: false
+  mutatingwebhookconfigurations: true
   namespaces: true
-  networkpolicies: false
+  networkpolicies: true
   nodes: true
   persistentvolumeclaims: true
   persistentvolumes: true
@@ -114,9 +114,9 @@ collectors:
   services: true
   statefulsets: true
   storageclasses: true
-  validatingwebhookconfigurations: false
-  verticalpodautoscalers: false
-  volumeattachments: false
+  validatingwebhookconfigurations: true
+  verticalpodautoscalers: true
+  volumeattachments: true
 
 # Namespace to be enabled for collecting resources. By default all namespaces are collected.
 # namespace: ""


### PR DESCRIPTION
#### Is this a new chart
No
#### What this PR does / why we need it:
Enables all kube-state-metrics collectors by default
#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
