### PR TITLE
[stable/kube2iam] Allow setting a custom secret name to use for AWS credentials

### DIFF
--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kube2iam
-version: 2.1.0
+version: 2.1.1
 appVersion: 0.10.7
 description: Provide IAM credentials to pods based on annotations.
 keywords:

--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kube2iam
-version: 2.1.1
+version: 2.2.0
 appVersion: 0.10.7
 description: Provide IAM credentials to pods based on annotations.
 keywords:

--- a/stable/kube2iam/README.md
+++ b/stable/kube2iam/README.md
@@ -70,7 +70,7 @@ Parameter | Description | Default
 `aws.secret_key` | The value to use for AWS_SECRET_ACCESS_KEY | `""`
 `aws.access_key` | The value to use for AWS_ACCESS_KEY_ID | `""`
 `aws.region` | The AWS region to use | `""`
-`aws.custom_secret_name` | Set the AWS credentials using a custom secret | `""`
+`existingSecret` | Set the AWS credentials using an existing secret | `""`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/kube2iam/README.md
+++ b/stable/kube2iam/README.md
@@ -67,6 +67,10 @@ Parameter | Description | Default
 `updateStrategy` | Strategy for DaemonSet updates (requires Kubernetes 1.6+) | `OnDelete`
 `verbose` | Enable verbose output | `false`
 `tolerations` | List of node taints to tolerate (requires Kubernetes 1.6+) | `[]`
+`aws.secret_key` | The value to use for AWS_SECRET_ACCESS_KEY | `""`
+`aws.access_key` | The value to use for AWS_ACCESS_KEY_ID | `""`
+`aws.region` | The AWS region to use | `""`
+`aws.custom_secret_name` | Set the AWS credentials using a custom secret | `""`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/kube2iam/templates/daemonset.yaml
+++ b/stable/kube2iam/templates/daemonset.yaml
@@ -62,16 +62,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          {{- if and .Values.aws.secret_key .Values.aws.access_key }}
+          {{- if or .Values.aws.custom_secret_name (and .Values.aws.secret_key .Values.aws.access_key) }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "kube2iam.fullname" . }}
+                  name: {{ if .Values.aws.custom_secret_name }}{{ .Values.aws.custom_secret_name }}{{ else }}{{ template "kube2iam.fullname" . }}{{ end }}
                   key: aws_access_key_id
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "kube2iam.fullname" . }}
+                  name: {{ if .Values.aws.custom_secret_name }}{{ .Values.aws.custom_secret_name }}{{ else }}{{ template "kube2iam.fullname" . }}{{ end }}
                   key: aws_secret_access_key
           {{- end }}
           {{- if .Values.aws.region }}

--- a/stable/kube2iam/templates/daemonset.yaml
+++ b/stable/kube2iam/templates/daemonset.yaml
@@ -62,16 +62,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          {{- if or .Values.aws.custom_secret_name (and .Values.aws.secret_key .Values.aws.access_key) }}
+          {{- if or .Values.existingSecret (and .Values.aws.secret_key .Values.aws.access_key) }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.aws.custom_secret_name }}{{ .Values.aws.custom_secret_name }}{{ else }}{{ template "kube2iam.fullname" . }}{{ end }}
+                  name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "kube2iam.fullname" . }}{{ end }}
                   key: aws_access_key_id
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.aws.custom_secret_name }}{{ .Values.aws.custom_secret_name }}{{ else }}{{ template "kube2iam.fullname" . }}{{ end }}
+                  name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "kube2iam.fullname" . }}{{ end }}
                   key: aws_secret_access_key
           {{- end }}
           {{- if .Values.aws.region }}

--- a/stable/kube2iam/templates/secret.yaml
+++ b/stable/kube2iam/templates/secret.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: {{ template "kube2iam.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-  name: {{ template "kube2iam.fullname" . }}
+  name: {{ if .Values.aws.custom_secret_name }}{{ .Values.aws.custom_secret_name }}{{ else }}{{ template "kube2iam.fullname" . }}{{ end }}
 type: Opaque
 data:
   aws_access_key_id: {{ .Values.aws.access_key | b64enc | quote }}

--- a/stable/kube2iam/templates/secret.yaml
+++ b/stable/kube2iam/templates/secret.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: {{ template "kube2iam.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-  name: {{ if .Values.aws.custom_secret_name }}{{ .Values.aws.custom_secret_name }}{{ else }}{{ template "kube2iam.fullname" . }}{{ end }}
+  name: {{ template "kube2iam.fullname" . }}
 type: Opaque
 data:
   aws_access_key_id: {{ .Values.aws.access_key | b64enc | quote }}

--- a/stable/kube2iam/values.yaml
+++ b/stable/kube2iam/values.yaml
@@ -49,7 +49,8 @@ aws:
   secret_key: ""
   access_key: ""
   region: ""
-  custom_secret_name: ""
+
+existingSecret: ""
 
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/

--- a/stable/kube2iam/values.yaml
+++ b/stable/kube2iam/values.yaml
@@ -49,6 +49,7 @@ aws:
   secret_key: ""
   access_key: ""
   region: ""
+  custom_secret_name: ""
 
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/


### PR DESCRIPTION
Allow setting a custom secret name to use for AWS credentials in the event that the secret is populated from outside of helm for security purposes

Signed-off-by: Mike Tougeron <tougeron@adobe.com>

#### What this PR does / why we need it:

The PR allows you to use a custom secret name (`aws.custom_secret_name`) for AWS credentials in the event that the secret is populated by a process outside of Helm. e.g., via one of the several tools that sync Vault secrets into Kubernetes Secrets.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
