### PR TITLE
[stable/datadog] Revert "Mount the directory containing the CRI socket instead of the socket itself"

### DIFF
--- a/stable/datadog/CHANGELOG.md
+++ b/stable/datadog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.0
 
+## 2.0.2
+
+* Revert the docker socket path inside the agent container to its standard location to fix #21223
+
 ## 2.0.1
 
 * Add parameters `datadog.logs.enabled` and `datadog.logs.containerCollectAll` to replace `datadog.logsEnabled` and `datadog.logsConfigContainerCollectAll`.

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.0.1
+version: 2.0.2
 appVersion: "7"
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/container-agent.yaml
+++ b/stable/datadog/templates/container-agent.yaml
@@ -87,7 +87,7 @@
       value: {{  (default false (or .Values.datadog.logs.containerCollectAll .Values.datadog.logsConfigContainerCollectAll)) | quote}}
     {{- if .Values.datadog.criSocketPath }}
     - name: DD_CRI_SOCKET_PATH
-      value: {{ print "/host/" .Values.datadog.criSocketPath | clean }}
+      value: {{ .Values.datadog.criSocketPath }}
     {{- end }}
     {{- if not .Values.datadog.livenessProbe }}
     - name: DD_HEALTH_PORT
@@ -113,8 +113,8 @@
       subPath: datadog.yaml
     {{- end }}
     {{- if .Values.datadog.criSocketPath }}
-    - name: runtimesocketdir
-      mountPath: {{ print "/host/" (dir .Values.datadog.criSocketPath) | clean }}
+    - name: runtimesocket
+      mountPath: {{ .Values.datadog.criSocketPath }}
       readOnly: true
     {{- end }}
     {{- if .Values.datadog.dogstatsd.useSocketVolume }}

--- a/stable/datadog/templates/container-process-agent.yaml
+++ b/stable/datadog/templates/container-process-agent.yaml
@@ -37,8 +37,8 @@
       mountPath: /host/proc
       readOnly: true
     {{- if .Values.datadog.criSocketPath }}
-    - name: runtimesocketdir
-      mountPath: {{ print "/host/" (dir .Values.datadog.criSocketPath) | clean }}
+    - name: runtimesocket
+      mountPath: {{ .Values.datadog.criSocketPath }}
       readOnly: true
     {{- end }}
     {{- if .Values.datadog.systemProbe.enabled }}

--- a/stable/datadog/templates/containers-init.yaml
+++ b/stable/datadog/templates/containers-init.yaml
@@ -31,8 +31,8 @@
       mountPath: /host/proc
       readOnly: true
     {{- if .Values.datadog.criSocketPath }}
-    - name: runtimesocketdir
-      mountPath: {{ print "/host/" (dir .Values.datadog.criSocketPath) | clean }}
+    - name: runtimesocket
+      mountPath: {{ .Values.datadog.criSocketPath }}
       readOnly: true
     {{- end }}
   env:

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -79,8 +79,8 @@ spec:
           emptyDir: {}
         {{- if .Values.datadog.criSocketPath }}
         - hostPath:
-            path: {{ dir .Values.datadog.criSocketPath }}
-          name: runtimesocketdir
+            path: {{ .Values.datadog.criSocketPath }}
+          name: runtimesocket
         {{- end }}
         {{- if .Values.datadog.dogstatsd.useSocketVolume }}
         - hostPath:


### PR DESCRIPTION
#### What this PR does / why we need it:

In order to fix an issue when the docker daemon is restarted while a containerized datadog agent is connected to it, we had to mount the directory containing the docker socket instead of the docker socket itself.
This led to have the docker socket lie in different, non-standard path. That path is passed to the datadog agent via the `DD_CRI_SOCKET_PATH` environment variables.

As pointed in #21223, the docker entrypoint script fails to honor this environment variable.
This will be fixed with DataDog/datadog-agent#5066.
In the mean time, let just revert that change so that existing released versions of the datadog agent can find the docker socket at the location they used to.

#### Which issue this PR fixes

Fixes #21223

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
