### PR TITLE
[incubator/solr] Zookeeper configuration optimization

### DIFF
--- a/incubator/solr/templates/statefulset.yaml
+++ b/incubator/solr/templates/statefulset.yaml
@@ -158,7 +158,7 @@ spec:
             - name: "SOLR_HOST"
               value: "$(POD_HOSTNAME).{{ include "solr.headless-service-name" . }}.{{ .Release.Namespace }}"
             - name: "ZK_HOST"
-              value: "{{ include "solr.zookeeper-service-name" . }}:2181"
+              value: "{{ include "solr.zookeeper-name" . }}-0.{{ include "solr.zookeeper-service-name" . }}:2181,{{ include "solr.zookeeper-name" . }}-1.{{ include "solr.zookeeper-service-name" . }}:2181,{{ include "solr.zookeeper-name" . }}-2.{{ include "solr.zookeeper-service-name" . }}:2181"
             - name: "SOLR_LOG_LEVEL"
               value: "{{ .Values.logLevel }}"
 {{- if .Values.extraEnvVars }}


### PR DESCRIPTION
Signed-off-by: Shiming Li <limingnihao@live.com>
#### What this PR does / why we need it:
When you use the headless link to zookeeper, it shows on solr's state that zookeeper has no leader. So instead, use the multi-node link zookeeper to see the status of zookeeper.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

