### PR TITLE
[stable/cockroachdb] Configure probes; remove liveness probe by default

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 3.0.7
+version: 3.0.8
 appVersion: 19.2.5
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -227,80 +227,90 @@ Verify that no pod is deleted and then upgrade as normal. A new StatefulSet will
 The following table lists the configurable parameters of the CockroachDB chart and their default values.
 For details see the [`values.yaml`](values.yaml) file.
 
-| Parameter                                | Description                                                     | Default                                          |
-| ---------                                | -----------                                                     | -------                                          |
-| `clusterDomain`                          | Cluster's default DNS domain                                    | `cluster.local`                                  |
-| `conf.attrs`                             | CockroachDB node attributes                                     | `[]`                                             |
-| `conf.cache`                             | Size of CockroachDB's in-memory cache                           | `25%`                                            |
-| `conf.cluster-name`                      | Name of CockroachDB cluster                                     | `""`                                             |
-| `conf.disable-cluster-name-verification` | Disable CockroachDB cluster name verification                   | `no`                                             |
-| `conf.join`                              | List of already-existing CockroachDB instances                  | `[]`                                             |
-| `conf.max-disk-temp-storage`             | Max storage capacity for temp data                              | `0`                                              |
-| `conf.max-offset`                        | Max allowed clock offset for CockroachDB cluster                | `500ms`                                          |
-| `conf.max-sql-memory`                    | Max memory to use processing SQL querie                         | `25%`                                            |
-| `conf.locality`                          | Locality attribute for this deployment                          | `""`                                             |
-| `conf.single-node`                       | Disable CockroachDB clustering (standalone mode)                | `no`                                             |
-| `conf.sql-audit-dir`                     | Directory for SQL audit log                                     | `""`                                             |
-| `conf.port`                              | CockroachDB primary serving port in Pods                        | `26257`                                          |
-| `conf.http-port`                         | CockroachDB HTTP port in Pods                                   | `8080`                                           |
-| `image.repository`                       | Container image name                                            | `cockroachdb/cockroach`                          |
-| `image.tag`                              | Container image tag                                             | `v19.2.5`                                        |
-| `image.pullPolicy`                       | Container pull policy                                           | `IfNotPresent`                                   |
-| `image.credentials`                      | `registry`, `user` and `pass` credentials to pull private image | `{}`                                             |
-| `statefulset.replicas`                   | StatefulSet replicas number                                     | `3`                                              |
-| `statefulset.updateStrategy`             | Update strategy for StatefulSet Pods                            | `{"type": "RollingUpdate"}`                      |
-| `statefulset.podManagementPolicy`        | `OrderedReady`/`Parallel` Pods creation/deletion order          | `Parallel`                                       |
-| `statefulset.budget.maxUnavailable`      | k8s PodDisruptionBudget parameter                               | `1`                                              |
-| `statefulset.args`                       | Extra command-line arguments                                    | `[]`                                             |
-| `statefulset.env`                        | Extra env vars                                                  | `[]`                                             |
-| `statefulset.secretMounts`               | Additional Secrets to mount at cluster members                  | `[]`                                             |
-| `statefulset.labels`                     | Additional labels of StatefulSet and its Pods                   | `{"app.kubernetes.io/component": "cockroachdb"}` |
-| `statefulset.annotations`                | Additional annotations of StatefulSet Pods                      | `{}`                                             |
-| `statefulset.nodeAffinity`               | [Node affinity rules][2] of StatefulSet Pods                    | `{}`                                             |
-| `statefulset.podAffinity`                | [Inter-Pod affinity rules][1] of StatefulSet Pods               | `{}`                                             |
-| `statefulset.podAntiAffinity`            | [Anti-affinity rules][1] of StatefulSet Pods                    | auto                                             |
-| `statefulset.podAntiAffinity.type`       | Type of auto [anti-affinity rules][1]                           | `soft`                                           |
-| `statefulset.podAntiAffinity.weight`     | Weight for `soft` auto [anti-affinity rules][1]                 | `100`                                            |
-| `statefulset.nodeSelector`               | Node labels for StatefulSet Pods assignment                     | `{}`                                             |
-| `statefulset.tolerations`                | Node taints to tolerate by StatefulSet Pods                     | `[]`                                             |
-| `statefulset.resources`                  | Resource requests and limits for StatefulSet Pods               | `{}`                                             |
-| `service.ports.grpc.external.port`       | CockroachDB primary serving port in Services                    | `26257`                                          |
-| `service.ports.grpc.external.name`       | CockroachDB primary serving port name in Services               | `grpc`                                           |
-| `service.ports.grpc.internal.port`       | CockroachDB inter-communication port in Services                | `26257`                                          |
-| `service.ports.grpc.internal.name`       | CockroachDB inter-communication port name in Services           | `grpc-internal`                                  |
-| `service.ports.http.port`                | CockroachDB HTTP port in Services                               | `8080`                                           |
-| `service.ports.http.name`                | CockroachDB HTTP port name in Services                          | `http`                                           |
-| `service.public.type`                    | Public Service type                                             | `ClusterIP`                                      |
-| `service.public.labels`                  | Additional labels of public Service                             | `{"app.kubernetes.io/component": "cockroachdb"}` |
-| `service.public.annotations`             | Additional annotations of public Service                        | `{}`                                             |
-| `service.discovery.labels`               | Additional labels of discovery Service                          | `{"app.kubernetes.io/component": "cockroachdb"}` |
-| `service.discovery.annotations`          | Additional annotations of discovery Service                     | `{}`                                             |
-| `storage.hostPath`                       | Absolute path on host to store data                             | `""`                                             |
-| `storage.persistentVolume.enabled`       | Whether to use PersistentVolume to store data                   | `yes`                                            |
-| `storage.persistentVolume.size`          | PersistentVolume size                                           | `100Gi`                                          |
-| `storage.persistentVolume.storageClass`  | PersistentVolume class                                          | `""`                                             |
-| `storage.persistentVolume.labels`        | Additional labels of PersistentVolumeClaim                      | `{}`                                             |
-| `storage.persistentVolume.annotations`   | Additional annotations of PersistentVolumeClaim                 | `{}`                                             |
-| `init.labels`                            | Additional labels of init Job and its Pod                       | `{"app.kubernetes.io/component": "init"}`        |
-| `init.annotations`                       | Additional labels of the Pod of init Job                        | `{}`                                             |
-| `init.affinity`                          | [Affinity rules][2] of init Job Pod                             | `{}`                                             |
-| `init.nodeSelector`                      | Node labels for init Job Pod assignment                         | `{}`                                             |
-| `init.tolerations`                       | Node taints to tolerate by init Job Pod                         | `[]`                                             |
-| `init.resources`                         | Resource requests and limits for the Pod of init Job            | `{}`                                             |
-| `tls.enabled`                            | Whether to run securely using TLS certificates                  | `no`                                             |
-| `tls.serviceAccount.create`              | Whether to create a new RBAC service account                    | `yes`                                            |
-| `tls.serviceAccount.name`                | Name of RBAC service account to use                             | `""`                                             |
-| `tls.certs.provided`                     | Bring your own certs scenario, i.e certificates are provided    | `no`                                             |
-| `tls.certs.clientRootSecret`             | If certs are provided, secret name for client root cert         | `cockroachdb-root`                               |
-| `tls.certs.nodeSecret`                   | If certs are provided, secret name for node cert                | `cockroachdb-node`                               |
-| `tls.certs.tlsSecret`                    | Own certs are stored in TLS secret                              | `no`                                             |
-| `tls.init.image.repository`              | Image to use for requesting TLS certificates                    | `cockroachdb/cockroach-k8s-request-cert`         |
-| `tls.init.image.tag`                     | Image tag to use for requesting TLS certificates                | `0.4`                                            |
-| `tls.init.image.pullPolicy`              | Requesting TLS certificates container pull policy               | `IfNotPresent`                                   |
-| `tls.init.image.credentials`             | `registry`, `user` and `pass` credentials to pull private image | `{}`                                             |
-| `networkPolicy.enabled`                  | Enable NetworkPolicy for CockroachDB's Pods                     | `no`                                             |
-| `networkPolicy.ingress.grpc`             | Whitelist resources to access gRPC port of CockroachDB's Pods   | `[]`                                             |
-| `networkPolicy.ingress.http`             | Whitelist resources to access gRPC port of CockroachDB's Pods   | `[]`                                             |
+| Parameter                                        | Description                                                     | Default                                          |
+| ---------                                        | -----------                                                     | -------                                          |
+| `clusterDomain`                                  | Cluster's default DNS domain                                    | `cluster.local`                                  |
+| `conf.attrs`                                     | CockroachDB node attributes                                     | `[]`                                             |
+| `conf.cache`                                     | Size of CockroachDB's in-memory cache                           | `25%`                                            |
+| `conf.cluster-name`                              | Name of CockroachDB cluster                                     | `""`                                             |
+| `conf.disable-cluster-name-verification`         | Disable CockroachDB cluster name verification                   | `no`                                             |
+| `conf.join`                                      | List of already-existing CockroachDB instances                  | `[]`                                             |
+| `conf.max-disk-temp-storage`                     | Max storage capacity for temp data                              | `0`                                              |
+| `conf.max-offset`                                | Max allowed clock offset for CockroachDB cluster                | `500ms`                                          |
+| `conf.max-sql-memory`                            | Max memory to use processing SQL querie                         | `25%`                                            |
+| `conf.locality`                                  | Locality attribute for this deployment                          | `""`                                             |
+| `conf.single-node`                               | Disable CockroachDB clustering (standalone mode)                | `no`                                             |
+| `conf.sql-audit-dir`                             | Directory for SQL audit log                                     | `""`                                             |
+| `conf.port`                                      | CockroachDB primary serving port in Pods                        | `26257`                                          |
+| `conf.http-port`                                 | CockroachDB HTTP port in Pods                                   | `8080`                                           |
+| `image.repository`                               | Container image name                                            | `cockroachdb/cockroach`                          |
+| `image.tag`                                      | Container image tag                                             | `v19.2.5`                                        |
+| `image.pullPolicy`                               | Container pull policy                                           | `IfNotPresent`                                   |
+| `image.credentials`                              | `registry`, `user` and `pass` credentials to pull private image | `{}`                                             |
+| `statefulset.replicas`                           | StatefulSet replicas number                                     | `3`                                              |
+| `statefulset.updateStrategy`                     | Update strategy for StatefulSet Pods                            | `{"type": "RollingUpdate"}`                      |
+| `statefulset.podManagementPolicy`                | `OrderedReady`/`Parallel` Pods creation/deletion order          | `Parallel`                                       |
+| `statefulset.budget.maxUnavailable`              | k8s PodDisruptionBudget parameter                               | `1`                                              |
+| `statefulset.args`                               | Extra command-line arguments                                    | `[]`                                             |
+| `statefulset.env`                                | Extra env vars                                                  | `[]`                                             |
+| `statefulset.secretMounts`                       | Additional Secrets to mount at cluster members                  | `[]`                                             |
+| `statefulset.labels`                             | Additional labels of StatefulSet and its Pods                   | `{"app.kubernetes.io/component": "cockroachdb"}` |
+| `statefulset.annotations`                        | Additional annotations of StatefulSet Pods                      | `{}`                                             |
+| `statefulset.nodeAffinity`                       | [Node affinity rules][2] of StatefulSet Pods                    | `{}`                                             |
+| `statefulset.podAffinity`                        | [Inter-Pod affinity rules][1] of StatefulSet Pods               | `{}`                                             |
+| `statefulset.podAntiAffinity`                    | [Anti-affinity rules][1] of StatefulSet Pods                    | auto                                             |
+| `statefulset.podAntiAffinity.type`               | Type of auto [anti-affinity rules][1]                           | `soft`                                           |
+| `statefulset.podAntiAffinity.weight`             | Weight for `soft` auto [anti-affinity rules][1]                 | `100`                                            |
+| `statefulset.nodeSelector`                       | Node labels for StatefulSet Pods assignment                     | `{}`                                             |
+| `statefulset.tolerations`                        | Node taints to tolerate by StatefulSet Pods                     | `[]`                                             |
+| `statefulset.resources`                          | Resource requests and limits for StatefulSet Pods               | `{}`                                             |
+| `statefulset.livenessProbe.enabled`              | Whether to use a liveness probe on the StatefulSet pods         | `no`                                             |
+| `statefulset.livenessProbe.initialDelaySeconds`  | Delay after pod starts before liveness probes start             | `30`                                             |
+| `statefulset.livenessProbe.periodSeconds`        | Frequency to send liveness probes to StatefulSet Pods           | `5`                                              |
+| `statefulset.livenessProbe.timeoutSeconds`       | Timeout on liveness probes                                      | `1`                                              |
+| `statefulset.livenessProbe.failureThreshold`     | Consecutive liveness probe failures before container restarts   | `3`                                              |
+| `statefulset.readinesssProbe.enabled`            | Whether to use a readiness probe on the StatefulSet pods        | `yes`                                            |
+| `statefulset.readinessProbe.initialDelaySeconds` | Delay after pod starts before readiness probes start            | `10`                                             |
+| `statefulset.readinessProbe.periodSeconds`       | Frequency to send readiness probes to StatefulSet Pods          | `5`                                              |
+| `statefulset.readinessProbe.timeoutSeconds`      | Timeout on readiness probes                                     | `1`                                              |
+| `statefulset.readinessProbe.failureThreshold`    | Consecutive readiness probe failures before container restarts  | `2`                                              |
+| `service.ports.grpc.external.port`               | CockroachDB primary serving port in Services                    | `26257`                                          |
+| `service.ports.grpc.external.name`               | CockroachDB primary serving port name in Services               | `grpc`                                           |
+| `service.ports.grpc.internal.port`               | CockroachDB inter-communication port in Services                | `26257`                                          |
+| `service.ports.grpc.internal.name`               | CockroachDB inter-communication port name in Services           | `grpc-internal`                                  |
+| `service.ports.http.port`                        | CockroachDB HTTP port in Services                               | `8080`                                           |
+| `service.ports.http.name`                        | CockroachDB HTTP port name in Services                          | `http`                                           |
+| `service.public.type`                            | Public Service type                                             | `ClusterIP`                                      |
+| `service.public.labels`                          | Additional labels of public Service                             | `{"app.kubernetes.io/component": "cockroachdb"}` |
+| `service.public.annotations`                     | Additional annotations of public Service                        | `{}`                                             |
+| `service.discovery.labels`                       | Additional labels of discovery Service                          | `{"app.kubernetes.io/component": "cockroachdb"}` |
+| `service.discovery.annotations`                  | Additional annotations of discovery Service                     | `{}`                                             |
+| `storage.hostPath`                               | Absolute path on host to store data                             | `""`                                             |
+| `storage.persistentVolume.enabled`               | Whether to use PersistentVolume to store data                   | `yes`                                            |
+| `storage.persistentVolume.size`                  | PersistentVolume size                                           | `100Gi`                                          |
+| `storage.persistentVolume.storageClass`          | PersistentVolume class                                          | `""`                                             |
+| `storage.persistentVolume.labels`                | Additional labels of PersistentVolumeClaim                      | `{}`                                             |
+| `storage.persistentVolume.annotations`           | Additional annotations of PersistentVolumeClaim                 | `{}`                                             |
+| `init.labels`                                    | Additional labels of init Job and its Pod                       | `{"app.kubernetes.io/component": "init"}`        |
+| `init.annotations`                               | Additional labels of the Pod of init Job                        | `{}`                                             |
+| `init.affinity`                                  | [Affinity rules][2] of init Job Pod                             | `{}`                                             |
+| `init.nodeSelector`                              | Node labels for init Job Pod assignment                         | `{}`                                             |
+| `init.tolerations`                               | Node taints to tolerate by init Job Pod                         | `[]`                                             |
+| `init.resources`                                 | Resource requests and limits for the Pod of init Job            | `{}`                                             |
+| `tls.enabled`                                    | Whether to run securely using TLS certificates                  | `no`                                             |
+| `tls.serviceAccount.create`                      | Whether to create a new RBAC service account                    | `yes`                                            |
+| `tls.serviceAccount.name`                        | Name of RBAC service account to use                             | `""`                                             |
+| `tls.certs.provided`                             | Bring your own certs scenario, i.e certificates are provided    | `no`                                             |
+| `tls.certs.clientRootSecret`                     | If certs are provided, secret name for client root cert         | `cockroachdb-root`                               |
+| `tls.certs.nodeSecret`                           | If certs are provided, secret name for node cert                | `cockroachdb-node`                               |
+| `tls.certs.tlsSecret`                            | Own certs are stored in TLS secret                              | `no`                                             |
+| `tls.init.image.repository`                      | Image to use for requesting TLS certificates                    | `cockroachdb/cockroach-k8s-request-cert`         |
+| `tls.init.image.tag`                             | Image tag to use for requesting TLS certificates                | `0.4`                                            |
+| `tls.init.image.pullPolicy`                      | Requesting TLS certificates container pull policy               | `IfNotPresent`                                   |
+| `tls.init.image.credentials`                     | `registry`, `user` and `pass` credentials to pull private image | `{}`                                             |
+| `networkPolicy.enabled`                          | Enable NetworkPolicy for CockroachDB's Pods                     | `no`                                             |
+| `networkPolicy.ingress.grpc`                     | Whitelist resources to access gRPC port of CockroachDB's Pods   | `[]`                                             |
+| `networkPolicy.ingress.http`                     | Whitelist resources to access gRPC port of CockroachDB's Pods   | `[]`                                             |
 
 Override the default parameters using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/cockroachdb/templates/statefulset.yaml
+++ b/stable/cockroachdb/templates/statefulset.yaml
@@ -235,6 +235,7 @@ spec:
               mountPath: {{ printf "/etc/cockroach/secrets/%s" . | quote }}
               readOnly: true
           {{- end }}
+          {{- if .Values.statefulset.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /health
@@ -242,8 +243,12 @@ spec:
             {{- if .Values.tls.enabled }}
               scheme: HTTPS
             {{- end }}
-            initialDelaySeconds: 30
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.statefulset.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.statefulset.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.statefulset.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.statefulset.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.statefulset.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /health?ready=1
@@ -251,9 +256,11 @@ spec:
             {{- if .Values.tls.enabled }}
               scheme: HTTPS
             {{- end }}
-            initialDelaySeconds: 10
-            periodSeconds: 5
-            failureThreshold: 2
+            initialDelaySeconds: {{ .Values.statefulset.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.statefulset.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.statefulset.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.statefulset.readinessProbe.failureThreshold }}
+          {{- end }}
         {{- with .Values.statefulset.resources }}
           resources: {{- toYaml . | nindent 12 }}
         {{- end }}

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -202,6 +202,23 @@ statefulset:
     #   cpu: 100m
     #   memory: 512Mi
 
+  # Controls settings for the liveness probe. We recommend against using a
+  # liveness probe with CockroachDB. See https://github.com/cockroachdb/cockroach/issues/44832
+  # further discussion.
+  livenessProbe:
+    enabled: no
+    initialDelaySeconds: 30
+    periodSeconds: 5
+    timeoutSeconds: 1
+    failureThreshold: 3
+
+  # Controls settings for the readiness probe.
+  readinessProbe:
+    enabled: yes
+    initialDelaySeconds: 10
+    periodSeconds: 5
+    timeoutSeconds: 1
+    failureThreshold: 2
 
 service:
   ports:


### PR DESCRIPTION
This makes our liveness and readiness probes more configurable. You can adjust
whether or not to enable them, and what the `failureThreshold`,
`initialDelayseconds`, `periodSeconds`, and `timeoutSeconds` are for each of
them.

This also removes the liveness probes by default.
In https://github.com/cockroachdb/cockroach/issues/#44832, we mostly
reached an agreement that the liveness probe is doing more harm than good.
There is still some disagreement about whether other failure conditions, such
as disk stalls, are better served by having CockroachDB detect them itself or
by detecting them in a separate process responsible for running the liveness
probe. Either way, that is not what the current liveness probe is doing.

The readiness probe has been left as-is for now.

Signed-off-by: Joel Kenny <joel@cockroachlabs.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
