### PR TITLE
[stable/cockroachdb] Added priorityClassName configuration option

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 3.0.7
+version: 3.1.0
 appVersion: 19.2.5
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -262,6 +262,7 @@ For details see the [`values.yaml`](values.yaml) file.
 | `statefulset.podAntiAffinity.type`       | Type of auto [anti-affinity rules][1]                           | `soft`                                           |
 | `statefulset.podAntiAffinity.weight`     | Weight for `soft` auto [anti-affinity rules][1]                 | `100`                                            |
 | `statefulset.nodeSelector`               | Node labels for StatefulSet Pods assignment                     | `{}`                                             |
+| `statefulset.priorityClassName`          | [PriorityClassName][4] for StatefulSet Pods                     | `""`                                          |
 | `statefulset.tolerations`                | Node taints to tolerate by StatefulSet Pods                     | `[]`                                             |
 | `statefulset.resources`                  | Resource requests and limits for StatefulSet Pods               | `{}`                                             |
 | `service.ports.grpc.external.port`       | CockroachDB primary serving port in Services                    | `26257`                                          |
@@ -461,3 +462,4 @@ Note, that if you are running in secure mode (`tls.enabled` is `yes`/`true`) and
 [1]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity
 [2]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity
 [3]: https://cert-manager.io/
+[4]: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass

--- a/stable/cockroachdb/templates/statefulset.yaml
+++ b/stable/cockroachdb/templates/statefulset.yaml
@@ -134,6 +134,9 @@ spec:
     {{- with .Values.statefulset.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if .Values.statefulset.priorityClassName }}
+      priorityClassName: {{ .Values.statefulset.priorityClassName }}
+    {{- end }}
       # No pre-stop hook is required, a SIGTERM plus some time is all that's
       # needed for graceful shutdown of a node.
       terminationGracePeriodSeconds: 60

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -191,6 +191,10 @@ statefulset:
   # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []
 
+  # PriorityClassName given to Pods of this StatefulSet
+  # https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+  priorityClassName: ""
+
   # Uncomment the following resources definitions or pass them from
   # command line to control the CPU and memory resources allocated
   # by Pods of this StatefulSet.


### PR DESCRIPTION
Signed-off-by: David Losert <david.losert@gmx.de>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
no 

#### What this PR does / why we need it:
This PR introduces the ability to set the optional `priorityClassName` field for `Pods` of the `StatefulSet`.

We were missing this option in our workflow, and I think it makes senseto be able to set a higher priority for Database pods 😃 

#### Which issue this PR fixes
no issue opened for this :)

#### Special notes for your reviewer:
@a-robinson , @DuskEagle , @joshimhoff , @keith-mcclellan 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
