### PR TITLE
[stable/external-dns] Added custom volume support

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.19.2
+version: 2.20.0
 appVersion: 0.6.0
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -176,6 +176,8 @@ The following table lists the configurable parameters of the external-dns chart 
 | `resources`                         | CPU/Memory resource requests/limits.                                                                     | `{}`                                                        |
 | `livenessProbe`                     | Deployment Liveness Probe                                                                                | See `values.yaml`                                           |
 | `readinessProbe`                    | Deployment Readiness Probe                                                                               | See `values.yaml`                                           |
+| `extraVolumes`                      | A list of volumes to be added to the pod                                                                 | `[]`                                                        |
+| `extraVolumeMounts`                 | A list of volume mounts to be added to the pod                                                           | `[]`                                                        |
 | `metrics.enabled`                   | Enable prometheus to access external-dns metrics endpoint                                                | `false`                                                     |
 | `metrics.podAnnotations`            | Annotations for enabling prometheus to access the metrics endpoint                                       |                                                             |
 | `metrics.serviceMonitor.enabled`    | Create ServiceMonitor object                                                                             | `false`                                                     |

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -424,6 +424,10 @@ spec:
           mountPath: /transip
           readOnly: true
         {{- end }}
+        # Extra volume mount(s)
+        {{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+        {{- end }}
       volumes:
       # AWS volume(s)
       {{- if and (eq .Values.provider "aws") (or (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey) .Values.aws.credentials.secretName) }}
@@ -481,4 +485,8 @@ spec:
       - name: transip-api-key
         secret:
           name: {{ template "external-dns.fullname" . }}
+      {{- end }}
+      # Extra volume(s)
+      {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
       {{- end }}

--- a/stable/external-dns/values-production.yaml
+++ b/stable/external-dns/values-production.yaml
@@ -105,7 +105,7 @@ aws:
   preferCNAME: ""
   ## Enable AWS evaluation of target health. Available values are: true, false
   ##
-  evaluateTargetHealth: ""  
+  evaluateTargetHealth: ""
 
 ## Azure configuration to be set via arguments/env. variables
 ##
@@ -470,6 +470,12 @@ readinessProbe:
   timeoutSeconds: 5
   failureThreshold: 6
   successThreshold: 1
+
+## Configure extra volumes
+extraVolumes: []
+
+## Configure extra volumeMounts
+extraVolumeMounts: []
 
 ## Prometheus Exporter / Metrics
 ##

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -482,6 +482,12 @@ readinessProbe:
   failureThreshold: 6
   successThreshold: 1
 
+## Configure extra volumes
+extraVolumes: []
+
+## Configure extra volumeMounts
+extraVolumeMounts: []
+
 ## Prometheus Exporter / Metrics
 ##
 metrics:


### PR DESCRIPTION
Signed-off-by: Dan Sexton <dan.b.sexton@gmail.com>

#### Is this a new chart

No

#### What this PR does / why we need it:

This allows for mounting arbitrary volumes to external-dns, such as CA certificates. 

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
