### PR TITLE
[stable/prometheus] Set rollingUpdate to null when strategy is Recreate

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.0.1
+version: 11.0.2
 appVersion: 2.16.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -178,6 +178,7 @@ Parameter | Description | Default
 `alertmanager.service.servicePort` | alertmanager service port | `80`
 `alertmanager.service.sessionAffinity` | Session Affinity for alertmanager service, can be `None` or `ClientIP` | `None`
 `alertmanager.service.type` | type of alertmanager service to create | `ClusterIP`
+`alertmanager.strategy` | Deployment strategy | `{ "type": "RollingUpdate" }`
 `alertmanagerFiles.alertmanager.yml` | Prometheus alertmanager configuration | example configuration
 `configmapReload.prometheus.enabled` | If false, the configmap-reload container for Prometheus will not be deployed | `true`
 `configmapReload.prometheus.name` | configmap-reload container name | `configmap-reload`
@@ -271,7 +272,7 @@ Parameter | Description | Default
 `pushgateway.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 `pushgateway.service.servicePort` | pushgateway service port | `9091`
 `pushgateway.service.type` | type of pushgateway service to create | `ClusterIP`
-`pushgateway.strategy.type` | Deployment strategy | `{ "type": "RollingUpdate" }`
+`pushgateway.strategy` | Deployment strategy | `{ "type": "RollingUpdate" }`
 `rbac.create` | If true, create & use RBAC resources | `true`
 `server.enabled` | If false, Prometheus server will not be created | `true`
 `server.name` | Prometheus server container name | `server`
@@ -350,6 +351,7 @@ Parameter | Description | Default
 `server.service.statefulsetReplica.enabled` | If true, send the traffic from the service to only one replica of the replicaset | `false`
 `server.service.statefulsetReplica.replica` | Which replica to send the traffice to | `0`
 `server.sidecarContainers` | array of snippets with your sidecar containers for prometheus server | `""`
+`server.strategy` | Deployment strategy | `{ "type": "RollingUpdate" }`
 `serviceAccounts.alertmanager.create` | If true, create the alertmanager service account | `true`
 `serviceAccounts.alertmanager.name` | name of the alertmanager service account to use or create | `{{ prometheus.alertmanager.fullname }}`
 `serviceAccounts.kubeStateMetrics.create` | If true, create the kubeStateMetrics service account | `true`

--- a/stable/prometheus/templates/alertmanager-deployment.yaml
+++ b/stable/prometheus/templates/alertmanager-deployment.yaml
@@ -10,9 +10,12 @@ spec:
     matchLabels:
       {{- include "prometheus.alertmanager.matchLabels" . | nindent 6 }}
   replicas: {{ .Values.alertmanager.replicaCount }}
-  {{- if .Values.server.strategy }}
+  {{- if .Values.alertmanager.strategy }}
   strategy:
-{{ toYaml .Values.server.strategy | indent 4 }}
+{{ toYaml .Values.alertmanager.strategy | indent 4 }}
+  {{- if eq .Values.alertmanager.strategy.type "Recreate" }}
+  rollingUpdate: null
+  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/stable/prometheus/templates/pushgateway-deployment.yaml
+++ b/stable/prometheus/templates/pushgateway-deployment.yaml
@@ -16,6 +16,9 @@ spec:
   {{- if .Values.pushgateway.strategy }}
   strategy:
 {{ toYaml .Values.pushgateway.strategy | indent 4 }}
+  {{- if eq .Values.pushgateway.strategy.type "Recreate" }}
+  rollingUpdate: null
+  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -18,6 +18,9 @@ spec:
   {{- if .Values.server.strategy }}
   strategy:
 {{ toYaml .Values.server.strategy | indent 4 }}
+  {{- if eq .Values.server.strategy.type "Recreate" }}
+  rollingUpdate: null
+  {{- end }}
   {{- end }}
   template:
     metadata:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

1) Improve documentation on strategy parameters.

2) Document & use alertmanager.strategy.type, which was present in
   values.yaml but unused. Alertmanager was previous using server.strategy

3) Set strategy.rollingUpdate to null when strategy.type is 'Recreate'.
   This is necessary to prevent the following error on an upgrade
   switching the strategy type from 'RollingUpdate' to 'Recreate':

   ```
   UPGRADE FAILED: Deployment.apps "prometheus-server" is invalid:
   spec.strategy.rollingUpdate: Forbidden: may not be specified
   when strategy `type` is 'Recreate'
   ```

#### Special notes for your reviewer:

This might be a backwards incompatible change if people relied on server.strategy.type to set alertmanager's deployment strategy. If you believe this is the case, I might need to bump the major version.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)