### PR TITLE
[incubator/zookeeper] Change the default value of initLimit & syncLimit

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 2.1.3
+version: 2.1.4
 appVersion: 3.5.5
 kubeVersion: "^1.10.0-0"
 description: Centralized service for maintaining configuration information, naming,

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -259,7 +259,7 @@ env:
 
   ## The number of Ticks that an ensemble member is allowed to perform leader
   ## election.
-  ZOO_INIT_LIMIT: 5
+  ZOO_INIT_LIMIT: 10
 
   ZOO_TICK_TIME: 2000
 
@@ -268,7 +268,7 @@ env:
   ZOO_MAX_CLIENT_CNXNS: 60
 
   ## The number of Tick by which a follower may lag behind the ensembles leader.
-  ZK_SYNC_LIMIT: 10
+  ZK_SYNC_LIMIT: 5
 
   ## The number of wall clock ms that corresponds to a Tick for the ensembles
   ## internal time.


### PR DESCRIPTION
Change the default value of  initLimit & syncLimit

#### Is this a new chart
No.

#### What this PR does / why we need it:
The default setting of "initLimit" & "syncLimit" don't look quite right.
It's more reasonable for "initLimit" to be set larger than "syncLimit"

#### Which issue this PR fixes
*N/A

#### Special notes for your reviewer:
See the default values set in zookeeper official Docker image: 
https://github.com/31z4/zookeeper-docker/blob/master/3.4.14/Dockerfile
https://github.com/31z4/zookeeper-docker/blob/master/3.5.7/Dockerfile

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
