### PR TITLE
[stable/atlantis] Updating AWS to not require 'credentials' for use with IRSA

### DIFF
--- a/stable/atlantis/Chart.yaml
+++ b/stable/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.11.1"
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 3.11.0
+version: 3.11.1
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/stable/atlantis/templates/secret-aws.yaml
+++ b/stable/atlantis/templates/secret-aws.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.aws}}
+{{- if .Values.aws -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,6 +9,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  credentials: {{ .Values.aws.credentials | b64enc }}
-  config: {{ .Values.aws.config | b64enc }}
+{{- if .Values.aws.credentials }}
+  credentials: {{ toYaml .Values.aws.credentials | b64enc }}
 {{- end }}
+{{- if .Values.aws.config }}
+  config: {{ toYaml .Values.aws.config | b64enc }}
+{{- end }}
+{{- end -}}

--- a/stable/atlantis/templates/secret-aws.yaml
+++ b/stable/atlantis/templates/secret-aws.yaml
@@ -12,7 +12,5 @@ data:
 {{- if .Values.aws.credentials }}
   credentials: {{ toYaml .Values.aws.credentials | b64enc }}
 {{- end }}
-{{- if .Values.aws.config }}
-  config: {{ toYaml .Values.aws.config | b64enc }}
-{{- end }}
+  config: {{ .Values.aws.config | b64enc }}
 {{- end -}}

--- a/stable/atlantis/templates/statefulset.yaml
+++ b/stable/atlantis/templates/statefulset.yaml
@@ -258,7 +258,7 @@ spec:
             readOnly: true
             mountPath: /etc/secret-gitconfig
           {{- end }}
-          {{- if or .Values.aws .Values.awsSecretName}}
+          {{- if or .Values.aws .Values.awsSecretName }}
           - name: aws-volume
             readOnly: true
             mountPath: /home/atlantis/.aws


### PR DESCRIPTION
Signed-off-by: Scott Crooks <scott.crooks@gmail.com>

#### What this PR does / why we need it

Updates the AWS `credentials` field to be optional. This is needed since with [IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) / [Kube2Iam](https://github.com/jtblin/kube2iam) / [KIAM](https://github.com/uswitch/kiam), a set of static AWS credentials is **_not_** needed since you can use an IAM role as a credentials source, which means you would only need the `aws.config` section.

Specifially for IRSA, an associated service account annotation like so would work:

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME
```

#### Which issue this PR fixes

N/A. I ran into this personally, and it needed a fix.

#### Special notes for your reviewer:

I tested this out locally, and since it's just checking for the presence of `aws.config` and `aws.credentials`, this is just a fix release since current implementations should not be broken.

#### Checklist

- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
