### PR TITLE
[stable/postgresql] Revert #21236

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 8.6.0
+version: 8.6.1
 appVersion: 11.7.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/_helpers.tpl
+++ b/stable/postgresql/templates/_helpers.tpl
@@ -40,18 +40,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Return the appropriate apiVersion for networkpolicy.
 */}}
 {{- define "postgresql.networkPolicy.apiVersion" -}}
-{{- if semverCompare ">=1.4-0, <1.7-0" (include "postgresql.kubernetesVersion" .)  -}}
+{{- if semverCompare ">=1.4-0, <1.7-0" .Capabilities.KubeVersion.GitVersion -}}
 "extensions/v1beta1"
-{{- else if semverCompare "^1.7-0" (include "postgresql.kubernetesVersion" .) -}}
+{{- else if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion -}}
 "networking.k8s.io/v1"
 {{- end -}}
-{{- end -}}
-
-{{/*
-Return the kubernetes semantic version.
-*/}}
-{{- define "postgresql.kubernetesVersion" -}}
-{{ (default .Capabilities.KubeVersion.GitVersion .Capabilities.KubeVersion.String) }}
 {{- end -}}
 
 {{/*
@@ -393,7 +386,7 @@ Usage:
 Return the appropriate apiVersion for statefulset.
 */}}
 {{- define "postgresql.statefulset.apiVersion" -}}
-{{- if semverCompare "<1.14-0" (include "postgresql.kubernetesVersion" .) -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "apps/v1beta2" -}}
 {{- else -}}
 {{- print "apps/v1" -}}


### PR DESCRIPTION
Revert https://github.com/helm/charts/pull/21236 because it produces the following error in Helm 2:
```
Error: parse error in "kubeapps/charts/postgresql/templates/_helpers.tpl": template: kubeapps/charts/postgresql/templates/_helpers.tpl:43: illegal number syntax: "-"
```

We will test it more carefully after the weekend.