### PR TITLE
[stable/postgres] fix credetials for initdbScripts

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 8.6.2
+version: 8.6.3
 appVersion: 11.7.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -146,13 +146,13 @@ spec:
             - name: POSTGRES_INITDB_WALDIR
               value: {{ .Values.postgresqlInitdbWalDir | quote }}
             {{- end }}
-            {{- if .Values.initdbUser }}
+            {{- if .Values.initdbUsername }}
             - name: POSTGRESQL_INITSCRIPTS_USERNAME
-              value: {{ .Values.initdbUser }}
+              value: {{ .Values.initdbUsername }}
             {{- end }}
             {{- if .Values.initdbPassword }}
             - name: POSTGRESQL_INITSCRIPTS_PASSWORD
-              value: .Values.initdbPassword
+              value: {{ .Values.initdbPassword }}
             {{- end }}
             {{- if .Values.persistence.mountPath }}
             - name: PGDATA

--- a/stable/postgresql/values-production.yaml
+++ b/stable/postgresql/values-production.yaml
@@ -201,7 +201,7 @@ extraEnv: []
 #      echo "Do something."
 
 ## Specify the PostgreSQL username and password to execute the initdb scripts
-# initdbUser:
+# initdbUsername:
 # initdbPassword:
 
 ## ConfigMap with scripts to be run at first boot

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -210,7 +210,7 @@ extraEnv: []
 # initdbScriptsSecret:
 
 ## Specify the PostgreSQL username and password to execute the initdb scripts
-# initdbUser:
+# initdbUsername:
 # initdbPassword:
 
 ## Optional duration in seconds the pod needs to terminate gracefully.


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix wrong passing password for ```initdbScrints``` and sync username value for initdbScripts with ```README.md```.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
