### PR TITLE
[stable/rabbitmq] Move chart to distributed bitnami repository

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -13,4 +13,5 @@ home: https://www.rabbitmq.com
 icon: https://bitnami.com/assets/stacks/rabbitmq/img/rabbitmq-stack-220x234.png
 sources:
 - https://github.com/bitnami/bitnami-docker-rabbitmq
+maintainers: []
 engine: gotpl

--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,8 +1,10 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.18.1
+version: 6.18.2
 appVersion: 3.8.2
-description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
+# The rabbitmq chart is deprecated and no longer maintained. For details deprecation, see the PROCESSES.md file.
+deprecated: true
+description: DEPRECATED Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:
 - rabbitmq
 - message queue
@@ -11,9 +13,4 @@ home: https://www.rabbitmq.com
 icon: https://bitnami.com/assets/stacks/rabbitmq/img/rabbitmq-stack-220x234.png
 sources:
 - https://github.com/bitnami/bitnami-docker-rabbitmq
-maintainers:
-- name: Bitnami
-  email: containers@bitnami.com
-- name: desaintmartin
-  email: cedric@desaintmartin.fr
 engine: gotpl

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -6,7 +6,7 @@
 
 Given the [`stable` deprecation timeline](https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained RabbitMQ Helm chart is now located at [bitnami/charts](https://github.com/bitnami/charts/).
 
-The Bitnami repository is already included in the Hubs and we will provide, at least, the same cadence of updates, support, etc that we've been keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installation (`bitnami/<chart>` instead of `stable/<chart>`)
+The Bitnami repository is already included in the Hubs and we will continue providing the same cadence of updates, support, etc that we've been keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installation (`bitnami/<chart>` instead of `stable/<chart>`)
 
 ```bash
 $ helm repo add bitnami https://charts.bitnami.com/bitnami

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -2,6 +2,27 @@
 
 [RabbitMQ](https://www.rabbitmq.com/) is an open source message broker software that implements the Advanced Message Queuing Protocol (AMQP).
 
+## This Helm chart is deprecated
+
+Given the [`stable` deprecation timeline](https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained RabbitMQ Helm chart is now located at [bitnami/charts](https://github.com/bitnami/charts/).
+
+The Bitnami repository is already included in the Hubs and we will provide, at least, the same cadence of updates, support, etc that we've been keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installation (`bitnami/<chart>` instead of `stable/<chart>`)
+
+```bash
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm install my-release bitnami/<chart>           # Helm 3
+$ helm install --name my-release bitnami/<chart>    # Helm 2
+```
+
+To update an exisiting _stable_ deployment with a chart hosted in the bitnami repository you can execute
+
+```bash
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm upgrade my-release bitnami/<chart>
+```
+
+Issues and PRs related to the chart itself will be redirected to `bitnami/charts` GitHub repository. In the same way, we'll be happy to answer questions related to this migration process in [this issue](https://github.com/helm/charts/issues/20969) created as a common place for discussion.
+
 ## TL;DR;
 
 ```bash

--- a/stable/rabbitmq/templates/NOTES.txt
+++ b/stable/rabbitmq/templates/NOTES.txt
@@ -2,7 +2,7 @@ This Helm chart is deprecated
 
 Given the `stable` deprecation timeline (https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained RabbitMQ Helm chart is now located at bitnami/charts (https://github.com/bitnami/charts/).
 
-The Bitnami repository is already included in the Hubs and we will provide, at least, the same cadence of updates, support, etc that we've been keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installation (`bitnami/<chart>` instead of `stable/<chart>`)
+The Bitnami repository is already included in the Hubs and we will continue providing the same cadence of updates, support, etc that we've been keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installation (`bitnami/<chart>` instead of `stable/<chart>`)
 
 ```bash
 $ helm repo add bitnami https://charts.bitnami.com/bitnami

--- a/stable/rabbitmq/templates/NOTES.txt
+++ b/stable/rabbitmq/templates/NOTES.txt
@@ -1,3 +1,21 @@
+This Helm chart is deprecated
+
+Given the `stable` deprecation timeline (https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained RabbitMQ Helm chart is now located at bitnami/charts (https://github.com/bitnami/charts/).
+
+The Bitnami repository is already included in the Hubs and we will provide, at least, the same cadence of updates, support, etc that we've been keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installation (`bitnami/<chart>` instead of `stable/<chart>`)
+
+```bash
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm install my-release bitnami/<chart>           # Helm 3
+$ helm install --name my-release bitnami/<chart>    # Helm 2
+```
+
+To update an exisiting _stable_ deployment with a chart hosted in the bitnami repository you can execute
+ ```bash                                                                                                                                                                                                                                                                                                                                                                    $ helm repo add bitnami https://charts.bitnami.com/bitnami
+ $ helm upgrade my-release bitnami/<chart>
+```
+
+Issues and PRs related to the chart itself will be redirected to `bitnami/charts` GitHub repository. In the same way, we'll be happy to answer questions related to this migration process in this issue (https://github.com/helm/charts/issues/20969) created as a common place for discussion.
 
 ** Please be patient while the chart is being deployed **
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Given the [`stable` deprecation timeline](https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained RabbitMQ Helm chart is now located at [bitnami/charts](https://github.com/bitnami/charts/).

Please, use [this issue](https://github.com/helm/charts/issues/20969) for common questions about the migration/deprecation process, for PR/Issues related to the chart itself, please visit the [bitnami/charts](https://github.com/bitnami/charts/) GitHub repository.
 
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
