### PR TITLE
[stable/cluster-autoscaler] ClusterRole leases and version bump to 1.17.1

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 7.0.0
-appVersion: 1.14.6
+version: 7.1.0
+appVersion: 1.17.1
 home: https://github.com/kubernetes/autoscaler
 sources:
 - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler

--- a/stable/cluster-autoscaler/README.md
+++ b/stable/cluster-autoscaler/README.md
@@ -2,6 +2,8 @@
 
 [The cluster autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) scales worker nodes within an AWS autoscaling group (ASG) or Spotinst Elastigroup.
 
+Cluster Autoscaler version: **v1.17.1**
+
 ## TL;DR:
 
 ```console

--- a/stable/cluster-autoscaler/templates/clusterrole.yaml
+++ b/stable/cluster-autoscaler/templates/clusterrole.yaml
@@ -66,6 +66,16 @@ rules:
       - list
       - get
   - apiGroups:
+    - batch
+    - extensions
+    resources:
+    - jobs
+    verbs:
+    - get
+    - list
+    - patch
+    - watch
+  - apiGroups:
       - extensions
     resources:
       - replicasets
@@ -107,6 +117,21 @@ rules:
     verbs:
       - list
       - watch
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - create
+  - apiGroups:
+    - coordination.k8s.io
+    resourceNames:
+    - cluster-autoscaler
+    resources:
+    - leases
+    verbs:
+    - get
+    - update
 {{- if .Values.rbac.pspEnabled }}
   - apiGroups:
     - extensions

--- a/stable/cluster-autoscaler/values.yaml
+++ b/stable/cluster-autoscaler/values.yaml
@@ -53,7 +53,7 @@ cloudConfigPath: /etc/gce.conf
 
 image:
   repository: k8s.gcr.io/cluster-autoscaler
-  tag: v1.14.6
+  tag: v1.17.1
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
Signed-off-by: Scott Crooks <scott.crooks@gmail.com>

#### What this PR does / why we need it

Bumps the Cluster Autoscaler version to v1.17.1, and fixes the needed `ClusterRole` to add required `coordination.k8s.io` groups.

#### Which issue this PR fixes
  - fixes #20514 

#### Special notes for your reviewer:

#### Checklist

- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
