### PR TITLE
[stable/datadog] Fix trace agent and useConfigMap

### DIFF
--- a/stable/datadog/CHANGELOG.md
+++ b/stable/datadog/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2.0
 
+## 2.0.3
+
+* Fix templating error when `agents.useConfigMap` is set to true.
+* Add DD_APM_ENABLED environment variable to trace agent container.
+
 ## 2.0.2
 
 * Revert the docker socket path inside the agent container to its standard location to fix #21223

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.0.2
+version: 2.0.3
 appVersion: "7"
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/container-trace-agent.yaml
+++ b/stable/datadog/templates/container-trace-agent.yaml
@@ -14,6 +14,8 @@
     {{- include "containers-common-env" . | nindent 4 }}
     - name: DD_LOG_LEVEL
       value: {{ .Values.agents.containers.traceAgent.logLevel | default .Values.datadog.logLevel | quote }}
+    - name: DD_APM_ENABLED
+      value: "true"
     - name: DD_APM_NON_LOCAL_TRAFFIC
       value: "true"
     - name: DD_APM_RECEIVER_PORT

--- a/stable/datadog/templates/datadog-yaml-configmap.yaml
+++ b/stable/datadog/templates/datadog-yaml-configmap.yaml
@@ -35,7 +35,7 @@ data:
       max_memory: 0
       max_cpu_percent: 0
 
-    {{- $version := (.Values.image.tag | toString | trimSuffix "-jmx") }}
+    {{- $version := (.Values.agents.image.tag | toString | trimSuffix "-jmx") }}
     {{- $length := len (split "." $version ) -}} 
     {{- if and (eq $length 1) (ge $version "6") -}}
     {{- $version := "6.15" }}  


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:

Version 2.0.0 of the stable/datadog introduced new issues.

1. If `agents.useConfigMap` is set to to true, it causes a templating error because `.Values.image` no longer exists.

```
Error: template: datadog/templates/datadog-yaml-configmap.yaml:38:28: executing "datadog/templates/datadog-yaml-configmap.yaml" at <.Values.image.tag>: nil pointer evaluating interface {}.tag
```

2. If `agents.useConfigMap` is false and `agents.apm.enabled` is true, the Datadog trace agent container fails to startup with this error:

```
trace-agent not enabled. Set the environment variable DD_APM_ENABLED=true or add "apm_config.enabled: true" entry to your datadog.yaml. Exiting...
```

#### Special notes for your reviewer:

Recreating this PR from https://github.com/helm/charts/pull/21118 due to issues rebasing my branch.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
