### PR TITLE
[stable/unifi] hotfix: fixing ingress name + nodePorts references

### DIFF
--- a/stable/unifi/Chart.yaml
+++ b/stable/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 5.11.50
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 0.6.2
+version: 0.6.3
 keywords:
   - ubiquiti
   - unifi

--- a/stable/unifi/templates/captive-svc.yaml
+++ b/stable/unifi/templates/captive-svc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "unifi.fullname" . }}-captivePortalService
+  name: {{ template "unifi.fullname" . }}-captiveportalservice
   labels:
     app.kubernetes.io/name: {{ include "unifi.name" . }}
     helm.sh/chart: {{ include "unifi.chart" . }}
@@ -45,15 +45,15 @@ spec:
       targetPort: captive-http
       protocol: TCP
       name: captive-http
-{{ if (and (eq .Values.captivePortalService.type "NodePort") (not (empty .Values.captivePortalService.nodePorts.http))) }}
-      nodePort: {{.Values.captivePortalService.nodePorts.http}}
+{{ if (and (eq .Values.captivePortalService.type "NodePort") (not (empty .Values.captivePortalService.http))) }}
+      nodePort: {{.Values.captivePortalService.http}}
 {{ end }}
     - port: {{ .Values.captivePortalService.https }}
       targetPort: captive-https
       protocol: TCP
       name: captive-https
-{{ if (and (eq .Values.captivePortalService.type "NodePort") (not (empty .Values.captivePortalService.nodePorts.https))) }}
-      nodePort: {{.Values.captivePortalService.nodePorts.https}}
+{{ if (and (eq .Values.captivePortalService.type "NodePort") (not (empty .Values.captivePortalService.https))) }}
+      nodePort: {{.Values.captivePortalService.https}}
 {{ end }}
   selector:
     app.kubernetes.io/name: {{ include "unifi.name" . }}

--- a/stable/unifi/templates/unified-svc.yaml
+++ b/stable/unifi/templates/unified-svc.yaml
@@ -75,14 +75,14 @@ spec:
       protocol: TCP
       targetPort: captive-http
 {{ if (and (eq .Values.unifiedService.type "NodePort") (not (empty .Values.captivePortalService.http))) }}
-      nodePort: {{.Values.captivePortalService.nodePorts.http}}
+      nodePort: {{.Values.captivePortalService.http}}
 {{ end }}
     - name: captive-https
       port: {{ .Values.captivePortalService.https }}
       protocol: TCP
       targetPort: captive-https
 {{ if (and (eq .Values.unifiedService.type "NodePort") (not (empty .Values.captivePortalService.https))) }}
-      nodePort: {{.Values.captivePortalService.nodePorts.https}}
+      nodePort: {{.Values.captivePortalService.https}}
 {{ end }}
 {{ end }}
 

--- a/stable/unifi/values.yaml
+++ b/stable/unifi/values.yaml
@@ -62,14 +62,11 @@ guiService:
 captivePortalService:
   enabled: false
   type: ClusterIP
-  http: 8880
-  https: 8843
   ## Specify the nodePort value for the LoadBalancer and NodePort service types.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
   ##
-  # nodePort:
-  #   http: 8880
-  #   https: 8843
+  http: 8880
+  https: 8843
   ## Provide any additional annotations which may be required. This can be used to
   ## set the LoadBalancer service type to internal only.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer


### PR DESCRIPTION
Signed-off-by: Arno <arno.du@orange.fr>

This should be reviewed fast, this is only a hotfix with a few changes.

#### Is this a new chart
Nope.

#### What this PR does / why we need it:
Some mistakes were still in, preventing the deployment in some cases

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

@billimek 
@mcronce 