### PR TITLE
[stable/unifi] Ingress was not referring to the good service

### DIFF
--- a/stable/unifi/Chart.yaml
+++ b/stable/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 5.11.50
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 0.6.3
+version: 0.6.4
 keywords:
   - ubiquiti
   - unifi

--- a/stable/unifi/templates/captive-ingress.yaml
+++ b/stable/unifi/templates/captive-ingress.yaml
@@ -33,7 +33,7 @@ spec:
         paths:
           - path: {{ $ingressPath }}
             backend:
-              serviceName: {{ $fullName }}-captivePortalService
+              serviceName: {{ $fullName }}-captiveportalservice
               servicePort: captive-http
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Arno <arno.du@orange.fr>

#### What this PR does / why we need it:

Since I changed the service name, the ingress was still referring to the old one, outputing an error.


#### Special notes for your reviewer:

I'm really unprofessionnal. I can't test with my current environnement, creating all these errors. I apologize, and try to fix these as fast as possible. Hope this is the last one of this kind.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
