### PR TITLE
[stable/kube-state-metrics] Allow use of PodSecurityPolicies in ClusterRole if podSecurityPolicy.enabled=true

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - monitoring
 - prometheus
 - kubernetes
-version: 2.8.12
+version: 2.8.13
 appVersion: 1.9.7
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/templates/clusterrole.yaml
+++ b/stable/kube-state-metrics/templates/clusterrole.yaml
@@ -177,4 +177,15 @@ rules:
     - verticalpodautoscalers
   verbs: ["list", "watch"]
 {{ end -}}
+{{ if .Values.podSecurityPolicy.enabled }}
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+{{- if semverCompare "> 1.15.0-0" $kubeTargetVersion }}
+- apiGroups: ['policy']
+{{- else }}
+- apiGroups: ['extensions']
+{{- end }}
+  resources:
+    - podsecuritypolicies
+  verbs: ["use"]
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
Allows access to `PodSecurityPolicy` if enabled by allowing it in the `ClusterRole`. If this is not added Pod creation fails on K8s >= 1.16.

#### Which issue this PR fixes
./.

#### Special notes for your reviewer:
./.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
