### PR TITLE
[stable/kube-state-metrics] Add PodDisruptionBudget

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - monitoring
 - prometheus
 - kubernetes
-version: 2.8.1
+version: 2.8.2
 appVersion: 1.9.5
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -38,6 +38,7 @@ $ helm install stable/kube-state-metrics
 | `affinity`                                   | Affinity settings for pod assignment                                                  | {}                                         |
 | `tolerations`                                | Tolerations for pod assignment                                                        | []                                         |
 | `podAnnotations`                             | Annotations to be added to the pod                                                    | {}                                         |
+| `podDisruptionBudget`                        | Optional PodDisruptionBudget                                                          | {}                                         |
 | `resources`                                  | kube-state-metrics resource requests and limits                                       | {}                                         |
 | `collectors.certificatesigningrequests`      | Enable the certificatesigningrequests collector.                                      | `true`                                     |
 | `collectors.configmaps`                      | Enable the configmaps collector.                                                      | `true`                                     |

--- a/stable/kube-state-metrics/templates/pdb.yaml
+++ b/stable/kube-state-metrics/templates/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "kube-state-metrics.fullname" . }}
+  namespace: {{ template "kube-state-metrics.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
+{{ toYaml .Values.podDisruptionBudget | indent 2 }}
+{{- end -}}

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -86,6 +86,9 @@ podAnnotations: {}
 ## Assign a PriorityClassName to pods if set
 # priorityClassName: ""
 
+# Ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+podDisruptionBudget: {}
+
 # Available collectors for kube-state-metrics. By default all available
 # collectors are enabled.
 collectors:


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
Adds a PodDisruptionBudget so that KSM can be ran with multiple replicas without incurring downtime during cluster maintenance.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
I mostly copied the template, values, and readme descriptions from the metrics-server chart.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
