### PR TITLE
[stable/external-dns] added support if rbac is true then allow options to create or skip se…

### DIFF
--- a/incubator/sparkoperator/Chart.yaml
+++ b/incubator/sparkoperator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sparkoperator
 description: A Helm chart for Spark on Kubernetes operator
-version: 0.6.6
+version: 0.6.7
 appVersion: v1beta2-1.1.0-2.4.5
 keywords:
   - spark

--- a/incubator/sparkoperator/templates/crds.yaml
+++ b/incubator/sparkoperator/templates/crds.yaml
@@ -1965,7 +1965,6 @@ spec:
       required:
       - metadata
       - spec
-      type: object
   version: v1beta2
   versions:
   - name: v1beta2
@@ -3963,7 +3962,6 @@ spec:
       required:
       - metadata
       - spec
-      type: object
   version: v1beta2
   versions:
   - name: v1beta2

--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 6.2.1
+version: 6.3.0
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -399,6 +399,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `flower.service.type`                    | service type for Flower UI                              | `ClusterIP`               |
 | `flower.service.annotations`             | (optional) service annotations for Flower UI            | `{}`                      |
 | `flower.service.externalPort`            | (optional) external port for Flower UI                  | `5555`                    |
+| `flower.securityContext`                 | (optional) security context for the flower deployment   | `{}`                      |
 | `web.baseUrl`                            | webserver UI URL                                        | `http://localhost:8080`   |
 | `web.resources`                          | custom resource configuration for web pod               | `{}`                      |
 | `web.labels`                             | labels for the web deployment                           | `{}`                      |
@@ -417,10 +418,12 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `web.initialDelaySeconds`                | initial delay on livenessprobe before checking if webserver is available    | `360` |
 | `web.secretsDir`                         | directory in which to mount secrets on webserver nodes  | /var/airflow/secrets      |
 | `web.secrets`                            | secrets to mount as volumes on webserver nodes          | []                        |
+| `web.securityContext`                    | (optional) security context for the web deployment      | `{}`                      |
 | `scheduler.resources`                    | custom resource configuration for scheduler pod         | `{}`                      |
 | `scheduler.labels`                       | labels for the scheduler deployment                     | `{}`                      |
 | `scheduler.annotations`                  | annotations for the scheduler deployment                | `{}`                      |
 | `scheduler.podAnnotations`               | podAnnotations for the scheduler deployment             | `{}`                      |
+| `scheduler.securityContext`              | (optional) security context for the scheduler deployment| `{}`                      |
 | `workers.enabled`                        | enable workers                                          | `true`                    |
 | `workers.replicas`                       | number of workers pods to launch                        | `1`                       |
 | `workers.terminationPeriod`              | gracefull termination period for workers to stop        | `30`                      |
@@ -433,6 +436,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `workers.podAnnotations`                 | annotations for the worker pods                         | `{}`                      |
 | `workers.secretsDir`                     | directory in which to mount secrets on worker nodes     | /var/airflow/secrets      |
 | `workers.secrets`                        | secrets to mount as volumes on worker nodes             | []                        |
+| `workers.securityContext`                 | (optional) security context for the worker statefulSet  | `{}`                      |
 | `nodeSelector`                           | Node labels for pod assignment                          | `{}`                      |
 | `affinity`                               | Affinity labels for pod assignment                      | `{}`                      |
 | `tolerations`                            | Toleration labels for pod assignment                    | `[]`                      |

--- a/stable/airflow/templates/deployments-flower.yaml
+++ b/stable/airflow/templates/deployments-flower.yaml
@@ -55,6 +55,11 @@ spec:
       tolerations:
 {{ toYaml .Values.flower.tolerations | indent 8 }}
       {{- end }}
+      serviceAccountName: {{ template "airflow.serviceAccountName" . }}
+      {{- if .Values.flower.securityContext }}
+      securityContext:
+{{ toYaml .Values.flower.securityContext | indent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-flower
           image: {{ .Values.airflow.image.repository }}:{{ .Values.airflow.image.tag }}

--- a/stable/airflow/templates/deployments-scheduler.yaml
+++ b/stable/airflow/templates/deployments-scheduler.yaml
@@ -68,6 +68,10 @@ spec:
       tolerations:
 {{ toYaml .Values.scheduler.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.scheduler.securityContext }}
+      securityContext:
+{{ toYaml .Values.scheduler.securityContext | indent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "airflow.serviceAccountName" . }}
       {{- if .Values.dags.initContainer.enabled }}
       initContainers:

--- a/stable/airflow/templates/deployments-web.yaml
+++ b/stable/airflow/templates/deployments-web.yaml
@@ -66,6 +66,11 @@ spec:
       tolerations:
 {{ toYaml .Values.web.tolerations | indent 8 }}
       {{- end }}
+      serviceAccountName: {{ template "airflow.serviceAccountName" . }}
+      {{- if .Values.web.securityContext }}
+      securityContext:
+{{ toYaml .Values.web.securityContext | indent 8 }}
+      {{- end }}
       {{- if .Values.dags.initContainer.enabled }}
       initContainers:
         - name: git-clone

--- a/stable/airflow/templates/statefulsets-workers.yaml
+++ b/stable/airflow/templates/statefulsets-workers.yaml
@@ -69,7 +69,10 @@ spec:
       tolerations:
 {{ toYaml .Values.workers.tolerations | indent 8 }}
       {{- end }}
-
+      {{- if .Values.workers.securityContext }}
+      securityContext:
+{{ toYaml .Values.workers.securityContext | indent 8 }}
+      {{- end }}
       {{- if .Values.dags.initContainer.enabled }}
       initContainers:
         - name: git-clone

--- a/stable/atlantis/Chart.yaml
+++ b/stable/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.11.1"
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 3.11.0
+version: 3.11.1
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/stable/atlantis/templates/secret-aws.yaml
+++ b/stable/atlantis/templates/secret-aws.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.aws}}
+{{- if .Values.aws -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,6 +9,8 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  credentials: {{ .Values.aws.credentials | b64enc }}
-  config: {{ .Values.aws.config | b64enc }}
+{{- if .Values.aws.credentials }}
+  credentials: {{ toYaml .Values.aws.credentials | b64enc }}
 {{- end }}
+  config: {{ .Values.aws.config | b64enc }}
+{{- end -}}

--- a/stable/atlantis/templates/statefulset.yaml
+++ b/stable/atlantis/templates/statefulset.yaml
@@ -258,7 +258,7 @@ spec:
             readOnly: true
             mountPath: /etc/secret-gitconfig
           {{- end }}
-          {{- if or .Values.aws .Values.awsSecretName}}
+          {{- if or .Values.aws .Values.awsSecretName }}
           - name: aws-volume
             readOnly: true
             mountPath: /home/atlantis/.aws

--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -7,9 +7,9 @@ keywords:
 - external-dns
 - network
 - dns
-home: https://github.com/kubernetes-incubator/external-dns
+home: https://github.com/kubernetes-sigs/external-dns
 sources:
-- https://github.com/kubernetes-incubator/external-dns
+- https://github.com/kubernetes-sigs/external-dns
 - https://github.com/bitnami/bitnami-docker-external-dns
 maintainers:
 - name: Bitnami

--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,15 +1,15 @@
 apiVersion: v1
 name: external-dns
-version: 2.20.0
+version: 3.0.0
 appVersion: 0.6.0
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:
 - external-dns
 - network
 - dns
-home: https://github.com/kubernetes-sigs/external-dns
+home: https://github.com/kubernetes-incubator/external-dns
 sources:
-- https://github.com/kubernetes-sigs/external-dns
+- https://github.com/kubernetes-incubator/external-dns
 - https://github.com/bitnami/bitnami-docker-external-dns
 maintainers:
 - name: Bitnami

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -1,6 +1,6 @@
 # external-dns
 
-[ExternalDNS](https://github.com/kubernetes-sigs/external-dns) is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
+[ExternalDNS](https://github.com/kubernetes-incubator/external-dns) is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 
 ## TL;DR;
 
@@ -169,15 +169,14 @@ The following table lists the configurable parameters of the external-dns chart 
 | `service.loadBalancerSourceRanges`  | List of IP CIDRs allowed access to load balancer (if supported)                                          | `[]`                                                        |
 | `service.annotations`               | Annotations to add to service                                                                            | `{}`                                                        |
 | `rbac.create`                       | Weather to create & use RBAC resources or not                                                            | `true`                                                      |
-| `rbac.serviceAccountName`           | ServiceAccount (ignored if rbac.create == true)                                                          | `default`                                                   |
+| `rbac.serviceAccount.create`        | If true and rbac.create is also true, a service account will be created                                  | `true`                                                      |
+| `rbac.serviceAccount.name`          | existing ServiceAccount to use (ignored if rbac.create=true and rbac.serviceAccount.create=true)         | `default`                                                   |
 | `rbac.serviceAccountAnnotations`    | Additional Service Account annotations                                                                   | `{}`                                                        |
 | `rbac.apiVersion`                   | Version of the RBAC API                                                                                  | `v1beta1`                                                   |
 | `rbac.pspEnabled`                   | PodSecurityPolicy                                                                                        | `false`                                                     |
 | `resources`                         | CPU/Memory resource requests/limits.                                                                     | `{}`                                                        |
 | `livenessProbe`                     | Deployment Liveness Probe                                                                                | See `values.yaml`                                           |
 | `readinessProbe`                    | Deployment Readiness Probe                                                                               | See `values.yaml`                                           |
-| `extraVolumes`                      | A list of volumes to be added to the pod                                                                 | `[]`                                                        |
-| `extraVolumeMounts`                 | A list of volume mounts to be added to the pod                                                           | `[]`                                                        |
 | `metrics.enabled`                   | Enable prometheus to access external-dns metrics endpoint                                                | `false`                                                     |
 | `metrics.podAnnotations`            | Annotations for enabling prometheus to access the metrics endpoint                                       |                                                             |
 | `metrics.serviceMonitor.enabled`    | Create ServiceMonitor object                                                                             | `false`                                                     |
@@ -228,12 +227,12 @@ This chart includes a `values-production.yaml` file where you can find some para
 
 Find information about the requirements for each DNS provider on the link below:
 
-- [ExternalDNS Tutorials](https://github.com/kubernetes-sigs/external-dns/tree/master/docs/tutorials)
+- [ExternalDNS Tutorials](https://github.com/kubernetes-incubator/external-dns/tree/master/docs/tutorials)
 
 For instance, to install ExternalDNS on AWS, you need to:
 
-- Provide the K8s worker node which runs the cluster autoscaler with a minimum IAM policy (check [IAM permissions docs](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md#iam-permissions) for more information).
-- Setup a hosted zone on Route53 and annotate the Hosted Zone ID and its associated "nameservers" as described on [these docs](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md#set-up-a-hosted-zone).
+- Provide the K8s worker node which runs the cluster autoscaler with a minimum IAM policy (check [IAM permissions docs](https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/aws.md#iam-permissions) for more information).
+- Setup a hosted zone on Route53 and annotate the Hosted Zone ID and its associated "nameservers" as described on [these docs](https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/aws.md#set-up-a-hosted-zone).
 - Install ExternalDNS chart using the command below:
 
 > Note: replace the placeholder HOSTED_ZONE_IDENTIFIER and HOSTED_ZONE_NAME, with your hosted zoned identifier and name, respectively.

--- a/stable/external-dns/templates/_helpers.tpl
+++ b/stable/external-dns/templates/_helpers.tpl
@@ -428,3 +428,14 @@ external-dns: transip.apiKey
     Please set the apiKey parameter (--set transip.apiKey="xxxx")
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the service account name.	Return the service account name used by the pod.
+*/}}
+{{- define "serviceaccount.name" -}}
+{{- if and .Values.rbac.create .Values.rbac.serviceAccount.create -}}
+{{ include "external-dns.fullname" . }}
+{{- else -}}
+{{ .Values.rbac.serviceAccount.name }}
+{{- end -}}	
+{{- end -}}

--- a/stable/external-dns/templates/clusterrolebinding.yaml
+++ b/stable/external-dns/templates/clusterrolebinding.yaml
@@ -10,6 +10,6 @@ roleRef:
   name: {{ template "external-dns.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "external-dns.fullname" . }}
+  name: {{ template "serviceaccount.name" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -34,11 +34,12 @@ spec:
       {{- with .Values.tolerations }}
       tolerations: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
-      {{- if .Values.rbac.create }}
-      serviceAccountName: {{ template "external-dns.fullname" . }}
-      {{- else }}
-      serviceAccountName: {{ .Values.rbac.serviceAccountName | quote }}
-      {{- end }}
+      # {{- if .Values.rbac.create }}
+      # serviceAccountName: {{ template "external-dns.fullname" . }}
+      # {{- else }}
+      # serviceAccountName: {{ .Values.rbac.serviceAccountName | quote }}
+      # {{- end }}
+      serviceAccountName: {{ template "serviceaccount.name" . }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
@@ -424,10 +425,6 @@ spec:
           mountPath: /transip
           readOnly: true
         {{- end }}
-        # Extra volume mount(s)
-        {{- if .Values.extraVolumeMounts }}
-{{ toYaml .Values.extraVolumeMounts | indent 8 }}
-        {{- end }}
       volumes:
       # AWS volume(s)
       {{- if and (eq .Values.provider "aws") (or (and .Values.aws.credentials.secretKey .Values.aws.credentials.accessKey) .Values.aws.credentials.secretName) }}
@@ -485,8 +482,4 @@ spec:
       - name: transip-api-key
         secret:
           name: {{ template "external-dns.fullname" . }}
-      {{- end }}
-      # Extra volume(s)
-      {{- if .Values.extraVolumes }}
-{{ toYaml .Values.extraVolumes | indent 6 }}
       {{- end }}

--- a/stable/external-dns/templates/psp.yaml
+++ b/stable/external-dns/templates/psp.yaml
@@ -15,6 +15,7 @@ spec:
   - 'projected'
   - 'secret'
   - 'downwardAPI'
+  - 'hostPath'
   hostNetwork: false
   hostIPC: false
   hostPID: false

--- a/stable/external-dns/templates/serviceaccount.yaml
+++ b/stable/external-dns/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and .Values.rbac.create .Values.rbac.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -45,7 +45,7 @@ sources:
 provider: aws
 
 ## Flags related to processing sources
-## ref: https://github.com/kubernetes-sigs/external-dns/blob/master/pkg/apis/externaldns/types.go#L272
+## ref: https://github.com/kubernetes-incubator/external-dns/blob/master/pkg/apis/externaldns/types.go#L272
 ##
 ## Limit sources of endpoints to a specific namespace (default: all namespaces)
 ##
@@ -320,7 +320,7 @@ logFormat: text
 ##
 policy: upsert-only
 ## Registry Type. Available types are: txt, noop
-## ref: https://github.com/kubernetes-sigs/external-dns/blob/master/docs/proposal/registry.md
+## ref: https://github.com/kubernetes-incubator/external-dns/blob/master/docs/proposal/registry.md
 ##
 registry: "txt"
 ## TXT Registry Identifier
@@ -419,10 +419,11 @@ service:
 ##
 rbac:
   create: true
-  ## Service Account for pods
-  ## https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-  ##
-  serviceAccountName: default
+  ## if rbac.create is false or (if rbac.create is true and rbac.serviceAccount.create is false)
+  ## the service account rbac.serviceAccount.name will be used instead
+  serviceAccount:
+    create: true
+    name: default
   ## Annotations for the Service Account
   ##
   serviceAccountAnnotations: {}
@@ -481,12 +482,6 @@ readinessProbe:
   timeoutSeconds: 5
   failureThreshold: 6
   successThreshold: 1
-
-## Configure extra volumes
-extraVolumes: []
-
-## Configure extra volumeMounts
-extraVolumeMounts: []
 
 ## Prometheus Exporter / Metrics
 ##

--- a/stable/instana-agent/Chart.yaml
+++ b/stable/instana-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: instana-agent
-version: 1.0.23
+version: 1.0.24
 appVersion: 1.0
 description: Instana Agent for Kubernetes
 home: https://www.instana.com/

--- a/stable/instana-agent/README.md
+++ b/stable/instana-agent/README.md
@@ -10,7 +10,15 @@ This chart adds the Instana Agent to all schedulable nodes in your cluster via a
 
 Kubernetes 1.9.x - 1.16.x
 
-Working `helm` (version 3) with the `stable` repo added to your helm client.
+#### Helm 3 prerequisites
+
+Working `helm` with the `stable` repo added to your helm client.
+
+#### Helm 2 prerequisites
+
+Working `helm` and `tiller`.
+
+_Note:_ Tiller may need a service account and role binding if RBAC is enabled in your cluster.
 
 ## Installing the Chart
 
@@ -49,6 +57,8 @@ Agent can have APM, INFRASTRUCTURE or AWS mode. Default is APM and if you want t
 
 * agent.mode
 
+#### Installing with Helm 3
+
 First, create a namespace for the instana-agent
 
 ```bash
@@ -65,12 +75,32 @@ $ helm install instana-agent --namespace instana-agent \
 stable/instana-agent
 ```
 
+#### Installing with Helm 2
+
+To install the chart with the release name `instana-agent` and set the values on the command line run:
+
+```bash
+$ helm install --name instana-agent --namespace instana-agent \
+--set agent.key=INSTANA_AGENT_KEY \
+--set agent.endpointHost=HOST \
+--set zone.name=ZONE_NAME \
+stable/instana-agent
+```
+
 ## Uninstalling the Chart
 
-To uninstall/delete the `instana-agent` daemon set:
+To uninstall/delete the `instana-agent` release:
+
+#### Uninstalling with Helm 2
 
 ```bash
 $ helm del --purge instana-agent
+```
+
+#### Uninstalling with Helm 3
+
+```bash
+$ helm del instana-agent -n instana-agent
 ```
 
 ## Configuration

--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.33.4
+version: 1.33.5
 appVersion: 0.30.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/controller-psp.yaml
+++ b/stable/nginx-ingress/templates/controller-psp.yaml
@@ -17,7 +17,7 @@ spec:
   volumes:
     - 'configMap'
     #- 'emptyDir'
-    #- 'projected'
+    - 'projected'
     - 'secret'
     #- 'downwardAPI'
   hostNetwork: {{ .Values.controller.hostNetwork }}

--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-problem-detector
-version: "1.6.3"
+version: "1.6.4"
 appVersion: v0.7.0
 home: https://github.com/kubernetes/node-problem-detector
 description: Installs the node-problem-detector daemonset for monitoring extra attributes on nodes

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -58,6 +58,7 @@ The following table lists the configurable parameters for this chart and their d
 | `tolerations`                         | Optional daemonset tolerations             | `["effect: NoSchedule,operator: Exists"]`                                                         |
 | `nodeSelector`                        | Optional daemonset nodeSelector            | `{}`                                                         |
 | `env`                                 | Optional daemonset environment variables   | `[]`                                                         |
+| `labels`                              | Optional daemonset labels                  | `{}`                                                         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
 

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -7,6 +7,9 @@ metadata:
     helm.sh/chart: {{ include "node-problem-detector.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- range $key, $val := .Values.labels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end}}
 spec:
   selector:
     matchLabels:

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -61,6 +61,8 @@ resources: {}
 
 annotations: {}
 
+labels: {}
+
 tolerations:
   - effect: NoSchedule
     operator: Exists

--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,8 +12,8 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.11.1
-appVersion: 0.36.0
+version: 8.11.2
+appVersion: 0.37.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.11.2
+version: 8.12.0
 appVersion: 0.37.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 8.12.0
+version: 8.12.1
 appVersion: 0.37.0
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -81,12 +81,12 @@ You should upgrade to Helm 2.14 + in order to avoid this issue. However, if you 
 
 1. Create CRDs
 ```console
-kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.36/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
-kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.36/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
-kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.36/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
-kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.36/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
-kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.36/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
-kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.36/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.37/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.37/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.37/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.37/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.37/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.37/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 
 ```
 
@@ -202,7 +202,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.hyperkubeImage.tag` | Tag for hyperkube image used to perform maintenance tasks | `v1.12.1` |
 | `prometheusOperator.image.pullPolicy` | Pull policy for prometheus operator image | `IfNotPresent` |
 | `prometheusOperator.image.repository` | Repository for prometheus operator image | `quay.io/coreos/prometheus-operator` |
-| `prometheusOperator.image.tag` | Tag for prometheus operator image | `v0.36.0` |
+| `prometheusOperator.image.tag` | Tag for prometheus operator image | `v0.37.0` |
 | `prometheusOperator.kubeletService.enabled` | If true, the operator will create and maintain a service for scraping kubelets | `true` |
 | `prometheusOperator.kubeletService.namespace` | Namespace to deploy kubelet service | `kube-system` |
 | `prometheusOperator.logFormat` | Operator log output formatting | `"logfmt"` |
@@ -212,7 +212,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `prometheusOperator.podLabels` | Labels to add to the operator pod | `{}` |
 | `prometheusOperator.priorityClassName` | Name of Priority Class to assign pods | `nil` |
 | `prometheusOperator.prometheusConfigReloaderImage.repository` | Repository for config-reloader image | `quay.io/coreos/prometheus-config-reloader` |
-| `prometheusOperator.prometheusConfigReloaderImage.tag` | Tag for config-reloader image | `v0.36.0` |
+| `prometheusOperator.prometheusConfigReloaderImage.tag` | Tag for config-reloader image | `v0.37.0` |
 | `prometheusOperator.resources` | Resource limits for prometheus operator | `{}` |
 | `prometheusOperator.securityContext` | SecurityContext for prometheus operator | `{"runAsNonRoot": true, "runAsUser": 65534}` |
 | `prometheusOperator.service.annotations` | Annotations to be added to the prometheus operator service | `{}` |

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -398,6 +398,7 @@ The following tables list the configurable parameters of the prometheus-operator
 | `alertmanager.service.loadBalancerSourceRanges` | Alertmanager Load Balancer Source Ranges | `[]` |
 | `alertmanager.service.nodePort` | Alertmanager Service port for NodePort service type | `30903` |
 | `alertmanager.service.port` | Port for Alertmanager Service to listen on | `9093` |
+| `alertmanager.service.targetPort` | AlertManager Service internal port | `9093` |
 | `alertmanager.service.type` | Alertmanager Service type | `ClusterIP` |
 | `alertmanager.serviceAccount.create` | Create a `serviceAccount` for alertmanager | `true` |
 | `alertmanager.serviceAccount.name` | Name for Alertmanager service account | `""` |

--- a/stable/prometheus-operator/requirements.lock
+++ b/stable/prometheus-operator/requirements.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 1.8.2
 - name: grafana
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.0.4
+  version: 5.0.5
 digest: sha256:91fd7999520c95c52890b552bc27a4abfcd78372c3fa4e7432756319b952c032
-generated: "2020-03-03T14:33:13.599263+03:00"
+generated: "2020-03-05T09:02:41.550096-05:00"

--- a/stable/prometheus-operator/templates/alertmanager/service.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/service.yaml
@@ -37,7 +37,7 @@ spec:
       nodePort: {{ .Values.alertmanager.service.nodePort }}
     {{- end }}
       port: {{ .Values.alertmanager.service.port }}
-      targetPort: 9093
+      targetPort: {{ .Values.alertmanager.service.targetPort }}
       protocol: TCP
   selector:
     app: alertmanager

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -199,6 +199,9 @@ alertmanager:
     ## Port for Alertmanager Service to listen on
     ##
     port: 9093
+    ## To be used with a proxy extraContainer port
+    ##
+    targetPort: 9093
     ## Port to expose on each node
     ## Only used if service.type is 'NodePort'
     ##

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -1184,7 +1184,7 @@ prometheusOperator:
   ##
   image:
     repository: quay.io/coreos/prometheus-operator
-    tag: v0.36.0
+    tag: v0.37.0
     pullPolicy: IfNotPresent
 
   ## Configmap-reload image to use for reloading configmaps
@@ -1197,7 +1197,7 @@ prometheusOperator:
   ##
   prometheusConfigReloaderImage:
     repository: quay.io/coreos/prometheus-config-reloader
-    tag: v0.36.0
+    tag: v0.37.0
 
   ## Set the prometheus config reloader side-car CPU limit
   ##

--- a/stable/sysdig/CHANGELOG.md
+++ b/stable/sysdig/CHANGELOG.md
@@ -3,6 +3,12 @@
 This file documents all notable changes to Sysdig Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.7.5
+
+### Minor changes
+
+* Use the latest image from Agent (9.7.0) by default.
+
 ## v1.7.4
 
 ### Minor changes

--- a/stable/sysdig/Chart.yaml
+++ b/stable/sysdig/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sysdig
-version: 1.7.4
-appVersion: 9.6.1
+version: 1.7.5
+appVersion: 9.7.0
 description: Sysdig Monitor and Secure agent
 keywords:
   - monitoring

--- a/stable/sysdig/README.md
+++ b/stable/sysdig/README.md
@@ -41,7 +41,7 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | ---                               | ---                                                                    | ---                                         |
 | `image.registry`                  | Sysdig Agent image registry                                            | `docker.io`                                 |
 | `image.repository`                | The image repository to pull from                                      | `sysdig/agent`                              |
-| `image.tag`                       | The image tag to pull                                                  | `9.6.1`                                     |
+| `image.tag`                       | The image tag to pull                                                  | `9.7.0`                                     |
 | `image.pullPolicy`                | The Image pull policy                                                  | `IfNotPresent`                              |
 | `image.pullSecrets`               | Image pull secrets                                                     | `nil`                                       |
 | `resources.requests.cpu`          | CPU requested for being run in a node                                  | `600m`                                      |

--- a/stable/sysdig/values.yaml
+++ b/stable/sysdig/values.yaml
@@ -3,7 +3,7 @@
 image:
   registry: docker.io
   repository: sysdig/agent
-  tag: 9.6.1
+  tag: 9.7.0
   # Specify a imagePullPolicy
   # Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   # ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: Aaron T. Jones <aaronj3.14@gmail.com>

#### Is this a new chart
No

#### What this PR does / why we need it:
This PR allows to reuse an existing service accounts (for instance created with eksctl with its related IAM role) and still manage the role and cluster role bindings with the chart.
An IAM role created by eksctl has a condition on the service account name it also creates, so we cannot just use the serviceAccountAnnotations value to do the mapping, unless we modify the role.
We are aware of the --override-existing-serviceaccounts eksctl argument will put the annotation on the service account if it already exists, and create the missing ones.
I'm interested in a workflow where the infra is created first (applying a YAML config file with eksctl specifying the cluster, including the IAM Roles for Service Accounts) and then the add-ons are deployed with Helm, including external-dns. Being able to specify all of that in config files in git and apply it to get a cluster fully configured is a challenge which today requires an extra step that could be eliminated with the help of this PR.


#### Special notes for your reviewer:
I've tested the PR, with the default value it behaves as before. The new feature is enabled only when both rbac.create is true, and rbac.serviceAccount is either true or false. 

Tested with Helm 3.1.1.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
