### PR TITLE
[stable/external-dns] Fix for mounting CA certs from host

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.20.0
+version: 2.20.1
 appVersion: 0.6.0
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/stable/external-dns/templates/psp.yaml
+++ b/stable/external-dns/templates/psp.yaml
@@ -15,6 +15,7 @@ spec:
   - 'projected'
   - 'secret'
   - 'downwardAPI'
+  - 'hostPath'
   hostNetwork: false
   hostIPC: false
   hostPID: false


### PR DESCRIPTION
Signed-off-by: Dan Sexton <dan.b.sexton@gmail.com>

#### Is this a new chart

No

#### What this PR does / why we need it:

The PodSecurityPolicy requires an update to allow CA certificates to be loaded from the host.

#### Which issue this PR fixes

Builds on top of #21285

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
