### PR TITLE
[stable/nginx-ldapauth-proxy] set variable for entire ldap filter, set sane retry default

### DIFF
--- a/stable/nginx-ldapauth-proxy/Chart.yaml
+++ b/stable/nginx-ldapauth-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: nginx proxy with ldapauth
 name: nginx-ldapauth-proxy
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
-version: 0.1.3
+version: 0.1.4
 appVersion: 1.13.5
 sources:
 - https://github.com/dweomer/dockerfiles-nginx-auth-ldap

--- a/stable/nginx-ldapauth-proxy/templates/configmap.yaml
+++ b/stable/nginx-ldapauth-proxy/templates/configmap.yaml
@@ -24,11 +24,12 @@ data:
 
 {{- if and .Values.proxy.ldapHost .Values.secrets.ldapBindPassword }}
         ldap_server ldapserver {
-            url {{ .Values.proxy.protocol }}://{{ .Values.proxy.ldapHost }}:{{ .Values.proxy.ldapPort }}/{{ .Values.proxy.ldapDN }}?uid?sub?(&({{ .Values.proxy.ldapFilter}}));
+            url {{ .Values.proxy.protocol }}://{{ .Values.proxy.ldapHost }}:{{ .Values.proxy.ldapPort }}/{{ .Values.proxy.ldapDN }}{{ .Values.proxy.ldapFilter}};
             binddn "{{ .Values.proxy.ldapBindDN }}";
             binddn_passwd {{ .Values.secrets.ldapBindPassword }};
             group_attribute {{ .Values.proxy.ldapGroup }};
             group_attribute_is_dn on;
+            max_down_retries {{ .Values.proxy.ldapMaxDownRetries }};
         {{- range $require := .Values.proxy.requires }}
             require group {{ $require.filter | quote }};
         {{- end }}

--- a/stable/nginx-ldapauth-proxy/values.yaml
+++ b/stable/nginx-ldapauth-proxy/values.yaml
@@ -22,8 +22,9 @@ proxy:
   ldapPort: 389
   ldapGroup: "memberUid"
   ldapDN: "dc=example,dc=com"
-  ldapFilter: "objectClass=organizationalPerson"
+  ldapFilter: "?uid?sub?(&(objectClass=organizationalPerson))"
   ldapBindDN: "cn=auth,dc=example,dc=com"
+  ldapMaxDownRetries: 10
   requires:
     - name: "authGroup"
       filter: "cn=secret,ou=groups,dc=example,dc=com"


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR allows for modification of the entire LDAP filter. In active directory based environments, this may be necessary.

Also this PR defines a default for the `max_down_retries` parameter with nginx ldap module. Leaving this unbounded (default value) can result in nginx becoming unresponsive as the ldap module is very sensitive to what it considers "down" and will sometimes retry so fast that upstream firewalls may block the connection as some kind of ddos protection.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
