### PR TITLE
Fixed a compatibility issue with K8s 1.11

### DIFF
--- a/incubator/sparkoperator/Chart.yaml
+++ b/incubator/sparkoperator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sparkoperator
 description: A Helm chart for Spark on Kubernetes operator
-version: 0.6.6
+version: 0.6.7
 appVersion: v1beta2-1.1.0-2.4.5
 keywords:
   - spark

--- a/incubator/sparkoperator/templates/crds.yaml
+++ b/incubator/sparkoperator/templates/crds.yaml
@@ -1965,7 +1965,6 @@ spec:
       required:
       - metadata
       - spec
-      type: object
   version: v1beta2
   versions:
   - name: v1beta2
@@ -3963,7 +3962,6 @@ spec:
       required:
       - metadata
       - spec
-      type: object
   version: v1beta2
   versions:
   - name: v1beta2


### PR DESCRIPTION
The CRD YAML is failing validation for K8s 1.11 with the following error:
```
must only have "properties", "required" or "description" at the root if the status subresource is enabled
```
This is a known issue. For example, see https://github.com/jetstack/cert-manager/issues/2200.
This PR made the chart installable on K8s 1.11