### PR TITLE
[stable/mongodb-replicaset] Fix init script for newer mongodb versions

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.13.0
+version: 3.13.1
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.


### PR DESCRIPTION
#### What this PR does / why we need it:

For newer MongoDB versions (we are using MongoDB 4.2.1) the init script fails, when it is used with TLS enabled.

The `--quiet` parameter isn't enough, so we have to ignore all printed lines,  except the last one.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
