### PR TITLE
[stable/node-problem-detector]: Bump to 0.8.1 NPD

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: node-problem-detector
-version: "1.6.4"
-appVersion: v0.7.0
+version: "1.7.0"
+appVersion: v0.8.1
 home: https://github.com/kubernetes/node-problem-detector
 description: Installs the node-problem-detector daemonset for monitoring extra attributes on nodes
 icon: https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -53,6 +53,7 @@ The following table lists the configurable parameters for this chart and their d
 | `settings.custom_plugin_monitors`     | Custom plugin monitor config files         | `[]`                                                         |
 | `settings.prometheus_address`         | Prometheus exporter address                | `0.0.0.0`                                                    |
 | `settings.prometheus_port`            | Prometheus exporter port                   | `20257`                                                      |
+| `settings.heartBeatPeriod`            | Syncing interval with API server           | `5m0s`                                                       |
 | `serviceAccount.create`               | Whether a ServiceAccount should be created | `true`                                                       |
 | `serviceAccount.name`                 | Name of the ServiceAccount to create       | Generated value from template                                |
 | `tolerations`                         | Optional daemonset tolerations             | `["effect: NoSchedule,operator: Exists"]`                                                         |

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -42,7 +42,7 @@ spec:
           command:
             - "/bin/sh"
             - "-c"
-            - "exec /node-problem-detector --logtostderr --system-log-monitors={{- range $index, $monitor := .Values.settings.log_monitors }}{{if ne $index 0}},{{end}}{{ $monitor }}{{- end }} {{- if .Values.settings.custom_plugin_monitors }} --custom-plugin-monitors={{- range $index, $monitor := .Values.settings.custom_plugin_monitors }}{{if ne $index 0}},{{end}}{{ $monitor }}{{- end }} {{- end }} --prometheus-address={{ .Values.settings.prometheus_address }} --prometheus-port={{ .Values.settings.prometheus_port }}"
+            - "exec /node-problem-detector --logtostderr --system-log-monitors={{- range $index, $monitor := .Values.settings.log_monitors }}{{if ne $index 0}},{{end}}{{ $monitor }}{{- end }} {{- if .Values.settings.custom_plugin_monitors }} --custom-plugin-monitors={{- range $index, $monitor := .Values.settings.custom_plugin_monitors }}{{if ne $index 0}},{{end}}{{ $monitor }}{{- end }} {{- end }} --prometheus-address={{ .Values.settings.prometheus_address }} --prometheus-port={{ .Values.settings.prometheus_port }} --k8s-exporter-heartbeat-period={{ .Values.settings.heartBeatPeriod }}"
           securityContext:
             privileged: true
           env:

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -36,12 +36,15 @@ settings:
   prometheus_address: 0.0.0.0
   prometheus_port: 20257
 
+  # The period at which k8s-exporter does forcibly sync with apiserver
+  heartBeatPeriod: 5m0s
+
 hostpath:
   logdir: /var/log/
 
 image:
   repository: k8s.gcr.io/node-problem-detector
-  tag: v0.7.0
+  tag: v0.8.1
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
#### What this PR does / why we need it:

The new version brings the following fixes

- Fixed several potential busy loops
- Added a k8s-exporter-heartbeat-period flag to make the heart beat period of K8s exporter configurable.
- Fixed a potential NPD panic caused by close of closed channel
- Added Stackdriver exporter for NPD
- Collect a lot more useful CPU/disk/memory metrics
- Fix a few metric units for disk metrics and the calculation for disk_avg_queue_len
- Fix the first 0 value metrics reported for disk_avg_queue_len
- Improve network_problem.sh to support nf_conntrack and report error when conntrack table is 90% full.
- Support host_uptime metrics for CentOS

Signed-off-by: Markos Chandras <markos@chandras.me>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
