### PR TITLE
chore(nginx-ingress): fix hpa issue

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress
-version: 1.33.5
+version: 1.34.0
 appVersion: 0.30.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -51,6 +51,7 @@ Parameter | Description | Default
 `controller.image.tag` | controller container image tag | `0.30.0`
 `controller.image.pullPolicy` | controller container image pull policy | `IfNotPresent`
 `controller.image.runAsUser` | User ID of the controller process. Value depends on the Linux distribution used inside of the container image. | `101`
+`controller.useComponentLabel` | Wether to add component label so the HPA can work separately for controller and defaultBackend. *Note: don't change this if you have an already running deployment as it will need the recreation of the controller deployment* | `false`
 `controller.containerPort.http` | The port that the controller container listens on for http connections. | `80`
 `controller.containerPort.https` | The port that the controller container listens on for https connections. | `443`
 `controller.config` | nginx [ConfigMap](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md) entries | none
@@ -182,6 +183,7 @@ Parameter | Description | Default
 `defaultBackend.image.tag` | default backend container image tag | `1.5`
 `defaultBackend.image.pullPolicy` | default backend container image pull policy | `IfNotPresent`
 `defaultBackend.image.runAsUser` | User ID of the controller process. Value depends on the Linux distribution used inside of the container image. By default uses nobody user. | `65534`
+`defaultBackend.useComponentLabel` | Whether to add component label so the HPA can work separately for controller and defaultBackend. *Note: don't change this if you have an already running deployment as it will need the recreation of the defaultBackend deployment* | `false`
 `defaultBackend.extraArgs` | Additional default backend container arguments | `{}`
 `defaultBackend.extraEnvs` | any additional environment variables to set in the defaultBackend pods | `[]`
 `defaultBackend.port` | Http port number | `8080`

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -7,9 +7,9 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+    app.kubernetes.io/component: controller
   name: {{ template "nginx-ingress.controller.fullname" . }}
   annotations:    
 {{ toYaml .Values.controller.deploymentAnnotations | indent 4}}
@@ -18,6 +18,9 @@ spec:
     matchLabels:
       app: {{ template "nginx-ingress.name" . }}
       release: {{ .Release.Name }}
+    {{- if .Values.controller.useComponentLabel }}
+      app.kubernetes.io/component: controller
+    {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   updateStrategy:
 {{ toYaml .Values.controller.updateStrategy | indent 4 }}
@@ -32,8 +35,8 @@ spec:
       {{- end }}
       labels:
         app: {{ template "nginx-ingress.name" . }}
-        component: "{{ .Values.controller.name }}"
         release: {{ .Release.Name }}
+        app.kubernetes.io/component: controller
         {{- if .Values.controller.podLabels }}
 {{ toYaml .Values.controller.podLabels | indent 8}}
         {{- end }}

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+    app.kubernetes.io/component: controller
   name: {{ template "nginx-ingress.controller.fullname" . }}
   annotations:
 {{ toYaml .Values.controller.deploymentAnnotations | indent 4}}
@@ -16,6 +16,9 @@ spec:
     matchLabels:
       app: {{ template "nginx-ingress.name" . }}
       release: {{ .Release.Name }}
+    {{- if .Values.controller.useComponentLabel }}
+      app.kubernetes.io/component: controller
+    {{- end }}
 {{- if not .Values.controller.autoscaling.enabled }}
   replicas: {{ .Values.controller.replicaCount }}
 {{- end }}
@@ -33,8 +36,8 @@ spec:
       {{- end }}
       labels:
         app: {{ template "nginx-ingress.name" . }}
-        component: "{{ .Values.controller.name }}"
         release: {{ .Release.Name }}
+        app.kubernetes.io/component: controller
         {{- if .Values.controller.podLabels }}
 {{ toYaml .Values.controller.podLabels | indent 8 }}
         {{- end }}

--- a/stable/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/stable/nginx-ingress/templates/default-backend-deployment.yaml
@@ -5,15 +5,18 @@ metadata:
   labels:
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ template "nginx-ingress.chart" . }}
-    component: "{{ .Values.defaultBackend.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+    app.kubernetes.io/component: default-backend
   name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
 spec:
   selector:
     matchLabels:
       app: {{ template "nginx-ingress.name" . }}
       release: {{ .Release.Name }}
+    {{- if .Values.defaultBackend.useComponentLabel }}
+      app.kubernetes.io/component: default-backend
+    {{- end }}
   replicas: {{ .Values.defaultBackend.replicaCount }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:
@@ -26,8 +29,8 @@ spec:
     {{- end }}
       labels:
         app: {{ template "nginx-ingress.name" . }}
-        component: "{{ .Values.defaultBackend.name }}"
         release: {{ .Release.Name }}
+        app.kubernetes.io/component: default-backend
         {{- if .Values.defaultBackend.podLabels }}
 {{ toYaml .Values.defaultBackend.podLabels | indent 8 }}
         {{- end }}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -11,6 +11,11 @@ controller:
     runAsUser: 101
     allowPrivilegeEscalation: true
 
+  # This will fix the issue of HPA not being able to read the metrics.
+  # Note that if you enable it for existing deployments, it won't work as the labels are immutable.
+  # We recommend setting this to true for new deployments.
+  useComponentLabel: false
+
   # Configures the ports the nginx-controller listens on
   containerPort:
     http: 80
@@ -437,6 +442,11 @@ defaultBackend:
     pullPolicy: IfNotPresent
     # nobody user -> uid 65534
     runAsUser: 65534
+
+  # This will fix the issue of HPA not being able to read the metrics.
+  # Note that if you enable it for existing deployments, it won't work as the labels are immutable.
+  # We recommend setting this to true for new deployments.
+  useComponentLabel: false
 
   extraArgs: {}
 


### PR DESCRIPTION
This will fix the issue where the HPA isn't able to read the metrics even when the resources of the controllers are set because the resources of the default-backend aren't set and both are using the same selectors