### PR TITLE
[stable/spinnaker] Fix registry passwords being garbed when email is specified

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.0.0-rc1
+version: 2.0.0-rc2
 appVersion: 1.16.2
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/configmap/halyard-config.yaml
+++ b/stable/spinnaker/templates/configmap/halyard-config.yaml
@@ -107,7 +107,7 @@ data:
     {{- else -}}
     CREDS+=" --password-file /opt/registry/passwords/{{ $registry.name }}"
     {{- end -}}
-    {{ if $registry.email -}}
+    {{ if $registry.email }}
     CREDS+=" --email {{ $registry.email }}"
     {{- end -}}
     {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
No

#### What this PR does / why we need it:

Container registry setup currenty fails if you specify both an email and a password.

Example variables:
```
dockerRegistries:
- name: dockerhub
  address: index.docker.io
  repositories:
    - library/alpine
    - library/ubuntu
    - library/centos
    - library/nginx
- name: gcr
  address: https://gcr.io
  username: _json_key
  password: '<INSERT YOUR SERVICE ACCOUNT JSON HERE>'
  email: 1234@5678.com
- name: ecr
  address: https://<AWS-ACCOUNT-ID>.dkr.ecr.<REGION>.amazonaws.com
  username: AWS
  passwordCommand: "aws --region <REGION> ecr get-authorization-token --output text --query 'authorizationData[].authorizationToken' | base64 -d | sed 's/^AWS://'"
```

Result in ConfigMap:

```
$helm template . -f test.yaml | grep /opt/registry/passwords/gcr -C5
      PROVIDER_COMMAND='add'
    fi

    CREDS=""
    CREDS+="--username _json_key"
    CREDS+=" --password-file /opt/registry/passwords/gcr"CREDS+=" --email 1234@5678.com"

    $HAL_COMMAND config provider docker-registry account $PROVIDER_COMMAND gcr --address https://gcr.io \
        ${CREDS}

    if $HAL_COMMAND config provider docker-registry account get ecr; then
```

Result when installing:

```
<snip>
+ Get gcr account
  Success
- Edit the gcr account
  Failure
Problems in default.provider.dockerRegistry.gcr:
! ERROR Cannot find provided path:
  /opt/registry/passwords/gcrCREDS+= (No such file or directory).:
  /opt/registry/passwords/gcrCREDS+= (No such file or directory).
<snip>
```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)

@viglesiasce 
@ezimanyi 
@dwardu89
@paulczar