### PR TITLE
[incubator/kube-registry-proxy] Update DaemonSet from extensions/v1beta1 to apps/v1

### DIFF
--- a/incubator/kube-registry-proxy/Chart.yaml
+++ b/incubator/kube-registry-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kube-registry-proxy
 home: https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/registry
-version: 0.3.1
+version: 0.3.2
 appVersion: 0.4
 description: Installs the kubernetes-registry-proxy cluster addon.
 maintainers:

--- a/incubator/kube-registry-proxy/templates/daemon.yaml
+++ b/incubator/kube-registry-proxy/templates/daemon.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "kube-registry-proxy.fullname" . }}


### PR DESCRIPTION
#### Is this a new chart

No

#### What this PR does / why we need it:

`DaemonSet` is no longer part of `extensions/v1beta1` as of Kubernetes v1.16.0. Please see https://github.com/kubernetes/kubernetes/issues/84782 for more information on this.

Installing now results in the following for Kubernetes v1.16.0+:

```
Error: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "DaemonSet" in version "extensions/v1beta1"
```

`DaemonSet` has been moved to `apps/v1`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
