### PR TITLE
[incubator/haproxy-ingress] Made terminationGracePeriodSeconds configurable

### DIFF
--- a/incubator/haproxy-ingress/Chart.yaml
+++ b/incubator/haproxy-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: haproxy-ingress
-version: 0.0.22
+version: 0.0.23
 appVersion: 0.7.2
 home: https://github.com/jcmoraisjr/haproxy-ingress
 description: Ingress controller implementation for haproxy loadbalancer.

--- a/incubator/haproxy-ingress/README.md
+++ b/incubator/haproxy-ingress/README.md
@@ -73,6 +73,7 @@ Parameter | Description | Default
 `controller.config` | additional haproxy-ingress [ConfigMap entries](https://github.com/jcmoraisjr/haproxy-ingress/blob/v0.6/README.md#configmap) | `{}`
 `controller.hostNetwork` | Optionally set to true when using CNI based kubernetes installations | `false`
 `controller.dnsPolicy` | Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true' | `ClusterFirst`
+`controller.terminationGracePeriodSeconds` | How much to wait before terminating a pod (in seconds) | `60`
 `controller.kind` | Type of deployment, DaemonSet or Deployment | `Deployment`
 `controller.tcp` | TCP [service ConfigMap](https://github.com/jcmoraisjr/haproxy-ingress/blob/v0.6/README.md#tcp-services-configmap): `<port>: <namespace>/<servicename>:<portnumber>[:[<in-proxy>][:<out-proxy>]]` | `{}`
 `controller.enableStaticPorts` | Set to `false` to only rely on ports from `controller.tcp` | `true`

--- a/incubator/haproxy-ingress/templates/controller-daemonset.yaml
+++ b/incubator/haproxy-ingress/templates/controller-daemonset.yaml
@@ -177,7 +177,7 @@ spec:
           configMap:
             name: {{ template "haproxy-ingress.controller.fullname" . }}-template
 {{- end }}
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
       dnsPolicy: {{ .Values.controller.dnsPolicy }}
       hostNetwork: {{ .Values.controller.hostNetwork }}
     {{- if .Values.controller.nodeSelector }}

--- a/incubator/haproxy-ingress/templates/controller-deployment.yaml
+++ b/incubator/haproxy-ingress/templates/controller-deployment.yaml
@@ -171,7 +171,7 @@ spec:
           configMap:
             name: {{ template "haproxy-ingress.controller.fullname" . }}-template
 {{- end }}
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
       dnsPolicy: {{ .Values.controller.dnsPolicy }}
       hostNetwork: {{ .Values.controller.hostNetwork }}
     {{- if .Values.controller.nodeSelector }}

--- a/incubator/haproxy-ingress/values.yaml
+++ b/incubator/haproxy-ingress/values.yaml
@@ -111,6 +111,9 @@ controller:
   # to keep resolving names inside the k8s network, use ClusterFirstWithHostNet.
   dnsPolicy: ClusterFirst
 
+  # How many seconds to wait before terminating a pod.
+  terminationGracePeriodSeconds: 60
+
   ## DaemonSet or Deployment
   ##
   kind: Deployment


### PR DESCRIPTION
#### Is this a new chart
No

#### What this PR does / why we need it:
It makes terminationGracePeriodSeconds of haproxy pod configurable and not hard coded to 60 seconds.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
