### PR TITLE
[stable/datadog] Fix typo and update docs

### DIFF
--- a/stable/datadog/CHANGELOG.md
+++ b/stable/datadog/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 2.0
 
+## 2.0.7
+
+* Pass expected `DD_DOGSTATSD_PORT` to datadog-agent rather than invalid `DD_DOGSTATD_PORT`
+
+## 2.0.6
+
+* Introduces `procesAgent.processCollection` to correctly configure `DD_PROCESS_AGENT_ENABLED` for the process agent.
+
 ## 2.0.5
 
 * Honor the `datadog.env` parameter in all containers.

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: datadog
-version: 2.0.6
+version: 2.0.7
 appVersion: "7"
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/container-agent.yaml
+++ b/stable/datadog/templates/container-agent.yaml
@@ -26,7 +26,7 @@
       value: {{ .Values.agents.containers.agent.logLevel | default .Values.datadog.logLevel | quote }}
     {{- end }}  
     {{- if .Values.datadog.dogstatsd.port }}
-    - name: DD_DOGSTATD_PORT
+    - name: DD_DOGSTATSD_PORT
       value: {{ .Values.datadog.dogstatsd.port | quote }}
     {{- end }}
     {{- if .Values.datadog.dogstatsd.nonLocalTraffic }}


### PR DESCRIPTION
@hkaj @irabinovitch @CharlyF @mfpierre @clamoriniere @xlucas @L3n41c @celenechang

#### What this PR does / why we need it:
This PR fixes a typo in the `container-agent` for the statsd port. I currently cannot override the statsd port used by the DataDog-Agent as the environment variable is incorrect. 

#### Which issue this PR fixes
  - fixes #21384

#### Special notes for your reviewer:
Link to DataDog-Agent StatsD Port environment variable: https://github.com/helm/charts/blob/master/stable/datadog/templates/container-agent.yaml#L29

I tested the change by overriding the yaml to fix the typo and the metrics appeared in DataDog as expected. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
