### PR TITLE
[stable/prometheus-redis-exporter] Add support for Prometheus Operator Rules

### DIFF
--- a/stable/prometheus-redis-exporter/Chart.yaml
+++ b/stable/prometheus-redis-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.3.4
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 3.2.3
+version: 3.3.3
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/stable/prometheus-redis-exporter/README.md
+++ b/stable/prometheus-redis-exporter/README.md
@@ -67,6 +67,10 @@ The following table lists the configurable parameters and their default values.
 | `serviceMonitor.labels`        | Labels for the servicemonitor passed to Prometheus Operator      |  `{}`            |
 | `serviceMonitor.timeout`       | Timeout after which the scrape is ended                |                            |
 | `serviceMonitor.targetLabels`  | Set of labels to transfer on the Kubernetes Service onto the target.  |             |
+| `prometheusRule.enabled`           | Set this to true to create prometheusRules for Prometheus operator | `false`     |
+| `prometheusRule.additionalLabels`  | Additional labels that can be used so prometheusRules will be discovered by Prometheus  | `{}`  |
+| `prometheusRule.namespace`         | namespace where prometheusRules resource should be created |      |
+| `prometheusRule.rules`             | [rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) to be created, check values for an example.                      | `[]`                                                    |
 | `script.configmap`     | Let you run a custom lua script from a configmap. The corresponding environment variable `REDIS_EXPORTER_SCRIPT` will be set automatically ||
 | `script.keyname`       | Name of the key inside configmap which contains your script ||
 | `auth.enabled`       | Specifies whether redis uses authentication | `false` |

--- a/stable/prometheus-redis-exporter/templates/prometheusrule.yaml
+++ b/stable/prometheus-redis-exporter/templates/prometheusrule.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "prometheus-redis-exporter.fullname" . }}
+{{- with .Values.prometheusRule.namespace }}
+  namespace: {{ . }}
+{{- end }}
+  labels:
+    app: {{ template "prometheus-redis-exporter.name" . }}
+    chart: {{ template "prometheus-redis-exporter.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+{{- with .Values.prometheusRule.additionalLabels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- with .Values.prometheusRule.rules }}
+  groups:
+    - name: {{ template "prometheus-redis-exporter.name" $ }}
+      rules: {{ tpl (toYaml .) $ | nindent 8 }}
+{{- end }}
+{{- end }}

--- a/stable/prometheus-redis-exporter/values.yaml
+++ b/stable/prometheus-redis-exporter/values.yaml
@@ -59,11 +59,11 @@ serviceMonitor:
 ## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
 prometheusRule:
   enabled: false
-  # additionalLabels: {}
-  # namespace: ""
-  # rules: []
+  additionalLabels: {}
+  namespace: ""
+  rules: []
     ## These are just examples rules, please adapt them to your needs.
-    ## Make sure to constraint the rules to the current service. 
+    ## Make sure to constraint the rules to the current service.
     #  - alert: RedisDown
     #    expr: redis_up{service="{{ template "prometheus-redis-exporter.fullname" . }}"} == 0
     #    for: 2m

--- a/stable/prometheus-redis-exporter/values.yaml
+++ b/stable/prometheus-redis-exporter/values.yaml
@@ -54,6 +54,48 @@ serviceMonitor:
   # Set of labels to transfer on the Kubernetes Service onto the target.
   # targetLabels: []
 
+## Custom PrometheusRules to be defined
+## The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart
+## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
+prometheusRule:
+  enabled: false
+  # additionalLabels: {}
+  # namespace: ""
+  # rules: []
+    ## These are just examples rules, please adapt them to your needs.
+    ## Make sure to constraint the rules to the current service. 
+    #  - alert: RedisDown
+    #    expr: redis_up{service="{{ template "prometheus-redis-exporter.fullname" . }}"} == 0
+    #    for: 2m
+    #    labels:
+    #      severity: error
+    #    annotations:
+    #      summary: Redis instance {{ "{{ $labels.instance }}" }} down
+    #      description: Redis instance {{ "{{ $labels.instance }}" }} is down.
+    #  - alert: RedisMemoryHigh
+    #    expr: >
+    #       redis_memory_used_bytes{service="{{ template "prometheus-redis-exporter.fullname" . }}"} * 100
+    #       /
+    #       redis_memory_max_bytes{service="{{ template "prometheus-redis-exporter.fullname" . }}"}
+    #       > 90 <= 100
+    #    for: 2m
+    #    labels:
+    #      severity: error
+    #    annotations:
+    #      summary: Redis instance {{ "{{ $labels.instance }}" }} is using too much memory
+    #      description: |
+    #         Redis instance {{ "{{ $labels.instance }}" }} is using {{ "{{ $value }}" }}% of its available memory.
+    #  - alert: RedisKeyEviction
+    #    expr: |
+    #      increase(redis_evicted_keys_total{service="{{ template "prometheus-redis-exporter.fullname" . }}"}[5m]) > 0
+    #    for: 1s
+    #    labels:
+    #      severity: error
+    #    annotations:
+    #      summary: Redis instance {{ "{{ $labels.instance }}" }} has evicted keys
+    #      description: |
+    #        Redis instance {{ "{{ $labels.instance }}" }} has evicted {{ "{{ $value }}" }} keys in the last 5 minutes.
+
 # Used to mount a LUA-Script via config map and use it for metrics-collection
 # script:
 #   configmap: prometheus-redis-exporter-script


### PR DESCRIPTION
#### Is this a new chart
No.

#### What this PR does / why we need it:
This PR adds support for creating PrometheusRule objects for Prometheus Operator. The management of rules is quite comfortable when they can just ship together with the application itself.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
