### PR TITLE
[stable/testlink] Move chart to distributed bitnami repository

### DIFF
--- a/stable/testlink/Chart.yaml
+++ b/stable/testlink/Chart.yaml
@@ -1,8 +1,10 @@
 apiVersion: v1
 name: testlink
-version: 7.1.5
+version: 7.1.6
 appVersion: 1.9.20
-description: Web-based test management system that facilitates software quality assurance.
+# The redis chart is deprecated and no longer maintained. For details deprecation, see the PROCESSES.md file.
+deprecated: true
+description: DEPRECATED Web-based test management system that facilitates software quality assurance.
 icon: https://bitnami.com/assets/stacks/testlink/img/testlink-stack-220x234.png
 keywords:
 - testlink
@@ -12,7 +14,5 @@ keywords:
 home: http://www.testlink.org/
 sources:
 - https://github.com/bitnami/bitnami-docker-testlink
-maintainers:
-- name: Bitnami
-  email: containers@bitnami.com
+maintainers: []
 engine: gotpl

--- a/stable/testlink/README.md
+++ b/stable/testlink/README.md
@@ -2,6 +2,27 @@
 
 [TestLink](http://www.testlink.org) is a web-based test management system that facilitates software quality assurance. It is developed and maintained by Teamtest. The platform offers support for test cases, test suites, test plans, test projects and user management, as well as various reports and statistics.
 
+## This Helm chart is deprecated
+
+Given the [`stable` deprecation timeline](https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained TestLink Helm chart is now located at [bitnami/charts](https://github.com/bitnami/charts/).
+
+The Bitnami repository is already included in the Hubs and we will continue providing the same cadence of updates, support, etc that we've been keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installation (`bitnami/<chart>` instead of `stable/<chart>`)
+
+```bash
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm install my-release bitnami/<chart>           # Helm 3
+$ helm install --name my-release bitnami/<chart>    # Helm 2
+```
+
+To update an exisiting _stable_ deployment with a chart hosted in the bitnami repository you can execute
+
+```bash
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm upgrade my-release bitnami/<chart>
+```
+
+Issues and PRs related to the chart itself will be redirected to `bitnami/charts` GitHub repository. In the same way, we'll be happy to answer questions related to this migration process in [this issue](https://github.com/helm/charts/issues/20969) created as a common place for discussion.
+
 ## TL;DR;
 
 ```console

--- a/stable/testlink/templates/NOTES.txt
+++ b/stable/testlink/templates/NOTES.txt
@@ -1,3 +1,24 @@
+This Helm chart is deprecated
+
+Given the `stable` deprecation timeline (https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained Helm chart is now located at bitnami/charts (https://github.com/bitnami/charts/).
+
+The Bitnami repository is already included in the Hubs and we will continue providing the same cadence of updates, support, etc that we've been keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installation (`bitnami/<chart>` instead of `stable/<chart>`)
+
+```bash
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm install my-release bitnami/<chart>           # Helm 3
+$ helm install --name my-release bitnami/<chart>    # Helm 2
+```
+
+To update an exisiting _stable_ deployment with a chart hosted in the bitnami repository you can execute
+
+```bash
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm upgrade my-release bitnami/<chart>
+```
+
+Issues and PRs related to the chart itself will be redirected to `bitnami/charts` GitHub repository. In the same way, we'll be happy to answer questions related to this migration process in this issue (https://github.com/helm/charts/issues/20969) created as a common place for discussion.
+
 {{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
 1. Get the TestLink URL by running:
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Given the [`stable` deprecation timeline](https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained Helm chart is now located at [bitnami/charts](https://github.com/bitnami/charts/).

Please, use [this issue](https://github.com/helm/charts/issues/20969) for common questions about the migration/deprecation process, for PR/Issues related to the chart itself, please visit the [bitnami/charts](https://github.com/bitnami/charts/) GitHub repository.
 
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
