### PR TITLE
[stable/airflow] adding podLabels to web, scheduler, flower and worker pods

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 6.3.2
+version: 6.4.0
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 6.3.1
+version: 6.3.2
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -395,6 +395,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `flower.urlPrefix`                       | path of the flower ui                                   | ""                        |
 | `flower.resources`                       | custom resource configuration for flower pod            | `{}`                      |
 | `flower.labels`                          | labels for the flower deployment                        | `{}`                      |
+| `flower.podLabels`                       | podLabels for the flower deployment                     | `{}`                      |
 | `flower.annotations`                     | annotations for the flower deployment                   | `{}`                      |
 | `flower.service.type`                    | service type for Flower UI                              | `ClusterIP`               |
 | `flower.service.annotations`             | (optional) service annotations for Flower UI            | `{}`                      |
@@ -403,6 +404,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `web.baseUrl`                            | webserver UI URL                                        | `http://localhost:8080`   |
 | `web.resources`                          | custom resource configuration for web pod               | `{}`                      |
 | `web.labels`                             | labels for the web deployment                           | `{}`                      |
+| `web.podLabels`                          | podLabels for the web deployment                        | `{}`                      |
 | `web.annotations`                        | annotations for the web deployment                      | `{}`                      |
 | `web.podAnnotations`                     | pod-annotations for the web deployment                  | `{}`                      |
 | `web.initialStartupDelay`                | amount of time webserver pod should sleep before initializing webserver             | `60`  |
@@ -421,6 +423,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `web.securityContext`                    | (optional) security context for the web deployment      | `{}`                      |
 | `scheduler.resources`                    | custom resource configuration for scheduler pod         | `{}`                      |
 | `scheduler.labels`                       | labels for the scheduler deployment                     | `{}`                      |
+| `scheduler.podLabels`                    | podLabels for the scheduler deployment                  | `{}`                      |
 | `scheduler.annotations`                  | annotations for the scheduler deployment                | `{}`                      |
 | `scheduler.podAnnotations`               | podAnnotations for the scheduler deployment             | `{}`                      |
 | `scheduler.securityContext`              | (optional) security context for the scheduler deployment| `{}`                      |
@@ -430,10 +433,10 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `workers.resources`                      | custom resource configuration for worker pod            | `{}`                      |
 | `workers.celery.instances`               | number of parallel celery tasks per worker              | `1`                       |
 | `workers.labels`                         | labels for the worker statefulSet                       | `{}`                      |
+| `workers.podLabels`                      | podLabels for the worker statefulset                    | `{}`                      |
 | `workers.annotations`                    | annotations for the worker statefulSet                  | `{}`                      |
 | `workers.podAnnotations`                 | podAnnotations for the worker statefulSet               | `{}`                      |
 | `workers.celery.gracefullTermination`    | cancel the consumer and wait for the current task to finish before stopping the worker      | `false`     |
-| `workers.podAnnotations`                 | annotations for the worker pods                         | `{}`                      |
 | `workers.secretsDir`                     | directory in which to mount secrets on worker nodes     | /var/airflow/secrets      |
 | `workers.secrets`                        | secrets to mount as volumes on worker nodes             | []                        |
 | `workers.securityContext`                 | (optional) security context for the worker statefulSet  | `{}`                      |

--- a/stable/airflow/templates/deployments-flower.yaml
+++ b/stable/airflow/templates/deployments-flower.yaml
@@ -37,6 +37,9 @@ spec:
         app: {{ template "airflow.name" . }}
         component: flower
         release: {{ .Release.Name }}
+{{- if .Values.flower.podLabels }}
+{{ toYaml .Values.flower.podLabels | indent 8 }}
+{{- end }}
     spec:
       {{- if .Values.airflow.image.pullSecret }}
       imagePullSecrets:

--- a/stable/airflow/templates/deployments-scheduler.yaml
+++ b/stable/airflow/templates/deployments-scheduler.yaml
@@ -50,6 +50,9 @@ spec:
         app: {{ template "airflow.name" . }}
         component: scheduler
         release: {{ .Release.Name }}
+{{- if .Values.scheduler.podLabels }}
+{{ toYaml .Values.scheduler.podLabels | indent 8 }}
+{{- end }}
     spec:
       {{- if .Values.airflow.image.pullSecret }}
       imagePullSecrets:

--- a/stable/airflow/templates/deployments-web.yaml
+++ b/stable/airflow/templates/deployments-web.yaml
@@ -48,6 +48,9 @@ spec:
         app: {{ template "airflow.name" . }}
         component: web
         release: {{ .Release.Name }}
+{{- if .Values.scheduler.podLabels }}
+{{ toYaml .Values.scheduler.podLabels | indent 8 }}
+{{- end }}
     spec:
       {{- if .Values.airflow.image.pullSecret }}
       imagePullSecrets:

--- a/stable/airflow/templates/deployments-web.yaml
+++ b/stable/airflow/templates/deployments-web.yaml
@@ -48,8 +48,8 @@ spec:
         app: {{ template "airflow.name" . }}
         component: web
         release: {{ .Release.Name }}
-{{- if .Values.scheduler.podLabels }}
-{{ toYaml .Values.scheduler.podLabels | indent 8 }}
+{{- if .Values.web.podLabels }}
+{{ toYaml .Values.web.podLabels | indent 8 }}
 {{- end }}
     spec:
       {{- if .Values.airflow.image.pullSecret }}

--- a/stable/airflow/templates/statefulsets-workers.yaml
+++ b/stable/airflow/templates/statefulsets-workers.yaml
@@ -49,6 +49,9 @@ spec:
         app: {{ template "airflow.name" . }}
         component: worker
         release: {{ .Release.Name }}
+{{- if .Values.workers.podLabels }}
+{{ toYaml .Values.workers.podLabels | indent 8 }}
+{{- end }}
     spec:
       {{- if .Values.airflow.image.pullSecret }}
       imagePullSecrets:

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -186,11 +186,15 @@ scheduler:
   ##
   ## Labels for the scheduler deployment
   labels: {}
-  ## Pod Annotations for the web deployment
-  podAnnotations: {}
+  ##
+  ## Pod Labels for the scheduler deployment
+  podLabels: {}
   ##
   ## Annotations for the scheduler deployment
   annotations: {}
+  ##
+  ## Pod Annotations for the scheduler deployment
+  podAnnotations: {}
 
   ## Support Node, affinity and tolerations for scheduler pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
@@ -216,6 +220,9 @@ flower:
   ##
   ## Labels for the flower deployment
   labels: {}
+  ##
+  ## Pod Labels for the flower deployment
+  podLabels: {}
   ##
   ## Annotations for the flower deployment
   annotations: {}
@@ -255,10 +262,15 @@ web:
   ## Labels for the web deployment
   labels: {}
   ##
+  ## Pod Labels for the web deployment
+  podLabels: {}
+  ##
   ## Annotations for the web deployment
   annotations: {}
+  ##
   ## Pod Annotations for the web deployment
   podAnnotations: {}
+  ##
   initialStartupDelay: "60"
   initialDelaySeconds: "360"
   minReadySeconds: 120
@@ -310,6 +322,9 @@ workers:
   ##
   ## Labels for the Worker statefulSet
   labels: {}
+  ##
+  ## Pod Labels for the Worker statefulSet
+  podLabels: {}
   ##
   ## Annotations for the Worker statefulSet
   annotations: {}


### PR DESCRIPTION
## What this PR does / why we need it:

Adds the ability to set labels on pods for the web, scheduler, flower deployments and worker statefulSet.  

Copied the same format already used for setting podAnnotations.

Also cleaned up a duplicate "workers.podAnnotations" in the README

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
