### PR TITLE
stable/airflow: fix initcontainer dependency bug

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 6.3.1
+version: 6.3.2
 appVersion: 1.10.4
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -289,6 +289,8 @@ If you are using a private Git repo, you can set `dags.gitSecret` to the name of
 
 For example, this will create a secret named `my-git-secret` from your ed25519 key and known_hosts file stored in your home directory:  `kubectl create secret generic my-git-secret --from-file=id_ed25519=~/.ssh/id_ed25519 --from-file=known_hosts=~/.ssh/known_hosts --from-file=id_id_ed25519.pub=~/.ssh/id_ed25519.pub`
 
+If you have custom database hooks defined in your synced folder, it is possible to create dependency loops that will prevent initdb from completing successfully in the airflow scheduler.  In this case, you cannot use the init-container, but it is still possible to use the sidecar container: set `dags.initContainer.enabled` to false, but set `dags.git.gitSync.enabled` to true and set `dags.git.gitSync.initDelay.scheduler` to at least 60 in order to provide a window in which initdb can complete before any custom hooks are loaded.
+
 #### Init-container git connection ssh
 
 This set of instructions will enable you to clone your repository in the initContainer git-clone.sh script through an ssh connection.
@@ -483,6 +485,9 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `dags.git.gitSync.enabled`               | Enables a sidecar container that syncs dags             | `false`                   |
 | `dags.git.gitSync.image.repository`      | Image of the sidecar container that syncs dags          | `alpine/git`                  |
 | `dags.git.gitSync.image.tag`             | Image tag of sidecar container that syncs dags          | `1.0.4`                  |
+| `dags.git.gitSync.initDelay.scheduler`   | How long the git-sync sidecar pauses at startup before commencing synchronication for airflow-scheduler (in seconds) | nil |
+| `dags.git.gitSync.initDelay.web`         | How long the git-sync sidecar pauses at startup before commencing synchronication for airflow-web (in seconds) | nil |
+| `dags.git.gitSync.initDelay.worker`      | How long the git-sync sidecar pauses at startup before commencing synchronication for airflow-worker (in seconds) | nil |
 | `dags.git.gitSync.refreshTime`           | How often the sidecar container syncs dags up with repository(in seconds)         | nil                  |
 | `logs.path`                              | mount path for logs persistent volume                   | `/usr/local/airflow/logs` |
 | `rbac.create`                            | create RBAC resources                                   | `true`                    |

--- a/stable/airflow/templates/configmap-git-clone.yaml
+++ b/stable/airflow/templates/configmap-git-clone.yaml
@@ -35,6 +35,7 @@ data:
     REPO_HOST=$4
     PRIVATE_KEY=$5
     SYNC_TIME=$6
+    INIT_DELAY=$7
     {{- if .Values.dags.git.secret }}
     mkdir -p ~/.ssh/
     cp -rL /keys/* ~/.ssh/
@@ -44,11 +45,13 @@ data:
     {{- if eq .Values.dags.initContainer.enabled  false }}
     git clone $REPO -b $REF $DIR
     {{- end }}
+    if [ "${INIT_DELAY}" -gt 0 ] 2>/dev/null; then echo "*** sleeping ${INIT_DELAY} seconds before syncing"; sleep "${INIT_DELAY}"; fi
     cd $DIR
     while true; do
       git fetch origin $REF;
       git reset --hard origin/$REF;
       git clean -fd;
       date;
+      echo "*** sleeping ${SYNC_TIME} seconds"
       sleep $SYNC_TIME;
     done

--- a/stable/airflow/templates/deployments-scheduler.yaml
+++ b/stable/airflow/templates/deployments-scheduler.yaml
@@ -126,6 +126,7 @@ spec:
             - "{{ .Values.dags.git.repoHost}}"
             - "{{ .Values.dags.git.privateKeyName }}"
             - "{{ .Values.dags.git.gitSync.refreshTime }}"
+            - "{{ .Values.dags.git.gitSync.initDelay.scheduler }}"
           volumeMounts:
             - name: git-clone
               mountPath: /usr/local/git
@@ -153,7 +154,7 @@ spec:
             - name: dags-data
               mountPath: {{ .Values.dags.path }}
               subPath: {{ .Values.persistence.subPath | default "" }}
-          {{- else if .Values.dags.initContainer.enabled }}
+          {{- else if or (.Values.dags.initContainer.enabled) (.Values.dags.git.gitSync.enabled) }}
             - name: dags-data
               mountPath: {{ .Values.dags.path }}
           {{- end }}

--- a/stable/airflow/templates/deployments-scheduler.yaml
+++ b/stable/airflow/templates/deployments-scheduler.yaml
@@ -192,6 +192,10 @@ spec:
               mkdir -p /usr/local/airflow/.local/bin &&
               export PATH=/usr/local/airflow/.local/bin:$PATH &&
               /usr/local/scripts/install-requirements.sh &&
+              {{- if .Values.airflow.initdb }}
+              echo "*** executing initdb" &&
+              airflow initdb &&
+              {{- end }}
               {{- if .Values.airflow.variables }}
                 echo "*** adding variables" &&
                 airflow variables -i /usr/local/variables-pools/variables.json &&
@@ -199,10 +203,6 @@ spec:
               {{- if .Values.airflow.connections }}
                 echo "*** adding connections" &&
                 /usr/local/connections/add-connections.sh &&
-              {{- end }}
-              {{- if .Values.airflow.initdb }}
-              echo "*** executing initdb" &&
-              airflow initdb &&
               {{- end }}
             {{- if .Values.airflow.pools }}
               echo "*** adding pools" &&
@@ -216,6 +216,10 @@ spec:
               sleep 10 &&
               mkdir -p /usr/local/airflow/.local/bin &&
               export PATH=/usr/local/airflow/.local/bin:$PATH &&
+              {{- if .Values.airflow.initdb }}
+              echo "*** executing initdb" &&
+              airflow initdb &&
+              {{- end }}
               {{- if .Values.airflow.variables }}
                 echo "*** adding variables" &&
                 airflow variables -i /usr/local/variables-pools/variables.json &&
@@ -223,10 +227,6 @@ spec:
               {{- if .Values.airflow.connections }}
                 echo "*** adding connections" &&
                 /usr/local/connections/add-connections.sh &&
-              {{- end }}
-              {{- if .Values.airflow.initdb }}
-              echo "*** executing initdb" &&
-              airflow initdb &&
               {{- end }}
             {{- if .Values.airflow.pools }}
               echo "*** adding pools" &&
@@ -255,7 +255,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.logsPersistence.existingClaim | default (printf "%s-logs" (include "airflow.fullname" . | trunc 58 )) }}
         {{- end }}
-        {{- if .Values.dags.initContainer.enabled }}
+        {{- if or (.Values.dags.initContainer.enabled) (.Values.dags.git.gitSync.enabled) }}
         - name: git-clone
           configMap:
             name: {{ template "airflow.fullname" . }}-git-clone

--- a/stable/airflow/templates/deployments-web.yaml
+++ b/stable/airflow/templates/deployments-web.yaml
@@ -118,6 +118,7 @@ spec:
             - "{{ .Values.dags.git.repoHost}}"
             - "{{ .Values.dags.git.privateKeyName }}"
             - "{{ .Values.dags.git.gitSync.refreshTime }}"
+            - "{{ .Values.dags.git.gitSync.initDelay.web }}"
           volumeMounts:
             - name: git-clone
               mountPath: /usr/local/git
@@ -246,7 +247,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.logsPersistence.existingClaim | default (printf "%s-logs" (include "airflow.fullname" . | trunc 58 )) }}
         {{- end }}
-        {{- if .Values.dags.initContainer.enabled }}
+        {{- if or (.Values.dags.initContainer.enabled) (.Values.dags.git.gitSync.enabled) }}
         - name: git-clone
           configMap:
             name: {{ template "airflow.fullname" . }}-git-clone

--- a/stable/airflow/templates/deployments-web.yaml
+++ b/stable/airflow/templates/deployments-web.yaml
@@ -156,7 +156,7 @@ spec:
             - name: dags-data
               mountPath: {{ .Values.dags.path }}
               subPath: {{ .Values.persistence.subPath | default "" }}
-          {{- else if .Values.dags.initContainer.enabled }}
+          {{- else if or (.Values.dags.initContainer.enabled) (.Values.dags.git.gitSync.enabled) }}
             - name: dags-data
               mountPath: {{ .Values.dags.path }}
           {{- end }}

--- a/stable/airflow/templates/statefulsets-workers.yaml
+++ b/stable/airflow/templates/statefulsets-workers.yaml
@@ -120,6 +120,7 @@ spec:
             - "{{ .Values.dags.git.repoHost}}"
             - "{{ .Values.dags.git.privateKeyName }}"
             - "{{ .Values.dags.git.gitSync.refreshTime }}"
+            - "{{ .Values.dags.git.gitSync.initDelay.worker }}"
           volumeMounts:
             - name: git-clone
               mountPath: /usr/local/git
@@ -230,7 +231,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.logsPersistence.existingClaim | default (printf "%s-logs" (include "airflow.fullname" . | trunc 58 )) }}
         {{- end }}
-        {{- if .Values.dags.initContainer.enabled }}
+        {{- if or (.Values.dags.initContainer.enabled) (.Values.dags.git.gitSync.enabled) }}
         - name: git-clone
           configMap:
             name: {{ template "airflow.fullname" . }}-git-clone

--- a/stable/airflow/templates/statefulsets-workers.yaml
+++ b/stable/airflow/templates/statefulsets-workers.yaml
@@ -158,7 +158,7 @@ spec:
             - name: dags-data
               mountPath: {{ .Values.dags.path }}
               subPath: {{ .Values.persistence.subPath | default "" }}
-          {{- else if .Values.dags.initContainer.enabled }}
+          {{- else if or (.Values.dags.initContainer.enabled) (.Values.dags.git.gitSync.enabled) }}
             - name: dags-data
               mountPath: {{ .Values.dags.path }}
           {{- end }}

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -135,7 +135,7 @@ airflow:
   ## This should be a json string with your pools in it
   ## Examples:
   ##   pools: '{ "example": { "description": "This is an example of a pool", "slots": 2 } }'
-  pools: {}
+  pools: '{}'
 
   ##
   ## Annotations for the Scheduler, Worker and Web pods
@@ -554,9 +554,19 @@ dags:
         ## values: Always or IfNotPresent
         pullPolicy: IfNotPresent
       ## The amount of time in seconds to git pull dags
-      refreshTime:
+      refreshTime: 0
+      ## The amount of time in seconds before the first sync. (See notes in dags.initContainer for why you might want this.)
+      initDelay:
+        scheduler: 0
+        web: 0
+        worker: 0
   initContainer:
     ## Fetch the source code when the pods starts
+    ##
+    ## WARNING: if your synced resources include custom database hooks, it is possible to create unresolveable
+    ##          dependencies that will prevent initdb from completing. In that case you will want to disable
+    ##          the initContainer and set an appropriate dags.git.gitSync.initDelay.scheduler value
+    ##          in order to ensure that initdb finishes before the custom resources are loaded.
     enabled: false
     ## Image for the init container (any image with git will do)
     image:


### PR DESCRIPTION
More fixes for git sync and initcontainer behavior.

Signed-off-by: Nathan J. Mehl <n@oden.io>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### Is this a new chart
> NOTE: We're experiencing a high volume of PRs to this repo and reviews will be delayed. Please host your own chart repository and submit your repository to the Helm Hub instead of this repo to make them discoverable to the community. [Here](https://github.com/helm/hub/blob/master/Repositories.md) is how to submit new chart repositories to the Helm Hub.

#### What this PR does / why we need it:

- fix a bug wherein if the git-clone initcontainer was not activated,
  but the git-sync sidecar container was, the web and scheduler
  deployments would fail due to not correctly creating the
  git-clone-secret volume, which is needed by both the initcontainer
  and the sidecar:

```
Error: release airflow failed, and has been uninstalled due to atomic being set: Deployment.apps "airflow-web" is invalid: [spec.template.spec.containers[0].volumeMounts[0].name: Not found: "git-clone", spec.template.spec.containers[0].volumeMounts[2].name: Not found: "git-clone-secret"]
```

- Roll back the init order change from
  https://github.com/helm/charts/pull/21368; this turned out to allow
  circular initdb-vs-createconnections dependencies, and the correct
  approach is to disable the initcontainer (which is how the previous
  bug was discovered) and let git-sync populate the dags after initdb
  has happened.  Add warnings in values.yaml and README.md to this effect.

- Add an `init_delay` variable to git-sync.sh and expose it via
  `dags.git.gitSync.initDelay.(web|worker|scheduler` in order to
  provide a workaround for the above.

- Fix another cosmetic data type mismatch bug in values.yaml:
  `airflow.pools` should be a string containing a JSON
  object, not a yaml map:

```
coalesce.go:196: warning: cannot overwrite table with non table for pools (map[])
```

#### Which issue this PR fixes
n/a

#### Special notes for your reviewer:
Hi @gsemet ! :)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
