### PR TITLE
Adds resource tags to downloadDashboardsImage (Fixes #21428)

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 5.0.5
+version: 5.0.6
 appVersion: 6.6.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/_pod.tpl
+++ b/stable/grafana/templates/_pod.tpl
@@ -37,6 +37,8 @@ initContainers:
     image: "{{ .Values.downloadDashboardsImage.repository }}:{{ .Values.downloadDashboardsImage.tag }}"
     imagePullPolicy: {{ .Values.downloadDashboardsImage.pullPolicy }}
     command: ["/bin/sh"]
+    resources:
+{{ toYaml .Values.downloadDashboardsImage.resources | indent 6 }}
     args: [ "-c", "mkdir -p /var/lib/grafana/dashboards/default && /bin/sh /etc/grafana/download_dashboards.sh" ]
     env:
 {{- range $key, $value := .Values.downloadDashboards.env }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -92,6 +92,14 @@ downloadDashboardsImage:
   tag: 7.68.0
   pullPolicy: IfNotPresent
 
+  resources: {}
+  #  limits:
+  #    cpu: 100m
+  #    memory: 128Mi
+  #  requests:
+  #    cpu: 100m
+  #    memory: 128Mi
+
 downloadDashboards:
   env: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
In order to be able to use the dashboard funtionality when resourcequotas are in place you need to specify the resources for all container (including all initcontainers)

#### Which issue this PR fixes
  - fixes #21428

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
